### PR TITLE
[Stable8.2] autoloader fixup retry

### DIFF
--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -31,12 +31,9 @@ namespace OC;
 use \OCP\AutoloadNotAllowedException;
 
 class Autoloader {
+	/** @var bool */
 	private $useGlobalClassPath = true;
-
-	private $prefixPaths = array();
-
-	private $classPaths = array();
-
+	/** @var array */
 	private $validRoots = [];
 
 	/**
@@ -91,9 +88,7 @@ class Autoloader {
 		$class = trim($class, '\\');
 
 		$paths = array();
-		if (array_key_exists($class, $this->classPaths)) {
-			$paths[] = $this->classPaths[$class];
-		} else if ($this->useGlobalClassPath and array_key_exists($class, \OC::$CLASSPATH)) {
+		if ($this->useGlobalClassPath && array_key_exists($class, \OC::$CLASSPATH)) {
 			$paths[] = \OC::$CLASSPATH[$class];
 			/**
 			 * @TODO: Remove this when necessary
@@ -129,6 +124,10 @@ class Autoloader {
 		return $paths;
 	}
 
+	/**
+	 * @param string $fullPath
+	 * @return bool
+	 */
 	protected function isValidPath($fullPath) {
 		foreach ($this->validRoots as $root => $true) {
 			if (substr($fullPath, 0, strlen($root) + 1) === $root . '/') {

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -99,14 +99,30 @@ class Autoloader {
 				$paths[] = str_replace('apps/', '', \OC::$CLASSPATH[$class]);
 			}
 		} elseif (strpos($class, 'OC_') === 0) {
-			// first check for legacy classes if underscores are used
-			$paths[] = 'private/legacy/' . strtolower(str_replace('_', '/', substr($class, 3)) . '.php');
-			$paths[] = 'private/' . strtolower(str_replace('_', '/', substr($class, 3)) . '.php');
+			$paths[] = \OC::$SERVERROOT . '/lib/private/legacy/' . strtolower(str_replace('_', '/', substr($class, 3)) . '.php');
+			$paths[] = \OC::$SERVERROOT . '/lib/private/' . strtolower(str_replace('_', '/', substr($class, 3)) . '.php');
 		} elseif (strpos($class, 'OC\\') === 0) {
-			$paths[] = 'private/' . strtolower(str_replace('\\', '/', substr($class, 3)) . '.php');
-			$paths[] = strtolower(str_replace('\\', '/', substr($class, 3)) . '.php');
+			$split = explode('\\', $class, 3);
+
+			if (count($split) === 3) {
+				$split[1] = strtolower($split[1]);
+
+				if ($split[1] === 'core') {
+					$paths[] = \OC::$SERVERROOT . '/core/' . strtolower(str_replace('\\', '/', $split[2])) . '.php';
+				} else if ($split[1] === 'settings') {
+					$paths[] = \OC::$SERVERROOT . '/settings/' . strtolower(str_replace('\\', '/', $split[2])) . '.php';
+				} else if ($split[1] === 'repair') {
+					$paths[] = \OC::$SERVERROOT . '/lib/repair/' . strtolower(str_replace('\\', '/', $split[2])) . '.php';
+
+				} else {
+					$paths[] = \OC::$SERVERROOT . '/lib/private/' . $split[1] . '/' . strtolower(str_replace('\\', '/', $split[2])) . '.php';
+				}
+
+			} else {
+				$paths[] = \OC::$SERVERROOT . '/lib/private/' . strtolower(str_replace('\\', '/', $split[1])) . '.php';
+			}
 		} elseif (strpos($class, 'OCP\\') === 0) {
-			$paths[] = 'public/' . strtolower(str_replace('\\', '/', substr($class, 4)) . '.php');
+			$paths[] = \OC::$SERVERROOT . '/lib/public/' . strtolower(str_replace('\\', '/', substr($class, 4)) . '.php');
 		} elseif (strpos($class, 'OCA\\') === 0) {
 			list(, $app, $rest) = explode('\\', $class, 3);
 			$app = strtolower($app);
@@ -117,9 +133,9 @@ class Autoloader {
 				$paths[] = $appPath . '/lib/' . strtolower(str_replace('\\', '/', $rest) . '.php');
 			}
 		} elseif (strpos($class, 'Test_') === 0) {
-			$paths[] = 'tests/lib/' . strtolower(str_replace('_', '/', substr($class, 5)) . '.php');
+			$paths[] = \OC::$SERVERROOT . '/tests/lib/' . strtolower(str_replace('_', '/', substr($class, 5)) . '.php');
 		} elseif (strpos($class, 'Test\\') === 0) {
-			$paths[] = 'tests/lib/' . strtolower(str_replace('\\', '/', substr($class, 5)) . '.php');
+			$paths[] = \OC::$SERVERROOT . '/tests/lib/' . strtolower(str_replace('\\', '/', substr($class, 5)) . '.php');
 		}
 		return $paths;
 	}

--- a/lib/base.php
+++ b/lib/base.php
@@ -117,12 +117,6 @@ class OC {
 	 * the app path list is empty or contains an invalid path
 	 */
 	public static function initPaths() {
-		// ensure we can find OC_Config
-		set_include_path(
-			OC::$SERVERROOT . '/lib' . PATH_SEPARATOR .
-			get_include_path()
-		);
-
 		if(defined('PHPUNIT_CONFIG_DIR')) {
 			self::$configDir = OC::$SERVERROOT . '/' . PHPUNIT_CONFIG_DIR . '/';
 		} elseif(defined('PHPUNIT_RUN') and PHPUNIT_RUN and is_dir(OC::$SERVERROOT . '/tests/config/')) {

--- a/tests/lib/autoloader.php
+++ b/tests/lib/autoloader.php
@@ -20,41 +20,78 @@ class AutoLoader extends TestCase {
 	}
 
 	public function testLeadingSlashOnClassName() {
-		$this->assertEquals(array('private/files/storage/local.php', 'files/storage/local.php'), $this->loader->findClass('\OC\Files\Storage\Local'));
+		$this->assertEquals([
+			\OC::$SERVERROOT . '/lib/private/files/storage/local.php',
+		], $this->loader->findClass('\OC\Files\Storage\Local'));
 	}
 
 	public function testNoLeadingSlashOnClassName() {
-		$this->assertEquals(array('private/files/storage/local.php', 'files/storage/local.php'), $this->loader->findClass('OC\Files\Storage\Local'));
+		$this->assertEquals([
+			\OC::$SERVERROOT . '/lib/private/files/storage/local.php', 
+		], $this->loader->findClass('OC\Files\Storage\Local'));
 	}
 
 	public function testLegacyPath() {
-		$this->assertEquals(array('private/legacy/files.php', 'private/files.php'), $this->loader->findClass('OC_Files'));
+		$this->assertEquals([
+			\OC::$SERVERROOT . '/lib/private/legacy/files.php', 
+			\OC::$SERVERROOT . '/lib/private/files.php',
+		], $this->loader->findClass('OC_Files'));
 	}
 
 	public function testLoadTestNamespace() {
-		$this->assertEquals(array('tests/lib/foo/bar.php'), $this->loader->findClass('Test\Foo\Bar'));
+		$this->assertEquals([
+			\OC::$SERVERROOT . '/tests/lib/foo/bar.php'
+		], $this->loader->findClass('Test\Foo\Bar'));
 	}
 
 	public function testLoadTest() {
-		$this->assertEquals(array('tests/lib/foo/bar.php'), $this->loader->findClass('Test_Foo_Bar'));
+		$this->assertEquals([
+			\OC::$SERVERROOT . '/tests/lib/foo/bar.php'
+		], $this->loader->findClass('Test_Foo_Bar'));
 	}
 
 	public function testLoadCoreNamespace() {
-		$this->assertEquals(array('private/foo/bar.php', 'foo/bar.php'), $this->loader->findClass('OC\Foo\Bar'));
+		$this->assertEquals([
+			\OC::$SERVERROOT . '/lib/private/foo/bar.php', 
+		], $this->loader->findClass('OC\Foo\Bar'));
 	}
 
 	public function testLoadCore() {
-		$this->assertEquals(array('private/legacy/foo/bar.php', 'private/foo/bar.php'), $this->loader->findClass('OC_Foo_Bar'));
+		$this->assertEquals([
+			\OC::$SERVERROOT . '/lib/private/legacy/foo/bar.php', 
+			\OC::$SERVERROOT . '/lib/private/foo/bar.php',
+		], $this->loader->findClass('OC_Foo_Bar'));
 	}
 
 	public function testLoadPublicNamespace() {
-		$this->assertEquals(array('public/foo/bar.php'), $this->loader->findClass('OCP\Foo\Bar'));
+		$this->assertEquals([
+			\OC::$SERVERROOT . '/lib/public/foo/bar.php',
+		], $this->loader->findClass('OCP\Foo\Bar'));
 	}
 
 	public function testLoadAppNamespace() {
 		$result = $this->loader->findClass('OCA\Files\Foobar');
+		print_r($result);
 		$this->assertEquals(2, count($result));
 		$this->assertStringEndsWith('apps/files/foobar.php', $result[0]);
 		$this->assertStringEndsWith('apps/files/lib/foobar.php', $result[1]);
+	}
+
+	public function testLoadCoreNamespaceCore() {
+		$this->assertEquals([
+			\OC::$SERVERROOT . '/core/foo/bar.php', 
+		], $this->loader->findClass('OC\Core\Foo\Bar'));
+	}
+
+	public function testLoadCoreNamespaceSettings() {
+		$this->assertEquals([
+			\OC::$SERVERROOT . '/settings/foo/bar.php', 
+		], $this->loader->findClass('OC\Settings\Foo\Bar'));
+	}
+
+	public function testLoadCoreNamespaceRepair() {
+		$this->assertEquals([
+			\OC::$SERVERROOT . '/lib/repair/foo/bar.php', 
+		], $this->loader->findClass('OC\Repair\Foo\Bar'));
 	}
 }

--- a/tests/lib/autoloader.php
+++ b/tests/lib/autoloader.php
@@ -71,7 +71,6 @@ class AutoLoader extends TestCase {
 
 	public function testLoadAppNamespace() {
 		$result = $this->loader->findClass('OCA\Files\Foobar');
-		print_r($result);
 		$this->assertEquals(2, count($result));
 		$this->assertStringEndsWith('apps/files/foobar.php', $result[0]);
 		$this->assertStringEndsWith('apps/files/lib/foobar.php', $result[1]);


### PR DESCRIPTION
## Description
Two autoloader-related commits cherry-picked from stable9
https://github.com/owncloud/core/commit/ff1271c7f348b615998489c770741cec277b6684
and
https://github.com/owncloud/core/pull/20365/commits/0bb5eadf8984fbb21e9f573da9a37e4a75e83a68

## Related Issue
https://github.com/owncloud/enterprise/issues/1769

## Motivation and Context
Fixes autoloader failure while executing occ script from `config` directory

## How Has This Been Tested?
`cd owncloud/config && sudo -uwww-data php ../occ status`

### Expected
occ status executed

### Actual
`OCP\AutoloadNotAllowedException` is thrown


## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

