### PR TITLE
Restrict proppatch to the proper nodes

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -361,24 +361,21 @@ class FilesPlugin extends ServerPlugin {
 	 * @return void
 	 */
 	public function handleUpdateProperties($path, PropPatch $propPatch) {
-		$propPatch->handle(self::LASTMODIFIED_PROPERTYNAME, function($time) use ($path) {
+		$node = $this->tree->getNodeForPath($path);
+		if (!($node instanceof \OCA\DAV\Connector\Sabre\Node)) {
+			return;
+		}
+
+		$propPatch->handle(self::LASTMODIFIED_PROPERTYNAME, function($time) use ($node) {
 			if (empty($time)) {
 				return false;
-			}
-			$node = $this->tree->getNodeForPath($path);
-			if (is_null($node)) {
-				return 404;
 			}
 			$node->touch($time);
 			return true;
 		});
-		$propPatch->handle(self::GETETAG_PROPERTYNAME, function($etag) use ($path) {
+		$propPatch->handle(self::GETETAG_PROPERTYNAME, function($etag) use ($node) {
 			if (empty($etag)) {
 				return false;
-			}
-			$node = $this->tree->getNodeForPath($path);
-			if (is_null($node)) {
-				return 404;
 			}
 			if ($node->setEtag($etag) !== -1) {
 				return true;

--- a/apps/dav/lib/Connector/Sabre/TagsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/TagsPlugin.php
@@ -266,20 +266,17 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin
 	 * @return void
 	 */
 	public function handleUpdateProperties($path, PropPatch $propPatch) {
-		$propPatch->handle(self::TAGS_PROPERTYNAME, function($tagList) use ($path) {
-			$node = $this->tree->getNodeForPath($path);
-			if (is_null($node)) {
-				return 404;
-			}
+		$node = $this->tree->getNodeForPath($path);
+		if (!($node instanceof \OCA\DAV\Connector\Sabre\Node)) {
+			return;
+		}
+
+		$propPatch->handle(self::TAGS_PROPERTYNAME, function($tagList) use ($node) {
 			$this->updateTags($node->getId(), $tagList->getTags());
 			return true;
 		});
 
-		$propPatch->handle(self::FAVORITE_PROPERTYNAME, function($favState) use ($path) {
-			$node = $this->tree->getNodeForPath($path);
-			if (is_null($node)) {
-				return 404;
-			}
+		$propPatch->handle(self::FAVORITE_PROPERTYNAME, function($favState) use ($node) {
 			if ((int)$favState === 1 || $favState === 'true') {
 				$this->getTagger()->tagAs($node->getId(), self::TAG_FAVORITE);
 			} else {

--- a/apps/dav/lib/SystemTag/SystemTagPlugin.php
+++ b/apps/dav/lib/SystemTag/SystemTagPlugin.php
@@ -268,17 +268,17 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 	 * @return void
 	 */
 	public function handleUpdateProperties($path, PropPatch $propPatch) {
+		$node = $this->server->tree->getNodeForPath($path);
+		if (!($node instanceof SystemTagNode)) {
+			return;
+		}
+
 		$propPatch->handle([
 			self::DISPLAYNAME_PROPERTYNAME,
 			self::USERVISIBLE_PROPERTYNAME,
 			self::USERASSIGNABLE_PROPERTYNAME,
 			self::GROUPS_PROPERTYNAME,
-		], function($props) use ($path) {
-			$node = $this->server->tree->getNodeForPath($path);
-			if (!($node instanceof SystemTagNode)) {
-				return;
-			}
-
+		], function($props) use ($node) {
 			$tag = $node->getSystemTag();
 			$name = $tag->getName();
 			$userVisible = $tag->isUserVisible();


### PR DESCRIPTION
## Description
Need to fetch the node earlier because cancelling from within the
handler is not possible. Well, it is but it prevents other node types
using the same property names to run because the failure marks the
property with status 403.

## Related Issue
Discovered while working on the customgroups code: https://github.com/owncloud/customgroups/pull/13
Basically the custom groups also have a property called "oc:display-name" and it conflicted with the one from the system tags. This fixes the conflict by preventing system tag handlers to register themselves if the node is not a system tag.

## Motivation and Context
Because it prevents other apps to reuse property names.

## How Has This Been Tested?
PROPPATCH on "oc:display-name" on an existing group on " http://localhost/owncloud/remote.php/dav/customgroups/groups/existinggroup" with the custom groups app.
Before the fix: internal server error, Sabre complains about a handler not returning anything.
After the fix: the property is accepted.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Let's see if some tests fail.

@DeepDiver1975 @jvillafanez 