### PR TITLE
Add paginated collection for Backbone adapter

### DIFF
--- a/core/js/oc-backbone-webdav.js
+++ b/core/js/oc-backbone-webdav.js
@@ -56,6 +56,10 @@
 /* global dav */
 
 (function(Backbone) {
+	var defaultXmlNamespaces = {
+		'DAV:': 'd',
+		'http://owncloud.org/ns': 'oc'
+	};
 	var methodMap = {
 		'create': 'POST',
 		'update': 'PROPPATCH',
@@ -64,9 +68,29 @@
 		'read':   'PROPFIND'
 	};
 
+	// borrow this method from the dav client library
+	var parseClarkNotation = dav.Client.prototype.parseClarkNotation;
+	var escapeXml = dav._escapeXml;
+
 	// Throw an error when a URL is needed, and none is supplied.
 	function urlError() {
 		throw new Error('A "url" property or function must be specified');
+	}
+
+	function getDavProperties(model, options) {
+		var davProperties = model.davProperties;
+		if (!davProperties && model.model) {
+			// use dav properties from model in case of collection
+			davProperties = model.model.prototype.davProperties;
+		}
+		if (davProperties) {
+			if (_.isFunction(davProperties)) {
+				davProperties = davProperties.call(model);
+			}
+		}
+
+		davProperties = _.extend(davProperties || {}, options.davProperties);
+		return davProperties;
 	}
 
 	/**
@@ -261,10 +285,7 @@
 	function davCall(options, model) {
 		var client = new dav.Client({
 			baseUrl: options.url,
-			xmlNamespaces: _.extend({
-				'DAV:': 'd',
-				'http://owncloud.org/ns': 'oc'
-			}, options.xmlNamespaces || {})
+			xmlNamespaces: _.extend(defaultXmlNamespaces, options.xmlNamespaces || {})
 		});
 		client.resolveUrl = function() {
 			return options.url;
@@ -352,20 +373,7 @@
 		}
 
 		if (params.type === 'PROPFIND' || params.type === 'PROPPATCH' || params.type === 'MKCOL') {
-			var davProperties = model.davProperties;
-			if (!davProperties && model.model) {
-				// use dav properties from model in case of collection
-				davProperties = model.model.prototype.davProperties;
-			}
-			if (davProperties) {
-				if (_.isFunction(davProperties)) {
-					params.davProperties = davProperties.call(model);
-				} else {
-					params.davProperties = davProperties;
-				}
-			}
-
-			params.davProperties = _.extend(params.davProperties || {}, options.davProperties);
+			params.davProperties = getDavProperties(model, options);
 
 			if (_.isUndefined(options.depth)) {
 				if (isCollection) {
@@ -477,6 +485,99 @@
 		}
 	});
 
+	var WebdavChildrenPaginatedCollection = WebdavChildrenCollection.extend({
+
+		limit: 20,
+		endReached: false,
+
+		reportName: '{http://owncloud.org/ns}search-query',
+
+		reset: function() {
+			this.endReached = false;
+			return WebdavChildrenCollection.prototype.reset.apply(this, arguments);
+		},
+
+		fetchNext: function(options) {
+			var self = this;
+			options = options || {};
+			if (this.endReached) {
+				return null;
+			}
+
+			var reportName = _.result(this, 'reportName');
+			if (!reportName) {
+				throw 'reportName attribute must be set';
+			}
+
+			options.xmlNamespaces = _.extend(defaultXmlNamespaces, options.xmlNamespaces || {});
+
+			// convert clark notation to namespaced name
+			reportName = parseClarkNotation(reportName);
+			reportName = options.xmlNamespaces[reportName.namespace] + ':' + reportName.name;
+
+			// header
+			var body =
+				'<?xml version="1.0" encoding="utf-8" ?>\n' +
+				'<' + reportName + ' ';
+			var namespace;
+			for (namespace in options.xmlNamespaces) {
+				body += ' xmlns:' + options.xmlNamespaces[namespace] + '="' + namespace + '"';
+			}
+			body += '>\n';
+
+			// properties query
+			var davProperties = getDavProperties(this, options);
+			body += '    <d:prop>\n';
+			_.each(davProperties, function(prop) {
+				var property = parseClarkNotation(prop);
+				body += '        <' + options.xmlNamespaces[property.namespace] + ':' + property.name + ' />\n';
+			});
+			body += '    </d:prop>\n';
+
+			// search query
+			body +=
+				'    <oc:search>\n';
+			if (options.searchPattern) {
+				body += '        <oc:pattern>' + escapeXml(options.searchPattern) + '</oc:pattern>\n';
+			}
+			body +=
+				'        <oc:offset>' + escapeXml('' + this.length) + '</oc:offset>\n' +
+				'        <oc:limit>' + escapeXml('' + (this.limit + 1)) + '</oc:limit>\n' +
+				'    </oc:search>\n';
+
+			body += '</' + reportName + '>';
+
+			var success = options.success;
+			options = _.extend({
+				remove: false,
+				parse: true,
+				data: body,
+				davProperties: davProperties
+			}, options);
+
+			options.success = function(resp) {
+				if (resp.length <= self.limit) {
+					// no new entries, end reached
+					self.endReached = true;
+				} else {
+					// remove last entry, for next page load
+					resp = _.initial(resp);
+				}
+
+				if (!self.set(resp, options)) {
+					return false;
+				}
+				if (success) {
+					success.apply(null, arguments);
+				}
+				self.trigger('sync', self, resp, options);
+			};
+
+			return this.sync('REPORT', this, options);
+		}
+
+	});
+
 	// exports
 	Backbone.davCall = davCall;
 	Backbone.davSync = davSync;
@@ -484,6 +585,7 @@
 	Backbone.WebdavNode = WebdavNode;
 	Backbone.WebdavChildrenCollection = WebdavChildrenCollection;
 	Backbone.WebdavCollectionNode = WebdavCollectionNode;
+	Backbone.WebdavChildrenPaginatedCollection = WebdavChildrenPaginatedCollection;
 
 })(OC.Backbone);
 


### PR DESCRIPTION
## Description
Paginated collection uses REPORT method with some conventions to achieve simple search (pattern) and pagination (offset, limit). When calling `fetchNext()` it uses REPORT instead of PROPFIND on the same endpoint to fetch results, then adds them to the collection.

## Related Issue
None

## Motivation and Context
Abilty to quickly reuse paginated collection code instead of rewriting this in every app

## How Has This Been Tested?
Manually with a customgroups branch (to be posted)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## TODOs:

- [ ] add JS unit tests