### PR TITLE
This should break postgre

### DIFF
--- a/tests/lib/DB/LegacyDBTest.php
+++ b/tests/lib/DB/LegacyDBTest.php
@@ -427,4 +427,15 @@ class LegacyDBTest extends \Test\TestCase {
 			['💩', true], # :hankey: on github
 		];
 	}
+
+	public function testSelectIntegerType(){
+		$table = "*PREFIX*{$this->table4}";
+
+		$query = OC_DB::prepare("INSERT INTO `$table` (`decimaltest`) VALUES ('18.63')");
+		$result = $query->execute();
+		$this->assertEquals(1, $result);
+
+		$actual = OC_DB::prepare("SELECT `id` FROM `$table`")->execute()->fetchOne();
+		$this->assertTrue(is_string($actual));
+	}
 }

--- a/tests/lib/DB/LegacyDBTest.php
+++ b/tests/lib/DB/LegacyDBTest.php
@@ -435,7 +435,13 @@ class LegacyDBTest extends \Test\TestCase {
 		$result = $query->execute();
 		$this->assertEquals(1, $result);
 
+
 		$actual = OC_DB::prepare("SELECT `id` FROM `$table`")->execute()->fetchOne();
-		$this->assertTrue(is_string($actual));
+
+		ob_start();
+		var_dump($actual);
+		$message = ob_get_clean();
+
+		$this->assertTrue(is_string($actual), $message);
 	}
 }


### PR DESCRIPTION
Investigating types returned for integer field

Table:
```
 <table>
  <name>*dbprefix*decimal</name>
  <declaration>
   <field>
    <name>id</name>
    <autoincrement>1</autoincrement>
    <type>integer</type>
    <default>0</default>
    <notnull>true</notnull>
    <length>4</length>
   </field>

   <field>
    <name>decimaltest</name>
    <type>decimal</type>
    <default/>
    <notnull>true</notnull>
    <precision>12</precision>
    <scale>2</scale>
   </field>
  </declaration>
 </table>
```


I just fetch any `id` and assert it to be string:
```
                $actual = OC_DB::prepare("SELECT `id` FROM `$table`")->execute()->fetchOne();
 		$this->assertTrue(is_string($actual));
```