### PR TITLE
Avoid the restriction of having only the specific core apps enabled in apps scenario

### DIFF
--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -486,12 +486,10 @@ trait Provisioning {
 			$apps = $appList->getRows();
 			$appsSimplified = $this->simplifyArray($apps);
 			$respondedArray = $this->getArrayOfAppsResponded($this->response);
-			if(($key = array_search('testing', $respondedArray)) !== false) {
-				array_splice($respondedArray, $key, 1);
+			foreach ($appsSimplified as $app) {
+				PHPUnit_Framework_Assert::assertContains($app, $respondedArray);
 			}
-			PHPUnit_Framework_Assert::assertEquals($appsSimplified, $respondedArray, "", 0.0, 10, true);
 		}
-
 	}
 
 	/**


### PR DESCRIPTION
This will be needed in every app running core tests.