### PR TITLE
Use preDelete hook to delete encryption keys

### DIFF
--- a/apps/encryption/lib/Hooks/UserHooks.php
+++ b/apps/encryption/lib/Hooks/UserHooks.php
@@ -137,9 +137,9 @@ class UserHooks implements IHook {
 				'postCreateUser');
 
 			OCUtil::connectHook('OC_User',
-				'post_deleteUser',
+				'pre_deleteUser',
 				$this,
-				'postDeleteUser');
+				'preDeleteUser');
 		}
 	}
 
@@ -194,7 +194,7 @@ class UserHooks implements IHook {
 	 * @param array $params : uid, password
 	 * @note This method should never be called for users using client side encryption
 	 */
-	public function postDeleteUser($params) {
+	public function preDeleteUser($params) {
 
 		if (App::isEnabled('encryption')) {
 			$this->keyManager->deletePublicKey($params['uid']);

--- a/apps/encryption/tests/Hooks/UserHooksTest.php
+++ b/apps/encryption/tests/Hooks/UserHooksTest.php
@@ -108,12 +108,12 @@ class UserHooksTest extends TestCase {
 		$this->assertTrue(true);
 	}
 
-	public function testPostDeleteUser() {
+	public function testPreDeleteUser() {
 		$this->keyManagerMock->expects($this->once())
 			->method('deletePublicKey')
 			->with('testUser');
 
-		$this->instance->postDeleteUser($this->params);
+		$this->instance->preDeleteUser($this->params);
 		$this->assertTrue(true);
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Because we sometimes need to mount the user's home before deleting
encryption keys, this must happen in a preDelete hook because the
postDelete is too late. In postDelete the user's home already doesn't
exist any more and cannot be mounted.

## Related Issue
Fixes https://github.com/owncloud/core/issues/26935 which is a regression from https://github.com/owncloud/core/pull/26917

## Motivation and Context
To fix the regression from https://github.com/owncloud/core/pull/26917

## How Has This Been Tested?
Enable encryption then delete a user.
Before the fix: errors in log `NoUserException`.
After this fix: no more errors.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Notes

One might argue that it's pointless to process the keys from the home since the home is deleted anyway. However, this here is only for out own default implementation of encryption key manager. Custom implementations could want to do things like backing up encryption keys before the user is deleted, in which case the preDelete hook makes even more sense.

Please review @jvillafanez @SergioBertolinSG 

@SergioBertolinSG this should fix the failures in https://github.com/owncloud/core/pull/26844