### PR TITLE
reworked image loading/overwriting

### DIFF
--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -48,6 +48,8 @@ class URLGenerator implements IURLGenerator {
 	private $cacheFactory;
 	/** @var IRouter */
 	private $router;
+	/** @var Theme */
+	private $theme;
 
 	/**
 	 * @param IConfig $config
@@ -60,6 +62,7 @@ class URLGenerator implements IURLGenerator {
 		$this->config = $config;
 		$this->cacheFactory = $cacheFactory;
 		$this->router = $router;
+		$this->theme = \OC_Util::getTheme();
 	}
 
 	/**
@@ -152,48 +155,7 @@ class URLGenerator implements IURLGenerator {
 			return $key;
 		}
 
-		/** @var Theme $theme */
-		$theme = \OC_Util::getTheme();
-		$themeName = $theme->getName();
-
-		//if a theme has a png but not an svg always use the png
-		$basename = substr(basename($image),0,-4);
-
-		$appPath = \OC_App::getAppPath($app);
-
-		// Check if the app is in the app folder
-		$path = '';
-		if (file_exists(\OC::$SERVERROOT . "/themes/$themeName/apps/$app/img/$image")) {
-			$path = \OC::$WEBROOT . "/themes/$themeName/apps/$app/img/$image";
-		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$themeName/apps/$app/img/$basename.svg")
-			&& file_exists(\OC::$SERVERROOT . "/themes/$themeName/apps/$app/img/$basename.png")) {
-			$path =  \OC::$WEBROOT . "/themes/$themeName/apps/$app/img/$basename.png";
-		} elseif (!empty($app) and file_exists(\OC::$SERVERROOT . "/themes/$themeName/$app/img/$image")) {
-			$path =  \OC::$WEBROOT . "/themes/$themeName/$app/img/$image";
-		} elseif (!empty($app) and (!file_exists(\OC::$SERVERROOT . "/themes/$themeName/$app/img/$basename.svg")
-			&& file_exists(\OC::$SERVERROOT . "/themes/$themeName/$app/img/$basename.png"))) {
-			$path =  \OC::$WEBROOT . "/themes/$themeName/$app/img/$basename.png";
-		} elseif (file_exists(\OC::$SERVERROOT . "/themes/$themeName/core/img/$image")) {
-			$path =  \OC::$WEBROOT . "/themes/$themeName/core/img/$image";
-		} elseif (!file_exists(\OC::$SERVERROOT . "/themes/$themeName/core/img/$basename.svg")
-			&& file_exists(\OC::$SERVERROOT . "/themes/$themeName/core/img/$basename.png")) {
-			$path =  \OC::$WEBROOT . "/themes/$themeName/core/img/$basename.png";
-		} elseif ($appPath && file_exists($appPath . "/img/$image")) {
-			$path =  \OC_App::getAppWebPath($app) . "/img/$image";
-		} elseif ($appPath && !file_exists($appPath . "/img/$basename.svg")
-			&& file_exists($appPath . "/img/$basename.png")) {
-			$path =  \OC_App::getAppWebPath($app) . "/img/$basename.png";
-		} elseif (!empty($app) and file_exists(\OC::$SERVERROOT . "/$app/img/$image")) {
-			$path =  \OC::$WEBROOT . "/$app/img/$image";
-		} elseif (!empty($app) and (!file_exists(\OC::$SERVERROOT . "/$app/img/$basename.svg")
-				&& file_exists(\OC::$SERVERROOT . "/$app/img/$basename.png"))) {
-			$path =  \OC::$WEBROOT . "/$app/img/$basename.png";
-		} elseif (file_exists(\OC::$SERVERROOT . "/core/img/$image")) {
-			$path =  \OC::$WEBROOT . "/core/img/$image";
-		} elseif (!file_exists(\OC::$SERVERROOT . "/core/img/$basename.svg")
-			&& file_exists(\OC::$SERVERROOT . "/core/img/$basename.png")) {
-			$path =  \OC::$WEBROOT . "/themes/$themeName/core/img/$basename.png";
-		}
+		$path = $this->getImagePath($app, $image);
 
 		if($path !== '') {
 			$cache->set($cacheKey, $path);
@@ -203,6 +165,55 @@ class URLGenerator implements IURLGenerator {
 		}
 	}
 
+	/**
+	 * @param string $app
+	 * @param string $imageName
+	 * @return string
+	 */
+	private function getImagePath($app, $imageName) {
+		$appWebPath = \OC_App::getAppWebPath($app);
+		$appPath = substr($appWebPath, strlen(\OC::$WEBROOT));
+
+		$directories = ["/core", ""];
+
+		if ($app) {
+			array_unshift($directories, "$appPath", "/$app");
+		}
+
+		foreach($directories as $directory) {
+			$directory = $directory . "/img/";
+			$themeDirectory = $this->theme->getDirectory();
+
+			$file = $directory . $imageName;
+
+			if (!empty($themeDirectory)) {
+				if ($imagePath = $this->getImagePathOrFallback('/' . substr($this->theme->getDirectory(), 0, -1) . $file)) {
+					return $imagePath;
+				}
+			}
+
+			if ($imagePath = $this->getImagePathOrFallback($file)) {
+				return $imagePath;
+			}
+		}
+	}
+
+	/**
+	 * @param string $file
+	 * @return string
+	 */
+	private function getImagePathOrFallback($file) {
+
+		if (file_exists(\OC::$SERVERROOT . $file)) {
+			return \OC::$WEBROOT . $file;
+		}
+
+		$fallback = substr($file, 0, -3) . 'png';
+
+		if (file_exists(\OC::$SERVERROOT . $fallback)) {
+			return \OC::$WEBROOT . $fallback;
+		}
+	}
 
 	/**
 	 * Makes an URL absolute


### PR DESCRIPTION
## Description
Since we had problems overwriting favicons in themes, i took a closer look at the existing code for that functionality. Turned out it was clustered with several edge cases and included non functional legacy workarounds. I took some time to re-work that piece of code to harden the implementation of that feature and make it more readable in general.

Themes are now able to overwrite the following images:
 - images from apps, even from apps with special locations
 - images from core "apps" like core or settings

I threw out all the svg checks, since they did not make any sense. Overwriting and falling back from any image extension to png files still works, but the requested file will be treated preferred.

## Related Issue
https://github.com/owncloud/enterprise/issues/1832

## Motivation and Context
It solves mainly the error where some files could not be overwritten. (like favicons)

## How Has This Been Tested?
Has been tested by hand with example and enterprise themes.
Image loading will be tested in a reasonable extend. It's really hard to provide solid test cases for all the possibilities this provides. This has not been tested before either, i suspect that was because of the same reasons.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

