### PR TITLE
Allow revert quota to Unlimited. 

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -524,7 +524,10 @@ var UserList = {
 		if (quota === 'other') {
 			return;
 		}
-		if (isNaN(parseInt(quota, 10)) || parseInt(quota, 10) < 0) {
+		if (
+			['default', 'none'].indexOf(quota) === -1
+			&& (isNaN(parseInt(quota, 10)) || parseInt(quota, 10) < 0)
+		) {
 			// the select component has added the bogus value, delete it again
 			$select.find('option[selected]').remove();
 			OC.Notification.showTemporary(t('core', 'Invalid quota value "{val}"', {val: quota}));


### PR DESCRIPTION
## Description
Allow quota to be 'none'

## Related Issue
Fixes #26975

## Motivation and Context
If user has a quota set, it can't be reverted to `Unlimited` value

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

