### PR TITLE
Fix public link download button

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -166,7 +166,7 @@ OCA.Sharing.PublicApp = {
 						filesPart += '&files[]=' + encodeURIComponent(name);
 					});
 				} else {
-					filesPart = '&files=' + encodeURIComponent(filename);
+					filesPart = '&files=' + encodeURIComponent(filename || '');
 				}
 				return base + filesPart;
 			};

--- a/apps/files_sharing/tests/js/publicAppSpec.js
+++ b/apps/files_sharing/tests/js/publicAppSpec.js
@@ -125,6 +125,10 @@ describe('OCA.Sharing.PublicApp tests', function() {
 				expect(fileList.getAjaxUrl('test', {a:1, b:'x y'}))
 					.toEqual(OC.webroot + '/index.php/apps/files_sharing/ajax/test.php?a=1&b=x%20y&t=sh4tok');
 			});
+			it('returns correct download URL for downloading everything', function() {
+				expect(fileList.getDownloadUrl())
+					.toEqual(OC.webroot + '/index.php/s/sh4tok/download?path=%2Fsubdir&files=');
+			});
 		});
 		describe('Upload Url', function() {
 			var fileList;


### PR DESCRIPTION
## Description
Fix public link download button.
It was broken through https://github.com/owncloud/core/pull/26751

## Related Issue
None raised

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Create a public link for a folder then click the "Download" button on the top right.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review @davitol @noveens 