### PR TITLE
Proper edition text used when not Enterprise

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -62,7 +62,7 @@ OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $_['previewI
 		<div class="header-appname-container">
 			<h1 class="header-appname">
 				<?php
-					if(OC_Util::getEditionString() === '') {
+					if(OC_Util::getEditionString() === OC_Util::$editonString[1]) {
 						p($theme->getName());
 					} else {
 						print_unescaped($theme->getHTMLName());

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -60,8 +60,13 @@ class StorageTest extends \Test\TestCase {
 		\OC_Hook::clear();
 		\OCA\Files_Trashbin\Trashbin::registerHooks();
 
+		// the encryption wrapper does some twisted stuff with moveFromStorage...
+		// we need to register it here so that the tested behavior is closer to reality
+		\OC::$server->getEncryptionManager()->setupStorage();
+
 		$this->user = $this->getUniqueId('user');
 		\OC::$server->getUserManager()->createUser($this->user, $this->user);
+
 
 		// this will setup the FS
 		$this->loginAsUser($this->user);
@@ -82,6 +87,7 @@ class StorageTest extends \Test\TestCase {
 		$user = \OC::$server->getUserManager()->get($this->user);
 		if ($user !== null) { $user->delete(); }
 		\OC_Hook::clear();
+		\OC\Files\Filesystem::getLoader()->removeStorageWrapper('oc_encryption');
 		parent::tearDown();
 	}
 
@@ -444,6 +450,80 @@ class StorageTest extends \Test\TestCase {
 		// check that versions were moved and not trashed
 		$results = $this->rootView->getDirectoryContent($this->user . '/files_trashbin/versions/');
 		$this->assertEquals(0, count($results));
+	}
+
+	/**
+	 * Test that the owner receives a backup of the file that was moved
+	 * out of the shared folder
+	 */
+	public function testOwnerBackupWhenMovingFileOutOfShare() {
+		\OCA\Files_Versions\Hooks::connectHooks();
+
+		$this->userView->mkdir('share');
+		$this->userView->mkdir('share/sub');
+		// trigger a version (multiple would not work because of the expire logic)
+		$this->userView->file_put_contents('share/test.txt', 'v1');
+		$this->userView->file_put_contents('share/test.txt', 'v2');
+
+		$this->userView->file_put_contents('share/sub/testsub.txt', 'v1');
+		$this->userView->file_put_contents('share/sub/testsub.txt', 'v2');
+
+		$results = $this->rootView->getDirectoryContent($this->user . '/files_versions/share/');
+		$this->assertEquals(2, count($results));
+		$results = $this->rootView->getDirectoryContent($this->user . '/files_versions/share/sub');
+		$this->assertEquals(1, count($results));
+
+		$recipientUser = $this->getUniqueId('recipient_');
+		$user2 = \OC::$server->getUserManager()->createUser($recipientUser, $recipientUser);
+
+		$node = \OC::$server->getUserFolder($this->user)->get('share');
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedBy($this->user)
+			->setSharedWith($recipientUser)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		\OC::$server->getShareManager()->createShare($share);
+
+		$this->loginAsUser($recipientUser);
+
+		// delete as recipient
+		$recipientHome = \OC::$server->getUserFolder($recipientUser);
+
+		// rename received share folder to catch potential issues if using the wrong name in the code
+		$recipientHome->get('share')->move($recipientHome->getPath() . '/share_renamed');
+		$recipientHome->get('share_renamed/test.txt')->move($recipientHome->getPath() . '/test.txt');
+		$recipientHome->get('share_renamed/sub')->move($recipientHome->getPath() . '/sub');
+
+		$this->assertTrue($recipientHome->nodeExists('test.txt'));
+		$this->assertTrue($recipientHome->nodeExists('sub'));
+
+		// check if file and versions are in trashbin for owner
+		$results = $this->rootView->getDirectoryContent($this->user . '/files_trashbin/files');
+		$this->assertEquals(2, count($results), 'Files in owner\'s trashbin');
+		// grab subdir name
+		$subDirName = $results[0]->getName();
+		$name = $results[1]->getName();
+		$this->assertEquals('test.txt.d', substr($name, 0, strlen('test.txt.d')));
+
+		$results = $this->rootView->getDirectoryContent($this->user . '/files_trashbin/versions');
+		$this->assertEquals(2, count($results), 'Versions in owner\'s trashbin');
+		// note: entry 0 is the "sub" entry for versions
+		$name = $results[1]->getName();
+		$this->assertEquals('test.txt.v', substr($name, 0, strlen('test.txt.v')));
+
+		// check if sub-file and versions are in trashbin for owner
+		$results = $this->rootView->getDirectoryContent($this->user . '/files_trashbin/files/' . $subDirName);
+		$this->assertEquals(1, count($results), 'Subfile in owner\'s trashbin');
+		$this->assertEquals('testsub.txt', $results[0]->getName());
+
+		$results = $this->rootView->getDirectoryContent($this->user . '/files_trashbin/versions/' . $subDirName);
+		$this->assertEquals(1, count($results), 'Versions in owner\'s trashbin');
+		$name = $results[0]->getName();
+		$this->assertEquals('testsub.txt.v', substr($name, 0, strlen('testsub.txt.v')));
+
+		$this->logout();
+		$user2->delete();
 	}
 
 	/**

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -1133,3 +1133,31 @@ Feature: sharing
     Then as "user1" the file "/shared/shared_file.txt" exists
     And as "user0" the file "/shared/shared_file.txt" exists
 
+  Scenario: moving file out of a share as recipient creates a backup for the owner
+    Given As an "admin"
+    And user "user0" exists
+    And user "user1" exists
+    And user "user0" created a folder "/shared"
+    And User "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And file "/shared" of user "user0" is shared with user "user1"
+    And User "user1" moved folder "/shared" to "/shared_renamed"
+    When User "user1" moved file "/shared_renamed/shared_file.txt" to "/taken_out.txt"
+    Then as "user1" the file "/taken_out.txt" exists
+    And as "user0" the file "/shared/shared_file.txt" does not exist
+    And as "user0" the file "/shared_file.txt" exists in trash
+
+  Scenario: moving folder out of a share as recipient creates a backup for the owner
+    Given As an "admin"
+    And user "user0" exists
+    And user "user1" exists
+    And user "user0" created a folder "/shared"
+    And user "user0" created a folder "/shared/sub"
+    And User "user0" moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
+    And file "/shared" of user "user0" is shared with user "user1"
+    And User "user1" moved folder "/shared" to "/shared_renamed"
+    When User "user1" moved folder "/shared_renamed/sub" to "/taken_out"
+    Then as "user1" the file "/taken_out" exists
+    And as "user0" the folder "/shared/sub" does not exist
+    And as "user0" the folder "/sub" exists in trash
+    And as "user0" the file "/sub/shared_file.txt" exists in trash
+

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -50,7 +50,7 @@
 			<a href="#" class="header-appname-container menutoggle" tabindex="2">
 				<h1 class="header-appname">
 					<?php
-						if(OC_Util::getEditionString() === '') {
+						if(OC_Util::getEditionString() === OC_Util::$editonString[1]) {
 							p(!empty($_['application'])?$_['application']: $l->t('Apps'));
 						} else {
 							print_unescaped($theme->getHTMLName());

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -422,7 +422,7 @@ class OC_App {
 
 		$settings = [];
 		// by default, settings only contain the help menu
-		if (OC_Util::getEditionString() === '' &&
+		if (OC_Util::getEditionString() === OC_Util::$editonString[1] &&
 			\OC::$server->getSystemConfig()->getValue('knowledgebaseenabled', true) == true
 		) {
 			$settings = [

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -64,6 +64,7 @@ class OC_Util {
 	public static $scripts = [];
 	public static $styles = [];
 	public static $headers = [];
+	public static $editonString = ["Enterprise", "Community"];
 	private static $rootMounted = false;
 	private static $fsSetup = false;
 	private static $version;
@@ -394,9 +395,11 @@ class OC_Util {
 	 */
 	public static function getEditionString() {
 		if (OC_App::isEnabled('enterprise_key')) {
-			return "Enterprise";
+			// Enterprise
+			return OC_Util::$editonString[0];
 		} else {
-			return "";
+			// Community
+			return OC_Util::$editonString[1];
 		}
 
 	}

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -149,7 +149,7 @@ class CheckSetupController extends Controller {
 	private function isUsedTlsLibOutdated() {
 		// Appstore is disabled by default in EE
 		$appStoreDefault = false;
-		if (\OC_Util::getEditionString() === '') {
+		if (\OC_Util::getEditionString() === \OC_Util::$editonString[1]) {
 			$appStoreDefault = true;
 		}
 

--- a/settings/js/admin-apps.js
+++ b/settings/js/admin-apps.js
@@ -536,6 +536,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 			var categoryId = $(this).data('category');
 			OC.Settings.Apps.loadCategory(categoryId);
 			OC.Util.History.pushState({
+				sectionid: 'apps',
 				category: categoryId
 			});
 			$('#searchbox').val('');

--- a/settings/templates/panels/personal/clients.php
+++ b/settings/templates/panels/personal/clients.php
@@ -12,7 +12,7 @@
 		<img src="<?php print_unescaped(image_path('core', 'appstore.svg')); ?>"
 		alt="<?php p($l->t('iOS app'));?>" />
 	</a>
-	<?php if (OC_Util::getEditionString() === ''): ?>
+	<?php if (OC_Util::getEditionString() === OC_Util::$editonString[1]): ?>
 		<p>
 			<?php print_unescaped($l->t('If you want to support the project
 			<a href="https://owncloud.org/contribute"

--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -131,7 +131,7 @@ if($_['passwordChangeSupported']) {
 			</option>
 		<?php endforeach;?>
 	</select>
-	<?php if (OC_Util::getEditionString() === ''): ?>
+	<?php if (OC_Util::getEditionString() === OC_Util::$editonString[1]): ?>
 	<a href="https://www.transifex.com/projects/p/owncloud/"
 		target="_blank" rel="noreferrer">
 		<em><?php p($l->t('Help translate'));?></em>

--- a/settings/templates/panels/personal/settings.development.notice.php
+++ b/settings/templates/panels/personal/settings.development.notice.php
@@ -1,4 +1,4 @@
-<?php if (OC_Util::getEditionString() === ''): ?>
+<?php if (OC_Util::getEditionString() === OC_Util::$editonString[1]): ?>
 	<p>
 		<?php print_unescaped(str_replace(
 			[

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -534,7 +534,7 @@ class CheckSetupControllerTest extends TestCase {
 	public function testIsUsedTlsLibOutdatedWithAppstoreDisabledAndServerToServerSharingEnabled() {
 		// Appstore is disabled by default in EE
 		$appStoreDefault = false;
-		if (\OC_Util::getEditionString() === '') {
+		if (\OC_Util::getEditionString() === \OC_Util::$editonString[1]) {
 			$appStoreDefault = true;
 		}
 
@@ -569,7 +569,7 @@ class CheckSetupControllerTest extends TestCase {
 	public function testIsUsedTlsLibOutdatedWithAppstoreDisabledAndServerToServerSharingDisabled() {
 		// Appstore is disabled by default in EE
 		$appStoreDefault = false;
-		if (\OC_Util::getEditionString() === '') {
+		if (\OC_Util::getEditionString() === \OC_Util::$editonString[1]) {
 			$appStoreDefault = true;
 		}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

@PVince81 

## Description
This adds the edition text ``Community`` to the available editions. Used when not ``Enterprise``

## Related Issue
https://github.com/owncloud/core/issues/27091

## Motivation and Context
The edition text is currently empty when not Enterprise. 

## How Has This Been Tested?
yourdomain.com/status.php
```
"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"10.0.0.0","versionstring":"10.0.0","edition":"Community","productname":"ownCloud"}
```
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

