### PR TITLE
[stable8.2] Redirect unlink to rmdir

### DIFF
--- a/lib/private/files/view.php
+++ b/lib/private/files/view.php
@@ -602,7 +602,11 @@ class View {
 		if ($mount and $mount->getInternalPath($absolutePath) === '') {
 			return $this->removeMount($mount, $absolutePath);
 		}
-		return $this->basicOperation('unlink', $path, array('delete'));
+		if ($this->is_dir($path)) {
+			return $this->basicOperation('rmdir', $path, array('delete'));
+		} else {
+			return $this->basicOperation('unlink', $path, array('delete'));
+		}
 	}
 
 	/**

--- a/tests/lib/files/view.php
+++ b/tests/lib/files/view.php
@@ -481,6 +481,29 @@ class View extends \Test\TestCase {
 		$this->assertFalse($rootView->file_exists('substorage/bar.txt'));
 	}
 
+	public function rmdirOrUnlinkDataProvider() {
+		return [['rmdir'], ['unlink']];
+	}
+
+	/**
+	 * @dataProvider rmdirOrUnlinkDataProvider
+	 */
+	public function testRmdir($method) {
+		$storage1 = $this->getTestStorage();
+		\OC\Files\Filesystem::mount($storage1, [], '/');
+
+		$rootView = new \OC\Files\View('');
+		$rootView->mkdir('sub');
+		$rootView->mkdir('sub/deep');
+		$rootView->file_put_contents('/sub/deep/foo.txt', 'asd');
+
+		$this->assertTrue($rootView->file_exists('sub/deep/foo.txt'));
+
+		$this->assertTrue($rootView->$method('sub'));
+
+		$this->assertFalse($rootView->file_exists('sub'));
+	}
+
 	/**
 	 * @medium
 	 */


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/27101 to stable8.2.

See steps in https://github.com/owncloud/core/pull/27101.

Since the web UI uses ajax/delete.php, that one uses unlink instead of rmdir.

Please review @jvillafanez @mmattel @DeepDiver1975 

I have retested this and it works fine.
Since `fopen()` of a folder seems to work on my environment, I had to use a debugger to verify that the encryption wrapper `getHeader()` is not called any more after the fix.