### PR TITLE
Always enable files_external

### DIFF
--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -240,6 +240,15 @@ class ViewControllerTest extends TestCase {
 				'icon' => '',
 			],
 			[
+				'id' => 'extstoragemounts',
+				'appname' => 'files_external',
+				'script' => 'list.php',
+				'order' => 30,
+				'name' => new \OC_L10N_String(\OC::$server->getL10NFactory()->get('files_external'), 'External storage', []),
+				'active' => false,
+				'icon' => '',
+			],
+			[
 				'id' => 'trashbin',
 				'appname' => 'files_trashbin',
 				'script' => 'list.php',
@@ -247,7 +256,7 @@ class ViewControllerTest extends TestCase {
 				'name' => new \OC_L10N_String(\OC::$server->getL10NFactory()->get('files_trashbin'), 'Deleted files', []),
 				'active' => false,
 				'icon' => '',
-				],
+			],
 		]);
 
 		$expected = new Http\TemplateResponse(
@@ -290,6 +299,10 @@ class ViewControllerTest extends TestCase {
 					],
 					[
 						'id' => 'systemtagsfilter',
+						'content' => null,
+					],
+					[
+						'id' => 'extstoragemounts',
 						'content' => null,
 					],
 					[

--- a/core/shipped.json
+++ b/core/shipped.json
@@ -42,6 +42,7 @@
   ],
   "alwaysEnabled": [
     "files",
+    "files_external",
     "dav",
     "federatedfilesharing"
   ]

--- a/tests/apps.php
+++ b/tests/apps.php
@@ -40,6 +40,10 @@ function getSubclasses($parentClassName) {
 $apps = OC_App::getEnabledApps();
 
 foreach ($apps as $app) {
+	// skip files_external, it has its own test suite
+	if ($app === 'files_external') {
+		continue;
+	}
 	$dir = OC_App::getAppPath($app);
 	if (is_dir($dir . '/tests')) {
 		loadDirectory($dir . '/tests');

--- a/tests/lib/App/ManagerTest.php
+++ b/tests/lib/App/ManagerTest.php
@@ -286,7 +286,14 @@ class ManagerTest extends TestCase {
 		$this->appConfig->setValue('test1', 'enabled', 'yes');
 		$this->appConfig->setValue('test2', 'enabled', 'no');
 		$this->appConfig->setValue('test3', 'enabled', '["foo"]');
-		$this->assertEquals(['dav', 'federatedfilesharing', 'files', 'test1', 'test3'], $this->manager->getInstalledApps());
+		$this->assertEquals([
+			'dav',
+			'federatedfilesharing',
+			'files',
+		   	'files_external',
+		   	'test1',
+			'test3'
+		], $this->manager->getInstalledApps());
 	}
 
 	public function testGetAppsForUser() {
@@ -300,7 +307,14 @@ class ManagerTest extends TestCase {
 		$this->appConfig->setValue('test2', 'enabled', 'no');
 		$this->appConfig->setValue('test3', 'enabled', '["foo"]');
 		$this->appConfig->setValue('test4', 'enabled', '["asd"]');
-		$this->assertEquals(['dav', 'federatedfilesharing', 'files', 'test1', 'test3'], $this->manager->getEnabledAppsForUser($user));
+		$this->assertEquals([
+			'dav',
+		   	'federatedfilesharing',
+		   	'files',
+			'files_external',
+		   	'test1',
+			'test3'
+		], $this->manager->getEnabledAppsForUser($user));
 	}
 
 	public function testGetAppsNeedingUpgrade() {
@@ -312,6 +326,7 @@ class ManagerTest extends TestCase {
 		$appInfos = [
 			'dav' => ['id' => 'dav'],
 			'files' => ['id' => 'files'],
+		   	'files_external' => ['id' => 'files_external'],
 			'federatedfilesharing' => ['id' => 'federatedfilesharing'],
 			'test1' => ['id' => 'test1', 'version' => '1.0.1', 'requiremax' => '9.0.0'],
 			'test2' => ['id' => 'test2', 'version' => '1.0.0', 'requiremin' => '8.2.0'],
@@ -353,6 +368,7 @@ class ManagerTest extends TestCase {
 		$appInfos = [
 			'dav' => ['id' => 'dav'],
 			'files' => ['id' => 'files'],
+		   	'files_external' => ['id' => 'files_external'],
 			'federatedfilesharing' => ['id' => 'federatedfilesharing'],
 			'test1' => ['id' => 'test1', 'version' => '1.0.1', 'requiremax' => '8.0.0'],
 			'test2' => ['id' => 'test2', 'version' => '1.0.0', 'requiremin' => '8.2.0'],

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -316,6 +316,7 @@ class AppTest extends \Test\TestCase {
 					'appforgroup12',
 					'dav',
 					'federatedfilesharing',
+					'files_external',
 				],
 				false
 			],
@@ -330,6 +331,7 @@ class AppTest extends \Test\TestCase {
 					'appforgroup2',
 					'dav',
 					'federatedfilesharing',
+					'files_external',
 				],
 				false
 			],
@@ -345,6 +347,7 @@ class AppTest extends \Test\TestCase {
 					'appforgroup2',
 					'dav',
 					'federatedfilesharing',
+					'files_external',
 				],
 				false
 			],
@@ -360,6 +363,7 @@ class AppTest extends \Test\TestCase {
 					'appforgroup2',
 					'dav',
 					'federatedfilesharing',
+					'files_external',
 				],
 				false,
 			],
@@ -375,6 +379,7 @@ class AppTest extends \Test\TestCase {
 					'appforgroup2',
 					'dav',
 					'federatedfilesharing',
+					'files_external',
 				],
 				true,
 			],
@@ -452,11 +457,23 @@ class AppTest extends \Test\TestCase {
 			);
 
 		$apps = \OC_App::getEnabledApps();
-		$this->assertEquals(['files', 'app3', 'dav', 'federatedfilesharing',], $apps);
+		$this->assertEquals([
+			'files',
+		   	'app3',
+		   	'dav',
+		   	'federatedfilesharing',
+		   	'files_external',
+		], $apps);
 
 		// mock should not be called again here
 		$apps = \OC_App::getEnabledApps();
-		$this->assertEquals(['files', 'app3', 'dav', 'federatedfilesharing',], $apps);
+		$this->assertEquals([
+			'files',
+		   	'app3',
+		   	'dav',
+		   	'federatedfilesharing',
+		   	'files_external',
+		], $apps);
 
 		$this->restoreAppConfig();
 		\OC_User::setUserId(null);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Because we want the UI to still be available while the backend is
already in core.

Eventually the files_external backends will be moved to separate apps and all that will be left is the GUI and the OCC commands which we'll eventually move to core. Ref: https://github.com/owncloud/core/issues/27050

## How Has This Been Tested?
- [x] TEST: update from 9.1 with files_external disabled to master: app is now enabled
- [x] TEST: setup OC 10.0 from scratch, app is enabled
- [x] TEST: cannot disable files_external app

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


Please review @pmaier1 @DeepDiver1975 as discussed