### PR TITLE
[stable9.1] Fix public link for master key

### DIFF
--- a/apps/encryption/lib/KeyManager.php
+++ b/apps/encryption/lib/KeyManager.php
@@ -399,17 +399,28 @@ class KeyManager {
 	 * @return string
 	 */
 	public function getFileKey($path, $uid) {
+		if ($uid === '') {
+			$uid = null;
+		}
+		$publicAccess = is_null($uid);
 		$encryptedFileKey = $this->keyStorage->getFileKey($path, $this->fileKeyId, Encryption::ID);
 
 		if (empty($encryptedFileKey)) {
 			return '';
 		}
 
-		if (!is_null($uid) && $this->util->isMasterKeyEnabled()) {
+		if ($this->util->isMasterKeyEnabled()) {
 			$uid = $this->getMasterKeyId();
-		}
-
-		if (is_null($uid)) {
+			$shareKey = $this->getShareKey($path, $uid);
+			if ($publicAccess) {
+				$privateKey = $this->getSystemPrivateKey($uid);
+				$privateKey = $this->crypt->decryptPrivateKey($privateKey, $this->getMasterKeyPassword(), $uid);
+			} else {
+				// when logged in, the master key is already decrypted in the session
+				$privateKey = $this->session->getPrivateKey();
+			}
+		} else if ($publicAccess) {
+			// use public share key for public links
 			$uid = $this->getPublicShareKeyId();
 			$shareKey = $this->getShareKey($path, $uid);
 			$privateKey = $this->keyStorage->getSystemUserKey($this->publicShareKeyId . '.privateKey', Encryption::ID);

--- a/apps/encryption/lib/KeyManager.php
+++ b/apps/encryption/lib/KeyManager.php
@@ -405,7 +405,7 @@ class KeyManager {
 			return '';
 		}
 
-		if ($this->util->isMasterKeyEnabled()) {
+		if (!is_null($uid) && $this->util->isMasterKeyEnabled()) {
 			$uid = $this->getMasterKeyId();
 		}
 

--- a/apps/encryption/tests/KeyManagerTest.php
+++ b/apps/encryption/tests/KeyManagerTest.php
@@ -344,6 +344,19 @@ class KeyManagerTest extends TestCase {
 		$this->assertTrue($this->instance->getEncryptedFileKey('/'));
 	}
 
+	public function dataTestGetFileKey() {
+		return [
+			['user1', false, 'privateKey', true],
+			['user1', false, false, ''],
+			['user1', true, 'privateKey', true],
+			['user1', true, false, ''],
+			[null, false, 'privateKey', true],
+			[null, false, false, ''],
+			[null, true, 'privateKey', true],
+			[null, true, false, '']
+		];
+	}
+
 	/**
 	 * @dataProvider dataTestGetFileKey
 	 *
@@ -358,6 +371,10 @@ class KeyManagerTest extends TestCase {
 
 		if ($isMasterKeyEnabled) {
 			$expectedUid = 'masterKeyId';
+			$this->configMock->expects($this->any())->method('getSystemValue')->with('secret')
+				->willReturn('password');
+		} else if (!$uid) {
+			$expectedUid = 'systemKeyId';
 		} else {
 			$expectedUid = $uid;
 		}
@@ -374,6 +391,9 @@ class KeyManagerTest extends TestCase {
 			->with($path, $expectedUid . '.shareKey', 'OC_DEFAULT_MODULE')
 			->willReturn(true);
 
+		$this->utilMock->expects($this->any())->method('isMasterKeyEnabled')
+			->willReturn($isMasterKeyEnabled);
+
 		if (is_null($uid)) {
 			$this->keyStorageMock->expects($this->once())
 				->method('getSystemUserKey')
@@ -384,8 +404,6 @@ class KeyManagerTest extends TestCase {
 		} else {
 			$this->keyStorageMock->expects($this->never())
 				->method('getSystemUserKey');
-			$this->utilMock->expects($this->once())->method('isMasterKeyEnabled')
-				->willReturn($isMasterKeyEnabled);
 			$this->sessionMock->expects($this->once())->method('getPrivateKey')->willReturn($privateKey);
 		}
 
@@ -402,23 +420,6 @@ class KeyManagerTest extends TestCase {
 			$this->instance->getFileKey($path, $uid)
 		);
 
-	}
-
-	public function dataTestGetFileKey() {
-		return [
-			['user1', false, 'privateKey', true],
-			['user1', false, false, ''],
-			['user1', true, 'privateKey', true],
-			['user1', true, false, ''],
-			['', false, 'privateKey', true],
-			['', false, false, ''],
-			['', true, 'privateKey', true],
-			['', true, false, ''],
-			[null, false, 'privateKey', true],
-			[null, false, false, ''],
-			[null, true, 'privateKey', true],
-			[null, true, false, '']
-		];
 	}
 
 	public function testDeletePrivateKey() {

--- a/apps/encryption/tests/KeyManagerTest.php
+++ b/apps/encryption/tests/KeyManagerTest.php
@@ -413,7 +413,11 @@ class KeyManagerTest extends TestCase {
 			['', false, 'privateKey', true],
 			['', false, false, ''],
 			['', true, 'privateKey', true],
-			['', true, false, '']
+			['', true, false, ''],
+			[null, false, 'privateKey', true],
+			[null, false, false, ''],
+			[null, true, 'privateKey', true],
+			[null, true, false, '']
 		];
 	}
 


### PR DESCRIPTION
## Description
In public link mode there is no session, so the code should use the
public key instead.

## Related Issue
Fixes https://github.com/owncloud/core/issues/27261

## How Has This Been Tested?
See https://github.com/owncloud/core/issues/27261#issuecomment-282724784

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODOs:

- [x] adjust unit test
- [ ] add integration test https://github.com/owncloud/QA/issues/340

