### PR TITLE
[stable9] Redirect unlink to rmdir

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -677,7 +677,11 @@ class View {
 		if ($mount and $mount->getInternalPath($absolutePath) === '') {
 			return $this->removeMount($mount, $absolutePath);
 		}
-		return $this->basicOperation('unlink', $path, array('delete'));
+		if ($this->is_dir($path)) {
+			return $this->basicOperation('rmdir', $path, array('delete'));
+		} else {
+			return $this->basicOperation('unlink', $path, array('delete'));
+		}
 	}
 
 	/**

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -505,6 +505,29 @@ class View extends \Test\TestCase {
 		$this->assertFalse($rootView->file_exists('substorage/bar.txt'));
 	}
 
+	public function rmdirOrUnlinkDataProvider() {
+		return [['rmdir'], ['unlink']];
+	}
+
+	/**
+	 * @dataProvider rmdirOrUnlinkDataProvider
+	 */
+	public function testRmdir($method) {
+		$storage1 = $this->getTestStorage();
+		\OC\Files\Filesystem::mount($storage1, [], '/');
+
+		$rootView = new \OC\Files\View('');
+		$rootView->mkdir('sub');
+		$rootView->mkdir('sub/deep');
+		$rootView->file_put_contents('/sub/deep/foo.txt', 'asd');
+
+		$this->assertTrue($rootView->file_exists('sub/deep/foo.txt'));
+
+		$this->assertTrue($rootView->$method('sub'));
+
+		$this->assertFalse($rootView->file_exists('sub'));
+	}
+
 	/**
 	 * @medium
 	 */


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/27101 to stable9.

Note that the original problem with disabled trashbin is not reproducible here because the web UI uses Webdav DELETE which already uses rmdir instead of unlink.

@DeepDiver1975 @mmattel @jvillafanez please review