### PR TITLE
cache getStorageById

### DIFF
--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -31,9 +31,12 @@
 
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Cache\CappedMemoryCache;
+use OC\Files\Cache\Storage;
 use OC\Files\Filesystem;
 use OCA\Files_Sharing\AppInfo\Application;
 use OCA\Files_Sharing\SharedStorage;
+use OCP\ICache;
 
 /**
  * Class TestCase
@@ -186,6 +189,24 @@ abstract class TestCase extends \Test\TestCase {
 		$isInitialized->setAccessible(true);
 		$isInitialized->setValue($storage, false);
 		$isInitialized->setAccessible(false);
+
+		$storage = new \ReflectionClass(Storage::class);
+		$property = $storage->getProperty('localCache');
+		$property->setAccessible(true);
+		/** @var ICache $localCache */
+		$localCache = $property->getValue();
+		if ($localCache instanceof ICache) {
+			$localCache->clear();
+		}
+		$property->setAccessible(false);
+		$property = $storage->getProperty('distributedCache');
+		$property->setAccessible(true);
+		/** @var ICache $localCache */
+		$distributedCache = $property->getValue();
+		if ($distributedCache instanceof ICache) {
+			$distributedCache->clear();
+		}
+		$property->setAccessible(false);
 	}
 
 	/**

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -31,7 +31,6 @@
 
 namespace OCA\Files_Sharing\Tests;
 
-use OC\Cache\CappedMemoryCache;
 use OC\Files\Cache\Storage;
 use OC\Files\Filesystem;
 use OCA\Files_Sharing\AppInfo\Application;

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -543,11 +543,7 @@ class Cache implements ICache {
 	 * remove all entries for files that are stored on the storage from the cache
 	 */
 	public function clear() {
-		$sql = 'DELETE FROM `*PREFIX*filecache` WHERE `storage` = ?';
-		$this->connection->executeQuery($sql, [$this->getNumericStorageId()]);
-
-		$sql = 'DELETE FROM `*PREFIX*storages` WHERE `id` = ?';
-		$this->connection->executeQuery($sql, [$this->storageId]);
+		Storage::remove($this->storageId);
 	}
 
 	/**

--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -85,14 +85,14 @@ class Storage {
 	/**
 	 * query the local cache, a distributed cache and the db for a storageid
 	 * @param string $storageId
-	 * @return array|null
+	 * @return array|false
 	 */
 	public static function getStorageById($storageId) {
 		if (self::$localCache === null) {
 			self::$localCache = new CappedMemoryCache();
 		}
 		$result = self::$localCache->get($storageId);
-		if (empty($result)) {
+		if ($result === null) {
 			$result = self::getStorageByIdFromCache($storageId);
 			self::$localCache->set($storageId, $result);
 		}
@@ -102,7 +102,7 @@ class Storage {
 	/**
 	 * query the distributed cache for a storageid
 	 * @param string $storageId
-	 * @return array|null
+	 * @return array|false
 	 */
 	private static function getStorageByIdFromCache($storageId) {
 		if (self::$distributedCache === null) {
@@ -110,7 +110,7 @@ class Storage {
 				\OC::$server->getMemCacheFactory()->create('getStorageById');
 		}
 		$result = self::$distributedCache->get($storageId);
-		if (empty($result)) {
+		if ($result === null) {
 			$result = self::getStorageByIdFromDb($storageId);
 			self::$distributedCache->set(
 				$storageId,
@@ -124,7 +124,7 @@ class Storage {
 	/**
 	 * query the db for a storageid
 	 * @param string $storageId
-	 * @return array|null
+	 * @return array|false
 	 */
 	private static function getStorageByIdFromDb($storageId) {
 		$sql = 'SELECT * FROM `*PREFIX*storages` WHERE `id` = ?';
@@ -232,7 +232,7 @@ class Storage {
 		\OC_DB::executeAudited($sql, [$storageId]);
 
 		// delete from local cache
-		if(self::$localCache) {
+		if(self::$localCache === null) {
 			self::$localCache->remove($storageId);
 		}
 		// delete from distributed cache

--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -26,6 +26,8 @@
  */
 
 namespace OC\Files\Cache;
+use OC\Cache\CappedMemoryCache;
+use OCP\ICache;
 
 /**
  * Handle the mapping between the string and numeric storage ids
@@ -41,6 +43,14 @@ namespace OC\Files\Cache;
 class Storage {
 	private $storageId;
 	private $numericId;
+
+	/** @var CappedMemoryCache */
+	protected static $localCache = null;
+
+	/** @var ICache  */
+	protected static $distributedCache = null;
+
+	protected static $distributedCacheTTL = 300; // 5 Min
 
 	/**
 	 * @param \OC\Files\Storage\Storage|string $storage
@@ -73,13 +83,53 @@ class Storage {
 	}
 
 	/**
+	 * query the local cache, a distributed cache and the db for a storageid
 	 * @param string $storageId
 	 * @return array|null
 	 */
 	public static function getStorageById($storageId) {
+		if (self::$localCache === null) {
+			self::$localCache = new CappedMemoryCache();
+		}
+		$result = self::$localCache->get($storageId);
+		if (empty($result)) {
+			$result = self::getStorageByIdFromCache($storageId);
+			self::$localCache->set($storageId, $result);
+		}
+		return $result;
+	}
+
+	/**
+	 * query the distributed cache for a storageid
+	 * @param string $storageId
+	 * @return array|null
+	 */
+	private static function getStorageByIdFromCache($storageId) {
+		if (self::$distributedCache === null) {
+			self::$distributedCache =
+				\OC::$server->getMemCacheFactory()->create('getStorageById');
+		}
+		$result = self::$distributedCache->get($storageId);
+		if (empty($result)) {
+			$result = self::getStorageByIdFromDb($storageId);
+			self::$distributedCache->set(
+				$storageId,
+				$result,
+				self::$distributedCacheTTL
+			);
+		}
+		return $result;
+	}
+
+	/**
+	 * query the db for a storageid
+	 * @param string $storageId
+	 * @return array|null
+	 */
+	private static function getStorageByIdFromDb($storageId) {
 		$sql = 'SELECT * FROM `*PREFIX*storages` WHERE `id` = ?';
-		$result = \OC_DB::executeAudited($sql, [$storageId]);
-		return $result->fetchRow();
+		$resultSet = \OC_DB::executeAudited($sql, [$storageId]);
+		return $resultSet->fetchRow();
 	}
 
 	/**
@@ -181,6 +231,17 @@ class Storage {
 		$sql = 'DELETE FROM `*PREFIX*storages` WHERE `id` = ?';
 		\OC_DB::executeAudited($sql, [$storageId]);
 
+		// delete from local cache
+		if(self::$localCache) {
+			self::$localCache->remove($storageId);
+		}
+		// delete from distributed cache
+		if (self::$distributedCache === null) {
+			self::$distributedCache =
+				\OC::$server->getMemCacheFactory()->create('getStorageById');
+		}
+		self::$distributedCache->remove($storageId);
+		// delete from db
 		if (!is_null($numericId)) {
 			$sql = 'DELETE FROM `*PREFIX*filecache` WHERE `storage` = ?';
 			\OC_DB::executeAudited($sql, [$numericId]);

--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -70,6 +70,7 @@ class Storage {
 		} else {
 			$connection = \OC::$server->getDatabaseConnection();
 			$available = $isAvailable ? 1 : 0;
+			self::unsetCache($this->storageId);
 			if ($connection->insertIfNotExist('*PREFIX*storages', ['id' => $this->storageId, 'available' => $available])) {
 				$this->numericId = (int)$connection->lastInsertId('*PREFIX*storages');
 			} else {
@@ -130,6 +131,19 @@ class Storage {
 		$sql = 'SELECT * FROM `*PREFIX*storages` WHERE `id` = ?';
 		$resultSet = \OC_DB::executeAudited($sql, [$storageId]);
 		return $resultSet->fetchRow();
+	}
+
+	private static function unsetCache($storageId) {
+		// delete from local cache
+		if(self::$localCache === null) {
+			self::$localCache->remove($storageId);
+		}
+		// delete from distributed cache
+		if (self::$distributedCache === null) {
+			self::$distributedCache =
+				\OC::$server->getMemCacheFactory()->create('getStorageById');
+		}
+		self::$distributedCache->remove($storageId);
 	}
 
 	/**
@@ -232,15 +246,7 @@ class Storage {
 		\OC_DB::executeAudited($sql, [$storageId]);
 
 		// delete from local cache
-		if(self::$localCache === null) {
-			self::$localCache->remove($storageId);
-		}
-		// delete from distributed cache
-		if (self::$distributedCache === null) {
-			self::$distributedCache =
-				\OC::$server->getMemCacheFactory()->create('getStorageById');
-		}
-		self::$distributedCache->remove($storageId);
+		self::unsetCache($storageId);
 		// delete from db
 		if (!is_null($numericId)) {
 			$sql = 'DELETE FROM `*PREFIX*filecache` WHERE `storage` = ?';

--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -135,7 +135,7 @@ class Storage {
 
 	private static function unsetCache($storageId) {
 		// delete from local cache
-		if(self::$localCache === null) {
+		if(self::$localCache !== null) {
 			self::$localCache->remove($storageId);
 		}
 		// delete from distributed cache
@@ -219,6 +219,8 @@ class Storage {
 	 * @param bool $isAvailable
 	 */
 	public function setAvailability($isAvailable) {
+		// delete from local cache
+		self::unsetCache($this->storageId);
 		$sql = 'UPDATE `*PREFIX*storages` SET `available` = ?, `last_checked` = ? WHERE `id` = ?';
 		$available = $isAvailable ? 1 : 0;
 		\OC_DB::executeAudited($sql, [$available, time(), $this->storageId]);

--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -81,7 +81,7 @@ class Storage {
 				$storageData['numeric_id'] = $this->numericId;
 				$storageData['last_checked'] = null;
 
-				// local cache has been initialized
+				// local cache has been initialized by self::getStorageById
 				self::$localCache->set($this->storageId, $storageData);
 
 				// distributed cache may need initializing

--- a/tests/lib/Files/External/Service/StoragesServiceTest.php
+++ b/tests/lib/Files/External/Service/StoragesServiceTest.php
@@ -23,6 +23,7 @@
  */
 namespace Test\Files\External\Service;
 
+use OC\Files\Cache\Storage;
 use OC\Files\Filesystem;
 use OC\Files\External\StorageConfig;
 use OC\Files\External\Service\StoragesService;
@@ -302,6 +303,7 @@ abstract class StoragesServiceTest extends TestCase {
 			->from('storages')
 			->where($qb->expr()->eq('numeric_id', $qb->expr()->literal($numericId)));
 		$this->assertCount($expectedCountAfterDeletion, $storageCheckQuery->execute()->fetchAll());
+		Storage::remove($rustyStorageId);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
getStorageById is indirectly called by the Availability wrapper, easily leading to hundreds of db queries. With this PR we not only cache the result for the current request but also push it to a distributed cache for 5 min, relieving the DB from executing that query.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with a user_shibboleth user and 100 incoming shares from 100 different user_shibboleth users (each user shared a single folder).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

