### PR TITLE
[Stable8.2] Check if color exists in palette before using it

### DIFF
--- a/lib/private/image.php
+++ b/lib/private/image.php
@@ -735,12 +735,12 @@ class OC_Image implements \OCP\IImage {
 						break;
 					case 8:
 						$color = @unpack('n', $vide . substr($data, $p, 1));
-						$color[1] = $palette[$color[1] + 1];
+						$color[1] = (isset($palette[$color[1] + 1])) ? $palette[$color[1] + 1] : $palette[1];
 						break;
 					case 4:
 						$color = @unpack('n', $vide . substr($data, floor($p), 1));
 						$color[1] = ($p * 2) % 2 == 0 ? $color[1] >> 4 : $color[1] & 0x0F;
-						$color[1] = $palette[$color[1] + 1];
+						$color[1] = (isset($palette[$color[1] + 1])) ? $palette[$color[1] + 1] : $palette[1];
 						break;
 					case 1:
 						$color = @unpack('n', $vide . substr($data, floor($p), 1));
@@ -770,7 +770,7 @@ class OC_Image implements \OCP\IImage {
 								$color[1] = ($color[1] & 0x1);
 								break;
 						}
-						$color[1] = $palette[$color[1] + 1];
+						$color[1] = (isset($palette[$color[1] + 1])) ? $palette[$color[1] + 1] : $palette[1];
 						break;
 					default:
 						fclose($fh);


### PR DESCRIPTION
## Description
If there is a reference to non-existing color use first color instead it

## Related Issue
#27044

## Motivation and Context
Clear log file

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
