### PR TITLE
[WIP] introducing federated cluster

### DIFF
--- a/apps/federatedcluster/Readme.md
+++ b/apps/federatedcluster/Readme.md
@@ -1,0 +1,93 @@
+Federated Cluster
+=================
+
+Distribute requests for a single ownCloud URL over multiple ownCloud instances.
+
+
+Architecture
+------------
+
+### Login 
+
+A load balancer like haproxy is used to direct http requests to separate
+ownCloud Installations, based on a cookie. Upon login the cookie is set by
+ownCloud to make subsequent requests directly reach the correct ownCloud instance.
+
+
+### Internal Sharing
+
+Sharing between instances is handled by the existing federated sharing mechanism.
+Some changes to core are required to make federation aware of members of the
+federated cluster so cluster internal hosts names are used to establish the share
+but are not exposed to the end user.
+- [ ] sharing ui: remove server name, make it look like normal share
+- [ ] share notification on recipient side: remove server name from sharer id
+- [ ] Requires CORE branch/PR
+- [ ] make hosts / user map configurable? query redis or other nodes?
+- [ ] where should the Cluster class go? core?
+    - [ ] fix DI for it
+
+
+### Public sharing
+
+Links need to be unique over all instances and the haproxy needs to be able to
+choose the right server based on the link token. For this redis is used to store
+a map of link token to cluster node. It can be used for both: checking if a link
+already exists as well as finding the right host. A fallback mechanism based on
+cookies has been implemented
+- [ ] occ command to repopulate redis with mapping?
+- [ ] check link uniqueness, overwrite token until it is unique
+
+
+Implementation
+--------------
+
+### haproxy
+
+haproxy.conf excerpt:
+```
+frontend localnodes
+    bind *:443 ssl crt /etc/ssl/localcerts/bpicln01.pem
+    mode http
+
+    acl is_ocnode1 hdr_sub(cookie) SRVNAME=node1
+        use_backend ocnode1 if is_ocnode1
+
+    acl is_ocnode2 hdr_sub(cookie) SRVNAME=node2
+        use_backend ocnode2 if is_ocnode2
+
+    # if no cookie is set start anywhere
+    default_backend ocnodes
+
+backend ocnodes
+    mode http
+    balance roundrobin
+    option forwardfor
+    http-request set-header X-Forwarded-Port %[dst_port]
+    http-request add-header X-Forwarded-Proto https if { ssl_fc }
+    server ochost1 host1:80
+    server ochost2 host2:80
+    
+backend ocnode1
+    mode http
+    option forwardfor
+    http-request set-header X-Forwarded-Port %[dst_port]
+    http-request add-header X-Forwarded-Proto https if { ssl_fc }
+    server ochost1 host1:80
+
+backend ocnode2
+    mode http
+    option forwardfor
+    http-request set-header X-Forwarded-Port %[dst_port]
+    http-request add-header X-Forwarded-Proto https if { ssl_fc }
+    server ochost2 host2:80
+```
+
+### Federated Cluster App
+To respond to a login request with a correct session and node cookie the
+Federated Cluster app implements a user backend that tries to log in the user at
+the other nodes. The default login url /index.php/login requires a CSRF check so
+the app also provides a dedicated login url for this 'inter node login'.
+
+### Core branch
+The app needs the `stable9.1-federated-cluster` branch.

--- a/apps/federatedcluster/appinfo/app.php
+++ b/apps/federatedcluster/appinfo/app.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+$userBackend  = new OCA\FederatedCluster\Backend();
+OC_User::useBackend($userBackend);
+
+$handler = new OCA\FederatedCluster\SharingHandler();
+\OCP\Util::connectHook('OCP\Share', 'pre_shared', $handler, 'alterShardShare');
+
+\OCP\Util::connectHook('OCP\Share', 'shareByTokenNotFound', $handler, 'getShareByToken');
+
+//tie requests to this instance
+$cookiename = \OC::$server->getConfig()->getSystemValue('cluster.cookie');
+$node = \OC::$server->getConfig()->getSystemValue('node.name');
+if (!isset($_COOKIE[$cookiename]) || $_COOKIE[$cookiename] !== $node) {
+	setcookie($cookiename, $node, 0, '/', null, true, true);
+}

