### PR TITLE
Optimize PROPFIND for non-shared/shared by reducing the number of que…

### DIFF
--- a/apps/dav/lib/Connector/Sabre/SharesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/SharesPlugin.php
@@ -104,34 +104,49 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 	}
 
 	/**
-	 * Return a list of share types for outgoing shares
+	 * Converts IShare[] to int[][] hash map
 	 *
-	 * @param \OCP\Files\Node $node file node
+	 * @param  IShare[] $allShares - array containing shares
+	 * @param  int[][] $initShareTypes - array containing hash map nodeIds->shareTypes $initShareTypes[$currentNodeID][$currentShareType]
 	 *
-	 * @return int[] array of share types
+	 * @return int[][] hashmap of share types
 	 */
-	private function getShareTypes(\OCP\Files\Node $node) {
-		$shareTypes = [];
+	private function convertToHashMap($allShares, $initShareTypes) {
+		// Use some already preinitialized hash map which may contain some values e.g. empty arrays
+		$shareTypes = $initShareTypes;
+		
+		foreach ($allShares as $share) {
+			$currentNodeID = $share->getNodeId();
+			$currentShareType = $share->getShareType();
+			$shareTypes[$currentNodeID][$currentShareType] = true;
+		}
+		
+		return $shareTypes;
+	}
+	
+	/**
+	 * Get all shares for specific nodeIDs
+	 *
+	 * @param int[] $nodeIDs - array of folder/file nodeIDs
+	 *
+	 * @return IShare[] array containing shares
+	 */
+	private function getSharesForNodeIds($nodeIDs) {
 		$requestedShareTypes = [
 			\OCP\Share::SHARE_TYPE_USER,
 			\OCP\Share::SHARE_TYPE_GROUP,
 			\OCP\Share::SHARE_TYPE_LINK,
 			\OCP\Share::SHARE_TYPE_REMOTE
 		];
-		foreach ($requestedShareTypes as $requestedShareType) {
-			// one of each type is enough to find out about the types
-			$shares = $this->shareManager->getSharesBy(
-				$this->userId,
-				$requestedShareType,
-				$node,
-				false,
-				1
-			);
-			if (!empty($shares)) {
-				$shareTypes[] = $requestedShareType;
-			}
-		}
-		return $shareTypes;
+
+		// Query DB for share types for specified node IDs
+		$allShares = $this->shareManager->getAllSharesBy(
+			$this->userId,
+			$requestedShareTypes,
+			$nodeIDs
+		);
+		
+		return $allShares;
 	}
 
 	/**
@@ -156,19 +171,50 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 			$folderNode = $this->userFolder->get($sabreNode->getPath());
 			$children = $folderNode->getDirectoryListing();
 
-			$this->cachedShareTypes[$folderNode->getId()] = $this->getShareTypes($folderNode);
+			// Get ID of parent folder
+			$folderNodeID = intval($folderNode->getId());
+			$nodeIdsArray = [$folderNodeID];
+
+			// Initialize share types array for this node in case there would be no shares for this node
+			$initShareTypes[$folderNodeID] = [];
+			
+			// Get IDs for all children of the parent folder
 			foreach ($children as $childNode) {
-				$this->cachedShareTypes[$childNode->getId()] = $this->getShareTypes($childNode);
+				// Ensure that they are of File or Folder type
+				if (!($childNode instanceof \OCP\Files\File) &&
+					!($childNode instanceof \OCP\Files\Folder)) {
+					return;
+				}
+
+				// Put node ID into an array and initialize cache for it
+				$nodeId = intval($childNode->getId());
+				array_push($nodeIdsArray, $nodeId);
+				
+				// Initialize share types array for this node in case there would be no shares for this node
+				$initShareTypes[$nodeId] = [];
 			}
+
+			// Get all shares for specified nodes obtaining them from DB
+			$returnedShares = $this->getSharesForNodeIds($nodeIdsArray);
+			
+			// Convert to hash map and cache so that $propFind->handle() can use it
+			$this->cachedShareTypes = $this->convertToHashMap($returnedShares, $initShareTypes);
 		}
 
 		$propFind->handle(self::SHARETYPES_PROPERTYNAME, function() use ($sabreNode) {
 			if (isset($this->cachedShareTypes[$sabreNode->getId()])) {
-				$shareTypes = $this->cachedShareTypes[$sabreNode->getId()];
+				// Share types in cache for this node
+				$shareTypesHash = $this->cachedShareTypes[$sabreNode->getId()];
 			} else {
-				$node = $this->userFolder->get($sabreNode->getPath());
-				$shareTypes = $this->getShareTypes($node);
+				// Share types for this node not in cache, obtain if any
+				$nodeId = $this->userFolder->get($sabreNode->getPath())->getId();
+				$returnedShares = $this->getSharesForNodeIds([$nodeId]);
+
+				// Initialize share types for this node and obtain share types hash if any
+				$initShareTypes[$nodeId] = [];
+				$shareTypesHash = $this->convertToHashMap($returnedShares, $initShareTypes)[$nodeId];
 			}
+			$shareTypes = array_keys($shareTypesHash);
 
 			return new ShareTypeList($shareTypes);
 		});

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -36,6 +36,7 @@ use OC\Share20\Exception\InvalidShare;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Files\NotFoundException;
 use OCP\IDBConnection;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Node;
 
 /**
@@ -561,6 +562,61 @@ class FederatedShareProvider implements IShareProvider {
 		return;
 	}
 
+	/**
+	 * @inheritdoc
+	 */
+	public function getAllSharesBy($userId, $shareTypes, $nodeIDs, $reshares) {
+		$shares = [];
+		$qb = $this->dbConnection->getQueryBuilder();
+
+		$nodeIdsChunks = array_chunk($nodeIDs, 100);
+		foreach ($nodeIdsChunks as $nodeIdsChunk) {
+			// In federates sharing currently we have only one share_type_remote
+			$qb->select('*')
+				->from('share');
+
+			$qb->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(self::SHARE_TYPE_REMOTE)));
+
+			/**
+			 * Reshares for this user are shares where they are the owner.
+			 */
+			if ($reshares === false) {
+				//Special case for old shares created via the web UI
+				$or1 = $qb->expr()->andX(
+					$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId)),
+					$qb->expr()->isNull('uid_initiator')
+				);
+
+				$qb->andWhere(
+					$qb->expr()->orX(
+						$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId)),
+						$or1
+					)
+				);
+			} else {
+				$qb->andWhere(
+					$qb->expr()->orX(
+						$qb->expr()->eq('uid_owner', $qb->createNamedParameter($userId)),
+						$qb->expr()->eq('uid_initiator', $qb->createNamedParameter($userId))
+					)
+				);
+			}
+
+			$qb->andWhere($qb->expr()->in('file_source', $qb->createParameter('file_source_ids')));
+			$qb->setParameter('file_source_ids', $nodeIdsChunk, IQueryBuilder::PARAM_INT_ARRAY);
+
+			$qb->orderBy('id');
+
+			$cursor = $qb->execute();
+			while($data = $cursor->fetch()) {
+				$shares[] = $this->createShareObject($data);
+			}
+			$cursor->closeCursor();
+		}
+		
+		return $shares;
+	}
+	
 	/**
 	 * @inheritdoc
 	 */

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -87,6 +87,18 @@ interface IManager {
 	public function moveShare(IShare $share, $recipientId);
 
 	/**
+	 * Get all shares shared by (initiated) by the provided user for specific node IDs.
+	 *
+	 * @param string $userId
+	 * @param int[] $shareTypes
+	 * @param int[] $nodeIDs
+	 * @param bool $reshares
+	 * @return IShare[]
+	 * @since 10.0.0
+	 */
+	public function getAllSharesBy($userId, $shareTypes, $nodeIDs, $reshares = false);
+	
+	/**
 	 * Get shares shared by (initiated) by the provided user.
 	 *
 	 * @param string $userId

--- a/lib/public/Share/IShareProvider.php
+++ b/lib/public/Share/IShareProvider.php
@@ -105,6 +105,18 @@ interface IShareProvider {
 	public function getSharesBy($userId, $shareType, $node, $reshares, $limit, $offset);
 
 	/**
+	 * Get all shares by the given user for specified shareTypes array
+	 *
+	 * @param string $userId
+	 * @param int[] $shareTypes
+	 * @param Node[] $nodeIDs
+	 * @param bool $reshares - Also get the shares where $user is the owner instead of just the shares where $user is the initiator
+	 * @return \OCP\Share\IShare[]
+	 * @since 10.0.0
+	 */
+	public function getAllSharesBy($userId, $shareTypes, $nodeIDs, $reshares);
+	
+	/**
 	 * Get share by id
 	 *
 	 * @param int $id

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1946,6 +1946,105 @@ class ManagerTest extends \Test\TestCase {
 		$manager->createShare($share);
 	}
 
+	public function testGetAllSharesBy() {
+		$share = $this->manager->newShare();
+
+		$node = $this->createMock('OCP\Files\Folder');
+		$node->expects($this->any())
+			->method('getId')
+			->will($this->returnValue(0));
+
+		$nodes = [$node->getId()];
+
+		for ($i = 1; $i <= 201; $i++) {
+			$node = $this->createMock('OCP\Files\File');
+			$node->expects($this->any())
+				->method('getId')
+				->will($this->returnValue($i));
+			array_push($nodes, $node->getId());
+		}
+
+		// Test chunking here
+		$this->defaultProvider->expects($this->any())
+			->method('getAllSharesBy')
+			->with(
+				$this->equalTo('user'),
+				$this->anything(),
+				$this->anything(),
+				$this->equalTo(true)
+			)->willReturn(array_fill(0, 201, $share));
+
+		$shares = $this->manager->getAllSharesBy('user', [\OCP\Share::SHARE_TYPE_USER], $nodes, true);
+
+		$this->assertCount(201, $shares);
+		$this->assertSame($share, $shares[0]);
+		$this->assertSame($share, $shares[100]);
+		$this->assertSame($share, $shares[200]);
+	}
+
+	public function testGetAllSharesByExpiration() {
+		$manager = $this->createManagerMock()
+			->setMethods(['deleteShare'])
+			->getMock();
+
+		$share = $this->manager->newShare();
+
+		$shareExpired = $this->createMock(IShare::class);
+		$shareExpired->method('getShareType')->willReturn(\OCP\Share::SHARE_TYPE_LINK);
+		$shareExpired->method('getNodeId')->willReturn(201);
+		$today = new \DateTime();
+		$shareExpired->method('getExpirationDate')->willReturn($today);
+
+
+		$node = $this->createMock('OCP\Files\Folder');
+		$node->expects($this->any())
+			->method('getId')
+			->will($this->returnValue(0));
+
+		$nodes = [$node->getId()];
+
+		for ($i = 1; $i <= 201; $i++) {
+			$node = $this->createMock('OCP\Files\File');
+			$node->expects($this->any())
+				->method('getId')
+				->will($this->returnValue($i));
+			array_push($nodes, $node->getId());
+		}
+
+		// Add 201 shares, including expired
+		$fillShares = array_fill(0, 200, $share);
+		$fillShares[] = $shareExpired;
+
+		// Test chunking here
+		$this->defaultProvider->expects($this->any())
+			->method('getAllSharesBy')
+			->with(
+				$this->equalTo('user'),
+				$this->anything(),
+				$this->anything(),
+				$this->equalTo(true)
+			)->willReturn($fillShares);
+
+		$manager->expects($this->any())
+			->method('deleteShare')
+			->will($this->throwException(new \OCP\Files\NotFoundException));
+
+		$shares = $manager->getAllSharesBy('user', [\OCP\Share::SHARE_TYPE_USER], $nodes, true);
+
+		// One share whould be expired
+		$this->assertCount(200, $shares);
+		$this->assertSame($share, $shares[0]);
+		$this->assertSame($share, $shares[100]);
+		$this->assertNotContains($shareExpired, $shares);
+	}
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testGetAllSharesByException() {
+		$shares = $this->manager->getAllSharesBy('user', [\OCP\Share::SHARE_TYPE_USER], [], true);
+	}
+
 	public function testGetSharesBy() {
 		$share = $this->manager->newShare();
 


### PR DESCRIPTION
Hello guys, after exams I am back at work with a lot of new energy, knowledge and ideas. Lets start the fun with this PR. 

The idea here is behavior of SharedPlugin, which I found out reviewing our code with BlackFire e.g:
This is example query if you have 100 NON-SHARED files, it put my attention on quering sharing table while we dont have shares there, and why dont we just 1 query or so..
![selection_019](https://cloud.githubusercontent.com/assets/13368647/23460015/41c5a002-fe83-11e6-8633-8b1fa2948fba.jpg)

I have been interested in what causes that amount of share_table accesses and started optimizing the code:
* [x] If the same provider, query cumulatively instead of separate queries
* [x] Write Unit tests for opt. 1
* [x] Dont do query for all the nodes, rather use IN() clause https://github.com/owncloud/core/issues/25266#issuecomment-283274412
* [x] Write Unit tests for opt. 2
* [x] Give to support @felixboehm @cdamken to test with customers
 