### PR TITLE
Fix user language in personal settings page

### DIFF
--- a/settings/Panels/Personal/Profile.php
+++ b/settings/Panels/Personal/Profile.php
@@ -61,9 +61,10 @@ class Profile implements ISettings {
 
 	public function getPanel() {
 		$tmpl = new Template('settings', 'panels/personal/profile');
+
 		// Assign some data
 		$lang = $this->lfactory->findLanguage();
-		$userLang = $this->config->getUserValue( $this->userSession->getUser(), 'core', 'lang', $lang);
+		$userLang = $this->config->getUserValue( $this->userSession->getUser()->getUID(), 'core', 'lang', $lang);
 		$languageCodes = $this->lfactory->findAvailableLanguages();
 		// array of common languages
 		$commonLangCodes = [


### PR DESCRIPTION
Before, a load of `/settings/personal` would throw up some errors in the log:

```
{"reqId":"BmnXB0C8T4ECK00QEJST","remoteAddr":"172.17.0.1","app":"PHP","message":"Object of class OC\\User\\User could not be converted to string at \/var\/www\/owncloud-docker-dev\/lib\/composer\/doctrine\/dbal\/lib\/Doctrine\/DBAL\/Driver\/PDOStatement.php#91","level":3,"time":"2017-02-20T17:03:00+00:00","method":"GET","url":"\/settings\/personal","user":"test"}
{"reqId":"BmnXB0C8T4ECK00QEJST","remoteAddr":"172.17.0.1","app":"PHP","message":"Illegal offset type at \/var\/www\/owncloud-docker-dev\/lib\/private\/Cache\/CappedMemoryCache.php#49","level":3,"time":"2017-02-20T17:03:00+00:00","method":"GET","url":"\/settings\/personal","user":"test"}
```

This was a regression in the profile panel of the personal settings page. 

Fixes the log messages and also should fix the user language option issue reported here https://github.com/owncloud/core/issues/27117#issuecomment-278391505 @davitol .