--- a/apps/federatedcluster/appinfo/app.php
+++ b/apps/federatedcluster/appinfo/app.php
@@ -23,7 +23,7 @@ $userBackend  = new OCA\FederatedCluster\Backend();
 OC_User::useBackend($userBackend);
 
 $handler = new OCA\FederatedCluster\SharingHandler();
-\OCP\Util::connectHook('OCP\Share', 'pre_shared', $handler, 'alterShardShare');
+\OCP\Util::connectHook('OCP\Share', 'pre_shared', $handler, 'assureUniqueToken');
 
 \OCP\Util::connectHook('OCP\Share', 'shareByTokenNotFound', $handler, 'getShareByToken');
 

--- a/apps/federatedcluster/appinfo/info.xml
+++ b/apps/federatedcluster/appinfo/info.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<info>
+	<id>federatedcluster</id>
+	<name>Federated Cluster</name>
+	<namespace>FederatedCluster</namespace>
+	<description>Allows direct login to other cluster nodes</description>
+	<licence>AGPL</licence>
+	<author>Jörn Dreyer</author>
+	<version>0.0.1</version>
+	<dependencies>
+		<owncloud min-version="9.1" max-version="10.0" />
+	</dependencies>
+	<types>
+		<authentication/>
+	</types>
+</info>

--- a/apps/federatedcluster/appinfo/routes.php
+++ b/apps/federatedcluster/appinfo/routes.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+return [
+	'routes' => [
+		['verb' => 'POST', 'url' => '/login', 'name' => 'NodeLogin#tryLogin']
+	]
+];

--- a/apps/federatedcluster/lib/Backend.php
+++ b/apps/federatedcluster/lib/Backend.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedCluster;
+
+
+use OCA\Federation\Cluster;
+
+class Backend extends \OC\User\Backend implements \OCP\UserInterface {
+
+	const USER_AGENT = 'ownCloud Federated Cluster Login';
+
+	/**
+	 * Check if the password is correct without logging in the user
+	 *
+	 * @param string $uid      The username
+	 * @param string $password The password
+	 *
+	 * @return true/false
+	 */
+	public function checkPassword($uid, $password) {
+		\OC::$server->getLogger()->debug("checkPassword('$uid', '$password')", ['app'=>'clusterlogin']);
+		$agent = \OC::$server->getRequest()->getHeader('User-Agent');
+		if ($agent === self::USER_AGENT) {
+			// ignore request
+			\OC::$server->getLogger()->debug("ignoring request from ".self::USER_AGENT, ['app'=>'clusterlogin']);
+			return false;
+		}
+
+		$cluster = new Cluster();
+		list($node, $url) = $cluster->getUserNode($uid);
+		if ($url) {
+			$client = \OC::$server->getHTTPClientService()->newClient();
+			$url .= "/index.php/apps/federatedcluster/login";
+			\OC::$server->getLogger()->debug("dispatching login to $url", ['app'=>'clusterlogin']);
+			$response = $client->post($url, [
+				'body' => [
+					'login' => $uid,
+					'password' => $password,
+				],
+				'headers' => [ 'User-Agent' => self::USER_AGENT ]
+				//'verify' => false, // todo make configurable?
+			]);
+		}
+
+		if (isset($response)) {
+			$body = $response->getBody();
+			\OC::$server->getLogger()->debug("got response " . $body, ['app'=>'clusterlogin']);
+			$result = json_decode($body);
+			$location = $result->location;
+			$session_name = $result->session_name;
+			$session_id = $result->session_id;
+			\OC::$server->getLogger()->debug("got session '$session_name=$session_id'", ['app'=>'clusterlogin']);
+			\OC::$server->getLogger()->debug("got location '$location'", ['app'=>'clusterlogin']);
+			\OC::$server->getLogger()->debug("redirecting $uid to $location at $node", ['app'=>'clusterlogin']);
+
+			$cluster->redirect($node, $location, '/', $session_name, $session_id);
+		}
+		return false;
+	}
+}

