### PR TITLE
Exclude group backend from showing groups in users page (group manager filter approach)

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -220,7 +220,7 @@ class ShareesController extends OCSController  {
 	protected function getGroups($search) {
 		$this->result['groups'] = $this->result['exact']['groups'] = [];
 
-		$groups = $this->groupManager->search($search, $this->limit, $this->offset);
+		$groups = $this->groupManager->search($search, $this->limit, $this->offset, 'sharing');
 		$groupIds = array_map(function (IGroup $group) { return $group->getGID(); }, $groups);
 
 		if (!$this->shareeEnumeration || sizeof($groups) < $this->limit) {
@@ -230,7 +230,7 @@ class ShareesController extends OCSController  {
 		$userGroups =  [];
 		if (!empty($groups) && $this->shareWithGroupOnly) {
 			// Intersect all the groups that match with the groups this user is a member of
-			$userGroups = $this->groupManager->getUserGroups($this->userSession->getUser());
+			$userGroups = $this->groupManager->getUserGroups($this->userSession->getUser(), 'sharing');
 			$userGroups = array_map(function (IGroup $group) { return $group->getGID(); }, $userGroups);
 			$groupIds = array_intersect($groupIds, $userGroups);
 		}

--- a/apps/provisioning_api/lib/Groups.php
+++ b/apps/provisioning_api/lib/Groups.php
@@ -71,7 +71,7 @@ class Groups{
 			$offset = (int)$offset;
 		}
 
-		$groups = $this->groupManager->search($search, $limit, $offset);
+		$groups = $this->groupManager->search($search, $limit, $offset, 'management');
 		$groups = array_map(function($group) {
 			/** @var IGroup $group */
 			return $group->getGID();

--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -416,7 +416,7 @@ class Users {
 		if($targetUser->getUID() === $loggedInUser->getUID() || $this->groupManager->isAdmin($loggedInUser->getUID())) {
 			// Self lookup or admin lookup
 			return new Result([
-				'groups' => $this->groupManager->getUserGroupIds($targetUser)
+				'groups' => $this->groupManager->getUserGroupIds($targetUser, 'management')
 			]);
 		} else {
 			$subAdminManager = $this->groupManager->getSubAdmin();

--- a/lib/private/Group/Backend.php
+++ b/lib/private/Group/Backend.php
@@ -129,4 +129,8 @@ abstract class Backend implements \OCP\GroupInterface {
 	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0) {
 		return [];
 	}
+
+	public function isVisibleForScope($scope) {
+		return true;
+	}
 }

--- a/lib/private/Group/Group.php
+++ b/lib/private/Group/Group.php
@@ -297,4 +297,16 @@ class Group implements IGroup {
 		}
 		return $users;
 	}
+
+	/**
+	 * Returns the backend for this group
+	 *
+	 * @return \OC\Group\Backend
+	 * @since 10.0.0
+	 */
+	public function getBackend() {
+		// multiple backends can exist for the same group name,
+		// but in practice there is only a single one, so return that one
+		return $this->backends[0];
+	}
 }

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -213,14 +213,19 @@ class Manager extends PublicEmitter implements IGroupManager {
 	}
 
 	/**
-	 * @param string $search
-	 * @param int $limit
-	 * @param int $offset
-	 * @return \OC\Group\Group[]
+	 * @param string $search search string
+	 * @param int|null $limit limit
+	 * @param int|null $offset offset
+	 * @param string|null $scope scope string
+	 * @return \OC\Group\Group[] groups
 	 */
-	public function search($search, $limit = null, $offset = null) {
+	public function search($search, $limit = null, $offset = null, $scope = null) {
 		$groups = [];
 		foreach ($this->backends as $backend) {
+			if (!$backend->isVisibleForScope($scope)) {
+				// skip backend
+				continue;
+			}
 			$groupIds = $backend->getGroups($search, $limit, $offset);
 			foreach ($groupIds as $groupId) {
 				$aGroup = $this->get($groupId);
@@ -238,40 +243,79 @@ class Manager extends PublicEmitter implements IGroupManager {
 	}
 
 	/**
-	 * @param \OC\User\User|null $user
+	 * @param \OC\User\User|null $user user
+	 * @param string|null $scope scope string
 	 * @return \OC\Group\Group[]
 	 */
-	public function getUserGroups($user) {
+	public function getUserGroups($user, $scope = null) {
 		if (is_null($user)) {
 			return [];
 		}
-		return $this->getUserIdGroups($user->getUID());
+		return $this->getUserIdGroups($user->getUID(), $scope);
+	}
+
+	/**
+	 * Gathers a list of backends that opt out of the given scope.
+	 *
+	 * @param string|null $scope scope string
+	 * @return \OCP\GroupInterface[] excluded backends
+	 */
+	private function getExcludedBackendsForScope($scope) {
+		$excludedBackendsForScope = [];
+		foreach ($this->backends as $backend) {
+			if (!$backend->isVisibleForScope($scope)) {
+				$excludedBackendsForScope[] = $backend;
+			}
+		}
+		return $excludedBackendsForScope;
+	}
+
+	/**
+	 * Filter groups by backends that opt-out of the given scope
+	 *
+	 * @param \OCP\IGroup[] $groups groups to filter
+	 * @param string|null $scope scope string
+	 * @return \OCP\IGroup[] filtered groups
+	 */
+	private function filterExcludedBackendsForScope($groups, $scope) {
+		$excludedBackendsForScope = $this->getExcludedBackendsForScope($scope);
+		if (!empty($excludedBackendsForScope)) {
+			return array_filter($groups, function($group) use ($excludedBackendsForScope) {
+				return !in_array($group->getBackend(), $excludedBackendsForScope);
+			});
+		}
+		return $groups;
 	}
 
 	/**
 	 * @param string $uid the user id
+	 * @param string|null $scope scope string
 	 * @return \OC\Group\Group[]
 	 */
-	public function getUserIdGroups($uid) {
-		if (isset($this->cachedUserGroups[$uid])) {
-			return $this->cachedUserGroups[$uid];
-		}
-		$groups = [];
-		foreach ($this->backends as $backend) {
-			$groupIds = $backend->getUserGroups($uid);
-			if (is_array($groupIds)) {
-				foreach ($groupIds as $groupId) {
-					$aGroup = $this->get($groupId);
-					if (!is_null($aGroup)) {
-						$groups[$groupId] = $aGroup;
-					} else {
-						\OC::$server->getLogger()->debug('User "' . $uid . '" belongs to deleted group: "' . $groupId . '"', array('app' => 'core'));
+	public function getUserIdGroups($uid, $scope = null) {
+		if (!isset($this->cachedUserGroups[$uid])) {
+			$groups = [];
+
+			foreach ($this->backends as $backend) {
+				$groupIds = $backend->getUserGroups($uid);
+				if (is_array($groupIds)) {
+					foreach ($groupIds as $groupId) {
+						$aGroup = $this->get($groupId);
+						if (!is_null($aGroup)) {
+							$groups[$groupId] = $aGroup;
+						} else {
+							\OC::$server->getLogger()->debug('User "' . $uid . '" belongs to deleted group: "' . $groupId . '"', array('app' => 'core'));
+						}
 					}
 				}
 			}
+			$this->cachedUserGroups[$uid] = $groups;
+		} else {
+			$groups = $this->cachedUserGroups[$uid];
 		}
-		$this->cachedUserGroups[$uid] = $groups;
-		return $this->cachedUserGroups[$uid];
+
+		// filter out groups that must be omitted for the given scope
+		return $this->filterExcludedBackendsForScope($groups, $scope);
 	}
 
 	/**
@@ -296,12 +340,13 @@ class Manager extends PublicEmitter implements IGroupManager {
 	/**
 	 * get a list of group ids for a user
 	 * @param \OC\User\User $user
+	 * @param string|null $scope string
 	 * @return array with group ids
 	 */
-	public function getUserGroupIds($user) {
+	public function getUserGroupIds($user, $scope = null) {
 		return array_map(function($value) {
 			return (string) $value;
-		}, array_keys($this->getUserGroups($user)));
+		}, array_keys($this->getUserGroups($user, $scope)));
 	}
 
 	/**

--- a/lib/private/Group/MetaData.php
+++ b/lib/private/Group/MetaData.php
@@ -185,7 +185,7 @@ class MetaData {
 	 */
 	protected function getGroups($search = '') {
 		if($this->isAdmin) {
-			return $this->groupManager->search($search);
+			return $this->groupManager->search($search, null, null, 'management');
 		} else {
 			$userObject = $this->userSession->getUser();
 			if($userObject !== null) {

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -654,7 +654,7 @@ class DefaultShareProvider implements IShareProvider {
 
 		} else if ($shareType === \OCP\Share::SHARE_TYPE_GROUP) {
 			$user = $this->userManager->get($userId);
-			$allGroups = $this->groupManager->getUserGroups($user);
+			$allGroups = $this->groupManager->getUserGroups($user, 'sharing');
 
 			/** @var Share[] $shares2 */
 			$shares2 = [];

--- a/lib/public/GroupInterface.php
+++ b/lib/public/GroupInterface.php
@@ -116,4 +116,14 @@ interface GroupInterface {
 	 */
 	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0);
 
+	/**
+	 * Returns whether the groups are visible for a given scope.
+	 *
+	 * @param string|null $scope scope string
+	 * @return bool true if searchable, false otherwise
+	 *
+	 * @since 10.0.0
+	 */
+	public function isVisibleForScope($scope);
+
 }

--- a/lib/public/IGroup.php
+++ b/lib/public/IGroup.php
@@ -115,4 +115,12 @@ interface IGroup {
 	 * @since 8.0.0
 	 */
 	public function delete();
+
+	/**
+	 * Returns the backend for this group
+	 *
+	 * @return \OC\Group\Backend
+	 * @since 10.0.0
+	 */
+	public function getBackend();
 }

--- a/lib/public/IGroupManager.php
+++ b/lib/public/IGroupManager.php
@@ -89,24 +89,27 @@ interface IGroupManager {
 	 * @param string $search
 	 * @param int $limit
 	 * @param int $offset
+	 * @param string $scope
 	 * @return \OCP\IGroup[]
 	 * @since 8.0.0
 	 */
-	public function search($search, $limit = null, $offset = null);
+	public function search($search, $limit = null, $offset = null, $scope = null);
 
 	/**
 	 * @param \OCP\IUser|null $user
+	 * @param string $scope
 	 * @return \OCP\IGroup[]
 	 * @since 8.0.0
 	 */
-	public function getUserGroups($user);
+	public function getUserGroups($user, $scope = null);
 
 	/**
 	 * @param \OCP\IUser $user
+	 * @param string $scope
 	 * @return array with group names
 	 * @since 8.0.0
 	 */
-	public function getUserGroupIds($user);
+	public function getUserGroupIds($user, $scope = null);
 
 	/**
 	 * get a list of all display names in a group

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -188,7 +188,7 @@ class UsersController extends Controller {
 		return [
 			'name' => $user->getUID(),
 			'displayname' => $user->getDisplayName(),
-			'groups' => (empty($userGroups)) ? $this->groupManager->getUserGroupIds($user) : $userGroups,
+			'groups' => (empty($userGroups)) ? $this->groupManager->getUserGroupIds($user, 'management') : $userGroups,
 			'subadmin' => $subAdminGroups,
 			'quota' => $user->getQuota(),
 			'storageLocation' => $user->getHome(),

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -37,7 +37,7 @@ class ManagerTest extends \Test\TestCase {
 		return $mockUser;
 	}
 
-	private function getTestBackend($implementedActions = null) {
+	private function getTestBackend($implementedActions = null, $visibleForScopes = null) {
 		if (is_null($implementedActions)) {
 			$implementedActions =
 				GroupInterface::ADD_TO_GROUP |
@@ -61,6 +61,7 @@ class ManagerTest extends \Test\TestCase {
 				'createGroup',
 				'addToGroup',
 				'removeFromGroup',
+				'isVisibleForScope',
 			])
 			->getMock();
 		$backend->expects($this->any())
@@ -68,6 +69,15 @@ class ManagerTest extends \Test\TestCase {
 			->will($this->returnCallback(function($actions) use ($implementedActions) {
 				return (bool)($actions & $implementedActions);
 			}));
+		if (is_null($visibleForScopes)) {
+			$backend->expects($this->any())
+				->method('isVisibleForScope')
+				->willReturn(true);
+		} else {
+			$backend->expects($this->any())
+				->method('isVisibleForScope')
+				->will($this->returnValueMap($visibleForScopes));
+		}
 		return $backend;
 	}
 
@@ -345,6 +355,9 @@ class ManagerTest extends \Test\TestCase {
 			->method('groupExists')
 			->with('group1')
 			->will($this->returnValue(false));
+		$backend->expects($this->once())
+			->method('isVisibleForScope')
+			->will($this->returnValue(true));
 
 		/**
 		 * @var \OC\User\Manager $userManager
@@ -356,6 +369,57 @@ class ManagerTest extends \Test\TestCase {
 
 		$groups = $manager->search('1');
 		$this->assertEmpty($groups);
+	}
+
+	public function testSearchBackendsForScope() {
+		/**
+		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend1
+		 */
+		$backend1 = $this->getTestBackend();
+		$backend1->expects($this->any())
+			->method('getGroups')
+			->with('1')
+			->will($this->returnValue(['group1']));
+		$backend1->expects($this->any())
+			->method('groupExists')
+			->will($this->returnValue(true));
+
+		/**
+		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend2
+		 */
+		$backend2 = $this->getTestBackend(null, [
+			[null, false],
+			['sharing', true],
+		]);
+		$backend2->expects($this->any())
+			->method('getGroups')
+			->with('1')
+			->will($this->returnValue(['group12', 'group1']));
+		$backend2->expects($this->any())
+			->method('groupExists')
+			->will($this->returnValue(true));
+
+		/**
+		 * @var \OC\User\Manager $userManager
+		 */
+		$userManager = $this->createMock('\OC\User\Manager');
+		$manager = new \OC\Group\Manager($userManager);
+		$manager->addBackend($backend1);
+		$manager->addBackend($backend2);
+
+		// search without scope
+		$groups = $manager->search('1', null, null, null);
+		$this->assertEquals(1, count($groups));
+		$group1 = reset($groups);
+		$this->assertEquals('group1', $group1->getGID());
+
+		// search with scope
+		$groups = $manager->search('1', null, null, 'sharing');
+		$this->assertEquals(2, count($groups));
+		$group1 = reset($groups);
+		$group12 = next($groups);
+		$this->assertEquals('group1', $group1->getGID());
+		$this->assertEquals('group12', $group12->getGID());
 	}
 
 	public function testGetUserGroups() {
@@ -440,6 +504,40 @@ class ManagerTest extends \Test\TestCase {
 
 		$groups = $manager->getUserGroups($user);
 		$this->assertEmpty($groups);
+	}
+
+	public function testGetUserGroupsWithScope() {
+		/**
+		 * @var \PHPUnit_Framework_MockObject_MockObject | \OC\Group\Backend $backend
+		 */
+		$backend = $this->getTestBackend(null, [
+			[null, false],
+			['sharing', true],
+		]);
+		$backend->expects($this->any())
+			->method('getUserGroups')
+			->with('user1')
+			->will($this->returnValue(['group1']));
+		$backend->expects($this->any())
+			->method('groupExists')
+			->with('group1')
+			->will($this->returnValue(true));
+
+		/**
+		 * @var \OC\User\Manager $userManager
+		 */
+		$userManager = $this->createMock('\OC\User\Manager');
+		$userBackend = $this->createMock('\OC_User_Backend');
+		$manager = new \OC\Group\Manager($userManager);
+		$manager->addBackend($backend);
+
+		$groups = $manager->getUserGroups($this->getTestUser('user1'));
+		$this->assertEmpty($groups);
+
+		$groups = $manager->getUserGroups($this->getTestUser('user1'), 'sharing');
+		$this->assertCount(1, $groups);
+		$group1 = reset($groups);
+		$this->assertEquals('group1', $group1->getGID());
 	}
 
 	public function testInGroup() {

--- a/tests/lib/Repair/RepairUnmergedSharesTest.php
+++ b/tests/lib/Repair/RepairUnmergedSharesTest.php
@@ -552,9 +552,9 @@ class RepairUnmergedSharesTest extends TestCase {
 			->method('getUserGroupIds')
 			->will($this->returnValueMap([
 				// owner
-				[$user1, ['samegroup1', 'samegroup2']],
+				[$user1, null, ['samegroup1', 'samegroup2']],
 				// recipient
-				[$user2, ['recipientgroup1', 'recipientgroup2']],
+				[$user2, null, ['recipientgroup1', 'recipientgroup2']],
 			]));
 
 		$this->userManager->expects($this->once())

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1000,8 +1000,8 @@ class ManagerTest extends \Test\TestCase {
 			->method('getUserGroupIds')
 			->will(
 				$this->returnValueMap([
-					[$sharedBy, ['group1']],
-					[$sharedWith, ['group2']],
+					[$sharedBy, null, ['group1']],
+					[$sharedWith, null, ['group2']],
 				])
 			);
 
@@ -1033,8 +1033,8 @@ class ManagerTest extends \Test\TestCase {
 			->method('getUserGroupIds')
 			->will(
 				$this->returnValueMap([
-					[$sharedBy, ['group1', 'group3']],
-					[$sharedWith, ['group2', 'group3']],
+					[$sharedBy, null, ['group1', 'group3']],
+					[$sharedWith, null, ['group2', 'group3']],
 				])
 			);
 


### PR DESCRIPTION
To be able to exclude backends for specific scopes.

WIP for https://github.com/owncloud/customgroups/issues/6