### PR TITLE
Copy file to owner's trash when recipient moves out of share

### DIFF
--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -60,8 +60,13 @@ class StorageTest extends \Test\TestCase {
 		\OC_Hook::clear();
 		\OCA\Files_Trashbin\Trashbin::registerHooks();
 
+		// the encryption wrapper does some twisted stuff with moveFromStorage...
+		// we need to register it here so that the tested behavior is closer to reality
+		\OC::$server->getEncryptionManager()->setupStorage();
+
 		$this->user = $this->getUniqueId('user');
 		\OC::$server->getUserManager()->createUser($this->user, $this->user);
+
 
 		// this will setup the FS
 		$this->loginAsUser($this->user);
@@ -82,6 +87,7 @@ class StorageTest extends \Test\TestCase {
 		$user = \OC::$server->getUserManager()->get($this->user);
 		if ($user !== null) { $user->delete(); }
 		\OC_Hook::clear();
+		\OC\Files\Filesystem::getLoader()->removeStorageWrapper('oc_encryption');
 		parent::tearDown();
 	}
 

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -1133,3 +1133,31 @@ Feature: sharing
     Then as "user1" the file "/shared/shared_file.txt" exists
     And as "user0" the file "/shared/shared_file.txt" exists
 
+  Scenario: moving file out of a share as recipient creates a backup for the owner
+    Given As an "admin"
+    And user "user0" exists
+    And user "user1" exists
+    And user "user0" created a folder "/shared"
+    And User "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And file "/shared" of user "user0" is shared with user "user1"
+    And User "user1" moved folder "/shared" to "/shared_renamed"
+    When User "user1" moved file "/shared_renamed/shared_file.txt" to "/taken_out.txt"
+    Then as "user1" the file "/taken_out.txt" exists
+    And as "user0" the file "/shared/shared_file.txt" does not exist
+    And as "user0" the file "/shared_file.txt" exists in trash
+
+  Scenario: moving folder out of a share as recipient creates a backup for the owner
+    Given As an "admin"
+    And user "user0" exists
+    And user "user1" exists
+    And user "user0" created a folder "/shared"
+    And user "user0" created a folder "/shared/sub"
+    And User "user0" moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
+    And file "/shared" of user "user0" is shared with user "user1"
+    And User "user1" moved folder "/shared" to "/shared_renamed"
+    When User "user1" moved folder "/shared_renamed/sub" to "/taken_out"
+    Then as "user1" the file "/taken_out" exists
+    And as "user0" the folder "/shared/sub" does not exist
+    And as "user0" the folder "/sub" exists in trash
+    And as "user0" the file "/sub/shared_file.txt" exists in trash
+


### PR DESCRIPTION
## Description
Whenever a share recipient moves files or folders out of the share,
make a backup copy in the owner's trash just in case.

The metadata stays on the recipient's copy that was moved out.

## Related Issue
Fixes https://github.com/owncloud/core/issues/24053 (without activity entry)

## Motivation and Context
Solves the case where the recipient is not reachable any more so the owner still has a chance to restore the file.

## How Has This Been Tested?

1. Login as "user0" (owner)
1. Create a folder "shared"
1. Share "shared" with "user1" (recipient)
1. Login as "user1"
1. Create a file "shared/test.txt" and overwrite several times to create versions
1. Create a folder "shared/sub"
1. Create a file "shared/sub/testsub.txt" and overwrite several times to create versions
1. Rename "shared" to "shared_renamed" (this covers the path matching logic)
1. Move "sub" and "test.txt" out of the "shared_renamed" folder.
1. Login as "owner"
1. Check that trashbin contains both "sub/testsub.txt" and "test.txt"
1. Restore both
1. Check that both "test.txt" and "sub/testsub.txt" are restored in the "shared" folder (from the owner's perspective)
1. Check that both entries still have their versions attached

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODOs:

- [x] find a way to bypass the locking issue or find another place / hook to do this operation...