### PR TITLE
Add authentication admin settings section for user backend settings

### DIFF
--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -198,6 +198,7 @@ class SettingsManager implements ISettingsManager {
 				new Section('general', $this->l->t('General'), 100),
 				new Section('storage', $this->l->t('Storage'), 95, 'folder'),
 				new Section('security', $this->l->t('Security'), 90, 'password'),
+				new Section('authentication', $this->l->t('Authentication'), 87, 'user'),
 				new Section('encryption', $this->l->t('Encryption'), 85, 'password'),
 				new Section('sharing', $this->l->t('Sharing'), 80, 'share'),
 				new Section('monitoring', $this->l->t('Monitoring'), 75, 'search'),


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Added a new admin section for user backend settings / authentication related settings

![screen shot 2017-03-02 at 12 55 47](https://cloud.githubusercontent.com/assets/660805/23508008/9a248294-ff47-11e6-82fd-a050d9a6a37f.png)


## Related Issue
 - Needed for converting user_ldap, shibboleth etc apps to the new settings registration
