### PR TITLE
Fix ocs expectation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,25 +126,26 @@ timestampedNode('SLAVE') {
             '''
         }
 
-    if (isOnReleaseBranch()) {
-        stage 'Integration Testing'
-            executeAndReport('build/integration/output/*.xml') {
-                sh '''phpenv local 7.0
-                rm -rf config/config.php data/*
-                ./occ maintenance:install --admin-pass=admin
-                make clean-test-integration
-                make test-integration
-               '''
-            }
+	stage 'Integration Testing'
+		executeAndReport('build/integration/output/*.xml') {
+			sh '''phpenv local 7.0
+			rm -rf config/config.php data/*
+			./occ maintenance:install --admin-pass=admin
+			make clean-test-integration
+			make test-integration
+		   '''
+		}
 
-            executeAndReport('build/integration/output/*.xml') {
-                sh '''phpenv local 7.0
-                rm -rf config/config.php data/*
-                ./occ maintenance:install --admin-pass=admin
-                make clean-test-integration
-                make test-integration OC_TEST_ALT_HOME=1
-               '''
-            }
+		if (isOnReleaseBranch()) {
+
+			executeAndReport('build/integration/output/*.xml') {
+				sh '''phpenv local 7.0
+				rm -rf config/config.php data/*
+				./occ maintenance:install --admin-pass=admin
+				make clean-test-integration
+				make test-integration OC_TEST_ALT_HOME=1
+			   '''
+			}
 			executeAndReport('build/integration/output/*.xml') {
 				sh '''phpenv local 7.0
 				rm -rf config/config.php data/*
@@ -161,7 +162,7 @@ timestampedNode('SLAVE') {
 				make test-integration OC_TEST_ALT_HOME=1 OC_TEST_ENCRYPTION_ENABLED=1
 			   '''
 			}
-    }
+		}
 }
 
 def isOnReleaseBranch ()  {

--- a/build/integration/sharees_features/sharees_provisioningapiv2.feature
+++ b/build/integration/sharees_features/sharees_provisioningapiv2.feature
@@ -169,7 +169,7 @@ Feature: sharees_provisioningapiv2
     When getting sharees for
       | search | shareegroup |
       | itemType | file |
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     Then "exact users" sharees returned is empty
     Then "users" sharees returned is empty

--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -122,6 +122,9 @@ abstract class OCSController extends ApiController {
 		if (substr($script, -11) === '/ocs/v2.php') {
 			$statusCode = \OC_API::mapStatusCodes($resp->getStatusCode());
 			if (!is_null($statusCode)) {
+				// HTTP code
+				$resp->setStatus($statusCode);
+				// OCS code
 				$resp->setStatusCode($statusCode);
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
OCS madness requires a status code in the response and also the HTTP status code.
When I fixed https://github.com/owncloud/core/pull/27076 I forgot that there were two status codes and forgot to leave the old one in. Fortunately some tests failed to enforce this.

## Related Issue
Fixes https://github.com/owncloud/core/issues/27098

## Motivation and Context
Don't ask, it's OCS madness...

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 please review this OCS madness
