### PR TITLE
Extract mail admin panel js into separate file

### DIFF
--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -111,55 +111,6 @@ $(document).ready(function(){
 		$('#setDefaultExpireDate').toggleClass('hidden', !(this.checked && $('#shareapiDefaultExpireDate')[0].checked));
 	});
 
-	$('#mail_smtpauth').change(function() {
-		if (!this.checked) {
-			$('#mail_credentials').addClass('hidden');
-		} else {
-			$('#mail_credentials').removeClass('hidden');
-		}
-	});
-
-	$('#mail_smtpmode').change(function() {
-		if ($(this).val() !== 'smtp') {
-			$('#setting_smtpauth').addClass('hidden');
-			$('#setting_smtphost').addClass('hidden');
-			$('#mail_smtpsecure_label').addClass('hidden');
-			$('#mail_smtpsecure').addClass('hidden');
-			$('#mail_credentials').addClass('hidden');
-		} else {
-			$('#setting_smtpauth').removeClass('hidden');
-			$('#setting_smtphost').removeClass('hidden');
-			$('#mail_smtpsecure_label').removeClass('hidden');
-			$('#mail_smtpsecure').removeClass('hidden');
-			if ($('#mail_smtpauth').is(':checked')) {
-				$('#mail_credentials').removeClass('hidden');
-			}
-		}
-	});
-
-	$('#mail_general_settings_form').change(function(){
-		OC.msg.startSaving('#mail_settings_msg');
-		var post = $( "#mail_general_settings_form" ).serialize();
-		$.post(OC.generateUrl('/settings/admin/mailsettings'), post, function(data){
-			OC.msg.finishedSaving('#mail_settings_msg', data);
-		});
-	});
-
-	$('#mail_credentials_settings_submit').click(function(){
-		OC.msg.startSaving('#mail_settings_msg');
-		var post = $( "#mail_credentials_settings" ).serialize();
-		$.post(OC.generateUrl('/settings/admin/mailsettings/credentials'), post, function(data){
-			OC.msg.finishedSaving('#mail_settings_msg', data);
-		});
-	});
-
-	$('#sendtestemail').click(function(event){
-		event.preventDefault();
-		OC.msg.startAction('#sendtestmail_msg', t('settings', 'Sending...'));
-		$.post(OC.generateUrl('/settings/admin/mailtest'), '', function(data){
-			OC.msg.finishedAction('#sendtestmail_msg', data);
-		});
-	});
 
 	$('#allowGroupSharing').change(function() {
 		$('#allowGroupSharing').toggleClass('hidden', !this.checked);

--- a/settings/js/panels/mail.js
+++ b/settings/js/panels/mail.js
@@ -1,0 +1,53 @@
+$(document).ready(function() {
+
+	$('#mail_smtpauth').change(function () {
+		if (!this.checked) {
+			$('#mail_credentials').addClass('hidden');
+		} else {
+			$('#mail_credentials').removeClass('hidden');
+		}
+	});
+
+	$('#mail_smtpmode').change(function () {
+		if ($(this).val() !== 'smtp') {
+			$('#setting_smtpauth').addClass('hidden');
+			$('#setting_smtphost').addClass('hidden');
+			$('#mail_smtpsecure_label').addClass('hidden');
+			$('#mail_smtpsecure').addClass('hidden');
+			$('#mail_credentials').addClass('hidden');
+		} else {
+			$('#setting_smtpauth').removeClass('hidden');
+			$('#setting_smtphost').removeClass('hidden');
+			$('#mail_smtpsecure_label').removeClass('hidden');
+			$('#mail_smtpsecure').removeClass('hidden');
+			if ($('#mail_smtpauth').is(':checked')) {
+				$('#mail_credentials').removeClass('hidden');
+			}
+		}
+	});
+
+	$('#mail_general_settings_form').change(function () {
+		OC.msg.startSaving('#mail_settings_msg');
+		var post = $("#mail_general_settings_form").serialize();
+		$.post(OC.generateUrl('/settings/admin/mailsettings'), post, function (data) {
+			OC.msg.finishedSaving('#mail_settings_msg', data);
+		});
+	});
+
+	$('#mail_credentials_settings_submit').click(function () {
+		OC.msg.startSaving('#mail_settings_msg');
+		var post = $("#mail_credentials_settings").serialize();
+		$.post(OC.generateUrl('/settings/admin/mailsettings/credentials'), post, function (data) {
+			OC.msg.finishedSaving('#mail_settings_msg', data);
+		});
+	});
+
+	$('#sendtestemail').click(function (event) {
+		event.preventDefault();
+		OC.msg.startAction('#sendtestmail_msg', t('settings', 'Sending...'));
+		$.post(OC.generateUrl('/settings/admin/mailtest'), '', function (data) {
+			OC.msg.finishedAction('#sendtestmail_msg', data);
+		});
+	});
+
+});

--- a/settings/templates/panels/admin/mail.php
+++ b/settings/templates/panels/admin/mail.php
@@ -1,4 +1,5 @@
 <?php
+script('settings', 'panels/mail');
 $mail_smtpauthtype = [
 	''	=> $l->t('None'),
 	'LOGIN'	=> $l->t('Login'),


### PR DESCRIPTION
Splits the mail admin panel js into a separate file so that the frontend logic is only loaded whilst the panel is visible. This will help us with AJAX loading the panels later and splits up the large old `admin.js`.

@davitol @SergioBertolinSG @DeepDiver1975 

See also https://github.com/owncloud/core/pull/27129