### PR TITLE
Solves issue #26749 - UPDATED

### DIFF
--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -340,7 +340,7 @@
 				error: function() {
 					$loading.addClass('hidden');
 					$comment.removeClass('disabled');
-					OC.Notification.showTemporary(t('comments', 'Error occurred while retrieving comment with id {id}', {id: commentId}));
+					OC.Notification.show('Error occurred while retrieving comment with id {id}', {id: commentId, timeout: 7, type: 'error'});
 				}
 			});
 
@@ -393,7 +393,7 @@
 						$loading.addClass('hidden');
 						$textArea.prop('disabled', false);
 
-						OC.Notification.showTemporary(t('comments', 'Error occurred while updating comment with id {id}', {id: commentId}));
+						OC.Notification.show('Error occurred while updating comment with id {id}', {id: commentId, timeout: 7, type: 'error'});
 					}
 				});
 			} else {
@@ -418,7 +418,7 @@
 						$loading.addClass('hidden');
 						$textArea.prop('disabled', false);
 
-						OC.Notification.showTemporary(t('comments', 'Error occurred while posting comment'));
+						OC.Notification.show('Error occurred while posting comment', {timeout: 7, type: 'error'});
 					}
 				});
 			}

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -393,7 +393,7 @@
 						$loading.addClass('hidden');
 						$textArea.prop('disabled', false);
 
-						OC.Notification.show('Error occurred while updating comment with id {id}', {id: commentId, timeout: 7, type: 'error'});
+						OC.Notification.show('Error occurred while updating comment with id {id}', {id: commentId, type: 'error'});
 					}
 				});
 			} else {
@@ -418,7 +418,7 @@
 						$loading.addClass('hidden');
 						$textArea.prop('disabled', false);
 
-						OC.Notification.show('Error occurred while posting comment', {timeout: 7, type: 'error'});
+						OC.Notification.show('Error occurred while posting comment', {type: 'error'});
 					}
 				});
 			}

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -393,7 +393,7 @@
 						$loading.addClass('hidden');
 						$textArea.prop('disabled', false);
 
-						OC.Notification.show('Error occurred while updating comment with id {id}', {id: commentId, type: 'error'});
+						OC.Notification.show(t('comments', 'Error occurred while updating comment with id {id}', {id: commentId}), {type: 'error'});
 					}
 				});
 			} else {
@@ -418,7 +418,7 @@
 						$loading.addClass('hidden');
 						$textArea.prop('disabled', false);
 
-						OC.Notification.show('Error occurred while posting comment', {type: 'error'});
+						OC.Notification.show(t('comments', 'Error occurred while posting comment'), {type: 'error'});
 					}
 				});
 			}

--- a/apps/comments/js/commentstabview.js
+++ b/apps/comments/js/commentstabview.js
@@ -340,7 +340,7 @@
 				error: function() {
 					$loading.addClass('hidden');
 					$comment.removeClass('disabled');
-					OC.Notification.show('Error occurred while retrieving comment with id {id}', {id: commentId, timeout: 7, type: 'error'});
+					OC.Notification.showTemporary(t('comments', 'Error occurred while retrieving comment with id {id}', {id: commentId}));
 				}
 			});
 

