### PR TITLE
Cache image paths depending on the theme

### DIFF
--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -139,14 +139,14 @@ class URLGenerator implements IURLGenerator {
 	 * Returns the path to the image.
 	 */
 	public function imagePath($app, $image) {
+		// Read the selected theme from the config file
+		$theme = \OC_Util::getTheme();
+
 		$cache = $this->cacheFactory->create('imagePath');
-		$cacheKey = $app.'-'.$image;
+		$cacheKey = $theme.'-'.$app.'-'.$image;
 		if($key = $cache->get($cacheKey)) {
 			return $key;
 		}
-
-		// Read the selected theme from the config file
-		$theme = \OC_Util::getTheme();
 
 		//if a theme has a png but not an svg always use the png
 		$basename = substr(basename($image),0,-4);


### PR DESCRIPTION
$cacheKey includes the theme so the image paths will be cached dependng on the theme.

## Description
Because the image paths should be cached depending on the theme, the theme has to be a part of the cacheKey. This bugfix is already accepted for stable9 and comes for stable9.1 now.

## Related Issue
https://github.com/owncloud/core/issues/27288

## Motivation and Context
We've already fixed this bug in stable9.  For consistency we fixed the bug in stable9.1 as well. This is the original PR: https://github.com/owncloud/core/pull/27289

## How Has This Been Tested?
The changes are the same as in stable9. I've tested this modified code in a virtual machine using a customized theme for the favicon.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

