### PR TITLE
[Stable8.2] autoloader fixup

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -117,11 +117,21 @@ class OC {
 	 * the app path list is empty or contains an invalid path
 	 */
 	public static function initPaths() {
+		// fixup: strip current dir from include path
+		$includePath = get_include_path();
+		$includePathArray = explode(PATH_SEPARATOR, $includePath);
+		$dotIndex = array_search('.', $includePathArray, true);
+		if ($dotIndex !== false){
+			unset($includePathArray[$dotIndex]);
+			$includePath = implode(PATH_SEPARATOR, $includePathArray);
+		}
+		
 		// ensure we can find OC_Config
 		set_include_path(
 			OC::$SERVERROOT . '/lib' . PATH_SEPARATOR .
-			get_include_path()
+			$includePath
 		);
+		
 
 		if(defined('PHPUNIT_CONFIG_DIR')) {
 			self::$configDir = OC::$SERVERROOT . '/' . PHPUNIT_CONFIG_DIR . '/';

--- a/lib/base.php
+++ b/lib/base.php
@@ -113,19 +113,28 @@ class OC {
 	public static $server = null;
 
 	/**
+	 * Remove current directory from include path
+	 * @param string $oldIncludePath
+	 * @return string
+	 */
+	public static function fixupIncludePath($oldIncludePath){
+		$newIncludePath = $oldIncludePath;
+		$includePathArray = explode(PATH_SEPARATOR, $oldIncludePath);
+		$dotIndex = array_search('.', $includePathArray, true);
+		if ($dotIndex !== false){
+			unset($includePathArray[$dotIndex]);
+			$newIncludePath = implode(PATH_SEPARATOR, $includePathArray);
+		}
+		return $newIncludePath;
+	}
+	
+	/**
 	 * @throws \RuntimeException when the 3rdparty directory is missing or
 	 * the app path list is empty or contains an invalid path
 	 */
 	public static function initPaths() {
 		// fixup: strip current dir from include path
-		$includePath = get_include_path();
-		$includePathArray = explode(PATH_SEPARATOR, $includePath);
-		$dotIndex = array_search('.', $includePathArray, true);
-		if ($dotIndex !== false){
-			unset($includePathArray[$dotIndex]);
-			$includePath = implode(PATH_SEPARATOR, $includePathArray);
-		}
-		
+		$includePath = self::fixupIncludePath(get_include_path());
 		// ensure we can find OC_Config
 		set_include_path(
 			OC::$SERVERROOT . '/lib' . PATH_SEPARATOR .

--- a/tests/lib/base.php
+++ b/tests/lib/base.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @author Victor Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test;
+
+class BaseTest extends \PHPUnit_Framework_TestCase {
+	public function fixupIncludePathData(){
+		return [
+			['', ''],
+			['.', ''],
+			['.:', ''],
+			[':.', ''],
+			['/usr/share/php7:/usr/share/php7/PEAR', '/usr/share/php7:/usr/share/php7/PEAR'],
+			['.:/usr/share/php7:/usr/share/php7/PEAR', '/usr/share/php7:/usr/share/php7/PEAR'],
+			['/usr/share/php7:/usr/share/php7/PEAR:.', '/usr/share/php7:/usr/share/php7/PEAR'],
+			['/usr/share/php7:.:/usr/share/php7/PEAR', '/usr/share/php7:/usr/share/php7/PEAR'],
+		];
+	}
+
+	/**
+	 * @dataProvider fixupIncludePathData
+	 */
+	public function testFixupIncludePath($includePath, $expectedIncludePath){
+		$actualIncludePath = \OC::fixupIncludePath($includePath);
+		$this->assertEquals($expectedIncludePath, $actualIncludePath);
+	}
+}


### PR DESCRIPTION
## Description
Remove current directory (dot) from include path
## Related Issue
https://github.com/owncloud/enterprise/issues/1769

## Motivation and Context
Fixes autoloader failure while executing occ script from `config` directory

## How Has This Been Tested?
`cd owncloud/config && sudo -uwww-data php ../occ status`

### Expected
occ status executed

### Actual
`OCP\AutoloadNotAllowedException` is thrown


## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

