### PR TITLE
Proper edition text used when not Enterprise (fixed)

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -62,7 +62,7 @@ OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $_['previewI
 		<div class="header-appname-container">
 			<h1 class="header-appname">
 				<?php
-					if(OC_Util::getEditionString() === '') {
+					if(OC_Util::getEditionString() === OC_Util::EDITION_COMMUNITY) {
 						p($theme->getName());
 					} else {
 						print_unescaped($theme->getHTMLName());

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -50,7 +50,7 @@
 			<a href="#" class="header-appname-container menutoggle" tabindex="2">
 				<h1 class="header-appname">
 					<?php
-						if(OC_Util::getEditionString() === '') {
+						if(OC_Util::getEditionString() === OC_Util::EDITION_COMMUNITY) {
 							p(!empty($_['application'])?$_['application']: $l->t('Apps'));
 						} else {
 							print_unescaped($theme->getHTMLName());

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -422,7 +422,7 @@ class OC_App {
 
 		$settings = [];
 		// by default, settings only contain the help menu
-		if (OC_Util::getEditionString() === '' &&
+		if (OC_Util::getEditionString() === OC_Util::EDITION_COMMUNITY &&
 			\OC::$server->getSystemConfig()->getValue('knowledgebaseenabled', true) == true
 		) {
 			$settings = [

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -67,6 +67,8 @@ class OC_Util {
 	private static $rootMounted = false;
 	private static $fsSetup = false;
 	private static $version;
+	const EDITION_COMMUNITY = 'Community';
+	const EDITION_ENTERPRISE = 'Enterprise';
 
 	protected static function getAppManager() {
 		return \OC::$server->getAppManager();
@@ -394,10 +396,9 @@ class OC_Util {
 	 */
 	public static function getEditionString() {
 		if (OC_App::isEnabled('enterprise_key')) {
-			return "Enterprise";
-		} else {
-			return "";
-		}
+ 			return OC_Util::EDITION_ENTERPRISE;
+ 		} else {
+			return OC_Util::EDITION_COMMUNITY;		}
 
 	}
 

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -149,7 +149,7 @@ class CheckSetupController extends Controller {
 	private function isUsedTlsLibOutdated() {
 		// Appstore is disabled by default in EE
 		$appStoreDefault = false;
-		if (\OC_Util::getEditionString() === '') {
+		if (\OC_Util::getEditionString() === \OC_Util::EDITION_COMMUNITY) {
 			$appStoreDefault = true;
 		}
 

--- a/settings/templates/panels/personal/clients.php
+++ b/settings/templates/panels/personal/clients.php
@@ -12,7 +12,7 @@
 		<img src="<?php print_unescaped(image_path('core', 'appstore.svg')); ?>"
 		alt="<?php p($l->t('iOS app'));?>" />
 	</a>
-	<?php if (OC_Util::getEditionString() === ''): ?>
+	<?php if (OC_Util::getEditionString() === OC_Util::EDITION_COMMUNITY): ?>
 		<p>
 			<?php print_unescaped($l->t('If you want to support the project
 			<a href="https://owncloud.org/contribute"

--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -131,7 +131,7 @@ if($_['passwordChangeSupported']) {
 			</option>
 		<?php endforeach;?>
 	</select>
-	<?php if (OC_Util::getEditionString() === ''): ?>
+	<?php if (OC_Util::getEditionString() === OC_Util::EDITION_COMMUNITY): ?>
 	<a href="https://www.transifex.com/projects/p/owncloud/"
 		target="_blank" rel="noreferrer">
 		<em><?php p($l->t('Help translate'));?></em>

--- a/settings/templates/panels/personal/settings.development.notice.php
+++ b/settings/templates/panels/personal/settings.development.notice.php
@@ -1,4 +1,4 @@
-<?php if (OC_Util::getEditionString() === ''): ?>
+<?php if (OC_Util::getEditionString() === OC_Util::EDITION_COMMUNITY): ?>
 	<p>
 		<?php print_unescaped(str_replace(
 			[

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -534,7 +534,7 @@ class CheckSetupControllerTest extends TestCase {
 	public function testIsUsedTlsLibOutdatedWithAppstoreDisabledAndServerToServerSharingEnabled() {
 		// Appstore is disabled by default in EE
 		$appStoreDefault = false;
-		if (\OC_Util::getEditionString() === '') {
+		if (\OC_Util::getEditionString() === \OC_Util::EDITION_COMMUNITY) {
 			$appStoreDefault = true;
 		}
 
@@ -569,7 +569,7 @@ class CheckSetupControllerTest extends TestCase {
 	public function testIsUsedTlsLibOutdatedWithAppstoreDisabledAndServerToServerSharingDisabled() {
 		// Appstore is disabled by default in EE
 		$appStoreDefault = false;
-		if (\OC_Util::getEditionString() === '') {
+		if (\OC_Util::getEditionString() === \OC_Util::EDITION_COMMUNITY) {
 			$appStoreDefault = true;
 		}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

@PVince81 

## Description
This adds the edition text ``Community`` to the available editions. Used when not ``Enterprise``

## Related Issue
https://github.com/owncloud/core/issues/27091

## Motivation and Context
The edition text is currently empty when not Enterprise. 

## How Has This Been Tested?
yourdomain.com/status.php
```
"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"10.0.0.0","versionstring":"10.0.0","edition":"Community","productname":"ownCloud"}
```
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

