### PR TITLE
Add icons to settings sections for UI

### DIFF
--- a/lib/private/Settings/Section.php
+++ b/lib/private/Settings/Section.php
@@ -25,32 +25,38 @@ namespace OC\Settings;
 
 use OCP\Settings\ISection;
 
-/*
+/**
  * @since 10.0
  */
 class Section implements ISection {
 
-    protected $id;
-    protected $name;
-    /** @var int */
-    protected $priority;
+	protected $id;
+	protected $name;
+	/** @var int */
+	protected $priority;
+	protected $icon;
 
-    public function __construct($id, $name, $priority) {
-        $this->id = $id;
-        $this->name = $name;
-        $this->priority = $priority;
-    }
+	public function __construct($id, $name, $priority, $icon='settings') {
+		$this->id = $id;
+		$this->name = $name;
+		$this->priority = $priority;
+		$this->icon = $icon;
+	}
 
-    public function getID() {
-        return $this->id;
-    }
+	public function getID() {
+		return $this->id;
+	}
 
-    public function getName() {
-        return $this->name;
-    }
+	public function getName() {
+		return $this->name;
+	}
 
-    public function getPriority() {
-        return $this->priority;
-    }
+	public function getPriority() {
+		return $this->priority;
+	}
+
+	public function getIconName() {
+		return $this->icon;
+	}
 
 }

--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -195,22 +195,22 @@ class SettingsManager implements ISettingsManager {
 		if($type === 'admin') {
 			return [
 				new Section('general', $this->l->t('General'), 100),
-				new Section('storage', $this->l->t('Storage'), 95),
-				new Section('security', $this->l->t('Security'), 90),
-				new Section('encryption', $this->l->t('Encryption'), 85),
-				new Section('sharing', $this->l->t('Sharing'), 80),
-				new Section('monitoring', $this->l->t('Monitoring'), 75),
-				new Section('apps', $this->l->t('Apps'), 70),
-				new Section('updates', $this->l->t('Updates'), 20),
-				new Section('additional', $this->l->t('Additional'), -10),
+				new Section('storage', $this->l->t('Storage'), 95, 'folder'),
+				new Section('security', $this->l->t('Security'), 90, 'password'),
+				new Section('encryption', $this->l->t('Encryption'), 85, 'password'),
+				new Section('sharing', $this->l->t('Sharing'), 80, 'share'),
+				new Section('monitoring', $this->l->t('Monitoring'), 75, 'search'),
+				new Section('apps', $this->l->t('Apps'), 70, 'list'),
+				new Section('updates', $this->l->t('Updates'), 20, 'update'),
+				new Section('additional', $this->l->t('Additional'), -10, 'more'),
 			];
 		} else if($type === 'personal') {
 			return [
 				new Section('general', $this->l->t('General'), 100),
-				new Section('storage', $this->l->t('Storage'), 50),
-				new Section('security', $this->l->t('Security'), 30),
+				new Section('storage', $this->l->t('Storage'), 50, 'folder'),
+				new Section('security', $this->l->t('Security'), 30, 'password'),
 				new Section('encryption', $this->l->t('Encryption'), 20),
-				new Section('additional', $this->l->t('Additional'), 5),
+				new Section('additional', $this->l->t('Additional'), 5, 'more'),
 			];
 		}
 	}

--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -206,7 +206,7 @@ class SettingsManager implements ISettingsManager {
 			];
 		} else if($type === 'personal') {
 			return [
-				new Section('general', $this->l->t('General'), 100),
+				new Section('general', $this->l->t('General'), 100, 'user'),
 				new Section('storage', $this->l->t('Storage'), 50, 'folder'),
 				new Section('security', $this->l->t('Security'), 30, 'password'),
 				new Section('encryption', $this->l->t('Encryption'), 20),

--- a/lib/public/Settings/ISection.php
+++ b/lib/public/Settings/ISection.php
@@ -47,4 +47,10 @@ interface ISection {
 	 */
 	public function getPriority();
 
+	/**
+	 * @since 10.0
+	 * @return string
+	 */
+	public function getIconName();
+
 }

--- a/settings/Controller/SettingsPageController.php
+++ b/settings/Controller/SettingsPageController.php
@@ -125,6 +125,7 @@ class SettingsPageController extends Controller {
 				),
 				'name' => ucfirst($section->getName()),
 				'active' => $section->getID() === $currentSectionID,
+				'icon' => $section->getIconName()
 			];
 		}
 		return $nav;

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -648,6 +648,16 @@ li > a.icon-upload {
 	background-image: url(../../core/img/actions/upload.svg);
 }
 
+li > a.icon-user {
+	background-image: url(../../core/img/actions/user.svg);
+}
+
+#app-navigation li.divider {
+	background: none;
+}
+
+
+
 li > a.icon-settings {
 	background-image: url(../../core/img/actions/settings.svg);
 }

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -615,3 +615,39 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 #warning {
 	color: red;
 }
