### PR TITLE
Update the occ:encrypt-all prompt

### DIFF
--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -108,10 +108,10 @@ class EncryptAll extends Command {
 		}
 
 		$output->writeln("\n");
-		$output->writeln('You are about to start to encrypt all files stored in your ownCloud.');
-		$output->writeln('It will depend on the encryption module you use which files get encrypted.');
-		$output->writeln('Depending on the number and size of your files this can take some time');
-		$output->writeln('Please make sure that no user access his files during this process!');
+		$output->writeln('You are about to encrypt all files stored in your ownCloud installation.');
+		$output->writeln('Depending on the number of available files, and their size, this may take quite some time.');
+		$output->writeln('Please ensure that no user accesses their files during this time!');
+		$output->writeln('Note: The encryption module you use determines which files get encrypted.');
 		$output->writeln('');
 		$question = new ConfirmationQuestion('Do you really want to continue? (y/n) ', false);
 		if ($this->questionHelper->ask($input, $output, $question)) {


### PR DESCRIPTION
## Description

Update the prompt rendered by `occ:encrypt-all`.

## Motivation and Context

The prompt rendered by `occ:encrypt-all` isn't as clear, nor as succinct as it could be.
Given that, this commit updates the prompt so that the message is as to the point as it can be.
It was prompted by owncloud/documentation/pull/2835.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.