--- a/apps/federatedcluster/lib/Controller/NodeLoginController.php
+++ b/apps/federatedcluster/lib/Controller/NodeLoginController.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedCluster\Controller;
+
+use OC\Authentication\TwoFactorAuth\Manager;
+use OC\Core\Controller\LoginController;
+use OC\User\Session;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\IUserSession;
+
+
+class NodeLoginController extends Controller {
+
+	/** @var LoginController */
+	private $loginController;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IUserManager $userManager
+	 * @param IConfig $config
+	 * @param ISession $session
+	 * @param IUserSession $userSession
+	 * @param IURLGenerator $urlGenerator
+	 * @param Manager $twoFactorManager
+	 */
+	function __construct($appName, IRequest $request, IUserManager $userManager, IConfig $config, ISession $session,
+						 IUserSession $userSession, IURLGenerator $urlGenerator, Manager $twoFactorManager) {
+		parent::__construct($appName, $request);
+		if ($userSession instanceof Session) {
+			$this->loginController = new LoginController($appName, $request, $userManager, $config, $session, $userSession, $urlGenerator, $twoFactorManager);
+		} else {
+			throw new \InvalidArgumentException('IUserSession must be an instance of OC\User\Session');
+		}
+	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 * @UseSession
+	 *
+	 * @param string $login
+	 * @param string $password
+	 * @return DataResponse
+	 */
+	public function tryLogin($login, $password) {
+		\OC::$server->getLogger()->debug("tryLogin('$login', '$password')", ['app'=>'clusterlogin']);
+		$response = $this->loginController->tryLogin($login, $password, null);
+		$headers = $response->getHeaders();
+		return new DataResponse([
+			'session_name' => session_name(),
+			'session_id' => session_id(),
+			'location' => $headers['Location'],
+		]);
+	}
+}

--- a/apps/federatedcluster/lib/SharingHandler.php
+++ b/apps/federatedcluster/lib/SharingHandler.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedCluster;
+
+use OC\HTTPHelper;
+use OCA\Federation\Cluster;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+
+class SharingHandler {
+
+	/** @var  Cluster */
+	private $cluster;
+
+	const USER_AGENT = 'ownCloud Federated Cluster';
+
+	function __construct() {
+		$this->cluster = new Cluster();
+	}
+
+	public function alterShardShare ($preHookData) {
+		/** @var \OCP\Share\IShare $share */
+		$share = $preHookData['\OCP\Share\IShare'];
+		\OC::$server->getLogger()->debug('alterShardShare shareWith:'.$share->getSharedWith(), ['app'=>'clusterlogin']);
+	}
+
+	//redirects to another instance in case it knows the token
+	public function getShareByToken ($params) {
+		\OC::$server->getLogger()->debug("getShareByToken {$params['token']}", ['app'=>'clusterlogin']);
+		$agent = \OC::$server->getRequest()->getHeader('User-Agent');
+		if ($agent === self::USER_AGENT) {
+			// ignore request
+			return;
+		}
+
+		foreach ($this->cluster->getClusterNodes() as $name => $config) {
+			if ($this->cluster->getNodeUrl() === $config['url']) {
+				continue;
+			}
+			$client = \OC::$server->getHTTPClientService()->newClient();
+			$url = $config['url'].'/index.php/s/'.$params['token'];
+			\OC::$server->getLogger()->debug("checking $url", ['app'=>'clusterlogin']);
+			try {
+				$response = $client->head($url, [
+					'headers' => [ 'User-Agent' => self::USER_AGENT ]
+				]);
+				\OC::$server->getLogger()->debug("status code {$response->getStatusCode()}", ['app'=>'clusterlogin']);
+				if ($response->getStatusCode() === Http::STATUS_OK
+					|| $response->getStatusCode() === Http::STATUS_FORBIDDEN) {
+					$location = \OC::$server->getRequest()->getRequestUri();
+					$this->cluster->redirect($name, $location, '/');
+				}
+			} catch (\Exception $ex) {
+				// try the next one
+			}
+		}
+
+
+	}
+}

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -234,7 +234,9 @@ class FederatedShareProvider implements IShareProvider {
 			$remote = $this->addressHandler->generateRemoteURL();
 		}
 		if ($this->userManager->userExists($sharedByFederatedId)) {
-			// TODO can we omit the remote part in the custer?
+			// TODO can we omit the remote part in the custer? no web has different ways of building the id:
+			// list shared with me uses the share with uid and the remote und builds the id in the web ui
+			// -> needs to be done as a platform effort
 			$sharedByFederatedId = $sharedByFederatedId . '@' . $remote;
 		}
 		$send = $this->notifications->sendRemoteShare(

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -3,6 +3,7 @@
  * @author Björn Schießle <bjoern@schiessle.org>
  * @author Roeland Jago Douma <rullzer@owncloud.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  *
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @license AGPL-3.0
@@ -24,6 +25,7 @@
 namespace OCA\FederatedFileSharing;
 
 use OC\Share20\Share;
+use OCA\Federation\Cluster;
 use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -76,6 +78,9 @@ class FederatedShareProvider implements IShareProvider {
 	/** @var IUserManager */
 	private $userManager;
 
+	/** @var Cluster  */
+	private $cluster;
+
 	/**
 	 * DefaultShareProvider constructor.
 	 *
@@ -109,6 +114,7 @@ class FederatedShareProvider implements IShareProvider {
 		$this->rootFolder = $rootFolder;
 		$this->config = $config;
 		$this->userManager = $userManager;
+		$this->cluster = $cluster = new Cluster(); // FIXME DI
 	}
 
 	/**
@@ -218,16 +224,25 @@ class FederatedShareProvider implements IShareProvider {
 			$token
 		);
 		$sharedByFederatedId = $share->getSharedBy();
+		$shareWith = $share->getSharedWith();
+		$clusterId = $this->cluster->getClusterUserId($shareWith);
+		if ($clusterId) {
+			$shareWith = $clusterId;
+			$remote = $this->cluster->getNodeHost();
+		} else {
+			$remote = $this->addressHandler->generateRemoteURL();
+		}
 		if ($this->userManager->userExists($sharedByFederatedId)) {
-			$sharedByFederatedId = $sharedByFederatedId . '@' . $this->addressHandler->generateRemoteURL();
+			// TODO can we omit the remote part in the custer?
+			$sharedByFederatedId = $sharedByFederatedId . '@' . $remote;
 		}
 		$send = $this->notifications->sendRemoteShare(
 			$token,
-			$share->getSharedWith(),
+			$shareWith,
 			$share->getNode()->getName(),
 			$shareId,
 			$share->getShareOwner(),
-			$share->getShareOwner() . '@' . $this->addressHandler->generateRemoteURL(),
+			$share->getShareOwner() . '@' . $remote,
 			$share->getSharedBy(),
 			$sharedByFederatedId
 		);

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -228,7 +228,8 @@ class FederatedShareProvider implements IShareProvider {
 		$clusterId = $this->cluster->getClusterUserId($shareWith);
 		if ($clusterId) {
 			$shareWith = $clusterId;
-			$remote = $this->cluster->getNodeHost();
+			// remote is only used for notification, use cluster host
+			$remote = $this->cluster->getClusterHost();
 		} else {
 			$remote = $this->addressHandler->generateRemoteURL();
 		}

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -137,6 +137,7 @@ class Notifications {
 			'remoteId' => $shareId
 		);
 
+		// FIXME url
 		$url = $this->addressHandler->removeProtocolFromUrl($remote);
 		$result = $this->tryHttpPostToShareEndpoint(rtrim($url, '/'), '/' . $id . '/reshare', $fields);
 		$status = json_decode($result['result'], true);
@@ -234,7 +235,10 @@ class Notifications {
 		}
 
 		$url = $this->addressHandler->removeProtocolFromUrl($remote);
-		$result = $this->tryHttpPostToShareEndpoint(rtrim($url, '/'), '/' . $remoteId . '/' . $action, $fields);
+		// FIXME url we may neet to iterate over all cluster nodes because we have no owner here?
+		// if remote is the cluster get the owner from the db, then ask that instance?
+
+				$result = $this->tryHttpPostToShareEndpoint(rtrim($url, '/'), '/' . $remoteId . '/' . $action, $fields);
 		$status = json_decode($result['result'], true);
 
 		if ($result['success'] &&

--- a/apps/federation/lib/Cluster.php
+++ b/apps/federation/lib/Cluster.php
@@ -77,6 +77,32 @@ class Cluster {
 	}
 
 	/**
+	 * @param string $userId
+	 * @return string
+	 */
+	public function hideClusterInUserId($userId) {
+		if (empty(\OC::$server->getConfig()->getSystemValue('cluster.nodes', []))) {
+			return $userId;
+		}
+		try {
+			list ($user, $remote) = $this->addressHandler->splitUserRemote($userId);
+		} catch (HintException $ex) {
+			return $userId;
+		}
+		$remote = $this->addressHandler->removeProtocolFromUrl($remote);
+
+		// check if id has cluster remote
+		if ($this->isClusterMember($remote)) {
+			$cluster = $this->getClusterHost();
+			\OC::$server->getLogger()->debug("$userId mapped to $user@$cluster", ['app' => 'cluster']);
+			return "$user@$cluster";
+		}
+
+		\OC::$server->getLogger()->warning("$userId is not a cluster member", ['app' => 'cluster']);
+		return $userId;
+	}
+
+	/**
 	 * @param $userId
 	 * @return array with node name and node url
 	 */

--- a/apps/federation/lib/Cluster.php
+++ b/apps/federation/lib/Cluster.php
@@ -82,7 +82,7 @@ class Cluster {
 	 */
 	public function getUserNode($userId) {
 		// find correct host
-		$nodes = \OC::$server->getConfig()->getSystemValue('cluster.nodes');
+		$nodes = \OC::$server->getConfig()->getSystemValue('cluster.nodes', []);
 		foreach ($nodes as $name => $config) {
 			preg_match($config['users'], $userId, $matches);
 			if (!empty($matches)) {
@@ -102,7 +102,7 @@ class Cluster {
 	 */
 	public function isClusterMember($host) {
 		$host = $this->addressHandler->removeProtocolFromUrl($host);
-		$nodes = \OC::$server->getConfig()->getSystemValue('cluster.nodes');
+		$nodes = \OC::$server->getConfig()->getSystemValue('cluster.nodes', []);
 		foreach ($nodes as $name => $config) {
 			$node = parse_url($config['url'], PHP_URL_HOST);
 			if ($node === $host) {
@@ -141,17 +141,13 @@ class Cluster {
 		return parse_url($url, PHP_URL_HOST);
 	}
 
-	public function getExternalUrl() {
-		return \OC::$server->getConfig()->getSystemValue('overwrite.cli.url');
-	}
-
 	public function getClusterNodes() {
-		return \OC::$server->getConfig()->getSystemValue('cluster.nodes');
+		return \OC::$server->getConfig()->getSystemValue('cluster.nodes', []);
 	}
 
 	public function getScheme($host, $default = 'https') {
 		$host = $this->addressHandler->removeProtocolFromUrl($host);
-		$nodes = \OC::$server->getConfig()->getSystemValue('cluster.nodes');
+		$nodes = $this->getClusterNodes();
 		foreach ($nodes as $name => $config) {
 			$parse = parse_url($config['url']);
 			if ($host === $parse['host']) {

--- a/apps/federation/lib/Cluster.php
+++ b/apps/federation/lib/Cluster.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Federation;
+
+
+use OC\HintException;
+use OCA\FederatedFileSharing\AddressHandler;
+
+/**
+ *
+ * Class Cluster
+ *
+ * @package OCA\Federation
+ */
+class Cluster {
+
+	/**
+	 * @var AddressHandler
+	 */
+	private $addressHandler;
+
+	function __construct() {
+		$this->addressHandler = new AddressHandler(
+			\OC::$server->getURLGenerator(),
+			\OC::$server->getL10N('federatedfilesharing')
+		);
+	}
+
+	/**
+	 * @param string $userId
+	 * @return string|null
+	 */
+	public function getClusterUserId($userId) {
+		try {
+			list ($user, $remote) = $this->addressHandler->splitUserRemote($userId);
+		} catch (HintException $ex) {
+			return null;
+		}
+		$remote = $this->addressHandler->removeProtocolFromUrl($remote);
+
+		// check if id has cluster remote
+		$cluster = $this->getClusterHost();
+		if ($cluster !== $remote) {
+			\OC::$server->getLogger()->debug("$userId is not a cluster id for $cluster", ['app' => 'cluster']);
+			return null;
+		}
+
+		// find correct host
+		list ( , $url) = $this->getUserNode($user);
+		if ($url) {
+			$host = parse_url($url, PHP_URL_HOST);
+			\OC::$server->getLogger()->debug("$userId mapped to $user@$host", ['app' => 'cluster']);
+			return "$user@$host";
+		}
+
+		\OC::$server->getLogger()->warning("$userId could not be mapped to a node", ['app' => 'cluster']);
+		return null;
+	}
+
+	/**
+	 * @param $userId
+	 * @return array with node name and node url
+	 */
+	public function getUserNode($userId) {
+		// find correct host
+		$nodes = \OC::$server->getConfig()->getSystemValue('cluster.nodes');
+		foreach ($nodes as $name => $config) {
+			preg_match($config['users'], $userId, $matches);
+			if (!empty($matches)) {
+				$url = $config['url'];
+				\OC::$server->getLogger()->debug("Node for $userId is $name / $url", ['app' => 'cluster']);
+				return [$name, $url];
+			}
+		}
+
+		\OC::$server->getLogger()->debug("No Node for $userId found", ['app' => 'cluster']);
+		return [null, null];
+	}
+
+	/**
+	 * @param string $host
+	 * @return bool
+	 */
+	public function isClusterMember($host) {
+		$host = $this->addressHandler->removeProtocolFromUrl($host);
+		$nodes = \OC::$server->getConfig()->getSystemValue('cluster.nodes');
+		foreach ($nodes as $name => $config) {
+			$node = parse_url($config['url'], PHP_URL_HOST);
+			if ($node === $host) {
+				\OC::$server->getLogger()->debug("$host is a cluster node", ['app' => 'cluster']);
+				return true;
+			}
+		}
+		\OC::$server->getLogger()->debug("$host is not a cluster node", ['app' => 'cluster']);
+		return false;
+	}
+
+	public function getSourceFor($target) {
+		if ($this->isClusterMember($target)) {
+			$source = $this->getNodeUrl();
+		} else {
+			$source = \OC::$server->getURLGenerator()->getAbsoluteURL('/');
+		}
+		return rtrim($source, '/');
+	}
+
+	public function getNodeUrl() {
+		return \OC::$server->getConfig()->getSystemValue('node.url');
+	}
+
+	public function getNodeHost() {
+		$url = $this->getNodeUrl();
+		return parse_url($url, PHP_URL_HOST);
+	}
+
+	public function getClusterUrl() {
+		return \OC::$server->getConfig()->getSystemValue('overwrite.cli.url');
+	}
+
+	public function getClusterHost() {
+		$url = $this->getClusterUrl();
+		return parse_url($url, PHP_URL_HOST);
+	}
+
+	public function getExternalUrl() {
+		return \OC::$server->getConfig()->getSystemValue('overwrite.cli.url');
+	}
+
+	public function getClusterNodes() {
+		return \OC::$server->getConfig()->getSystemValue('cluster.nodes');
+	}
+
+	public function getScheme($host, $default = 'https') {
+		$host = $this->addressHandler->removeProtocolFromUrl($host);
+		$nodes = \OC::$server->getConfig()->getSystemValue('cluster.nodes');
+		foreach ($nodes as $name => $config) {
+			$parse = parse_url($config['url']);
+			if ($host === $parse['host']) {
+				return $parse['scheme'];
+			}
+		}
+		return $default;
+	}
+
+	public function redirect($nodeName, $location, $path = '/', $session_name = null, $session_id = null) {
+		header('HTTP/1.1 303 See Other'); // 303 because we need get request after login, 307 would do POST
+		header('Cache-Control: no-cache, no-store, must-revalidate');
+		if ($session_name && $session_id) {
+			setcookie($session_name, $session_id, 0, '/', null, true, true);
+		}
+		setcookie(\OC::$server->getConfig()->getSystemValue('cluster.cookie'), $nodeName, 0, $path, null, true, true);
+		header('Location: ' . $location);
+		exit(0);
+	}
+}

--- a/apps/files_external/lib/Lib/Storage/OwnCloud.php
+++ b/apps/files_external/lib/Lib/Storage/OwnCloud.php
@@ -22,6 +22,7 @@
  */
 
 namespace OCA\Files_External\Lib\Storage;
+use Sabre\DAV\Client;
 
 /**
  * ownCloud backend for external storage based on DAV backend.
@@ -68,6 +69,7 @@ class OwnCloud extends \OC\Files\Storage\DAV{
 
 		$params['host'] = $host;
 		$params['root'] = $contextPath . self::OC_URL_SUFFIX . $root;
+		$params['authType'] = Client::AUTH_BASIC;
 
 		parent::__construct($params);
 	}

--- a/apps/files_sharing/lib/API/Remote.php
+++ b/apps/files_sharing/lib/API/Remote.php
@@ -3,6 +3,7 @@
  * @author Joas Schilling <nickvergessen@owncloud.com>
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Roeland Jago Douma <rullzer@owncloud.com>
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  *
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @license AGPL-3.0
@@ -25,6 +26,7 @@ namespace OCA\Files_Sharing\API;
 
 use OC\Files\Filesystem;
 use OCA\FederatedFileSharing\DiscoveryManager;
+use OCA\Federation\Cluster;
 use OCA\Files_Sharing\External\Manager;
 
 class Remote {
@@ -50,7 +52,11 @@ class Remote {
 			\OC_User::getUser()
 		);
 
-		return new \OC_OCS_Result($externalManager->getOpenShares());
+		$shares = $externalManager->getOpenShares();
+
+		$shares = array_map('self::hideCluster', $shares);
+
+		return new \OC_OCS_Result($shares);
 	}
 
 	/**
@@ -133,6 +139,26 @@ class Remote {
 	}
 
 	/**
+	 * @param array $share Share with info from the share_external table
+	 * @return array updated share info with the externally visible cluster remote url
+	 */
+	private static function hideCluster($share) {
+
+		$cluster = new Cluster();
+		if ($cluster->isClusterMember($share['remote'])) {
+
+			$url = $cluster->getClusterUrl();
+			\OC::$server->getLogger()->debug(
+				'hideCluster overwriting remote with '.$url.' in '.json_encode($share),
+				['app' => self::class]
+			);
+			$share['remote'] = $url;
+		}
+
+		return $share;
+	}
+
+	/**
 	 * List accepted remote shares
 	 *
 	 * @param array $params 
@@ -156,6 +182,8 @@ class Remote {
 		$shares = $externalManager->getAcceptedShares();
 
 		$shares = array_map('self::extendShareInfo', $shares);
+
+		$shares = array_map('self::hideCluster', $shares);
 	
 		return new \OC_OCS_Result($shares);
 	}
@@ -191,6 +219,7 @@ class Remote {
 			return new \OC_OCS_Result(null, 404, 'share does not exist');
 		} else {
 			$shareInfo = self::extendShareInfo($shareInfo);
+			$shareInfo = self::hideCluster($shareInfo);
 			return new \OC_OCS_Result($shareInfo);
 		}
 	}

--- a/apps/files_sharing/lib/API/Remote.php
+++ b/apps/files_sharing/lib/API/Remote.php
@@ -182,6 +182,10 @@ class Remote {
 		);
 
 		$shareInfo = $externalManager->getShare($params['id']);
+		//FIXME the remote needs to be set on the server side, otherwise we have to touch
+		// the client code, even if we use '' as a remote, the web ui appends an @
+		// We should always translate the Federated Cloud id to a federated cluster id?
+
 
 		if ($shareInfo === false) {
 			return new \OC_OCS_Result(null, 404, 'share does not exist');

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -62,6 +62,8 @@ class DAV extends Common {
 	/** @var string */
 	protected $user;
 	/** @var string */
+	protected $authType;
+	/** @var string */
 	protected $host;
 	/** @var bool */
 	protected $secure;
@@ -95,6 +97,9 @@ class DAV extends Common {
 			$this->host = $host;
 			$this->user = $params['user'];
 			$this->password = $params['password'];
+			if (isset($params['authType'])) {
+				$this->authType = $params['authType'];
+			}
 			if (isset($params['secure'])) {
 				if (is_string($params['secure'])) {
 					$this->secure = ($params['secure'] === 'true');
@@ -138,6 +143,9 @@ class DAV extends Common {
 			'userName' => $this->user,
 			'password' => $this->password,
 		);
+		if (isset($this->authType)) {
+			$settings['authType'] = $this->authType;
+		}
 
 		$proxy = \OC::$server->getConfig()->getSystemValue('proxy', '');
 		if($proxy !== '') {

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -42,6 +42,7 @@ namespace OC\Share;
 
 use OC\Files\Filesystem;
 use OCA\FederatedFileSharing\DiscoveryManager;
+use OCA\Federation\Cluster;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IUserSession;
 use OCP\IDBConnection;
@@ -2653,7 +2654,8 @@ class Share extends Constants {
 	 * @return array
 	 */
 	private static function tryHttpPostToShareEndpoint($remoteDomain, $urlSuffix, array $fields) {
-		$protocol = 'https://';
+		$cluster = new Cluster(); // FIXME DI
+		$protocol = $cluster->getScheme($remoteDomain).'://';
 		$result = [
 			'success' => false,
 			'result' => '',

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -598,6 +598,7 @@ class Manager implements IManager {
 			'token' => $share->getToken(),
 			'itemTarget' => $share->getTarget(),
 			'shareWith' => $share->getSharedWith(),
+			'\OCP\Share\IShare' => &$share, // allows manipulating the share with hooks
 			'run' => &$run,
 			'error' => &$error,
 		];
@@ -1009,7 +1010,17 @@ class Manager implements IManager {
 		// If it is not a link share try to fetch a federated share by token
 		if ($share === null) {
 			$provider = $this->factory->getProviderForType(\OCP\Share::SHARE_TYPE_REMOTE);
-			$share = $provider->getShareByToken($token);
+			try {
+				$share = $provider->getShareByToken($token);
+			} catch (ShareNotFound $ex) {
+				\OC::$server->getLogger()->debug(
+					'shareByTokenNotFound', ['app'=>'\OC\Share20\Manager']
+				);
+				\OCP\Util::emitHook('OCP\Share', 'shareByTokenNotFound', [
+					'token' => $token
+				]);
+				throw $ex;
+			}
 		}
 
 		if ($share->getExpirationDate() !== null &&

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -31,6 +31,7 @@ namespace OC\User;
 
 use OC\Hooks\Emitter;
 use OC_Helper;
+use OCA\Federation\Cluster;
 use OCP\IAvatarManager;
 use OCP\IImage;
 use OCP\IURLGenerator;
@@ -121,7 +122,8 @@ class User implements IUser {
 			if (!empty($displayName)) {
 				$this->displayName = $displayName;
 			} else {
-				$this->displayName = $this->uid;
+				$cluster = new Cluster();
+				$this->displayName = $cluster->hideClusterInUserId($this->uid);
 			}
 		}
 		return $this->displayName;


### PR DESCRIPTION
Federated Cluster
=================

Distribute requests for a single ownCloud URL over multiple ownCloud instances.


Architecture
------------

### Login 

A load balancer like haproxy is used to direct http requests to separate
ownCloud Installations, based on a cookie. Upon login the cookie is set by
ownCloud to make subsequent requests directly reach the correct ownCloud instance.


### Internal Sharing

Sharing between instances is handled by the existing federated sharing mechanism.
Some changes to core are required to make federation aware of members of the
federated cluster so cluster internal hosts names are used to establish the share
but are not exposed to the end user.
- [ ] sharing ui: remove server name, make it look like normal share
- [ ] share notification on recipient side: remove server name from sharer id
- [ ] Requires CORE branch/PR
- [ ] make hosts / user map configurable? query redis or other nodes?
- [ ] where should the Cluster class go? core?
    - [ ] fix DI for it


### Public sharing

Links need to be unique over all instances and the haproxy needs to be able to
choose the right server based on the link token. For this redis is used to store
a map of link token to cluster node. It can be used for both: checking if a link
already exists as well as finding the right host. A fallback mechanism based on
cookies has been implemented
- [ ] occ command to repopulate redis with mapping?
- [ ] check link uniqueness, overwrite token until it is unique


Implementation
--------------

### haproxy

haproxy.conf excerpt:
```
frontend localnodes
    bind *:443 ssl crt /etc/ssl/localcerts/bpicln01.pem
    mode http

    acl is_ocnode1 hdr_sub(cookie) SRVNAME=node1
        use_backend ocnode1 if is_ocnode1

    acl is_ocnode2 hdr_sub(cookie) SRVNAME=node2
        use_backend ocnode2 if is_ocnode2

    # if no cookie is set start anywhere
    default_backend ocnodes

backend ocnodes
    mode http
    balance roundrobin
    option forwardfor
    http-request set-header X-Forwarded-Port %[dst_port]
    http-request add-header X-Forwarded-Proto https if { ssl_fc }
    server ochost1 host1:80
    server ochost2 host2:80
    
backend ocnode1
    mode http
    option forwardfor
    http-request set-header X-Forwarded-Port %[dst_port]
    http-request add-header X-Forwarded-Proto https if { ssl_fc }
    server ochost1 host1:80

backend ocnode2
    mode http
    option forwardfor
    http-request set-header X-Forwarded-Port %[dst_port]
    http-request add-header X-Forwarded-Proto https if { ssl_fc }
    server ochost2 host2:80
```

### Federated Cluster App
To respond to a login request with a correct session and node cookie the
Federated Cluster app implements a user backend that tries to log in the user at
the other nodes. The default login url /index.php/login requires a CSRF check so
the app also provides a dedicated login url for this 'inter node login'.

### Core branch
The app needs the `stable9.1-federated-cluster` branch.