### PR TITLE
[stable9] Log files:scan exception

### DIFF
--- a/apps/files/command/scan.php
+++ b/apps/files/command/scan.php
@@ -28,6 +28,7 @@ namespace OCA\Files\Command;
 
 use Doctrine\DBAL\Connection;
 use OC\Core\Command\Base;
+use OC\Core\Command\InterruptedException;
 use OC\ForbiddenException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IDBConnection;
@@ -101,14 +102,14 @@ class Scan extends Base {
 				$output->writeln("\tFile   <info>$path</info>");
 				$this->filesCounter += 1;
 				if ($this->hasBeenInterrupted()) {
-					throw new \Exception('ctrl-c');
+					throw new InterruptedException();
 				}
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output) {
 				$output->writeln("\tFolder <info>$path</info>");
 				$this->foldersCounter += 1;
 				if ($this->hasBeenInterrupted()) {
-					throw new \Exception('ctrl-c');
+					throw new InterruptedException();
 				}
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'StorageNotAvailable', function (StorageNotAvailableException $e) use ($output) {
@@ -119,13 +120,13 @@ class Scan extends Base {
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function () use ($output) {
 				$this->filesCounter += 1;
 				if ($this->hasBeenInterrupted()) {
-					throw new \Exception('ctrl-c');
+					throw new InterruptedException();
 				}
 			});
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function () use ($output) {
 				$this->foldersCounter += 1;
 				if ($this->hasBeenInterrupted()) {
-					throw new \Exception('ctrl-c');
+					throw new InterruptedException();
 				}
 			});
 		}
@@ -135,9 +136,12 @@ class Scan extends Base {
 		} catch (ForbiddenException $e) {
 			$output->writeln("<error>Home storage for user $user not writable</error>");
 			$output->writeln("Make sure you're running the scan command only as the user the web server runs as");
-		} catch (\Exception $e) {
+		} catch (InterruptedException $e) {
 			# exit the function if ctrl-c has been pressed 
+			$output->writeln('Interrupted by user');
 			return;
+		} catch (\Exception $e) {
+			$output->writeln('<error>Exception during scan: ' . $e->getMessage() . "\n" . $e->getTraceAsString() . '</error>');
 		}
 	}
 

--- a/core/command/interruptedexception.php
+++ b/core/command/interruptedexception.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Core\Command;
+
+/**
+ * Exception for when the user hit ctrl-c
+ */
+class InterruptedException extends \Exception {}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Log files:scan exception

## Related Issue

## Motivation and Context
Because else it looks like all was fine but the scanner actually aborted and the summary was still displayed.
The exception could be useful to debug the actual issue.

## How Has This Been Tested?
Manually threw an exception from within the scanner to see that it's displayed properly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Forward ports
- [ ] stable9.1
- [ ] master

@jvillafanez