### PR TITLE
Ignore NoUserException for shares from ghosts

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -38,6 +38,7 @@ use OCP\Files\Storage\IStorage;
 use OCP\Lock\ILockingProvider;
 use OC\Files\Storage\FailedStorage;
 use OCP\Files\NotFoundException;
+use OC\User\NoUserException;
 
 /**
  * Convert target path to source path and pass the function call to the correct storage provider
@@ -102,12 +103,16 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 			$this->sourceRootInfo = $this->sourceStorage->getCache()->get($sourceInternalPath);
 			// adjust jail
 			$this->rootPath = $sourceInternalPath;
-
-		} catch (\Exception $e) {
+		} catch (NotFoundException $e) {
+			// original file not accessible or deleted, set FailedStorage
 			$this->sourceStorage = new FailedStorage(['exception' => $e]);
-			if (!$e instanceof NotFoundException) {
-				$this->logger->logException($e);
-			}
+		} catch (NoUserException $e) {
+			// sharer user deleted, set FailedStorage
+			$this->sourceStorage = new FailedStorage(['exception' => $e]);
+		} catch (\Exception $e) {
+			// something unexpected happened, log exception and set failed storage
+			$this->sourceStorage = new FailedStorage(['exception' => $e]);
+			$this->logger->logException($e);
 		}
 		$this->storage = $this->sourceStorage;
 	}

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -27,6 +27,11 @@
 
 namespace OCA\Files_Sharing\Tests;
 
+use OCA\Files_Sharing\SharedStorage;
+use OCP\Share\IShare;
+use OC\Files\View;
+use OCP\Files\NotFoundException;
+
 /**
  * Class SharedStorageTest
  *
@@ -561,5 +566,38 @@ class SharedStorageTest extends TestCase {
 		$this->assertTrue($cache->inCache('/vincent'));
 		$this->assertTrue($cache->inCache('/vincent/' . $fn));
 		$this->assertEquals(16, $cache->get('/vincent/' . $fn)['size']);
+	}
+
+	public function testInitWithNonExistingUser() {
+		$share = $this->createMock(IShare::class);
+		$share->method('getShareOwner')->willReturn('unexist');
+		$ownerView = $this->createMock(View::class);
+		$storage = new SharedStorage([
+			'ownerView' => $ownerView,
+			'superShare' => $share,
+			'groupedShares' => [$share],
+			'user' => 'user1',
+		]);
+
+		// trigger init
+		$this->assertInstanceOf(\OC\Files\Cache\FailedCache::class, $storage->getCache());
+		$this->assertInstanceOf(\OC\Files\Storage\FailedStorage::class, $storage->getSourceStorage());
+	}
+
+	public function testInitWithNotFoundSource() {
+		$share = $this->createMock(IShare::class);
+		$share->method('getShareOwner')->willReturn(self::TEST_FILES_SHARING_API_USER1);
+		$ownerView = $this->createMock(View::class);
+		$ownerView->method('getPath')->will($this->throwException(new NotFoundException()));
+		$storage = new SharedStorage([
+			'ownerView' => $ownerView,
+			'superShare' => $share,
+			'groupedShares' => [$share],
+			'user' => 'user1',
+		]);
+
+		// trigger init
+		$this->assertInstanceOf(\OC\Files\Cache\FailedCache::class, $storage->getCache());
+		$this->assertInstanceOf(\OC\Files\Storage\FailedStorage::class, $storage->getSourceStorage());
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Don't log the exception when setting up a share from a ghost/deleted user.

## Related Issue
Fixes https://github.com/owncloud/core/issues/27026

## Motivation and Context
Because the logs are useless and ghosts are an expected situation until the background job reaper comes to carry these away.

## How Has This Been Tested?
See original steps.
After the fix: no more exception logged.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review @IljaN @jvillafanez @butonic 