--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -54,7 +54,7 @@
 			var showHidden = $('#showHiddenFiles').val() === "1";
 			this.$showHiddenFiles.prop('checked', showHidden);
 			if ($('#fileNotFound').val() === "1") {
-				OC.Notification.show('File could not be found', {timeout: 7, type: 'error'});
+				OC.Notification.show('File could not be found', {type: 'error'});
 			}
 
 			this._filesConfig = new OC.Backbone.Model({

--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -54,7 +54,7 @@
 			var showHidden = $('#showHiddenFiles').val() === "1";
 			this.$showHiddenFiles.prop('checked', showHidden);
 			if ($('#fileNotFound').val() === "1") {
-				OC.Notification.showTemporary(t('files', 'File could not be found'));
+				OC.Notification.show('File could not be found', {timeout: 7, type: 'error'});
 			}
 
 			this._filesConfig = new OC.Backbone.Model({
@@ -315,4 +315,3 @@ $(document).ready(function() {
 		OCA.Files.App.initialize();
 	});
 });
-

--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -54,7 +54,7 @@
 			var showHidden = $('#showHiddenFiles').val() === "1";
 			this.$showHiddenFiles.prop('checked', showHidden);
 			if ($('#fileNotFound').val() === "1") {
-				OC.Notification.show('File could not be found', {type: 'error'});
+				OC.Notification.show(t('files', 'File could not be found'), {type: 'error'});
 			}
 
 			this._filesConfig = new OC.Backbone.Model({

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -932,7 +932,7 @@ OC.Uploader.prototype = _.extend({
 						self.cancelUploads();
 					} else {
 						// HTTP connection problem or other error
-						OC.Notification.show(t('files', data.errorThrown), {type: 'error'});
+						OC.Notification.show(data.errorThrown, {type: 'error'});
 					}
 
 					if (upload) {

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -466,7 +466,7 @@ OC.Uploader.prototype = _.extend({
 						deferred.resolve();
 						return;
 					}
-					OC.Notification.showTemporary(t('files', 'Could not create folder "{dir}"', {dir: fullPath}));
+					OC.Notification.show('Could not create folder "{dir}"', {dir: fullPath, timeout: 7, type: 'error'});
 					deferred.reject();
 				});
 			}, function() {
@@ -547,7 +547,7 @@ OC.Uploader.prototype = _.extend({
 	},
 
 	showUploadCancelMessage: _.debounce(function() {
-		OC.Notification.showTemporary(t('files', 'Upload cancelled.'), {timeout: 10});
+		OC.Notification.show('Upload cancelled.', {timeout: 7, type: 'error'});
 	}, 500),
 	/**
 	 * Checks the currently known uploads.
@@ -924,19 +924,15 @@ OC.Uploader.prototype = _.extend({
 						self.showConflict(upload);
 					} else if (status === 404) {
 						// target folder does not exist any more
-						OC.Notification.showTemporary(
-							t('files', 'Target folder "{dir}" does not exist any more', {dir: upload.getFullPath()})
-						);
+						OC.Notification.show('Target folder "{dir}" does not exist any more', {dir: upload.getFullPath(), timeout: 7, type: 'error'});
 						self.cancelUploads();
 					} else if (status === 507) {
 						// not enough space
-						OC.Notification.showTemporary(
-							t('files', 'Not enough free space')
-						);
+						OC.Notification.show('Not enough free space', {timeout: 7, type: 'error'});
 						self.cancelUploads();
 					} else {
 						// HTTP connection problem or other error
-						OC.Notification.showTemporary(data.errorThrown, {timeout: 10});
+						OC.Notification.show(data.errorThrown, {timeout: 10, type: 'error'});
 					}
 
 					if (upload) {
@@ -1098,5 +1094,3 @@ OC.Uploader.prototype = _.extend({
 		return this.fileUploadParam;
 	}
 }, OC.Backbone.Events);
-
-

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -466,7 +466,7 @@ OC.Uploader.prototype = _.extend({
 						deferred.resolve();
 						return;
 					}
-					OC.Notification.show('Could not create folder "{dir}"', {dir: fullPath, type: 'error'});
+					OC.Notification.show(t('files', 'Could not create folder "{dir}"', {dir: fullPath}), {type: 'error'});
 					deferred.reject();
 				});
 			}, function() {
@@ -547,7 +547,7 @@ OC.Uploader.prototype = _.extend({
 	},
 
 	showUploadCancelMessage: _.debounce(function() {
-		OC.Notification.show('Upload cancelled.', {type: 'error'});
+		OC.Notification.show(t('files', 'Upload cancelled.'), {timeout : 7, type: 'error'});
 	}, 500),
 	/**
 	 * Checks the currently known uploads.
@@ -924,15 +924,15 @@ OC.Uploader.prototype = _.extend({
 						self.showConflict(upload);
 					} else if (status === 404) {
 						// target folder does not exist any more
-						OC.Notification.show('Target folder "{dir}" does not exist any more', {dir: upload.getFullPath(), type: 'error'});
+						OC.Notification.show(t('files', 'Target folder "{dir}" does not exist any more', {dir: upload.getFullPath()} ), {type: 'error'});
 						self.cancelUploads();
 					} else if (status === 507) {
 						// not enough space
-						OC.Notification.show('Not enough free space', {type: 'error'});
+						OC.Notification.show(t('files', 'Not enough free space'), {type: 'error'});
 						self.cancelUploads();
 					} else {
 						// HTTP connection problem or other error
-						OC.Notification.show(data.errorThrown, {type: 'error'});
+						OC.Notification.show(t('files', data.errorThrown), {type: 'error'});
 					}
 
 					if (upload) {

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -466,7 +466,7 @@ OC.Uploader.prototype = _.extend({
 						deferred.resolve();
 						return;
 					}
-					OC.Notification.show('Could not create folder "{dir}"', {dir: fullPath, timeout: 7, type: 'error'});
+					OC.Notification.show('Could not create folder "{dir}"', {dir: fullPath, type: 'error'});
 					deferred.reject();
 				});
 			}, function() {
@@ -547,7 +547,7 @@ OC.Uploader.prototype = _.extend({
 	},
 
 	showUploadCancelMessage: _.debounce(function() {
-		OC.Notification.show('Upload cancelled.', {timeout: 7, type: 'error'});
+		OC.Notification.show('Upload cancelled.', {type: 'error'});
 	}, 500),
 	/**
 	 * Checks the currently known uploads.
@@ -924,15 +924,15 @@ OC.Uploader.prototype = _.extend({
 						self.showConflict(upload);
 					} else if (status === 404) {
 						// target folder does not exist any more
-						OC.Notification.show('Target folder "{dir}" does not exist any more', {dir: upload.getFullPath(), timeout: 7, type: 'error'});
+						OC.Notification.show('Target folder "{dir}" does not exist any more', {dir: upload.getFullPath(), type: 'error'});
 						self.cancelUploads();
 					} else if (status === 507) {
 						// not enough space
-						OC.Notification.show('Not enough free space', {timeout: 7, type: 'error'});
+						OC.Notification.show('Not enough free space', {type: 'error'});
 						self.cancelUploads();
 					} else {
 						// HTTP connection problem or other error
-						OC.Notification.show(data.errorThrown, {timeout: 10, type: 'error'});
+						OC.Notification.show(data.errorThrown, {type: 'error'});
 					}
 
 					if (upload) {

--- a/apps/files/js/fileinfomodel.js
+++ b/apps/files/js/fileinfomodel.js
@@ -112,7 +112,7 @@
 					deferred.resolve(status, data);
 				})
 				.fail(function(status) {
-					OC.Notification.show('Could not load info for file "{file}"', {file: self.get('name'), type: 'error'});
+					OC.Notification.show(t('files', 'Could not load info for file "{file}"', {file: self.get('name')}), {type: 'error'});
 					deferred.reject(status);
 				});
 

--- a/apps/files/js/fileinfomodel.js
+++ b/apps/files/js/fileinfomodel.js
@@ -112,7 +112,7 @@
 					deferred.resolve(status, data);
 				})
 				.fail(function(status) {
-					OC.Notification.showTemporary(t('files', 'Could not load info for file "{file}"', {file: self.get('name')}));
+					OC.Notification.show('Could not load info for file "{file}"', {file: self.get('name'), timeout: 7, type: 'error'});
 					deferred.reject(status);
 				});
 

--- a/apps/files/js/fileinfomodel.js
+++ b/apps/files/js/fileinfomodel.js
@@ -112,7 +112,7 @@
 					deferred.resolve(status, data);
 				})
 				.fail(function(status) {
-					OC.Notification.show('Could not load info for file "{file}"', {file: self.get('name'), timeout: 7, type: 'error'});
+					OC.Notification.show('Could not load info for file "{file}"', {file: self.get('name'), type: 'error'});
 					deferred.reject(status);
 				});
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1569,7 +1569,7 @@
 				if (e instanceof DOMException) {
 					console.error(e);
 					this.changeDirectory('/');
-					OC.Notification.show(t('files', 'Invalid path'), {meout: 7, type: 'error'});
+					OC.Notification.show(t('files', 'Invalid path'), {timeout: 7, type: 'error'});
 					return;
 				}
 				throw e;

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1455,7 +1455,7 @@
 		_setCurrentDir: function(targetDir, changeUrl, fileId) {
 			targetDir = targetDir.replace(/\\/g, '/');
 			if (!this._isValidPath(targetDir)) {
-				OC.Notification.show('Invalid path', {type: 'error'});
+				OC.Notification.show(t('files', 'Invalid path'), {type: 'error'});
 				targetDir = '/';
 				changeUrl = true;
 			}
@@ -1569,7 +1569,7 @@
 				if (e instanceof DOMException) {
 					console.error(e);
 					this.changeDirectory('/');
-					OC.Notification.show('Invalid path', {meout: 7, type: 'error'});
+					OC.Notification.show(t('files', 'Invalid path'), {meout: 7, type: 'error'});
 					return;
 				}
 				throw e;
@@ -1593,7 +1593,7 @@
 			if (status === 403 || status === 400) {
 				// Go home
 				this.changeDirectory('/');
-				OC.Notification.show('This operation is forbidden', {type: 'error'});
+				OC.Notification.show(t('files', 'This operation is forbidden'), {type: 'error'});
 				return false;
 			}
 
@@ -1601,7 +1601,7 @@
 			if (status === 500) {
 				// Go home
 				this.changeDirectory('/');
-				OC.Notification.show('This directory is unavailable, please check the logs or contact the administrator', 
+				OC.Notification.show(t('files', 'This directory is unavailable, please check the logs or contact the administrator'), 
 					{type: 'error'}
 				);
 				return false;
@@ -1612,7 +1612,7 @@
 				if (this.getCurrentDirectory() !== '/') {
 					this.changeDirectory('/');
 					// TODO: read error message from exception
-					OC.Notification.show('Storage is temporarily not available', 
+					OC.Notification.show(t('files', 'Storage is temporarily not available'), 
 						{type: 'error'}
 					);
 				}
@@ -1930,12 +1930,12 @@
 					.fail(function(status) {
 						if (status === 412) {
 							// TODO: some day here we should invoke the conflict dialog
-							OC.Notification.show('Could not move "{file}", target exists', 
-								{file: fileName, type: 'error'}
+							OC.Notification.show(t('files', 'Could not move "{file}", target exists', 
+								{file: fileName}), {type: 'error'}
 							);
 						} else {
-							OC.Notification.show('Could not move "{file}"', 
-								{file: fileName, type: 'error'}
+							OC.Notification.show(t('files', 'Could not move "{file}"', 
+								{file: fileName}), {type: 'error'}
 							);
 						}
 					})
@@ -2050,8 +2050,8 @@
 								// TODO: 409 means current folder does not exist, redirect ?
 								if (status === 404) {
 									// source not found, so remove it from the list
-									OC.Notification.show('Could not rename "{fileName}", it does not exist any more', 
-										{fileName: oldName, type: 'error'}
+									OC.Notification.show(t('files', 'Could not rename "{fileName}", it does not exist any more', 
+										{fileName: oldName}), {timeout: 7, type: 'error'}
 									);
 
 									self.remove(newName, {updateSummary: true});
@@ -2059,18 +2059,19 @@
 								} else if (status === 412) {
 									// target exists
 									OC.Notification.show(
-										'The name "{targetName}" is already used in the folder "{dir}". Please choose a different name.', 
+										t('files', 'The name "{targetName}" is already used in the folder "{dir}". Please choose a different name.', 
 										{
 											targetName: newName,
 											dir: self.getCurrentDirectory(),
-											
+										}),
+										{	
 											type: 'error'
 										}
 									);
 								} else {
 									// restore the item to its previous state
-									OC.Notification.show('Could not rename "{fileName}"', 
-										{fileName: oldName, type: 'error'}
+									OC.Notification.show(t('files', 'Could not rename "{fileName}"', 
+										{fileName: oldName}), {type: 'error'}
 									);
 								}
 								updateInList(oldFileInfo);
@@ -2152,19 +2153,19 @@
 					self.addAndFetchFileInfo(targetPath, '', {scrollTo: true}).then(function(status, data) {
 						deferred.resolve(status, data);
 					}, function() {
-						OC.Notification.show('Could not create file "{file}"', 
-							{file: name, type: 'error'}
+						OC.Notification.show(t('files', 'Could not create file "{file}"', 
+							{file: name}), {type: 'error'}
 						);
 					});
 				})
 				.fail(function(status) {
 					if (status === 412) {
-						OC.Notification.show('Could not create file "{file}" because it already exists', 
-							{file: name, type: 'error'}
+						OC.Notification.show(t('files', 'Could not create file "{file}" because it already exists', 
+							{file: name}), {type: 'error'}
 						);
 					} else {
-						OC.Notification.show('Could not create file "{file}"', 
-							{file: name, type: 'error'}
+						OC.Notification.show(t('files', 'Could not create file "{file}"', 
+							{file: name}), {type: 'error'}
 						);
 					}
 					deferred.reject(status);
@@ -2202,8 +2203,8 @@
 					self.addAndFetchFileInfo(targetPath, '', {scrollTo:true}).then(function(status, data) {
 						deferred.resolve(status, data);
 					}, function() {
-						OC.Notification.show('Could not create folder "{dir}"', 
-							{dir: name, type: 'error'}
+						OC.Notification.show(t('files', 'Could not create folder "{dir}"', 
+							{dir: name}), {type: 'error'}
 						);
 					});
 				})
@@ -2213,21 +2214,21 @@
 						// add it to the list, for completeness
 						self.addAndFetchFileInfo(targetPath, '', {scrollTo:true})
 							.done(function(status, data) {
-								OC.Notification.show('Could not create folder "{dir}" because it already exists', 
-									{dir: name, type: 'error'}
+								OC.Notification.show(t('files', 'Could not create folder "{dir}" because it already exists', 
+									{dir: name}), {type: 'error'}
 								);
 								// still consider a failure
 								deferred.reject(createStatus, data);
 							})
 							.fail(function() {
-								OC.Notification.show('Could not create folder "{dir}"', 
-									{dir: name, type: 'error'}
+								OC.Notification.show(t('files', 'Could not create folder "{dir}"', 
+									{dir: name}), {type: 'error'}
 								);
 								deferred.reject(status);
 							});
 					} else {
-						OC.Notification.show('Could not create folder "{dir}"', 
-							{dir: name, type: 'error'}
+						OC.Notification.show(t('files', 'Could not create folder "{dir}"', 
+							{dir: name}), {type: 'error'}
 						);
 						deferred.reject(createStatus);
 					}
@@ -2283,8 +2284,8 @@
 					deferred.resolve(status, data);
 				})
 				.fail(function(status) {
-					OC.Notification.show('Could not create file "{file}"', 
-						{file: name, type: 'error'}
+					OC.Notification.show(t('files', 'Could not create file "{file}"', 
+						{file: name}), {type: 'error'}
 					);
 					deferred.reject(status);
 				});
@@ -2394,8 +2395,8 @@
 							removeFromList(file);
 						} else {
 							// only reset the spinner for that one file
-							OC.Notification.show('Error deleting file "{fileName}".', 
-								{fileName: file, type: 'error'}
+							OC.Notification.show(t('files', 'Error deleting file "{fileName}".', 
+								{fileName: file}), {type: 'error'}
 							);
 							var deleteAction = self.findFileEl(file).find('.action.delete');
 							deleteAction.removeClass('icon-loading-small').addClass('icon-delete');
@@ -2655,7 +2656,7 @@
 		 */
 		_showPermissionDeniedNotification: function() {
 			var message = t('core', 'You don’t have permission to upload or create files here');
-			OC.Notification.show(message, {type: 'error'});
+			OC.Notification.show(t('files', message), {type: 'error'});
 		},
 
 		/**

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1455,7 +1455,7 @@
 		_setCurrentDir: function(targetDir, changeUrl, fileId) {
 			targetDir = targetDir.replace(/\\/g, '/');
 			if (!this._isValidPath(targetDir)) {
-				OC.Notification.showTemporary(t('files', 'Invalid path'));
+				OC.Notification.show('Invalid path', {timeout: 7, type: 'error'});
 				targetDir = '/';
 				changeUrl = true;
 			}
@@ -1569,7 +1569,7 @@
 				if (e instanceof DOMException) {
 					console.error(e);
 					this.changeDirectory('/');
-					OC.Notification.showTemporary(t('files', 'Invalid path'));
+					OC.Notification.show('Invalid path', {timeout: 7, type: 'error'});
 					return;
 				}
 				throw e;
@@ -1593,7 +1593,7 @@
 			if (status === 403 || status === 400) {
 				// Go home
 				this.changeDirectory('/');
-				OC.Notification.showTemporary(t('files', 'This operation is forbidden'));
+				OC.Notification.show('This operation is forbidden', {timeout: 7, type: 'error'});
 				return false;
 			}
 
@@ -1601,8 +1601,8 @@
 			if (status === 500) {
 				// Go home
 				this.changeDirectory('/');
-				OC.Notification.showTemporary(
-					t('files', 'This directory is unavailable, please check the logs or contact the administrator')
+				OC.Notification.show('This directory is unavailable, please check the logs or contact the administrator', 
+					{timeout: 7, type: 'error'}
 				);
 				return false;
 			}
@@ -1612,8 +1612,8 @@
 				if (this.getCurrentDirectory() !== '/') {
 					this.changeDirectory('/');
 					// TODO: read error message from exception
-					OC.Notification.showTemporary(
-						t('files', 'Storage is temporarily not available')
+					OC.Notification.show('Storage is temporarily not available', 
+						{timeout: 7, type: 'error'}
 					);
 				}
 				return false;
@@ -1930,12 +1930,12 @@
 					.fail(function(status) {
 						if (status === 412) {
 							// TODO: some day here we should invoke the conflict dialog
-							OC.Notification.showTemporary(
-								t('files', 'Could not move "{file}", target exists', {file: fileName})
+							OC.Notification.show('Could not move "{file}", target exists', 
+								{file: fileName, timeout: 7, type: 'error'}
 							);
 						} else {
-							OC.Notification.showTemporary(
-								t('files', 'Could not move "{file}"', {file: fileName})
+							OC.Notification.show('Could not move "{file}"', 
+								{file: fileName, timeout: 7, type: 'error'}
 							);
 						}
 					})
@@ -2050,31 +2050,27 @@
 								// TODO: 409 means current folder does not exist, redirect ?
 								if (status === 404) {
 									// source not found, so remove it from the list
-									OC.Notification.showTemporary(
-										t(
-											'files',
-											'Could not rename "{fileName}", it does not exist any more',
-											{fileName: oldName}
-										)
+									OC.Notification.show('Could not rename "{fileName}", it does not exist any more', 
+										{fileName: oldName, timeout: 7, type: 'error'}
 									);
+
 									self.remove(newName, {updateSummary: true});
 									return;
 								} else if (status === 412) {
 									// target exists
-									OC.Notification.showTemporary(
-										t(
-											'files',
-											'The name "{targetName}" is already used in the folder "{dir}". Please choose a different name.',
-											{
-												targetName: newName,
-												dir: self.getCurrentDirectory()
-											}
-										)
+									OC.Notification.show(
+										'The name "{targetName}" is already used in the folder "{dir}". Please choose a different name.', 
+										{
+											targetName: newName,
+											dir: self.getCurrentDirectory(),
+											timeout: 7, 
+											type: 'error'
+										}
 									);
 								} else {
 									// restore the item to its previous state
-									OC.Notification.showTemporary(
-										t('files', 'Could not rename "{fileName}"', {fileName: oldName})
+									OC.Notification.show('Could not rename "{fileName}"', 
+										{fileName: oldName, timeout: 7, type: 'error'}
 									);
 								}
 								updateInList(oldFileInfo);
@@ -2156,16 +2152,20 @@
 					self.addAndFetchFileInfo(targetPath, '', {scrollTo: true}).then(function(status, data) {
 						deferred.resolve(status, data);
 					}, function() {
-						OC.Notification.showTemporary(t('files', 'Could not create file "{file}"', {file: name}));
+						OC.Notification.show('Could not create file "{file}"', 
+							{file: name, timeout: 7, type: 'error'}
+						);
 					});
 				})
 				.fail(function(status) {
 					if (status === 412) {
-						OC.Notification.showTemporary(
-							t('files', 'Could not create file "{file}" because it already exists', {file: name})
+						OC.Notification.show('Could not create file "{file}" because it already exists', 
+							{file: name, timeout: 7, type: 'error'}
 						);
 					} else {
-						OC.Notification.showTemporary(t('files', 'Could not create file "{file}"', {file: name}));
+						OC.Notification.show('Could not create file "{file}"', 
+							{file: name, timeout: 7, type: 'error'}
+						);
 					}
 					deferred.reject(status);
 				});
@@ -2202,7 +2202,9 @@
 					self.addAndFetchFileInfo(targetPath, '', {scrollTo:true}).then(function(status, data) {
 						deferred.resolve(status, data);
 					}, function() {
-						OC.Notification.showTemporary(t('files', 'Could not create folder "{dir}"', {dir: name}));
+						OC.Notification.show('Could not create folder "{dir}"', 
+							{dir: name, timeout: 7, type: 'error'}
+						);
 					});
 				})
 				.fail(function(createStatus) {
@@ -2211,20 +2213,22 @@
 						// add it to the list, for completeness
 						self.addAndFetchFileInfo(targetPath, '', {scrollTo:true})
 							.done(function(status, data) {
-								OC.Notification.showTemporary(
-									t('files', 'Could not create folder "{dir}" because it already exists', {dir: name})
+								OC.Notification.show('Could not create folder "{dir}" because it already exists', 
+									{dir: name, timeout: 7, type: 'error'}
 								);
 								// still consider a failure
 								deferred.reject(createStatus, data);
 							})
 							.fail(function() {
-								OC.Notification.showTemporary(
-									t('files', 'Could not create folder "{dir}"', {dir: name})
+								OC.Notification.show('Could not create folder "{dir}"', 
+									{dir: name, timeout: 7, type: 'error'}
 								);
 								deferred.reject(status);
 							});
 					} else {
-						OC.Notification.showTemporary(t('files', 'Could not create folder "{dir}"', {dir: name}));
+						OC.Notification.show('Could not create folder "{dir}"', 
+							{dir: name, timeout: 7, type: 'error'}
+						);
 						deferred.reject(createStatus);
 					}
 				});
@@ -2279,7 +2283,9 @@
 					deferred.resolve(status, data);
 				})
 				.fail(function(status) {
-					OC.Notification.showTemporary(t('files', 'Could not create file "{file}"', {file: name}));
+					OC.Notification.show('Could not create file "{file}"', 
+						{file: name, timeout: 7, type: 'error'}
+					);
 					deferred.reject(status);
 				});
 
@@ -2388,9 +2394,8 @@
 							removeFromList(file);
 						} else {
 							// only reset the spinner for that one file
-							OC.Notification.showTemporary(
-									t('files', 'Error deleting file "{fileName}".', {fileName: file}),
-									{timeout: 10}
+							OC.Notification.show('Error deleting file "{fileName}".', 
+								{fileName: file, timeout: 7, type: 'error'}
 							);
 							var deleteAction = self.findFileEl(file).find('.action.delete');
 							deleteAction.removeClass('icon-loading-small').addClass('icon-delete');
@@ -2650,7 +2655,7 @@
 		 */
 		_showPermissionDeniedNotification: function() {
 			var message = t('core', 'You don’t have permission to upload or create files here');
-			OC.Notification.showTemporary(message);
+			OC.Notification.show(message, {timeout: 7, type: 'error'});
 		},
 
 		/**

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1455,7 +1455,7 @@
 		_setCurrentDir: function(targetDir, changeUrl, fileId) {
 			targetDir = targetDir.replace(/\\/g, '/');
 			if (!this._isValidPath(targetDir)) {
-				OC.Notification.show('Invalid path', {timeout: 7, type: 'error'});
+				OC.Notification.show('Invalid path', {type: 'error'});
 				targetDir = '/';
 				changeUrl = true;
 			}
@@ -1569,7 +1569,7 @@
 				if (e instanceof DOMException) {
 					console.error(e);
 					this.changeDirectory('/');
-					OC.Notification.show('Invalid path', {timeout: 7, type: 'error'});
+					OC.Notification.show('Invalid path', {meout: 7, type: 'error'});
 					return;
 				}
 				throw e;
@@ -1593,7 +1593,7 @@
 			if (status === 403 || status === 400) {
 				// Go home
 				this.changeDirectory('/');
-				OC.Notification.show('This operation is forbidden', {timeout: 7, type: 'error'});
+				OC.Notification.show('This operation is forbidden', {type: 'error'});
 				return false;
 			}
 
@@ -1602,7 +1602,7 @@
 				// Go home
 				this.changeDirectory('/');
 				OC.Notification.show('This directory is unavailable, please check the logs or contact the administrator', 
-					{timeout: 7, type: 'error'}
+					{type: 'error'}
 				);
 				return false;
 			}
@@ -1613,7 +1613,7 @@
 					this.changeDirectory('/');
 					// TODO: read error message from exception
 					OC.Notification.show('Storage is temporarily not available', 
-						{timeout: 7, type: 'error'}
+						{type: 'error'}
 					);
 				}
 				return false;
@@ -1931,11 +1931,11 @@
 						if (status === 412) {
 							// TODO: some day here we should invoke the conflict dialog
 							OC.Notification.show('Could not move "{file}", target exists', 
-								{file: fileName, timeout: 7, type: 'error'}
+								{file: fileName, type: 'error'}
 							);
 						} else {
 							OC.Notification.show('Could not move "{file}"', 
-								{file: fileName, timeout: 7, type: 'error'}
+								{file: fileName, type: 'error'}
 							);
 						}
 					})
@@ -2051,7 +2051,7 @@
 								if (status === 404) {
 									// source not found, so remove it from the list
 									OC.Notification.show('Could not rename "{fileName}", it does not exist any more', 
-										{fileName: oldName, timeout: 7, type: 'error'}
+										{fileName: oldName, type: 'error'}
 									);
 
 									self.remove(newName, {updateSummary: true});
@@ -2063,14 +2063,14 @@
 										{
 											targetName: newName,
 											dir: self.getCurrentDirectory(),
-											timeout: 7, 
+											
 											type: 'error'
 										}
 									);
 								} else {
 									// restore the item to its previous state
 									OC.Notification.show('Could not rename "{fileName}"', 
-										{fileName: oldName, timeout: 7, type: 'error'}
+										{fileName: oldName, type: 'error'}
 									);
 								}
 								updateInList(oldFileInfo);
@@ -2153,18 +2153,18 @@
 						deferred.resolve(status, data);
 					}, function() {
 						OC.Notification.show('Could not create file "{file}"', 
-							{file: name, timeout: 7, type: 'error'}
+							{file: name, type: 'error'}
 						);
 					});
 				})
 				.fail(function(status) {
 					if (status === 412) {
 						OC.Notification.show('Could not create file "{file}" because it already exists', 
-							{file: name, timeout: 7, type: 'error'}
+							{file: name, type: 'error'}
 						);
 					} else {
 						OC.Notification.show('Could not create file "{file}"', 
-							{file: name, timeout: 7, type: 'error'}
+							{file: name, type: 'error'}
 						);
 					}
 					deferred.reject(status);
@@ -2203,7 +2203,7 @@
 						deferred.resolve(status, data);
 					}, function() {
 						OC.Notification.show('Could not create folder "{dir}"', 
-							{dir: name, timeout: 7, type: 'error'}
+							{dir: name, type: 'error'}
 						);
 					});
 				})
@@ -2214,20 +2214,20 @@
 						self.addAndFetchFileInfo(targetPath, '', {scrollTo:true})
 							.done(function(status, data) {
 								OC.Notification.show('Could not create folder "{dir}" because it already exists', 
-									{dir: name, timeout: 7, type: 'error'}
+									{dir: name, type: 'error'}
 								);
 								// still consider a failure
 								deferred.reject(createStatus, data);
 							})
 							.fail(function() {
 								OC.Notification.show('Could not create folder "{dir}"', 
-									{dir: name, timeout: 7, type: 'error'}
+									{dir: name, type: 'error'}
 								);
 								deferred.reject(status);
 							});
 					} else {
 						OC.Notification.show('Could not create folder "{dir}"', 
-							{dir: name, timeout: 7, type: 'error'}
+							{dir: name, type: 'error'}
 						);
 						deferred.reject(createStatus);
 					}
@@ -2284,7 +2284,7 @@
 				})
 				.fail(function(status) {
 					OC.Notification.show('Could not create file "{file}"', 
-						{file: name, timeout: 7, type: 'error'}
+						{file: name, type: 'error'}
 					);
 					deferred.reject(status);
 				});
@@ -2395,7 +2395,7 @@
 						} else {
 							// only reset the spinner for that one file
 							OC.Notification.show('Error deleting file "{fileName}".', 
-								{fileName: file, timeout: 7, type: 'error'}
+								{fileName: file, type: 'error'}
 							);
 							var deleteAction = self.findFileEl(file).find('.action.delete');
 							deleteAction.removeClass('icon-loading-small').addClass('icon-delete');
@@ -2655,7 +2655,7 @@
 		 */
 		_showPermissionDeniedNotification: function() {
 			var message = t('core', 'You don’t have permission to upload or create files here');
-			OC.Notification.show(message, {timeout: 7, type: 'error'});
+			OC.Notification.show(message, {type: 'error'});
 		},
 
 		/**

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2656,7 +2656,7 @@
 		 */
 		_showPermissionDeniedNotification: function() {
 			var message = t('core', 'You don’t have permission to upload or create files here');
-			OC.Notification.show(t('files', message), {type: 'error'});
+			OC.Notification.show(message, {type: 'error'});
 		},
 
 		/**

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -114,8 +114,9 @@
 				ownerDisplayName = $('#ownerDisplayName').val();
 			if (usedSpacePercent > 98) {
 				if (owner !== oc_current_user) {
-					OC.Notification.showTemporary(t('files', 'Storage of {owner} is full, files can not be updated or synced anymore!',
-						{ owner: ownerDisplayName }));
+					OC.Notification.show('Storage of {owner} is full, files can not be updated or synced anymore!', 
+						{owner: ownerDisplayName, timeout: 7, type: 'error'}
+					);
 					return;
 				}
 				OC.Notification.show(t('files', 'Your storage is full, files can not be updated or synced anymore!'));
@@ -123,8 +124,14 @@
 			}
 			if (usedSpacePercent > 90) {
 				if (owner !== oc_current_user) {
-					OC.Notification.showTemporary(t('files', 'Storage of {owner} is almost full ({usedSpacePercent}%)',
-						{ usedSpacePercent: usedSpacePercent,  owner: ownerDisplayName }));
+					OC.Notification.show('Storage of {owner} is almost full ({usedSpacePercent}%)', 
+						{
+							usedSpacePercent: usedSpacePercent,  
+							owner: ownerDisplayName, 
+							owner: ownerDisplayName, 
+							timeout: 7, type: 'error'
+						}
+					);
 					return;
 				}
 				OC.Notification.show(t('files', 'Your storage is almost full ({usedSpacePercent}%)',

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -115,7 +115,7 @@
 			if (usedSpacePercent > 98) {
 				if (owner !== oc_current_user) {
 					OC.Notification.show('Storage of {owner} is full, files can not be updated or synced anymore!', 
-						{owner: ownerDisplayName, timeout: 7, type: 'error'}
+						{owner: ownerDisplayName, type: 'error'}
 					);
 					return;
 				}
@@ -129,7 +129,7 @@
 							usedSpacePercent: usedSpacePercent,  
 							owner: ownerDisplayName, 
 							owner: ownerDisplayName, 
-							timeout: 7, type: 'error'
+							type: 'error'
 						}
 					);
 					return;

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -114,28 +114,34 @@
 				ownerDisplayName = $('#ownerDisplayName').val();
 			if (usedSpacePercent > 98) {
 				if (owner !== oc_current_user) {
-					OC.Notification.show('Storage of {owner} is full, files can not be updated or synced anymore!', 
-						{owner: ownerDisplayName, type: 'error'}
+					OC.Notification.show(t('files', 'Storage of {owner} is full, files can not be updated or synced anymore!', 
+						{owner: ownerDisplayName}), {type: 'error'}
 					);
 					return;
 				}
-				OC.Notification.show(t('files', 'Your storage is full, files can not be updated or synced anymore!'));
+				OC.Notification.show(t('files', 
+					'Your storage is full, files can not be updated or synced anymore!'), 
+					{type : 'error'}
+				);
 				return;
 			}
 			if (usedSpacePercent > 90) {
 				if (owner !== oc_current_user) {
-					OC.Notification.show('Storage of {owner} is almost full ({usedSpacePercent}%)', 
+					OC.Notification.show(t('files', 'Storage of {owner} is almost full ({usedSpacePercent}%)', 
 						{
 							usedSpacePercent: usedSpacePercent,  
-							owner: ownerDisplayName, 
-							owner: ownerDisplayName, 
+							owner: ownerDisplayName
+						}),
+						{  
 							type: 'error'
 						}
 					);
 					return;
 				}
 				OC.Notification.show(t('files', 'Your storage is almost full ({usedSpacePercent}%)',
-					{usedSpacePercent: usedSpacePercent}));
+					{usedSpacePercent: usedSpacePercent}), 
+					{type : 'error'}
+				);
 			}
 		},
 

--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -237,7 +237,7 @@
 				if(response.responseJSON && response.responseJSON.message) {
 					message = ': ' + response.responseJSON.message;
 				}
-				OC.Notification.showTemporary(t('files', 'An error occurred while trying to update the tags') + message);
+				OC.Notification.show('An error occurred while trying to update the tags' + message, {timeout: 7, type: 'error'});
 				toggleStar($actionEl, isFavorite);
 			});
 		}

--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -237,7 +237,7 @@
 				if(response.responseJSON && response.responseJSON.message) {
 					message = ': ' + response.responseJSON.message;
 				}
-				OC.Notification.show('An error occurred while trying to update the tags' + message, {type: 'error'});
+				OC.Notification.show(t('files', 'An error occurred while trying to update the tags' + message), {type: 'error'});
 				toggleStar($actionEl, isFavorite);
 			});
 		}

--- a/apps/files/js/tagsplugin.js
+++ b/apps/files/js/tagsplugin.js
@@ -237,7 +237,7 @@
 				if(response.responseJSON && response.responseJSON.message) {
 					message = ': ' + response.responseJSON.message;
 				}
-				OC.Notification.show('An error occurred while trying to update the tags' + message, {timeout: 7, type: 'error'});
+				OC.Notification.show('An error occurred while trying to update the tags' + message, {type: 'error'});
 				toggleStar($actionEl, isFavorite);
 			});
 		}

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -68,7 +68,7 @@ describe('OCA.Files.FileList tests', function() {
 			useHTTPS: false
 		});
 		redirectStub = sinon.stub(OC, 'redirect');
-		notificationStub = sinon.stub(OC.Notification, 'showTemporary');
+		notificationStub = sinon.stub(OC.Notification, 'show');
 		// prevent resize algo to mess up breadcrumb order while
 		// testing
 		bcResizeStub = sinon.stub(OCA.Files.BreadCrumb.prototype, '_resize');

--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -155,7 +155,9 @@ OCA.External.StatusManager = {
 				},
 				error: function (jqxhr, state, error) {
 					self.mountPointList = [];
-					OC.Notification.showTemporary(t('files_external', 'Couldn\'t get the list of external mount points: {type}', {type: error}));
+					OC.Notification.show('Couldn\'t get the list of external mount points: {type}', 
+						{type: error, timeout: 7, type: 'error'}
+					);
 				},
 				complete: function () {
 					self.isGetMountPointListRunning = false;
@@ -263,7 +265,9 @@ OCA.External.StatusManager = {
 			// check if we have a list first
 			if (list === undefined && !self.emptyWarningShown) {
 				self.emptyWarningShown = true;
-				OC.Notification.showTemporary(t('files_external', 'Couldn\'t get the list of Windows network drive mount points: empty response from the server'));
+				OC.Notification.show('Couldn\'t get the list of Windows network drive mount points: empty response from the server', 
+					{timeout: 7, type: 'error'}
+				);
 				return;
 			}
 			if (list && list.length > 0) {
@@ -293,7 +297,9 @@ OCA.External.StatusManager = {
 							}
 						});
 						if (showNotification) {
-							OC.Notification.showTemporary(t('files_external', 'Some of the configured external mount points are not connected. Please click on the red row(s) for more information'));
+							OC.Notification.show('Some of the configured external mount points are not connected. Please click on the red row(s) for more information', 
+								{timeout: 7, type: 'error'}
+							);
 						}
 					}
 				});
@@ -412,14 +418,14 @@ OCA.External.StatusManager = {
 					}
 				},
 				success: function (data) {
-					OC.Notification.showTemporary(t('files_external', 'Credentials saved'));
+					OC.Notification.show('Credentials saved', {timeout: 7, type: 'error'});
 					dialog.ocdialog('close');
 					/* Trigger status check again */
 					OCA.External.StatusManager.recheckConnectivityForMount([OC.basename(data.mountPoint)], true);
 				},
 				error: function () {
 					$('.oc-dialog-close').show();
-					OC.Notification.showTemporary(t('files_external', 'Credentials saving failed'));
+					OC.Notification.show('Credentials saving failed', {timeout: 7, type: 'error'});
 				}
 			});
 			return false;

--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -155,8 +155,8 @@ OCA.External.StatusManager = {
 				},
 				error: function (jqxhr, state, error) {
 					self.mountPointList = [];
-					OC.Notification.show('Couldn\'t get the list of external mount points: {type}', 
-						{type: error, type: 'error'}
+					OC.Notification.show(t('files_external', 'Couldn\'t get the list of external mount points: {type}', 
+						{type: error}), {type: 'error'}
 					);
 				},
 				complete: function () {
@@ -265,7 +265,7 @@ OCA.External.StatusManager = {
 			// check if we have a list first
 			if (list === undefined && !self.emptyWarningShown) {
 				self.emptyWarningShown = true;
-				OC.Notification.show('Couldn\'t get the list of Windows network drive mount points: empty response from the server', 
+				OC.Notification.show(t('files_external', 'Couldn\'t get the list of Windows network drive mount points: empty response from the server'), 
 					{type: 'error'}
 				);
 				return;
@@ -297,7 +297,7 @@ OCA.External.StatusManager = {
 							}
 						});
 						if (showNotification) {
-							OC.Notification.show('Some of the configured external mount points are not connected. Please click on the red row(s) for more information', 
+							OC.Notification.show(t('files_external', 'Some of the configured external mount points are not connected. Please click on the red row(s) for more information'), 
 								{type: 'error'}
 							);
 						}
@@ -418,14 +418,14 @@ OCA.External.StatusManager = {
 					}
 				},
 				success: function (data) {
-					OC.Notification.show('Credentials saved', {type: 'error'});
+					OC.Notification.show(t('files_external', 'Credentials saved'), {type: 'error'});
 					dialog.ocdialog('close');
 					/* Trigger status check again */
 					OCA.External.StatusManager.recheckConnectivityForMount([OC.basename(data.mountPoint)], true);
 				},
 				error: function () {
 					$('.oc-dialog-close').show();
-					OC.Notification.show('Credentials saving failed', {type: 'error'});
+					OC.Notification.show(t('files_external', 'Credentials saving failed'), {type: 'error'});
 				}
 			});
 			return false;

--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -156,7 +156,7 @@ OCA.External.StatusManager = {
 				error: function (jqxhr, state, error) {
 					self.mountPointList = [];
 					OC.Notification.show('Couldn\'t get the list of external mount points: {type}', 
-						{type: error, timeout: 7, type: 'error'}
+						{type: error, type: 'error'}
 					);
 				},
 				complete: function () {
@@ -266,7 +266,7 @@ OCA.External.StatusManager = {
 			if (list === undefined && !self.emptyWarningShown) {
 				self.emptyWarningShown = true;
 				OC.Notification.show('Couldn\'t get the list of Windows network drive mount points: empty response from the server', 
-					{timeout: 7, type: 'error'}
+					{type: 'error'}
 				);
 				return;
 			}
@@ -298,7 +298,7 @@ OCA.External.StatusManager = {
 						});
 						if (showNotification) {
 							OC.Notification.show('Some of the configured external mount points are not connected. Please click on the red row(s) for more information', 
-								{timeout: 7, type: 'error'}
+								{type: 'error'}
 							);
 						}
 					}
@@ -418,14 +418,14 @@ OCA.External.StatusManager = {
 					}
 				},
 				success: function (data) {
-					OC.Notification.show('Credentials saved', {timeout: 7, type: 'error'});
+					OC.Notification.show('Credentials saved', {type: 'error'});
 					dialog.ocdialog('close');
 					/* Trigger status check again */
 					OCA.External.StatusManager.recheckConnectivityForMount([OC.basename(data.mountPoint)], true);
 				},
 				error: function () {
 					$('.oc-dialog-close').show();
-					OC.Notification.show('Credentials saving failed', {timeout: 7, type: 'error'});
+					OC.Notification.show('Credentials saving failed', {type: 'error'});
 				}
 			});
 			return false;

--- a/apps/files_sharing/js/external.js
+++ b/apps/files_sharing/js/external.js
@@ -108,7 +108,7 @@
 							name: share.name,
 							password: password}, function(result) {
 							if (result.status === 'error') {
-								OC.Notification.show(result.data.message, {timeout: 7, type: 'error'});
+								OC.Notification.show(result.data.message, {type: 'error'});
 							} else {
 								fileList.reload();
 							}

--- a/apps/files_sharing/js/external.js
+++ b/apps/files_sharing/js/external.js
@@ -108,7 +108,7 @@
 							name: share.name,
 							password: password}, function(result) {
 							if (result.status === 'error') {
-								OC.Notification.showTemporary(result.data.message);
+								OC.Notification.show(result.data.message, {timeout: 7, type: 'error'});
 							} else {
 								fileList.reload();
 							}
@@ -166,4 +166,3 @@
 })();
 
 OC.Plugins.register('OCA.Files.App', OCA.Sharing.ExternalShareDialogPlugin);
