### PR TITLE
In the real world id is an initial filename

### DIFF
--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -72,8 +72,9 @@ class Helper {
 				$timestamp = substr(pathinfo($parts[0], PATHINFO_EXTENSION), 1);
 			}
 			$originalPath = '';
-			if (isset($originalLocations[$id][$timestamp])) {
-				$originalPath = $originalLocations[$id][$timestamp];
+			$originalName = substr($entryName, 0, -strlen($timestamp)-2);
+			if (isset($originalLocations[$originalName][$timestamp])) {
+				$originalPath = $originalLocations[$originalName][$timestamp];
 				if (substr($originalPath, -1) === '/') {
 					$originalPath = substr($originalPath, 0, -1);
 				}
@@ -89,7 +90,7 @@ class Helper {
 				'permissions' => Constants::PERMISSION_ALL - Constants::PERMISSION_SHARE
 			];
 			if ($originalPath) {
-				$i['extraData'] = $originalPath . '/' . $id;
+				$i['extraData'] = $originalPath . '/' . $originalName;
 			}
 			$result[] = new FileInfo($absoluteDir . '/' . $i['name'], $storage, $internalPath . '/' . $i['name'], $i, $mount);
 		}


### PR DESCRIPTION
## Description
Fixes tooltip with original path in thrashbin

## Motivation and Context
### Steps to reproduce
1. Upload a file through the web UI in IE
2. delete file afterwards in the UI
3. change into "deleted files view" in the web ui


### Expected behaviour
the file is presented and when moving with the mouse over it, a tooltip presents the path, the file has been stored before in ownCloud

### Actual behaviour
The file is there, but not tooltip present, so no information about the previous location of the file before deletion.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

