### PR TITLE
Map sr@latin to sr - required for proper setup of moment.js

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -126,6 +126,9 @@ class TemplateLayout extends \OC_Template {
 		}
 		// Send the language to our layouts
 		$lang = \OC::$server->getL10NFactory()->findLanguage();
+		if ($lang === 'sr@latin') {
+			$lang = 'sr';
+		}
 		$this->assign('language', $lang);
 
 		if(\OC::$server->getSystemConfig()->getValue('installed', false)) {


### PR DESCRIPTION
## Description
moment.js uses 'sr' as key for Serbian with Latin characters. ownCloud uses 'sr@latin'.
As a result anything related to dates and times is translated wrong.

## Related Issue
fixes https://github.com/owncloud/activity/issues/560

## How Has This Been Tested?
- choose Serbian from the language settings ('Srpski')
- goto files app
- see the modified columns not being translated (master) or in Chinese (9.1.x)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

