### PR TITLE
filelist only refreshed if directory changes

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -549,6 +549,10 @@
 		 */
 		_onUrlChanged: function(e) {
 			if (e && _.isString(e.dir)) {
+				var currentDir = this.getCurrentDirectory();
+				if(this._currentDirectory && currentDir === e.dir) {
+					return;
+				}
 				this.changeDirectory(e.dir, false, true);
 			}
 		},
@@ -1414,9 +1418,6 @@
 			var currentDir = this.getCurrentDirectory();
 			targetDir = targetDir || '/';
 			if (!force && currentDir === targetDir) {
-				return;
-			}
-			if(this._currentDirectory && currentDir === targetDir) {
 				return;
 			}
 			this._setCurrentDir(targetDir, changeUrl, fileId);

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -550,6 +550,7 @@
 		_onUrlChanged: function(e) {
 			if (e && _.isString(e.dir)) {
 				var currentDir = this.getCurrentDirectory();
+				// if this._currentDirectory is NULL when fileList is first initialised
 				if(this._currentDirectory && currentDir === e.dir) {
 					return;
 				}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -550,7 +550,7 @@
 		_onUrlChanged: function(e) {
 			if (e && _.isString(e.dir)) {
 				var currentDir = this.getCurrentDirectory();
-				// if this._currentDirectory is NULL when fileList is first initialised
+				// this._currentDirectory is NULL when fileList is first initialised
 				if(this._currentDirectory && currentDir === e.dir) {
 					return;
 				}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -551,7 +551,7 @@
 			if (e && _.isString(e.dir)) {
 				var currentDir = this.getCurrentDirectory();
 				// this._currentDirectory is NULL when fileList is first initialised
-				if(this._currentDirectory && currentDir === e.dir) {
+				if( (this._currentDirectory || this.$el.find('#dir').val()) && currentDir === e.dir) {
 					return;
 				}
 				this.changeDirectory(e.dir, false, true);

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1416,6 +1416,9 @@
 			if (!force && currentDir === targetDir) {
 				return;
 			}
+			if(this._currentDirectory && currentDir === targetDir) {
+				return;
+			}
 			this._setCurrentDir(targetDir, changeUrl, fileId);
 			// discard finished uploads list, we'll get it through a regular reload
 			this._uploads = {};

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2991,4 +2991,42 @@ describe('OCA.Files.FileList tests', function() {
 			testMountType(123, 'external-root', 'external', 'external');
 		});
 	});
+	describe('file list should not refresh if url does not change', function() {
+		var fileListStub;
+
+		beforeEach(function() {
+			fileListStub = sinon.stub(OCA.Files.FileList.prototype, 'changeDirectory');
+		});
+		afterEach(function() {
+			fileListStub.restore();
+		})
+		it('File list must not be refreshed', function() {
+			$('#app-content-files').trigger(new $.Event('urlChanged', {dir: '/subdir'}));
+			expect(fileListStub.notCalled).toEqual(true);
+		});
+	});
+	describe('after file list creation file list should refresh', function() {
+		var fileListStub;
+
+		beforeEach(function() {
+			if (fileList) {
+				fileList.destroy();
+			}
+			fileList = new OCA.Files.FileList($('#app-content-files'), {
+				filesClient: filesClient,
+				config: filesConfig,
+				enableUpload: true
+			});
+
+			fileListStub = sinon.stub(OCA.Files.FileList.prototype, 'changeDirectory');
+		});
+		afterEach(function() {
+			fileListStub.restore();
+		})
+		it('File list must be refreshed', function() {
+			console.log(fileList.getCurrentDirectory());
+			$('#app-content-files').trigger(new $.Event('urlChanged', {dir: '/'}));
+			expect(fileListStub.notCalled).toEqual(false);
+		});
+	});
 });

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2999,7 +2999,7 @@ describe('OCA.Files.FileList tests', function() {
 		});
 		afterEach(function() {
 			fileListStub.restore();
-		})
+		});
 		it('File list must not be refreshed', function() {
 			$('#app-content-files').trigger(new $.Event('urlChanged', {dir: '/subdir'}));
 			expect(fileListStub.notCalled).toEqual(true);

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -3004,27 +3004,7 @@ describe('OCA.Files.FileList tests', function() {
 			$('#app-content-files').trigger(new $.Event('urlChanged', {dir: '/subdir'}));
 			expect(fileListStub.notCalled).toEqual(true);
 		});
-	});
-	describe('after file list creation file list should refresh', function() {
-		var fileListStub;
-
-		beforeEach(function() {
-			if (fileList) {
-				fileList.destroy();
-			}
-			fileList = new OCA.Files.FileList($('#app-content-files'), {
-				filesClient: filesClient,
-				config: filesConfig,
-				enableUpload: true
-			});
-
-			fileListStub = sinon.stub(OCA.Files.FileList.prototype, 'changeDirectory');
-		});
-		afterEach(function() {
-			fileListStub.restore();
-		})
 		it('File list must be refreshed', function() {
-			console.log(fileList.getCurrentDirectory());
 			$('#app-content-files').trigger(new $.Event('urlChanged', {dir: '/'}));
 			expect(fileListStub.notCalled).toEqual(false);
 		});


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Fixes #15520 
Fixes #26318 

The filelist is refreshed if and only if the directory is changed and not otherwise.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/15520
https://github.com/owncloud/core/issues/26318

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested at all directories.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

