### PR TITLE
[stable9.1] Don't rerepair unmerged shares if updating from OC > 9.0.3

### DIFF
--- a/lib/private/Repair/RepairUnmergedShares.php
+++ b/lib/private/Repair/RepairUnmergedShares.php
@@ -353,9 +353,14 @@ class RepairUnmergedShares implements IRepairStep {
 
 	public function run(IOutput $output) {
 		$ocVersionFromBeforeUpdate = $this->config->getSystemValue('version', '0.0.0');
-		if (version_compare($ocVersionFromBeforeUpdate, '9.1.0.16', '<')) {
-			// this situation was only possible between 9.0.0 and 9.0.3 included
-
+		// this situation was only possible between 9.0.0 and 9.0.3 included, and 9.1.0
+		if ((
+			version_compare($ocVersionFromBeforeUpdate, '9.0.0', '>=')
+			&& version_compare($ocVersionFromBeforeUpdate, '9.0.4', '<')
+			) || (
+			version_compare($ocVersionFromBeforeUpdate, '9.1.0', '>=')
+			&& version_compare($ocVersionFromBeforeUpdate, '9.1.0.16', '<'))
+		) {
 			$function = function(IUser $user) use ($output) {
 				$this->fixUnmergedShares($output, $user);
 				$output->advance();


### PR DESCRIPTION
Because unmerged shares existed only between OC 9.0.0 and 9.0.3 included and in OC <= 9.0.0, when someone updated to OC > 9.0.3 they already had the repair routine running.

Tested as follows:

1. Set breakpoint on the changed line
1. Set version to 9.0.3 in config.php
1. Run `occ upgrade`
1. See that code runs into the repair part
1. Set version to 9.0.4 in config.php
1. Run `occ upgrade`
1. See that code runs skips the repair part

Please review @VicDeo @jvillafanez @IljaN 
