### PR TITLE
fix computerFileSize to parse correctly, prerapation to fix #25358

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1768,7 +1768,7 @@ OC.Util = {
 
 		var matches = s.match(/^[\s+]?([0-9]*)(\.([0-9]+))?( +)?([kmgtp]?b?)$/i);
 		if (matches !== null) {
-			var bytes = parseFloat(s);
+			bytes = parseFloat(s);
 			if (!isFinite(bytes)) {
 				return null;
 			}

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1745,12 +1745,13 @@ OC.Util = {
 	 *
 	 */
 	computerFileSize: function (string) {
-		if (typeof string != 'string') {
+		if (typeof string !== 'string') {
 			return null;
 		}
 
 		var s = string.toLowerCase();
-
+		var bytes = null;
+		
 		var bytesArray = {
 			'b': 1,
 			'k': 1024,
@@ -1766,8 +1767,8 @@ OC.Util = {
 		};
 
 		var matches = s.match(/^[\s+]?([0-9]*)(\.([0-9]+))?( +)?([kmgtp]?b?)$/i);
-		if (matches != null) {
-			var bytes = parseFloat(s)
+		if (matches !== null) {
+			var bytes = parseFloat(s);
 			if (!isFinite(bytes)) {
 				return null;
 			}

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1755,7 +1755,7 @@ OC.Util = {
 			return null;
 		}
 
-		var s = string.toLowerCase();
+		var s = string.toLowerCase().trim();
 		var bytes = null;
 		
 		var bytesArray = {

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1734,6 +1734,12 @@ function relative_modified_date(timestamp) {
 OC.Util = {
 	// TODO: remove original functions from global namespace
 	humanFileSize: humanFileSize,
+	
+	/**
+	* regular expression to parse size in bytes from a humanly readable string
+	* see computerFileSize(string)
+	*/
+	_computerFileSizeRegexp: /^[\s+]?([0-9]*)(\.([0-9]+))?( +)?([kmgtp]?b?)$/i,
 
 	/**
 	 * Returns a file size in bytes from a humanly readable string
@@ -1766,7 +1772,7 @@ OC.Util = {
 			'p': 1024 * 1024 * 1024 * 1024 * 1024
 		};
 
-		var matches = s.match(/^[\s+]?([0-9]*)(\.([0-9]+))?( +)?([kmgtp]?b?)$/i);
+		var matches = s.match(this._computerFileSizeRegexp);
 		if (matches !== null) {
 			bytes = parseFloat(s);
 			if (!isFinite(bytes)) {

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1750,11 +1750,6 @@ OC.Util = {
 		}
 
 		var s = string.toLowerCase();
-		var bytes = parseFloat(s)
-
-		if (!isNaN(bytes) && isFinite(s)) {
-			return bytes;
-		}
 
 		var bytesArray = {
 			'b': 1,
@@ -1770,11 +1765,17 @@ OC.Util = {
 			'p': 1024 * 1024 * 1024 * 1024 * 1024
 		};
 
-		var matches = s.match(/([kmgtp]?b?)$/i);
-		if (matches[1]) {
-			bytes = bytes * bytesArray[matches[1]];
+		var matches = s.match(/^[\s+]?([0-9]*)(\.([0-9]+))?( +)?([kmgtp]?b?)$/i);
+		if (matches != null) {
+			var bytes = parseFloat(s)
+			if (!isFinite(bytes)) {
+				return null;
+			}
 		} else {
 			return null;
+		}
+		if (matches[5]) {
+			bytes = bytes * bytesArray[matches[5]];
 		}
 
 		bytes = Math.round(bytes);

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -619,6 +619,13 @@ describe('Core base tests', function() {
 					['B', null],
 					['40/0', null],
 					['40,30 kb', null],
+					[' 122.1 MB ', 128031130],
+					['122.1 MB ', 128031130],
+					[' 122.1 MB ', 128031130],
+					['	122.1 MB ', 128031130],
+					['122.1    MB ', 128031130],
+					[' 125', 125],
+					[' 125 ', 125],					
 				];
 				for (var i = 0; i < data.length; i++) {
 					expect(OC.Util.computerFileSize(data[i][0])).toEqual(data[i][1]);

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -594,8 +594,14 @@ describe('Core base tests', function() {
 			it('correctly parses file sizes from a human readable formated string', function() {
 				var data = [
 					['125', 125],
-					['125.25', 125.25],
+					['125.25', 125],
+					['125.25B', 125],
+					['125.25 B', 125],
 					['0 B', 0],
+					['99999999999999999999999999999999999999999999 B', 99999999999999999999999999999999999999999999],
+					['0 MB', 0],
+					['0 kB', 0],
+					['0kB', 0],
 					['125 B', 125],
 					['125b', 125],
 					['125 KB', 128000],
@@ -605,7 +611,14 @@ describe('Core base tests', function() {
 					['119.2 GB', 127990025421],
 					['119.2gb', 127990025421],
 					['116.4 TB', 127983153473126],
-					['116.4tb', 127983153473126]
+					['116.4tb', 127983153473126],
+					['8776656778888777655.4tb', 9.650036181387265e+30],
+					[1234, null],
+					[-1234, null],
+					['-1234 B', null],
+					['B', null],
+					['40/0', null],
+					['40,30 kb', null],
 				];
 				for (var i = 0; i < data.length; i++) {
 					expect(OC.Util.computerFileSize(data[i][0])).toEqual(data[i][1]);


### PR DESCRIPTION
## Description
I've added some more tests for computerFileSize and they would fail, so fixed
the function to be more picky on what input to accept and try to parse and also fixed the rounding of values without units

## Motivation and Context
@PVince81 mentioned this function in the context of fixing #25358 but it does not work correct
1. input of "B" would return "NaN" and not null
2. invalid values like "40/0" or "40,30 kb" would be parsed
3. negative values would be parsed and returned as negative values
4. values without unit would not be rounded to full bytes. 125.5 would return 125.5, but I don't think oC runs on 4bit systems :-)

That are exact the problems we have in #25358
After this PR is accepted I'm happy to look into fixing #25358

## How Has This Been Tested?
wrote more tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.