### PR TITLE
Fix Jail getSourcePath to use underlying path

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -55,10 +55,11 @@ class Jail extends Wrapper {
 			throw new \InvalidArgumentException('Jail rootPath is null');
 		}
 		if ($path === '') {
-			return $this->rootPath;
+			$fullPath = $this->rootPath;
 		} else {
-			return $this->rootPath . '/' . $path;
+			$fullPath = $this->rootPath . '/' . $path;
 		}
+		return $this->getWrapperStorage()->getSourcePath($fullPath);
 	}
 
 	public function getId() {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
The Jail wrapper's getSourcePath method should return absolute paths
based on the underlying storage.

## Related Issue
For https://github.com/owncloud/core/issues/27124

## Motivation and Context
There is currently no visible bug regarding this because the encryption wrapper is always applied, so it hides this issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## TODO:

- [ ] expect test failures
- [ ] add unit test