### PR TITLE
Using a customized theme should include the name of this theme in $cacheKey.

### DIFF
--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -150,7 +150,7 @@ class URLGenerator implements IURLGenerator {
 	 */
 	public function imagePath($app, $image) {
 		$cache = $this->cacheFactory->create('imagePath');
-		$cacheKey = $app.'-'.$image;
+		$cacheKey = $this->theme->getName().'-'.$app.'-'.$image;
 		if($key = $cache->get($cacheKey)) {
 			return $key;
 		}


### PR DESCRIPTION
## Description
The name of the current theme will be a part of the $cacheKey. It allows to cache image paths depending on the theme. This fixed a bug in v9.0.8 and must be ported to master for consistency.

## Related Issue
https://github.com/owncloud/core/issues/27288

## Motivation and Context
This was a bug in v9.0.8 which caused to load the default favicon instead of the theme favicon. This behavior was limited to this version and did not happen after that version. But accordingly to @PVince81 the change must be forwarded to master as well.

## How Has This Been Tested?
Until now this change is not tested, because I have to prepare my development environment first. But I wanted to share tis with you. Maybe there are some thoughts you want to share.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