-

--- a/apps/files_sharing/js/external.js
+++ b/apps/files_sharing/js/external.js
@@ -108,7 +108,7 @@
 							name: share.name,
 							password: password}, function(result) {
 							if (result.status === 'error') {
-								OC.Notification.show(result.data.message, {type: 'error'});
+								OC.Notification.show(t('files_sharing', result.data.message), {type: 'error'});
 							} else {
 								fileList.reload();
 							}

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -131,7 +131,7 @@
 						{
 							file: versionModel.getFullPath(),
 							timestamp: OC.Util.formatDate(versionModel.get('timestamp') * 1000),
-							timeout: 7, type: 'error'
+							type: 'error'
 						}
 					);
 				}

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -127,11 +127,12 @@
 					fileInfoModel.trigger('busy', fileInfoModel, false);
 					self.$el.find('.versions').removeClass('hidden');
 					self._toggleLoading(false);
-					OC.Notification.showTemporary(
-						t('files_version', 'Failed to revert {file} to revision {timestamp}.', {
+					OC.Notification.show('Failed to revert {file} to revision {timestamp}.', 
+						{
 							file: versionModel.getFullPath(),
-							timestamp: OC.Util.formatDate(versionModel.get('timestamp') * 1000)
-						})
+							timestamp: OC.Util.formatDate(versionModel.get('timestamp') * 1000),
+							timeout: 7, type: 'error'
+						}
 					);
 				}
 			});

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -127,10 +127,12 @@
 					fileInfoModel.trigger('busy', fileInfoModel, false);
 					self.$el.find('.versions').removeClass('hidden');
 					self._toggleLoading(false);
