### PR TITLE
Selenium implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
   global:
     - TEST_DAV=$(tests/travis/changed_app.sh dav)
     - TC=litmus-v2
-    - TEST_SELENIUM=1
     - SRV_HOST_NAME=owncloud
     - SRV_HOST_PORT=8888
   matrix:
@@ -39,6 +38,7 @@ addons:
 
 before_install:
   - make
+  - if [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ]; then export TEST_SELENIUM=1 ; else export TEST_SELENIUM=0 ; fi
   - sh -c "if [ '$TEST_DAV' = '1' ] || [ '$TEST_SELENIUM' = '1' ]; then bash tests/travis/before_install.sh $DB; fi"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
   global:
     - TEST_DAV=$(tests/travis/changed_app.sh dav)
     - TC=litmus-v2
+    - TEST_SELENIUM=1
+    - SRV_HOST_NAME=owncloud
+    - SRV_HOST_PORT=8888
   matrix:
     - DB=sqlite
 
@@ -21,20 +24,29 @@ branches:
   only:
     - master
     - /^stable\d+(\.\d+)?$/
+    - /^.*selenium.*$/
 
 addons:
   apt:
     packages:
     - realpath
+  hosts:
+    - owncloud
+  sauce_connect:
+    username: "individual-it"
+  jwt:
+    secure: "WaPqAVjcC6B4T5NWA1nffrywsnR9UZ5u3c2DrNLDR12cXJti0SbxGcE2Er8EGS1iCMxqMnpZfchbCelYmew5FOyeErqMTtni3lZ1gAu4KM35V5gUaRau8uEvTZk7AVHfDRSYlB/TJJV8sl8I33i3UvzUgsz4Il41X8qribycQOWoUCsiABIy/Fm05MhWugKjzBJ3Au/ZnNkYEjLW5z1cPymiuvNsUGvm9ushu2WwEc31hsS9lvpOcNVgdPJy2OaxNIZip8yH0c9gteo6rE7oElc81773K4QFf/0H0pD7Q4lUhqdHTn/aNyqWu8QaiS2BtygFKR15vxqbkloPQovM7S/Xr+PV7wQxItLE/E0QD8FkvIjoIVC4L448Mw+zBntpdGtmV4/UJJLl+VRFlLf5l2Do5fum1SeLI0kYaaN9rTXsFp/rmC7vT6dk3CiAm9owD69uWTVUecTqx2gRgNRdEXvL7t/6AZ8kspmWYdL9ekBSQ83rXlo7p8ZZm/Iu4k10JPCKxGfxVHFLVlPB6Z43+yBAtNjLkPdDP3+2FxU4LvvDKKXn2eESwkG2Mq5dEm4HAethygPJ48QmTYGPgg4b6PlcxWHoiC7qGZYWYj0Pmxt3kE6iZ4wxHG4cCU5p0/2MyGXzynjLz1qC6CZtXZbuyXDfrjvwcPXvvuANg0IX3hw="
 
 before_install:
   - make
-  - sh -c "if [ '$TEST_DAV' = '1' ]; then bash tests/travis/before_install.sh $DB; fi"
+  - sh -c "if [ '$TEST_DAV' = '1' ] || [ '$TEST_SELENIUM' = '1' ]; then bash tests/travis/before_install.sh $DB; fi"
 
 install:
-  - sh -c "if [ '$TEST_DAV' = '1' ]; then bash tests/travis/install.sh $DB; fi"
+  - sh -c "if [ '$TEST_DAV' = '1' ] || [ '$TEST_SELENIUM' = '1' ]; then bash tests/travis/install.sh $DB; fi"
   - sh -c "if [ '$TEST_DAV' = '1' ]; then bash apps/dav/tests/travis/$TC/install.sh; fi"
 
+before_script:
+  - sh -c "if [ '$TEST_SELENIUM' = '1' ]; then bash tests/travis/start_php_dev_server.sh; fi"
 
 script:
   - sh -c "if [ '$TC' = 'syntax' ]; then make test-php-lint ; fi"
@@ -42,6 +54,7 @@ script:
   - sh -c "if [ '$TEST_DAV' = '1' ]; then echo \"Testing DAV\"; fi"
 
   - sh -c "if [ '$TEST_DAV' = '1' ]; then bash apps/dav/tests/travis/$TC/script.sh; fi"
+  - sh -c "if [ '$TEST_SELENIUM' = '1' ]; then phpunit -c tests/phpunit-selenium-autotest.xml; fi"
 
 matrix:
   include:

--- a/tests/Core/Frontend/LoginTest.php
+++ b/tests/Core/Frontend/LoginTest.php
@@ -22,10 +22,7 @@
 
 use Test\SeleniumTestCase;
 
