### PR TITLE
Setting to disable external storage subsystem in core

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -34,6 +34,9 @@
 OC.FileUpload = function(uploader, data) {
 	this.uploader = uploader;
 	this.data = data;
+	if (!data) {
+		throw 'Missing "data" argument in OC.FileUpload constructor';
+	}
 	var path = '';
 	if (this.uploader.fileList) {
 		path = OC.joinPaths(this.uploader.fileList.getCurrentDirectory(), this.getFile().name);

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -157,7 +157,13 @@ OC.FileUpload.prototype = {
 	 * @return {bool}
 	 */
 	isPending: function() {
-		return this.data.state() === 'pending';
+		if (!this.data) {
+			// this should not be possible!
+			var stack = new Error().stack;
+			console.error(stack);
+			return false;
+		}
+		return this.data && this.data.state() === 'pending';
 	},
 
 	deleteUpload: function() {

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -240,15 +240,6 @@ class ViewControllerTest extends TestCase {
 				'icon' => '',
 			],
 			[
-				'id' => 'extstoragemounts',
-				'appname' => 'files_external',
-				'script' => 'list.php',
-				'order' => 30,
-				'name' => new \OC_L10N_String(\OC::$server->getL10NFactory()->get('files_external'), 'External storage', []),
-				'active' => false,
-				'icon' => '',
-			],
-			[
 				'id' => 'trashbin',
 				'appname' => 'files_trashbin',
 				'script' => 'list.php',
@@ -299,10 +290,6 @@ class ViewControllerTest extends TestCase {
 					],
 					[
 						'id' => 'systemtagsfilter',
-						'content' => null,
-					],
-					[
-						'id' => 'extstoragemounts',
 						'content' => null,
 					],
 					[

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -36,11 +36,15 @@ $appContainer = \OC_Mount_Config::$app->getContainer();
 
 $l = \OC::$server->getL10N('files_external');
 
-\OCA\Files\App::getNavigationManager()->add([
-	"id" => 'extstoragemounts',
-	"appname" => 'files_external',
-	"script" => 'list.php',
-	"order" => 30,
-	"name" => $l->t('External storage')
-]);
+$config = \OC::$server->getConfig();
+if ($config->getAppValue('core', 'enable_external_storage', 'no') === 'yes') {
+	\OCA\Files\App::getNavigationManager()->add([
+
+		"id" => 'extstoragemounts',
+		"appname" => 'files_external',
+		"script" => 'list.php',
+		"order" => 30,
+		"name" => $l->t('External storage')
+	]);
+}
 

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -1347,6 +1347,34 @@ $(document).ready(function() {
 		}
 	});
 
+	$('#files_external input[name=enableExternalStorage]').on('change', function(event) {
+		var $target = $(event.target);
+		var checked = $target.is(':checked');
+
+		var saveSetting = function(checked) {
+			var value = checked ? 'yes' : 'no';
+			OC.AppConfig.setValue('core', 'enable_external_storage', value);
+			$('#files_external_settings').toggleClass('hidden', !checked);
+		};
+
+		if (checked === false) {
+			OC.dialogs.confirm(
+				t('files_external', 'Disabling external storage will unmount all storages for all users, are you sure ?'),
+				t('files_external', 'Disable external storage'),
+				function(confirmation) {
+					if (confirmation) {
+						saveSetting(false);
+					} else {
+						$target.prop('checked', true);
+					}
+				},
+				true
+			);
+		} else {
+			saveSetting(true);
+		}
+	});
+
 	// global instance
 	OCA.External.Settings.mountConfig = mountConfigListView;
 

--- a/apps/files_external/lib/Panels/Admin.php
+++ b/apps/files_external/lib/Panels/Admin.php
@@ -25,6 +25,7 @@ use OCP\Files\External\Service\IGlobalStoragesService;
 use OCP\Settings\ISettings;
 use OCP\Files\External\IStoragesBackendService;
 use OCP\Template;
+use OCP\IConfig;
 
 class Admin implements ISettings {
 
@@ -32,14 +33,18 @@ class Admin implements ISettings {
 	protected $globalStoragesService;
 	/** @var IStoragesBackendService */
 	protected $backendService;
+	/** @var IConfig */
+	protected $config;
 	/** @var Manager */
 	protected $encManager;
 
 	public function __construct(IGlobalStoragesService $globalStoragesService,
 								IStoragesBackendService $backendService,
+								IConfig $config,
 								Manager $encManager) {
 		$this->globalStoragesService = $globalStoragesService;
 		$this->backendService = $backendService;
+		$this->config = $config;
 		$this->encManager = $encManager;
 	}
 
@@ -54,6 +59,7 @@ class Admin implements ISettings {
 	public function getPanel() {
 		// we must use the same container
 		$tmpl = new Template('files_external', 'settings');
+		$tmpl->assign('enableExternalStorage', $this->config->getAppValue('core', 'enable_external_storage', 'no') === 'yes');
 		$tmpl->assign('encryptionEnabled', $this->encManager->isEnabled());
 		$tmpl->assign('visibilityType', IStoragesBackendService::VISIBILITY_ADMIN);
 		$tmpl->assign('storages', $this->globalStoragesService->getStorages());

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -32,6 +32,17 @@
 ?>
 <form id="files_external" class="section" data-encryption-enabled="<?php echo $_['encryptionEnabled']?'true': 'false'; ?>">
 	<h2 class="app-name"><?php p($l->t('External Storage')); ?></h2>
+
+	<p>
+		<input type="checkbox" name="enableExternalStorage" id="enableExternalStorageCheckbox" class="checkbox"
+			   value="1" <?php if ($_['enableExternalStorage']) print_unescaped('checked="checked"'); ?> />
+		<label for="enableExternalStorageCheckbox">
+			<?php p($l->t('Enable external storage'));?>
+		</label>
+	</p>
+
+	<div id="files_external_settings" class=" <?php if (!$_['enableExternalStorage']) print('hidden'); ?>">
+
 	<?php if (isset($_['dependencies']) and ($_['dependencies']<>'')) print_unescaped(''.$_['dependencies'].''); ?>
 	<table id="externalStorage" class="grid" data-admin='<?php print_unescaped(json_encode($_['visibilityType'] === IStoragesBackendService::VISIBILITY_ADMIN)); ?>'>
 		<thead>
@@ -129,4 +140,5 @@
 			<?php endforeach; ?>
 		</p>
 	<?php endif; ?>
+	</div>
 </form>

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -33,6 +33,7 @@
 <form id="files_external" class="section" data-encryption-enabled="<?php echo $_['encryptionEnabled']?'true': 'false'; ?>">
 	<h2 class="app-name"><?php p($l->t('External Storage')); ?></h2>
 
+	<?php if ($_['visibilityType'] === IStoragesBackendService::VISIBILITY_ADMIN): ?>
 	<p>
 		<input type="checkbox" name="enableExternalStorage" id="enableExternalStorageCheckbox" class="checkbox"
 			   value="1" <?php if ($_['enableExternalStorage']) print_unescaped('checked="checked"'); ?> />
@@ -40,6 +41,10 @@
 			<?php p($l->t('Enable external storage'));?>
 		</label>
 	</p>
+	<?php endif; ?>
+	<?php if (!$_['enableExternalStorage']): ?>
+	<p><?php p($l->t('External storage has been disabled by the administrator')); ?></p>
+	<?php endif; ?>
 
 	<div id="files_external_settings" class=" <?php if (!$_['enableExternalStorage']) print('hidden'); ?>">
 

--- a/apps/files_external/tests/Panels/AdminTest.php
+++ b/apps/files_external/tests/Panels/AdminTest.php
@@ -22,10 +22,10 @@
 namespace OCA\Files_External\Tests\Panels;
 
 use OC\Encryption\Manager;
-use OC\Settings\Panels\Helper;
 use OCA\Files_External\Panels\Admin;
 use OCP\Files\External\IStoragesBackendService;
 use OCP\Files\External\Service\IGlobalStoragesService;
+use OCP\IConfig;
 
 /**
  * @package OCA\Files_External\Tests
@@ -40,20 +40,21 @@ class AdminTest extends \Test\TestCase {
 	private $storagesService;
 	/** @var Manager */
 	private $encManager;
-	/** @var Helper  */
-	private $helper;
+	/** @var IConfig */
+	private $config;
 
 	public function setUp() {
 		parent::setUp();
 		$this->backendService = $this->createMock(IStoragesBackendService::class);
 		$this->storagesService = $this->createMock(IGlobalStoragesService::class);
-		$this->encManager = $this->getMockBuilder(Manager::class)->disableOriginalConstructor()->getMock();
-		$this->helper = $this->getMockBuilder(Helper::class)->getMock();
+		$this->config = $this->createMock(IConfig::class);
+		$this->encManager = $this->createMock(Manager::class);
 		$this->panel = new Admin(
 			$this->storagesService,
 			$this->backendService,
-			$this->encManager,
-			$this->helper);
+			$this->config,
+			$this->encManager
+		);
 	}
 
 	public function testGetSection() {

--- a/apps/files_external/tests/Panels/PersonalTest.php
+++ b/apps/files_external/tests/Panels/PersonalTest.php
@@ -22,10 +22,10 @@
 namespace OCA\Files_External\Tests\Panels;
 
 use OC\Encryption\Manager;
-use OC\Settings\Panels\Helper;
 use OCA\Files_External\Panels\Personal;
 use OCP\Files\External\IStoragesBackendService;
 use OCP\Files\External\Service\IUserStoragesService;
+use OCP\IConfig;
 
 /**
  * @package OCA\Files_External\Tests
@@ -38,23 +38,23 @@ class PersonalTest extends \Test\TestCase {
 	private $backendService;
 	/** @var IUserStoragesService */
 	private $storagesService;
+	/** @var IConfig */
+	private $config;
 	/** @var Manager */
 	private $encManager;
-	/** @var Helper */
-	private $helper;
 
 	public function setUp() {
 		parent::setUp();
 		$this->backendService = $this->createMock(IStoragesBackendService::class);
 		$this->storagesService = $this->createMock(IUserStoragesService::class);
-		$this->encManager = $this->getMockBuilder(Manager::class)
-			->disableOriginalConstructor()->getMock();
-		$this->helper = $this->getMockBuilder(Helper::class)->getMock();
+		$this->config = $this->createMock(IConfig::class);
+		$this->encManager = $this->createMock(Manager::class);
 		$this->panel = new Personal(
 			$this->backendService,
 			$this->storagesService,
-			$this->encManager,
-			$this->helper);
+			$this->config,
+			$this->encManager
+		);
 	}
 
 	public function testGetSection() {

--- a/core/Migrations/Version20170221121536.php
+++ b/core/Migrations/Version20170221121536.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Migrations;
+
+use OCP\Migration\ISimpleMigration;
+use OCP\Migration\IOutput;
+use OCP\IConfig;
+
+/**
+ * If files_external app was disable before, set flag in app config to disable it in core.
+ * This is necessary because starting with 10.0 the files_external app will always be enabled.
+ */
+class Version20170221121536 implements ISimpleMigration {
+
+	public function run(IOutput $out) {
+		$config = \OC::$server->getConfig();
+		$filesExternalEnabled = $config->getAppValue('files_external', 'enabled', 'no') === 'yes';
+		if (!$filesExternalEnabled) {
+			// was not enabled before, keep default disabled
+			return;
+		}
+
+		$externalStorageEnabled = $config->getAppValue('core', 'enable_external_storage', null);
+		if ($externalStorageEnabled !== null) {
+			// this was already set before for some reason
+			return;
+		}
+
+		$value = $filesExternalEnabled ? 'yes' : 'no';
+		$out->info('Enable external storage: ' . $value);
+		$config->setAppValue('core', 'enable_external_storage', $value);
+	}
+}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -534,10 +534,12 @@ class Server extends ServerContainer implements IServerContainer {
 			$manager->registerHomeProvider(new ObjectHomeMountProvider($config));
 
 			// external storage
-			$manager->registerProvider(new \OC\Files\External\ConfigAdapter(
-				$c->query('UserStoragesService'),
-				$c->query('UserGlobalStoragesService')
-			));
+			if ($config->getAppValue('core', 'enable_external_storage', 'no') === 'yes') {
+				$manager->registerProvider(new \OC\Files\External\ConfigAdapter(
+					$c->query('UserStoragesService'),
+					$c->query('UserGlobalStoragesService')
+				));
+			}
 
 			return $manager;
 		});

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -57,7 +57,7 @@ export TEST_SERVER_FED_URL="http://localhost:$PORT_FED/ocs/"
 $OCC config:system:set skeletondirectory --value="$(pwd)/skeleton"
 
 #Enable external storage app
-$OCC app:enable files_external
+$OCC config:app:set core enable_external_storage --value=yes
 
 mkdir -p work/local_storage || { echo "Unable to create work folder" >&2; exit 1; }
 OUTPUT_CREATE_STORAGE=`$OCC files_external:create local_storage local null::null -c datadir=$SCRIPT_PATH/work/local_storage` 
@@ -95,7 +95,7 @@ kill $PHPPID_FED
 $OCC files_external:delete -y $ID_STORAGE
 
 #Disable external storage app
-$OCC app:disable files_external
+$OCC config:app:set core enable_external_storage --value=no
 
 # Clear storage folder
 rm -Rf work/local_storage/*


### PR DESCRIPTION
## Description
Because files_external is now always enabled and the external storage
subsystem is in core, a setting makes it possible to disable it to save
some performance and remove related UI elements for regular users.

## Related Issue
Fixes https://github.com/owncloud/core/issues/27195

## Motivation and Context
Some admins might still want to disable external storage.
Or at least they want the "External storage" section in the user's files navigation to disappear.

## How Has This Been Tested?

- [x] TEST: external storage subsystem (checkbox) disabled by default
- [x] TEST: migration: enable/disable files_external before upgrading, see that the checkbox matches previous state
- [x] TEST: disable ext storage will unmount all storages, reenabling brings them back

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@jvillafanez @DeepDiver1975 @davitol @pmaier1 