### PR TITLE
Exclude group backend from showing groups in users page (post-filter approach)

### DIFF
--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -297,4 +297,8 @@ class Group implements IGroup {
 		}
 		return $users;
 	}
+
+	public function getBackends() {
+		return $this->backends;
+	}
 }

--- a/lib/private/Group/MetaData.php
+++ b/lib/private/Group/MetaData.php
@@ -27,6 +27,7 @@
 namespace OC\Group;
 
 use OCP\IUserSession;
+use OCP\GroupInterface;
 
 class MetaData {
 	const SORT_NONE = 0;
@@ -89,6 +90,15 @@ class MetaData {
 
 		foreach($this->getGroups($groupSearch) as $group) {
 			$groupMetaData = $this->generateGroupMetaData($group, $userSearch);
+			$skip = false;
+			foreach ($group->getBackends() as $backend) {
+				if (!$backend->implementsActions(GroupInterface::ADD_TO_GROUP | GroupInterface::REMOVE_FROM_GROUP)) {
+					$skip = true;
+				}
+			}
+			if ($skip) {
+				continue;
+			}
 			if (strtolower($group->getGID()) !== 'admin') {
 				$this->addEntry(
 					$groups,

--- a/lib/public/IGroup.php
+++ b/lib/public/IGroup.php
@@ -115,4 +115,11 @@ interface IGroup {
 	 * @since 8.0.0
 	 */
 	public function delete();
+
+	/**
+	 * Returns the backends associated with the group
+	 *
+	 * @since 10.0.0
+	 */
+	public function getBackends();
 }


### PR DESCRIPTION
## Description
Some group backends are providing groups only for the share dialog like the customgroups app.
This PR provides a somewhat clumsy way to exclude these from the users page and provisioning API.

## Related Issue
https://github.com/owncloud/customgroups/issues/6

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Notes

The approach is not good as it also excludes LDAP groups because it relies on the "can this backend manage group memberships" attribute.

We might need a new attribute (but then all old backends must implement it) or a new interface + method to check whether groups can be managed.

@jvillafanez @DeepDiver1975 any advice ?