### PR TITLE
print error message when no password in occ

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2699,36 +2699,39 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.1.3",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f9e638e8149e9e41b570ff092f8007c477ef0ce5"
+                "reference": "4f9e449e76996adf310498a8ca955c6deebe29dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f9e638e8149e9e41b570ff092f8007c477ef0ce5",
-                "reference": "f9e638e8149e9e41b570ff092f8007c477ef0ce5",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4f9e449e76996adf310498a8ca955c6deebe29dd",
+                "reference": "4f9e449e76996adf310498a8ca955c6deebe29dd",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9",
+                "symfony/debug": "~2.8|~3.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/filesystem": "~2.8|~3.0",
                 "symfony/process": "~2.8|~3.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
+                "symfony/filesystem": "",
                 "symfony/process": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2755,7 +2758,64 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-26 08:04:17"
+            "time": "2017-01-08 20:47:33"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "v3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "810ba5c1c5352a4ddb15d4719e8936751dff0b05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/810ba5c1c5352a4ddb15d4719e8936751dff0b05",
+                "reference": "810ba5c1c5352a4ddb15d4719e8936751dff0b05",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+            },
+            "require-dev": {
+                "symfony/class-loader": "~2.8|~3.0",
+                "symfony/http-kernel": "~2.8|~3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-01-02 20:32:22"
         },
         {
             "name": "symfony/event-dispatcher",

--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -90,21 +90,19 @@ class ResetPassword extends Command {
 					return 1;
 				}
 			}
