### PR TITLE
Only load setup checks when panel is visible

### DIFF
--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -169,58 +169,5 @@ $(document).ready(function(){
 		$("#selectExcludedGroups").toggleClass('hidden', !this.checked);
 	});
 
-	// run setup checks then gather error messages
-	$.when(
-		OC.SetupChecks.checkWebDAV(),
-		OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav/', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === 'true'),
-		OC.SetupChecks.checkWellKnownUrl('/.well-known/carddav/', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === 'true'),
-		OC.SetupChecks.checkSetup(),
-		OC.SetupChecks.checkGeneric(),
-		OC.SetupChecks.checkDataProtected()
-	).then(function(check1, check2, check3, check4, check5, check6) {
-		var messages = [].concat(check1, check2, check3, check4, check5, check6);
-		var $el = $('#postsetupchecks');
-		$el.find('.loading').addClass('hidden');
 
-		var hasMessages = false;
-		var $errorsEl = $el.find('.errors');
-		var $warningsEl = $el.find('.warnings');
-		var $infoEl = $el.find('.info');
-
-		for (var i = 0; i < messages.length; i++ ) {
-			switch(messages[i].type) {
-				case OC.SetupChecks.MESSAGE_TYPE_INFO:
-					$infoEl.append('<li>' + messages[i].msg + '</li>');
-					break;
-				case OC.SetupChecks.MESSAGE_TYPE_WARNING:
-					$warningsEl.append('<li>' + messages[i].msg + '</li>');
-					break;
-				case OC.SetupChecks.MESSAGE_TYPE_ERROR:
-				default:
-					$errorsEl.append('<li>' + messages[i].msg + '</li>');
-			}
-		}
-
-		if ($errorsEl.find('li').length > 0) {
-			$errorsEl.removeClass('hidden');
-			hasMessages = true;
-		}
-		if ($warningsEl.find('li').length > 0) {
-			$warningsEl.removeClass('hidden');
-			hasMessages = true;
-		}
-		if ($infoEl.find('li').length > 0) {
-			$infoEl.removeClass('hidden');
-			hasMessages = true;
-		}
-
-		if (hasMessages) {
-			$el.find('.hint').removeClass('hidden');
-		} else {
-			var securityWarning = $('#security-warning');
-			if (securityWarning.children('ul').children().length === 0) {
-				$('#security-warning-state').find('span').removeClass('hidden');
-			}
-		}
-	});
 });

--- a/settings/js/panels/setupchecks.js
+++ b/settings/js/panels/setupchecks.js
@@ -1,0 +1,58 @@
+$(document).ready(function() {
+
+	// run setup checks then gather error messages
+	$.when(
+		OC.SetupChecks.checkWebDAV(),
+		OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav/', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === 'true'),
+		OC.SetupChecks.checkWellKnownUrl('/.well-known/carddav/', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === 'true'),
+		OC.SetupChecks.checkSetup(),
+		OC.SetupChecks.checkGeneric(),
+		OC.SetupChecks.checkDataProtected()
+	).then(function (check1, check2, check3, check4, check5, check6) {
+		var messages = [].concat(check1, check2, check3, check4, check5, check6);
+		var $el = $('#postsetupchecks');
+		$el.find('.loading').addClass('hidden');
+
+		var hasMessages = false;
+		var $errorsEl = $el.find('.errors');
+		var $warningsEl = $el.find('.warnings');
+		var $infoEl = $el.find('.info');
+
+		for (var i = 0; i < messages.length; i++) {
+			switch (messages[i].type) {
+				case OC.SetupChecks.MESSAGE_TYPE_INFO:
+					$infoEl.append('<li>' + messages[i].msg + '</li>');
+					break;
+				case OC.SetupChecks.MESSAGE_TYPE_WARNING:
+					$warningsEl.append('<li>' + messages[i].msg + '</li>');
+					break;
+				case OC.SetupChecks.MESSAGE_TYPE_ERROR:
+				default:
+					$errorsEl.append('<li>' + messages[i].msg + '</li>');
+			}
+		}
+
+		if ($errorsEl.find('li').length > 0) {
+			$errorsEl.removeClass('hidden');
+			hasMessages = true;
+		}
+		if ($warningsEl.find('li').length > 0) {
+			$warningsEl.removeClass('hidden');
+			hasMessages = true;
+		}
+		if ($infoEl.find('li').length > 0) {
+			$infoEl.removeClass('hidden');
+			hasMessages = true;
+		}
+
+		if (hasMessages) {
+			$el.find('.hint').removeClass('hidden');
+		} else {
+			var securityWarning = $('#security-warning');
+			if (securityWarning.children('ul').children().length === 0) {
+				$('#security-warning-state').find('span').removeClass('hidden');
+			}
+		}
+	});
+
+});

--- a/settings/templates/panels/admin/securitywarning.php
+++ b/settings/templates/panels/admin/securitywarning.php
@@ -4,6 +4,8 @@
  * @var \OCP\IL10N $l
  * @var OC_Defaults $theme
  */
+script('core', 'setupchecks');
+script('settings', 'panels/setupchecks');
 ?>
 <div id="security-warning" class="section">
 	<h2 class="app-name"><?php p($l->t('Security & setup warnings'));?></h2>

--- a/settings/templates/settingsPage.php
+++ b/settings/templates/settingsPage.php
@@ -16,9 +16,6 @@ vendor_style('select2/select2');
 script('core', 'multiselect');
 style('settings', 'settings');
 
-if($_['type'] === 'admin') {
-	script('core', ['multiselect', 'setupchecks']);
-}
 ?>
 
 <div id="app-navigation">


### PR DESCRIPTION
Splits out the javascript from the old large `admin.js` into a file just for the security-warnings panel so the checks are only performed when the security-warnings panel is shown.

@davitol @SergioBertolinSG @DeepDiver1975 