### PR TITLE
Dont try to refresh log entries on log level change.

### DIFF
--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -30,9 +30,7 @@ $(document).ready(function(){
 
 
 	$('#loglevel').change(function(){
-		$.post(OC.generateUrl('/settings/admin/log/level'), {level: $(this).val()},function(){
-			OC.Log.reload();
-		} );
+		$.post(OC.generateUrl('/settings/admin/log/level'), {level: $(this).val()});
 	});
 
 	$('#backgroundjobs span.crondate').tipsy({gravity: 's', live: true});


### PR DESCRIPTION
Fixes the JS console bug mentioned here: https://github.com/owncloud/core/issues/27117

Changing the log level used to cause a JS error as the front-end code was still trying to refresh the log entries but we don't show these anymore.

@davitol 