### PR TITLE
Defining App name "cron" for "Invalidating tokens older than" message

### DIFF
--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -206,7 +206,7 @@ class DefaultTokenProvider implements IProvider {
 	 */
 	public function invalidateOldTokens() {
 		$olderThan = $this->time->getTime() - (int) $this->config->getSystemValue('session_lifetime', 60 * 60 * 24);
-		$this->logger->info('Invalidating tokens older than ' . date('c', $olderThan));
+		$this->logger->info('Invalidating tokens older than ' . date('c', $olderThan), ['app' => 'cron']);
 		$this->mapper->invalidateOld($olderThan);
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

@PVince81 
## Description
Gives the message "Invalidating tokens older than" an an app name: ``cron``

## Related Issue
https://github.com/owncloud/core/issues/27167

## Motivation and Context
Originally, ``no app in context`` is not an app name and does not reference to where this message comes from
**Before:**
```
{"reqId":"nM8fTfnY5grBxtGxSUpJ","remoteAddr":"","app":"no app in context","message":"Invalidating tokens older than 2017-02-20T12:45:05+00:00","level":1,"time":"2017-02-21T13:45:05+01:00","method":"--","url":"--","user":"--"}
```
**After:**
```
{"reqId":"gi5/lUjspneHNKo5QJCe","remoteAddr":"","app":"cron","message":"Invalidating tokens older than 2017-02-20T12:45:59+00:00","level":1,"time":"2017-02-21T13:45:59+01:00","method":"--","url":"--","user":"--"}
```
## How Has This Been Tested?
With loglevel set to info, 
sudo -uwww-data php -f /var/www/owncloud/core/cron.php

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

