### PR TITLE
Replace @since 9.2 with @since 10.0

### DIFF
--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -727,7 +727,7 @@
 		/**
 		 * Returns the dav.Client instance used internally
 		 *
-		 * @since 9.2
+		 * @since 10.0
 		 * @return {dav.Client}
 		 */
 		getClient: function() {
@@ -737,7 +737,7 @@
 		/**
 		 * Returns the user name
 		 *
-		 * @since 9.2
+		 * @since 10.0
 		 * @return {String} userName
 		 */
 		getUserName: function() {
@@ -747,7 +747,7 @@
 		/**
 		 * Returns the password
 		 *
-		 * @since 9.2
+		 * @since 10.0
 		 * @return {String} password
 		 */
 		getPassword: function() {
@@ -757,7 +757,7 @@
 		/**
 		 * Returns the base URL
 		 *
-		 * @since 9.2
+		 * @since 10.0
 		 * @return {String} base URL
 		 */
 		getBaseUrl: function() {

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -375,7 +375,7 @@ class AppManager implements IAppManager {
 	/**
 	 * @param string $package
 	 * @return mixed
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function installApp($package) {
 		return Installer::installApp([
@@ -387,7 +387,7 @@ class AppManager implements IAppManager {
 	/**
 	 * @param string $package
 	 * @return mixed
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function updateApp($package) {
 		return Installer::updateApp([
@@ -400,7 +400,7 @@ class AppManager implements IAppManager {
 	 * Returns the list of all apps, enabled and disabled
 	 *
 	 * @return string[]
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getAllApps() {
 		return $this->appConfig->getApps();

--- a/lib/private/Files/External/Service/StoragesService.php
+++ b/lib/private/Files/External/Service/StoragesService.php
@@ -230,7 +230,7 @@ abstract class StoragesService implements IStoragesService {
 	 * Creates a new storage configuration
 	 *
 	 * @return IStorageConfig
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function createConfig() {
 		return new StorageConfig();

--- a/lib/private/Files/Mount/MoveableMount.php
+++ b/lib/private/Files/Mount/MoveableMount.php
@@ -49,7 +49,7 @@ interface MoveableMount {
 	 *
 	 * @return bool true if allowed, false otherwise
 	 *
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	public function isTargetAllowed($target);
 }

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -374,7 +374,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * returns how many users have logged in once
 	 *
 	 * @return int
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function countSeenUsers() {
 		$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
@@ -396,7 +396,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	/**
 	 * @param \Closure $callback
 	 * @param string $search
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function callForSeenUsers (\Closure $callback) {
 		$limit = 1000;

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -116,14 +116,14 @@ interface IAppManager {
 	/**
 	 * @param string $package
 	 * @return mixed
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function installApp($package);
 
 	/**
 	 * @param string $package
 	 * @return mixed
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function updateApp($package);
 
@@ -132,7 +132,7 @@ interface IAppManager {
 	 *
 	 * @param string $appId app id
 	 * @return array app info
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getAppInfo($appId);
 
@@ -140,7 +140,7 @@ interface IAppManager {
 	 * Returns the list of all apps, enabled and disabled
 	 *
 	 * @return string[]
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getAllApps();
 

--- a/lib/public/AppFramework/Http/OCSResponse.php
+++ b/lib/public/AppFramework/Http/OCSResponse.php
@@ -89,7 +89,7 @@ class OCSResponse extends Response {
 
 	/**
 	 * @return int
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getStatusCode() {
 		return $this->statuscode;
@@ -97,7 +97,7 @@ class OCSResponse extends Response {
 
 	/**
 	 * @param int $statuscode
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setStatusCode($statuscode) {
 		$this->statuscode = $statuscode;

--- a/lib/public/Authentication/TwoFactorAuth/IProvider2.php
+++ b/lib/public/Authentication/TwoFactorAuth/IProvider2.php
@@ -22,14 +22,14 @@
 namespace OCP\Authentication\TwoFactorAuth;
 
 /**
- * @since 9.2.0
+ * @since 10.0
  */
 interface IProvider2 extends IProvider {
 
 	 /**
 	 * Get the Content Security Policy for the template (required for showing external content, otherwise optional)
 	 *
-	 * @since 9.2.0
+	 * @since 10.0
 	 *
 	 * @return \OCP\AppFramework\Http\ContentSecurityPolicy
 	 */

--- a/lib/public/Authentication/TwoFactorAuth/TwoFactorException.php
+++ b/lib/public/Authentication/TwoFactorAuth/TwoFactorException.php
@@ -32,6 +32,6 @@ namespace OCP\Authentication\TwoFactorAuth;
 
 /**
  * Two Factor Authentication failed
- * @since 9.2.0
+ * @since 10.0
  */
 class TwoFactorException extends \Exception {}

--- a/lib/public/Files/External/Auth/AuthMechanism.php
+++ b/lib/public/Files/External/Auth/AuthMechanism.php
@@ -49,7 +49,7 @@ use OCP\Files\External\IStorageConfig;
  *  - StorageModifierTrait
  *      Object can affect storage mounting
  *
- * @since 9.2.0
+ * @since 10.0
  */
 abstract class AuthMechanism implements \JsonSerializable {
 
@@ -75,7 +75,7 @@ abstract class AuthMechanism implements \JsonSerializable {
 	 * See self::SCHEME_* constants
 	 *
 	 * @return string
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getScheme() {
 		return $this->scheme;
@@ -84,7 +84,7 @@ abstract class AuthMechanism implements \JsonSerializable {
 	/**
 	 * @param string $scheme
 	 * @return self
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setScheme($scheme) {
 		$this->scheme = $scheme;
@@ -95,7 +95,7 @@ abstract class AuthMechanism implements \JsonSerializable {
 	 * Serialize into JSON for client-side JS
 	 *
 	 * @return array
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function jsonSerialize() {
 		$data = $this->jsonSerializeDefinition();
@@ -112,7 +112,7 @@ abstract class AuthMechanism implements \JsonSerializable {
 	 *
 	 * @param IStorageConfig $storage
 	 * @return bool
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function validateStorage(IStorageConfig $storage) {
 		// does the backend actually support this scheme

--- a/lib/public/Files/External/Auth/IUserProvided.php
+++ b/lib/public/Files/External/Auth/IUserProvided.php
@@ -26,14 +26,14 @@ use OCP\IUser;
 /**
  * For auth mechanisms where the user needs to provide credentials
  *
- * @since 9.2.0
+ * @since 10.0
  */
 interface IUserProvided {
 	/**
 	 * @param IUser $user the user for which to save the user provided options
 	 * @param int $mountId the mount id to save the options for
 	 * @param array $options the user provided options
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function saveBackendOptions(IUser $user, $mountId, array $options);
 }

--- a/lib/public/Files/External/Backend/Backend.php
+++ b/lib/public/Files/External/Backend/Backend.php
@@ -55,7 +55,7 @@ use OCP\Files\External\IStorageConfig;
  *  - StorageModifierTrait
  *      Object can affect storage mounting
  *
- * @since 9.2.0
+ * @since 10.0
  */
 abstract class Backend implements \JsonSerializable {
 
@@ -77,7 +77,7 @@ abstract class Backend implements \JsonSerializable {
 
 	/**
 	 * @return string
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getStorageClass() {
 		return $this->storageClass;
@@ -86,7 +86,7 @@ abstract class Backend implements \JsonSerializable {
 	/**
 	 * @param string $class
 	 * @return self
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setStorageClass($class) {
 		$this->storageClass = $class;
@@ -95,7 +95,7 @@ abstract class Backend implements \JsonSerializable {
 
 	/**
 	 * @return array
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getAuthSchemes() {
 		if (empty($this->authSchemes)) {
@@ -107,7 +107,7 @@ abstract class Backend implements \JsonSerializable {
 	/**
 	 * @param string $scheme
 	 * @return self
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function addAuthScheme($scheme) {
 		$this->authSchemes[$scheme] = true;
@@ -118,7 +118,7 @@ abstract class Backend implements \JsonSerializable {
 	 * Serialize into JSON for client-side JS
 	 *
 	 * @return array
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function jsonSerialize() {
 		$data = $this->jsonSerializeDefinition();
@@ -136,7 +136,7 @@ abstract class Backend implements \JsonSerializable {
 	 *
 	 * @param IStorageConfig $storage
 	 * @return bool
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function validateStorage(IStorageConfig $storage) {
 		return $this->validateStorageDefinition($storage);

--- a/lib/public/Files/External/Config/IAuthMechanismProvider.php
+++ b/lib/public/Files/External/Config/IAuthMechanismProvider.php
@@ -27,7 +27,7 @@ use OCP\Files\External\Auth\AuthMechanism;
 /**
  * Provider of external storage auth mechanisms
  *
- * @since 9.2.0
+ * @since 10.0
  */
 interface IAuthMechanismProvider {
 

--- a/lib/public/Files/External/Config/IBackendProvider.php
+++ b/lib/public/Files/External/Config/IBackendProvider.php
@@ -27,7 +27,7 @@ use OCP\Files\External\Backend\Backend;
 /**
  * Provider of external storage backends
  *
- * @since 9.2.0
+ * @since 10.0
  */
 interface IBackendProvider {
 

--- a/lib/public/Files/External/DefinitionParameter.php
+++ b/lib/public/Files/External/DefinitionParameter.php
@@ -25,7 +25,7 @@ namespace OCP\Files\External;
 /**
  * Parameter for an external storage definition
  *
- * @since 9.2.0
+ * @since 10.0
  */
 class DefinitionParameter implements \JsonSerializable {
 
@@ -55,7 +55,7 @@ class DefinitionParameter implements \JsonSerializable {
 	/**
 	 * @param string $name
 	 * @param string $text
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function __construct($name, $text) {
 		$this->name = $name;
@@ -64,7 +64,7 @@ class DefinitionParameter implements \JsonSerializable {
 
 	/**
 	 * @return string
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getName() {
 		return $this->name;
@@ -72,7 +72,7 @@ class DefinitionParameter implements \JsonSerializable {
 
 	/**
 	 * @return string
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getText() {
 		return $this->text;
@@ -82,7 +82,7 @@ class DefinitionParameter implements \JsonSerializable {
 	 * Get value type
 	 *
 	 * @return int
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getType() {
 		return $this->type;
@@ -93,7 +93,7 @@ class DefinitionParameter implements \JsonSerializable {
 	 *
 	 * @param int $type
 	 * @return self
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setType($type) {
 		$this->type = $type;
@@ -102,7 +102,7 @@ class DefinitionParameter implements \JsonSerializable {
 
 	/**
 	 * @return string
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getTypeName() {
 		switch ($this->type) {
@@ -119,7 +119,7 @@ class DefinitionParameter implements \JsonSerializable {
 
 	/**
 	 * @return int
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getFlags() {
 		return $this->flags;
@@ -128,7 +128,7 @@ class DefinitionParameter implements \JsonSerializable {
 	/**
 	 * @param int $flags
 	 * @return self
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setFlags($flags) {
 		$this->flags = $flags;
@@ -138,7 +138,7 @@ class DefinitionParameter implements \JsonSerializable {
 	/**
 	 * @param int $flag
 	 * @return self
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setFlag($flag) {
 		$this->flags |= $flag;
@@ -148,7 +148,7 @@ class DefinitionParameter implements \JsonSerializable {
 	/**
 	 * @param int $flag
 	 * @return bool
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function isFlagSet($flag) {
 		return (bool)($this->flags & $flag);
@@ -158,7 +158,7 @@ class DefinitionParameter implements \JsonSerializable {
 	 * Serialize into JSON for client-side JS
 	 *
 	 * @return string
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function jsonSerialize() {
 		return [
@@ -172,7 +172,7 @@ class DefinitionParameter implements \JsonSerializable {
 	 * Returns whether the parameter is optional
 	 *
 	 * @return bool true if optional, false otherwise
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function isOptional() {
 		return $this->isFlagSet(self::FLAG_OPTIONAL) || $this->isFlagSet(self::FLAG_USER_PROVIDED);
@@ -184,7 +184,7 @@ class DefinitionParameter implements \JsonSerializable {
 	 *
 	 * @param mixed $value Value to check
 	 * @return bool success
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function validateValue(&$value) {
 		switch ($this->getType()) {

--- a/lib/public/Files/External/IStorageConfig.php
+++ b/lib/public/Files/External/IStorageConfig.php
@@ -33,7 +33,7 @@ use OCP\Files\External\Auth\IUserProvided;
 /**
  * External storage configuration
  *
- * @since 9.2.0
+ * @since 10.0
  */
 interface IStorageConfig extends \JsonSerializable {
 	const MOUNT_TYPE_ADMIN = 1;
@@ -48,7 +48,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Returns the configuration id
 	 *
 	 * @return int
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getId();
 
@@ -56,7 +56,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Sets the configuration id
 	 *
 	 * @param int $id configuration id
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setId($id);
 
@@ -65,7 +65,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * "files" folder.
 	 *
 	 * @return string path
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getMountPoint();
 
@@ -75,31 +75,31 @@ interface IStorageConfig extends \JsonSerializable {
 	 * The path will be normalized.
 	 *
 	 * @param string $mountPoint path
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setMountPoint($mountPoint);
 
 	/**
 	 * @return Backend
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getBackend();
 
 	/**
 	 * @param Backend $backend
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setBackend(Backend $backend);
 
 	/**
 	 * @return AuthMechanism
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getAuthMechanism();
 
 	/**
 	 * @param AuthMechanism $authMechanism
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setAuthMechanism(AuthMechanism $authMechanism);
 
@@ -107,7 +107,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Returns the external storage backend-specific options
 	 *
 	 * @return array backend options
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getBackendOptions();
 
@@ -115,21 +115,21 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Sets the external storage backend-specific options
 	 *
 	 * @param array $backendOptions backend options
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setBackendOptions($backendOptions);
 
 	/**
 	 * @param string $key
 	 * @return mixed
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getBackendOption($key);
 
 	/**
 	 * @param string $key
 	 * @param mixed $value
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setBackendOption($key, $value);
 
@@ -137,7 +137,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Returns the mount priority
 	 *
 	 * @return int priority
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getPriority();
 
@@ -145,7 +145,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Sets the mount priotity
 	 *
 	 * @param int $priority priority
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setPriority($priority);
 
@@ -153,7 +153,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Returns the users for which to mount this storage
 	 *
 	 * @return array applicable users
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getApplicableUsers();
 
@@ -161,7 +161,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Sets the users for which to mount this storage
 	 *
 	 * @param array|null $applicableUsers applicable users
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setApplicableUsers($applicableUsers);
 
@@ -169,7 +169,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Returns the groups for which to mount this storage
 	 *
 	 * @return array applicable groups
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getApplicableGroups();
 
@@ -177,7 +177,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Sets the groups for which to mount this storage
 	 *
 	 * @param array|null $applicableGroups applicable groups
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setApplicableGroups($applicableGroups);
 
@@ -185,7 +185,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Returns the mount-specific options
 	 *
 	 * @return array mount specific options
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getMountOptions();
 
@@ -193,21 +193,21 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Sets the mount-specific options
 	 *
 	 * @param array $mountOptions applicable groups
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setMountOptions($mountOptions);
 
 	/**
 	 * @param string $key
 	 * @return mixed
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getMountOption($key);
 
 	/**
 	 * @param string $key
 	 * @param mixed $value
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setMountOption($key, $value);
 
@@ -215,7 +215,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Gets the storage status, whether the config worked last time
 	 *
 	 * @return int $status status
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getStatus();
 
@@ -223,7 +223,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Gets the message describing the storage status
 	 *
 	 * @return string|null
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getStatusMessage();
 
@@ -232,19 +232,19 @@ interface IStorageConfig extends \JsonSerializable {
 	 *
 	 * @param int $status status
 	 * @param string|null $message optional message
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setStatus($status, $message = null);
 
 	/**
 	 * @return int self::MOUNT_TYPE_ADMIN or self::MOUNT_TYPE_PERSONAl
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getType();
 
 	/**
 	 * @param int $type self::MOUNT_TYPE_ADMIN or self::MOUNT_TYPE_PERSONAl
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function setType($type);
 
@@ -252,7 +252,7 @@ interface IStorageConfig extends \JsonSerializable {
 	 * Serialize config to JSON
 	 *
 	 * @return array
- 	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function jsonSerialize();
 }

--- a/lib/public/Files/External/IStoragesBackendService.php
+++ b/lib/public/Files/External/IStoragesBackendService.php
@@ -32,7 +32,7 @@ use \OCP\Files\External\Config\IAuthMechanismProvider;
 /**
  * Service to manage external storage backend definitions
  *
- * @since 9.2.0
+ * @since 10.0
  */
 interface IStoragesBackendService {
 

--- a/lib/public/Files/External/InsufficientDataForMeaningfulAnswerException.php
+++ b/lib/public/Files/External/InsufficientDataForMeaningfulAnswerException.php
@@ -27,7 +27,7 @@ use \OCP\Files\StorageNotAvailableException;
 /**
  * Authentication mechanism or backend has insufficient data
  *
- * @since 9.2.0
+ * @since 10.0
  */
 class InsufficientDataForMeaningfulAnswerException extends StorageNotAvailableException {
 	/**

--- a/lib/public/Files/External/NotFoundException.php
+++ b/lib/public/Files/External/NotFoundException.php
@@ -25,7 +25,7 @@ namespace OCP\Files\External;
 /**
  * Storage is not found
  *
- * @since 9.2
+ * @since 10.0
  */
 class NotFoundException extends \Exception {
 }

--- a/lib/public/Files/External/Service/IGlobalStoragesService.php
+++ b/lib/public/Files/External/Service/IGlobalStoragesService.php
@@ -24,7 +24,7 @@ namespace OCP\Files\External\Service;
 /**
  * Service class to manage global external storages
  *
- * @since 9.2
+ * @since 10.0
  */
 interface IGlobalStoragesService extends IStoragesService {
 	/**
@@ -32,7 +32,7 @@ interface IGlobalStoragesService extends IStoragesService {
 	 *
 	 * @return array map of storage id to storage config
 	 *
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getStorageForAllUsers();
 }

--- a/lib/public/Files/External/Service/IStoragesService.php
+++ b/lib/public/Files/External/Service/IStoragesService.php
@@ -27,7 +27,7 @@ use OCP\Files\External\NotFoundException;
 /**
  * Service interface to manage external storages
  *
- * @since 9.2
+ * @since 10.0
  */
 interface IStoragesService {
 	/**
@@ -38,7 +38,7 @@ interface IStoragesService {
 	 * @return IStorageConfig
 	 * @throws NotFoundException if the storage with the given id was not found
 	 *
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	public function getStorage($id);
 
@@ -47,7 +47,7 @@ interface IStoragesService {
 	 *
 	 * @return IStorageConfig[] array of storage configs
 	 *
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	public function getAllStorages();
 
@@ -56,7 +56,7 @@ interface IStoragesService {
 	 *
 	 * @return IStorageConfig[]
 	 *
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	public function getStorages();
 
@@ -65,7 +65,7 @@ interface IStoragesService {
 	 *
 	 * @return string IStoragesBackendService::VISIBILITY_* constants
 	 *
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	public function getVisibilityType();
 
@@ -74,7 +74,7 @@ interface IStoragesService {
 	 *
 	 * @return IStorageConfig
 	 *
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function createConfig();
 
@@ -85,7 +85,7 @@ interface IStoragesService {
 	 *
 	 * @return IStorageConfig storage config, with added id
 	 *
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function addStorage(IStorageConfig $newStorage);
 
@@ -103,7 +103,7 @@ interface IStoragesService {
 	 *
 	 * @return IStorageConfig
 	 *
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function createStorage(
 		$mountPoint,
@@ -124,7 +124,7 @@ interface IStoragesService {
 	 * @return IStorageConfig storage config
 	 * @throws NotFoundException if the given storage does not exist in the config
 	 *
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function updateStorage(IStorageConfig $updatedStorage);
 
@@ -135,7 +135,7 @@ interface IStoragesService {
 	 *
 	 * @throws NotFoundException if no storage was found with the given id
 	 *
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function removeStorage($id);
 

--- a/lib/public/Files/External/Service/IUserGlobalStoragesService.php
+++ b/lib/public/Files/External/Service/IUserGlobalStoragesService.php
@@ -28,7 +28,7 @@ use OCP\Files\External\IStorageConfig;
  * Service class to read global storages applicable to the user
  * Read-only access available, attempting to write will throw DomainException
  *
- * @since 9.2
+ * @since 10.0
  */
 interface IUserGlobalStoragesService extends IGlobalStoragesService {
 	/**
@@ -37,7 +37,7 @@ interface IUserGlobalStoragesService extends IGlobalStoragesService {
 	 *
 	 * @return IStorageConfig[]
 	 *
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function getUniqueStorages();
 }

--- a/lib/public/Files/External/Service/IUserStoragesService.php
+++ b/lib/public/Files/External/Service/IUserStoragesService.php
@@ -29,7 +29,7 @@ namespace OCP\Files\External\Service;
  * Service class to manage user external storages
  * (aka personal storages)
  *
- * @since 9.2
+ * @since 10.0
  */
 interface IUserStoragesService extends IStoragesService {
 

--- a/lib/public/Files/Storage/FlysystemStorageAdapter.php
+++ b/lib/public/Files/Storage/FlysystemStorageAdapter.php
@@ -25,7 +25,7 @@ namespace OCP\Files\Storage;
  * Public storage adapter to be extended to connect to
  * flysystem adapters
  *
- * @since 9.2
+ * @since 10.0
  */
 abstract class FlysystemStorageAdapter extends \OC\Files\Storage\Flysystem {
 
@@ -35,7 +35,7 @@ abstract class FlysystemStorageAdapter extends \OC\Files\Storage\Flysystem {
 	 * and two storage objects with the same id should refer to two storages that display the same files.
 	 *
 	 * @return string storage id
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	abstract public function getId();
 }

--- a/lib/public/Files/Storage/PolyFill/CopyDirectory.php
+++ b/lib/public/Files/Storage/PolyFill/CopyDirectory.php
@@ -22,7 +22,7 @@
 namespace OCP\Files\Storage\PolyFill;
 
 /**
- * @since 9.2
+ * @since 10.0
  */
 trait CopyDirectory {
 	use \OC\Files\Storage\PolyFill\CopyDirectory;

--- a/lib/public/Files/Storage/StorageAdapter.php
+++ b/lib/public/Files/Storage/StorageAdapter.php
@@ -26,7 +26,7 @@ use OCP\Files\StorageNotAvailableException;
 /**
  * Storage adapter implementing most of the common methods from IStorage.
  *
- * @since 9.2
+ * @since 10.0
  */
 abstract class StorageAdapter extends \OC\Files\Storage\Common {
 
@@ -36,7 +36,7 @@ abstract class StorageAdapter extends \OC\Files\Storage\Common {
 	 * and two storage objects with the same id should refer to two storages that display the same files.
 	 *
 	 * @return string storage id
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	abstract public function getId();
 
@@ -47,7 +47,7 @@ abstract class StorageAdapter extends \OC\Files\Storage\Common {
 	 * @param string $path
 	 * @return bool true on success, false otherwise
 	 * @throws StorageNotAvailableException if the storage is temporarily not available
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	abstract public function mkdir($path);
 
@@ -57,7 +57,7 @@ abstract class StorageAdapter extends \OC\Files\Storage\Common {
 	 * @param string $path
 	 * @return bool true on success, false otherwise
 	 * @throws StorageNotAvailableException if the storage is temporarily not available
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	abstract public function rmdir($path);
 
@@ -67,7 +67,7 @@ abstract class StorageAdapter extends \OC\Files\Storage\Common {
 	 * @param string $path
 	 * @return resource|false
 	 * @throws StorageNotAvailableException if the storage is temporarily not available
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	abstract public function opendir($path);
 
@@ -78,7 +78,7 @@ abstract class StorageAdapter extends \OC\Files\Storage\Common {
 	 * @param string $path
 	 * @return array|false
 	 * @throws StorageNotAvailableException if the storage is temporarily not available
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	abstract public function stat($path);
 
@@ -88,7 +88,7 @@ abstract class StorageAdapter extends \OC\Files\Storage\Common {
 	 * @param string $path
 	 * @return string|false
 	 * @throws StorageNotAvailableException if the storage is temporarily not available
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	abstract public function filetype($path);
 
@@ -98,7 +98,7 @@ abstract class StorageAdapter extends \OC\Files\Storage\Common {
 	 * @param string $path
 	 * @return bool
 	 * @throws StorageNotAvailableException if the storage is temporarily not available
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	abstract public function file_exists($path);
 
@@ -108,7 +108,7 @@ abstract class StorageAdapter extends \OC\Files\Storage\Common {
 	 * @param string $path
 	 * @return bool true on success, false otherwise
 	 * @throws StorageNotAvailableException if the storage is temporarily not available
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	abstract public function unlink($path);
 
@@ -119,7 +119,7 @@ abstract class StorageAdapter extends \OC\Files\Storage\Common {
 	 * @param string $mode
 	 * @return resource|false
 	 * @throws StorageNotAvailableException if the storage is temporarily not available
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	abstract public function fopen($path, $mode);
 
@@ -131,7 +131,7 @@ abstract class StorageAdapter extends \OC\Files\Storage\Common {
 	 * @param int $mtime
 	 * @return bool true on success, false otherwise
 	 * @throws StorageNotAvailableException if the storage is temporarily not available
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	abstract public function touch($path, $mtime = NULL);
 }

--- a/lib/public/IGroup.php
+++ b/lib/public/IGroup.php
@@ -40,7 +40,7 @@ interface IGroup {
 	 * Returns the group display name
 	 *
 	 * @return string
-	 * @since 9.2
+	 * @since 10.0
 	 */
 	public function getDisplayName();
 

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -147,14 +147,14 @@ interface IUserManager {
 	 * returns how many users have logged in once
 	 *
 	 * @return int
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function countSeenUsers();
 
 	/**
 	 * @param \Closure $callback
 	 * @param string $search
-	 * @since 9.2.0
+	 * @since 10.0
 	 */
 	public function callForSeenUsers (\Closure $callback);
 


### PR DESCRIPTION
Because 9.2 is now called 10.0.

Used the following command:
```bash
% find apps lib core settings -name \*.php -exec sed -i -re 's#@since 9\.2(\.0)?#@since 10.0#g' \{\} \;
% find apps lib core settings -name \*.js -exec sed -i -re 's#@since 9\.2(\.0)?#@since 10.0#g' \{\} \;
```

Please review @DeepDiver1975 @VicDeo @IljaN 