### PR TITLE
Let files_share only fetch data from oc_appconfig what is actually needed.

### DIFF
--- a/lib/private/appconfig.php
+++ b/lib/private/appconfig.php
@@ -153,6 +153,17 @@ class AppConfig implements IAppConfig {
 	 * not exist the default value will be returned
 	 */
 	public function getValue($app, $key, $default = null) {
+		if ($app == 'files_sharing') {
+			$query = 'SELECT `configvalue` FROM `*PREFIX*appconfig`'
+				. ' WHERE `appid` = ? AND `configkey` = ?';
+			$result = $this->conn->executeQuery($query, [$app, $key]);
+			
+			if ($row = $result->fetch()) {
+				return $row['configvalue'];
+			} else {
+				return $default;
+			}
+		}
 		$values = $this->getAppValues($app);
 		if (isset($values[$key])) {
 			return $values[$key];


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->

We at SWTICH had severe performance problems due to a large oc_appconfig table which was fetched from the db on every request.

With this patch, we could retire 80% of the app-server hardware and get a much faster average response times.

Also we could reduce our db galera cluster back to a three node cluster and now it is running with very little load (we had six servers before and they could hardly keep up).

It is a very small change, but it make a hell of a difference performance wise.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/owncloud/core/issues/26900

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

performance

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On our production site. We have 24K Users.

## Screenshots (if appropriate):

The following graphs show some load and timing graphs from the day when we applied the patch. 

<img width="549" alt="screen shot 2017-02-27 at 11 59 34" src="https://cloud.githubusercontent.com/assets/8652424/23367858/23553498-fd0c-11e6-9849-e16c72784ddc.png">
<img width="407" alt="screen shot 2017-02-27 at 12 01 46" src="https://cloud.githubusercontent.com/assets/8652424/23367863/26ea1fec-fd0c-11e6-9a61-3a3eaba2ea45.png">
<img width="402" alt="screen shot 2017-02-27 at 11 59 58" src="https://cloud.githubusercontent.com/assets/8652424/23367864/28f8af1a-fd0c-11e6-92cb-08af9b04053d.png">



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

