### PR TITLE
Add postLogout hook to finish sessions from external session managers

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -10,6 +10,7 @@
  * @author Robin McCorkell <robin@mccorkell.me.uk>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Felix Rupp <kontakt@felixrupp.com>
  *
  * @copyright Copyright (c) 2016, ownCloud GmbH.
  * @license AGPL-3.0
@@ -66,6 +67,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * - preRememberedLogin(string $uid)
  * - postRememberedLogin(\OC\User\User $user)
  * - logout()
+ * - postLogout()
  *
  * @package OC\User
  */
@@ -725,6 +727,7 @@ class Session implements IUserSession, Emitter {
 		$this->setLoginName(null);
 		$this->unsetMagicInCookie();
 		$this->session->clear();
+		$this->manager->emit('\OC\User', 'postLogout');
 	}
 
 	/**

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -10,6 +10,7 @@
  * @author Robin McCorkell <robin@mccorkell.me.uk>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Felix Rupp <kontakt@felixrupp.com>
  *
  * @copyright Copyright (c) 2016, ownCloud GmbH.
  * @license AGPL-3.0
@@ -725,6 +726,7 @@ class Session implements IUserSession, Emitter {
 		$this->setLoginName(null);
 		$this->unsetMagicInCookie();
 		$this->session->clear();
+		$this->manager->emit('\OC\User', 'postLogout');
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Added a second hook emit in the logout method in \OC\User\Session to achieve a cleaner logout routine, when using external session managers, like [CAS](https://wiki.jasig.org/display/CAS/Home).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Issue 26692](https://github.com/owncloud/core/issues/26692)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When using external session managers, owncloud logout only allows to execute my own code before the oc session is terminated. Some of the mentioned session managers must be called after local sessions are terminated, otherwise the oc session is not terminated correctly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The new hook has been testet on an Ubuntu 14 installation with PHP 5.6 and Owncloud 9.1.3-1.1 and a CAS session management via user_cas Application.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