+
+
+/**
+ * Icons for settings sections
+ */
+li > a.icon-search {
+	background-image: url(../../core/img/actions/search.svg);
+}
+
+li > a.icon-share {
+	background-image: url(../../core/img/actions/share.svg);
+}
+
+li > a.icon-folder {
+	background-image: url(../../core/img/filetypes/folder.svg);
+}
+
+li > a.icon-list {
+	background-image: url(../../core/img/actions/menu.svg);
+}
+
+li > a.icon-password {
+	background-image: url(../../core/img/actions/password.svg);
+}
+
+li > a.icon-more {
+	background-image: url(../../core/img/actions/more.svg);
+}
+
+li > a.icon-upload {
+	background-image: url(../../core/img/actions/upload.svg);
+}
+
+li > a.icon-settings {
+	background-image: url(../../core/img/actions/settings.svg);
+}

--- a/settings/templates/settingsPage.php
+++ b/settings/templates/settingsPage.php
@@ -19,36 +19,39 @@ style('settings', 'settings');
 ?>
 
 <div id="app-navigation">
-	<ul>
+	<ul class="with-icon">
 		<li class="divider"><?php p($l->t('Personal')); ?></li>
 		<?php foreach($_['personalNav'] as $item) {
-		$active = $item['active'] ? 'class="active"' : '';
-		print_unescaped(
-			sprintf(
-				"<li><a %shref='%s'>%s</a></li>",
-				$active,
-				\OCP\Util::sanitizeHTML($item['link']),
-				\OCP\Util::sanitizeHTML($item['name'])
-			)
-		);
-	}
-	if(!empty($_['adminNav'])) { ?>
-
-		<li class="divider"><?php p($l->t('Admin')); ?></li>
-		<?php
-
-		foreach ($_['adminNav'] as $item) {
-			$active = $item['active'] ? 'class="active"' : '';
+			$active = $item['active'] ? ' active ' : '';
 			print_unescaped(
 				sprintf(
-					"<li><a %shref='%s'>%s</a></li>",
+					"<li><a class=\"svg %s %s\" href='%s'>%s</a></li>",
 					$active,
+					'icon-'.\OCP\Util::sanitizeHTML($item['icon']),
 					\OCP\Util::sanitizeHTML($item['link']),
 					\OCP\Util::sanitizeHTML($item['name'])
 				)
 			);
 		}
-	}?>
+		if(!empty($_['adminNav'])) { ?>
+
+			<li class="divider"><?php p($l->t('Admin')); ?></li>
+			<?php
+
+			foreach ($_['adminNav'] as $item) {
+				$active = $item['active'] ? ' active ' : '';
+				print_unescaped(
+					sprintf(
+						"<li><a class=\"svg %s %s\" href='%s'>%s</a></li>",
+						$active,
+						'icon-'.\OCP\Util::sanitizeHTML($item['icon']),
+						\OCP\Util::sanitizeHTML($item['link']),
+						\OCP\Util::sanitizeHTML($item['name'])
+					)
+				);
+			}
+		}
+		?>
 	</ul>
 </div>
 <div id="app-content">

--- a/tests/Settings/Controller/SettingsPageControllerTest.php
+++ b/tests/Settings/Controller/SettingsPageControllerTest.php
@@ -87,7 +87,7 @@ class SettingsPageControllerTest extends TestCase {
 		$this->settingsManager
 			->expects($this->once())
 			->method('getPersonalSections')
-			->willReturn([new Section('testSectionID', 'testSectionID', 1)]);
+			->willReturn([new Section('testSectionID', 'testSectionID', 1, 'list')]);
 		$this->settingsManager
 			->expects($this->once())
 			->method('getPersonalPanels')
@@ -124,11 +124,11 @@ class SettingsPageControllerTest extends TestCase {
 		$this->settingsManager
 			->expects($this->once())
 			->method('getPersonalSections')
-			->willReturn([new Section('testSectionID', 'testSectionID', 1)]);
+			->willReturn([new Section('testSectionID', 'testSectionID', 1, 'list')]);
 		$this->settingsManager
 			->expects($this->once())
 			->method('getAdminSections')
-			->willReturn([new Section('testAdminSectionID', 'testAdminSectionID', 1)]);
+			->willReturn([new Section('testAdminSectionID', 'testAdminSectionID', 1, 'list')]);
 		$this->settingsManager
 			->expects($this->once())
 			->method('getPersonalPanels')
@@ -145,6 +145,9 @@ class SettingsPageControllerTest extends TestCase {
 		$this->assertArrayHasKey('adminNav', $response->getParams());
 		$this->assertNotEmpty($response->getParams()['adminNav']);
 		$this->assertArrayHasKey('panels', $response->getParams());
+		$this->assertArrayHasKey('icon', $response->getParams()['personalNav'][0]);
+		$this->assertArrayHasKey('link', $response->getParams()['personalNav'][0]);
+		$this->assertArrayHasKey('id', $response->getParams()['personalNav'][0]);
 		$this->assertContains('testSectionID', $response->getParams()['personalNav'][0]['id']);
 		$this->assertContains('testAdminSectionID', $response->getParams()['adminNav'][0]['id']);
 	}


### PR DESCRIPTION
## Description
Adds icons to the settings page sections for extra prettiness  💄 

 - Use existing set of icons
 - By default, sections get a generic 'cog' icon

## Related Issue
Replacement PR for https://github.com/owncloud/core/pull/26759 since rebasing was not fun.

## How Has This Been Tested?
 - Updated the unit tests to check for icon file. 

## Screenshots (if appropriate):
![screen shot 2017-02-21 at 17 29 02](https://cloud.githubusercontent.com/assets/660805/23176536/42bbfde0-f85b-11e6-8f04-944c2e314c81.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

