### PR TITLE
Integration test check download without saving file locally

### DIFF
--- a/build/integration/features/bootstrap/Sharing.php
+++ b/build/integration/features/bootstrap/Sharing.php
@@ -73,21 +73,13 @@ trait Sharing {
 			$url = $this->lastShareData->data->url;
 		}
 		$fullUrl = $url . "/download";
-		$options['save_to'] = "./$filename";
-		$this->response = $client->get($fullUrl, $options);
-		$finfo = new finfo;
-		$fileinfo = $finfo->file("./$filename", FILEINFO_MIME_TYPE);
-		PHPUnit_Framework_Assert::assertEquals($fileinfo, "text/plain");
-		if (file_exists("./$filename")) {
-			unlink("./$filename");
-		}
+		$this->checkDownload($fullUrl, null, 'text/plain');
 	}
 
 	/**
 	 * @Then /^Public shared file "([^"]*)" with password "([^"]*)" can be downloaded$/
 	 */
 	public function checkPublicSharedFileWithPassword($filename, $password) {
-		$client = new Client();
 		$options = [];
 		if (count($this->lastShareData->data->element) > 0){
 			$token = $this->lastShareData->data[0]->token;
@@ -97,14 +89,30 @@ trait Sharing {
 		}
 
 		$fullUrl = substr($this->baseUrl, 0, -4) . "public.php/webdav";
-		$options['auth'] = [$token, $password];
-		$options['save_to'] = "./$filename";
-		$this->response = $client->get($fullUrl, $options);
-		$finfo = new finfo;
-		$fileinfo = $finfo->file("./$filename", FILEINFO_MIME_TYPE);
-		PHPUnit_Framework_Assert::assertEquals($fileinfo, "text/plain");
-		if (file_exists("./$filename")) {
-			unlink("./$filename");
+		$this->checkDownload($fullUrl, [$token, $password], 'text/plain');
+	}
+
+	private function checkDownload($url, $auth = null, $mimeType = null) {
+		if ($auth !== null) {
+			$options['auth'] = $auth;
+		}
+		$options['stream'] = true;
+
+		$client = new Client();
+		$this->response = $client->get($url, $options);
+		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+
+		$buf = '';
+		$body = $this->response->getBody();
+		while (!$body->eof()) {
+			// read everything
+			$buf .= $body->read(8192);
+		}
+		$body->close();
+
+		if ($mimeType !== null) {
+			$finfo = new finfo;
+			PHPUnit_Framework_Assert::assertEquals($mimeType, $finfo->buffer($buf, FILEINFO_MIME_TYPE));
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Use Guzzle stream mode to download the contents instead of using a
temporary local file.

## Related Issue
Fixes https://github.com/owncloud/core/issues/27006

## Motivation and Context
Makes it possible for all tests to pass on my env where I have different permissions (www-run, etc)

## How Has This Been Tested?
Ran on my env, the test from the ticket passes now.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@SergioBertolinSG please review