### PR TITLE
.ocTransferIDXXXXX.part makes filename too long #25425

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -111,7 +111,7 @@ class File extends Node implements IFile {
 
 		if ($needsPartFile) {
 			// mark file as partial while uploading (ignored by the scanner)
-			$partFilePath = $this->getPartFileBasePath($this->path) . '.ocTransferId' . rand() . '.part';
+			$partFilePath = sha1($this->getPartFileBasePath($this->path)) . '.part';
 		} else {
 			// upload file directly as the final path
 			$partFilePath = $this->path;

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -111,7 +111,7 @@ class File extends Node implements IFile {
 
 		if ($needsPartFile) {
 			// mark file as partial while uploading (ignored by the scanner)
-			$partFilePath = sha1($this->getPartFileBasePath($this->path)) . '.part';
+			$partFilePath = sha1($this->getPartFileBasePath($this->path)) . '.ocTransferId' . rand() . '.part';
 		} else {
 			// upload file directly as the final path
 			$partFilePath = $this->path;

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -427,11 +427,10 @@ class File extends Node implements IFile {
 				list($targetStorage, $targetInternalPath) = $this->fileView->resolvePath($targetPath);
 
 				if ($needsPartFile) {
-					// we first assembly the target file as a part file
-					$partFile = $this->getPartFileBasePath($path . '/' . $info['name']) . '.ocTransferId' . $info['transferid'] . '.part';
+					// we first assemble the target file as a part file
+					$partFile = $this->getPartFileBasePath($path . '/' . sha1($info['name'])) . '.ocTransferId' . $info['transferid'] . '.part';
 					/** @var \OC\Files\Storage\Storage $targetStorage */
 					list($partStorage, $partInternalPath) = $this->fileView->resolvePath($partFile);
-
 
 					$chunk_handler->file_assemble($partStorage, $partInternalPath);
 

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -111,7 +111,8 @@ class File extends Node implements IFile {
 
 		if ($needsPartFile) {
 			// mark file as partial while uploading (ignored by the scanner)
-			$partFilePath = sha1($this->getPartFileBasePath($this->path)) . '.ocTransferId' . rand() . '.part';
+			$fullPath = $this->getPartFileBasePath($this->path);
+			$partFilePath = dirname($fullPath) . '/' . sha1(basename($fullPath)) . '.ocTransferId' . rand() . '.part';
 		} else {
 			// upload file directly as the final path
 			$partFilePath = $this->path;

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -1012,7 +1012,7 @@ class FileTest extends TestCase {
 
 		$storage->expects($this->atLeastOnce())
 			->method('fopen')
-			->with($this->matchesRegularExpression('/^([0-9a-f]{40})(.ocTransferId)([0-9]+)(.part)$/i'))
+			->with($this->matchesRegularExpression('/a1f13b3bc20a296e08c212be9c56c706c10abc4f.ocTransferId([0-9]+).part$/i'))
 			->willReturn($stream);
 
 		$storage->method('moveFromStorage')
@@ -1054,7 +1054,7 @@ class FileTest extends TestCase {
 
 		$storage->expects($this->atLeastOnce())
 			->method('fopen')
-			->with($this->matchesRegularExpression('/^(\/[0-9a-f]{40})(.ocTransferId)([0-9]+)(.part)$/i'))
+			->with($this->matchesRegularExpression('/^\/1cf7c9c735f7fd721ebe33ea1e7d259397f24007.ocTransferId([0-9]+).part$/i'))
 			->willReturn($this->getStream('FOO1231'));
 
 		$path = 'foo.dat-chunking-13242432-0-0';


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Fixing an error where file-uploads with long filenames failed because a .part suffix was attached to the filename during the upload thus exceeding the max allowed filename limit.  

## Related Issue
#25425


## How Has This Been Tested?
- Manual test with long filename over webui.
- Unit-Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

