### PR TITLE
Don't mount user home with alternate keys root

### DIFF
--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -345,6 +345,11 @@ class Storage implements IStorage {
 	 * @param string $uid user id
 	 */
 	protected function setupUserMounts($uid) {
+		if ($this->root_dir !== '') {
+			// this means that the keys are stored outside of the user's homes,
+			// so we don't need to mount anything
+			return;
+		}
 		if (!is_null($uid) && $uid !== '' && $uid !== $this->currentUser) {
 			\OC\Files\Filesystem::initMountPoints($uid);
 		}

--- a/tests/lib/Encryption/Keys/StorageTest.php
+++ b/tests/lib/Encryption/Keys/StorageTest.php
@@ -61,6 +61,8 @@ class StorageTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$this->util->method('getKeyStorageRoot')->willReturn('');
+
 		$this->view = $this->getMockBuilder('OC\Files\View')
 			->disableOriginalConstructor()
 			->getMock();
@@ -77,6 +79,10 @@ class StorageTest extends TestCase {
 		$this->createUser('user1', '123456');
 		$this->createUser('user2', '123456');
 		$this->storage = new Storage($this->view, $this->util, $userSession);
+	}
+
+	public function tearDown() {
+		\OC\Files\Filesystem::tearDown();
 	}
 
 	public function testSetFileKey() {
@@ -275,6 +281,33 @@ class StorageTest extends TestCase {
 		);
 
 		$this->assertTrue($this->isUserHomeMounted('user2'));
+	}
+
+	public function testGetUserKeyWhenKeyStorageIsOutsideHome() {
+		$this->view->expects($this->once())
+			->method('file_get_contents')
+			->with($this->equalTo('/enckeys/user2/files_encryption/encModule/user2.publicKey'))
+			->willReturn('key');
+		$this->view->expects($this->once())
+			->method('file_exists')
+			->with($this->equalTo('/enckeys/user2/files_encryption/encModule/user2.publicKey'))
+			->willReturn(true);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user1');
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn($user);
+		$util = $this->createMock(\OC\Encryption\Util::class);
+		$util->method('getKeyStorageRoot')->willReturn('enckeys');
+		$storage = new Storage($this->view, $util, $userSession);
+
+		$this->assertFalse($this->isUserHomeMounted('user2'));
+
+		$this->assertSame('key',
+			$storage->getUserKey('user2', 'publicKey', 'encModule')
+		);
+
+		$this->assertFalse($this->isUserHomeMounted('user2'), 'mounting was not necessary');
 	}
 
 	/**


### PR DESCRIPTION


<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
When encryption keys are stored outside the user's homes, there is no
need to mount said homes.

## Related Issue
Follow up of https://github.com/owncloud/core/pull/26917.
Discovered while working on https://github.com/owncloud/core/issues/26935.
This only fixes the "alternative key storage" case from https://github.com/owncloud/core/issues/26935 and might also improve the performance a bit as we don't need to mount the user's homes.

## Motivation and Context
Don't do unnecessary stuff.
But also I feel that this was missing from https://github.com/owncloud/core/pull/26917

## How Has This Been Tested?
- unit tests
- use steps from https://github.com/owncloud/core/issues/26936 on this PR and see that there is `NoUserException` when deleting a user in this "alternate keys storage root" setup.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review @jvillafanez @SergioBertolinSG 