### PR TITLE
Allowing email for password recovery

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -251,12 +251,11 @@ class LostController extends Controller {
 				return false;
 			}
 		} else {
-			$this->logger->error('User with input as username does not exist. User: {user}', ['app' => 'core', 'user' => $user]);
 			$users = $this->userManager->getByEmail($user);
 
 			switch (count($users)) {
 				case 0:
-					$this->logger->error('Could not send reset email because User with input as email also does not exist. User: {user}', ['app' => 'core', 'user' => $user]);
+					$this->logger->error('Could not send reset email because User does not exist. User: {user}', ['app' => 'core', 'user' => $user]);
 					return false;
 				case 1:
 					$this->logger->info('User with input as email address found. User: {user}', ['app' => 'core', 'user' => $user]);

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -259,7 +259,7 @@ class LostController extends Controller {
 					return false;
 				case 1:
 					$this->logger->info('User with input as email address found. User: {user}', ['app' => 'core', 'user' => $user]);
-					$email = $user;
+					$email = $users[0]->getEMailAddress();
 					$user = $users[0]->getUID();
 					break;
 				default:


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
The function sendEmail in core/LostController.php was checking if a user with the given name exists or not. What I did is, in the else condition used the function getByEmail() and checked if the count of users is 0, 1 or else. In the first case,  the following error was logged

> {"reqId":"kPpSJNX5ONqosvDdN\/QO","remoteAddr":"119.82.86.231","app":"core","message":"Could` not send reset email because User does not exist. User: jhghjgj","level":3,"time":"2017-02-15T19:31:21+00:00","method":"POST","url":"\/core\/index.php\/lostpassword\/email","u$`

and in the third case

> {"reqId":"iuivYECI2anrgAXQP4Wx","remoteAddr":"119.82.86.231","app":"core","message":"Could` not send reset email because the email id is not unique. User: ujjwalb1996@gmail.com","level":3,"time":"2017-02-15T19:31:32+00:00","method":"POST","url":"\/core\/index.php\/los$`

A recovery mail was sent only when the count of email was singular in this case.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/27111

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves the problem raised in issue: https://github.com/owncloud/core/issues/27111

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I forked and clone the repository in my VPS and tested their with all the changes. Recovery mails were received by providing either username or an email address(unique) associated to that user. If a recovery mail was requested for an incorrect username(non existing) or for an email address that was not unique, proper error messages were logged and check in the core/owncloud.log file.
  
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

