### PR TITLE
App would not be enabled if not existing

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -212,6 +212,9 @@ class AppManager implements IAppManager {
 	 * @param string $appId
 	 */
 	public function enableApp($appId) {
+		if(!Installer::isInstalled($appId)) {
+			throw new \Exception("$appId can't be enabled since it is not installed.");
+		}
 		$this->installedAppsCache[$appId] = 'yes';
 		$this->appConfig->setValue($appId, 'enabled', 'yes');
 		$this->dispatcher->dispatch(ManagerEvent::EVENT_APP_ENABLE, new ManagerEvent(

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -30,6 +30,7 @@
 
 namespace OC\App;
 
+use OC_App;
 use OC\Installer;
 use OCP\App\IAppManager;
 use OCP\App\ManagerEvent;
@@ -212,7 +213,7 @@ class AppManager implements IAppManager {
 	 * @param string $appId
 	 */
 	public function enableApp($appId) {
-		if(!Installer::isInstalled($appId)) {
+		if(OC_App::getAppPath($appId) === false) {
 			throw new \Exception("$appId can't be enabled since it is not installed.");
 		}
 		$this->installedAppsCache[$appId] = 'yes';

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -171,7 +171,7 @@ class Installer {
 	 *
 	 * Checks whether or not an app is installed, i.e. registered in apps table.
 	 */
-	public static function 	isInstalled( $app ) {
+	public static function isInstalled( $app ) {
 		return (\OC::$server->getConfig()->getAppValue($app, "installed_version", null) !== null);
 	}
 

--- a/tests/lib/App/ManagerTest.php
+++ b/tests/lib/App/ManagerTest.php
@@ -106,14 +106,27 @@ class ManagerTest extends TestCase {
 
 	public function testEnableApp() {
 		$this->expectClearCache();
-		$this->manager->enableApp('test');
-		$this->assertEquals('yes', $this->appConfig->getValue('test', 'enabled', 'no'));
+		// making sure "files_trashbin" is disabled
+		if ($this->manager->isEnabledForUser('files_trashbin')) {
+			$this->manager->disableApp('files_trashbin');
+		}
+		$this->manager->enableApp('files_trashbin');
+		$this->assertEquals('yes', $this->appConfig->getValue('files_trashbin', 'enabled', 'no'));
 	}
 
 	public function testDisableApp() {
 		$this->expectClearCache();
-		$this->manager->disableApp('test');
-		$this->assertEquals('no', $this->appConfig->getValue('test', 'enabled', 'no'));
+		$this->manager->disableApp('files_trashbin');
+		$this->assertEquals('no', $this->appConfig->getValue('files_trashbin', 'enabled', 'no'));
+	}
+	/**
+	 * @expectedException \Exception
+	 */
+	public function testNotEnableIfNotInstalled() {
+		$this->manager->enableApp('some_random_name_which_i_hope_is_not_an_app');
+		$this->assertEquals('no', $this->appConfig->getValue(
+			'some_random_name_which_i_hope_is_not_an_app', 'enabled', 'no'
+		));
 	}
 
 	public function testEnableAppForGroups() {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Fixes #26604

An app would not be enabled if that app is non-existent when ```enableApp``` API is called.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/26604

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tried to call the API without my fix and after my fix, wihtout fix app inserted into oc_appconfig, with fix, not inserted.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@PVince81 @DeepDiver1975 