### PR TITLE
Remove contact id in share with email code

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -231,7 +231,6 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 
 						foreach($emails as $email) {
 							$result[] = [
-								'id' => $contact['id'],
 								'email' => $email,
 								'displayname' => $contact['FN'],
 							];


### PR DESCRIPTION
## Description
The id is not used and would cause warnings when results come from the
system address book.

## Related Issue
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Steps to reproduce:

1. Setup LDAP users with LDAP docker: https://github.com/owncloud/administration/tree/master/ldap-testing
1. Setup LDAP in ownCloud and set "mail" attribute in the wizard (you might need to do it twice due to this annoying bug https://github.com/owncloud/user_ldap/issues/22)
1. Run `occ dav:sync-system-addressbook`
1. Go to admin page, untick then tick again the setting "Allow username autocompletion in share dialog." (because of this bug https://github.com/owncloud/core/issues/27224)
1. Tick "Allow users to send mail notification for shared files"
1. Go to files list
1. Share a file with link
1. Type in "zom" in the email link field to autocomplete zombie email addresses
1. Check log

This message repeats for every result:
```
{"reqId":"XJyzTH3u73t6NhHOdyXr","remoteAddr":"127.0.0.1","app":"PHP","message":"Undefined index: id at \/srv\/www\/htdocs\/owncloud\/core\/ajax\/share.php#233","level":3,"time":"2017-02-23T10:48:40+00:00","method":"GET","url":"\/owncloud\/index.php\/core\/ajax\/share.php?fetch=getShareWithEmail&search=zom","user":"admin"}
```

After the fix: no more warning messages.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @jvillafanez @VicDeo @IljaN please review