### PR TITLE
allow configuring authType for DAV backend

### DIFF
--- a/apps/files_external/lib/Lib/Storage/OwnCloud.php
+++ b/apps/files_external/lib/Lib/Storage/OwnCloud.php
@@ -22,6 +22,7 @@
  */
 
 namespace OCA\Files_External\Lib\Storage;
+use Sabre\DAV\Client;
 
 /**
  * ownCloud backend for external storage based on DAV backend.
@@ -68,6 +69,7 @@ class OwnCloud extends \OC\Files\Storage\DAV{
 
 		$params['host'] = $host;
 		$params['root'] = $contextPath . self::OC_URL_SUFFIX . $root;
+		$params['authType'] = Client::AUTH_BASIC;
 
 		parent::__construct($params);
 	}

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -62,6 +62,8 @@ class DAV extends Common {
 	/** @var string */
 	protected $user;
 	/** @var string */
+	protected $authType;
+	/** @var string */
 	protected $host;
 	/** @var bool */
 	protected $secure;
@@ -95,6 +97,9 @@ class DAV extends Common {
 			$this->host = $host;
 			$this->user = $params['user'];
 			$this->password = $params['password'];
+			if (isset($params['authType'])) {
+				$this->authType = $params['authType'];
+			}
 			if (isset($params['secure'])) {
 				if (is_string($params['secure'])) {
 					$this->secure = ($params['secure'] === 'true');
@@ -138,6 +143,9 @@ class DAV extends Common {
 			'userName' => $this->user,
 			'password' => $this->password,
 		];
+		if (isset($this->authType)) {
+			$settings['authType'] = $this->authType;
+		}
 
 		$proxy = \OC::$server->getConfig()->getSystemValue('proxy', '');
 		if($proxy !== '') {


### PR DESCRIPTION
## Description

CURL tries DIGEST AUTH before BASIC auth, leading to ugly debug messages when creating federated shares on the receiving side, like:
```json
{"reqId":"9HLHbKSMBLfU506wwdoq","remoteAddr":"192.168.1.32","app":"webdav",
"message":"Exception: {
  \"Message\":\"HTTP\\\/1.1 401 No 'Authorization: Basic' header found. Either the client didn't send one, or the server is misconfigured\",
  \"Exception\":\"Sabre\\\\DAV\\\\Exception\\\\NotAuthenticated\",\"Code\":0,\"Trace\":\"
  #0 [internal function]: Sabre\\\\DAV\\\\Auth\\\\Plugin->beforeMethod(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\
  #1 \\\/var\\\/www\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/event\\\/lib\\\/EventEmitterTrait.php(105): call_user_func_array(Array, Array)\
  #2 \\\/var\\\/www\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(466): Sabre\\\\Event\\\\EventEmitter->emit('beforeMethod', Array)\
  #3 \\\/var\\\/www\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(254): Sabre\\\\DAV\\\\Server->invokeMethod(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\
  #4 \\\/var\\\/www\\\/owncloud\\\/apps\\\/dav\\\/appinfo\\\/v1\\\/publicwebdav.php(90): Sabre\\\\DAV\\\\Server->exec()\
  #5 \\\/var\\\/www\\\/owncloud\\\/public.php(76): require_once('\\\/var\\\/www\\\/ownclo...')\
  #6 {main}\",
  \"File\":\"\\\/var\\\/www\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Auth\\\/Plugin.php\",
  \"Line\":168,
  \"User\":false}",
"level":0,
"time":"2017-02-22T20:31:42+00:00"
,"method":"PROPFIND",
"url":"\/public.php\/webdav\/","user":"--"}
```

This is caused by not explicitly specifying that we want BASIC AUTH, which we can always set for federated shares. 



## Motivation and Context
Found it while working on federated cluster. This PR makes the authType configurable and forces BASIC AUTH for Owncloud Storages, saving a completely unnecessary http request with digest auth as a bonus to getting rid of the exception in the log.

## How Has This Been Tested?
manually, hard to test distributed setups. hints welcome

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

