### PR TITLE
fix objectstore rename

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -507,7 +507,8 @@ class File extends Node implements IFile {
 		// TODO: in the future use ChunkHandler provided by storage
 		// and/or add method on Storage called "needsPartFile()"
 		return !$storage->instanceOfStorage('OCA\Files_Sharing\External\Storage') &&
-		!$storage->instanceOfStorage('OC\Files\Storage\OwnCloud');
+			!$storage->instanceOfStorage('OC\Files\Storage\OwnCloud') &&
+			!$storage->instanceOfStorage('OC\Files\ObjectStore\ObjectStoreStorage');
 	}
 
 	/**

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -532,7 +532,12 @@ class FileTest extends TestCase {
 			$thrown = true;
 		}
 
-		$this->assertTrue($thrown);
+		// objectstore does not use partfiles -> no move after upload -> no exception
+		if (getenv('RUN_OBJECTSTORE_TESTS')) {
+			$this->assertFalse($thrown);
+		} else {
+			$this->assertTrue($thrown);
+		}
 		$this->assertEmpty($this->listPartFiles(), 'No stray part files');
 	}
 

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -311,8 +311,9 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	public function rename($source, $target) {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
-		$this->remove($target);
-		$this->getCache()->move($source, $target);
+		$sourceEntry = $this->getCache()->get($source);
+		$this->getCache()->copyFromCache($this->getCache(), $sourceEntry, $target);
+		$this->remove($source);
 		$this->touch(dirname($target));
 		return true;
 	}

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -311,9 +311,8 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	public function rename($source, $target) {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
-		$sourceEntry = $this->getCache()->get($source);
-		$this->getCache()->copyFromCache($this->getCache(), $sourceEntry, $target);
-		$this->remove($source);
+		$this->remove($target);
+		$this->getCache()->move($source, $target);
 		$this->touch(dirname($target));
 		return true;
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
This PR makes oc keep the old fileId when using PUT. Objectstorage implementations do not need a part file. Metadata is kept in the filecache, no scanning is possible.

## Motivation and Context
fileids must be stable or shares, tags and comments get lost

## How Has This Been Tested?
locally with minio and the desktop client.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

