### PR TITLE
Use the expected method depending on the target being a file or folder

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -253,7 +253,11 @@ class Trashbin {
 		}
 
 		if ($sourceStorage->file_exists($sourceInternalPath)) { // failed to delete the original file, abort
-			$sourceStorage->unlink($sourceInternalPath);
+			if ($sourceStorage->is_dir($sourceInternalPath)) {
+				$sourceStorage->rmdir($sourceInternalPath);
+			} else {
+				$sourceStorage->unlink($sourceInternalPath);
+			}
 			return false;
 		}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Use the expected method to delete the target file or folder

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/26278
Might affect to https://github.com/owncloud/enterprise/issues/1720

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Storages are expected to delete files with `unlink` and folders with `rmdir`. Using `unlink` for folders can have unexpected consecuences (see linked core issue)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual tested using SMB storage with session credentials. The account has read-only access to the SMB storage.
NOTE: It's not intended that the file will be deleted. As stated in https://github.com/owncloud/core/issues/26278, the folder won't be deleted and an error message will be shown, but the log will be different.
```
{"reqId":"foIHTwhq52ee\/72NdaBU","remoteAddr":"10.0.2.4","app":"webdav","message":"Exception: {\"Message\":\"HTTP\\\/1.1 403 Forbidden\",\"Exception\":\"Sabre\\\\DAV\\\\Exception\\\\Forbidden\",\"Code\":0,\"Trace\":\"#0 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Tree.php(179): OCA\\\\DAV\\\\Connector\\\\Sabre\\\\Directory->delete()\\n#1 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/CorePlugin.php(287): Sabre\\\\DAV\\\\Tree->delete('windows\\\/dummy\\\/B...')\\n#2 [internal function]: Sabre\\\\DAV\\\\CorePlugin->httpDelete(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#3 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/event\\\/lib\\\/EventEmitterTrait.php(105): call_user_func_array(Array, Array)\\n#4 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(479): Sabre\\\\Event\\\\EventEmitter->emit('method:DELETE', Array)\\n#5 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(254): Sabre\\\\DAV\\\\Server->invokeMethod(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#6 \\\/opt\\\/owncloud\\\/apps\\\/dav\\\/appinfo\\\/v1\\\/webdav.php(58): Sabre\\\\DAV\\\\Server->exec()\\n#7 \\\/opt\\\/owncloud\\\/remote.php(164): require_once('\\\/opt\\\/owncloud\\\/a...')\\n#8 {main}\",\"File\":\"\\\/opt\\\/owncloud\\\/apps\\\/dav\\\/lib\\\/Connector\\\/Sabre\\\/Directory.php\",\"Line\":301,\"User\":\"user1\"}","level":0,"time":"2017-01-25T16:19:03+00:00","method":"DELETE","url":"\/remote.php\/webdav\/windows\/dummy\/B2","user":"user1"}
```
notice the forbidden exception instead of the invalid type exception.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Backports required.

@PVince81 @DeepDiver1975 