### PR TITLE
use closure to properly defer l10n initialization

### DIFF
--- a/apps/federatedfilesharing/appinfo/app.php
+++ b/apps/federatedfilesharing/appinfo/app.php
@@ -24,14 +24,13 @@ $app = new \OCA\FederatedFileSharing\AppInfo\Application('federatedfilesharing')
 
 use OCA\FederatedFileSharing\Notifier;
 
-$l = \OC::$server->getL10N('files_sharing');
-
 $manager = \OC::$server->getNotificationManager();
 $manager->registerNotifier(function() {
 	return new Notifier(
 		\OC::$server->getL10NFactory()
 	);
-}, function() use ($l) {
+}, function() {
+	$l = \OC::$server->getL10N('files_sharing');
 	return [
 		'id' => 'files_sharing',
 		'name' => $l->t('Federated sharing'),

--- a/apps/files_external/appinfo/app.php
+++ b/apps/files_external/appinfo/app.php
@@ -34,17 +34,17 @@ require_once __DIR__ . '/../3rdparty/autoload.php';
 \OC_Mount_Config::$app = new \OCA\Files_External\AppInfo\Application();
 $appContainer = \OC_Mount_Config::$app->getContainer();
 
-$l = \OC::$server->getL10N('files_external');
-
 $config = \OC::$server->getConfig();
 if ($config->getAppValue('core', 'enable_external_storage', 'no') === 'yes') {
-	\OCA\Files\App::getNavigationManager()->add([
-
-		"id" => 'extstoragemounts',
-		"appname" => 'files_external',
-		"script" => 'list.php',
-		"order" => 30,
-		"name" => $l->t('External storage')
-	]);
+	\OCA\Files\App::getNavigationManager()->add(function () {
+		$l = \OC::$server->getL10N('files_external');
+		return [
+			'id' => 'extstoragemounts',
+			'appname' => 'files_external',
+			'script' => 'list.php',
+			'order' => 30,
+			'name' => $l->t('External storage'),
+		];
+	});
 }
 

--- a/apps/files_sharing/appinfo/app.php
+++ b/apps/files_sharing/appinfo/app.php
@@ -27,8 +27,6 @@
  *
  */
 
-$l = \OC::$server->getL10N('files_sharing');
-
 \OCA\Files_Sharing\Helper::registerHooks();
 
 \OCP\Share::registerBackend('file', 'OCA\Files_Sharing\ShareBackend\File');
@@ -63,38 +61,41 @@ $eventDispatcher->addListener(
 $config = \OC::$server->getConfig();
 if ($config->getAppValue('core', 'shareapi_enabled', 'yes') === 'yes') {
 
-	\OCA\Files\App::getNavigationManager()->add(
-		[
-			"id" => 'sharingin',
-			"appname" => 'files_sharing',
-			"script" => 'list.php',
-			"order" => 10,
-			"name" => $l->t('Shared with you')
-		]
-	);
+	\OCA\Files\App::getNavigationManager()->add(function () {
+		$l = \OC::$server->getL10N('files_sharing');
+		return [
+			'id' => 'sharingin',
+			'appname' => 'files_sharing',
+			'script' => 'list.php',
+			'order' => 10,
+			'name' => $l->t('Shared with you'),
+		];
+	});
 
 	if (\OCP\Util::isSharingDisabledForUser() === false) {
 
-		\OCA\Files\App::getNavigationManager()->add(
-			[
-				"id" => 'sharingout',
-				"appname" => 'files_sharing',
-				"script" => 'list.php',
-				"order" => 15,
-				"name" => $l->t('Shared with others')
-			]
-		);
+		\OCA\Files\App::getNavigationManager()->add(function () {
+			$l = \OC::$server->getL10N('files_sharing');
+			return [
+				'id' => 'sharingout',
+				'appname' => 'files_sharing',
+				'script' => 'list.php',
+				'order' => 15,
+				'name' => $l->t('Shared with others'),
+			];
+		});
 		// Check if sharing by link is enabled
 		if ($config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes') {
-			\OCA\Files\App::getNavigationManager()->add(
-				[
-					"id" => 'sharinglinks',
-					"appname" => 'files_sharing',
-					"script" => 'list.php',
-					"order" => 20,
-					"name" => $l->t('Shared by link')
-				]
-			);
+			\OCA\Files\App::getNavigationManager()->add(function () {
+				$l = \OC::$server->getL10N('files_sharing');
+				return [
+					'id' => 'sharinglinks',
+					'appname' => 'files_sharing',
+					'script' => 'list.php',
+					'order' => 20,
+					'name' => $l->t('Shared by link'),
+				];
+			});
 		}
 	}
 }

--- a/apps/files_trashbin/appinfo/app.php
+++ b/apps/files_trashbin/appinfo/app.php
@@ -25,17 +25,16 @@
  *
  */
 
-$l = \OC::$server->getL10N('files_trashbin');
-
 // register hooks
 \OCA\Files_Trashbin\Trashbin::registerHooks();
 
-\OCA\Files\App::getNavigationManager()->add(
-[
-	"id" => 'trashbin',
-	"appname" => 'files_trashbin',
-	"script" => 'list.php',
-	"order" => 50,
-	"name" => $l->t('Deleted files')
-]
-);
+\OCA\Files\App::getNavigationManager()->add(function () {
+	$l = \OC::$server->getL10N('files_trashbin');
+	return [
+		'id' => 'trashbin',
+		'appname' => 'files_trashbin',
+		'script' => 'list.php',
+		'order' => 50,
+		'name' => $l->t('Deleted files'),
+	];
+});

--- a/apps/systemtags/appinfo/app.php
+++ b/apps/systemtags/appinfo/app.php
@@ -78,14 +78,13 @@ $mapperListener = function(MapperEvent $event) use ($activityManager) {
 $eventDispatcher->addListener(MapperEvent::EVENT_ASSIGN, $mapperListener);
 $eventDispatcher->addListener(MapperEvent::EVENT_UNASSIGN, $mapperListener);
 
-$l = \OC::$server->getL10N('systemtags');
-
-\OCA\Files\App::getNavigationManager()->add(
-	[
+\OCA\Files\App::getNavigationManager()->add(function () {
+	$l = \OC::$server->getL10N('systemtags');
+	return [
 		'id' => 'systemtagsfilter',
 		'appname' => 'systemtags',
 		'script' => 'list.php',
 		'order' => 25,
 		'name' => $l->t('Tags')
-	]
-);
+	];
+});


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
fixes translation of web ui for ldap users. backport to 9.1 requested

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Mixed language in the UI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
locally, with ldap and german, english, spanish language mix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

