### PR TITLE
WebdavNode backbone models and collections

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "underscore": "1.8.3",
     "bootstrap": "3.3.6",
     "backbone": "1.2.3",
-    "davclient.js": "https://github.com/evert/davclient.js.git#0.0.1",
+    "davclient.js": "https://github.com/PVince81/davclient.js.git#aac276bfb304d474b7be7e13edf2e87addf2965c",
     "es6-promise": "https://github.com/jakearchibald/es6-promise.git#2.3.0",
     "base64": "0.3.0",
     "clipboard": "1.5.12",

--- a/core/js/tests/specs/oc-backbone-webdavSpec.js
+++ b/core/js/tests/specs/oc-backbone-webdavSpec.js
@@ -650,6 +650,8 @@ describe('Backbone Webdav extension', function() {
 		});
 
 		it('creates the Webdav collection with MKCOL', function() {
+			var mkcolStub = sinon.stub(dav.Client.prototype, 'mkcol');
+			mkcolStub.returns(deferredRequest.promise());
 			var model = new NodeModel({
 				id: 'davcol'
 			});
@@ -658,15 +660,17 @@ describe('Backbone Webdav extension', function() {
 				lastName: 'World',
 			});
 
-			expect(davClientRequestStub.calledOnce).toEqual(true);
-			expect(davClientRequestStub.getCall(0).args[0])
-				.toEqual('MKCOL');
-			expect(davClientRequestStub.getCall(0).args[1])
+			expect(mkcolStub.calledOnce).toEqual(true);
+			expect(mkcolStub.getCall(0).args[0])
 				.toEqual('http://example.com/owncloud/remote.php/dav/davcol');
-			expect(davClientRequestStub.getCall(0).args[2]['X-Requested-With'])
+			expect(mkcolStub.getCall(0).args[1])
+				.toEqual({
+					'{http://owncloud.org/ns}first-name': 'Hello',
+					'{http://owncloud.org/ns}last-name': 'World',
+					'{DAV:}resourcetype': '<d:collection/>'
+				});
+			expect(mkcolStub.getCall(0).args[2]['X-Requested-With'])
 				.toEqual('XMLHttpRequest');
-			expect(davClientRequestStub.getCall(0).args[3])
-				.toEqual(null);
 
 			deferredRequest.resolve({
 				status: 201,
@@ -678,6 +682,8 @@ describe('Backbone Webdav extension', function() {
 
 			expect(model.id).toEqual('davcol');
 			expect(model.isNew()).toEqual(false);
+
+			mkcolStub.restore();
 		});
 		it('updates Webdav collection properties with PROPPATCH', function() {
 			var model = new NodeModel({


### PR DESCRIPTION
It turns out MKCOL should only be used on create.
The previous patch to this file broke updates with PROPPATCH.

Required to be able to use inner collections for custom groups: https://github.com/owncloud/customgroups/pull/13

@jvillafanez 