### PR TITLE
Stop creating skeleton dinamically

### DIFF
--- a/build/integration/features/bootstrap/BasicStructure.php
+++ b/build/integration/features/bootstrap/BasicStructure.php
@@ -312,46 +312,6 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @BeforeSuite
-	 */
-	public static function addFilesToSkeleton(){
-		for ($i=0; $i<5; $i++){
-			file_put_contents("../../core/skeleton/" . "textfile" . "$i" . ".txt", "ownCloud test text file\n");
-		}
-		if (!file_exists("../../core/skeleton/FOLDER")) {
-			mkdir("../../core/skeleton/FOLDER", 0777, true);
-		}
-		if (!file_exists("../../core/skeleton/PARENT")) {
-			mkdir("../../core/skeleton/PARENT", 0777, true);
-		}
-		file_put_contents("../../core/skeleton/PARENT/" . "parent.txt", "ownCloud test text file\n");
-		if (!file_exists("../../core/skeleton/PARENT/CHILD")) {
-			mkdir("../../core/skeleton/PARENT/CHILD", 0777, true);
-		}
-		file_put_contents("../../core/skeleton/PARENT/CHILD/" . "child.txt", "ownCloud test text file\n");
-	}
-
-	/**
-	 * @AfterSuite
-	 */
-	public static function removeFilesFromSkeleton(){
-		for ($i=0; $i<5; $i++){
-			self::removeFile("../../core/skeleton/", "textfile" . "$i" . ".txt");
-		}
-		if (is_dir("../../core/skeleton/FOLDER")) {
-			rmdir("../../core/skeleton/FOLDER");
-		}
-		self::removeFile("../../core/skeleton/PARENT/CHILD/", "child.txt");
-		if (is_dir("../../core/skeleton/PARENT/CHILD")) {
-			rmdir("../../core/skeleton/PARENT/CHILD");
-		}
-		self::removeFile("../../core/skeleton/PARENT/", "parent.txt");
-		if (is_dir("../../core/skeleton/PARENT")) {
-			rmdir("../../core/skeleton/PARENT");
-		}
-	}
-
-	/**
 	 * @BeforeScenario @local_storage
 	 */
 	public static function removeFilesFromLocalStorageBefore(){

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -156,7 +156,7 @@ Feature: webdav-related
 		When user "user0" has a quota of "10 MB"
 		Then as "user0" gets properties of folder "/" with
 		  |{DAV:}quota-available-bytes|
-		And the single response should contain a property "{DAV:}quota-available-bytes" with value "10485429"
+		And the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
 
 	Scenario: Retrieving folder quota of shared folder with quota when no quota is set for recipient
 		Given using old dav path
@@ -174,7 +174,7 @@ Feature: webdav-related
 		  | shareWith | user0 |
 		Then as "user0" gets properties of folder "/testquota" with
 		  |{DAV:}quota-available-bytes|
-		And the single response should contain a property "{DAV:}quota-available-bytes" with value "10485429"
+		And the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
 
 	Scenario: Uploading a file as recipient using webdav having quota
 		Given using old dav path
@@ -202,7 +202,7 @@ Feature: webdav-related
 		And user "user0" adds a file of 93 bytes to "/prueba.txt"
 		When as "user0" gets properties of folder "/" with
 		  |{DAV:}quota-available-bytes|
-		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "600"
+		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "529"
 
 	Scenario: Retrieving folder quota when quota is set and a file was recieved
 		Given using old dav path
@@ -214,7 +214,7 @@ Feature: webdav-related
 		And file "user0.txt" of user "user0" is shared with user "user1"
 		When as "user1" gets properties of folder "/" with
 		  |{DAV:}quota-available-bytes|
-		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "693"
+		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "622"
 
 	Scenario: download a public shared file with range
 		Given user "user0" exists

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -47,6 +47,9 @@ echo $PHPPID_FED
 export TEST_SERVER_URL="http://localhost:$PORT/ocs/"
 export TEST_SERVER_FED_URL="http://localhost:$PORT_FED/ocs/"
 
+#Set up personalized skeleton
+$OCC config:system:set skeletondirectory --value="$(pwd)/skeleton"
+
 #Enable external storage app
 $OCC app:enable files_external
 

--- a/build/integration/skeleton/FOLDER/.gitignore
+++ b/build/integration/skeleton/FOLDER/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/build/integration/skeleton/PARENT/CHILD/child.txt
+++ b/build/integration/skeleton/PARENT/CHILD/child.txt
@@ -1,0 +1,1 @@
+ownCloud test text file

--- a/build/integration/skeleton/PARENT/parent.txt
+++ b/build/integration/skeleton/PARENT/parent.txt
@@ -1,0 +1,1 @@
+ownCloud test text file

--- a/build/integration/skeleton/textfile0.txt
+++ b/build/integration/skeleton/textfile0.txt
@@ -1,0 +1,1 @@
+ownCloud test text file

--- a/build/integration/skeleton/textfile1.txt
+++ b/build/integration/skeleton/textfile1.txt
@@ -1,0 +1,1 @@
+ownCloud test text file

--- a/build/integration/skeleton/textfile2.txt
+++ b/build/integration/skeleton/textfile2.txt
@@ -1,0 +1,1 @@
+ownCloud test text file

--- a/build/integration/skeleton/textfile3.txt
+++ b/build/integration/skeleton/textfile3.txt
@@ -1,0 +1,1 @@
+ownCloud test text file

--- a/build/integration/skeleton/textfile4.txt
+++ b/build/integration/skeleton/textfile4.txt
@@ -1,0 +1,1 @@
+ownCloud test text file

--- a/build/integration/skeleton/welcome.txt
+++ b/build/integration/skeleton/welcome.txt
@@ -1,0 +1,5 @@
+Welcome to your ownCloud account!
+
+This is just an example file for developers and git users. 
+The packaged and released versions will come with better examples.
+


### PR DESCRIPTION
This PRs adds a way to stop creating a skeleton when running integration tests.

The goal is to avoid having to give permissions and not use a hardcoded path.