### PR TITLE
Ignore exception when deleting keys of deleted user

### DIFF
--- a/apps/encryption/lib/Hooks/UserHooks.php
+++ b/apps/encryption/lib/Hooks/UserHooks.php
@@ -137,9 +137,9 @@ class UserHooks implements IHook {
 				'postCreateUser');
 
 			OCUtil::connectHook('OC_User',
-				'pre_deleteUser',
+				'post_deleteUser',
 				$this,
-				'preDeleteUser');
+				'postDeleteUser');
 		}
 	}
 
@@ -194,7 +194,7 @@ class UserHooks implements IHook {
 	 * @param array $params : uid, password
 	 * @note This method should never be called for users using client side encryption
 	 */
-	public function preDeleteUser($params) {
+	public function postDeleteUser($params) {
 
 		if (App::isEnabled('encryption')) {
 			$this->keyManager->deletePublicKey($params['uid']);

--- a/apps/encryption/tests/Hooks/UserHooksTest.php
+++ b/apps/encryption/tests/Hooks/UserHooksTest.php
@@ -108,12 +108,12 @@ class UserHooksTest extends TestCase {
 		$this->assertTrue(true);
 	}
 
-	public function testPreDeleteUser() {
+	public function testPostDeleteUser() {
 		$this->keyManagerMock->expects($this->once())
 			->method('deletePublicKey')
 			->with('testUser');
 
-		$this->instance->preDeleteUser($this->params);
+		$this->instance->postDeleteUser($this->params);
 		$this->assertTrue(true);
 	}
 

--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -28,6 +28,7 @@ use OC\Files\Filesystem;
 use OC\Files\View;
 use OCP\Encryption\Keys\IStorage;
 use OCP\IUserSession;
+use OC\User\NoUserException;
 
 class Storage implements IStorage {
 
@@ -138,8 +139,21 @@ class Storage implements IStorage {
 	 * @inheritdoc
 	 */
 	public function deleteUserKey($uid, $keyId, $encryptionModuleId) {
-		$path = $this->constructUserKeyPath($encryptionModuleId, $keyId, $uid);
-		return !$this->view->file_exists($path) || $this->view->unlink($path);
+		try {
+			$path = $this->constructUserKeyPath($encryptionModuleId, $keyId, $uid);
+			return !$this->view->file_exists($path) || $this->view->unlink($path);
+		} catch (NoUserException $e) {
+			// this exception can come from initMountPoints() from setupUserMounts()
+			// for a deleted user.
+			//
+			// It means, that:
+			// - we are not running in alternative storage mode because we don't call
+			// initMountPoints() in that mode
+			// - the keys were in the user's home but since the user was deleted, the
+			// user's home is gone and so are the keys
+			//
+			// So there is nothing to do, just ignore.
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Reverts https://github.com/owncloud/core/pull/26938 and provides an alternative solution.
Whenever a user was deleted for encryption where the keys are stored in the home, we can ignore user existence exceptions because it means the keys are already gone.

## Related Issue
See https://github.com/owncloud/core/pull/26824#issuecomment-273049684
and https://github.com/owncloud/core/issues/26935

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Enable encryption with or without "alternative home" mode.
Create then delete a user.

Before this fix:
- in normal encryption mode, NoUserException appears in log
- in alternative home mode: no exception

After this fix: no exception in both modes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@jvillafanez please review