### PR TITLE
[stable9.1] Redirect unlink to rmdir

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -687,7 +687,11 @@ class View {
 		if ($mount and $mount->getInternalPath($absolutePath) === '') {
 			return $this->removeMount($mount, $absolutePath);
 		}
-		$result = $this->basicOperation('unlink', $path, array('delete'));
+		if ($this->is_dir($path)) {
+			$result = $this->basicOperation('rmdir', $path, array('delete'));
+		} else {
+			$result = $this->basicOperation('unlink', $path, array('delete'));
+		}
 		if (!$result && !$this->file_exists($path)) { //clear ghost files from the cache on delete
 			$storage = $mount->getStorage();
 			$internalPath = $mount->getInternalPath($absolutePath);

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -512,6 +512,29 @@ class ViewTest extends \Test\TestCase {
 		$this->assertFalse($rootView->file_exists('substorage/bar.txt'));
 	}
 
+	public function rmdirOrUnlinkDataProvider() {
+		return [['rmdir'], ['unlink']];
+	}
+
+	/**
+	 * @dataProvider rmdirOrUnlinkDataProvider
+	 */
+	public function testRmdir($method) {
+		$storage1 = $this->getTestStorage();
+		\OC\Files\Filesystem::mount($storage1, [], '/');
+
+		$rootView = new \OC\Files\View('');
+		$rootView->mkdir('sub');
+		$rootView->mkdir('sub/deep');
+		$rootView->file_put_contents('/sub/deep/foo.txt', 'asd');
+
+		$this->assertTrue($rootView->file_exists('sub/deep/foo.txt'));
+
+		$this->assertTrue($rootView->$method('sub'));
+
+		$this->assertFalse($rootView->file_exists('sub'));
+	}
+
 	/**
 	 * @medium
 	 */


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/27101 to stable9.1.

Note that the original problem with disabled trashbin is not reproducible here because the web UI uses Webdav DELETE which already uses rmdir instead of unlink.

@DeepDiver1975 @mmattel @jvillafanez please review