### PR TITLE
Disable encryption integration tests with external storage

### DIFF
--- a/build/integration/features/external-storage.feature
+++ b/build/integration/features/external-storage.feature
@@ -4,6 +4,7 @@ Feature: external-storage
     Given using old dav path
 
   @local_storage
+  @no_encryption
   Scenario: Share by link a file inside a local external storage
     Given user "user0" exists
     And user "user1" exists


### PR DESCRIPTION
Because encryption leaves stray keys that sabotage subsequent runs.
Needs to be fixed separately as part of https://github.com/owncloud/core/issues/10371


Backports to be cherry-picked on https://github.com/owncloud/core/pull/26993 and https://github.com/owncloud/core/pull/26996

@SergioBertolinSG 