### PR TITLE
cache loadUser if not exists

### DIFF
--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -80,9 +80,12 @@ class Database extends Backend implements IUserBackend {
 	public function createUser($uid, $password) {
 		unset($this->cache[$uid]); // make sure we are reading from the db
 		if (!$this->userExists($uid)) {
-			unset($this->cache[$uid]); // invalidate non existing user in cache
 			$query = \OC_DB::prepare('INSERT INTO `*PREFIX*users` ( `uid`, `password` ) VALUES( ?, ? )');
 			$result = $query->execute([$uid, \OC::$server->getHasher()->hash($password)]);
+
+			if ($result) {
+				unset($this->cache[$uid]); // invalidate non existing user in cache
+			}
 
 			return $result ? true : false;
 		}

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -220,9 +220,10 @@ class Database extends Backend implements IUserBackend {
 	/**
 	 * Load an user in the cache
 	 * @param string $uid the username
-	 * @return boolean
+	 * @return boolean true if user was found, false otherwise
 	 */
 	private function loadUser($uid) {
+		// if not in cache (false is a valid value)
 		if (!isset($this->cache[$uid]) && $this->cache[$uid] !== false) {
 			$query = \OC_DB::prepare('SELECT `uid`, `displayname` FROM `*PREFIX*users` WHERE LOWER(`uid`) = LOWER(?)');
 			$result = $query->execute([$uid]);
@@ -237,6 +238,7 @@ class Database extends Backend implements IUserBackend {
 				$this->cache[$uid]['displayname'] = $row['displayname'];
 			} else {
 			    $this->cache[$uid] = false;
+				return false;
 			}
 		}
 

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -207,8 +207,8 @@ class Database extends Backend implements IUserBackend {
 			if(\OC::$server->getHasher()->verify($password, $storedHash, $newHash)) {
 				if(!empty($newHash)) {
 					$this->setPassword($uid, $password);
+					unset($this->cache[$uid]); // invalidate cache
 				}
-				unset($this->cache[$uid]); // invalidate cache
 				return $row['uid'];
 			}
 
@@ -233,13 +233,15 @@ class Database extends Backend implements IUserBackend {
 				return false;
 			}
 
+			// "uid" is primary key, so there can only be a single result
 			if ($row = $result->fetchRow()) {
 				$this->cache[$uid]['uid'] = $row['uid'];
 				$this->cache[$uid]['displayname'] = $row['displayname'];
 			} else {
-			    $this->cache[$uid] = false;
+				$this->cache[$uid] = false;
 				return false;
 			}
+			$result->closeCursor();
 		}
 
 		return true;

--- a/tests/lib/User/DatabaseTest.php
+++ b/tests/lib/User/DatabaseTest.php
@@ -51,4 +51,21 @@ class DatabaseTest extends BackendTestCase {
 		}
 		parent::tearDown();
 	}
+
+	public function testCreateUserInvalidatesCache() {
+		$user1 = $this->getUniqueID('test_');
+		$this->assertFalse($this->backend->userExists($user1));
+		$this->backend->createUser($user1, 'pw');
+		$this->assertTrue($this->backend->userExists($user1));
+	}
+
+	public function testDeleteUserInvalidatesCache() {
+		$user1 = $this->getUniqueID('test_');
+		$this->backend->createUser($user1, 'pw');
+		$this->assertTrue($this->backend->userExists($user1));
+		$this->backend->deleteUser($user1);
+		$this->assertFalse($this->backend->userExists($user1));
+		$this->backend->createUser($user1, 'pw2');
+		$this->assertTrue($this->backend->userExists($user1));
+	}
 }


### PR DESCRIPTION
## TL;dr

This PR caches a non existing user in the DB, killing ~30 queries on every request when an ldap user logs in.

## Long version

user_ldap (type authentication) depends upon the AvatarManager, which in turn triggers a setupfs(), which in turn pulls in all apps of type 'filesystem' (activity, dav, files, files_sharing, files_trashbin and files_versions. Probably objectstore, search_elastic / search_lucene and whatever app has type filesystem).

Loading an app causes the I10n to be initialized whenever \OC::$server->getL10N() is used in the app.php directly or if it is a dependency of the other classes used when enabling the app.

L10N tries to get the user object which somewhere calls userExists() ... aaaand that is why for every request we do ~30 ` SELECT "uid", "displayname" FROM "oc_users" WHERE LOWER("uid") = LOWER(?)` queries. when loading the user_ldap app only user_database is enabled and since a non existing user is not cached the userExists check is constantly walking to the db ...

There are probably other things doing a userExists check, but L10N is the most frequent. 

@DeepDiver1975 I don't know if the user backend loading order may be the cause for the mixed UI languages issue you were investigating. It sure smells like it.

Yes, this only removes a symptom of the mess described above. Maybe this is no longer an issue whan the user table has been merged. I don't know. Looking at the app loading made my head hurt because we are constantly calling \OC_App::registerAutoloading()  for apps that don't even match the type https://github.com/owncloud/core/blob/fe1806c5a7f09a9c6cf6669cdce7986b1df9231d/lib/private/legacy/app.php#L108-L114. And then we are calling it again when loading the app: https://github.com/owncloud/core/blob/fe1806c5a7f09a9c6cf6669cdce7986b1df9231d/lib/private/legacy/app.php#L143-L143 :hankey: 

cc @PhilippSchaffrath 