-					OC.Notification.show('Failed to revert {file} to revision {timestamp}.', 
+					OC.Notification.show(t('files_version', 'Failed to revert {file} to revision {timestamp}.', 
 						{
 							file: versionModel.getFullPath(),
-							timestamp: OC.Util.formatDate(versionModel.get('timestamp') * 1000),
+							timestamp: OC.Util.formatDate(versionModel.get('timestamp') * 1000)
+						}),
+						{
 							type: 'error'
 						}
 					);

--- a/apps/files_versions/tests/js/versionstabviewSpec.js
+++ b/apps/files_versions/tests/js/versionstabviewSpec.js
@@ -221,7 +221,7 @@ describe('OCA.Versions.VersionsTabView', function() {
 			expect(changes.etag).toBeDefined();
 		});
 		it('shows notification on revert error', function() {
-			var notificationStub = sinon.stub(OC.Notification, 'showTemporary');
+			var notificationStub = sinon.stub(OC.Notification, 'show');
 
 			tabView.$el.find('.revertVersion').eq(1).click();
 

--- a/apps/updatenotification/js/notification.js
+++ b/apps/updatenotification/js/notification.js
@@ -20,11 +20,10 @@ $(document).ready(function(){
 		text = t('core', '{version} is available. Get more information on how to update.', {version: version}),
 		element = $('<a>').attr('href', docLink).attr('target','_blank').text(text);
 
-	OC.Notification.showTemporary(
-		element,
+	OC.Notification.show(element, 
 		{
-			isHTML: true
+			isHTML: true,
+			timeout: 7, type: 'error'
 		}
 	);
 });
-

--- a/apps/updatenotification/js/notification.js
+++ b/apps/updatenotification/js/notification.js
@@ -23,7 +23,7 @@ $(document).ready(function(){
 	OC.Notification.show(element, 
 		{
 			isHTML: true,
-			timeout: 7, type: 'error'
+			type: 'error'
 		}
 	);
 });


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
I replaced all instances of showTemporary with show which has a cross to remove notifications.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/26749

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Brings a cross to remove pop-up notifications.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

