### PR TITLE
[stable9] Integration test check download without saving file locally

### DIFF
--- a/build/integration/features/bootstrap/Sharing.php
+++ b/build/integration/features/bootstrap/Sharing.php
@@ -73,21 +73,13 @@ trait Sharing {
 			$url = $this->lastShareData->data->url;
 		}
 		$fullUrl = $url . "/download";
-		$options['save_to'] = "./$filename";
-		$this->response = $client->get($fullUrl, $options);
-		$finfo = new finfo;
-		$fileinfo = $finfo->file("./$filename", FILEINFO_MIME_TYPE);
-		PHPUnit_Framework_Assert::assertEquals($fileinfo, "text/plain");
-		if (file_exists("./$filename")) {
-			unlink("./$filename");
-		}
+		$this->checkDownload($fullUrl, null, 'text/plain');
 	}
 
 	/**
 	 * @Then /^Public shared file "([^"]*)" with password "([^"]*)" can be downloaded$/
 	 */
 	public function checkPublicSharedFileWithPassword($filename, $password) {
-		$client = new Client();
 		$options = [];
 		if (count($this->lastShareData->data->element) > 0){
 			$token = $this->lastShareData->data[0]->token;
@@ -97,14 +89,30 @@ trait Sharing {
 		}
 
 		$fullUrl = substr($this->baseUrl, 0, -4) . "public.php/webdav";
-		$options['auth'] = [$token, $password];
-		$options['save_to'] = "./$filename";
-		$this->response = $client->get($fullUrl, $options);
-		$finfo = new finfo;
-		$fileinfo = $finfo->file("./$filename", FILEINFO_MIME_TYPE);
-		PHPUnit_Framework_Assert::assertEquals($fileinfo, "text/plain");
-		if (file_exists("./$filename")) {
-			unlink("./$filename");
+		$this->checkDownload($fullUrl, [$token, $password], 'text/plain');
+	}
+
+	private function checkDownload($url, $auth = null, $mimeType = null) {
+		if ($auth !== null) {
+			$options['auth'] = $auth;
+		}
+		$options['stream'] = true;
+
+		$client = new Client();
+		$this->response = $client->get($url, $options);
+		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+
+		$buf = '';
+		$body = $this->response->getBody();
+		while (!$body->eof()) {
+			// read everything
+			$buf .= $body->read(8192);
+		}
+		$body->close();
+
+		if ($mimeType !== null) {
+			$finfo = new finfo;
+			PHPUnit_Framework_Assert::assertEquals($mimeType, $finfo->buffer($buf, FILEINFO_MIME_TYPE));
 		}
 	}
 


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/27008 to stable9