### PR TITLE
user notification for file uploads > 4GB in IE11

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -336,6 +336,21 @@ OC.Upload = {
 						data.errorThrown = errorMessage;
 					}
 
+					// detect browser and version to handle IE11 upload file size limit
+					if (OC.Util.isIE11()) {
+						var maxUploadFileSize = 4187593113;
+						// check filesize (> 4 GB is not supported in IE11); limit is set to 3.9GB
+						if (file.size > maxUploadFileSize) {
+							data.textStatus = 'sizeexceedbrowserlimit';
+							data.errorThrown = t('files',
+								'Total file size {size1} exceeds your browser upload limit. Please use the {ownCloud} desktop client to upload files bigger than {size2}.', {
+								'size1': humanFileSize(file.size),
+								'ownCloud' : OC.theme.name || 'ownCloud',
+								'size2': humanFileSize(maxUploadFileSize)
+							});
+						}
+					}
+
 					// in case folder drag and drop is not supported file will point to a directory
 					// http://stackoverflow.com/a/20448357
 					if ( ! file.type && file.size%4096 === 0 && file.size <= 102400) {
@@ -583,7 +598,7 @@ OC.Upload = {
 							+ '</span><span class="mobile">'
 							+ t('files', '...')
 							+ '</span></em>');
-                    $('#uploadprogressbar').tipsy({gravity:'n', fade:true, live:true});
+					$('#uploadprogressbar').tipsy({gravity:'n', fade:true, live:true});
 					OC.Upload._showProgressBar();
 				});
 				fileupload.on('fileuploadprogress', function(e, data) {

--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -118,6 +118,43 @@ describe('OC.Upload tests', function() {
 				'Not enough free space, you are uploading 5 KB but only 1000 B is left'
 			);
 		});
+		it('does not add file if too big for IE11', function() {
+			var ieStub = sinon.stub(OC.Util, 'isIE11').returns(true);
+			var oldTheme = OC.theme.name;
+			OC.theme.name = 'SomeThing';
+
+			$('#free_space').val(1000000000000);
+			$('#upload_limit').val(1000000000000);
+
+			var result;
+			testFile.size = 4187593113 + 1;
+			result = addFile(testFile);
+
+			expect(result).toEqual(false);
+			expect(failStub.calledOnce).toEqual(true);
+			expect(failStub.getCall(0).args[1].textStatus).toEqual('sizeexceedbrowserlimit');
+			expect(failStub.getCall(0).args[1].errorThrown).toEqual(
+				'Total file size 3.9 GB exceeds your browser upload limit. Please use the SomeThing desktop client to upload files bigger than 3.9 GB.'
+			);
+
+			OC.theme.name = oldTheme;
+			ieStub.restore();
+		});
+		it('adds big files when not dealing with IE11', function() {
+			var ieStub = sinon.stub(OC.Util, 'isIE11').returns(false);
+
+			$('#free_space').val(1000000000000);
+			$('#upload_limit').val(1000000000000);
+
+			var result;
+			testFile.size = 4187593113 + 1;
+			result = addFile(testFile);
+
+			expect(result).toEqual(true);
+			expect(failStub.notCalled).toEqual(true);
+
+			ieStub.restore();
+		});
 	});
 	describe('Upload conflicts', function() {
 		var oldFileList;

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1444,6 +1444,10 @@ function initCore() {
 	if (msie > 0 || trident > 0) {
 		// (IE 10 or older) || IE 11
 		$('html').addClass('ie');
+		if(trident > 0) {
+			var rv = userAgent.indexOf('rv:');
+			$('html').addClass('ie' + parseInt(userAgent.substring(rv + 3, userAgent.indexOf('.', rv)), 10));
+		}
 	} else if (edge > 0) {
 		// for edge
 		$('html').addClass('edge');
@@ -1868,6 +1872,15 @@ OC.Util = {
 	 */
 	isIE: function() {
 		return $('html').hasClass('ie');
+	},
+
+	/**
+	 * Returns whether this is IE11
+	 *
+	 * @return {bool} true if this is IE11, false otherwise
+	 */
+	isIE11: function() {
+		return $('html').hasClass('ie11');
 	},
 
 	/**


### PR DESCRIPTION
## Description
Notify users with IE11 to use desktop client for uploading files bigger than 4GB.

## Related Issue
https://github.com/owncloud/enterprise/issues/1779

## Motivation and Context
IE11 can't handle file uploads bigger than 4GB

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
