### PR TITLE
Optimize PROPFIND having CommentsApp enabled by default

### DIFF
--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -21,7 +21,7 @@
  *
  */
 namespace OCP\Comments;
-
+use \OCP\IUser;
 /**
  * Interface ICommentsManager
  *
@@ -113,6 +113,27 @@ interface ICommentsManager {
 			$offset = 0,
 			\DateTime $notOlderThan = null
 	);
+
+	/**
+	 * Returns number of unread messages for specified nodeIDs, if there are any unread comments
+	 * 
+	 * Example query:
+	 * SELECT object_id, COUNT(object_id) FROM oc_comments C
+	 * 	WHERE object_id IN('79', '80', '34', '36', '38', '33')
+	 * 	AND object_id NOT IN(
+	 * 		SELECT object_id FROM oc_comments_read_markers CRM
+	 * 			WHERE C.object_id = CRM.object_id
+	 * 			AND user_id = 'receiver2'
+	 * 			AND marker_datetime > C.creation_timestamp)
+	 * GROUP BY object_id;
+	 *
+	 * @param string $objectType string the object type: Example 'files'
+	 * @param int[] $objectIds NodeIDs that may be returned: Example { 44, 36, 50, 60 }[4]
+	 * @param IUser $user
+	 * @return int[] $unreadCountsForNodes hash table: Example { 44 => 2, 36 => 1 }[2]
+	 * @since 10.0.0
+	 */
+	public function getNumberOfUnreadCommentsForNodes($objectType, $objectIds, IUser $user);
 
 	/**
 	 * @param $objectType string the object type, e.g. 'files'

--- a/tests/lib/Comments/FakeManager.php
+++ b/tests/lib/Comments/FakeManager.php
@@ -38,4 +38,6 @@ class FakeManager implements \OCP\Comments\ICommentsManager {
 	public function deleteReadMarksFromUser(\OCP\IUser $user) {}
 
 	public function deleteReadMarksOnObject($objectType, $objectId) {}
+
+	public function getNumberOfUnreadCommentsForNodes($objectType, $objectIds, \OCP\IUser $user) {}
 }


### PR DESCRIPTION
The idea here is to reduce number of O(n) queries coming from each PROPFIND in the web browser for instance with enabled comments app (this is by default). 

Prefetching required data in one query instead of iterative queries should reduce number of queries to O(1), where N is number of files in the folder.

Query 
`SELECT object_id, COUNT(object_id) FROM oc_comments C WHERE object_id IN(?) AND object_id NOT IN(SELECT object_id FROM oc_comments_read_markers CRM WHERE C.object_id = CRM.object_id AND CRM.user_id = '?' AND CRM.marker_datetime > C.creation_timestamp) GROUP BY object_id;` 
does the job very well. Yes, I know it is more OLAP query, but this is what Web Front End is about. This is also most optimal query in our case https://sqlperformance.com/2012/12/t-sql-queries/left-anti-semi-join 


- [x] Finish first optimization
- [x] Add chunking of IN() query for more NodeIDs to 100
- [x] Add unit tests for optimization 
- [x] Inform that Comments app is now "usable" for bigger instances @felixboehm @cdamken 

**Case 1**
![selection_051](https://cloud.githubusercontent.com/assets/13368647/23796605/197f0582-059c-11e7-8079-c2fd3aa30ee1.jpg)

`- 16 queries` - this is worst case because caching of `getDirectoryListing` is not yet done
![selection_050](https://cloud.githubusercontent.com/assets/13368647/23796591/fc578254-059b-11e7-8e44-832364296702.jpg)


**Case 2**
100 NON-SHARED/SHARED files, just someone uploaded >100 files to the folder

`- 200 queries` - this is best case
![selection_057](https://cloud.githubusercontent.com/assets/13368647/23822489/b4e96196-064d-11e7-8598-126bdd14fd7f.jpg)
![selection_056](https://cloud.githubusercontent.com/assets/13368647/23822492/b9a63132-064d-11e7-9e0c-35f480f20ab6.jpg)




