### PR TITLE
Fix SharedCache to forward numeric id of wrapped cache

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -73,14 +73,6 @@ class Cache extends CacheJail {
 		);
 	}
 
-	public function getNumericStorageId() {
-		if (isset($this->numericId)) {
-			return $this->numericId;
-		} else {
-			return false;
-		}
-	}
-
 	protected function formatCacheEntry($entry) {
 		$path = isset($entry['path']) ? $entry['path'] : '';
 		$entry = parent::formatCacheEntry($entry);

--- a/apps/files_sharing/tests/CacheTest.php
+++ b/apps/files_sharing/tests/CacheTest.php
@@ -523,4 +523,28 @@ class CacheTest extends TestCase {
 		$this->assertEquals('', $sharedCache->getPathById($folderInfo->getId()));
 		$this->assertEquals('bar/test.txt', $sharedCache->getPathById($fileInfo->getId()));
 	}
+
+	public function testNumericStorageId() {
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		\OC\Files\Filesystem::mkdir('foo');
+
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1);
+		$node = $rootFolder->get('foo');
+		$share = $this->shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$this->shareManager->createShare($share);
+		\OC_Util::tearDownFS();
+
+		list($sourceStorage) = \OC\Files\Filesystem::resolvePath('/' . self::TEST_FILES_SHARING_API_USER1 . '/files/foo');
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue(\OC\Files\Filesystem::file_exists('/foo'));
+		list($sharedStorage) = \OC\Files\Filesystem::resolvePath('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/foo');
+
+		$this->assertEquals($sourceStorage->getCache()->getNumericStorageId(), $sharedStorage->getCache()->getNumericStorageId());
+	}
 }

--- a/build/integration/features/external-storage.feature
+++ b/build/integration/features/external-storage.feature
@@ -24,4 +24,27 @@ Feature: external-storage
       | token | A_TOKEN |
       | mimetype | httpd/unix-directory |
 
+  @local_storage
+  @no_encryption
+  Scenario: Move a file into storage works
+    Given user "user0" exists
+    And user "user1" exists
+    And As an "user0"
+    And user "user0" created a folder "/local_storage/foo1"
+    When User "user0" moved file "/textfile0.txt" to "/local_storage/foo1/textfile0.txt"
+    Then as "user1" the file "/local_storage/foo1/textfile0.txt" exists
+    And as "user0" the file "/local_storage/foo1/textfile0.txt" exists
+
+  @local_storage
+  @no_encryption
+  Scenario: Move a file out of the storage works
+    Given user "user0" exists
+    And user "user1" exists
+    And As an "user0"
+    And user "user0" created a folder "/local_storage/foo2"
+    And User "user0" moved file "/textfile0.txt" to "/local_storage/foo2/textfile0.txt"
+    When User "user1" moved file "/local_storage/foo2/textfile0.txt" to "/local.txt"
+    Then as "user1" the file "/local_storage/foo2/textfile0.txt" does not exist
+    And as "user0" the file "/local_storage/foo2/textfile0.txt" does not exist
+    And as "user1" the file "/local.txt" exists
 

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -1123,3 +1123,13 @@ Feature: sharing
     And as "user1" the folder "/sub" exists in trash
     And as "user1" the file "/sub/shared_file.txt" exists in trash
 
+  Scenario: moving a file into a share as recipient
+    Given As an "admin"
+    And user "user0" exists
+    And user "user1" exists
+    And user "user0" created a folder "/shared"
+    And folder "/shared" of user "user0" is shared with user "user1"
+    When User "user1" moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    Then as "user1" the file "/shared/shared_file.txt" exists
+    And as "user0" the file "/shared/shared_file.txt" exists
+

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -91,6 +91,9 @@ $OCC files_external:delete -y $ID_STORAGE
 #Disable external storage app
 $OCC app:disable files_external
 
+# Clear storage folder
+rm -Rf work/local_storage/*
+
 if test "$OC_TEST_ALT_HOME" = "1"; then
 	env_alt_home_clear
 fi

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -491,6 +491,7 @@ class Cache implements ICache {
 	 * @param string $sourcePath
 	 * @param string $targetPath
 	 * @throws \OC\DatabaseException
+	 * @throws \Exception if the given storages have an invalid id
 	 */
 	public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath) {
 		if ($sourceCache instanceof Cache) {
@@ -504,6 +505,13 @@ class Cache implements ICache {
 
 			list($sourceStorageId, $sourcePath) = $sourceCache->getMoveInfo($sourcePath);
 			list($targetStorageId, $targetPath) = $this->getMoveInfo($targetPath);
+
+			if (is_null($sourceStorageId) || $sourceStorageId === false) {
+				throw new \Exception('Invalid source storage id: ' . $sourceStorageId);
+			}
+			if (is_null($targetStorageId) || $targetStorageId === false) {
+				throw new \Exception('Invalid target storage id: ' . $targetStorageId);
+			}
 
 			// sql for final update
 			$moveSql = 'UPDATE `*PREFIX*filecache` SET `storage` =  ?, `path` = ?, `path_hash` = ?, `name` = ?, `parent` =? WHERE `fileid` = ?';


### PR DESCRIPTION
## Description
The SharedCache is a CacheJail which is a CacheWrapper.
Its method `getNumericStorageId()` was returning a non-existing attribute value `$this->numericId` which was always false.
This fix makes sure it returns the numeric id of the underlying `$this->sourceCache` instead.

## Related Issue
None

## Motivation and Context
Because it fixes the unit test for https://github.com/owncloud/core/pull/27042 where a cross-storage move requires the numeric id of the source storage (shared cache).

## How Has This Been Tested?
Unit test only and ran all tests locally on https://github.com/owncloud/core/pull/27042 with mysql.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## TODO:

- [ ] investigate all code paths using this method to make sure that returning a proper value doesn't cause other side effects

@jvillafanez crazy stuff...