### PR TITLE
Clear onpopstate handlers after unit tests

### DIFF
--- a/core/js/tests/specHelper.js
+++ b/core/js/tests/specHelper.js
@@ -178,6 +178,10 @@ window.isPhantom = /phantom/i.test(navigator.userAgent);
 		delete($.fn.select2);
 
 		ajaxErrorStub.restore();
+
+		// reset pop state handlers
+		OC.Util.History._handlers = [];
+
 	});
 })();
 


### PR DESCRIPTION
Fixes issue when running Karma tests in Firefox.

How to test:

1. `make`
1. `build/node_modules/karma/bin/karma start tests/karma.config.js` (or use `make test-js-debug` after reviewing https://github.com/owncloud/core/pull/27222)
1. Open `localhost:9876` in Firefox

Before this fix: failure about `this.navigation` not being defined. This is because tests did not clean up the onpopstate handler. (there is no API to clear this anyway).
After this fix: all Firefox JS tests pass.

Please review @felixheidecke @jvillafanez @VicDeo @individual-it 