-
 class LoginTest extends SeleniumTestCase {
-
-
 
 	public function testNormalLogin() {
 

--- a/tests/Core/Frontend/LoginTest.php
+++ b/tests/Core/Frontend/LoginTest.php
@@ -23,7 +23,7 @@
 use Test\SeleniumTestCase;
 
 
-class Test extends SeleniumTestCase {
+class LoginTest extends SeleniumTestCase {
 
 
 

--- a/tests/Core/Frontend/LoginTest.php
+++ b/tests/Core/Frontend/LoginTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * ownCloud
+*
+* @author Artur Neumann
+* @copyright 2017 Artur Neumann info@individual-it.net
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+*
+* You should have received a copy of the GNU Affero General Public
+* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+use Test\SeleniumTestCase;
+
+
+class Test extends SeleniumTestCase {
+
+
+
+	public function testNormalLogin() {
+
+		$this->webDriver->get($this->rootURL);
+		$login = $this->webDriver->findElement ( WebDriverBy::id("user"));
+		$login->click();
+		$login->sendKeys("admin");
+
+		$login = $this->webDriver->findElement ( WebDriverBy::id("password"));
+		$login->click();
+		$login->sendKeys("admin");
+
+		$login = $this->webDriver->findElement ( WebDriverBy::id("submit"));
+		$login->click();
+		sleep(5);
+		$fileElement = $this->webDriver->findElement(WebDriverBy::xpath("//span[@class='innernametext']"));
+		$this->assertEquals($fileElement->getText(), "welcome");
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,7 @@ if ($configDir) {
 }
 
 require_once __DIR__ . '/../lib/base.php';
+require_once __DIR__ . '/vendor/facebook/webdriver/lib/__init__.php';
 
 // especially with code coverage it will require some more time
 set_time_limit(0);

--- a/tests/lib/SeleniumTestCase.php
+++ b/tests/lib/SeleniumTestCase.php
@@ -46,6 +46,16 @@ abstract class SeleniumTestCase extends TestCase {
 		}
 	
 	}
+	
+	public static function setUpBeforeClass() {
+		$dataDir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data-autotest');
+		if (!file_exists($dataDir . "/admin")) {
+			mkdir($dataDir . "/admin");
+			mkdir($dataDir . "/admin/files");
+			copy(\OC::$SERVERROOT . '/core/skeleton/welcome.txt', $dataDir. "/admin/files/welcome.txt");
+		}
+	}
+	
 	protected function tearDown() {
 		parent::tearDown();
 		$this->webDriver->quit ();

--- a/tests/lib/SeleniumTestCase.php
+++ b/tests/lib/SeleniumTestCase.php
@@ -78,7 +78,7 @@ abstract class SeleniumTestCase extends TestCase {
 	protected  function waitTillElementIsStale($element, $timeout = 30) {
 		for ($i=0; $i<=$timeout; $i++) {
 			try {
-				$element->findElements(WebDriverBy::id("does-not-matter"));
+				$element->findElements(\WebDriverBy::id("does-not-matter"));
 			} catch (StaleElementReferenceException $e) {
 				return true;
 			}

--- a/tests/lib/SeleniumTestCase.php
+++ b/tests/lib/SeleniumTestCase.php
@@ -1,0 +1,88 @@
+<?php
+/**
+* ownCloud
+*
+* @author Artur Neumann
+* @copyright 2017 Artur Neumann info@individual-it.net
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+*
+* You should have received a copy of the GNU Affero General Public
+* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+namespace Test;
+
+use Test\TestCase;
+
+abstract class SeleniumTestCase extends TestCase {
+	protected $webDriver;
+	protected $rootURL;
+	
+	protected function setUp() {
+		parent::setUp();
+	
+		$sauceUserName =  getenv("SAUCE_USERNAME");
+		$sauceAccessKey =  getenv("SAUCE_ACCESS_KEY");
+		$capabilities = array (
+				\WebDriverCapabilityType::BROWSER_NAME => 'chrome',
+				'tunnel-identifier' => getenv('TRAVIS_JOB_NUMBER')
+		);
+		$this->rootURL="http://". getenv('SRV_HOST_NAME') .":" . getenv('SRV_HOST_PORT'). "/" . getenv('SRV_HOST_URL');
+
+		if ($sauceAccessKey != "") {
+			$this->webDriver = \RemoteWebDriver::create ( 'http://'.$sauceUserName.':'.$sauceAccessKey.'@localhost:4445/wd/hub', $capabilities );
+		} else {
+			$this->webDriver = \RemoteWebDriver::create ( 'http://localhost:4444/wd/hub', $capabilities );
+		}
+	
+	}
+	protected function tearDown() {
+		parent::tearDown();
+		$this->webDriver->quit ();
+	}
+	
+	/**
+	 * waits till an element is displayed on page
+	 * @param WebDriverElement $element to wait for
+	 * @param INT $timeout max. time to wait
+	 */
+	protected function waitTillElementIsDisplayed($element, $timeout = 30) {
+		for($counter = 0; $counter <= $timeout; $counter ++) {
+			try {
+				if ($element->isDisplayed () === false) {
+					break;
+				}
+			} catch ( Exception $e ) {
+				break;
+			}
+	
+			sleep (1);
+		}
+	}
+	
+	/**
+	 * waits till an element is stale
+	 * @param WebDriverElement $element to wait for
+	 * @param INT $timeout max. time to wait
+	 */
+	protected  function waitTillElementIsStale($element, $timeout = 30) {
+		for ($i=0; $i<=$timeout; $i++) {
+			try {
+				$element->findElements(WebDriverBy::id("does-not-matter"));
+			} catch (StaleElementReferenceException $e) {
+				return true;
+			}
+			sleep(1);
+		}
+	}
+}

--- a/tests/phpunit-selenium-autotest.xml
+++ b/tests/phpunit-selenium-autotest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpunit bootstrap="bootstrap.php"
+		 verbose="true"
+		 timeoutForSmallTests="900"
+		 timeoutForMediumTests="900"
+		 timeoutForLargeTests="900"
+>
+	<testsuite name='ownCloud'>
+		<directory suffix='.php'>Core/Frontend</directory>
+	</testsuite>
+	<!-- filters for code coverage -->
+	<filter>
+		<!-- whitelist processUncoveredFilesFromWhitelist="true" -->
+		<whitelist>
+			<directory suffix=".php">..</directory>
+		</whitelist>
+	</filter>
+	<listeners>
+		<listener class="StartSessionListener" file="startsessionlistener.php" />
+	</listeners>
+</phpunit>

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -45,6 +45,11 @@ cat > ./tests/autoconfig-sqlite.php <<DELIM
 <?php
 \$AUTOCONFIG = array (
   'installed' => false,
+  'trusted_domains' => 
+    array (
+      0 => 'localhost',
+      1 => '$SRV_HOST_NAME',
+    ),
   'dbtype' => 'sqlite',
   'dbtableprefix' => 'oc_',
   'adminlogin' => '$ADMINLOGIN',
@@ -57,6 +62,11 @@ cat > ./tests/autoconfig-mysql.php <<DELIM
 <?php
 \$AUTOCONFIG = array (
   'installed' => false,
+  'trusted_domains' => 
+    array (
+      0 => 'localhost',
+      1 => '$SRV_HOST_NAME',
+    ),
   'dbtype' => 'mysql',
   'dbtableprefix' => 'oc_',
   'adminlogin' => '$ADMINLOGIN',
@@ -73,6 +83,11 @@ cat > ./tests/autoconfig-pgsql.php <<DELIM
 <?php
 \$AUTOCONFIG = array (
   'installed' => false,
+  'trusted_domains' => 
+    array (
+      0 => 'localhost',
+      1 => '$SRV_HOST_NAME',
+    ),
   'dbtype' => 'pgsql',
   'dbtableprefix' => 'oc_',
   'adminlogin' => '$ADMINLOGIN',
@@ -89,6 +104,11 @@ cat > ./tests/autoconfig-oracle.php <<DELIM
 <?php
 \$AUTOCONFIG = array (
   'installed' => false,
+  'trusted_domains' => 
+    array (
+      0 => 'localhost',
+      1 => '$SRV_HOST_NAME',
+    ),
   'dbtype' => 'oci',
   'dbtableprefix' => 'oc_',
   'adminlogin' => '$ADMINLOGIN',

--- a/tests/travis/start_php_dev_server.sh
+++ b/tests/travis/start_php_dev_server.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# ownCloud
+#
+# @author Artur Neumann
+# @copyright 2017 Artur Neumann info@individual-it.net
+#
+
+
+set -e
+
+php -S $SRV_HOST_NAME:$SRV_HOST_PORT > /dev/null 2>&1 &

--- a/tests/vendor/facebook/webdriver/README.md
+++ b/tests/vendor/facebook/webdriver/README.md
@@ -1,0 +1,105 @@
+php-webdriver -- WebDriver bindings for PHP
+===========================================
+
+##  DESCRIPTION
+
+This WebDriver client aims to be as close as possible to bindings in other languages. The concepts are very similar to the Java, .NET, Python and Ruby bindings for WebDriver.
+
+Looking for documentation about php-webdriver? See http://facebook.github.io/php-webdriver/
+
+The PHP client was rewritten from scratch. Using the old version? Check out Adam Goucher's fork of it at https://github.com/Element-34/php-webdriver
+
+Any complaint, question, idea? You can post it on the user group https://www.facebook.com/groups/phpwebdriver/.
+
+##  GETTING THE CODE
+
+### Github
+    git clone git@github.com:facebook/php-webdriver.git
+
+### Packagist
+Add the dependency. https://packagist.org/packages/facebook/webdriver
+
+    {
+      "require": {
+        "facebook/webdriver": "dev-master"
+      }
+    }
+    
+Download the composer.phar
+
+    curl -sS https://getcomposer.org/installer | php
+
+Install the library.
+
+    php composer.phar install
+        
+   
+
+##  GETTING STARTED
+
+*   All you need as the server for this client is the selenium-server-standalone-#.jar file provided here: http://selenium-release.storage.googleapis.com/index.html
+
+*   Download and run that file, replacing # with the current server version.
+
+        java -jar selenium-server-standalone-#.jar
+
+*   Then when you create a session, be sure to pass the url to where your server is running.
+
+        // This would be the url of the host running the server-standalone.jar
+        $host = 'http://localhost:4444/wd/hub'; // this is the default
+
+*   Launch Firefox
+
+        $driver = RemoteWebDriver::create($host, DesiredCapabilities::firefox());
+        
+*   Launch Chrome
+
+        $driver = RemoteWebDriver::create($host, DesiredCapabilities::chrome());
+
+*   You can also customize the desired capabilities. 
+
+        $desired_capabilities = DesiredCapabilities::firefox();
+        $desired_capabilities->setJavascriptEnabled(false);
+        RemoteWebDriver::create($host, $desired_capabilities);
+
+*   See https://code.google.com/p/selenium/wiki/DesiredCapabilities for more details.
+
+## RUN UNIT TESTS
+
+To run unit tests simply run:
+
+    ./vendor/bin/phpunit -c ./tests
+
+Note: For the functional test suite, a running selenium server is required.
+
+## MORE INFORMATION
+
+Check out the Selenium docs and wiki at http://docs.seleniumhq.org/docs/ and https://code.google.com/p/selenium/wiki
+
+Learn how to integrate it with PHPUnit [Blogpost](http://codeception.com/11-12-2013/working-with-phpunit-and-selenium-webdriver.html) | [Demo Project](https://github.com/DavertMik/php-webdriver-demo)
+
+## SUPPORT
+
+We have a great community willing to try and help you!
+
+Currently we offer support in two manners:
+
+### Via our Facebook Group
+
+If you have questions or are an active contributor consider joining our facebook group and contributing to the communal discussion and support
+
+https://www.facebook.com/groups/phpwebdriver/
+
+### Via Github
+
+If you're reading this you've already found our Github repository. If you have a question, feel free to submit it as an issue and our staff will do their best to help you as soon as possible.
+
+## CONTRIBUTING
+
+We love to have your help to make php-webdriver better. Feel free to 
+
+*   open an [issue](https://github.com/facebook/php-webdriver/issues) if you run into any problem. 
+*   fork the project and submit [pull request](https://github.com/facebook/php-webdriver/pulls). Before the pull requests can be accepted, a [Contributors Licensing Agreement](http://developers.facebook.com/opensource/cla) must be signed. 
+
+When you are going to contribute, please keep in mind that this webdriver client aims to be as close as possible to other languages Java/Ruby/Python/C#.
+FYI, here is the overview of [the official Java API](http://selenium.googlecode.com/svn/trunk/docs/api/java/index.html?overview-summary.html)

--- a/tests/vendor/facebook/webdriver/composer.json
+++ b/tests/vendor/facebook/webdriver/composer.json
@@ -1,0 +1,23 @@
+{
+  "name": "facebook/webdriver",
+  "description": "A php client for WebDriver",
+  "keywords": ["webdriver", "selenium", "php", "facebook"],
+  "homepage": "https://github.com/facebook/php-webdriver",
+  "type": "library",
+  "license": "Apache-2.0",
+  "support": {
+    "issues": "https://github.com/facebook/php-webdriver/issues",
+    "forum": "https://www.facebook.com/groups/phpwebdriver/",
+    "source": "https://github.com/facebook/php-webdriver"
+  },
+  "require": {
+    "php": ">=5.3.19"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "3.7.*",
+    "phpdocumentor/phpdocumentor": "2.*"
+  },
+  "autoload": {
+    "classmap": ["lib/"]
+  }
+}

--- a/tests/vendor/facebook/webdriver/example.php
+++ b/tests/vendor/facebook/webdriver/example.php
@@ -1,0 +1,49 @@
+<?php
+// An example of using php-webdriver.
+
+require_once('lib/__init__.php');
+
+// start Firefox with 5 second timeout
+$host = 'http://localhost:4444/wd/hub'; // this is the default
+$capabilities = DesiredCapabilities::firefox();
+$driver = RemoteWebDriver::create($host, $capabilities, 5000);
+
+// navigate to 'http://docs.seleniumhq.org/'
+$driver->get('http://docs.seleniumhq.org/');
+
+// adding cookie
+$driver->manage()->deleteAllCookies();
+$driver->manage()->addCookie(array(
+  'name' => 'cookie_name',
+  'value' => 'cookie_value',
+));
+$cookies = $driver->manage()->getCookies();
+print_r($cookies);
+
+// click the link 'About'
+$link = $driver->findElement(
+  WebDriverBy::id('menu_about')
+);
+$link->click();
+
+// print the title of the current page
+echo "The title is " . $driver->getTitle() . "'\n";
+
+// print the title of the current page
+echo "The current URI is " . $driver->getCurrentURL() . "'\n";
+
+// Search 'php' in the search box
+$input = $driver->findElement(
+  WebDriverBy::id('q')
+);
+$input->sendKeys('php')->submit();
+
+// wait at most 10 seconds until at least one result is shown
+$driver->wait(10)->until(
+  WebDriverExpectedCondition::presenceOfAllElementsLocatedBy(
+    WebDriverBy::className('gsc-result')
+  )
+);
+
+// close the Firefox
+$driver->quit();

--- a/tests/vendor/facebook/webdriver/lib/JavaScriptExecutor.php
+++ b/tests/vendor/facebook/webdriver/lib/JavaScriptExecutor.php
@@ -1,0 +1,47 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * WebDriver interface implemented by drivers that support JavaScript.
+ */
+interface JavaScriptExecutor {
+
+  /**
+   * Inject a snippet of JavaScript into the page for execution in the context
+   * of the currently selected frame. The executed script is assumed to be
+   * synchronous and the result of evaluating the script will be returned.
+   *
+   * @param string $script The script to inject.
+   * @param array $arguments The arguments of the script.
+   * @return mixed The return value of the script.
+   */
+  public function executeScript($script, array $arguments = array());
+
+  /**
+   * Inject a snippet of JavaScript into the page for asynchronous execution in
+   * the context of the currently selected frame.
+   *
+   * The driver will pass a callback as the last argument to the snippet, and
+   * block until the callback is invoked.
+   *
+   * @see WebDriverExecuteAsyncScriptTestCase
+   *
+   * @param string $script The script to inject.
+   * @param array $arguments The arguments of the script.
+   * @return mixed The value passed by the script to the callback.
+   */
+  public function executeAsyncScript($script, array $arguments = array());
+
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriver.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriver.php
@@ -1,0 +1,134 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The interface for WebDriver.
+ */
+interface WebDriver extends WebDriverSearchContext {
+
+  /**
+   * Close the current window.
+   *
+   * @return WebDriver The current instance.
+   */
+  public function close();
+
+  /**
+   * Load a new web page in the current browser window.
+   *
+   * @param string $url
+   * @return WebDriver The current instance.
+   */
+  public function get($url);
+
+  /**
+   * Get a string representing the current URL that the browser is looking at.
+   *
+   * @return string The current URL.
+   */
+  public function getCurrentURL();
+
+  /**
+   * Get the source of the last loaded page.
+   *
+   * @return string The current page source.
+   */
+  public function getPageSource();
+
+  /**
+   * Get the title of the current page.
+   *
+   * @return string The title of the current page.
+   */
+  public function getTitle();
+
+  /**
+   * Return an opaque handle to this window that uniquely identifies it within
+   * this driver instance.
+   *
+   * @return string The current window handle.
+   */
+  public function getWindowHandle();
+
+  /**
+   * Get all window handles available to the current session.
+   *
+   * @return array An array of string containing all available window handles.
+   */
+  public function getWindowHandles();
+
+  /**
+   * Quits this driver, closing every associated window.
+   *
+   * @return void
+   */
+  public function quit();
+
+  /**
+   * Take a screenshot of the current page.
+   *
+   * @param string $save_as The path of the screenshot to be saved.
+   * @return string The screenshot in PNG format.
+   */
+  public function takeScreenshot($save_as = null);
+
+  /**
+   * Construct a new WebDriverWait by the current WebDriver instance.
+   * Sample usage:
+   *
+   *   $driver->wait(20, 1000)->until(
+   *     WebDriverExpectedCondition::titleIs('WebDriver Page')
+   *   );
+   *
+   * @param int $timeout_in_second
+   * @param int $interval_in_millisecond
+   * @return WebDriverWait
+   */
+  public function wait(
+      $timeout_in_second = 30,
+      $interval_in_millisecond = 250);
+
+  /**
+   * An abstraction for managing stuff you would do in a browser menu. For
+   * example, adding and deleting cookies.
+   *
+   * @return WebDriverOptions
+   */
+  public function manage();
+
+  /**
+   * An abstraction allowing the driver to access the browser's history and to
+   * navigate to a given URL.
+   *
+   * @return WebDriverNavigation
+   * @see WebDriverNavigation
+   */
+  public function navigate();
+
+  /**
+   * Switch to a different window or frame.
+   *
+   * @return WebDriverTargetLocator
+   * @see WebDriverTargetLocator
+   */
+  public function switchTo();
+
+  /**
+   * @param string $name
+   * @param array $params
+   * @return mixed
+   */
+  public function execute($name, $params);
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverAction.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverAction.php
@@ -1,0 +1,25 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Interface representing a single user-interaction action.
+ */
+interface WebDriverAction {
+
+  /**
+   * @return void
+   */
+  public function perform();
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverAlert.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverAlert.php
@@ -1,0 +1,70 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * An abstraction allowing the driver to manipulate the javascript alerts
+ */
+class WebDriverAlert {
+
+  protected $executor;
+
+  public function __construct($executor) {
+    $this->executor = $executor;
+  }
+
+  /**
+   * Accept alert
+   *
+   * @return WebDriverAlert The instance.
+   */
+  public function accept() {
+    $this->executor->execute(DriverCommand::ACCEPT_ALERT);
+    return $this;
+  }
+
+  /**
+   * Dismiss alert
+   *
+   * @return WebDriverAlert The instance.
+   */
+  public function dismiss() {
+    $this->executor->execute(DriverCommand::DISMISS_ALERT);
+    return $this;
+  }
+
+  /**
+   * Get alert text
+   *
+   * @return string
+   */
+  public function getText() {
+    return $this->executor->execute(DriverCommand::GET_ALERT_TEXT);
+  }
+
+  /**
+   * Send keystrokes to javascript prompt() dialog
+   *
+   * @param string $value
+   * @return WebDriverAlert
+   */
+  public function sendKeys($value) {
+    $this->executor->execute(
+      DriverCommand::SET_ALERT_VALUE,
+      array('text' => $value)
+    );
+    return $this;
+  }
+
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverBy.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverBy.php
@@ -1,0 +1,128 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The basic 8 mechanisms supported by webdriver to locate a web element.
+ * ie. 'class name', 'css selector', 'id', 'name', 'link text',
+ *     'partial link text', 'tag name' and 'xpath'.
+ *
+ * @see WebDriver::findElement, WebDriverElement::findElement
+ */
+class WebDriverBy {
+
+  private $mechanism;
+  private $value;
+
+  protected function __construct($mechanism, $value) {
+    $this->mechanism = $mechanism;
+    $this->value = $value;
+  }
+
+  /**
+   * @return string
+   */
+  public function getMechanism() {
+    return $this->mechanism;
+  }
+
+  /**
+   * @return string
+   */
+  public function getValue() {
+    return $this->value;
+  }
+
+  /**
+   * Locates elements whose class name contains the search value; compound class
+   * names are not permitted.
+   *
+   * @param string $class_name
+   * @return WebDriverBy
+   */
+  public static function className($class_name) {
+    return new WebDriverBy('class name', $class_name);
+  }
+
+  /**
+   * Locates elements matching a CSS selector.
+   *
+   * @param string $css_selector
+   * @return WebDriverBy
+   */
+  public static function cssSelector($css_selector) {
+    return new WebDriverBy('css selector', $css_selector);
+  }
+
+  /**
+   * Locates elements whose ID attribute matches the search value.
+   *
+   * @param string $id
+   * @return WebDriverBy
+   */
+  public static function id($id) {
+    return new WebDriverBy('id', $id);
+  }
+
+  /**
+   * Locates elements whose NAME attribute matches the search value.
+   *
+   * @param string $name
+   * @return WebDriverBy
+   */
+  public static function name($name) {
+    return new WebDriverBy('name', $name);
+  }
+
+  /**
+   * Locates anchor elements whose visible text matches the search value.
+   *
+   * @param string $link_text
+   * @return WebDriverBy
+   */
+  public static function linkText($link_text) {
+    return new WebDriverBy('link text', $link_text);
+  }
+
+  /**
+   * Locates anchor elements whose visible text partially matches the search
+   * value.
+   *
+   * @param string $partial_link_text
+   * @return WebDriverBy
+   */
+  public static function partialLinkText($partial_link_text) {
+    return new WebDriverBy('partial link text', $partial_link_text);
+  }
+
+  /**
+   * Locates elements whose tag name matches the search value.
+   *
+   * @param string $tag_name
+   * @return WebDriverBy
+   */
+  public static function tagName($tag_name) {
+    return new WebDriverBy('tag name', $tag_name);
+  }
+
+  /**
+   * Locates elements matching an XPath expression.
+   *
+   * @param string $xpath
+   * @return WebDriverBy
+   */
+  public static function xpath($xpath) {
+    return new WebDriverBy('xpath', $xpath);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverCapabilities.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverCapabilities.php
@@ -1,0 +1,49 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+interface WebDriverCapabilities {
+
+  /**
+   * @return string The name of the browser.
+   */
+  public function getBrowserName();
+
+  /**
+   * @param string $name
+   * @return mixed The value of a capability.
+   */
+  public function getCapability($name);
+
+  /**
+   * @return string The name of the platform.
+   */
+  public function getPlatform();
+
+  /**
+   * @return string The version of the browser.
+   */
+  public function getVersion();
+
+  /**
+   * @param string $capability_name
+   * @return bool Whether the value is not null and not false.
+   */
+  public function is($capability_name);
+
+  /**
+   * @return bool Whether javascript is enabled.
+   */
+  public function isJavascriptEnabled();
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverCommandExecutor.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverCommandExecutor.php
@@ -1,0 +1,26 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Interface for all command executor.
+ */
+interface WebDriverCommandExecutor {
+
+  /**
+   * @param WebDriverCommand $command
+   * @return mixed
+   */
+  public function execute(WebDriverCommand $command);
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverDimension.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverDimension.php
@@ -1,0 +1,57 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Represent a dimension.
+ */
+class WebDriverDimension {
+
+  private $height, $width;
+
+  public function __construct($width, $height) {
+    $this->width = $width;
+    $this->height = $height;
+  }
+
+  /**
+   * Get the height.
+   *
+   * @return int The height.
+   */
+  public function getHeight() {
+    return $this->height;
+  }
+
+  /**
+   * Get the width.
+   *
+   * @return int The width.
+   */
+  public function getWidth() {
+    return $this->width;
+  }
+
+  /**
+   * Check whether the given dimension is the same as the instance.
+   *
+   * @param WebDriverDimension $dimension The dimension to be compared with.
+   * @return bool Whether the height and the width are the same as the
+   *              instance.
+   */
+  public function equals(WebDriverDimension $dimension) {
+    return $this->height === $dimension->getHeight() &&
+           $this->width === $dimension->getWidth();
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverDispatcher.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverDispatcher.php
@@ -1,0 +1,80 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverDispatcher {
+
+  /**
+   * @var array
+   */
+  protected $listeners = array();
+
+  /**
+   * @var EventFiringWebDriver
+   */
+  protected $driver = null;
+
+  /**
+   * this is needed so that EventFiringWebElement can pass the driver to the
+   * exception handling
+   *
+   * @param EventFiringWebDriver $driver
+   * @return $this
+   */
+  public function setDefaultDriver(EventFiringWebDriver $driver) {
+    $this->driver = $driver;
+    return $this;
+  }
+
+  /**
+   * @return null|EventFiringWebDriver
+   */
+  public function getDefaultDriver() {
+    return $this->driver;
+  }
+
+  /**
+   * @param WebDriverEventListener $listener
+   * @return $this
+   */
+  public function register(WebDriverEventListener $listener) {
+    $this->listeners[] = $listener;
+    return $this;
+  }
+
+  /**
+   * @param WebDriverEventListener $listener
+   * @return $this
+   */
+  public function unregister(WebDriverEventListener $listener) {
+    $key = array_search($listener, $this->listeners, true);
+    if ($key !== false) {
+      unset($this->listeners[$key]);
+    }
+    return $this;
+  }
+
+  /**
+   * @param mixed $method
+   * @param mixed $arguments
+   * @return $this
+   */
+  public function dispatch($method, $arguments) {
+    foreach ($this->listeners as $listener) {
+      call_user_func_array(array($listener, $method), $arguments);
+    }
+    return $this;
+  }
+
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverElement.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverElement.php
@@ -1,0 +1,134 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Interface for an HTML element in the WebDriver framework.
+ */
+interface WebDriverElement extends WebDriverSearchContext {
+
+  /**
+   * If this element is a TEXTAREA or text INPUT element, this will clear the
+   * value.
+   *
+   * @return WebDriverElement The current instance.
+   */
+  public function clear();
+
+  /**
+   * Click this element.
+   *
+   * @return WebDriverElement The current instance.
+   */
+  public function click();
+
+  /**
+   * Get the value of a the given attribute of the element.
+   *
+   * @param string $attribute_name The name of the attribute.
+   * @return string The value of the attribute.
+   */
+  public function getAttribute($attribute_name);
+
+  /**
+   * Get the value of a given CSS property.
+   *
+   * @param string $css_property_name The name of the CSS property.
+   * @return string The value of the CSS property.
+   */
+  public function getCSSValue($css_property_name);
+
+  /**
+   * Get the location of element relative to the top-left corner of the page.
+   *
+   * @return WebDriverPoint The location of the element.
+   */
+  public function getLocation();
+
+  /**
+   * Try scrolling the element into the view port and return the location of
+   * element relative to the top-left corner of the page afterwards.
+   *
+   * @return WebDriverPoint The location of the element.
+   */
+  public function getLocationOnScreenOnceScrolledIntoView();
+
+  /**
+   * Get the size of element.
+   *
+   * @return WebDriverDimension The dimension of the element.
+   */
+  public function getSize();
+
+  /**
+   * Get the tag name of this element.
+   *
+   * @return string The tag name.
+   */
+  public function getTagName();
+
+  /**
+   * Get the visible (i.e. not hidden by CSS) innerText of this element,
+   * including sub-elements, without any leading or trailing whitespace.
+   *
+   * @return string The visible innerText of this element.
+   */
+  public function getText();
+
+  /**
+   * Is this element displayed or not? This method avoids the problem of having
+   * to parse an element's "style" attribute.
+   *
+   * @return bool
+   */
+  public function isDisplayed();
+
+  /**
+   * Is the element currently enabled or not? This will generally return true
+   * for everything but disabled input elements.
+   *
+   * @return bool
+   */
+  public function isEnabled();
+
+  /**
+   * Determine whether or not this element is selected or not.
+   *
+   * @return bool
+   */
+  public function isSelected();
+
+  /**
+   * Simulate typing into an element, which may set its value.
+   *
+   * @param mixed $value The data to be typed.
+   * @return WebDriverElement The current instance.
+   */
+  public function sendKeys($value);
+
+  /**
+   * If this current element is a form, or an element within a form, then this
+   * will be submitted to the remote server.
+   *
+   * @return WebDriverElement The current instance.
+   */
+  public function submit();
+
+  /**
+   * Get the opaque ID of the element.
+   *
+   * @return string The opaque ID.
+   */
+  public function getID();
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverEventListener.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverEventListener.php
@@ -1,0 +1,122 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+interface WebDriverEventListener {
+
+  /**
+   * @param string               $url
+   * @param EventFiringWebDriver $driver
+   * @return void
+   */
+  public function beforeNavigateTo($url, EventFiringWebDriver $driver);
+
+  /**
+   * @param string               $url
+   * @param EventFiringWebDriver $driver
+   * @return void
+   */
+  public function afterNavigateTo($url, EventFiringWebDriver $driver);
+
+  /**
+   * @param EventFiringWebDriver $driver
+   * @return void
+   */
+  public function beforeNavigateBack(EventFiringWebDriver $driver);
+
+  /**
+   * @param EventFiringWebDriver $driver
+   * @return void
+   */
+  public function afterNavigateBack(EventFiringWebDriver $driver);
+
+  /**
+   * @param EventFiringWebDriver $driver
+   * @return void
+   */
+  public function beforeNavigateForward(EventFiringWebDriver $driver);
+
+  /**
+   * @param EventFiringWebDriver $driver
+   * @return void
+   */
+  public function afterNavigateForward(EventFiringWebDriver $driver);
+
+  /**
+   * @param WebDriverBy          $by
+   * @param EventFiringWebElement|null $element
+   * @param EventFiringWebDriver  $driver
+   * @return void
+   */
+  public function beforeFindBy(WebDriverBy $by,
+                               $element,
+                               EventFiringWebDriver $driver);
+
+  /**
+   * @param WebDriverBy           $by
+   * @param EventFiringWebElement|null $element
+   * @param EventFiringWebDriver  $driver
+   * @return void
+   */
+  public function afterFindBy(WebDriverBy $by,
+                              $element,
+                              EventFiringWebDriver $driver);
+
+  /**
+   * @param string               $script
+   * @param EventFiringWebDriver $driver
+   * @return void
+   */
+  public function beforeScript($script, EventFiringWebDriver $driver);
+
+  /**
+   * @param string               $script
+   * @param EventFiringWebDriver $driver
+   * @return void
+   */
+  public function afterScript($script, EventFiringWebDriver $driver);
+
+  /**
+   * @param EventFiringWebElement $element
+   * @return void
+   */
+  public function beforeClickOn(EventFiringWebElement $element);
+
+  /**
+   * @param EventFiringWebElement $element
+   * @return void
+   */
+  public function afterClickOn(EventFiringWebElement $element);
+
+  /**
+   * @param EventFiringWebElement $element
+   * @return void
+   */
+  public function beforeChangeValueOf(EventFiringWebElement $element);
+
+  /**
+   * @param EventFiringWebElement $element
+   * @return void
+   */
+  public function afterChangeValueOf(EventFiringWebElement $element);
+
+  /**
+   * @param WebDriverException   $exception
+   * @param EventFiringWebDriver $driver
+   * @return void
+   */
+  public function onException(WebDriverException $exception,
+                              EventFiringWebDriver $driver = null);
+
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverExceptions.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverExceptions.php
@@ -1,0 +1,184 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+final class WebDriverCurlException extends Exception {} // When curls fail
+
+class WebDriverException extends Exception {
+
+  private $results;
+
+  /**
+   * @param string $message
+   * @param mixed $results
+   */
+  public function __construct($message, $results = null) {
+    parent::__construct($message);
+    $this->results = $results;
+  }
+
+  /**
+   * @return mixed
+   */
+  public function getResults() {
+    return $this->results;
+  }
+
+  /**
+   * Throw WebDriverExceptions.
+   * For $status_code >= 0, they are errors defined in the json wired protocol.
+   * For $status_code < 0, they are errors defined in php-webdriver.
+   *
+   * @param int $status_code
+   * @param string $message
+   * @param mixed $results
+   */
+  public static function throwException($status_code, $message, $results) {
+    switch ($status_code) {
+      case -1:
+        throw new WebDriverCurlException($message);
+      case 0:
+        // Success
+        break;
+      case 1:
+        throw new IndexOutOfBoundsException($message, $results);
+      case 2:
+        throw new NoCollectionException($message, $results);
+      case 3:
+        throw new NoStringException($message, $results);
+      case 4:
+        throw new NoStringLengthException($message, $results);
+      case 5:
+        throw new NoStringWrapperException($message, $results);
+      case 6:
+        throw new NoSuchDriverException($message, $results);
+      case 7:
+        throw new NoSuchElementException($message, $results);
+      case 8:
+        throw new NoSuchFrameException($message, $results);
+      case 9:
+        throw new UnknownCommandException($message, $results);
+      case 10:
+        throw new StaleElementReferenceException($message, $results);
+      case 11:
+        throw new ElementNotVisibleException($message, $results);
+      case 12:
+        throw new InvalidElementStateException($message, $results);
+      case 13:
+        throw new UnknownServerException($message, $results);
+      case 14:
+        throw new ExpectedException($message, $results);
+      case 15:
+        throw new ElementNotSelectableException($message, $results);
+      case 16:
+        throw new NoSuchDocumentException($message, $results);
+      case 17:
+        throw new UnexpectedJavascriptException($message, $results);
+      case 18:
+        throw new NoScriptResultException($message, $results);
+      case 19:
+        throw new XPathLookupException($message, $results);
+      case 20:
+        throw new NoSuchCollectionException($message, $results);
+      case 21:
+        throw new TimeOutException($message, $results);
+      case 22:
+        throw new NullPointerException($message, $results);
+      case 23:
+        throw new NoSuchWindowException($message, $results);
+      case 24:
+        throw new InvalidCookieDomainException($message, $results);
+      case 25:
+        throw new UnableToSetCookieException($message, $results);
+      case 26:
+        throw new UnexpectedAlertOpenException($message, $results);
+      case 27:
+        throw new NoAlertOpenException($message, $results);
+      case 28:
+        throw new ScriptTimeoutException($message, $results);
+      case 29:
+        throw new InvalidCoordinatesException($message, $results);
+      case 30:
+        throw new IMENotAvailableException($message, $results);
+      case 31:
+        throw new IMEEngineActivationFailedException($message, $results);
+      case 32:
+        throw new InvalidSelectorException($message, $results);
+      case 33:
+        throw new SessionNotCreatedException($message, $results);
+      case 34:
+        throw new MoveTargetOutOfBoundsException($message, $results);
+      default:
+        throw new UnrecognizedExceptionException($message, $results);
+    }
+  }
+}
+
+class IndexOutOfBoundsException extends WebDriverException {} // 1
+class NoCollectionException extends WebDriverException {} // 2
+class NoStringException extends WebDriverException {} // 3
+class NoStringLengthException extends WebDriverException {} // 4
+class NoStringWrapperException extends WebDriverException {} // 5
+class NoSuchDriverException extends WebDriverException {} // 6
+class NoSuchElementException extends WebDriverException {} // 7
+class NoSuchFrameException extends WebDriverException {} // 8
+class UnknownCommandException extends WebDriverException {} // 9
+class StaleElementReferenceException extends WebDriverException {} // 10
+class ElementNotVisibleException extends WebDriverException {} // 11
+class InvalidElementStateException extends WebDriverException {} // 12
+class UnknownServerException extends WebDriverException {} // 13
+class ExpectedException extends WebDriverException {} // 14
+class ElementNotSelectableException extends WebDriverException {} // 15
+class NoSuchDocumentException extends WebDriverException {} // 16
+class UnexpectedJavascriptException extends WebDriverException {} // 17
+class NoScriptResultException extends WebDriverException {} // 18
+class XPathLookupException extends WebDriverException {} // 19
+class NoSuchCollectionException extends WebDriverException {} // 20
+class TimeOutException extends WebDriverException {} // 21
+class NullPointerException extends WebDriverException {} // 22
+class NoSuchWindowException extends WebDriverException {} // 23
+class InvalidCookieDomainException extends WebDriverException {} // 24
+class UnableToSetCookieException extends WebDriverException {} // 25
+class UnexpectedAlertOpenException extends WebDriverException {} // 26
+class NoAlertOpenException extends WebDriverException {} // 27
+class ScriptTimeoutException extends WebDriverException {} // 28
+class InvalidCoordinatesException extends WebDriverException {}// 29
+class IMENotAvailableException extends WebDriverException {} // 30
+class IMEEngineActivationFailedException extends WebDriverException {}// 31
+class InvalidSelectorException extends WebDriverException {} // 32
+class SessionNotCreatedException extends WebDriverException {} // 33
+class MoveTargetOutOfBoundsException extends WebDriverException {} // 34
+
+// Fallback
+class UnrecognizedExceptionException extends WebDriverException {}
+
+class UnexpectedTagNameException extends WebDriverException {
+
+  /**
+   * @param string $expected_tag_name
+   * @param string $actual_tag_name
+   */
+  public function __construct(
+      $expected_tag_name,
+      $actual_tag_name) {
+    parent::__construct(
+      sprintf(
+        "Element should have been \"%s\" but was \"%s\"",
+        $expected_tag_name, $actual_tag_name
+      )
+    );
+  }
+}
+
+class UnsupportedOperationException extends WebDriverException {}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverExpectedCondition.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverExpectedCondition.php
@@ -1,0 +1,409 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Canned ExpectedConditions which are generally useful within webdriver tests.
+ *
+ * @see WebDriverWait
+ */
+class WebDriverExpectedCondition {
+
+  /**
+   * A closure function to be executed by WebDriverWait. It should return
+   * a truthy value, mostly boolean or a WebDriverElement, on success.
+   */
+  private $apply;
+
+  /**
+   * @return (function():T) a closure function to be executed by WebDriverWait
+   */
+  public function getApply() {
+    return $this->apply;
+  }
+
+  protected function __construct($apply) {
+    $this->apply = $apply;
+  }
+
+  /**
+   * An expectation for checking the title of a page.
+   *
+   * @param string $title The expected title, which must be an exact match.
+   * @return bool WebDriverExpectedCondition True when the title matches,
+   *         false otherwise.
+   */
+  public static function titleIs($title) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($title) {
+        return $title === $driver->getTitle();
+      }
+    );
+  }
+
+  /**
+   * An expectation for checking substring of a page Title.
+   *
+   * @param string $title The expected substring of Title.
+   * @return bool WebDriverExpectedCondition True when in title,
+   *         false otherwise.
+   */
+  public static function titleContains($title) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($title) {
+        return strpos($driver->getTitle(), $title) !== false;
+      }
+    );
+  }
+
+  /**
+   * An expectation for checking that an element is present on the DOM of a
+   * page. This does not necessarily mean that the element is visible.
+   *
+   * @param WebDriverBy $by The locator used to find the element.
+   * @return WebDriverExpectedCondition<WebDriverElement> The element which
+   *         is located.
+   */
+  public static function presenceOfElementLocated(WebDriverBy $by) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($by) {
+        return $driver->findElement($by);
+      }
+    );
+  }
+
+  /**
+   * An expectation for checking that an element is present on the DOM of a page
+   * and visible. Visibility means that the element is not only displayed but
+   * also has a height and width that is greater than 0.
+   *
+   * @param WebDriverBy $by The locator used to find the element.
+   * @return WebDriverExpectedCondition<WebDriverElement> The element which is
+   *         located and visible.
+   */
+  public static function visibilityOfElementLocated(WebDriverBy $by) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($by) {
+        try {
+          $element = $driver->findElement($by);
+          return $element->isDisplayed() ? $element : null;
+        } catch (StaleElementReferenceException $e) {
+          return null;
+        }
+      }
+    );
+  }
+
+  /**
+   * An expectation for checking that an element, known to be present on the DOM
+   * of a page, is visible. Visibility means that the element is not only
+   * displayed but also has a height and width that is greater than 0.
+   *
+   * @param WebDriverElement $element The element to be checked.
+   * @return WebDriverExpectedCondition<WebDriverElement> The same
+   *         WebDriverElement once it is visible.
+   */
+  public static function visibilityOf(WebDriverElement $element) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($element) {
+        return $element->isDisplayed() ? $element : null;
+      }
+    );
+  }
+
+  /**
+   * An expectation for checking that there is at least one element present on a
+   * web page.
+   *
+   * @param WebDriverBy $by The locator used to find the element.
+   * @return WebDriverExpectedCondition<array> An array of WebDriverElements
+   *         once they are located.
+   */
+  public static function presenceOfAllElementsLocatedBy(WebDriverBy $by) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($by) {
+        $elements = $driver->findElements($by);
+        return count($elements) > 0 ? $elements : null;
+      }
+    );
+  }
+
+  /**
+   * An expectation for checking if the given text is present in the specified
+   * element.
+   *
+   * @param WebDriverBy $by The locator used to find the element.
+   * @param string $text The text to be presented in the element.
+   * @return bool WebDriverExpectedCondition Whether the text is presented.
+   */
+  public static function textToBePresentInElement(
+      WebDriverBy $by, $text) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($by, $text) {
+        try {
+          $element_text = $driver->findElement($by)->getText();
+          return strpos($element_text, $text) !== false;
+        } catch (StaleElementReferenceException $e) {
+          return null;
+        }
+      }
+    );
+  }
+
+  /**
+   * An expectation for checking if the given text is present in the specified
+   * elements value attribute.
+   *
+   * @param WebDriverBy $by The locator used to find the element.
+   * @param string $text The text to be presented in the element value.
+   * @return bool WebDriverExpectedCondition Whether the text is presented.
+   */
+  public static function textToBePresentInElementValue(
+      WebDriverBy $by, $text) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($by, $text) {
+        try {
+          $element_text = $driver->findElement($by)->getAttribute('value');
+          return strpos($element_text, $text) !== false;
+        } catch (StaleElementReferenceException $e) {
+          return null;
+        }
+      }
+    );
+  }
+
+  /**
+   * Expectation for checking if iFrame exists.
+   * If iFrame exists switches driver's focus to the iFrame
+   *
+   * @param string $frame_locator The locator used to find the iFrame
+   *   expected to be either the id or name value of the i/frame
+   * @return WebDriverExpectedCondition<WebDriver> object focused on new frame
+   *         when frame is found bool false otherwise
+   */
+  public static function frameToBeAvailableAndSwitchToIt($frame_locator) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($frame_locator) {
+        try {
+          return $driver->switchTo()->frame($frame_locator);
+        } catch (NoSuchFrameException $e) {
+          return false;
+        }
+      }
+    );
+  }
+
+  /**
+   * An expectation for checking that an element is either invisible or not
+   * present on the DOM.
+   *
+   * @param WebDriverBy $by The locator used to find the element.
+   * @return bool WebDriverExpectedCondition Whether there is no element
+   *         located.
+   */
+  public static function invisibilityOfElementLocated(WebDriverBy $by) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($by) {
+        try {
+          return !($driver->findElement($by)->isDisplayed());
+        } catch (NoSuchElementException $e) {
+          return true;
+        } catch (StaleElementReferenceException $e) {
+          return true;
+        }
+      }
+    );
+  }
+
+  /**
+   * An expectation for checking that an element with text is either invisible
+   * or not present on the DOM.
+   *
+   * @param WebdriverBy $by The locator used to find the element.
+   * @param string $text The text of the element.
+   * @return bool WebDriverExpectedCondition Whether the text is found in the
+   *         element located.
+   */
+  public static function invisibilityOfElementWithText(
+      WebDriverBy $by, $text) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($by, $text) {
+        try {
+          return !($driver->findElement($by)->getText() === $text);
+        } catch (NoSuchElementException $e) {
+          return true;
+        } catch (StaleElementReferenceException $e) {
+          return true;
+        }
+      }
+    );
+  }
+
+  /**
+   * An expectation for checking an element is visible and enabled such that you
+   * can click it.
+   *
+   * @param WebDriverBy $by The locator used to find the element
+   * @return WebDriverExpectedCondition<WebDriverElement> The WebDriverElement
+   *         once it is located, visible and clickable
+   */
+  public static function elementToBeClickable(WebDriverBy $by) {
+    $visibility_of_element_located =
+      WebDriverExpectedCondition::visibilityOfElementLocated($by);
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($visibility_of_element_located) {
+        $element = call_user_func(
+          $visibility_of_element_located->getApply(),
+          $driver
+        );
+        try {
+          if ($element !== null && $element->isEnabled()) {
+            return $element;
+          } else {
+            return null;
+          }
+        } catch (StaleElementReferenceException $e) {
+          return null;
+        }
+      }
+    );
+  }
+
+  /**
+   * Wait until an element is no longer attached to the DOM.
+   *
+   * @param WebDriverElement $element The element to wait for.
+   * @return bool WebDriverExpectedCondition false if the element is still
+   *         attached to the DOM, true otherwise.
+   */
+  public static function stalenessOf(WebDriverElement $element) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($element) {
+        try {
+          $element->isEnabled();
+          return false;
+        } catch (StaleElementReferenceException $e) {
+          return true;
+        }
+      }
+    );
+  }
+
+  /**
+   * Wrapper for a condition, which allows for elements to update by redrawing.
+   *
+   * This works around the problem of conditions which have two parts: find an
+   * element and then check for some condition on it. For these conditions it is
+   * possible that an element is located and then subsequently it is redrawn on
+   * the client. When this happens a StaleElementReferenceException is thrown
+   * when the second part of the condition is checked.
+   *
+   * @param WebDriverExpectedCondition $condition The condition wrapped.
+   * @return WebDriverExpectedCondition<mixed> The return value of the
+   *         getApply() of the given condition.
+   */
+  public static function refreshed(WebDriverExpectedCondition $condition) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($condition) {
+        try {
+          return call_user_func($condition->getApply(), $driver);
+        } catch (StaleElementReferenceException $e) {
+          return null;
+        }
+      }
+    );
+  }
+
+  /**
+   * An expectation for checking if the given element is selected.
+   *
+   * @param mixed $element_or_by Either the element or the locator.
+   * @return bool WebDriverExpectedCondition whether the element is selected.
+   */
+  public static function elementToBeSelected($element_or_by) {
+    return WebDriverExpectedCondition::elementSelectionStateToBe(
+      $element_or_by,
+      true
+    );
+  }
+
+  /**
+   * An expectation for checking if the given element is selected.
+   *
+   * @param mixed $element_or_by Either the element or the locator.
+   * @param bool $selected The required state.
+   * @return bool WebDriverExpectedCondition Whether the element is selected.
+   */
+  public static function elementSelectionStateToBe(
+      $element_or_by,
+      $selected
+  ) {
+    if ($element_or_by instanceof WebDriverElement) {
+      return new WebDriverExpectedCondition(
+        function ($driver) use ($element_or_by, $selected) {
+          return $element_or_by->isSelected() === $selected;
+        }
+      );
+    } else if ($element_or_by instanceof WebDriverBy) {
+      return new WebDriverExpectedCondition(
+        function ($driver) use ($element_or_by, $selected) {
+          try {
+            $element = $driver->findElement($element_or_by);
+            return $element->isSelected() === $selected;
+          } catch (StaleElementReferenceException $e) {
+            return null;
+          }
+        }
+      );
+    }
+  }
+
+  /**
+   * An expectation for whether an alert() box is present.
+   *
+   * @return WebDriverExpectedCondition<?WebDriverAlert> if alert() is present,
+   *         null otherwise.
+   */
+  public static function alertIsPresent() {
+    return new WebDriverExpectedCondition(
+      function ($driver) {
+        try {
+          // Unlike the Java code, we get a WebDriverAlert object regardless
+          // of whether there is an alert.  Calling getText() will throw
+          // an exception if it is not really there.
+          $alert = $driver->switchTo()->alert();
+          $alert->getText();
+          return $alert;
+        } catch (NoAlertOpenException $e) {
+          return null;
+        }
+      }
+    );
+  }
+
+  /**
+   * An expectation with the logical opposite condition of the given condition.
+   *
+   * @param WebDriverExpectedCondition $condition The condition to be negated.
+   * @return mixed The negation of the result of the given condition.
+   */
+  public static function not(WebDriverExpectedCondition $condition) {
+    return new WebDriverExpectedCondition(
+      function ($driver) use ($condition) {
+        $result = call_user_func($condition->getApply(), $driver);
+        return !$result;
+      }
+    );
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverHasInputDevices.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverHasInputDevices.php
@@ -1,0 +1,30 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Interface implemented by each driver that allows access to the input devices.
+ */
+interface WebDriverHasInputDevices {
+
+  /**
+   * @return WebDriverKeyBoard
+   */
+  public function getKeyboard();
+
+  /**
+   * @return WebDriverMouse
+   */
+  public function getMouse();
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverKeyboard.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverKeyboard.php
@@ -1,0 +1,43 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+interface WebDriverKeyboard {
+
+  /**
+   * Send a sequence of keys.
+   *
+   * @param string $keys
+   * @return $this
+   */
+  public function sendKeys($keys);
+
+  /**
+   * Press a key
+   *
+   * @see WebDriverKeys
+   * @param string $key
+   * @return $this
+   */
+  public function pressKey($key);
+
+  /**
+   * Release a key
+   *
+   * @see WebDriverKeys
+   * @param string $key
+   * @return $this
+   */
+  public function releaseKey($key);
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverKeys.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverKeys.php
@@ -1,0 +1,113 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License; Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     httpconst //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing; software
+// distributed under the License is distributed on an "AS IS" BASIS;
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND; either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Representations of pressable keys that aren't text.
+ * These are stored in the Unicode PUA (Private Use Area) code points.
+ */
+class WebDriverKeys {
+
+  const NULL            = "\xEE\x80\x80";
+  const CANCEL          = "\xEE\x80\x81";
+  const HELP            = "\xEE\x80\x82";
+  const BACKSPACE       = "\xEE\x80\x83";
+  const TAB             = "\xEE\x80\x84";
+  const CLEAR           = "\xEE\x80\x85";
+  const RETURN_KEY      = "\xEE\x80\x86"; // php does not allow RETURN
+  const ENTER           = "\xEE\x80\x87";
+  const SHIFT           = "\xEE\x80\x88";
+  const LEFT_SHIFT      = "\xEE\x80\x88";
+  const CONTROL         = "\xEE\x80\x89";
+  const LEFT_CONTROL    = "\xEE\x80\x89";
+  const ALT             = "\xEE\x80\x8A";
+  const LEFT_ALT        = "\xEE\x80\x8A";
+  const PAUSE           = "\xEE\x80\x8B";
+  const ESCAPE          = "\xEE\x80\x8C";
+  const SPACE           = "\xEE\x80\x8D";
+  const PAGE_UP         = "\xEE\x80\x8E";
+  const PAGE_DOWN       = "\xEE\x80\x8F";
+  const END             = "\xEE\x80\x90";
+  const HOME            = "\xEE\x80\x91";
+  const LEFT            = "\xEE\x80\x92";
+  const ARROW_LEFT      = "\xEE\x80\x92";
+  const UP              = "\xEE\x80\x93";
+  const ARROW_UP        = "\xEE\x80\x93";
+  const RIGHT           = "\xEE\x80\x94";
+  const ARROW_RIGHT     = "\xEE\x80\x94";
+  const DOWN            = "\xEE\x80\x95";
+  const ARROW_DOWN      = "\xEE\x80\x95";
+  const INSERT          = "\xEE\x80\x96";
+  const DELETE          = "\xEE\x80\x97";
+  const SEMICOLON       = "\xEE\x80\x98";
+  const EQUALS          = "\xEE\x80\x99";
+  const NUMPAD0         = "\xEE\x80\x9A";
+  const NUMPAD1         = "\xEE\x80\x9B";
+  const NUMPAD2         = "\xEE\x80\x9C";
+  const NUMPAD3         = "\xEE\x80\x9D";
+  const NUMPAD4         = "\xEE\x80\x9E";
+  const NUMPAD5         = "\xEE\x80\x9F";
+  const NUMPAD6         = "\xEE\x80\xA0";
+  const NUMPAD7         = "\xEE\x80\xA1";
+  const NUMPAD8         = "\xEE\x80\xA2";
+  const NUMPAD9         = "\xEE\x80\xA3";
+  const MULTIPLY        = "\xEE\x80\xA4";
+  const ADD             = "\xEE\x80\xA5";
+  const SEPARATOR       = "\xEE\x80\xA6";
+  const SUBTRACT        = "\xEE\x80\xA7";
+  const DECIMAL         = "\xEE\x80\xA8";
+  const DIVIDE          = "\xEE\x80\xA9";
+  const F1              = "\xEE\x80\xB1";
+  const F2              = "\xEE\x80\xB2";
+  const F3              = "\xEE\x80\xB3";
+  const F4              = "\xEE\x80\xB4";
+  const F5              = "\xEE\x80\xB5";
+  const F6              = "\xEE\x80\xB6";
+  const F7              = "\xEE\x80\xB7";
+  const F8              = "\xEE\x80\xB8";
+  const F9              = "\xEE\x80\xB9";
+  const F10             = "\xEE\x80\xBA";
+  const F11             = "\xEE\x80\xBB";
+  const F12             = "\xEE\x80\xBC";
+  const META            = "\xEE\x80\xBD";
+  const COMMAND         = "\xEE\x80\xBD"; // ALIAS
+  const ZENKAKU_HANKAKU = "\xEE\x80\xC0";
+
+  /**
+   * Encode input of `sendKeys()`.
+   * @param string|array $keys
+   * @return array
+   */
+  public static function encode($keys) {
+
+    if (is_numeric($keys)) {
+      $keys = '' . $keys;
+    }
+
+    if (is_string($keys)) {
+      $keys = array($keys);
+    }
+
+    $encoded = array();
+    foreach ($keys as $key) {
+      if (is_array($key)) {
+        // handle modified keys
+        $key = implode('', $key).self::NULL;
+      }
+      $encoded[] = (string)$key;
+    }
+
+    return $encoded;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverMouse.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverMouse.php
@@ -1,0 +1,60 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Interface representing basic mouse operations.
+ */
+interface WebDriverMouse {
+
+  /**
+   * @param WebDriverCoordinates $where
+   * @return WebDriverMouse
+   */
+  public function click(WebDriverCoordinates $where);
+
+  /**
+   * @param WebDriverCoordinates $where
+   * @return WebDriverMouse
+   */
+  public function contextClick(WebDriverCoordinates $where);
+
+  /**
+   * @param WebDriverCoordinates $where
+   * @return WebDriverMouse
+   */
+  public function doubleClick(WebDriverCoordinates $where);
+
+  /**
+   * @param WebDriverCoordinates $where
+   * @return WebDriverMouse
+   */
+  public function mouseDown(WebDriverCoordinates $where);
+
+  /**
+   * @param WebDriverCoordinates $where
+   * @param int $x_offset
+   * @param int $y_offset
+   * @return WebDriverMouse
+   */
+  public function mouseMove(WebDriverCoordinates $where,
+                            $x_offset = null,
+                            $y_offset = null);
+
+  /**
+   * @param WebDriverCoordinates $where
+   * @return WebDriverMouse
+   */
+  public function mouseUp(WebDriverCoordinates $where);
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverNavigation.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverNavigation.php
@@ -1,0 +1,74 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * An abstraction allowing the driver to access the browser's history and to
+ * navigate to a given URL.
+ *
+ * Note that they are all blocking functions until the page is loaded by
+ * by default. It could be overridden by 'webdriver.load.strategy' in the
+ * FirefoxProfile preferences.
+ * https://code.google.com/p/selenium/wiki/DesiredCapabilities#settings
+ */
+class WebDriverNavigation {
+
+  protected $executor;
+
+  public function __construct(ExecuteMethod $executor) {
+    $this->executor = $executor;
+  }
+
+  /**
+   * Move back a single entry in the browser's history, if possible.
+   *
+   * @return WebDriverNavigation The instance.
+   */
+  public function back() {
+    $this->executor->execute(DriverCommand::GO_BACK);
+    return $this;
+  }
+
+  /**
+   * Move forward a single entry in the browser's history, if possible.
+   *
+   * @return WebDriverNavigation The instance.
+   */
+  public function forward() {
+    $this->executor->execute(DriverCommand::GO_FORWARD);
+    return $this;
+  }
+
+  /**
+   * Refresh the current page.
+   *
+   * @return WebDriverNavigation The instance.
+   */
+  public function refresh() {
+    $this->executor->execute(DriverCommand::REFRESH);
+    return $this;
+  }
+
+  /**
+   * Navigate to the given URL.
+   *
+   * @param string $url
+   * @return WebDriverNavigation The instance.
+   */
+  public function to($url) {
+    $params = array('url' => (string)$url);
+    $this->executor->execute(DriverCommand::GET, $params);
+    return $this;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverOptions.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverOptions.php
@@ -1,0 +1,167 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Managing stuff you would do in a browser.
+ */
+class WebDriverOptions {
+
+  protected $executor;
+
+  public function __construct(ExecuteMethod $executor) {
+    $this->executor = $executor;
+  }
+
+  /**
+   * Add a specific cookie.
+   *
+   * Here are the valid attributes of a cookie array.
+   *  'name'  : string The name of the cookie; may not be null or an empty
+   *                    string.
+   *  'value' : string The cookie value; may not be null.
+   *  'path'  : string The path the cookie is visible to. If left blank or set
+   *                   to null, will be set to "/".
+   *  'domain': string The domain the cookie is visible to. It should be null or
+   *                   the same as the domain of the current URL.
+   *  'secure': bool   Whether this cookie requires a secure connection(https?).
+   *                   It should be null or equal to the security of the current
+   *                   URL.
+   *  'expiry': int    The cookie's expiration date; may be null.
+   *
+   * @param array $cookie An array with key as the attributes mentioned above.
+   * @return WebDriverOptions The current instance.
+   */
+  public function addCookie(array $cookie) {
+    $this->validate($cookie);
+    $this->executor->execute(
+      DriverCommand::ADD_COOKIE,
+      array('cookie' => $cookie)
+    );
+    return $this;
+  }
+
+  /**
+   * Delete all the cookies that are currently visible.
+   *
+   * @return WebDriverOptions The current instance.
+   */
+  public function deleteAllCookies() {
+    $this->executor->execute(DriverCommand::DELETE_ALL_COOKIES);
+    return $this;
+  }
+
+  /**
+   * Delete the cookie with the give name.
+   *
+   * @param string $name
+   * @return WebDriverOptions The current instance.
+   */
+  public function deleteCookieNamed($name) {
+    $this->executor->execute(
+      DriverCommand::DELETE_COOKIE,
+      array(':name' => $name)
+    );
+    return $this;
+  }
+
+  /**
+   * Get the cookie with a given name.
+   *
+   * @param string $name
+   * @return array The cookie, or null if no cookie with the given name is
+   *               presented.
+   */
+  public function getCookieNamed($name) {
+    $cookies = $this->getCookies();
+    foreach ($cookies as $cookie) {
+      if ($cookie['name'] === $name) {
+        return $cookie;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get all the cookies for the current domain.
+   *
+   * @return array The array of cookies presented.
+   */
+  public function getCookies() {
+    return $this->executor->execute(DriverCommand::GET_ALL_COOKIES);
+  }
+
+  private function validate(array $cookie) {
+    if (!isset($cookie['name']) ||
+        $cookie['name'] === '' ||
+        strpos($cookie['name'], ';') !== false) {
+      throw new InvalidArgumentException(
+        '"name" should be non-empty and does not contain a ";"');
+    }
+
+    if (!isset($cookie['value'])) {
+      throw new InvalidArgumentException(
+        '"value" is required when setting a cookie.');
+    }
+
+    if (isset($cookie['domain']) && strpos($cookie['domain'], ':') !== false) {
+      throw new InvalidArgumentException(
+        '"domain" should not contain a port:'.(string)$cookie['domain']);
+    }
+  }
+
+  /**
+   * Return the interface for managing driver timeouts.
+   *
+   * @return WebDriverTimeouts
+   */
+  public function timeouts() {
+    return new WebDriverTimeouts($this->executor);
+  }
+
+  /**
+   * An abstraction allowing the driver to manipulate the browser's window
+   *
+   * @return WebDriverWindow
+   * @see WebDriverWindow
+   */
+  public function window() {
+    return new WebDriverWindow($this->executor);
+  }
+
+  /**
+   * Get the log for a given log type. Log buffer is reset after each request.
+   *
+   * @param string $log_type The log type.
+   * @return array The list of log entries.
+   * @see https://code.google.com/p/selenium/wiki/JsonWireProtocol#Log_Type
+   */
+  public function getLog($log_type) {
+    return $this->executor->execute(
+      DriverCommand::GET_LOG,
+      array('type' => $log_type)
+    );
+  }
+
+  /**
+   * Get available log types.
+   *
+   * @return array The list of available log types.
+   * @see https://code.google.com/p/selenium/wiki/JsonWireProtocol#Log_Type
+   */
+  public function getAvailableLogTypes() {
+    return $this->executor->execute(DriverCommand::GET_AVAILABLE_LOG_TYPES);
+  }
+
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverPlatform.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverPlatform.php
@@ -1,0 +1,29 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The platforms supported by WebDriver.
+ */
+class WebDriverPlatform {
+
+  const ANDROID = 'ANDROID';
+  const ANY = 'ANY';
+  const LINUX = 'LINUX';
+  const MAC = 'MAC';
+  const UNIX = 'UNIX';
+  const VISTA = 'VISTA';
+  const WINDOWS = 'WINDOWS';
+  const XP = 'XP';
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverPoint.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverPoint.php
@@ -1,0 +1,82 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Represent a point.
+ */
+class WebDriverPoint {
+
+  private $x, $y;
+
+  public function __construct($x, $y) {
+    $this->x = $x;
+    $this->y = $y;
+  }
+
+  /**
+   * Get the x-coordinate.
+   *
+   * @return int The x-coordinate of the point.
+   */
+  public function getX() {
+    return $this->x;
+  }
+
+  /**
+   * Get the y-coordinate.
+   *
+   * @return int The y-coordinate of the point.
+   */
+  public function getY() {
+    return $this->y;
+  }
+
+  /**
+   * Set the point to a new position.
+   *
+   * @param int $new_x
+   * @param int $new_y
+   * @return WebDriverPoint The same instance with updated coordinates.
+   */
+  public function move($new_x, $new_y) {
+    $this->x = $new_x;
+    $this->y = $new_y;
+    return $this;
+  }
+
+  /**
+   * Move the current by offsets.
+   *
+   * @param int $x_offset
+   * @param int $y_offset
+   * @return WebDriverPoint The same instance with updated coordinates.
+   */
+  public function moveBy($x_offset, $y_offset) {
+    $this->x += $x_offset;
+    $this->y += $y_offset;
+    return $this;
+  }
+
+  /**
+   * Check whether the given point is the same as the instance.
+   *
+   * @param WebDriverPoint $point The point to be compared with.
+   * @return bool Whether the x and y coordinates are the same as the instance.
+   */
+  public function equals(WebDriverPoint $point) {
+    return $this->x === $point->getX() &&
+           $this->y === $point->getY();
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverSearchContext.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverSearchContext.php
@@ -1,0 +1,42 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The interface for WebDriver and WebDriverElement which is able to search for
+ * WebDriverElement inside.
+ */
+interface WebDriverSearchContext {
+
+  /**
+   * Find the first WebDriverElement within this element using the given
+   * mechanism.
+   *
+   * @param WebDriverBy $locator
+   * @return WebDriverElement NoSuchElementException is thrown in
+   *    HttpCommandExecutor if no element is found.
+   * @see WebDriverBy
+   */
+  public function findElement(WebDriverBy $locator);
+
+  /**
+   * Find all WebDriverElements within this element using the given mechanism.
+   *
+   * @param WebDriverBy $locator
+   * @return array A list of all WebDriverElements, or an empty array if
+   *    nothing matches
+   * @see WebDriverBy
+   */
+  public function findElements(WebDriverBy $locator);
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverSelect.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverSelect.php
@@ -1,0 +1,284 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Models a SELECT tag, providing helper methods to select and deselect options.
+ */
+class WebDriverSelect {
+
+  private $element;
+  private $isMulti;
+
+  public function __construct(WebDriverElement $element) {
+    $tag_name = $element->getTagName();
+
+    if ($tag_name !== 'select') {
+      throw new UnexpectedTagNameException('select', $tag_name);
+    }
+    $this->element = $element;
+    $value = $element->getAttribute('multiple');
+    $this->isMulti = ($value === 'true');
+  }
+
+  /**
+   * @return bool Whether this select element support selecting multiple
+   *              options. This is done by checking the value of the 'multiple'
+   *              attribute.
+   */
+  public function isMultiple() {
+    return $this->isMulti;
+  }
+
+  /**
+   * @return array All options belonging to this select tag.
+   */
+  public function getOptions() {
+    return $this->element->findElements(WebDriverBy::tagName('option'));
+  }
+
+  /**
+   * @return array All selected options belonging to this select tag.
+   */
+  public function getAllSelectedOptions() {
+    $selected_options = array();
+    foreach ($this->getOptions() as $option) {
+      if ($option->isSelected()) {
+        $selected_options[] = $option;
+      }
+    }
+    return $selected_options;
+  }
+
+  /**
+   * @return WebDriverElement The first selected option in this select tag (or
+   *                          the currently selected option in a normal select)
+   */
+  public function getFirstSelectedOption() {
+    foreach ($this->getOptions() as $option) {
+      if ($option->isSelected()) {
+        return $option;
+      }
+    }
+
+    throw new NoSuchElementException('No options are selected');
+  }
+
+  /**
+   * Deselect all options in multiple select tag.
+   *
+   * @return void
+   */
+  public function deselectAll() {
+    if (!$this->isMultiple()) {
+      throw new UnsupportedOperationException(
+        'You may only deselect all options of a multi-select'
+      );
+    }
+
+    foreach ($this->getOptions() as $option) {
+      if ($option->isSelected()) {
+        $option->click();
+      }
+    }
+  }
+
+  /**
+   * Select the option at the given index.
+   *
+   * @param int $index The index of the option. (0-based)
+   * @return void
+   */
+  public function selectByIndex($index) {
+    $matched = false;
+    foreach ($this->getOptions() as $option) {
+      if ($option->getAttribute('index') === (string)$index) {
+        if (!$option->isSelected()) {
+          $option->click();
+          if (!$this->isMultiple()) {
+            return;
+          }
+        }
+        $matched = true;
+      }
+    }
+    if (!$matched) {
+      throw new NoSuchElementException(
+        sprintf('Cannot locate option with index: %d', $index)
+      );
+    }
+  }
+
+  /**
+   * Select all options that have value attribute matching the argument. That
+   * is, when given "foo" this would select an option like:
+   *
+   * <option value="foo">Bar</option>;
+   *
+   * @param string $value The value to match against.
+   * @return void
+   */
+  public function selectByValue($value) {
+    $matched = false;
+    $xpath = './/option[@value = '.$this->escapeQuotes($value).']';
+    $options = $this->element->findElements(WebDriverBy::xpath($xpath));
+
+    foreach ($options as $option) {
+      if (!$option->isSelected()) {
+        $option->click();
+      }
+      if (!$this->isMultiple()) {
+        return;
+      }
+      $matched = true;
+    }
+
+    if (!$matched) {
+      throw new NoSuchElementException(
+        sprintf('Cannot locate option with value: %s', $value)
+      );
+    }
+  }
+
+  /**
+   * Select all options that display text matching the argument. That is, when
+   * given "Bar" this would select an option like:
+   *
+   * <option value="foo">Bar</option>;
+   *
+   * @param string $text The visible text to match against.
+   * @return void
+   */
+  public function selectByVisibleText($text) {
+    $matched = false;
+    $xpath = './/option[normalize-space(.) = '.$this->escapeQuotes($text).']';
+    $options = $this->element->findElements(WebDriverBy::xpath($xpath));
+
+    foreach ($options as $option) {
+      if (!$option->isSelected()) {
+        $option->click();
+      }
+      if (!$this->isMultiple()) {
+        return;
+      }
+      $matched = true;
+    }
+
+    // Since the mechanism of getting the text in xpath is not the same as
+    // webdriver, use the expensive getText() to check if nothing is matched.
+    if (!$matched) {
+      foreach ($this->getOptions() as $option) {
+        if ($option->getText() === $text) {
+           if (!$option->isSelected()) {
+             $option->click();
+           }
+           if (!$this->isMultiple()) {
+             return;
+           }
+           $matched = true;
+        }
+      }
+    }
+
+    if (!$matched) {
+      throw new NoSuchElementException(
+        sprintf('Cannot locate option with text: %s', $text)
+      );
+    }
+  }
+
+  /**
+   * Deselect the option at the given index.
+   *
+   * @param int $index The index of the option. (0-based)
+   * @return void
+   */
+  public function deselectByIndex($index) {
+    foreach ($this->getOptions() as $option) {
+      if ($option->getAttribute('index') === (string)$index &&
+          $option->isSelected()) {
+        $option->click();
+      }
+    }
+  }
+
+  /**
+   * Deselect all options that have value attribute matching the argument. That
+   * is, when given "foo" this would select an option like:
+   *
+   * <option value="foo">Bar</option>;
+   *
+   * @param string $value The value to match against.
+   * @return void
+   */
+  public function deselectByValue($value) {
+    $xpath = './/option[@value = '.$this->escapeQuotes($value).']';
+    $options = $this->element->findElements(WebDriverBy::xpath($xpath));
+    foreach ($options as $option) {
+      if ($option->isSelected()) {
+        $option->click();
+      }
+    }
+  }
+
+  /**
+   * Deselect all options that display text matching the argument. That is, when
+   * given "Bar" this would select an option like:
+   *
+   * <option value="foo">Bar</option>;
+   *
+   * @param string $text The visible text to match against.
+   * @return void
+   */
+  public function deselectByVisibleText($text) {
+    $xpath = './/option[normalize-space(.) = '.$this->escapeQuotes($text).']';
+    $options = $this->element->findElements(WebDriverBy::xpath($xpath));
+    foreach ($options as $option) {
+      if ($option->isSelected()) {
+        $option->click();
+      }
+    }
+  }
+
+  /**
+   * Convert strings with both quotes and ticks into:
+   *   foo'"bar -> concat("foo'", '"', "bar")
+   *
+   * @param string $to_escape The string to be converted.
+   * @return string The escaped string.
+   */
+  protected function escapeQuotes($to_escape) {
+    if (strpos($to_escape, '"') !== false && strpos($to_escape, "'") !== false) {
+      $substrings = explode('"', $to_escape);
+
+      $escaped = "concat(";
+      $first = true;
+      foreach ($substrings as $string) {
+         if (!$first) {
+           $escaped .= ", '\"',";
+           $first = false;
+         }
+         $escaped .= '"' . $string . '"';
+      }
+      return $escaped;
+    }
+
+    if (strpos($to_escape, '"') !== false) {
+      return sprintf("'%s'", $to_escape);
+    }
+
+    return sprintf('"%s"', $to_escape);
+  }
+
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverTargetLocator.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverTargetLocator.php
@@ -1,0 +1,62 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Used to locate a given frame or window.
+ */
+interface WebDriverTargetLocator {
+
+  /**
+   * Switch to the main document if the page contains iframes. Otherwise, switch
+   * to the first frame on the page.
+   *
+   * @return WebDriver The driver focused on the top window or the first frame.
+   */
+  public function defaultContent();
+
+  /**
+   * Switch to the iframe by its id or name.
+   *
+   * @param WebDriverElement|string $frame The WebDriverElement,
+   *                                       the id or the name of the frame.
+   * @return WebDriver The driver focused on the given frame.
+   */
+  public function frame($frame);
+
+  /**
+   * Switch the focus to another window by its handle.
+   *
+   * @param string $handle The handle of the window to be focused on.
+   * @return WebDriver The driver focused on the given window.
+   * @see WebDriver::getWindowHandles
+   */
+  public function window($handle);
+
+  /**
+   * Switch to the currently active modal dialog for this particular driver
+   * instance.
+   *
+   * @return WebDriverAlert
+   */
+  public function alert();
+
+  /**
+   * Switches to the element that currently has focus within the document
+   * currently "switched to", or the body element if this cannot be detected.
+   *
+   * @return WebDriverElement
+   */
+  public function activeElement();
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverTimeouts.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverTimeouts.php
@@ -1,0 +1,71 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Managing timeout behavior for WebDriver instances.
+ */
+class WebDriverTimeouts {
+
+  protected $executor;
+
+  public function __construct($executor) {
+    $this->executor = $executor;
+  }
+
+  /**
+   * Specify the amount of time the driver should wait when searching for an
+   * element if it is not immediately present.
+   *
+   * @param int $seconds Wait time in second.
+   * @return WebDriverTimeouts The current instance.
+   */
+  public function implicitlyWait($seconds) {
+    $this->executor->execute(
+      DriverCommand::IMPLICITLY_WAIT,
+      array('ms' => $seconds * 1000)
+    );
+    return $this;
+  }
+
+  /**
+   * Set the amount of time to wait for an asynchronous script to finish
+   * execution before throwing an error.
+   *
+   * @param int $seconds Wait time in second.
+   * @return WebDriverTimeouts The current instance.
+   */
+  public function setScriptTimeout($seconds) {
+    $this->executor->execute(
+      DriverCommand::SET_SCRIPT_TIMEOUT,
+      array('ms' => $seconds * 1000)
+    );
+    return $this;
+  }
+
+  /**
+   * Set the amount of time to wait for a page load to complete before throwing
+   * an error.
+   *
+   * @param int $seconds Wait time in second.
+   * @return WebDriverTimeouts The current instance.
+   */
+  public function pageLoadTimeout($seconds) {
+    $this->executor->execute(DriverCommand::SET_TIMEOUT, array(
+      'type' => 'page load',
+      'ms' => $seconds * 1000,
+    ));
+    return $this;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverWait.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverWait.php
@@ -1,0 +1,70 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * A utility class, designed to help the user to wait until a condition turns
+ * true.
+ *
+ * @see WebDriverExpectedCondition.
+ */
+class WebDriverWait {
+
+  protected $driver;
+  protected $timeout;
+  protected $interval;
+
+  public function __construct(
+      WebDriver $driver,
+      $timeout_in_second = null,
+      $interval_in_millisecond = null) {
+    $this->driver = $driver;
+    $this->timeout = $timeout_in_second ?: 30;
+    $this->interval = $interval_in_millisecond ?: 250;
+  }
+
+  /**
+   * Calls the function provided with the driver as an argument until the return
+   * value is not falsey.
+   *
+   * @param (closure|WebDriverExpectedCondition)
+   * @param string $message
+   * @return mixed The return value of $func_or_ec
+   */
+  public function until($func_or_ec, $message = "") {
+    $end = microtime(true) + $this->timeout;
+    $last_exception = null;
+
+    while ($end > microtime(true)) {
+      try {
+        if ($func_or_ec instanceof WebDriverExpectedCondition) {
+          $ret_val = call_user_func($func_or_ec->getApply(), $this->driver);
+        } else {
+          $ret_val = call_user_func($func_or_ec, $this->driver);
+        }
+        if ($ret_val) {
+          return $ret_val;
+        }
+      } catch (NoSuchElementException $e) {
+        $last_exception = $e;
+      }
+      usleep($this->interval * 1000);
+    }
+
+    if ($last_exception) {
+      throw $last_exception;
+    }
+    throw new TimeOutException($message);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/WebDriverWindow.php
+++ b/tests/vendor/facebook/webdriver/lib/WebDriverWindow.php
@@ -1,0 +1,143 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * An abstraction allowing the driver to manipulate the browser's window
+ */
+class WebDriverWindow {
+
+  protected $executor;
+
+  public function __construct($executor) {
+    $this->executor = $executor;
+  }
+
+  /**
+   * Get the position of the current window, relative to the upper left corner
+   * of the screen.
+   *
+   * @return array The current window position.
+   */
+  public function getPosition() {
+    $position = $this->executor->execute(
+      DriverCommand::GET_WINDOW_POSITION,
+      array(':windowHandle' => 'current')
+    );
+    return new WebDriverPoint(
+      $position['x'],
+      $position['y']
+    );
+  }
+
+  /**
+   * Get the size of the current window. This will return the outer window
+   * dimension, not just the view port.
+   *
+   * @return array The current window size.
+   */
+  public function getSize() {
+    $size = $this->executor->execute(
+      DriverCommand::GET_WINDOW_SIZE,
+      array(':windowHandle' => 'current')
+    );
+    return new WebDriverDimension(
+      $size['width'],
+      $size['height']
+    );
+  }
+
+  /**
+   * Maximizes the current window if it is not already maximized
+   *
+   * @return WebDriverWindow The instance.
+   */
+  public function maximize() {
+    $this->executor->execute(
+      DriverCommand::MAXIMIZE_WINDOW,
+      array(':windowHandle' => 'current')
+    );
+    return $this;
+  }
+
+  /**
+   * Set the size of the current window. This will change the outer window
+   * dimension, not just the view port.
+   *
+   * @param WebDriverDimension $size
+   * @return WebDriverWindow The instance.
+   */
+  public function setSize(WebDriverDimension $size) {
+    $params = array(
+      'width' => $size->getWidth(),
+      'height' => $size->getHeight(),
+      ':windowHandle' => 'current',
+    );
+    $this->executor->execute(DriverCommand::SET_WINDOW_SIZE, $params);
+    return $this;
+  }
+
+  /**
+   * Set the position of the current window. This is relative to the upper left
+   * corner of the screen.
+   *
+   * @param WebDriverPoint $position
+   * @return WebDriverWindow The instance.
+   */
+  public function setPosition(WebDriverPoint $position) {
+    $params = array(
+      'x' => $position->getX(),
+      'y' => $position->getY(),
+      ':windowHandle' => 'current',
+    );
+    $this->executor->execute(DriverCommand::SET_WINDOW_POSITION, $params);
+    return $this;
+  }
+
+  /**
+   * Get the current browser orientation.
+   *
+   * @return string Either LANDSCAPE|PORTRAIT
+   */
+  public function getScreenOrientation() {
+    return $this->executor->execute(DriverCommand::GET_SCREEN_ORIENTATION);
+  }
+
+
+  /**
+   * Set the browser orientation. The orientation should either
+   * LANDSCAPE|PORTRAIT
+   *
+   * @param string $orientation
+   * @return WebDriverWindow The instance.
+   * @throws IndexOutOfBoundsException
+   */
+  public function setScreenOrientation($orientation) {
+    $orientation = strtoupper($orientation);
+    if (!in_array($orientation, array('PORTRAIT', 'LANDSCAPE'))) {
+      throw new IndexOutOfBoundsException(
+        "Orientation must be either PORTRAIT, or LANDSCAPE"
+      );
+    }
+
+    $this->executor->execute(
+      DriverCommand::SET_SCREEN_ORIENTATION,
+      array('orientation' => $orientation)
+    );
+
+    return $this;
+
+  }
+
+}

--- a/tests/vendor/facebook/webdriver/lib/__init__.php
+++ b/tests/vendor/facebook/webdriver/lib/__init__.php
@@ -1,0 +1,116 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// interface
+require_once('WebDriverSearchContext.php');
+require_once('JavaScriptExecutor.php');
+require_once('WebDriver.php');
+require_once('WebDriverElement.php');
+require_once('WebDriverCommandExecutor.php');
+require_once('WebDriverAction.php');
+require_once('WebDriverEventListener.php');
+require_once('remote/FileDetector.php');
+require_once('WebDriverCapabilities.php');
+require_once('remote/ExecuteMethod.php');
+require_once('WebDriverTargetLocator.php');
+
+// abstract class
+require_once('interactions/internal/WebDriverKeysRelatedAction.php');
+require_once('interactions/internal/WebDriverSingleKeyAction.php');
+
+require_once('remote/WebDriverCommand.php');
+
+require_once('net/URLChecker.php');
+
+// class
+require_once('WebDriverAlert.php');
+require_once('WebDriverBy.php');
+require_once('WebDriverDimension.php');
+require_once('WebDriverExceptions.php');
+require_once('WebDriverExpectedCondition.php');
+require_once('WebDriverHasInputDevices.php');
+require_once('WebDriverKeys.php');
+require_once('WebDriverNavigation.php');
+require_once('WebDriverMouse.php');
+require_once('WebDriverKeyboard.php');
+require_once('WebDriverOptions.php');
+require_once('WebDriverPlatform.php');
+require_once('WebDriverPoint.php');
+require_once('WebDriverSelect.php');
+require_once('WebDriverTimeouts.php');
+require_once('WebDriverWait.php');
+require_once('WebDriverWindow.php');
+require_once('interactions/WebDriverActions.php');
+require_once('interactions/internal/WebDriverMouseAction.php');
+require_once('interactions/WebDriverCompositeAction.php');
+require_once('interactions/internal/WebDriverButtonReleaseAction.php');
+require_once('interactions/internal/WebDriverClickAction.php');
+require_once('interactions/internal/WebDriverClickAndHoldAction.php');
+require_once('interactions/internal/WebDriverContextClickAction.php');
+require_once('interactions/internal/WebDriverCoordinates.php');
+require_once('interactions/internal/WebDriverDoubleClickAction.php');
+require_once('interactions/internal/WebDriverMouseMoveAction.php');
+require_once('interactions/internal/WebDriverMoveToOffsetAction.php');
+require_once('internal/WebDriverLocatable.php');
+require_once('chrome/ChromeOptions.php');
+require_once('firefox/FirefoxDriver.php');
+require_once('firefox/FirefoxProfile.php');
+require_once('remote/DriverCommand.php');
+require_once('remote/LocalFileDetector.php');
+require_once('remote/UselessFileDetector.php');
+require_once('remote/RemoteMouse.php');
+require_once('remote/RemoteKeyboard.php');
+
+require_once('remote/service/DriverService.php');
+require_once('chrome/ChromeDriverService.php');
+
+require_once('remote/RemoteWebDriver.php');
+require_once('chrome/ChromeDriver.php');
+
+require_once('remote/RemoteWebElement.php');
+require_once('remote/RemoteExecuteMethod.php');
+require_once('remote/WebDriverBrowserType.php');
+require_once('remote/WebDriverCapabilityType.php');
+require_once('remote/DesiredCapabilities.php');
+require_once('remote/WebDriverResponse.php');
+require_once('remote/RemoteTargetLocator.php');
+
+require_once('remote/HttpCommandExecutor.php');
+require_once('remote/service/DriverCommandExecutor.php');
+
+require_once('interactions/internal/WebDriverSendKeysAction.php');
+require_once('interactions/internal/WebDriverKeyDownAction.php');
+require_once('interactions/internal/WebDriverKeyUpAction.php');
+
+require_once('support/events/EventFiringWebDriver.php');
+require_once('support/events/EventFiringWebDriverNavigation.php');
+require_once('WebDriverDispatcher.php');
+require_once('support/events/EventFiringWebElement.php');
+
+// touch
+require_once('interactions/WebDriverTouchScreen.php');
+require_once('remote/RemoteTouchScreen.php');
+require_once('interactions/WebDriverTouchActions.php');
+require_once('interactions/touch/WebDriverTouchAction.php');
+require_once('interactions/touch/WebDriverDoubleTapAction.php');
+require_once('interactions/touch/WebDriverDownAction.php');
+require_once('interactions/touch/WebDriverFlickAction.php');
+require_once('interactions/touch/WebDriverFlickFromElementAction.php');
+require_once('interactions/touch/WebDriverLongPressAction.php');
+require_once('interactions/touch/WebDriverMoveAction.php');
+require_once('interactions/touch/WebDriverScrollAction.php');
+require_once('interactions/touch/WebDriverScrollFromElementAction.php');
+require_once('interactions/touch/WebDriverTapAction.php');
+require_once('interactions/touch/WebDriverUpAction.php');

--- a/tests/vendor/facebook/webdriver/lib/chrome/ChromeDriver.php
+++ b/tests/vendor/facebook/webdriver/lib/chrome/ChromeDriver.php
@@ -1,0 +1,68 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class ChromeDriver extends RemoteWebDriver {
+
+  public static function start(
+    DesiredCapabilities $desired_capabilities = null,
+    ChromeDriverService $service = null
+  ) {
+    if ($desired_capabilities === null) {
+      $desired_capabilities = DesiredCapabilities::chrome();
+    }
+    if ($service === null) {
+      $service = ChromeDriverService::createDefaultService();
+    }
+    $executor = new DriverCommandExecutor($service);
+    $driver = new static();
+    $driver->setCommandExecutor($executor)
+           ->startSession($desired_capabilities);
+    return $driver;
+  }
+
+  public function startSession($desired_capabilities) {
+    $command = new WebDriverCommand(
+      null,
+      DriverCommand::NEW_SESSION,
+      array(
+        'desiredCapabilities' => $desired_capabilities->toArray(),
+      )
+    );
+    $response = $this->executor->execute($command);
+    $this->setSessionID($response->getSessionID());
+  }
+
+  /**
+   * @param string $url The url of the remote server
+   * @param DesiredCapabilities $desired_capabilities The desired capabilities
+   * @param int|null $connection_timeout_in_ms
+   * @param int|null $request_timeout_in_ms
+   */
+  public static function create(
+    $url = 'http://localhost:4444/wd/hub',
+    $desired_capabilities = null,
+    $timeout_in_ms = null,
+    $request_timeout_in_ms = null
+  ) {
+    throw new WebDriverException('Please use ChromeDriver::start() instead.');
+  }
+
+  public static function createBySessionID(
+    $session_id,
+    $url = 'http://localhost:4444/wd/hub'
+  ) {
+    throw new WebDriverException('Please use ChromeDriver::start() instead.');
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/chrome/ChromeDriverService.php
+++ b/tests/vendor/facebook/webdriver/lib/chrome/ChromeDriverService.php
@@ -1,0 +1,29 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class ChromeDriverService extends DriverService {
+
+  // The environment variable storing the path to the chrome driver executable.
+  const CHROME_DRIVER_EXE_PROPERTY = "webdriver.chrome.driver";
+
+  public static function createDefaultService() {
+    $exe = getenv(self::CHROME_DRIVER_EXE_PROPERTY);
+    $port = 9515; // TODO: Get another port if the default port is used.
+    $args = array("--port=$port");
+    $service = new ChromeDriverService($exe, $port, $args);
+    return $service;
+  }
+
+}

--- a/tests/vendor/facebook/webdriver/lib/chrome/ChromeOptions.php
+++ b/tests/vendor/facebook/webdriver/lib/chrome/ChromeOptions.php
@@ -1,0 +1,160 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The class manages the capabilities in ChromeDriver.
+ *
+ * @see https://sites.google.com/a/chromium.org/chromedriver/capabilities
+ */
+class ChromeOptions {
+
+  /**
+   * The key of chrome options in desired capabilities.
+   */
+  const CAPABILITY = "chromeOptions";
+
+  /**
+   * @var array
+   */
+  private $arguments = array();
+
+  /**
+   * @var string
+   */
+  private $binary = '';
+
+  /**
+   * @var array
+   */
+  private $extensions = array();
+
+  /**
+   * @var array
+   */
+  private $experimentalOptions = array();
+
+  /**
+   * Sets the path of the Chrome executable. The path should be either absolute
+   * or relative to the location running ChromeDriver server.
+   *
+   * @param string $path
+   * @return ChromeOptions
+   */
+  public function setBinary($path) {
+    $this->binary = $path;
+    return $this;
+  }
+
+  /**
+   * @param array $arguments
+   * @return ChromeOptions
+   */
+  public function addArguments(array $arguments) {
+    $this->arguments = array_merge($this->arguments, $arguments);
+    return $this;
+  }
+
+  /**
+   * Add a Chrome extension to install on browser startup. Each path should be
+   * a packed Chrome extension.
+   *
+   * @param array $paths
+   * @return ChromeOptions
+   */
+  public function addExtensions(array $paths) {
+    foreach ($paths as $path) {
+      $this->addExtension($path);
+    }
+    return $this;
+  }
+
+  /**
+   * @param array $encoded_extensions An array of base64 encoded of the
+   *                                  extensions.
+   * @return ChromeOptions
+   */
+  public function addEncodedExtensions(array $encoded_extensions) {
+    foreach ($encoded_extensions as $encoded_extension) {
+      $this->addEncodedExtension($encoded_extension);
+    }
+    return $this;
+  }
+
+  /**
+   * Sets an experimental option which has not exposed officially.
+   *
+   * @param string $name
+   * @param mixed $value
+   * @return ChromeOptions
+   */
+  public function setExperimentalOption($name, $value) {
+    $this->experimentalOptions[$name] = $value;
+    return $this;
+  }
+
+  /**
+   * @return DesiredCapabilities The DesiredCapabilities for Chrome with this
+   *                             options.
+   */
+  public function toCapabilities() {
+    $capabilities = DesiredCapabilities::chrome();
+    $capabilities->setCapability(self::CAPABILITY, $this);
+    return $capabilities;
+  }
+
+  /**
+   * @return array
+   */
+  public function toArray() {
+    $options = $this->experimentalOptions;
+
+    // The selenium server expects a 'dictionary' instead of a 'list' when
+    // reading the chrome option. However, an empty array in PHP will be
+    // converted to a 'list' instead of a 'dictionary'. To fix it, we always
+    // set the 'binary' to avoid returning an empty array.
+    $options['binary'] = $this->binary;
+
+    if ($this->arguments) {
+      $options['args'] = $this->arguments;
+    }
+
+    if ($this->extensions) {
+      $options['extensions'] = $this->extensions;
+    }
+
+    return $options;
+  }
+
+  /**
+   * Add a Chrome extension to install on browser startup. Each path should be a
+   * packed Chrome extension.
+   *
+   * @param string $path
+   * @return ChromeOptions
+   */
+  private function addExtension($path) {
+    $this->addEncodedExtension(base64_encode(file_get_contents($path)));
+    return $this;
+  }
+
+  /**
+   * @param string $encoded_extension Base64 encoded of the extension.
+   * @return ChromeOptions
+   */
+  private function addEncodedExtension($encoded_extension) {
+    $this->extensions[] = $encoded_extension;
+    return $this;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/firefox/FirefoxDriver.php
+++ b/tests/vendor/facebook/webdriver/lib/firefox/FirefoxDriver.php
@@ -1,0 +1,19 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class FirefoxDriver {
+
+  const PROFILE = 'firefox_profile';
+}

--- a/tests/vendor/facebook/webdriver/lib/firefox/FirefoxProfile.php
+++ b/tests/vendor/facebook/webdriver/lib/firefox/FirefoxProfile.php
@@ -1,0 +1,152 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class FirefoxProfile {
+
+  /**
+   * @var array
+   */
+  private $preferences = array();
+
+  /**
+   * @var array
+   */
+  private $extensions = array();
+
+  /**
+   * @param string $extension The path to the xpi extension.
+   * @return FirefoxProfile
+   */
+  public function addExtension($extension) {
+    $this->extensions[] = $extension;
+    return $this;
+  }
+
+  /**
+   * @param string $key
+   * @param string|bool|int $value
+   * @return FirefoxProfile
+   */
+  public function setPreference($key, $value) {
+    if (is_string($value)) {
+      $value = sprintf('"%s"', $value);
+    } else if (is_int($value)) {
+      $value = sprintf('%d', $value);
+    } else if (is_bool($value)) {
+      $value = $value ? 'true' : 'false';
+    } else {
+      throw new WebDriverException(
+        'The value of the preference should be either a string, int or bool.');
+    }
+    $this->preferences[$key] = $value;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function encode() {
+    $temp_dir = $this->createTempDirectory('WebDriverFirefoxProfile');
+
+    foreach ($this->extensions as $extension) {
+      $this->installExtension($extension, $temp_dir);
+    }
+
+    $content = "";
+    foreach ($this->preferences as $key => $value) {
+      $content .= sprintf("user_pref(\"%s\", %s);\n", $key, $value);
+    }
+    file_put_contents($temp_dir.'/user.js', $content);
+
+    $zip = new ZipArchive();
+    $temp_zip = tempnam('', 'WebDriverFirefoxProfileZip');
+    $zip->open($temp_zip, ZipArchive::CREATE);
+
+    $dir = new RecursiveDirectoryIterator($temp_dir);
+    $files = new RecursiveIteratorIterator($dir);
+    foreach ($files as $name => $object) {
+      if (is_dir($name)) {
+        continue;
+      }
+      $dir_prefix = preg_replace(
+        '#\\\\#',
+        '\\\\\\\\',
+        $temp_dir.DIRECTORY_SEPARATOR
+      );
+      $path = preg_replace("#^{$dir_prefix}#", "", $name);
+      $zip->addFile($name, $path);
+    }
+    $zip->close();
+
+    $profile = base64_encode(file_get_contents($temp_zip));
+    return $profile;
+  }
+
+  /**
+   * @param string $extension The path to the extension.
+   * @param string $profile_dir The path to the profile directory.
+   * @return string The path to the directory of this extension.
+   */
+  private function installExtension($extension, $profile_dir) {
+    $temp_dir = $this->createTempDirectory();
+
+    $this->extractTo($extension, $temp_dir);
+
+    $install_rdf_path = $temp_dir.'/install.rdf';
+    // This is a hacky way to parse the id since there is no offical
+    // RDF parser library.
+    $matches = array();
+    $xml = file_get_contents($install_rdf_path);
+    preg_match('#<em:id>([^<]+)</em:id>#', $xml, $matches);
+    $ext_dir = $profile_dir.'/extensions/'.$matches[1];
+
+    mkdir($ext_dir, 0777, true);
+
+    $this->extractTo($extension, $ext_dir);
+    return $ext_dir;
+  }
+
+  /**
+   * @param string $prefix Prefix of the temp directory.
+   * @return string The path to the temp directory created.
+   */
+  private function createTempDirectory($prefix = '') {
+    $temp_dir = tempnam('', $prefix);
+    if (file_exists($temp_dir)) {
+      unlink($temp_dir);
+      mkdir($temp_dir);
+      if (!is_dir($temp_dir)) {
+        throw new WebDriverException('Cannot create firefox profile.');
+      }
+    }
+    return $temp_dir;
+  }
+
+  /**
+   * @param string $xpi The path to the .xpi extension.
+   * @param string $target_dir The path to the unzip directory.
+   * @return FirefoxProfile
+   */
+  private function extractTo($xpi, $target_dir) {
+    $zip = new ZipArchive();
+    if ($zip->open($xpi)) {
+      $zip->extractTo($target_dir);
+      $zip->close();
+    } else {
+      throw new Exception("Failed to open the firefox extension. '$xpi'");
+    }
+    return $this;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/WebDriverActions.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/WebDriverActions.php
@@ -1,0 +1,236 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * WebDriver action builder. It implements the builder pattern.
+ */
+class WebDriverActions {
+
+  protected $driver;
+  protected $keyboard;
+  protected $mouse;
+  protected $action;
+
+  public function __construct(WebDriver $driver) {
+    $this->driver = $driver;
+    $this->keyboard = $driver->getKeyboard();
+    $this->mouse = $driver->getMouse();
+    $this->action = new WebDriverCompositeAction();
+  }
+
+  /**
+   * A convenience method for performing the actions without calling build().
+   * @return void
+   */
+  public function perform() {
+    $this->action->perform();
+  }
+
+  /**
+   * Mouse click.
+   * If $element is provided, move to the middle of the element first.
+   *
+   * @param WebDriverElement $element
+   * @return WebDriverActions
+   */
+  public function click(WebDriverElement $element = null) {
+    $this->action->addAction(
+      new WebDriverClickAction($this->mouse, $element)
+    );
+    return $this;
+  }
+
+  /**
+   * Mouse click and hold.
+   * If $element is provided, move to the middle of the element first.
+   *
+   * @param WebDriverElement $element
+   * @return WebDriverActions
+   */
+  public function clickAndHold(WebDriverElement $element = null) {
+    $this->action->addAction(
+      new WebDriverClickAndHoldAction($this->mouse, $element)
+    );
+    return $this;
+  }
+
+  /**
+   * Context-click (right click).
+   * If $element is provided, move to the middle of the element first.
+   *
+   * @param WebDriverElement $element
+   * @return WebDriverActions
+   */
+  public function contextClick(WebDriverElement $element = null) {
+    $this->action->addAction(
+      new WebDriverContextClickAction($this->mouse, $element)
+    );
+    return $this;
+  }
+
+  /**
+   * Double click.
+   * If $element is provided, move to the middle of the element first.
+   *
+   * @param WebDriverElement $element
+   * @return WebDriverActions
+   */
+  public function doubleClick(WebDriverElement $element = null) {
+    $this->action->addAction(
+      new WebDriverDoubleClickAction($this->mouse, $element)
+    );
+    return $this;
+  }
+
+  /**
+   * Drag and drop from $source to $target.
+   *
+   * @param WebDriverElement $source
+   * @param WebDriverElement $target
+   * @return WebDriverActions
+   */
+  public function dragAndDrop(WebDriverElement $source,
+                              WebDriverElement $target) {
+    $this->action->addAction(
+      new WebDriverClickAndHoldAction($this->mouse, $source)
+    );
+    $this->action->addAction(
+      new WebDriverMouseMoveAction($this->mouse, $target)
+    );
+    $this->action->addAction(
+      new WebDriverButtonReleaseAction($this->mouse, $target)
+    );
+    return $this;
+  }
+
+  /**
+   * Drag $source and drop by offset ($x_offset, $y_offset).
+   *
+   * @param WebDriverElement $source
+   * @param int $x_offset
+   * @param int $y_offset
+   * @return WebDriverActions
+   */
+  public function dragAndDropBy(WebDriverElement $source,
+                                $x_offset,
+                                $y_offset) {
+    $this->action->addAction(
+      new WebDriverClickAndHoldAction($this->mouse, $source)
+    );
+    $this->action->addAction(
+      new WebDriverMoveToOffsetAction($this->mouse, null, $x_offset, $y_offset)
+    );
+    $this->action->addAction(
+      new WebDriverButtonReleaseAction($this->mouse, null)
+    );
+    return $this;
+  }
+
+  /**
+   * Mouse move by offset.
+   *
+   * @param int $x_offset
+   * @param int $y_offset
+   * @return WebDriverActions
+   */
+  public function moveByOffset($x_offset, $y_offset) {
+    $this->action->addAction(
+      new WebDriverMoveToOffsetAction($this->mouse, null, $x_offset, $y_offset)
+    );
+    return $this;
+  }
+
+  /**
+   * Move to the middle of the given WebDriverElement. If offset are provided,
+   * move the an offset from the top-left cornerof that element.
+   *
+   * @param WebDriverElement $element
+   * @param int $x_offset
+   * @param int $y_offset
+   * @return WebDriverActions
+   */
+  public function moveToElement(WebDriverElement $element,
+                                $x_offset = null,
+                                $y_offset = null) {
+    $this->action->addAction(new WebDriverMoveToOffsetAction(
+      $this->mouse, $element, $x_offset, $y_offset
+    ));
+    return $this;
+  }
+
+  /**
+   * Release the mouse button.
+   * If $element is provided, move to the middle of the element first.
+   *
+   * @param WebDriverElement $element
+   * @return WebDriverActions
+   */
+  public function release(WebDriverElement $element = null) {
+    $this->action->addAction(
+      new WebDriverButtonReleaseAction($this->mouse, $element)
+    );
+    return $this;
+  }
+
+  /**
+   * Press a key on keyboard.
+   * If $element is provided, focus on that element first.
+   *
+   * @see WebDriverKeys for special keys like CONTROL, ALT, etc.
+   * @param WebDriverElement $element
+   * @param string $key
+   * @return WebDriverActions
+   */
+  public function keyDown(WebDriverElement $element = null, $key = null) {
+    $this->action->addAction(
+      new WebDriverKeyDownAction($this->keyboard, $this->mouse, $element, $key)
+    );
+    return $this;
+  }
+
+  /**
+   * Release a key on keyboard.
+   * If $element is provided, focus on that element first.
+   *
+   * @see WebDriverKeys for special keys like CONTROL, ALT, etc.
+   * @param WebDriverElement $element
+   * @param string $key
+   * @return WebDriverActions
+   */
+  public function keyUp(WebDriverElement $element = null, $key = null) {
+    $this->action->addAction(
+      new WebDriverKeyUpAction($this->keyboard, $this->mouse, $element, $key)
+    );
+    return $this;
+  }
+
+  /**
+   * Send keys by keyboard.
+   * If $element is provided, focus on that element first.
+   *
+   * @see WebDriverKeys for special keys like CONTROL, ALT, etc.
+   * @param WebDriverElement $element
+   * @param string $keys
+   * @return WebDriverActions
+   */
+  public function sendKeys(WebDriverElement $element = null, $keys = null) {
+    $this->action->addAction(
+      new WebDriverSendKeysAction(
+        $this->keyboard, $this->mouse, $element, $keys
+      )
+    );
+    return $this;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/WebDriverCompositeAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/WebDriverCompositeAction.php
@@ -1,0 +1,51 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * An action for aggregating actions and triggering all of them afterwards.
+ */
+class WebDriverCompositeAction implements WebDriverAction {
+
+  private $actions = array();
+
+  /**
+   * Add an WebDriverAction to the sequence.
+   *
+   * @param WebDriverAction $action
+   * @return WebDriverCompositeAction The current instance.
+   */
+  public function addAction(WebDriverAction $action) {
+    $this->actions[] = $action;
+    return $this;
+  }
+
+  /**
+   * Get the number of actions in the sequence.
+   *
+   * @return int The number of actions.
+   */
+  public function getNumberOfActions() {
+    return count($this->actions);
+  }
+
+  /**
+   * Perform the seqeunce of actions.
+   */
+  public function perform() {
+    foreach ($this->actions as $action) {
+      $action->perform();
+    }
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/WebDriverTouchActions.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/WebDriverTouchActions.php
@@ -1,0 +1,153 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * WebDriver action builder for touch events
+ */
+class WebDriverTouchActions extends WebDriverActions {
+
+  /**
+   * @var WebDriverTouchScreen
+   */
+  protected $touchScreen;
+
+  public function __construct(WebDriver $driver) {
+    parent::__construct($driver);
+    $this->touchScreen = $driver->getTouch();
+  }
+
+  /**
+   * @param WebDriverElement $element
+   * @return WebDriverTouchActions
+   */
+  public function tap(WebDriverElement $element) {
+    $this->action->addAction(
+      new WebDriverTapAction($this->touchScreen, $element)
+    );
+    return $this;
+  }
+
+  /**
+   * @param int $x
+   * @param int $y
+   * @return WebDriverTouchActions
+   */
+  public function down($x, $y) {
+    $this->action->addAction(
+      new WebDriverDownAction($this->touchScreen, $x, $y)
+    );
+    return $this;
+  }
+
+  /**
+   * @param int $x
+   * @param int $y
+   * @return WebDriverTouchActions
+   */
+  public function up($x, $y) {
+    $this->action->addAction(
+      new WebDriverUpAction($this->touchScreen, $x, $y)
+    );
+    return $this;
+  }
+
+  /**
+   * @param int $x
+   * @param int $y
+   * @return WebDriverTouchActions
+   */
+  public function move($x, $y) {
+    $this->action->addAction(
+      new WebDriverMoveAction($this->touchScreen, $x, $y)
+    );
+    return $this;
+  }
+
+  /**
+   * @param int $x
+   * @param int $y
+   * @return WebDriverTouchActions
+   */
+  public function scroll($x, $y) {
+    $this->action->addAction(
+      new WebDriverScrollAction($this->touchScreen, $x, $y)
+    );
+    return $this;
+  }
+
+  /**
+   * @param WebDriverElement $element
+   * @param int $x
+   * @param int $y
+   * @return WebDriverTouchActions
+   */
+  public function scrollFromElement(WebDriverElement $element, $x, $y) {
+    $this->action->addAction(
+      new WebDriverScrollFromElementAction($this->touchScreen, $element, $x, $y)
+    );
+    return $this;
+  }
+
+  /**
+   * @param WebDriverElement $element
+   * @return WebDriverTouchActions
+   */
+  public function doubleTap(WebDriverElement $element) {
+    $this->action->addAction(
+      new WebDriverDoubleTapAction($this->touchScreen, $element)
+    );
+    return $this;
+  }
+
+  /**
+   * @param WebDriverElement $element
+   * @return WebDriverTouchActions
+   */
+  public function longPress(WebDriverElement $element) {
+    $this->action->addAction(
+      new WebDriverLongPressAction($this->touchScreen, $element)
+    );
+    return $this;
+  }
+
+  /**
+   * @param int $x
+   * @param int $y
+   * @return WebDriverTouchActions
+   */
+  public function flick($x, $y) {
+    $this->action->addAction(
+      new WebDriverFlickAction($this->touchScreen, $x, $y)
+    );
+    return $this;
+  }
+
+  /**
+   * @param WebDriverElement $element
+   * @param int $x
+   * @param int $y
+   * @param int $speed
+   * @return WebDriverTouchActions
+   */
+  public function flickFromElement(WebDriverElement $element, $x, $y, $speed) {
+    $this->action->addAction(
+      new WebDriverFlickFromElementAction(
+        $this->touchScreen, $element, $x, $y, $speed
+      )
+    );
+    return $this;
+  }
+
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/WebDriverTouchScreen.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/WebDriverTouchScreen.php
@@ -1,0 +1,118 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Interface representing touch screen operations.
+ */
+interface WebDriverTouchScreen {
+
+  /**
+   * Single tap on the touch enabled device.
+   *
+   * @param WebDriverElement $element
+   * @return $this
+   */
+  public function tap(WebDriverElement $element);
+
+  /**
+   * Double tap on the touch screen using finger motion events.
+   *
+   * @param WebDriverElement $element
+   * @return $this
+   */
+  public function doubleTap(WebDriverElement $element);
+
+  /**
+   * Finger down on the screen.
+   *
+   * @param int $x
+   * @param int $y
+   * @return $this
+   */
+  public function down($x, $y);
+
+  /**
+   * Flick on the touch screen using finger motion events. Use this flick
+   * command if you don't care where the flick starts on the screen.
+   *
+   * @param int $xspeed
+   * @param int $yspeed
+   * @return $this
+   */
+  public function flick($xspeed, $yspeed);
+
+  /**
+   * Flick on the touch screen using finger motion events.
+   * This flickcommand starts at a particular screen location.
+   *
+   * @param WebDriverElement $element
+   * @param int              $xoffset
+   * @param int              $yoffset
+   * @param int              $speed
+   * @return $this
+   */
+  public function flickFromElement(
+    WebDriverElement $element, $xoffset, $yoffset, $speed);
+
+  /**
+   * Long press on the touch screen using finger motion events.
+   *
+   * @param WebDriverElement $element
+   * @return $this
+   */
+  public function longPress(WebDriverElement $element);
+
+  /**
+   * Finger move on the screen.
+   *
+   * @param int $x
+   * @param int $y
+   * @return $this
+   */
+  public function move($x, $y);
+
+
+  /**
+   * Scroll on the touch screen using finger based motion events. Use this
+   * command if you don't care where the scroll starts on the screen.
+   *
+   * @param int $xoffset
+   * @param int $yoffset
+   * @return $this
+   */
+  public function scroll($xoffset, $yoffset);
+
+  /**
+   * Scroll on the touch screen using finger based motion events. Use this
+   * command to start scrolling at a particular screen location.
+   *
+   * @param WebDriverElement $element
+   * @param int              $xoffset
+   * @param int              $yoffset
+   * @return $this
+   */
+  public function scrollFromElement(
+    WebDriverElement $element, $xoffset, $yoffset);
+
+  /**
+   * Finger up on the screen.
+   *
+   * @param int $x
+   * @param int $y
+   * @return $this
+   */
+  public function up($x, $y);
+
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverButtonReleaseAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverButtonReleaseAction.php
@@ -1,0 +1,26 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Move to the location and then release the mouse key.
+ */
+class WebDriverButtonReleaseAction
+    extends WebDriverMouseAction
+    implements WebDriverAction {
+
+  public function perform() {
+    $this->mouse->mouseUp($this->getActionLocation());
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverClickAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverClickAction.php
@@ -1,0 +1,23 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverClickAction
+    extends WebDriverMouseAction
+    implements WebDriverAction {
+
+  public function perform() {
+    $this->mouse->click($this->getActionLocation());
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverClickAndHoldAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverClickAndHoldAction.php
@@ -1,0 +1,26 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Move the the location, click and hold.
+ */
+class WebDriverClickAndHoldAction
+    extends WebDriverMouseAction
+    implements WebDriverAction {
+
+  public function perform() {
+    $this->mouse->mouseDown($this->getActionLocation());
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverContextClickAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverContextClickAction.php
@@ -1,0 +1,26 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * You can call it 'Right Click' if you like.
+ */
+class WebDriverContextClickAction
+    extends WebDriverMouseAction
+    implements WebDriverAction {
+
+  public function perform() {
+    $this->mouse->contextClick($this->getActionLocation());
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverCoordinates.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverCoordinates.php
@@ -1,0 +1,68 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Interface representing basic mouse operations.
+ */
+class WebDriverCoordinates {
+
+  private
+    $onScreen,
+    $inViewPort,
+    $onPage,
+    $auxiliary;
+
+  public function __construct(
+      $on_screen,
+      Closure $in_view_port,
+      Closure $on_page,
+      $auxiliary) {
+
+    $this->onScreen = $on_screen;
+    $this->inViewPort = $in_view_port;
+    $this->onPage = $on_page;
+    $this->auxiliary = $auxiliary;
+  }
+
+  /**
+   * @return WebDriverPoint
+   */
+  public function onScreen() {
+    throw new UnsupportedOperationException(
+      'onScreen is planned but not yet supported by Selenium'
+    );
+  }
+
+  /**
+   * @return WebDriverPoint
+   */
+  public function inViewPort() {
+    return call_user_func($this->inViewPort);
+  }
+
+  /**
+   * @return WebDriverPoint
+   */
+  public function onPage() {
+    return call_user_func($this->onPage);
+  }
+
+  /**
+   * @return Object The attached object.
+   */
+  public function getAuxiliary() {
+    return $this->auxiliary;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverDoubleClickAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverDoubleClickAction.php
@@ -1,0 +1,23 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverDoubleClickAction
+    extends WebDriverMouseAction
+    implements WebDriverAction {
+
+  public function perform() {
+    $this->mouse->doubleClick($this->getActionLocation());
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverKeyDownAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverKeyDownAction.php
@@ -1,0 +1,24 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverKeyDownAction
+    extends WebDriverSingleKeyAction
+    implements WebDriverAction {
+
+  public function perform() {
+    $this->focusOnElement();
+    $this->keyboard->pressKey($this->key);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverKeyUpAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverKeyUpAction.php
@@ -1,0 +1,24 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverKeyUpAction
+    extends WebDriverSingleKeyAction
+    implements WebDriverAction {
+
+  public function perform() {
+    $this->focusOnElement();
+    $this->keyboard->releaseKey($this->key);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverKeysRelatedAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverKeysRelatedAction.php
@@ -1,0 +1,47 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Base class for all keyboard-related actions.
+ */
+abstract class WebDriverKeysRelatedAction {
+
+  protected $keyboard;
+  protected $mouse;
+  protected $locationProvider;
+
+  /**
+   * @param WebDriverKeyboard $keyboard
+   * @param WebDriverMouse $mouse
+   * @param WebDriverLocatable $location_provider
+   */
+  public function __construct(
+      WebDriverKeyboard $keyboard,
+      WebDriverMouse $mouse,
+      WebDriverLocatable $location_provider = null) {
+    $this->keyboard = $keyboard;
+    $this->mouse = $mouse;
+    $this->locationProvider = $location_provider;
+  }
+
+  /**
+   * @return void
+   */
+  protected function focusOnElement() {
+    if ($this->locationProvider) {
+      $this->mouse->click($this->locationProvider->getCoordinates());
+    }
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverMouseAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverMouseAction.php
@@ -1,0 +1,48 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Base class for all mouse-related actions.
+ */
+class WebDriverMouseAction {
+
+  protected $mouse;
+  protected $locationProvider;
+
+  public function __construct(
+      WebDriverMouse $mouse,
+      WebDriverLocatable $location_provider = null) {
+    $this->mouse = $mouse;
+    $this->locationProvider = $location_provider;
+  }
+
+  /**
+   * @return null|WebDriverCoordinates
+   */
+  protected function getActionLocation() {
+    if ($this->locationProvider !== null) {
+      return $this->locationProvider->getCoordinates();
+    }
+
+    return null;
+  }
+
+  /**
+   * @return void
+   */
+  protected function moveToLocation() {
+    $this->mouse->mouseMove($this->locationProvider);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverMouseMoveAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverMouseMoveAction.php
@@ -1,0 +1,23 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverMouseMoveAction
+    extends WebDriverMouseAction
+    implements WebDriverAction {
+
+  public function perform() {
+    $this->mouse->mouseMove($this->getActionLocation());
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverMoveToOffsetAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverMoveToOffsetAction.php
@@ -1,0 +1,38 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverMoveToOffsetAction
+    extends WebDriverMouseAction
+    implements WebDriverAction {
+
+  private $xOffset, $yOffset;
+
+  public function __construct(WebDriverMouse $mouse,
+                              WebDriverLocatable $location_provider = null,
+                              $x_offset = null,
+                              $y_offset = null) {
+    parent::__construct($mouse, $location_provider);
+    $this->xOffset = $x_offset;
+    $this->yOffset = $y_offset;
+  }
+
+  public function perform() {
+    $this->mouse->mouseMove(
+      $this->getActionLocation(),
+      $this->xOffset,
+      $this->yOffset
+    );
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverSendKeysAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverSendKeysAction.php
@@ -1,0 +1,41 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverSendKeysAction
+    extends WebDriverKeysRelatedAction
+    implements WebDriverAction {
+
+  private $keys;
+
+  /**
+   * @param WebDriverKeyboard $keyboard
+   * @param WebDriverMouse $mouse
+   * @param WebDriverLocatable $location_provider
+   * @param string $keys
+   */
+  public function __construct(
+      WebDriverKeyboard $keyboard,
+      WebDriverMouse $mouse,
+      WebDriverLocatable $location_provider = null,
+      $keys = null) {
+    parent::__construct($keyboard, $mouse, $location_provider);
+    $this->keys = $keys;
+  }
+
+  public function perform() {
+    $this->focusOnElement();
+    $this->keyboard->sendKeys($this->keys);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverSingleKeyAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/internal/WebDriverSingleKeyAction.php
@@ -1,0 +1,30 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+abstract class WebDriverSingleKeyAction
+    extends WebDriverKeysRelatedAction
+    implements WebDriverAction {
+
+  protected $key;
+
+  public function __construct(
+      WebDriverKeyboard $keyboard,
+      WebDriverMouse $mouse,
+      WebDriverLocatable $location_provider = null,
+      $key = null) {
+    parent::__construct($keyboard, $mouse, $location_provider);
+    $this->key = $key;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverDoubleTapAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverDoubleTapAction.php
@@ -1,0 +1,23 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverDoubleTapAction
+  extends WebDriverTouchAction
+  implements WebDriverAction {
+
+  public function perform() {
+    $this->touchScreen->doubleTap($this->locationProvider);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverDownAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverDownAction.php
@@ -1,0 +1,37 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverDownAction
+  extends WebDriverTouchAction
+  implements WebDriverAction {
+
+  private $x;
+  private $y;
+
+  /**
+   * @param WebDriverTouchScreen $touch_screen
+   * @param int $x
+   * @param int $y
+   */
+  public function __construct(WebDriverTouchScreen $touch_screen, $x, $y) {
+    $this->x = $x;
+    $this->y = $y;
+    parent::__construct($touch_screen);
+  }
+
+  public function perform() {
+    $this->touchScreen->down($this->x, $this->y);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverFlickAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverFlickAction.php
@@ -1,0 +1,34 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverFlickAction
+  extends WebDriverTouchAction
+  implements WebDriverAction {
+
+  /**
+   * @param WebDriverTouchScreen $touch_screen
+   * @param int $x
+   * @param int $y
+   */
+  public function __construct(WebDriverTouchScreen $touch_screen, $x, $y) {
+    $this->x = $x;
+    $this->y = $y;
+    parent::__construct($touch_screen);
+  }
+
+  public function perform() {
+    $this->touchScreen->flick($this->x, $this->y);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverFlickFromElementAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverFlickFromElementAction.php
@@ -1,0 +1,49 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverFlickFromElementAction
+  extends WebDriverTouchAction
+  implements WebDriverAction {
+
+  private $x;
+  private $y;
+  private $speed;
+
+  /**
+   * @param WebDriverTouchScreen $touch_screen
+   * @param WebDriverElement $element
+   * @param int $x
+   * @param int $y
+   * @param int $speed
+   */
+  public function __construct(
+    WebDriverTouchScreen $touch_screen,
+    WebDriverElement $element, $x, $y, $speed
+  ) {
+    $this->x = $x;
+    $this->y = $y;
+    $this->speed = $speed;
+    parent::__construct($touch_screen, $element);
+  }
+
+  public function perform() {
+    $this->touchScreen->flickFromElement(
+      $this->locationProvider,
+      $this->x,
+      $this->y,
+      $this->speed
+    );
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverLongPressAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverLongPressAction.php
@@ -1,0 +1,23 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverLongPressAction
+  extends WebDriverTouchAction
+  implements WebDriverAction {
+
+  public function perform() {
+    $this->touchScreen->longPress($this->locationProvider);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverMoveAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverMoveAction.php
@@ -1,0 +1,37 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverMoveAction
+  extends WebDriverTouchAction
+  implements WebDriverAction {
+
+  private $x;
+  private $y;
+
+  /**
+   * @param WebDriverTouchScreen $touch_screen
+   * @param int $x
+   * @param int $y
+   */
+  public function __construct(WebDriverTouchScreen $touch_screen, $x, $y) {
+    $this->x = $x;
+    $this->y = $y;
+    parent::__construct($touch_screen);
+  }
+
+  public function perform() {
+    $this->touchScreen->move($this->x, $this->y);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverScrollAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverScrollAction.php
@@ -1,0 +1,37 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverScrollAction
+  extends WebDriverTouchAction
+  implements WebDriverAction {
+
+  private $x;
+  private $y;
+
+  /**
+   * @param WebDriverTouchScreen $touch_screen
+   * @param int $x
+   * @param int $y
+   */
+  public function __construct(WebDriverTouchScreen $touch_screen, $x, $y) {
+    $this->x = $x;
+    $this->y = $y;
+    parent::__construct($touch_screen);
+  }
+
+  public function perform() {
+    $this->touchScreen->scroll($this->x, $this->y);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverScrollFromElementAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverScrollFromElementAction.php
@@ -1,0 +1,44 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverScrollFromElementAction
+  extends WebDriverTouchAction
+  implements WebDriverAction {
+
+  private $x;
+  private $y;
+
+  /**
+   * @param WebDriverTouchScreen $touch_screen
+   * @param WebDriverElement $element
+   * @param int $x
+   * @param int $y
+   */
+  public function __construct(
+      WebDriverTouchScreen $touch_screen, WebDriverElement $element, $x, $y
+  ) {
+    $this->x = $x;
+    $this->y = $y;
+    parent::__construct($touch_screen, $element);
+  }
+
+  public function perform() {
+    $this->touchScreen->scrollFromElement(
+      $this->locationProvider,
+      $this->x,
+      $this->y
+    );
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverTapAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverTapAction.php
@@ -1,0 +1,23 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverTapAction
+  extends WebDriverTouchAction
+  implements WebDriverAction {
+
+  public function perform() {
+    $this->touchScreen->tap($this->locationProvider);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverTouchAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverTouchAction.php
@@ -1,0 +1,51 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Base class for all touch-related actions.
+ */
+abstract class WebDriverTouchAction {
+
+  /**
+   * @var WebDriverTouchScreen
+   */
+  protected $touchScreen;
+
+  /**
+   * @var WebDriverLocatable
+   */
+  protected $locationProvider;
+
+  /**
+   * @param WebDriverTouchScreen $touch_screen
+   * @param WebDriverLocatable $location_provider
+   */
+  public function __construct(
+    WebDriverTouchScreen $touch_screen,
+    WebDriverLocatable $location_provider = null
+  ) {
+    $this->touchScreen = $touch_screen;
+    $this->locationProvider = $location_provider;
+  }
+
+  /**
+   * @return null|WebDriverCoordinates
+   */
+  protected function getActionLocation() {
+    return $this->locationProvider !== null
+      ? $this->locationProvider->getCoordinates() : null;
+  }
+
+}

--- a/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverUpAction.php
+++ b/tests/vendor/facebook/webdriver/lib/interactions/touch/WebDriverUpAction.php
@@ -1,0 +1,37 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverUpAction
+  extends WebDriverTouchAction
+  implements WebDriverAction {
+
+  private $x;
+  private $y;
+
+  /**
+   * @param WebDriverTouchScreen $touch_screen
+   * @param int $x
+   * @param int $y
+   */
+  public function __construct(WebDriverTouchScreen $touch_screen, $x, $y) {
+    $this->x = $x;
+    $this->y = $y;
+    parent::__construct($touch_screen);
+  }
+
+  public function perform() {
+    $this->touchScreen->up($this->x, $this->y);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/internal/WebDriverLocatable.php
+++ b/tests/vendor/facebook/webdriver/lib/internal/WebDriverLocatable.php
@@ -1,0 +1,25 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Interface representing basic mouse operations.
+ */
+interface WebDriverLocatable {
+
+  /**
+   * @return WebDriverCoordinates
+   */
+  public function getCoordinates();
+}

--- a/tests/vendor/facebook/webdriver/lib/net/URLChecker.php
+++ b/tests/vendor/facebook/webdriver/lib/net/URLChecker.php
@@ -1,0 +1,76 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class URLChecker {
+
+  const POLL_INTERVAL_MS = 500;
+  const CONNECT_TIMEOUT_MS = 500;
+
+  public function waitUntilAvailable($timeout_in_ms, $url) {
+    $end = microtime(true) + $timeout_in_ms / 1000;
+
+    while ($end > microtime(true)) {
+      if ($this->getHTTPResponseCode($timeout_in_ms, $url) === 200) {
+        return $this;
+      }
+      usleep(self::POLL_INTERVAL_MS);
+    }
+
+    throw new TimeOutException(sprintf(
+      "Timed out waiting for %s to become available after %d ms.",
+      $url,
+      $timeout_in_ms
+    ));
+  }
+
+  public function waitUntilUnavailable($timeout_in_ms, $url) {
+    $end = microtime(true) + $timeout_in_ms / 1000;
+
+    while ($end > microtime(true)) {
+      if ($this->getHTTPResponseCode($timeout_in_ms, $url) !== 200) {
+        return $this;
+      }
+      usleep(self::POLL_INTERVAL_MS);
+    }
+
+    throw new TimeOutException(sprintf(
+      "Timed out waiting for %s to become unavailable after %d ms.",
+      $url,
+      $timeout_in_ms
+    ));
+  }
+
+  private function getHTTPResponseCode($timeout_in_ms, $url) {
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, self::CONNECT_TIMEOUT_MS);
+    // There is a PHP bug in some versions which didn't define the constant.
+    curl_setopt(
+      $ch,
+      156, // CURLOPT_CONNECTTIMEOUT_MS
+      self::CONNECT_TIMEOUT_MS
+    );
+    $code = null;
+    try {
+      curl_exec($ch);
+      $info = curl_getinfo($ch);
+      $code = $info['http_code'];
+    } catch (Exception $e) {
+    }
+    curl_close($ch);
+    return $code;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/DesiredCapabilities.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/DesiredCapabilities.php
@@ -1,0 +1,275 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class DesiredCapabilities implements WebDriverCapabilities {
+
+  private $capabilities;
+
+  public function __construct(array $capabilities = array()) {
+    $this->capabilities = $capabilities;
+  }
+
+  /**
+   * @return string The name of the browser.
+   */
+  public function getBrowserName() {
+    return $this->get(WebDriverCapabilityType::BROWSER_NAME, '');
+  }
+
+  /**
+   * @param string $browser_name
+   * @return DesiredCapabilities
+   */
+  public function setBrowserName($browser_name) {
+    $this->set(WebDriverCapabilityType::BROWSER_NAME, $browser_name);
+    return $this;
+  }
+
+  /**
+   * @return string The version of the browser.
+   */
+  public function getVersion() {
+    return $this->get(WebDriverCapabilityType::VERSION, '');
+  }
+
+  /**
+   * @param string $version
+   * @return DesiredCapabilities
+   */
+  public function setVersion($version) {
+    $this->set(WebDriverCapabilityType::VERSION, $version);
+    return $this;
+  }
+
+  /**
+   * @param string $name
+   * @return mixed The value of a capability.
+   */
+  public function getCapability($name) {
+    return $this->get($name);
+  }
+
+  /**
+   * @param string $name
+   * @param mixed $value
+   * @return DesiredCapabilities
+   */
+  public function setCapability($name, $value) {
+    $this->set($name, $value);
+    return $this;
+  }
+
+  /**
+   * @return string The name of the platform.
+   */
+  public function getPlatform() {
+    return $this->get(WebDriverCapabilityType::PLATFORM, '');
+  }
+
+  /**
+   * @param string $platform
+   * @return DesiredCapabilities
+   */
+  public function setPlatform($platform) {
+    $this->set(WebDriverCapabilityType::PLATFORM, $platform);
+    return $this;
+  }
+
+  /**
+   * @param string $capability_name
+   * @return bool Whether the value is not null and not false.
+   */
+  public function is($capability_name) {
+    return (bool) $this->get($capability_name);
+  }
+
+  /**
+   * @return bool Whether javascript is enabled.
+   */
+  public function isJavascriptEnabled() {
+    return $this->get(WebDriverCapabilityType::JAVASCRIPT_ENABLED, false);
+  }
+
+  /**
+   * This is a htmlUnit-only option.
+   *
+   * @param bool $enabled
+   * @return DesiredCapabilities
+   * @see https://code.google.com/p/selenium/wiki/DesiredCapabilities#Read-write_capabilities
+   */
+  public function setJavascriptEnabled($enabled) {
+    $browser = $this->getBrowserName();
+    if ($browser && $browser !== WebDriverBrowserType::HTMLUNIT) {
+      throw new Exception(
+        'isJavascriptEnable() is a htmlunit-only option. '.
+        'See https://code.google.com/p/selenium/wiki/DesiredCapabilities#Read-write_capabilities.'
+      );
+    }
+
+    $this->set(WebDriverCapabilityType::JAVASCRIPT_ENABLED, $enabled);
+    return $this;
+  }
+
+  /**
+   * @return array
+   */
+  public function toArray() {
+    if (isset($this->capabilities[ChromeOptions::CAPABILITY]) &&
+      $this->capabilities[ChromeOptions::CAPABILITY] instanceof ChromeOptions) {
+      $this->capabilities[ChromeOptions::CAPABILITY] =
+        $this->capabilities[ChromeOptions::CAPABILITY]->toArray();
+    }
+
+    if (isset($this->capabilities[FirefoxDriver::PROFILE]) &&
+      $this->capabilities[FirefoxDriver::PROFILE] instanceof FirefoxProfile) {
+      $this->capabilities[FirefoxDriver::PROFILE] =
+        $this->capabilities[FirefoxDriver::PROFILE]->encode();
+    }
+
+    return $this->capabilities;
+  }
+
+  /**
+   * @param string $key
+   * @param mixed $value
+   * @return DesiredCapabilities
+   */
+  private function set($key, $value) {
+    $this->capabilities[$key] = $value;
+    return $this;
+  }
+
+  /**
+   * @param string $key
+   * @param mixed $default
+   * @return mixed
+   */
+  private function get($key, $default = null) {
+    return isset($this->capabilities[$key])
+           ? $this->capabilities[$key]
+           : $default;
+  }
+
+  /**
+   * @return DesiredCapabilities
+   */
+  public static function android() {
+    return new DesiredCapabilities(array(
+      WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::ANDROID,
+      WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANDROID,
+    ));
+  }
+
+  /**
+   * @return DesiredCapabilities
+   */
+  public static function chrome() {
+    return new DesiredCapabilities(array(
+      WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::CHROME,
+      WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
+    ));
+  }
+
+  /**
+   * @return DesiredCapabilities
+   */
+  public static function firefox() {
+    return new DesiredCapabilities(array(
+      WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::FIREFOX,
+      WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
+    ));
+  }
+
+  /**
+   * @return DesiredCapabilities
+   */
+  public static function htmlUnit() {
+    return new DesiredCapabilities(array(
+      WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::HTMLUNIT,
+      WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
+    ));
+  }
+
+  /**
+   * @return DesiredCapabilities
+   */
+  public static function htmlUnitWithJS() {
+    $caps = new DesiredCapabilities(array(
+      WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::HTMLUNIT,
+      WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
+    ));
+    return $caps->setJavascriptEnabled(true);
+  }
+
+  /**
+   * @return DesiredCapabilities
+   */
+  public static function internetExplorer() {
+    return new DesiredCapabilities(array(
+      WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::IE,
+      WebDriverCapabilityType::PLATFORM => WebDriverPlatform::WINDOWS,
+    ));
+  }
+
+  /**
+   * @return DesiredCapabilities
+   */
+  public static function iphone() {
+    return new DesiredCapabilities(array(
+      WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::IPHONE,
+      WebDriverCapabilityType::PLATFORM => WebDriverPlatform::MAC,
+    ));
+  }
+
+  /**
+   * @return DesiredCapabilities
+   */
+  public static function ipad() {
+    return new DesiredCapabilities(array(
+      WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::IPAD,
+      WebDriverCapabilityType::PLATFORM => WebDriverPlatform::MAC,
+    ));
+  }
+
+  /**
+   * @return DesiredCapabilities
+   */
+  public static function opera() {
+    return new DesiredCapabilities(array(
+      WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::OPERA,
+      WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
+    ));
+  }
+
+  /**
+   * @return DesiredCapabilities
+   */
+  public static function safari() {
+    return new DesiredCapabilities(array(
+      WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::SAFARI,
+      WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
+    ));
+  }
+
+  /**
+   * @return DesiredCapabilities
+   */
+  public static function phantomjs() {
+    return new DesiredCapabilities(array(
+      WebDriverCapabilityType::BROWSER_NAME => WebDriverBrowserType::PHANTOMJS,
+      WebDriverCapabilityType::PLATFORM => WebDriverPlatform::ANY,
+    ));
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/DriverCommand.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/DriverCommand.php
@@ -1,0 +1,169 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * This list of command defined in the WebDriver json wire protocol.
+ */
+class DriverCommand {
+
+  const GET_ALL_SESSIONS = "getAllSessions";
+  const GET_CAPABILITIES = "getCapabilities";
+  const NEW_SESSION = "newSession";
+
+  const STATUS = "status";
+
+  const CLOSE = "close";
+  const QUIT = "quit";
+
+  const GET = "get";
+  const GO_BACK = "goBack";
+  const GO_FORWARD = "goForward";
+  const REFRESH = "refresh";
+
+  const ADD_COOKIE = "addCookie";
+  const GET_ALL_COOKIES = "getCookies";
+  const DELETE_COOKIE = "deleteCookie";
+  const DELETE_ALL_COOKIES = "deleteAllCookies";
+
+  const FIND_ELEMENT = "findElement";
+  const FIND_ELEMENTS = "findElements";
+  const FIND_CHILD_ELEMENT = "findChildElement";
+  const FIND_CHILD_ELEMENTS = "findChildElements";
+
+  const CLEAR_ELEMENT = "clearElement";
+  const CLICK_ELEMENT = "clickElement";
+  const SEND_KEYS_TO_ELEMENT = "sendKeysToElement";
+  const SEND_KEYS_TO_ACTIVE_ELEMENT = "sendKeysToActiveElement";
+  const SUBMIT_ELEMENT = "submitElement";
+  const UPLOAD_FILE = "uploadFile";
+
+  const GET_CURRENT_WINDOW_HANDLE = "getCurrentWindowHandle";
+  const GET_WINDOW_HANDLES = "getWindowHandles";
+
+  const GET_CURRENT_CONTEXT_HANDLE = "getCurrentContextHandle";
+  const GET_CONTEXT_HANDLES = "getContextHandles";
+
+  // Switching between to window/frame/iframe
+  const SWITCH_TO_WINDOW = "switchToWindow";
+  const SWITCH_TO_CONTEXT = "switchToContext";
+  const SWITCH_TO_FRAME = "switchToFrame";
+  const SWITCH_TO_PARENT_FRAME = "switchToParentFrame";
+  const GET_ACTIVE_ELEMENT = "getActiveElement";
+
+  // Information of the page
+  const GET_CURRENT_URL = "getCurrentUrl";
+  const GET_PAGE_SOURCE = "getPageSource";
+  const GET_TITLE = "getTitle";
+
+  // Javascript API
+  const EXECUTE_SCRIPT = "executeScript";
+  const EXECUTE_ASYNC_SCRIPT = "executeAsyncScript";
+
+  // API getting information from an element.
+  const GET_ELEMENT_TEXT = "getElementText";
+  const GET_ELEMENT_TAG_NAME = "getElementTagName";
+  const IS_ELEMENT_SELECTED = "isElementSelected";
+  const IS_ELEMENT_ENABLED = "isElementEnabled";
+  const IS_ELEMENT_DISPLAYED = "isElementDisplayed";
+  const GET_ELEMENT_LOCATION = "getElementLocation";
+  const GET_ELEMENT_LOCATION_ONCE_SCROLLED_INTO_VIEW =
+    "getElementLocationOnceScrolledIntoView";
+  const GET_ELEMENT_SIZE = "getElementSize";
+  const GET_ELEMENT_ATTRIBUTE = "getElementAttribute";
+  const GET_ELEMENT_VALUE_OF_CSS_PROPERTY = "getElementValueOfCssProperty";
+  const ELEMENT_EQUALS = "elementEquals";
+
+  const SCREENSHOT = "screenshot";
+
+  // Alert API
+  const ACCEPT_ALERT = "acceptAlert";
+  const DISMISS_ALERT = "dismissAlert";
+  const GET_ALERT_TEXT = "getAlertText";
+  const SET_ALERT_VALUE = "setAlertValue";
+
+  // Timeout API
+  const SET_TIMEOUT = "setTimeout";
+  const IMPLICITLY_WAIT = "implicitlyWait";
+  const SET_SCRIPT_TIMEOUT = "setScriptTimeout";
+
+  const EXECUTE_SQL = "executeSQL";
+  const GET_LOCATION = "getLocation";
+  const SET_LOCATION = "setLocation";
+  const GET_APP_CACHE = "getAppCache";
+  const GET_APP_CACHE_STATUS = "getStatus";
+  const CLEAR_APP_CACHE = "clearAppCache";
+  const IS_BROWSER_ONLINE = "isBrowserOnline";
+  const SET_BROWSER_ONLINE = "setBrowserOnline";
+
+  const GET_LOCAL_STORAGE_ITEM = "getLocalStorageItem";
+  const GET_LOCAL_STORAGE_KEYS = "getLocalStorageKeys";
+  const SET_LOCAL_STORAGE_ITEM = "setLocalStorageItem";
+  const REMOVE_LOCAL_STORAGE_ITEM = "removeLocalStorageItem";
+  const CLEAR_LOCAL_STORAGE = "clearLocalStorage";
+  const GET_LOCAL_STORAGE_SIZE = "getLocalStorageSize";
+
+  const GET_SESSION_STORAGE_ITEM = "getSessionStorageItem";
+  const GET_SESSION_STORAGE_KEYS = "getSessionStorageKey";
+  const SET_SESSION_STORAGE_ITEM = "setSessionStorageItem";
+  const REMOVE_SESSION_STORAGE_ITEM = "removeSessionStorageItem";
+  const CLEAR_SESSION_STORAGE = "clearSessionStorage";
+  const GET_SESSION_STORAGE_SIZE = "getSessionStorageSize";
+
+  const SET_SCREEN_ORIENTATION = "setScreenOrientation";
+  const GET_SCREEN_ORIENTATION = "getScreenOrientation";
+
+  // These belong to the Advanced user interactions - an element is
+  // optional for these commands.
+  const CLICK = "mouseClick";
+  const DOUBLE_CLICK = "mouseDoubleClick";
+  const MOUSE_DOWN = "mouseButtonDown";
+  const MOUSE_UP = "mouseButtonUp";
+  const MOVE_TO = "mouseMoveTo";
+
+  // Those allow interactions with the Input Methods installed on
+  // the system.
+  const IME_GET_AVAILABLE_ENGINES = "imeGetAvailableEngines";
+  const IME_GET_ACTIVE_ENGINE = "imeGetActiveEngine";
+  const IME_IS_ACTIVATED = "imeIsActivated";
+  const IME_DEACTIVATE = "imeDeactivate";
+  const IME_ACTIVATE_ENGINE = "imeActivateEngine";
+
+  // These belong to the Advanced Touch API
+  const TOUCH_SINGLE_TAP = "touchSingleTap";
+  const TOUCH_DOWN = "touchDown";
+  const TOUCH_UP = "touchUp";
+  const TOUCH_MOVE = "touchMove";
+  const TOUCH_SCROLL = "touchScroll";
+  const TOUCH_DOUBLE_TAP = "touchDoubleTap";
+  const TOUCH_LONG_PRESS = "touchLongPress";
+  const TOUCH_FLICK = "touchFlick";
+
+  // Window API (beta)
+  const SET_WINDOW_SIZE = "setWindowSize";
+  const SET_WINDOW_POSITION = "setWindowPosition";
+  const GET_WINDOW_SIZE = "getWindowSize";
+  const GET_WINDOW_POSITION = "getWindowPosition";
+  const MAXIMIZE_WINDOW = "maximizeWindow";
+
+  // Logging API
+  const GET_AVAILABLE_LOG_TYPES = "getAvailableLogTypes";
+  const GET_LOG = "getLog";
+  const GET_SESSION_LOGS = "getSessionLogs";
+
+  // Mobile API
+  const GET_NETWORK_CONNECTION = "getNetworkConnection";
+  const SET_NETWORK_CONNECTION = "setNetworkConnection";
+
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/ExecuteMethod.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/ExecuteMethod.php
@@ -1,0 +1,24 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+interface ExecuteMethod {
+
+  /**
+   * @param string $command_name
+   * @param array $parameters
+   * @return WebDriverResponse
+   */
+  public function execute($command_name, array $parameters = array());
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/FileDetector.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/FileDetector.php
@@ -1,0 +1,27 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+interface FileDetector {
+
+  /**
+   * Try to detect whether the given $file is a file or not. Return the path
+   * of the file. Otherwise, return null.
+   *
+   * @param string $file
+   *
+   * @return null|string The path of the file.
+   */
+  public function getLocalFile($file);
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/HttpCommandExecutor.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/HttpCommandExecutor.php
@@ -1,0 +1,282 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Command executor talking to the standalone server via HTTP.
+ */
+class HttpCommandExecutor implements WebDriverCommandExecutor {
+
+  /**
+   * @see
+   *   http://code.google.com/p/selenium/wiki/JsonWireProtocol#Command_Reference
+   */
+  protected static $commands = array(
+    DriverCommand::ACCEPT_ALERT =>            array('method' => 'POST', 'url' => '/session/:sessionId/accept_alert'),
+    DriverCommand::ADD_COOKIE =>              array('method' => 'POST', 'url' => '/session/:sessionId/cookie'),
+    DriverCommand::CLEAR_ELEMENT =>           array('method' => 'POST', 'url' => '/session/:sessionId/element/:id/clear'),
+    DriverCommand::CLICK_ELEMENT =>           array('method' => 'POST', 'url' => '/session/:sessionId/element/:id/click'),
+    DriverCommand::CLOSE =>                   array('method' => 'DELETE', 'url' => '/session/:sessionId/window'),
+    DriverCommand::DELETE_ALL_COOKIES =>      array('method' => 'DELETE',  'url' => '/session/:sessionId/cookie'),
+    DriverCommand::DELETE_COOKIE =>           array('method' => 'DELETE',  'url' => '/session/:sessionId/cookie/:name'),
+    DriverCommand::DISMISS_ALERT =>           array('method' => 'POST',   'url' => '/session/:sessionId/dismiss_alert'),
+    DriverCommand::ELEMENT_EQUALS =>          array('method' => 'GET', 'url' => '/session/:sessionId/element/:id/equals/:other'),
+    DriverCommand::FIND_CHILD_ELEMENT =>      array('method' => 'POST', 'url' => '/session/:sessionId/element/:id/element'),
+    DriverCommand::FIND_CHILD_ELEMENTS =>     array('method' => 'POST', 'url' => '/session/:sessionId/element/:id/elements'),
+    DriverCommand::EXECUTE_SCRIPT =>          array('method' => 'POST', 'url' => '/session/:sessionId/execute'),
+    DriverCommand::EXECUTE_ASYNC_SCRIPT =>    array('method' => 'POST', 'url' => '/session/:sessionId/execute_async'),
+    DriverCommand::FIND_ELEMENT =>            array('method' => 'POST', 'url' => '/session/:sessionId/element'),
+    DriverCommand::FIND_ELEMENTS =>           array('method' => 'POST', 'url' => '/session/:sessionId/elements'),
+    DriverCommand::SWITCH_TO_FRAME =>         array('method' => 'POST',  'url' => '/session/:sessionId/frame'),
+    DriverCommand::SWITCH_TO_WINDOW =>        array('method' => 'POST',  'url' => '/session/:sessionId/window'),
+    DriverCommand::GET =>                     array('method' => 'POST', 'url' => '/session/:sessionId/url'),
+    DriverCommand::GET_ACTIVE_ELEMENT =>      array('method' => 'POST', 'url' => '/session/:sessionId/element/active'),
+    DriverCommand::GET_ALERT_TEXT =>          array('method' => 'GET', 'url' => '/session/:sessionId/alert_text'),
+    DriverCommand::GET_ALL_COOKIES =>         array('method' => 'GET',  'url' => '/session/:sessionId/cookie'),
+    DriverCommand::GET_ALL_SESSIONS =>        array('method' => 'GET', 'url' => '/sessions'),
+    DriverCommand::GET_AVAILABLE_LOG_TYPES => array('method' => 'GET', 'url' => '/session/:sessionId/log/types'),
+    DriverCommand::GET_CURRENT_URL =>         array('method' => 'GET',  'url' => '/session/:sessionId/url'),
+    DriverCommand::GET_CURRENT_WINDOW_HANDLE => array('method' => 'GET',  'url' => '/session/:sessionId/window_handle'),
+    DriverCommand::GET_ELEMENT_ATTRIBUTE =>   array('method' => 'GET',  'url' => '/session/:sessionId/element/:id/attribute/:name'),
+    DriverCommand::GET_ELEMENT_VALUE_OF_CSS_PROPERTY =>     array('method' => 'GET',  'url' => '/session/:sessionId/element/:id/css/:propertyName'),
+    DriverCommand::GET_ELEMENT_LOCATION =>    array('method' => 'GET',  'url' => '/session/:sessionId/element/:id/location'),
+    DriverCommand::GET_ELEMENT_LOCATION_ONCE_SCROLLED_INTO_VIEW => array('method' => 'GET',  'url' => '/session/:sessionId/element/:id/location_in_view'),
+    DriverCommand::GET_ELEMENT_SIZE =>        array('method' => 'GET',  'url' => '/session/:sessionId/element/:id/size'),
+    DriverCommand::GET_ELEMENT_TAG_NAME =>    array('method' => 'GET',  'url' => '/session/:sessionId/element/:id/name'),
+    DriverCommand::GET_ELEMENT_TEXT =>        array('method' => 'GET',  'url' => '/session/:sessionId/element/:id/text'),
+    DriverCommand::GET_LOG =>                 array('method' => 'POST', 'url' => '/session/:sessionId/log'),
+    DriverCommand::GET_PAGE_SOURCE =>         array('method' => 'GET',  'url' => '/session/:sessionId/source'),
+    DriverCommand::GET_SCREEN_ORIENTATION =>  array('method' => 'GET',  'url' => '/session/:sessionId/orientation'),
+    DriverCommand::GET_CAPABILITIES =>        array('method' => 'GET',  'url' => '/session/:sessionId'),
+    DriverCommand::GET_TITLE =>               array('method' => 'GET',  'url' => '/session/:sessionId/title'),
+    DriverCommand::GET_WINDOW_HANDLES =>      array('method' => 'GET',  'url' => '/session/:sessionId/window_handles'),
+    DriverCommand::GET_WINDOW_POSITION =>     array('method' => 'GET',  'url' => '/session/:sessionId/window/:windowHandle/position'),
+    DriverCommand::GET_WINDOW_SIZE =>         array('method' => 'GET',  'url' => '/session/:sessionId/window/:windowHandle/size'),
+    DriverCommand::GO_BACK =>                 array('method' => 'POST',  'url' => '/session/:sessionId/back'),
+    DriverCommand::GO_FORWARD =>              array('method' => 'POST',  'url' => '/session/:sessionId/forward'),
+    DriverCommand::IS_ELEMENT_DISPLAYED=>     array('method' => 'GET',  'url' => '/session/:sessionId/element/:id/displayed'),
+    DriverCommand::IS_ELEMENT_ENABLED=>       array('method' => 'GET',  'url' => '/session/:sessionId/element/:id/enabled'),
+    DriverCommand::IS_ELEMENT_SELECTED=>      array('method' => 'GET',  'url' => '/session/:sessionId/element/:id/selected'),
+    DriverCommand::MAXIMIZE_WINDOW =>         array('method' => 'POST', 'url' => '/session/:sessionId/window/:windowHandle/maximize'),
+    DriverCommand::MOUSE_DOWN =>              array('method' => 'POST', 'url' => '/session/:sessionId/buttondown'),
+    DriverCommand::MOUSE_UP =>                array('method' => 'POST', 'url' => '/session/:sessionId/buttonup'),
+    DriverCommand::CLICK =>                   array('method' => 'POST', 'url' => '/session/:sessionId/click'),
+    DriverCommand::DOUBLE_CLICK =>            array('method' => 'POST', 'url' => '/session/:sessionId/doubleclick'),
+    DriverCommand::MOVE_TO =>                 array('method' => 'POST', 'url' => '/session/:sessionId/moveto'),
+    DriverCommand::NEW_SESSION =>             array('method' => 'POST', 'url' => '/session'),
+    DriverCommand::QUIT =>                    array('method' => 'DELETE', 'url' => '/session/:sessionId'),
+    DriverCommand::REFRESH =>                 array('method' => 'POST', 'url' => '/session/:sessionId/refresh'),
+    DriverCommand::UPLOAD_FILE =>             array('method' => 'POST', 'url' => '/session/:sessionId/file'), // undocumented
+    DriverCommand::SEND_KEYS_TO_ACTIVE_ELEMENT => array('method' => 'POST', 'url' => '/session/:sessionId/keys'),
+    DriverCommand::SET_ALERT_VALUE =>         array('method' => 'POST', 'url' => '/session/:sessionId/alert_text'),
+    DriverCommand::SEND_KEYS_TO_ELEMENT =>    array('method' => 'POST', 'url' => '/session/:sessionId/element/:id/value'),
+    DriverCommand::IMPLICITLY_WAIT =>         array('method' => 'POST', 'url' => '/session/:sessionId/timeouts/implicit_wait'),
+    DriverCommand::SET_SCREEN_ORIENTATION =>  array('method' => 'POST', 'url' => '/session/:sessionId/orientation'),
+    DriverCommand::SET_TIMEOUT =>             array('method' => 'POST', 'url' => '/session/:sessionId/timeouts'),
+    DriverCommand::SET_SCRIPT_TIMEOUT =>      array('method' => 'POST', 'url' => '/session/:sessionId/timeouts/async_script'),
+    DriverCommand::SET_WINDOW_POSITION =>     array('method' => 'POST', 'url' => '/session/:sessionId/window/:windowHandle/position'),
+    DriverCommand::SET_WINDOW_SIZE =>         array('method' => 'POST', 'url' => '/session/:sessionId/window/:windowHandle/size'),
+    DriverCommand::SUBMIT_ELEMENT =>          array('method' => 'POST', 'url' => '/session/:sessionId/element/:id/submit'),
+    DriverCommand::SCREENSHOT =>              array('method' => 'GET',  'url' => '/session/:sessionId/screenshot'),
+    DriverCommand::TOUCH_SINGLE_TAP =>        array('method' => 'POST', 'url' => '/session/:sessionId/touch/click'),
+    DriverCommand::TOUCH_DOWN =>              array('method' => 'POST', 'url' => '/session/:sessionId/touch/down'),
+    DriverCommand::TOUCH_DOUBLE_TAP =>        array('method' => 'POST', 'url' => '/session/:sessionId/touch/doubleclick'),
+    DriverCommand::TOUCH_FLICK =>             array('method' => 'POST', 'url' => '/session/:sessionId/touch/flick'),
+    DriverCommand::TOUCH_LONG_PRESS =>        array('method' => 'POST', 'url' => '/session/:sessionId/touch/longclick'),
+    DriverCommand::TOUCH_MOVE =>              array('method' => 'POST', 'url' => '/session/:sessionId/touch/move'),
+    DriverCommand::TOUCH_SCROLL =>            array('method' => 'POST', 'url' => '/session/:sessionId/touch/scroll'),
+    DriverCommand::TOUCH_UP =>                array('method' => 'POST', 'url' => '/session/:sessionId/touch/up'),
+  );
+
+  /**
+   * @var string
+   */
+  protected $url;
+  /**
+   * @var resource
+   */
+  protected $curl;
+
+  /**
+   * @param string $url
+   */
+  public function __construct($url) {
+    $this->url = $url;
+    $this->curl = curl_init();
+
+    // Get credentials from $url (if any)
+    $matches = null;
+    if (preg_match("/^(https?:\/\/)(.*):(.*)@(.*?)/U", $url, $matches)) {
+      $this->url = $matches[1].$matches[4];
+      $auth_creds = $matches[2].":".$matches[3];
+      curl_setopt($this->curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+      curl_setopt($this->curl, CURLOPT_USERPWD, $auth_creds);
+    }
+
+    curl_setopt($this->curl, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($this->curl, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt(
+      $this->curl,
+      CURLOPT_HTTPHEADER,
+      array(
+        'Content-Type: application/json;charset=UTF-8',
+        'Accept: application/json',
+      )
+    );
+    $this->setRequestTimeout(30000);
+    $this->setConnectionTimeout(30000);
+  }
+
+  /**
+   * Set timeout for the connect phase
+   *
+   * @param int $timeout_in_ms Timeout in milliseconds
+   * @return HttpCommandExecutor
+   */
+  public function setConnectionTimeout($timeout_in_ms) {
+    // There is a PHP bug in some versions which didn't define the constant.
+    curl_setopt(
+      $this->curl,
+      /* CURLOPT_CONNECTTIMEOUT_MS */ 156,
+      $timeout_in_ms
+    );
+    return $this;
+  }
+
+  /**
+   * Set the maximum time of a request
+   *
+   * @param int $timeout_in_ms Timeout in milliseconds
+   * @return HttpCommandExecutor
+   */
+  public function setRequestTimeout($timeout_in_ms) {
+    // There is a PHP bug in some versions (at least for PHP 5.3.3) which
+    // didn't define the constant.
+    curl_setopt(
+      $this->curl,
+      /* CURLOPT_TIMEOUT_MS */ 155,
+      $timeout_in_ms
+    );
+    return $this;
+  }
+
+  /**
+   * @param WebDriverCommand $command
+   * @return mixed
+   */
+  public function execute(WebDriverCommand $command) {
+    if (!isset(self::$commands[$command->getName()])) {
+      throw new InvalidArgumentException(
+        $command->getName()." is not a valid command."
+      );
+    }
+    $raw = self::$commands[$command->getName()];
+    $http_method = $raw['method'];
+    $url = $raw['url'];
+    $url = str_replace(':sessionId', $command->getSessionID(), $url);
+    $params = $command->getParameters();
+    foreach ($params as $name => $value) {
+      if ($name[0] === ':') {
+        $url = str_replace($name, $value, $url);
+        if ($http_method != 'POST') {
+          unset($params[$name]);
+        }
+      }
+    }
+
+    if ($params && is_array($params) && $http_method !== 'POST') {
+      throw new BadMethodCallException(sprintf(
+        'The http method called for %s is %s but it has to be POST' .
+        ' if you want to pass the JSON params %s',
+        $url,
+        $http_method,
+        json_encode($params)
+      ));
+    }
+
+    curl_setopt($this->curl, CURLOPT_URL, $this->url . $url);
+
+    // https://github.com/facebook/php-webdriver/issues/173
+    if ($command->getName() === DriverCommand::NEW_SESSION) {
+      curl_setopt($this->curl, CURLOPT_POST, 1);
+    } else {
+      curl_setopt($this->curl, CURLOPT_CUSTOMREQUEST, $http_method);
+    }
+
+    $encoded_params = null;
+
+    if ($http_method === 'POST' && $params && is_array($params)) {
+      $encoded_params = json_encode($params);
+    }
+
+    curl_setopt($this->curl, CURLOPT_POSTFIELDS, $encoded_params);
+
+    $raw_results = trim(curl_exec($this->curl));
+
+    if ($error = curl_error($this->curl)) {
+      $msg = sprintf(
+        'Curl error thrown for http %s to %s',
+        $http_method,
+        $url);
+      if ($params && is_array($params)) {
+        $msg .= sprintf(' with params: %s', json_encode($params));
+      }
+      WebDriverException::throwException(-1, $msg . "\n\n" . $error, array());
+    }
+
+    $results = json_decode($raw_results, true);
+
+    if ($results === null && json_last_error() !== JSON_ERROR_NONE) {
+      throw new WebDriverException(
+        sprintf(
+          "JSON decoding of remote response failed.\n".
+          "Error code: %d\n".
+          "The response: '%s'\n",
+          json_last_error(),
+          $raw_results
+        )
+      );
+    }
+
+    $value = null;
+    if (is_array($results) && array_key_exists('value', $results)) {
+      $value = $results['value'];
+    }
+
+    $message = null;
+    if (is_array($value) && array_key_exists('message', $value)) {
+      $message = $value['message'];
+    }
+
+    $sessionId = null;
+    if (is_array($results) && array_key_exists('sessionId', $results)) {
+      $sessionId = $results['sessionId'];
+    }
+
+    $status = isset($results['status']) ? $results['status'] : 0;
+    WebDriverException::throwException($status, $message, $results);
+
+    $response = new WebDriverResponse($sessionId);
+    return $response
+      ->setStatus($status)
+      ->setValue($value);
+  }
+
+  /**
+   * @return string
+   */
+  public function getAddressOfRemoteServer() {
+    return $this->url;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/LocalFileDetector.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/LocalFileDetector.php
@@ -1,0 +1,28 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class LocalFileDetector implements FileDetector {
+    /**
+     * @param string $file
+     *
+     * @return null|string
+     */
+    public function getLocalFile($file) {
+    if (is_file($file)) {
+      return $file;
+    }
+    return null;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/RemoteExecuteMethod.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/RemoteExecuteMethod.php
@@ -1,0 +1,38 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class RemoteExecuteMethod implements ExecuteMethod {
+
+  private $driver;
+
+  /**
+   * @param RemoteWebDriver $driver
+   */
+  public function __construct(RemoteWebDriver $driver) {
+    $this->driver = $driver;
+  }
+
+  /**
+   * @param string $command_name
+   * @param array $parameters
+   * @return mixed
+   */
+  public function execute(
+    $command_name,
+    array $parameters = array()
+  ) {
+    return $this->driver->execute($command_name, $parameters);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/RemoteKeyboard.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/RemoteKeyboard.php
@@ -1,0 +1,72 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Execute keyboard commands for RemoteWebDriver.
+ */
+class RemoteKeyboard implements WebDriverKeyboard {
+
+  /**
+   * @var RemoteExecuteMethod
+   */
+  private $executor;
+
+  /**
+   * @param RemoteExecuteMethod $executor
+   */
+  public function __construct(RemoteExecuteMethod $executor) {
+    $this->executor = $executor;
+  }
+
+  /**
+   * Send keys to active element
+   * @param string|array $keys
+   * @return $this
+   */
+  public function sendKeys($keys) {
+    $this->executor->execute(DriverCommand::SEND_KEYS_TO_ACTIVE_ELEMENT, array(
+      'value' => WebDriverKeys::encode($keys),
+    ));
+    return $this;
+  }
+
+  /**
+   * Press a modifier key
+   *
+   * @see WebDriverKeys
+   * @param string $key
+   * @return $this
+   */
+  public function pressKey($key) {
+    $this->executor->execute(DriverCommand::SEND_KEYS_TO_ACTIVE_ELEMENT, array(
+      'value' => array((string)$key),
+    ));
+    return $this;
+  }
+
+  /**
+   * Release a modifier key
+   *
+   * @see WebDriverKeys
+   * @param string $key
+   * @return $this
+   */
+  public function releaseKey($key) {
+    $this->executor->execute(DriverCommand::SEND_KEYS_TO_ACTIVE_ELEMENT, array(
+      'value' => array((string)$key),
+    ));
+    return $this;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/RemoteMouse.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/RemoteMouse.php
@@ -1,0 +1,125 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Execute mouse commands for RemoteWebDriver.
+ */
+class RemoteMouse implements WebDriverMouse {
+
+  /**
+   * @var RemoteExecuteMethod
+   */
+  private $executor;
+
+  /**
+   * @param RemoteExecuteMethod $executor
+   */
+  public function __construct(RemoteExecuteMethod $executor) {
+      $this->executor = $executor;
+  }
+
+  /**
+   * @param null|WebDriverCoordinates $where
+   *
+   * @return RemoteMouse
+   */
+  public function click(WebDriverCoordinates $where = null) {
+    $this->moveIfNeeded($where);
+    $this->executor->execute(DriverCommand::CLICK, array(
+      'button' => 0,
+    ));
+    return $this;
+  }
+
+  /**
+   * @param WebDriverCoordinates $where
+   *
+   * @return RemoteMouse
+   */
+  public function contextClick(WebDriverCoordinates $where = null) {
+    $this->moveIfNeeded($where);
+    $this->executor->execute(DriverCommand::CLICK, array(
+      'button' => 2,
+    ));
+    return $this;
+  }
+
+  /**
+   * @param WebDriverCoordinates $where
+   *
+   * @return RemoteMouse
+   */
+  public function doubleClick(WebDriverCoordinates $where = null) {
+    $this->moveIfNeeded($where);
+    $this->executor->execute(DriverCommand::DOUBLE_CLICK);
+    return $this;
+  }
+
+  /**
+   * @param WebDriverCoordinates $where
+   *
+   * @return RemoteMouse
+   */
+  public function mouseDown(WebDriverCoordinates $where = null) {
+    $this->moveIfNeeded($where);
+    $this->executor->execute(DriverCommand::MOUSE_DOWN);
+    return $this;
+  }
+
+  /**
+   * @param WebDriverCoordinates $where
+   * @param int|null $x_offset
+   * @param int|null $y_offset
+   *
+   * @return RemoteMouse
+   */
+  public function mouseMove(WebDriverCoordinates $where = null,
+                            $x_offset = null,
+                            $y_offset = null) {
+    $params = array();
+    if ($where !== null) {
+      $params['element'] = $where->getAuxiliary();
+    }
+    if ($x_offset !== null) {
+      $params['xoffset'] = $x_offset;
+    }
+    if ($y_offset !== null) {
+      $params['yoffset'] = $y_offset;
+    }
+    $this->executor->execute(DriverCommand::MOVE_TO, $params);
+    return $this;
+  }
+
+  /**
+   * @param WebDriverCoordinates $where
+   *
+   * @return RemoteMouse
+   */
+  public function mouseUp(WebDriverCoordinates $where = null) {
+    $this->moveIfNeeded($where);
+    $this->executor->execute(DriverCommand::MOUSE_UP);
+    return $this;
+  }
+
+  /**
+   * @param WebDriverCoordinates $where
+   * @return void
+   */
+  protected function moveIfNeeded(WebDriverCoordinates $where = null) {
+    if ($where) {
+      $this->mouseMove($where);
+    }
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/RemoteTargetLocator.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/RemoteTargetLocator.php
@@ -1,0 +1,97 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Used to locate a given frame or window for RemoteWebDriver.
+ */
+class RemoteTargetLocator implements WebDriverTargetLocator {
+
+  protected $executor;
+  protected $driver;
+
+  public function __construct($executor, $driver) {
+    $this->executor = $executor;
+    $this->driver = $driver;
+  }
+
+  /**
+   * Switch to the main document if the page contains iframes. Otherwise, switch
+   * to the first frame on the page.
+   *
+   * @return WebDriver The driver focused on the top window or the first frame.
+   */
+  public function defaultContent() {
+    $params = array('id' => null);
+    $this->executor->execute(DriverCommand::SWITCH_TO_FRAME, $params);
+
+    return $this->driver;
+  }
+
+  /**
+   * Switch to the iframe by its id or name.
+   *
+   * @param WebDriverElement|string $frame The WebDriverElement,
+                                           the id or the name of the frame.
+   * @return WebDriver The driver focused on the given frame.
+   */
+  public function frame($frame) {
+    if ($frame instanceof WebDriverElement) {
+      $id = array('ELEMENT' => $frame->getID());
+    } else {
+      $id = (string)$frame;
+    }
+
+    $params = array('id' => $id);
+    $this->executor->execute(DriverCommand::SWITCH_TO_FRAME, $params);
+
+    return $this->driver;
+  }
+
+  /**
+   * Switch the focus to another window by its handle.
+   *
+   * @param string $handle The handle of the window to be focused on.
+   * @return WebDriver Tge driver focused on the given window.
+   * @see WebDriver::getWindowHandles
+   */
+  public function window($handle) {
+    $params = array('name' => (string)$handle);
+    $this->executor->execute(DriverCommand::SWITCH_TO_WINDOW, $params);
+
+    return $this->driver;
+  }
+
+  /**
+   * Switch to the currently active modal dialog for this particular driver
+   * instance.
+   *
+   * @return WebDriverAlert
+   */
+  public function alert() {
+    return new WebDriverAlert($this->executor);
+  }
+
+  /**
+   * Switches to the element that currently has focus within the document
+   * currently "switched to", or the body element if this cannot be detected.
+   *
+   * @return RemoteWebElement
+   */
+  public function activeElement() {
+    $response = $this->driver->execute(DriverCommand::GET_ACTIVE_ELEMENT);
+    $method = new RemoteExecuteMethod($this->driver);
+    return new RemoteWebElement($method, $response['ELEMENT']);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/RemoteTouchScreen.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/RemoteTouchScreen.php
@@ -1,0 +1,192 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Execute touch commands for RemoteWebDriver.
+ */
+class RemoteTouchScreen implements WebDriverTouchScreen {
+
+  /**
+   * @var RemoteExecuteMethod
+   */
+  private $executor;
+
+  /**
+   * @param RemoteExecuteMethod $executor
+   */
+  public function __construct(RemoteExecuteMethod $executor) {
+      $this->executor = $executor;
+  }
+
+  /**
+   * @param WebDriverElement $element
+   *
+   * @return RemoteTouchScreen The instance.
+   */
+  public function tap(WebDriverElement $element) {
+    $this->executor->execute(
+      DriverCommand::TOUCH_SINGLE_TAP,
+      array('element' => $element->getID())
+    );
+
+    return $this;
+  }
+
+  /**
+   * @param WebDriverElement $element
+   *
+   * @return RemoteTouchScreen The instance.
+   */
+  public function doubleTap(WebDriverElement $element) {
+    $this->executor->execute(
+      DriverCommand::TOUCH_DOUBLE_TAP,
+      array('element' => $element->getID())
+    );
+
+    return $this;
+  }
+
+  /**
+   * @param int $x
+   * @param int $y
+   *
+   * @return RemoteTouchScreen The instance.
+   */
+  public function down($x, $y) {
+    $this->executor->execute(DriverCommand::TOUCH_DOWN, array(
+      'x' => $x,
+      'y' => $y,
+    ));
+
+    return $this;
+  }
+
+
+  /**
+   * @param int $xspeed
+   * @param int $yspeed
+   *
+   * @return RemoteTouchScreen The instance.
+   */
+  public function flick($xspeed, $yspeed) {
+    $this->executor->execute(DriverCommand::TOUCH_FLICK, array(
+      'xspeed' => $xspeed,
+      'yspeed' => $yspeed,
+    ));
+
+    return $this;
+  }
+
+  /**
+   * @param WebDriverElement $element
+   * @param int $xoffset
+   * @param int $yoffset
+   * @param int $speed
+   *
+   * @return RemoteTouchScreen The instance.
+   */
+  public function flickFromElement(
+    WebDriverElement $element, $xoffset, $yoffset, $speed
+  ) {
+    $this->executor->execute(DriverCommand::TOUCH_FLICK, array(
+      'xoffset' => $xoffset,
+      'yoffset' => $yoffset,
+      'element' => $element->getID(),
+      'speed'   => $speed,
+    ));
+
+    return $this;
+  }
+
+  /**
+   * @param WebDriverElement $element
+   *
+   * @return RemoteTouchScreen The instance.
+   */
+  public function longPress(WebDriverElement $element) {
+    $this->executor->execute(
+      DriverCommand::TOUCH_LONG_PRESS,
+      array('element' => $element->getID())
+    );
+
+    return $this;
+  }
+
+  /**
+   * @param int $x
+   * @param int $y
+   *
+   * @return RemoteTouchScreen The instance.
+   */
+  public function move($x, $y) {
+    $this->executor->execute(DriverCommand::TOUCH_MOVE, array(
+      'x' => $x,
+      'y' => $y,
+    ));
+
+    return $this;
+  }
+
+  /**
+   * @param int $xoffset
+   * @param int $yoffset
+   *
+   * @return RemoteTouchScreen The instance.
+   */
+  public function scroll($xoffset, $yoffset) {
+    $this->executor->execute(DriverCommand::TOUCH_SCROLL, array(
+      'xoffset' => $xoffset,
+      'yoffset' => $yoffset,
+    ));
+
+    return $this;
+  }
+
+  /**
+   * @param WebDriverElement $element
+   * @param int $xoffset
+   * @param int $yoffset
+   *
+   * @return RemoteTouchScreen The instance.
+   */
+  public function scrollFromElement(
+    WebDriverElement $element, $xoffset, $yoffset
+  ) {
+    $this->executor->execute(DriverCommand::TOUCH_SCROLL, array(
+      'element' => $element->getID(),
+      'xoffset' => $xoffset,
+      'yoffset' => $yoffset,
+    ));
+
+    return $this;
+  }
+
+
+  /**
+   * @param int $x
+   * @param int $y
+   *
+   * @return RemoteTouchScreen The instance.
+   */
+  public function up($x, $y) {
+    $this->executor->execute(DriverCommand::TOUCH_UP, array(
+      'x' => $x,
+      'y' => $y,
+    ));
+
+    return $this;
+  }
+
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/RemoteWebDriver.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/RemoteWebDriver.php
@@ -1,0 +1,494 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class RemoteWebDriver implements WebDriver, JavaScriptExecutor {
+  /**
+   * @var HttpCommandExecutor
+   */
+  protected $executor;
+  /**
+   * @var string
+   */
+  protected $sessionID;
+  /**
+   * @var RemoteMouse
+   */
+  protected $mouse;
+  /**
+   * @var RemoteKeyboard
+   */
+  protected $keyboard;
+  /**
+   * @var RemoteTouchScreen
+   */
+  protected $touch;
+  /**
+   * @var RemoteExecuteMethod
+   */
+  protected $executeMethod;
+
+  protected function __construct() {}
+
+  /**
+   * Construct the RemoteWebDriver by a desired capabilities.
+   *
+   * @param string $url The url of the remote server
+   * @param DesiredCapabilities $desired_capabilities The desired capabilities
+   * @param int|null $connection_timeout_in_ms
+   * @param int|null $request_timeout_in_ms
+   * @return RemoteWebDriver
+   */
+  public static function create(
+    $url = 'http://localhost:4444/wd/hub',
+    $desired_capabilities = null,
+    $connection_timeout_in_ms = null,
+    $request_timeout_in_ms = null
+  ) {
+    $url = preg_replace('#/+$#', '', $url);
+
+    // Passing DesiredCapabilities as $desired_capabilities is encourged but
+    // array is also accepted for legacy reason.
+    if ($desired_capabilities instanceof DesiredCapabilities) {
+      $desired_capabilities = $desired_capabilities->toArray();
+    }
+
+    $executor = new HttpCommandExecutor($url);
+    if ($connection_timeout_in_ms !== null) {
+      $executor->setConnectionTimeout($connection_timeout_in_ms);
+    }
+    if ($request_timeout_in_ms !== null) {
+      $executor->setRequestTimeout($request_timeout_in_ms);
+    }
+
+    $command = new WebDriverCommand(
+      null,
+      DriverCommand::NEW_SESSION,
+      array('desiredCapabilities' => $desired_capabilities)
+    );
+
+    $response = $executor->execute($command);
+
+    $driver = new static();
+    $driver->setSessionID($response->getSessionID())
+           ->setCommandExecutor($executor);
+    return $driver;
+  }
+
+  /**
+   * [Experimental] Construct the RemoteWebDriver by an existing session.
+   *
+   * This constructor can boost the performance a lot by reusing the same
+   * browser for the whole test suite. You do not have to pass the desired
+   * capabilities because the session was created before.
+   *
+   * @param string $url The url of the remote server
+   * @param string $session_id The existing session id
+   * @return RemoteWebDriver
+   */
+  public static function createBySessionID(
+    $session_id,
+    $url = 'http://localhost:4444/wd/hub'
+  ) {
+    $driver = new static();
+    $driver->setSessionID($session_id)
+           ->setCommandExecutor(new HttpCommandExecutor($url));
+    return $driver;
+  }
+
+  /**
+   * Close the current window.
+   *
+   * @return RemoteWebDriver The current instance.
+   */
+  public function close() {
+    $this->execute(DriverCommand::CLOSE, array());
+
+    return $this;
+  }
+
+  /**
+   * Find the first WebDriverElement using the given mechanism.
+   *
+   * @param WebDriverBy $by
+   * @return RemoteWebElement NoSuchElementException is thrown in
+   *    HttpCommandExecutor if no element is found.
+   * @see WebDriverBy
+   */
+  public function findElement(WebDriverBy $by) {
+    $params = array('using' => $by->getMechanism(), 'value' => $by->getValue());
+    $raw_element = $this->execute(
+      DriverCommand::FIND_ELEMENT,
+      $params
+    );
+
+    return $this->newElement($raw_element['ELEMENT']);
+  }
+
+  /**
+   * Find all WebDriverElements within the current page using the given
+   * mechanism.
+   *
+   * @param WebDriverBy $by
+   * @return RemoteWebElement[] A list of all WebDriverElements, or an empty
+   *    array if nothing matches
+   * @see WebDriverBy
+   */
+  public function findElements(WebDriverBy $by) {
+    $params = array('using' => $by->getMechanism(), 'value' => $by->getValue());
+    $raw_elements = $this->execute(
+      DriverCommand::FIND_ELEMENTS,
+      $params
+    );
+
+    $elements = array();
+    foreach ($raw_elements as $raw_element) {
+      $elements[] = $this->newElement($raw_element['ELEMENT']);
+    }
+    return $elements;
+  }
+
+    /**
+     * Load a new web page in the current browser window.
+     *
+     * @param string $url
+     *
+     * @return RemoteWebDriver The current instance.
+     */
+  public function get($url) {
+    $params = array('url' => (string)$url);
+    $this->execute(DriverCommand::GET, $params);
+
+    return $this;
+  }
+
+  /**
+   * Get a string representing the current URL that the browser is looking at.
+   *
+   * @return string The current URL.
+   */
+  public function getCurrentURL() {
+    return $this->execute(DriverCommand::GET_CURRENT_URL);
+  }
+
+  /**
+   * Get the source of the last loaded page.
+   *
+   * @return string The current page source.
+   */
+  public function getPageSource() {
+    return $this->execute(DriverCommand::GET_PAGE_SOURCE);
+  }
+
+  /**
+   * Get the title of the current page.
+   *
+   * @return string The title of the current page.
+   */
+  public function getTitle() {
+    return $this->execute(DriverCommand::GET_TITLE);
+  }
+
+  /**
+   * Return an opaque handle to this window that uniquely identifies it within
+   * this driver instance.
+   *
+   * @return string The current window handle.
+   */
+  public function getWindowHandle() {
+    return $this->execute(
+      DriverCommand::GET_CURRENT_WINDOW_HANDLE,
+      array()
+    );
+  }
+
+  /**
+   * Get all window handles available to the current session.
+   *
+   * @return array An array of string containing all available window handles.
+   */
+  public function getWindowHandles() {
+    return $this->execute(DriverCommand::GET_WINDOW_HANDLES, array());
+  }
+
+  /**
+   * Quits this driver, closing every associated window.
+   *
+   * @return void
+   */
+  public function quit() {
+    $this->execute(DriverCommand::QUIT);
+    $this->executor = null;
+  }
+
+  /**
+   * Prepare arguments for JavaScript injection
+   *
+   * @param array $arguments
+   * @return array
+   */
+  private function prepareScriptArguments(array $arguments) {
+    $args = array();
+    foreach ($arguments as $key => $value) {
+      if ($value instanceof WebDriverElement) {
+        $args[$key] = array('ELEMENT'=>$value->getID());
+      } else {
+        if (is_array($value)) {
+          $value = $this->prepareScriptArguments($value);
+        }
+        $args[$key] = $value;
+      }
+    }
+    return $args;
+  }
+
+  /**
+   * Inject a snippet of JavaScript into the page for execution in the context
+   * of the currently selected frame. The executed script is assumed to be
+   * synchronous and the result of evaluating the script will be returned.
+   *
+   * @param string $script The script to inject.
+   * @param array $arguments The arguments of the script.
+   * @return mixed The return value of the script.
+   */
+  public function executeScript($script, array $arguments = array()) {
+    $params = array(
+      'script' => $script,
+      'args' => $this->prepareScriptArguments($arguments),
+    );
+    return $this->execute(DriverCommand::EXECUTE_SCRIPT, $params);
+  }
+
+  /**
+   * Inject a snippet of JavaScript into the page for asynchronous execution in
+   * the context of the currently selected frame.
+   *
+   * The driver will pass a callback as the last argument to the snippet, and
+   * block until the callback is invoked.
+   *
+   * @see WebDriverExecuteAsyncScriptTestCase
+   *
+   * @param string $script The script to inject.
+   * @param array $arguments The arguments of the script.
+   * @return mixed The value passed by the script to the callback.
+   */
+  public function executeAsyncScript($script, array $arguments = array()) {
+    $params = array(
+      'script' => $script,
+      'args' => $this->prepareScriptArguments($arguments),
+    );
+    return $this->execute(
+      DriverCommand::EXECUTE_ASYNC_SCRIPT,
+      $params
+    );
+  }
+
+  /**
+   * Take a screenshot of the current page.
+   *
+   * @param string $save_as The path of the screenshot to be saved.
+   * @return string The screenshot in PNG format.
+   */
+  public function takeScreenshot($save_as = null) {
+    $screenshot = base64_decode(
+      $this->execute(DriverCommand::SCREENSHOT)
+    );
+    if ($save_as) {
+      file_put_contents($save_as, $screenshot);
+    }
+    return $screenshot;
+  }
+
+  /**
+   * Construct a new WebDriverWait by the current WebDriver instance.
+   * Sample usage:
+   *
+   *   $driver->wait(20, 1000)->until(
+   *     WebDriverExpectedCondition::titleIs('WebDriver Page')
+   *   );
+   *
+   * @param int $timeout_in_second
+   * @param int $interval_in_millisecond
+   *
+   * @return WebDriverWait
+   */
+  public function wait(
+      $timeout_in_second = 30,
+      $interval_in_millisecond = 250) {
+    return new WebDriverWait(
+      $this, $timeout_in_second, $interval_in_millisecond
+    );
+  }
+
+  /**
+   * An abstraction for managing stuff you would do in a browser menu. For
+   * example, adding and deleting cookies.
+   *
+   * @return WebDriverOptions
+   */
+  public function manage() {
+    return new WebDriverOptions($this->getExecuteMethod());
+  }
+
+  /**
+   * An abstraction allowing the driver to access the browser's history and to
+   * navigate to a given URL.
+   *
+   * @return WebDriverNavigation
+   * @see WebDriverNavigation
+   */
+  public function navigate() {
+    return new WebDriverNavigation($this->getExecuteMethod());
+  }
+
+  /**
+   * Switch to a different window or frame.
+   *
+   * @return RemoteTargetLocator
+   * @see RemoteTargetLocator
+   */
+  public function switchTo() {
+    return new RemoteTargetLocator($this->getExecuteMethod(), $this);
+  }
+
+  /**
+   * @return RemoteMouse
+   */
+  public function getMouse() {
+    if (!$this->mouse) {
+      $this->mouse = new RemoteMouse($this->getExecuteMethod());
+    }
+    return $this->mouse;
+  }
+
+  /**
+   * @return RemoteKeyboard
+   */
+  public function getKeyboard() {
+    if (!$this->keyboard) {
+      $this->keyboard = new RemoteKeyboard($this->getExecuteMethod());
+    }
+    return $this->keyboard;
+  }
+
+  /**
+   * @return RemoteTouchScreen
+   */
+  public function getTouch() {
+    if (!$this->touch) {
+      $this->touch = new RemoteTouchScreen($this->getExecuteMethod());
+    }
+    return $this->touch;
+  }
+
+  protected function getExecuteMethod() {
+    if (!$this->executeMethod) {
+      $this->executeMethod = new RemoteExecuteMethod($this);
+    }
+    return $this->executeMethod;
+  }
+
+  /**
+   * Construct a new action builder.
+   *
+   * @return WebDriverActions
+   */
+  public function action() {
+    return new WebDriverActions($this);
+  }
+
+  /**
+   * Return the WebDriverElement with the given id.
+   *
+   * @param string $id The id of the element to be created.
+   * @return RemoteWebElement
+   */
+  private function newElement($id) {
+    return new RemoteWebElement($this->getExecuteMethod(), $id);
+  }
+
+  /**
+   * Set the command executor of this RemoteWebdriver
+   *
+   * @param WebDriverCommandExecutor $executor
+   * @return RemoteWebDriver
+   */
+  public function setCommandExecutor(WebDriverCommandExecutor $executor) {
+    $this->executor = $executor;
+    return $this;
+  }
+
+  /**
+   * Set the command executor of this RemoteWebdriver
+   *
+   * @return HttpCommandExecutor
+   */
+  public function getCommandExecutor() {
+    return $this->executor;
+  }
+
+  /**
+   * Set the session id of the RemoteWebDriver.
+   *
+   * @param string $session_id
+   * @return RemoteWebDriver
+   */
+  public function setSessionID($session_id) {
+    $this->sessionID = $session_id;
+    return $this;
+  }
+
+  /**
+   * Get current selenium sessionID
+   *
+   * @return string sessionID
+   */
+  public function getSessionID() {
+    return $this->sessionID;
+  }
+
+  /**
+   * Get all selenium sessions.
+   *
+   * @param string $url The url of the remote server
+   * @param int $timeout_in_ms
+   * @return array
+   */
+  public static function getAllSessions(
+    $url = 'http://localhost:4444/wd/hub',
+    $timeout_in_ms = 30000
+  ) {
+    $executor = new HttpCommandExecutor($url);
+    $executor->setConnectionTimeout($timeout_in_ms);
+
+    $command = new WebDriverCommand(
+      null,
+      DriverCommand::GET_ALL_SESSIONS,
+      array()
+    );
+
+    return $executor->execute($command)->getValue();
+  }
+
+  public function execute($command_name, $params = array()) {
+    $command = new WebDriverCommand(
+      $this->sessionID,
+      $command_name,
+      $params
+    );
+
+    $response = $this->executor->execute($command);
+    return $response->getValue();
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/RemoteWebElement.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/RemoteWebElement.php
@@ -1,0 +1,410 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Represents an HTML element.
+ */
+class RemoteWebElement implements WebDriverElement, WebDriverLocatable {
+
+  /**
+   * @var RemoteExecuteMethod
+   */
+  protected $executor;
+  /**
+   * @var string
+   */
+  protected $id;
+  /**
+   * @var UselessFileDetector
+   */
+  protected $fileDetector;
+
+  /**
+   * @param RemoteExecuteMethod $executor
+   * @param string $id
+   */
+  public function __construct(RemoteExecuteMethod $executor, $id) {
+    $this->executor = $executor;
+    $this->id = $id;
+    $this->fileDetector = new UselessFileDetector();
+  }
+
+  /**
+   * If this element is a TEXTAREA or text INPUT element, this will clear the
+   * value.
+   *
+   * @return RemoteWebElement The current instance.
+   */
+  public function clear() {
+    $this->executor->execute(
+      DriverCommand::CLEAR_ELEMENT,
+      array(':id' => $this->id)
+    );
+    return $this;
+  }
+
+  /**
+   * Click this element.
+   *
+   * @return RemoteWebElement The current instance.
+   */
+  public function click() {
+    $this->executor->execute(
+      DriverCommand::CLICK_ELEMENT,
+      array(':id' => $this->id)
+    );
+    return $this;
+  }
+
+  /**
+   * Find the first WebDriverElement within this element using the given
+   * mechanism.
+   *
+   * @param WebDriverBy $by
+   * @return RemoteWebElement NoSuchElementException is thrown in
+   *    HttpCommandExecutor if no element is found.
+   * @see WebDriverBy
+   */
+  public function findElement(WebDriverBy $by) {
+    $params = array(
+      'using' => $by->getMechanism(),
+      'value' => $by->getValue(),
+      ':id'   => $this->id,
+    );
+    $raw_element = $this->executor->execute(
+      DriverCommand::FIND_CHILD_ELEMENT,
+      $params
+    );
+
+    return $this->newElement($raw_element['ELEMENT']);
+  }
+
+  /**
+   * Find all WebDriverElements within this element using the given mechanism.
+   *
+   * @param WebDriverBy $by
+   * @return RemoteWebElement[] A list of all WebDriverElements, or an empty
+   *    array if nothing matches
+   * @see WebDriverBy
+   */
+  public function findElements(WebDriverBy $by) {
+    $params = array(
+      'using' => $by->getMechanism(),
+      'value' => $by->getValue(),
+      ':id'   => $this->id,
+    );
+    $raw_elements = $this->executor->execute(
+      DriverCommand::FIND_CHILD_ELEMENTS,
+      $params
+    );
+
+    $elements = array();
+    foreach ($raw_elements as $raw_element) {
+      $elements[] = $this->newElement($raw_element['ELEMENT']);
+    }
+    return $elements;
+  }
+
+  /**
+   * Get the value of a the given attribute of the element.
+   *
+   * @param string $attribute_name The name of the attribute.
+   * @return string|null The value of the attribute.
+   */
+  public function getAttribute($attribute_name) {
+    $params = array(
+      ':name' => $attribute_name,
+      ':id'   => $this->id,
+    );
+    return $this->executor->execute(
+      DriverCommand::GET_ELEMENT_ATTRIBUTE,
+      $params
+    );
+  }
+
+  /**
+   * Get the value of a given CSS property.
+   *
+   * @param string $css_property_name The name of the CSS property.
+   * @return string The value of the CSS property.
+   */
+  public function getCSSValue($css_property_name) {
+    $params = array(
+      ':propertyName' => $css_property_name,
+      ':id'           => $this->id,
+    );
+    return $this->executor->execute(
+      DriverCommand::GET_ELEMENT_VALUE_OF_CSS_PROPERTY,
+      $params
+    );
+  }
+
+  /**
+   * Get the location of element relative to the top-left corner of the page.
+   *
+   * @return WebDriverPoint The location of the element.
+   */
+  public function getLocation() {
+    $location = $this->executor->execute(
+      DriverCommand::GET_ELEMENT_LOCATION,
+      array(':id' => $this->id)
+    );
+    return new WebDriverPoint($location['x'], $location['y']);
+  }
+
+  /**
+   * Try scrolling the element into the view port and return the location of
+   * element relative to the top-left corner of the page afterwards.
+   *
+   * @return WebDriverPoint The location of the element.
+   */
+  public function getLocationOnScreenOnceScrolledIntoView() {
+    $location = $this->executor->execute(
+      DriverCommand::GET_ELEMENT_LOCATION_ONCE_SCROLLED_INTO_VIEW,
+      array(':id' => $this->id)
+    );
+    return new WebDriverPoint($location['x'], $location['y']);
+  }
+
+  /**
+   * @return WebDriverCoordinates
+   */
+  public function getCoordinates() {
+    $element = $this;
+
+    $on_screen = null; // planned but not yet implemented
+    $in_view_port = function () use ($element) {
+      return $element->getLocationOnScreenOnceScrolledIntoView();
+    };
+    $on_page = function () use ($element) {
+      return $element->getLocation();
+    };
+    $auxiliary = $this->getID();
+
+    return new WebDriverCoordinates(
+      $on_screen,
+      $in_view_port,
+      $on_page,
+      $auxiliary
+    );
+  }
+
+  /**
+   * Get the size of element.
+   *
+   * @return WebDriverDimension The dimension of the element.
+   */
+  public function getSize() {
+    $size = $this->executor->execute(
+      DriverCommand::GET_ELEMENT_SIZE,
+      array(':id' => $this->id)
+    );
+    return new WebDriverDimension($size['width'], $size['height']);
+  }
+
+  /**
+   * Get the tag name of this element.
+   *
+   * @return string The tag name.
+   */
+  public function getTagName() {
+    // Force tag name to be lowercase as expected by protocol for Opera driver
+    // until this issue is not resolved :
+    // https://github.com/operasoftware/operadriver/issues/102
+    // Remove it when fixed to be consistent with the protocol.
+    return strtolower($this->executor->execute(
+      DriverCommand::GET_ELEMENT_TAG_NAME,
+      array(':id' => $this->id)
+    ));
+  }
+
+  /**
+   * Get the visible (i.e. not hidden by CSS) innerText of this element,
+   * including sub-elements, without any leading or trailing whitespace.
+   *
+   * @return string The visible innerText of this element.
+   */
+  public function getText() {
+    return $this->executor->execute(
+      DriverCommand::GET_ELEMENT_TEXT,
+      array(':id' => $this->id)
+    );
+  }
+
+  /**
+   * Is this element displayed or not? This method avoids the problem of having
+   * to parse an element's "style" attribute.
+   *
+   * @return bool
+   */
+  public function isDisplayed() {
+    return $this->executor->execute(
+      DriverCommand::IS_ELEMENT_DISPLAYED,
+      array(':id' => $this->id)
+    );
+  }
+
+  /**
+   * Is the element currently enabled or not? This will generally return true
+   * for everything but disabled input elements.
+   *
+   * @return bool
+   */
+  public function isEnabled() {
+    return $this->executor->execute(
+      DriverCommand::IS_ELEMENT_ENABLED,
+      array(':id' => $this->id)
+    );
+  }
+
+  /**
+   * Determine whether or not this element is selected or not.
+   *
+   * @return bool
+   */
+  public function isSelected() {
+    return $this->executor->execute(
+      DriverCommand::IS_ELEMENT_SELECTED,
+      array(':id' => $this->id)
+    );
+  }
+
+  /**
+   * Simulate typing into an element, which may set its value.
+   *
+   * @param mixed $value The data to be typed.
+   * @return RemoteWebElement The current instance.
+   */
+  public function sendKeys($value) {
+    $local_file = $this->fileDetector->getLocalFile($value);
+    if ($local_file === null) {
+      $params = array(
+        'value' => WebDriverKeys::encode($value),
+        ':id'   => $this->id,
+      );
+      $this->executor->execute(DriverCommand::SEND_KEYS_TO_ELEMENT, $params);
+    } else {
+      $remote_path = $this->upload($local_file);
+      $params = array(
+        'value' => WebDriverKeys::encode($remote_path),
+        ':id'   => $this->id,
+      );
+      $this->executor->execute(DriverCommand::SEND_KEYS_TO_ELEMENT, $params);
+    }
+    return $this;
+  }
+
+  /**
+   * Upload a local file to the server
+   *
+   * @param string $local_file
+   *
+   * @throws WebDriverException
+   * @return string The remote path of the file.
+   */
+  private function upload($local_file) {
+    if (!is_file($local_file)) {
+      throw new WebDriverException("You may only upload files: " . $local_file);
+    }
+
+    // Create a temporary file in the system temp directory.
+    $temp_zip = tempnam('', 'WebDriverZip');
+    $zip = new ZipArchive();
+    if ($zip->open($temp_zip, ZipArchive::CREATE) !== true) {
+      return false;
+    }
+    $info = pathinfo($local_file);
+    $file_name = $info['basename'];
+    $zip->addFile($local_file, $file_name);
+    $zip->close();
+    $params = array(
+      'file' => base64_encode(file_get_contents($temp_zip)),
+    );
+    $remote_path = $this->executor->execute(
+      DriverCommand::UPLOAD_FILE,
+      $params
+    );
+    unlink($temp_zip);
+    return $remote_path;
+  }
+
+  /**
+   * Set the fileDetector in order to let the RemoteWebElement to know that
+   * you are going to upload a file.
+   *
+   * Basically, if you want WebDriver trying to send a file, set the fileDetector
+   * to be LocalFileDetector. Otherwise, keep it UselessFileDetector.
+   *
+   *   eg. $element->setFileDetector(new LocalFileDetector);
+   *
+   * @param FileDetector $detector
+   * @return RemoteWebElement
+   * @see FileDetector
+   * @see LocalFileDetector
+   * @see UselessFileDetector
+   */
+  public function setFileDetector(FileDetector $detector) {
+    $this->fileDetector = $detector;
+    return $this;
+  }
+
+  /**
+   * If this current element is a form, or an element within a form, then this
+   * will be submitted to the remote server.
+   *
+   * @return RemoteWebElement The current instance.
+   */
+  public function submit() {
+    $this->executor->execute(
+      DriverCommand::SUBMIT_ELEMENT,
+      array(':id' => $this->id)
+    );
+
+    return $this;
+  }
+
+  /**
+   * Get the opaque ID of the element.
+   *
+   * @return string The opaque ID.
+   */
+  public function getID() {
+    return $this->id;
+  }
+
+  /**
+   * Test if two element IDs refer to the same DOM element.
+   *
+   * @param WebDriverElement $other
+   * @return bool
+   */
+  public function equals(WebDriverElement $other) {
+    return $this->executor->execute(DriverCommand::ELEMENT_EQUALS, array(
+      ':id'    => $this->id,
+      ':other' => $other->getID(),
+    ));
+  }
+
+  /**
+   * Return the WebDriverElement with $id
+   *
+   * @param string $id
+   *
+   * @return RemoteWebElement
+   */
+  private function newElement($id) {
+    return new RemoteWebElement($this->executor, $id);
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/UselessFileDetector.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/UselessFileDetector.php
@@ -1,0 +1,25 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class UselessFileDetector implements FileDetector {
+  /**
+   * @param string $file
+   *
+   * @return null
+   */
+  public function getLocalFile($file) {
+    return null;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/WebDriverBrowserType.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/WebDriverBrowserType.php
@@ -1,0 +1,43 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * All the browsers supported by selenium
+ */
+class WebDriverBrowserType {
+
+  const FIREFOX = "firefox";
+  const FIREFOX_2 = "firefox2";
+  const FIREFOX_3 = "firefox3";
+  const FIREFOX_PROXY = "firefoxproxy";
+  const FIREFOX_CHROME = "firefoxchrome";
+  const GOOGLECHROME = "googlechrome";
+  const SAFARI = "safari";
+  const OPERA = "opera";
+  const IEXPLORE= "iexplore";
+  const IEXPLORE_PROXY= "iexploreproxy";
+  const SAFARI_PROXY = "safariproxy";
+  const CHROME = "chrome";
+  const KONQUEROR = "konqueror";
+  const MOCK = "mock";
+  const IE_HTA="iehta";
+
+  const ANDROID = "android";
+  const HTMLUNIT = "htmlunit";
+  const IE = "internet explorer";
+  const IPHONE = "iphone";
+  const IPAD = "iPad";
+  const PHANTOMJS = "phantomjs";
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/WebDriverCapabilityType.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/WebDriverCapabilityType.php
@@ -1,0 +1,38 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * WebDriverCapabilityType contains all constants defined in the WebDriver
+ * Wire Protocol.
+ */
+class WebDriverCapabilityType {
+
+  const BROWSER_NAME = 'browserName';
+  const VERSION = 'version';
+  const PLATFORM = 'platform';
+  const JAVASCRIPT_ENABLED = 'javascriptEnabled';
+  const TAKES_SCREENSHOT = 'takesScreenshot';
+  const HANDLES_ALERTS = 'handlesAlerts';
+  const DATABASE_ENABLED = 'databaseEnabled';
+  const LOCATION_CONTEXT_ENABLED = 'locationContextEnabled';
+  const APPLICATION_CACHE_ENABLED = 'applicationCacheEnabled';
+  const BROWSER_CONNECTION_ENABLED = 'browserConnectionEnabled';
+  const CSS_SELECTORS_ENABLED = 'cssSelectorsEnabled';
+  const WEB_STORAGE_ENABLED = 'webStorageEnabled';
+  const ROTATABLE = 'rotatable';
+  const ACCEPT_SSL_CERTS = 'acceptSslCerts';
+  const NATIVE_EVENTS = 'nativeEvents';
+  const PROXY = 'proxy';
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/WebDriverCommand.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/WebDriverCommand.php
@@ -1,0 +1,39 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverCommand {
+
+  private $sessionID;
+  private $name;
+  private $parameters;
+
+  public function __construct($session_id, $name, $parameters) {
+    $this->sessionID = $session_id;
+    $this->name = $name;
+    $this->parameters = $parameters;
+  }
+
+  public function getName() {
+    return $this->name;
+  }
+
+  public function getSessionID() {
+    return $this->sessionID;
+  }
+
+  public function getParameters() {
+    return $this->parameters;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/WebDriverResponse.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/WebDriverResponse.php
@@ -1,0 +1,87 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverResponse {
+
+  /**
+   * @var int
+   */
+  private $status;
+
+  /**
+   * @var mixed
+   */
+  private $value;
+
+  /**
+   * @var string
+   */
+  private $sessionID;
+
+  /**
+   * @param null|string $session_id
+   */
+  public function __construct($session_id = null) {
+    $this->sessionID = $session_id;
+  }
+
+  /**
+   * @return null|int
+   */
+  public function getStatus() {
+    return $this->status;
+  }
+
+  /**
+   * @param int $status
+   * @return WebDriverResponse
+   */
+  public function setStatus($status) {
+    $this->status = $status;
+    return $this;
+  }
+
+  /**
+   * @return mixed
+   */
+  public function getValue() {
+    return $this->value;
+  }
+
+  /**
+   * @param mixed $value
+   * @return WebDriverResponse
+   */
+  public function setValue($value) {
+    $this->value = $value;
+    return $this;
+  }
+
+  /**
+   * @return null|string
+   */
+  public function getSessionID() {
+    return $this->sessionID;
+  }
+
+  /**
+   * @param mixed $session_id
+   * @return WebDriverResponse
+   */
+  public function setSessionID($session_id) {
+    $this->sessionID = $session_id;
+    return $this;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/service/DriverCommandExecutor.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/service/DriverCommandExecutor.php
@@ -1,0 +1,57 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * A HttpCommandExecutor that talks to a local driver service instead of
+ * a remote server.
+ */
+class DriverCommandExecutor extends HttpCommandExecutor {
+
+  /**
+   * @var DriverService
+   */
+  private $service;
+
+  public function __construct(DriverService $service) {
+    parent::__construct($service->getURL());
+    $this->service = $service;
+  }
+
+  /**
+   * @param WebDriverCommand $command
+   * @param array $curl_opts
+   *
+   * @return mixed
+   */
+  public function execute(WebDriverCommand $command, $curl_opts = array()) {
+    if ($command->getName() === DriverCommand::NEW_SESSION) {
+      $this->service->start();
+    }
+
+    try {
+      $value = parent::execute($command, $curl_opts);
+      if ($command->getName() === DriverCommand::QUIT) {
+        $this->service->stop();
+      }
+      return $value;
+    } catch (Exception $e) {
+      if (!$this->service->isRunning()) {
+        throw new WebDriverException('The driver server has died.');
+      }
+      throw $e;
+    }
+  }
+
+}

--- a/tests/vendor/facebook/webdriver/lib/remote/service/DriverService.php
+++ b/tests/vendor/facebook/webdriver/lib/remote/service/DriverService.php
@@ -1,0 +1,142 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class DriverService {
+
+  /**
+   * @var string
+   */
+  private $executable;
+
+  /**
+   * @var string
+   */
+  private $url;
+
+  /**
+   * @var array
+   */
+  private $args;
+
+  /**
+   * @var array
+   */
+  private $environment;
+
+  /**
+   * @var resource
+   */
+  private $process;
+
+  /**
+   * @param string $executable
+   * @param int $port The given port the service should use.
+   * @param array $args
+   * @param array|null $environment Use the system environment if it is null
+   */
+  public function __construct(
+    $executable,
+    $port,
+    $args = array(),
+    $environment = null
+  ) {
+    $this->executable = self::checkExecutable($executable);
+    $this->url = sprintf('http://localhost:%d', $port);
+    $this->args = $args;
+    $this->environment = $environment ?: $_ENV;
+  }
+
+  /**
+   * @return string
+   */
+  public function getURL() {
+    return $this->url;
+  }
+
+  /**
+   * @return DriverService
+   */
+  public function start() {
+    if ($this->process !== null) {
+      return $this;
+    }
+
+    $pipes = array();
+    $this->process = proc_open(
+      sprintf("%s %s", $this->executable, implode(' ', $this->args)),
+      $descriptorspec = array(
+        0 => array('pipe', 'r'), // stdin
+        1 => array('pipe', 'w'), // stdout
+        2 => array('pipe', 'a'), // stderr
+      ),
+      $pipes,
+      null,
+      $this->environment
+    );
+
+    $checker = new URLChecker();
+    $checker->waitUntilAvailable(20 * 1000, $this->url.'/status');
+
+    return $this;
+  }
+
+  /**
+   * @return DriverService
+   */
+  public function stop() {
+    if ($this->process === null) {
+      return $this;
+    }
+
+    proc_terminate($this->process);
+    $this->process = null;
+
+    $checker = new URLChecker();
+    $checker->waitUntilUnAvailable(3 * 1000, $this->url.'/shutdown');
+
+    return $this;
+  }
+
+  /**
+   * @return bool
+   */
+  public function isRunning() {
+    if ($this->process === null) {
+      return false;
+    }
+
+    $status = proc_get_status($this->process);
+    return $status['running'];
+  }
+
+  /**
+   * Check if the executable is executable.
+   *
+   * @param string $executable
+   * @return string
+   * @throws Exception
+   */
+  protected static function checkExecutable($executable) {
+    if (!is_file($executable)) {
+      throw new Exception("'$executable' is not a file.");
+    }
+
+    if (!is_executable($executable)) {
+      throw new Exception("'$executable' is not executable.");
+    }
+
+    return $executable;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/support/events/EventFiringWebDriver.php
+++ b/tests/vendor/facebook/webdriver/lib/support/events/EventFiringWebDriver.php
@@ -1,0 +1,351 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class EventFiringWebDriver implements WebDriver, JavaScriptExecutor {
+
+  /**
+   * @var WebDriver
+   */
+  protected $driver;
+
+  /**
+   * @var WebDriverDispatcher
+   */
+  protected $dispatcher;
+
+  /**
+   * @param WebDriver $driver
+   * @param WebDriverDispatcher $dispatcher
+   */
+  public function __construct(WebDriver $driver,
+                              WebDriverDispatcher $dispatcher = null) {
+    $this->dispatcher = $dispatcher ?: new WebDriverDispatcher();
+    if (!$this->dispatcher->getDefaultDriver()) {
+      $this->dispatcher->setDefaultDriver($this);
+    }
+    $this->driver = $driver;
+    return $this;
+  }
+
+  /**
+   * @return WebDriverDispatcher
+   */
+  public function getDispatcher() {
+    return $this->dispatcher;
+  }
+
+  /**
+   * @param mixed $method
+   * @return void
+   */
+  protected function dispatch($method) {
+    if (!$this->dispatcher) {
+      return;
+    }
+
+    $arguments = func_get_args();
+    unset($arguments[0]);
+    $this->dispatcher->dispatch($method, $arguments);
+  }
+
+  /**
+   * @return WebDriver
+   */
+  public function getWebDriver() {
+    return $this->driver;
+  }
+
+  /**
+   * @param WebDriverElement $element
+   * @return EventFiringWebElement
+   */
+  private function newElement(WebDriverElement $element) {
+    return new EventFiringWebElement($element, $this->getDispatcher());
+  }
+
+  /**
+   * @param mixed $url
+   * @return $this
+   * @throws WebDriverException
+   */
+  public function get($url) {
+    $this->dispatch('beforeNavigateTo', $url, $this);
+    try {
+      $this->driver->get($url);
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+    $this->dispatch('afterNavigateTo', $url, $this);
+    return $this;
+  }
+
+  /**
+   * @param WebDriverBy $by
+   * @return array
+   * @throws WebDriverException
+   */
+  public function findElements(WebDriverBy $by) {
+    $this->dispatch('beforeFindBy', $by, null, $this);
+    try {
+      $elements = array();
+      foreach ($this->driver->findElements($by) as $element) {
+        $elements[] = $this->newElement($element);
+      }
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+    $this->dispatch('afterFindBy', $by, null, $this);
+    return $elements;
+
+  }
+
+  /**
+   * @param WebDriverBy $by
+   * @return EventFiringWebElement
+   * @throws WebDriverException
+   */
+  public function findElement(WebDriverBy $by) {
+    $this->dispatch('beforeFindBy', $by, null, $this);
+    try {
+      $element = $this->newElement($this->driver->findElement($by));
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+    $this->dispatch('afterFindBy', $by, null, $this);
+    return $element;
+  }
+
+  /**
+   * @param       $script
+   * @param array $arguments
+   * @return mixed
+   * @throws WebDriverException
+   */
+  public function executeScript($script, array $arguments = array()) {
+    if (!$this->driver instanceof JavaScriptExecutor) {
+      throw new UnsupportedOperationException(
+        'driver does not implement JavaScriptExecutor'
+      );
+    }
+
+    $this->dispatch('beforeScript', $script, $this);
+    try {
+      $result = $this->driver->executeScript($script, $arguments);
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+    $this->dispatch('afterScript', $script, $this);
+    return $result;
+  }
+
+  /**
+   * @param       $script
+   * @param array $arguments
+   * @return mixed
+   * @throws WebDriverException
+   */
+  public function executeAsyncScript($script, array $arguments = array()) {
+    if (!$this->driver instanceof JavaScriptExecutor) {
+      throw new UnsupportedOperationException(
+        'driver does not implement JavaScriptExecutor'
+      );
+    }
+
+    $this->dispatch('beforeScript', $script, $this);
+    try {
+      $result = $this->driver->executeAsyncScript($script, $arguments);
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+    $this->dispatch('afterScript', $script, $this);
+    return $result;
+  }
+
+  /**
+   * @return $this
+   * @throws WebDriverException
+   */
+  public function close() {
+    try {
+      $this->driver->close();
+      return $this;
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return string
+   * @throws WebDriverException
+   */
+  public function getCurrentURL() {
+    try {
+      return $this->driver->getCurrentURL();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return string
+   * @throws WebDriverException
+   */
+  public function getPageSource() {
+    try {
+      return $this->driver->getPageSource();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return string
+   * @throws WebDriverException
+   */
+  public function getTitle() {
+    try {
+      return $this->driver->getTitle();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return string
+   * @throws WebDriverException
+   */
+  public function getWindowHandle() {
+    try {
+      return $this->driver->getWindowHandle();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return array
+   * @throws WebDriverException
+   */
+  public function getWindowHandles() {
+    try {
+      return $this->driver->getWindowHandles();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @throws WebDriverException
+   */
+  public function quit() {
+    try {
+      $this->driver->quit();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @param null|string $save_as
+   * @return string
+   * @throws WebDriverException
+   */
+  public function takeScreenshot($save_as = null) {
+    try {
+      return $this->driver->takeScreenshot($save_as);
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @param int $timeout_in_second
+   * @param int $interval_in_millisecond
+   * @return WebDriverWait
+   * @throws WebDriverException
+   */
+  public function wait($timeout_in_second = 30,
+                       $interval_in_millisecond = 250) {
+    try {
+      return $this->driver->wait($timeout_in_second, $interval_in_millisecond);
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return WebDriverOptions
+   * @throws WebDriverException
+   */
+  public function manage() {
+    try {
+      return $this->driver->manage();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return EventFiringWebDriverNavigation
+   * @throws WebDriverException
+   */
+  public function navigate() {
+    try {
+      return new EventFiringWebDriverNavigation(
+        $this->driver->navigate(),
+        $this->getDispatcher()
+      );
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return WebDriverTargetLocator
+   * @throws WebDriverException
+   */
+  public function switchTo() {
+    try {
+      return $this->driver->switchTo();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return WebDriverTouchScreen
+   * @throws WebDriverException
+   */
+  public function getTouch() {
+    try {
+      return $this->driver->getTouch();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  private function dispatchOnException($exception) {
+    $this->dispatch('onException', $exception, $this);
+    throw $exception;
+  }
+
+  public function execute($name, $params) {
+    try {
+      return $this->driver->execute($name, $params);
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/support/events/EventFiringWebDriverNavigation.php
+++ b/tests/vendor/facebook/webdriver/lib/support/events/EventFiringWebDriverNavigation.php
@@ -1,0 +1,150 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class EventFiringWebDriverNavigation {
+
+  /**
+   * @var WebDriverNavigation
+   */
+  protected $navigator;
+
+  /**
+   * @var WebDriverDispatcher
+   */
+  protected $dispatcher;
+
+  /**
+   * @param WebDriverNavigation $navigator
+   * @param WebDriverDispatcher $dispatcher
+   */
+  public function __construct(WebDriverNavigation $navigator,
+                              WebDriverDispatcher $dispatcher) {
+    $this->navigator  = $navigator;
+    $this->dispatcher = $dispatcher;
+    return $this;
+  }
+
+  /**
+   * @return WebDriverDispatcher
+   */
+  public function getDispatcher() {
+    return $this->dispatcher;
+  }
+
+  /**
+   * @param mixed $method
+   * @return void
+   */
+  protected function dispatch($method) {
+    if (!$this->dispatcher) {
+      return;
+    }
+
+    $arguments = func_get_args();
+    unset($arguments[0]);
+    $this->dispatcher->dispatch($method, $arguments);
+  }
+
+  /**
+   * @return WebDriverNavigation
+   */
+  public function getNavigator() {
+    return $this->navigator;
+  }
+
+  /**
+   * @return $this
+   * @throws WebDriverException
+   */
+  public function back() {
+    $this->dispatch(
+      'beforeNavigateBack',
+      $this->getDispatcher()->getDefaultDriver()
+    );
+    try {
+      $this->navigator->back();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+    $this->dispatch(
+      'afterNavigateBack',
+      $this->getDispatcher()->getDefaultDriver()
+    );
+    return $this;
+  }
+
+  /**
+   * @return $this
+   * @throws WebDriverException
+   */
+  public function forward() {
+    $this->dispatch(
+      'beforeNavigateForward',
+      $this->getDispatcher()->getDefaultDriver()
+    );
+    try {
+      $this->navigator->forward();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+    $this->dispatch(
+      'afterNavigateForward',
+      $this->getDispatcher()->getDefaultDriver()
+    );
+    return $this;
+  }
+
+  /**
+   * @return $this
+   * @throws WebDriverException
+   */
+  public function refresh() {
+    try {
+      $this->navigator->refresh();
+      return $this;
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @param mixed $url
+   * @return $this
+   * @throws WebDriverException
+   */
+  public function to($url) {
+    $this->dispatch(
+      'beforeNavigateTo',
+      $url,
+      $this->getDispatcher()->getDefaultDriver()
+    );
+    try {
+      $this->navigator->to($url);
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+    $this->dispatch(
+      'afterNavigateTo',
+      $url,
+      $this->getDispatcher()->getDefaultDriver()
+    );
+    return $this;
+  }
+
+  private function dispatchOnException($exception) {
+    $this->dispatch('onException', $exception);
+    throw $exception;
+  }
+}

--- a/tests/vendor/facebook/webdriver/lib/support/events/EventFiringWebElement.php
+++ b/tests/vendor/facebook/webdriver/lib/support/events/EventFiringWebElement.php
@@ -1,0 +1,358 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class EventFiringWebElement implements WebDriverElement, WebDriverLocatable {
+
+  /**
+   * @var WebDriverElement
+   */
+  protected $element;
+
+  /**
+   * @var WebDriverDispatcher
+   */
+  protected $dispatcher;
+
+  /**
+   * @param WebDriverElement    $element
+   * @param WebDriverDispatcher $dispatcher
+   */
+  public function __construct(WebDriverElement $element,
+                              WebDriverDispatcher $dispatcher) {
+    $this->element = $element;
+    $this->dispatcher = $dispatcher;
+    return $this;
+  }
+
+  /**
+   * @return WebDriverDispatcher
+   */
+  public function getDispatcher() {
+    return $this->dispatcher;
+  }
+
+  /**
+   * @param mixed $method
+   * @return void
+   */
+  protected function dispatch($method) {
+    if (!$this->dispatcher) {
+      return;
+    }
+    $arguments = func_get_args();
+    unset($arguments[0]);
+    $this->dispatcher->dispatch($method, $arguments);
+  }
+
+  /**
+   * @return WebDriverElement
+   */
+  public function getElement() {
+    return $this->element;
+  }
+
+  /**
+   * @param WebDriverElement $element
+   * @return EventFiringWebElement
+   */
+  private function newElement(WebDriverElement $element) {
+    return new EventFiringWebElement($element, $this->getDispatcher());
+  }
+
+  /**
+   * @param mixed $value
+   * @return $this
+   * @throws WebDriverException
+   */
+  public function sendKeys($value) {
+
+    $this->dispatch('beforeChangeValueOf', $this);
+    try {
+      $this->element->sendKeys($value);
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+    $this->dispatch('afterChangeValueOf', $this);
+    return $this;
+
+  }
+
+  /**
+   * @return $this
+   * @throws WebDriverException
+   */
+  public function click() {
+    $this->dispatch('beforeClickOn', $this);
+    try {
+      $this->element->click();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+    $this->dispatch('afterClickOn', $this);
+    return $this;
+  }
+
+  /**
+   * @param WebDriverBy $by
+   * @return EventFiringWebElement
+   * @throws WebDriverException
+   */
+  public function findElement(WebDriverBy $by) {
+    $this->dispatch(
+      'beforeFindBy',
+      $by,
+      $this,
+      $this->dispatcher->getDefaultDriver());
+    try {
+      $element = $this->newElement($this->element->findElement($by));
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+    $this->dispatch(
+      'afterFindBy',
+      $by,
+      $this,
+      $this->dispatcher->getDefaultDriver()
+    );
+    return $element;
+  }
+
+  /**
+   * @param WebDriverBy $by
+   * @return array
+   * @throws WebDriverException
+   */
+  public function findElements(WebDriverBy $by) {
+    $this->dispatch(
+      'beforeFindBy',
+      $by,
+      $this,
+      $this->dispatcher->getDefaultDriver()
+    );
+    try {
+      $elements = array();
+      foreach ($this->element->findElements($by) as $element) {
+        $elements[] = $this->newElement($element);
+      }
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+    $this->dispatch(
+      'afterFindBy',
+      $by,
+      $this,
+      $this->dispatcher->getDefaultDriver()
+    );
+    return $elements;
+  }
+
+  /**
+   * @return $this
+   * @throws WebDriverException
+   */
+  public function clear() {
+    try {
+      $this->element->clear();
+      return $this;
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @param string $attribute_name
+   * @return string
+   * @throws WebDriverException
+   */
+  public function getAttribute($attribute_name) {
+    try {
+      return $this->element->getAttribute($attribute_name);
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @param string $css_property_name
+   * @return string
+   * @throws WebDriverException
+   */
+  public function getCSSValue($css_property_name) {
+    try {
+      return $this->element->getCSSValue($css_property_name);
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return WebDriverPoint
+   * @throws WebDriverException
+   */
+  public function getLocation() {
+    try {
+      return $this->element->getLocation();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return WebDriverPoint
+   * @throws WebDriverException
+   */
+  public function getLocationOnScreenOnceScrolledIntoView() {
+    try {
+      return $this->element->getLocationOnScreenOnceScrolledIntoView();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return WebDriverCoordinates
+   */
+  public function getCoordinates() {
+    try {
+      return $this->element->getCoordinates();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+
+  /**
+   * @return WebDriverDimension
+   * @throws WebDriverException
+   */
+  public function getSize() {
+    try {
+      return $this->element->getSize();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return string
+   * @throws WebDriverException
+   */
+  public function getTagName() {
+    try {
+      return $this->element->getTagName();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return string
+   * @throws WebDriverException
+   */
+  public function getText() {
+    try {
+      return $this->element->getText();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return bool
+   * @throws WebDriverException
+   */
+  public function isDisplayed() {
+    try {
+      return $this->element->isDisplayed();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return bool
+   * @throws WebDriverException
+   */
+  public function isEnabled() {
+    try {
+      return $this->element->isEnabled();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return bool
+   * @throws WebDriverException
+   */
+  public function isSelected() {
+    try {
+      return $this->element->isSelected();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return $this
+   * @throws WebDriverException
+   */
+  public function submit() {
+    try {
+      $this->element->submit();
+      return $this;
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  /**
+   * @return string
+   * @throws WebDriverException
+   */
+  public function getID() {
+    try {
+      return $this->element->getID();
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+
+  /**
+   * Test if two element IDs refer to the same DOM element.
+   *
+   * @param WebDriverElement $other
+   * @return bool
+   */
+  public function equals(WebDriverElement $other) {
+    try {
+      return $this->element->equals($other);
+    } catch (WebDriverException $exception) {
+      $this->dispatchOnException($exception);
+    }
+  }
+
+  private function dispatchOnException($exception) {
+    $this->dispatch(
+      'onException',
+      $exception,
+      $this->dispatcher->getDefaultDriver()
+    );
+    throw $exception;
+  }
+
+
+}

--- a/tests/vendor/facebook/webdriver/tests/bootstrap.php
+++ b/tests/vendor/facebook/webdriver/tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+require_once __DIR__ . '/../lib/__init__.php';
+require_once __DIR__ . '/functional/WebDriverTestCase.php';

--- a/tests/vendor/facebook/webdriver/tests/functional/BaseTest.php
+++ b/tests/vendor/facebook/webdriver/tests/functional/BaseTest.php
@@ -1,0 +1,97 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class BaseTest extends WebDriverTestCase {
+  
+  public function testGetTitle() {
+    $this->driver->get($this->getTestPath('index.html'));
+    self::assertEquals(
+      'php-webdriver test page',
+      $this->driver->getTitle()
+    );
+  }
+  
+  public function testGetText() {
+    $this->driver->get($this->getTestPath('index.html'));
+    self::assertEquals(
+      'Welcome to the facebook/php-webdriver testing page.',
+      $this->driver->findElement(WebDriverBy::id('welcome'))->getText()
+    );
+  }
+
+  public function testGetById() {
+    $this->driver->get($this->getTestPath('index.html'));
+    self::assertEquals(
+      'Test by ID',
+      $this->driver->findElement(WebDriverBy::id('id_test'))->getText()
+    );
+  }
+
+  public function testGetByClassName() {
+    $this->driver->get($this->getTestPath('index.html'));
+    self::assertEquals(
+      'Test by Class',
+      $this->driver->findElement(WebDriverBy::className('test_class'))->getText()
+    );
+  }
+
+  public function testGetByCssSelector() {
+    $this->driver->get($this->getTestPath('index.html'));
+    self::assertEquals(
+     'Test by Class',
+     $this->driver->findElement(WebDriverBy::cssSelector('.test_class'))->getText()
+    );
+  }
+
+  public function testGetByLinkText() {
+    $this->driver->get($this->getTestPath('index.html'));
+    self::assertEquals(
+      'Click here',
+      $this->driver->findElement(WebDriverBy::linkText('Click here'))->getText()
+    );
+  }
+
+  public function testGetByName() {
+    $this->driver->get($this->getTestPath('index.html'));
+    self::assertEquals(
+      'Test Value',
+      $this->driver->findElement(WebDriverBy::name('test_name'))->getAttribute('value')
+    );
+  }
+
+  public function testGetByXpath() {
+    $this->driver->get($this->getTestPath('index.html'));
+    self::assertEquals(
+      'Test Value',
+      $this->driver->findElement(WebDriverBy::xpath('//input[@name="test_name"]'))->getAttribute('value')
+    );
+  }
+
+  public function testGetByPartialLinkText() {
+    $this->driver->get($this->getTestPath('index.html'));
+    self::assertEquals(
+      'Click here',
+      $this->driver->findElement(WebDriverBy::partialLinkText('Click'))->getText()
+    );
+  }
+
+  public function testGetByTagName() {
+    $this->driver->get($this->getTestPath('index.html'));
+    self::assertEquals(
+      'Test Value',
+      $this->driver->findElement(WebDriverBy::tagName('input'))->getAttribute('value')
+    );
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/functional/FileUploadTest.php
+++ b/tests/vendor/facebook/webdriver/tests/functional/FileUploadTest.php
@@ -1,0 +1,42 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * An example test case for php-webdriver.
+ * 
+ * Try running it by 
+ *   '../vendor/phpunit/phpunit/phpunit.php ExampleTestCase.php'
+ */
+class FileUploadTest extends WebDriverTestCase {
+  
+  public function testFileUploading() {
+    $this->driver->get($this->getTestPath('upload.html'));
+    $file_input = $this->driver->findElement(WebDriverBy::id('upload'));
+    $file_input->setFileDetector(new LocalFileDetector())
+               ->sendKeys(__DIR__ . '/files/FileUploadTestCaseFile.txt');
+    self::assertNotEquals($this->getFilePath(), $file_input->getAttribute('value'));
+  }
+
+  public function testUselessFileDetectorSendKeys() {
+    $this->driver->get($this->getTestPath('upload.html'));
+    $file_input = $this->driver->findElement(WebDriverBy::id('upload'));
+    $file_input->sendKeys($this->getFilePath());
+    self::assertEquals($this->getFilePath(), $file_input->getAttribute('value'));
+  }
+  
+  private function getFilePath() {
+    return __DIR__ . '/files/FileUploadTestCaseFile.txt';
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/functional/WebDriverTestCase.php
+++ b/tests/vendor/facebook/webdriver/tests/functional/WebDriverTestCase.php
@@ -1,0 +1,48 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The base class for test cases.
+ */
+class WebDriverTestCase extends PHPUnit_Framework_TestCase {
+
+  /** @var RemoteWebDriver $driver */
+  protected $driver;
+
+  protected function setUp() {
+    $this->driver = RemoteWebDriver::create(
+      'http://localhost:4444/wd/hub',
+      array(
+        WebDriverCapabilityType::BROWSER_NAME
+          //=> WebDriverBrowserType::FIREFOX,
+          => WebDriverBrowserType::HTMLUNIT,
+      )
+    );
+  }
+  
+  protected function tearDown() {
+    $this->driver->quit();
+  }
+
+  /**
+   * Get the URL of the test html.
+   *
+   * @param $path
+   * @return string
+   */
+  protected function getTestPath($path) {
+    return 'file:///'.dirname(__FILE__).'/html/'.$path;
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/functional/files/FileUploadTestCaseFile.txt
+++ b/tests/vendor/facebook/webdriver/tests/functional/files/FileUploadTestCaseFile.txt
@@ -1,0 +1,1 @@
+text file

--- a/tests/vendor/facebook/webdriver/tests/functional/html/index.html
+++ b/tests/vendor/facebook/webdriver/tests/functional/html/index.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <title>php-webdriver test page</title>
+</head>
+<body>
+  <h1 id='welcome'>Welcome to the facebook/php-webdriver testing page.</h1>
+  <p id="id_test">Test by ID</p>
+  <p class="test_class">Test by Class</p>
+  <a href="#">Click here</a>
+  <input type="text" name="test_name" value="Test Value" />
+</body>
+</html>

--- a/tests/vendor/facebook/webdriver/tests/functional/html/upload.html
+++ b/tests/vendor/facebook/webdriver/tests/functional/html/upload.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+  <title>Upload a file</title>
+</head>
+<body>
+  <form method="post" enctype="multipart/form-data">
+    <input type="file" id="upload"></input>
+  </form>
+</body>
+</html>

--- a/tests/vendor/facebook/webdriver/tests/phpunit.xml
+++ b/tests/vendor/facebook/webdriver/tests/phpunit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        backupGlobals               = "false"
+        backupStaticAttributes      = "false"
+        colors                      = "true"
+        convertErrorsToExceptions   = "true"
+        convertNoticesToExceptions  = "true"
+        convertWarningsToExceptions = "true"
+        processIsolation            = "false"
+        stopOnFailure               = "false"
+        syntaxCheck                 = "false"
+        bootstrap                   = "bootstrap.php" >
+
+    <testsuites>
+        <testsuite name="Facebook PHP-Webdriver Unit Testsuite">
+            <directory>./unit</directory>
+        </testsuite>
+        <testsuite name="Facebook PHP-Webdriver Functional Testsuite">
+            <directory>./functional</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>

--- a/tests/vendor/facebook/webdriver/tests/unit/bootstrap.php
+++ b/tests/vendor/facebook/webdriver/tests/unit/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../../lib/__init__.php';

--- a/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverButtonReleaseActionTest.php
+++ b/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverButtonReleaseActionTest.php
@@ -1,0 +1,40 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverButtonReleaseActionTest extends PHPUnit_Framework_TestCase {
+  /**
+   * @type WebDriverButtonReleaseAction
+   */
+  private $webDriverButtonReleaseAction;
+
+  private $webDriverMouse;
+  private $locationProvider;
+
+  public function setUp() {
+    $this->webDriverMouse = $this->getMock('WebDriverMouse');
+    $this->locationProvider = $this->getMock('WebDriverLocatable');
+    $this->webDriverButtonReleaseAction = new WebDriverButtonReleaseAction(
+      $this->webDriverMouse,
+      $this->locationProvider
+    );
+  }
+
+  public function testPerformSendsMouseUpCommand() {
+    $coords = $this->getMockBuilder('WebDriverCoordinates')->disableOriginalConstructor()->getMock();
+    $this->webDriverMouse->expects($this->once())->method('mouseUp')->with($coords);
+    $this->locationProvider->expects($this->once())->method('getCoordinates')->will($this->returnValue($coords));
+    $this->webDriverButtonReleaseAction->perform();
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverClickActionTest.php
+++ b/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverClickActionTest.php
@@ -1,0 +1,40 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverClickActionTest extends PHPUnit_Framework_TestCase {
+  /**
+   * @type WebDriverClickAction
+   */
+  private $webDriverClickAction;
+
+  private $webDriverMouse;
+  private $locationProvider;
+
+  public function setUp() {
+    $this->webDriverMouse = $this->getMock('WebDriverMouse');
+    $this->locationProvider = $this->getMock('WebDriverLocatable');
+    $this->webDriverClickAction = new WebDriverClickAction(
+      $this->webDriverMouse,
+      $this->locationProvider
+    );
+  }
+
+  public function testPerformSendsClickCommand() {
+    $coords = $this->getMockBuilder('WebDriverCoordinates')->disableOriginalConstructor()->getMock();
+    $this->webDriverMouse->expects($this->once())->method('click')->with($coords);
+    $this->locationProvider->expects($this->once())->method('getCoordinates')->will($this->returnValue($coords));
+    $this->webDriverClickAction->perform();
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverClickAndHoldActionTest.php
+++ b/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverClickAndHoldActionTest.php
@@ -1,0 +1,40 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverClickAndHoldActionTest extends PHPUnit_Framework_TestCase {
+  /**
+   * @type WebDriverClickAndHoldAction
+   */
+  private $webDriverClickAndHoldAction;
+
+  private $webDriverMouse;
+  private $locationProvider;
+
+  public function setUp() {
+    $this->webDriverMouse = $this->getMock('WebDriverMouse');
+    $this->locationProvider = $this->getMock('WebDriverLocatable');
+    $this->webDriverClickAndHoldAction = new WebDriverClickAndHoldAction(
+      $this->webDriverMouse,
+      $this->locationProvider
+    );
+  }
+
+  public function testPerformSendsMouseDownCommand() {
+    $coords = $this->getMockBuilder('WebDriverCoordinates')->disableOriginalConstructor()->getMock();
+    $this->webDriverMouse->expects($this->once())->method('mouseDown')->with($coords);
+    $this->locationProvider->expects($this->once())->method('getCoordinates')->will($this->returnValue($coords));
+    $this->webDriverClickAndHoldAction->perform();
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverContextClickActionTest.php
+++ b/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverContextClickActionTest.php
@@ -1,0 +1,40 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverContextClickActionTest extends PHPUnit_Framework_TestCase {
+  /**
+   * @type WebDriverContextClickAction
+   */
+  private $webDriverContextClickAction;
+
+  private $webDriverMouse;
+  private $locationProvider;
+
+  public function setUp() {
+    $this->webDriverMouse = $this->getMock('WebDriverMouse');
+    $this->locationProvider = $this->getMock('WebDriverLocatable');
+    $this->webDriverContextClickAction = new WebDriverContextClickAction(
+      $this->webDriverMouse,
+      $this->locationProvider
+    );
+  }
+
+  public function testPerformSendsContextClickCommand() {
+    $coords = $this->getMockBuilder('WebDriverCoordinates')->disableOriginalConstructor()->getMock();
+    $this->webDriverMouse->expects($this->once())->method('contextClick')->with($coords);
+    $this->locationProvider->expects($this->once())->method('getCoordinates')->will($this->returnValue($coords));
+    $this->webDriverContextClickAction->perform();
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverCoordinatesTest.php
+++ b/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverCoordinatesTest.php
@@ -1,0 +1,38 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverCoordinatesTest extends PHPUnit_Framework_TestCase {
+  public function testConstruct() {
+    $in_view_port = function() { };
+    $on_page = function() { };
+
+    $webDriverCoordinates = new WebDriverCoordinates(null, $in_view_port, $on_page, 'auxiliary');
+
+    self::assertAttributeEquals(null, 'onScreen', $webDriverCoordinates);
+    self::assertAttributeEquals($in_view_port, 'inViewPort', $webDriverCoordinates);
+    self::assertAttributeEquals($on_page, 'onPage', $webDriverCoordinates);
+    self::assertAttributeEquals('auxiliary', 'auxiliary', $webDriverCoordinates);
+  }
+
+  public function testGetAuxiliary()
+  {
+    $in_view_port = function() { };
+    $on_page = function() { };
+
+    $webDriverCoordinates = new WebDriverCoordinates(null, $in_view_port, $on_page, 'auxiliary');
+
+    self::assertEquals('auxiliary', $webDriverCoordinates->getAuxiliary());
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverDoubleClickActionTest.php
+++ b/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverDoubleClickActionTest.php
@@ -1,0 +1,40 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverDoubleClickActionTest extends PHPUnit_Framework_TestCase {
+  /**
+   * @type WebDriverDoubleClickAction
+   */
+  private $webDriverDoubleClickAction;
+
+  private $webDriverMouse;
+  private $locationProvider;
+
+  public function setUp() {
+    $this->webDriverMouse = $this->getMock('WebDriverMouse');
+    $this->locationProvider = $this->getMock('WebDriverLocatable');
+    $this->webDriverDoubleClickAction = new WebDriverDoubleClickAction(
+      $this->webDriverMouse,
+      $this->locationProvider
+    );
+  }
+
+  public function testPerformSendsDoubleClickCommand() {
+    $coords = $this->getMockBuilder('WebDriverCoordinates')->disableOriginalConstructor()->getMock();
+    $this->webDriverMouse->expects($this->once())->method('doubleClick')->with($coords);
+    $this->locationProvider->expects($this->once())->method('getCoordinates')->will($this->returnValue($coords));
+    $this->webDriverDoubleClickAction->perform();
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverKeyDownActionTest.php
+++ b/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverKeyDownActionTest.php
@@ -1,0 +1,44 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverKeyDownActionTest extends PHPUnit_Framework_TestCase {
+  /**
+   * @type WebDriverKeyDownAction
+   */
+  private $webDriverKeyDownAction;
+
+  private $webDriverKeyboard;
+  private $webDriverMouse;
+  private $locationProvider;
+
+  public function setUp() {
+    $this->webDriverKeyboard = $this->getMock('WebDriverKeyboard');
+    $this->webDriverMouse = $this->getMock('WebDriverMouse');
+    $this->locationProvider = $this->getMock('WebDriverLocatable');
+    $this->webDriverKeyDownAction = new WebDriverKeyDownAction(
+      $this->webDriverKeyboard,
+      $this->webDriverMouse,
+      $this->locationProvider
+    );
+  }
+
+  public function testPerformFocusesOnElementAndSendPressKeyCommand() {
+    $coords = $this->getMockBuilder('WebDriverCoordinates')->disableOriginalConstructor()->getMock();
+    $this->webDriverMouse->expects($this->once())->method('click')->with($coords);
+    $this->locationProvider->expects($this->once())->method('getCoordinates')->will($this->returnValue($coords));
+    $this->webDriverKeyboard->expects($this->once())->method('pressKey');
+    $this->webDriverKeyDownAction->perform();
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverKeyUpActionTest.php
+++ b/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverKeyUpActionTest.php
@@ -1,0 +1,45 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverKeyUpActionTest extends PHPUnit_Framework_TestCase {
+  /**
+   * @type WebDriverKeyUpAction
+   */
+  private $webDriverKeyUpAction;
+
+  private $webDriverKeyboard;
+  private $webDriverMouse;
+  private $locationProvider;
+
+  public function setUp() {
+    $this->webDriverKeyboard = $this->getMock('WebDriverKeyboard');
+    $this->webDriverMouse = $this->getMock('WebDriverMouse');
+    $this->locationProvider = $this->getMock('WebDriverLocatable');
+    $this->webDriverKeyUpAction = new WebDriverKeyUpAction(
+      $this->webDriverKeyboard,
+      $this->webDriverMouse,
+      $this->locationProvider,
+      'a'
+    );
+  }
+
+  public function testPerformFocusesOnElementAndSendPressKeyCommand() {
+    $coords = $this->getMockBuilder('WebDriverCoordinates')->disableOriginalConstructor()->getMock();
+    $this->webDriverMouse->expects($this->once())->method('click')->with($coords);
+    $this->locationProvider->expects($this->once())->method('getCoordinates')->will($this->returnValue($coords));
+    $this->webDriverKeyboard->expects($this->once())->method('releaseKey')->with('a');
+    $this->webDriverKeyUpAction->perform();
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverMouseMoveActionTest.php
+++ b/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverMouseMoveActionTest.php
@@ -1,0 +1,40 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverMouseMoveActionTest extends PHPUnit_Framework_TestCase {
+  /**
+   * @type WebDriverMouseMoveAction
+   */
+  private $webDriverMouseMoveAction;
+
+  private $webDriverMouse;
+  private $locationProvider;
+
+  public function setUp() {
+    $this->webDriverMouse = $this->getMock('WebDriverMouse');
+    $this->locationProvider = $this->getMock('WebDriverLocatable');
+    $this->webDriverMouseMoveAction = new WebDriverMouseMoveAction(
+      $this->webDriverMouse,
+      $this->locationProvider
+    );
+  }
+
+  public function testPerformFocusesOnElementAndSendPressKeyCommand() {
+    $coords = $this->getMockBuilder('WebDriverCoordinates')->disableOriginalConstructor()->getMock();
+    $this->webDriverMouse->expects($this->once())->method('mouseMove')->with($coords);
+    $this->locationProvider->expects($this->once())->method('getCoordinates')->will($this->returnValue($coords));
+    $this->webDriverMouseMoveAction->perform();
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverMouseToOffsetActionTest.php
+++ b/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverMouseToOffsetActionTest.php
@@ -1,0 +1,42 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverMouseToOffsetActionTest extends PHPUnit_Framework_TestCase {
+  /**
+   * @type WebDriverMoveToOffsetAction
+   */
+  private $webDriverMoveToOffsetAction;
+
+  private $webDriverMouse;
+  private $locationProvider;
+
+  public function setUp() {
+    $this->webDriverMouse = $this->getMock('WebDriverMouse');
+    $this->locationProvider = $this->getMock('WebDriverLocatable');
+    $this->webDriverMoveToOffsetAction = new WebDriverMoveToOffsetAction(
+      $this->webDriverMouse,
+      $this->locationProvider,
+      150,
+      200
+    );
+  }
+
+  public function testPerformFocusesOnElementAndSendPressKeyCommand() {
+    $coords = $this->getMockBuilder('WebDriverCoordinates')->disableOriginalConstructor()->getMock();
+    $this->webDriverMouse->expects($this->once())->method('mouseMove')->with($coords, 150, 200);
+    $this->locationProvider->expects($this->once())->method('getCoordinates')->will($this->returnValue($coords));
+    $this->webDriverMoveToOffsetAction->perform();
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverSendKeysActionTest.php
+++ b/tests/vendor/facebook/webdriver/tests/unit/interactions/internal/WebDriverSendKeysActionTest.php
@@ -1,0 +1,47 @@
+<?php
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class WebDriverSendKeysActionTest extends PHPUnit_Framework_TestCase {
+  /**
+   * @type WebDriverSendKeysAction
+   */
+  private $webDriverSendKeysAction;
+
+  private $webDriverKeyboard;
+  private $webDriverMouse;
+  private $locationProvider;
+  private $keys;
+
+  public function setUp() {
+    $this->webDriverKeyboard = $this->getMock('WebDriverKeyboard');
+    $this->webDriverMouse = $this->getMock('WebDriverMouse');
+    $this->locationProvider = $this->getMock('WebDriverLocatable');
+    $this->keys = array('t', 'e', 's', 't');
+    $this->webDriverSendKeysAction = new WebDriverSendKeysAction(
+      $this->webDriverKeyboard,
+      $this->webDriverMouse,
+      $this->locationProvider,
+      $this->keys
+    );
+  }
+
+  public function testPerformFocusesOnElementAndSendPressKeyCommand() {
+    $coords = $this->getMockBuilder('WebDriverCoordinates')->disableOriginalConstructor()->getMock();
+    $this->webDriverKeyboard->expects($this->once())->method('sendKeys')->with($this->keys);
+    $this->webDriverMouse->expects($this->once())->method('click')->with($coords);
+    $this->locationProvider->expects($this->once())->method('getCoordinates')->will($this->returnValue($coords));
+    $this->webDriverSendKeysAction->perform();
+  }
+}

--- a/tests/vendor/facebook/webdriver/tests/unit/phpunit.xml
+++ b/tests/vendor/facebook/webdriver/tests/unit/phpunit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        backupGlobals               = "false"
+        backupStaticAttributes      = "false"
+        colors                      = "true"
+        convertErrorsToExceptions   = "true"
+        convertNoticesToExceptions  = "true"
+        convertWarningsToExceptions = "true"
+        processIsolation            = "false"
+        stopOnFailure               = "false"
+        syntaxCheck                 = "false"
+        bootstrap                   = "bootstrap.php" >
+
+    <testsuites>
+        <testsuite name="Facebook PHP-Webdriver Unit Testsuite">
+            <directory>../unit</directory>
+        </testsuite>
+    </testsuites>
+
+</phpunit>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
This is a set-up for frontend test via [selenium](http://seleniumhq.org). The builds are run on travis-ci.org and it triggers selenium tests on [sauce labs]( http://saucelabs.com/)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#27055 (Proposal to run selenium tests)
#26975 (PR that is not covered by tests, but can be covered by selenium tests)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some bugs are hard to catch with karma & PHPUnit tests. Primarily this are front-end bugs. This PR implements end-to-end testing environment run on real browsers. Currently only Chrome browser is used, but it can be extended to multiple browsers/platforms including mobile browsers.
Currently my own sauce-labs account is used. Of course it would be good that a oC account would be used in future.

### run this tests locally
- download Selenium standalone server jar from http://docs.seleniumhq.org/download/
- download the chromedriver from: https://sites.google.com/a/chromium.org/chromedriver/ and place it in the same folder as the selenium server
- start selenium:` java -jar selenium-server-standalone-3.0.1.jar`
- set the 3 environment variables: `SRV_HOST_NAME, SRV_HOST_URL and SRV_HOST_PORT` e.g.:
```
export SRV_HOST_NAME=localhost
export SRV_HOST_URL=owncloud-core
export SRV_HOST_PORT=80
```
- if no webserver is already running start php development server with: `bash tests/travis/start_php_dev_server.sh`
it will bind to:` $SRV_HOST_NAME:$SRV_HOST_PORT`
- run tests: `phpunit --configuration tests/phpunit-selenium-autotest.xml
`
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've joined travis with my own account on [sauce labs]( http://saucelabs.com/) and run multiple tests. Created bugs and run tests again to see if they are failing.

## Screenshots (if appropriate):
Examples of travis jobs: 
https://travis-ci.org/individual-it/owncloud-core/jobs/196827720
https://travis-ci.org/individual-it/owncloud-core/jobs/196571894

Sauce-Labs view:
![sauce-lab](https://cloud.githubusercontent.com/assets/2425577/22452056/971709be-e79b-11e6-8803-98318742b77d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

