### PR TITLE
Let group backends return groups for shares only

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -220,7 +220,7 @@ class ShareesController extends OCSController  {
 	protected function getGroups($search) {
 		$this->result['groups'] = $this->result['exact']['groups'] = [];
 
-		$groups = $this->groupManager->search($search, $this->limit, $this->offset);
+		$groups = $this->groupManager->searchForSharing($search, $this->limit, $this->offset);
 		$groupIds = array_map(function (IGroup $group) { return $group->getGID(); }, $groups);
 
 		if (!$this->shareeEnumeration || sizeof($groups) < $this->limit) {
@@ -230,7 +230,7 @@ class ShareesController extends OCSController  {
 		$userGroups =  [];
 		if (!empty($groups) && $this->shareWithGroupOnly) {
 			// Intersect all the groups that match with the groups this user is a member of
-			$userGroups = $this->groupManager->getUserGroups($this->userSession->getUser());
+			$userGroups = $this->groupManager->getUserGroupsForSharing($this->userSession->getUser());
 			$userGroups = array_map(function (IGroup $group) { return $group->getGID(); }, $userGroups);
 			$groupIds = array_intersect($groupIds, $userGroups);
 		}

--- a/lib/private/Group/Backend.php
+++ b/lib/private/Group/Backend.php
@@ -95,6 +95,10 @@ abstract class Backend implements \OCP\GroupInterface {
 		return [];
 	}
 
+	public function getUserGroupsForSharing($uid) {
+		return $this->getUserGroups($uid);
+	}
+
 	/**
 	 * get a list of all groups
 	 * @param string $search
@@ -107,6 +111,10 @@ abstract class Backend implements \OCP\GroupInterface {
 
 	public function getGroups($search = '', $limit = -1, $offset = 0) {
 		return [];
+	}
+
+	public function getGroupsForSharing($search = '', $limit = -1, $offset = 0) {
+		return $this->getGroups($search, $limit, $offset);
 	}
 
 	/**

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -654,7 +654,7 @@ class DefaultShareProvider implements IShareProvider {
 
 		} else if ($shareType === \OCP\Share::SHARE_TYPE_GROUP) {
 			$user = $this->userManager->get($userId);
-			$allGroups = $this->groupManager->getUserGroups($user);
+			$allGroups = $this->groupManager->getUserGroupsForSharing($user);
 
 			/** @var Share[] $shares2 */
 			$shares2 = [];

--- a/lib/public/GroupInterface.php
+++ b/lib/public/GroupInterface.php
@@ -98,6 +98,18 @@ interface GroupInterface {
 	public function getGroups($search = '', $limit = -1, $offset = 0);
 
 	/**
+	 * Returns a list of groups available for sharing.
+	 *
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return array an array of group names
+	 *
+	 * @since 10.0.0
+	 */
+	public function getGroupsForSharing($search = '', $limit = -1, $offset = 0);
+
+	/**
 	 * check if a group exists
 	 * @param string $gid
 	 * @return bool


### PR DESCRIPTION
Another try for https://github.com/owncloud/core/pull/27184#issuecomment-281285310

Based on the idea from https://github.com/owncloud/core/pull/27184#issuecomment-281283745

Not too happy to add this specialization to group backends.

Used by custom groups: https://github.com/owncloud/customgroups/pull/25

@jvillafanez @DeepDiver1975 