-			{
-			do {
-				$q = new Question('<question>Enter a new password: </question>', false);
-				$q->setHidden(true);
-				$password = $dialog->ask($input, $output, $q);
-				$q = new Question('<question>Confirm the new password: </question>', false);
-				$q->setHidden(true);
-				$confirm = $dialog->ask($input, $output, $q);
-				if ($password !== $confirm || (strlen($password) == 0)) {
-					$output->writeln("<error>Passwords did not match or you didn't enter one!</error>");
-					return 1;
-				}
-				}while (strlen($password) == 0);
 
+			$q = new Question('<question>Enter a new password: </question>', false);
+			$q->setHidden(true);
+			$password = $dialog->ask($input, $output, $q);
+			$q = new Question('<question>Confirm the new password: </question>', false);
+			$q->setHidden(true);
+			$confirm = $dialog->ask($input, $output, $q);
+			if ($password !== $confirm || (strlen($password) === 0)) {
+				$output->writeln("<error>Passwords did not match or you didn't enter one!</error>");
+				return 1;
 			}
+
+
 
 		} else {
 			$output->writeln("<error>Interactive input or --password-from-env is needed for entering a new password!</error>");

--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -101,9 +101,6 @@ class ResetPassword extends Command {
 				$output->writeln("<error>Passwords did not match or you didn't enter one!</error>");
 				return 1;
 			}
-
-
-
 		} else {
 			$output->writeln("<error>Interactive input or --password-from-env is needed for entering a new password!</error>");
 			return 1;

--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -97,8 +97,12 @@ class ResetPassword extends Command {
 			$q = new Question('<question>Confirm the new password: </question>', false);
 			$q->setHidden(true);
 			$confirm = $dialog->ask($input, $output, $q);
-			if ($password !== $confirm || (strlen($password) === 0)) {
-				$output->writeln("<error>Passwords did not match or you didn't enter one!</error>");
+			if (strlen($password) === 0) {
+				$output->writeln("<error>You did not enter a Password!</error>");
+				return 1;
+			}
+			if ($password !== $confirm ) {
+				$output->writeln("<error>Passwords did not match! Please try again!</error>");
 				return 1;
 			}
 		} else {

--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -90,17 +90,22 @@ class ResetPassword extends Command {
 					return 1;
 				}
 			}
+			{
+			do {
+				$q = new Question('<question>Enter a new password: </question>', false);
+				$q->setHidden(true);
+				$password = $dialog->ask($input, $output, $q);
+				$q = new Question('<question>Confirm the new password: </question>', false);
+				$q->setHidden(true);
+				$confirm = $dialog->ask($input, $output, $q);
+				if ($password !== $confirm || (strlen($password) == 0)) {
+					$output->writeln("<error>Passwords did not match or you didn't enter one!</error>");
+					return 1;
+				}
+				}while (strlen($password) == 0);
 
-			$q = new Question('<question>Enter a new password: </question>', false);
-			$q->setHidden(true);
-			$password = $dialog->ask($input, $output, $q);
-			$q = new Question('<question>Confirm the new password: </question>', false);
-			$q->setHidden(true);
-			$confirm = $dialog->ask($input, $output, $q);
-			if ($password !== $confirm) {
-				$output->writeln("<error>Passwords did not match!</error>");
-				return 1;
 			}
+
 		} else {
 			$output->writeln("<error>Interactive input or --password-from-env is needed for entering a new password!</error>");
 			return 1;

--- a/tests/Core/Command/User/ResetPasswordTest.php
+++ b/tests/Core/Command/User/ResetPasswordTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class ResetPasswordTest extends TestCase
@@ -23,7 +25,7 @@ class ResetPasswordTest extends TestCase
 
 		$resetPasswordCommand = new ResetPassword($userManagerMock);
 
-		$inputInterfaceMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')
+		$inputInterfaceMock = $this->getMockBuilder(InputInterface::class)
 			->getMock();
 
 		$inputInterfaceMock
@@ -32,7 +34,7 @@ class ResetPasswordTest extends TestCase
 			->with('user')
 			->willReturn('test123');
 
-		$outputInterfaceMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+		$outputInterfaceMock = $this->getMockBuilder(OutputInterface::class)
 			->getMock();
 
 		$resetPasswordCommand->run($inputInterfaceMock, $outputInterfaceMock);
@@ -49,14 +51,14 @@ class ResetPasswordTest extends TestCase
 
 		$resetPasswordCommand = new ResetPassword($userManagerMock);
 
-		$inputInterfaceMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')
+		$inputInterfaceMock = $this->getMockBuilder(InputInterface::class)
 			->getMock();
 
 		$inputInterfaceMock
 			->method('getArgument')
 			->willReturn('test123');
 
-		$outputInterfaceMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+		$outputInterfaceMock = $this->getMockBuilder(OutputInterface::class)
 			->getMock();
 
 		$outputInterfaceMock

--- a/tests/Core/Command/User/ResetPasswordTest.php
+++ b/tests/Core/Command/User/ResetPasswordTest.php
@@ -15,8 +15,7 @@ class ResetPasswordTest extends TestCase
 {
 
 	public function testCommandGetsCorrectUserFromUserManager() {
-		$userManagerMock = $this->getMockBuilder('OCP\IUserManager')
-			->getMock();
+		$userManagerMock = $this->createMock('OCP\IUserManager');
 
 		$userManagerMock
 			->expects($this->once())
@@ -25,8 +24,7 @@ class ResetPasswordTest extends TestCase
 
 		$resetPasswordCommand = new ResetPassword($userManagerMock);
 
-		$inputInterfaceMock = $this->getMockBuilder(InputInterface::class)
-			->getMock();
+		$inputInterfaceMock = $this->createMock(InputInterface::class);
 
 		$inputInterfaceMock
 			->expects($this->once())
@@ -34,16 +32,14 @@ class ResetPasswordTest extends TestCase
 			->with('user')
 			->willReturn('test123');
 
-		$outputInterfaceMock = $this->getMockBuilder(OutputInterface::class)
-			->getMock();
+		$outputInterfaceMock = $this->createMock(OutputInterface::class);
 
 		$resetPasswordCommand->run($inputInterfaceMock, $outputInterfaceMock);
 
 	}
 
 	public function testErrorMessageIsPrintedIfUserDoesNotExists() {
-		$userManagerMock = $this->getMockBuilder('OCP\IUserManager')
-			->getMock();
+		$userManagerMock = $this->createMock('OCP\IUserManager');
 
 		$userManagerMock
 			->method('get')
@@ -51,15 +47,13 @@ class ResetPasswordTest extends TestCase
 
 		$resetPasswordCommand = new ResetPassword($userManagerMock);
 
-		$inputInterfaceMock = $this->getMockBuilder(InputInterface::class)
-			->getMock();
+		$inputInterfaceMock = $this->createMock(InputInterface::class);
 
 		$inputInterfaceMock
 			->method('getArgument')
 			->willReturn('test123');
 
-		$outputInterfaceMock = $this->getMockBuilder(OutputInterface::class)
-			->getMock();
+		$outputInterfaceMock = $this->createMock(OutputInterface::class);
 
 		$outputInterfaceMock
 			->expects($this->once())
@@ -71,8 +65,8 @@ class ResetPasswordTest extends TestCase
 	}
 
 	public function testPrintsErrorIfNoPasswordWasGiven() {
-		$userMock = $this->getMockBuilder('OCP\IUser')->getMock();
-		$userManagerMock = $this->getMockBuilder('OCP\IUserManager')->getMock();
+		$userMock = $this->createMock('OCP\IUser');
+		$userManagerMock = $this->createMock('OCP\IUserManager');
 		$userManagerMock->method('get')->with('test123')->willReturn($userMock);
 
 		$command = new ResetPassword($userManagerMock);
@@ -89,8 +83,8 @@ class ResetPasswordTest extends TestCase
 	}
 
 	public function testPrintsErrorIfPasswordConfirmationDidNotMatch() {
-		$userMock = $this->getMockBuilder('OCP\IUser')->getMock();
-		$userManagerMock = $this->getMockBuilder('OCP\IUserManager')->getMock();
+		$userMock = $this->createMock('OCP\IUser');
+		$userManagerMock = $this->createMock('OCP\IUserManager');
 		$userManagerMock->method('get')->with('test123')->willReturn($userMock);
 
 		$command = new ResetPassword($userManagerMock);

--- a/tests/Core/Command/User/ResetPasswordTest.php
+++ b/tests/Core/Command/User/ResetPasswordTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Core\Command\User;
+
+use OC\Core\Command\User\ResetPassword;
+use PHPUnit\Framework\TestCase;
+
+class ResetPasswordTest extends TestCase
+{
+
+	public function testCommandGetsCorrectUserFromUserManager() {
+		$userManagerMock = $this->getMockBuilder('OCP\IUserManager')
+			->getMock();
+
+		$userManagerMock
+			->expects($this->once())
+			->method('get')
+			->with('test123');
+
+		$resetPasswordCommand = new ResetPassword($userManagerMock);
+
+		$inputInterfaceMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')
+			->getMock();
+
+		$inputInterfaceMock
+			->expects($this->once())
+			->method('getArgument')
+			->with('user')
+			->willReturn('test123');
+
+		$outputInterfaceMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+			->getMock();
+
+		$resetPasswordCommand->run($inputInterfaceMock, $outputInterfaceMock);
+
+	}
+
+	public function testErrorMessageIsPrintedIfUserDoesNotExists() {
+		$userManagerMock = $this->getMockBuilder('OCP\IUserManager')
+			->getMock();
+
+		$userManagerMock
+			->method('get')
+			->willReturn(null);
+
+		$resetPasswordCommand = new ResetPassword($userManagerMock);
+
+		$inputInterfaceMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')
+			->getMock();
+
+		$inputInterfaceMock
+			->method('getArgument')
+			->willReturn('test123');
+
+		$outputInterfaceMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+			->getMock();
+
+		$outputInterfaceMock
+			->expects($this->once())
+			->method ('writeln')
+			->with('<error>User does not exist</error>');
+
+		$resetPasswordCommand->run($inputInterfaceMock, $outputInterfaceMock);
+	}
+}

--- a/tests/Core/Command/User/ResetPasswordTest.php
+++ b/tests/Core/Command/User/ResetPasswordTest.php
@@ -60,6 +60,39 @@ class ResetPasswordTest extends TestCase
 			->method ('writeln')
 			->with('<error>User does not exist</error>');
 
+
 		$resetPasswordCommand->run($inputInterfaceMock, $outputInterfaceMock);
+	}
+
+	public function PasswordFromEnvGivenButOC_PASSIsEmpty(){
+
+		$userManagerMock = $this->getMockBuilder('OCP\IUserManager')
+			->getMock();
+
+		$userManagerMock
+			->method('get')
+			->willReturn(null);
+
+		$resetPasswordCommand = new ResetPassword($userManagerMock);
+
+		$inputInterfaceMock = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')
+			->getMock();
+		$inputInterfaceMock
+			->method('getOption')
+			->with ('password-from-env')
+			->willReturn('OC_PASS');
+
+		$outputInterfaceMock = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')
+			->getMock();
+
+		$outputInterfaceMock
+			->expects($this->once())
+			->method ('writeln')
+			->with('<error>--password-from-env given, but OC_PASS is empty!</error>');
+
+		$resetPasswordCommand->run($inputInterfaceMock, $outputInterfaceMock);
+	}
+	public function EncryptionResetCausesLossOfData() {
+
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

This is a clean copy of #26481 sine i don't know how to fix a branch that messed up a rebase :stuck_out_tongue: .

Added a do-while loop to check if the password string length is larger than 0 when called by occ.

## Related Issue
#25206
## Motivation and Context

When you entered a password with a length of 0 in occ you could set a password with a length of 0. This is not desirable and also doesn't work in the ui. The behaviour should be consistent
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.