### PR TITLE
don't store empty groupids

### DIFF
--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -399,6 +399,9 @@ class SystemTagManager implements ISystemTagManager {
 					'gid' => $query->createParameter('gid'),
 				]);
 			foreach ($groupIds as $groupId) {
+				if ($groupId === '') {
+					continue;
+				}
 				$query->setParameter('gid', $groupId);
 				$query->execute();
 			}

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -517,6 +517,15 @@ class SystemTagManagerTest extends TestCase {
 	}
 
 	/**
+	 * empty groupIds should be ignored
+	 */
+	public function testEmptyTagGroup() {
+		$tag1 = $this->tagManager->createTag('tag1', true, false);
+		$this->tagManager->setTagGroups($tag1, ['']);
+		$this->assertEquals([], $this->tagManager->getTagGroups($tag1));
+	}
+
+	/**
 	 * @param ISystemTag $tag1
 	 * @param ISystemTag $tag2
 	 */


### PR DESCRIPTION
@PVince81 an empty string as groupid shouldnt make it to the DB, right? oracle doesnt like empty string on non nullable columns (which the systemtag_group.gid is)

This PR hardens the code should someone try to add an empty group id. Likely there is an empty group in https://github.com/owncloud/core/blob/aba539703c0b0388f5ebf8757067bafab56774ce/apps/dav/lib/SystemTag/SystemTagPlugin.php#L189-L194 but that is a different issue.