### PR TITLE
Updated UI messages relating to the encryption functionality

### DIFF
--- a/apps/encryption/lib/Controller/StatusController.php
+++ b/apps/encryption/lib/Controller/StatusController.php
@@ -78,7 +78,7 @@ class StatusController extends Controller {
 			case Session::NOT_INITIALIZED:
 				$status = 'interactionNeeded';
 				$message = (string)$this->l->t(
-					'Encryption App is enabled but your keys are not initialized, please log-out and log-in again'
+					'Encryption App is enabled, but your keys are not initialized. Please log-out and log-in again.'
 				);
 				break;
 			case Session::INIT_SUCCESSFUL:

--- a/apps/encryption/templates/settings-personal.php
+++ b/apps/encryption/templates/settings-personal.php
@@ -8,7 +8,7 @@ script('encryption', 'settings-personal');
 
 	<?php if ($_["initialized"] === \OCA\Encryption\Session::NOT_INITIALIZED ): ?>
 
-	<?php p($l->t("Encryption App is enabled but your keys are not initialized, please log-out and log-in again")); ?>
+	<?php p($l->t("Encryption App is enabled, but your keys are not initialized. Please log-out and log-in again.")); ?>
 
 	<?php elseif ( $_["initialized"] === \OCA\Encryption\Session::INIT_EXECUTED ): ?>
 		<p>

--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -134,7 +134,7 @@ class Controller {
 
 			if ($recoveryEnabledForUser && $recoveryPassword === '') {
 				\OC_JSON::error(['data' => [
-					'message' => $l->t('Please provide an admin recovery password, otherwise all user data will be lost')
+					'message' => $l->t('Please provide an admin recovery password; otherwise, all user data will be lost.')
 				]]);
 			} elseif ($recoveryEnabledForUser && ! $validRecoveryPassword) {
 				\OC_JSON::error(['data' => [


### PR DESCRIPTION
This PR:

- Updates three UI message strings. The reason for updating them is that grammatically they're
not quite correct. Specifically, the corrections were to address:
  - Related phrases, which could be either separated or joined better
  - Related sentences, but which should be expressed as separate ones
  - Missing full-stops