### PR TITLE
[stable9.1] Don't store empty group id for system tags

### DIFF
--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -399,6 +399,9 @@ class SystemTagManager implements ISystemTagManager {
 					'gid' => $query->createParameter('gid'),
 				]);
 			foreach ($groupIds as $groupId) {
+				if ($groupId === '') {
+					continue;
+				}
 				$query->setParameter('gid', $groupId);
 				$query->execute();
 			}

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -517,6 +517,15 @@ class SystemTagManagerTest extends TestCase {
 	}
 
 	/**
+	 * empty groupIds should be ignored
+	 */
+	public function testEmptyTagGroup() {
+		$tag1 = $this->tagManager->createTag('tag1', true, false);
+		$this->tagManager->setTagGroups($tag1, ['']);
+		$this->assertEquals([], $this->tagManager->getTagGroups($tag1));
+	}
+
+	/**
 	 * @param ISystemTag $tag1
 	 * @param ISystemTag $tag2
 	 */


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/27295 to stable9.1

@butonic @phisch @jvillafanez please review