### PR TITLE
Providing --path option to transfer-ownership

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -32,6 +32,7 @@ use OCP\IUserManager;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -64,6 +65,9 @@ class TransferOwnership extends Command {
 	private $destinationUser;
 
 	/** @var string */
+	private $inputPath;
+
+	/** @var string */
 	private $finalTarget;
 
 	public function __construct(IUserManager $userManager, IManager $shareManager, IMountManager $mountManager) {
@@ -86,6 +90,12 @@ class TransferOwnership extends Command {
 				'destination-user',
 				InputArgument::REQUIRED,
 				'user who will be the new owner of the files'
+			)
+			->addOption(
+				'path',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'selectively provide the path to transfer. For example --path="folder_name"'
 			);
 	}
 
@@ -103,6 +113,8 @@ class TransferOwnership extends Command {
 
 		$this->sourceUser = $sourceUserObject->getUID();
 		$this->destinationUser = $destinationUserObject->getUID();
+		$this->inputPath = $input->getOption('path');
+		$this->inputPath = ltrim($this->inputPath, '/');
 
 		// target user has to be ready
 		if (!\OC::$server->getEncryptionManager()->isReadyForUser($this->destinationUser)) {
@@ -117,6 +129,16 @@ class TransferOwnership extends Command {
 		// setup filesystem
 		Filesystem::initMountPoints($this->sourceUser);
 		Filesystem::initMountPoints($this->destinationUser);
+
+		if (strlen($this->inputPath) >= 1) {
+			$view = new View();
+			$unknownDir = $this->inputPath;
+			$this->inputPath = $this->sourceUser . "/files/" . $this->inputPath;
+			if (!$view->is_dir($this->inputPath)) {
+				$output->writeln("<error>Unknown path provided: $unknownDir</error>");
+				return 1;
+			}
+		}
 
 		// analyse source folder
 		$this->analyse($output);
@@ -152,7 +174,14 @@ class TransferOwnership extends Command {
 		$progress = new ProgressBar($output);
 		$progress->start();
 		$self = $this;
-		$this->walkFiles($view, "$this->sourceUser/files",
+		$walkPath = "$this->sourceUser/files";
+		if ( strlen($this->inputPath) > 0) {
+			if ($this->inputPath !== "$this->sourceUser/files") {
+				$walkPath = $this->inputPath;
+			}
+		}
+
+		$this->walkFiles($view, $walkPath,
 				function (FileInfo $fileInfo) use ($progress, $self) {
 					if ($fileInfo->getType() === FileInfo::TYPE_FOLDER) {
 						// only analyze into folders from main storage,
@@ -214,9 +243,20 @@ class TransferOwnership extends Command {
 	protected function transfer(OutputInterface $output) {
 		$view = new View();
 		$output->writeln("Transferring files to $this->finalTarget ...");
-		$view->rename("$this->sourceUser/files", $this->finalTarget);
-		// because the files folder is moved away we need to recreate it
-		$view->mkdir("$this->sourceUser/files");
+		$sourcePath = (strlen($this->inputPath) > 0) ? $this->inputPath : "$this->sourceUser/files";
+		// This change will help user to transfer the folder specified using --path option.
+		// Else only the content inside folder is transferred which is not correct.
+		if (strlen($this->inputPath) > 0) {
+			if($this->inputPath !== ltrim("$this->sourceUser/files", '/')) {
+				$view->mkdir($this->finalTarget);
+				$this->finalTarget = $this->finalTarget . '/' . basename($sourcePath);
+			}
+		}
+		$view->rename($sourcePath, $this->finalTarget);
+		if (!is_dir("$this->sourceUser/files")) {
+			// because the files folder is moved away we need to recreate it
+			$view->mkdir("$this->sourceUser/files");
+		}
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/CommandLineContext.php
+++ b/tests/integration/features/bootstrap/CommandLineContext.php
@@ -89,6 +89,20 @@ class CommandLineContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
+	 * @When /^transfering ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)"/
+	 */
+	public function transferingOwnershipPath($path, $user1, $user2) {
+		$path = '--path=' . $path;
+		if($this->runOcc(['files:transfer-ownership', $path, $user1, $user2]) === 0) {
+			$this->lastTransferPath = $this->findLastTransferFolderForUser($user1, $user2);
+		} else {
+			// failure
+			$this->lastTransferPath = null;
+		}
+	}
+
+
+	/**
 	 * @When /^using received transfer folder of "([^"]+)" as dav path$/
 	 */
 	public function usingTransferFolderAsDavPath($user) {

--- a/tests/integration/features/transfer-ownership.feature
+++ b/tests/integration/features/transfer-ownership.feature
@@ -126,3 +126,118 @@ Feature: transfer-ownership
 		Then the command error output contains the text "Unknown target user"
 		And the command failed with exit code 1
 
+	@no_encryption
+	Scenario: transfering ownership of a folder
+		Given user "user0" exists
+		And user "user1" exists
+		And User "user0" created a folder "/test"
+		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		When transfering ownership of path "test" from "user0" to "user1"
+		And the command was successful
+		And As an "user1"
+		And using received transfer folder of "user1" as dav path
+		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+
+	@no_encryption
+	Scenario: transfering ownership of file shares
+		Given user "user0" exists
+		And user "user1" exists
+		And user "user2" exists
+		And User "user0" created a folder "/test"
+		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		And file "/test/somefile.txt" of user "user0" is shared with user "user2" with permissions 19
+		When transfering ownership of path "test" from "user0" to "user1"
+		And the command was successful
+		And As an "user2"
+		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
+
+	@no_encryption
+	Scenario: transfering ownership of folder shared with third user
+		Given user "user0" exists
+		And user "user1" exists
+		And user "user2" exists
+		And User "user0" created a folder "/test"
+		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
+		When transfering ownership of path "test" from "user0" to "user1"
+		And the command was successful
+		And As an "user2"
+		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+
+	@no_encryption
+	Scenario: transfering ownership of folder shared with transfer recipient
+		Given user "user0" exists
+		And user "user1" exists
+		And User "user0" created a folder "/test"
+		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		And folder "/test" of user "user0" is shared with user "user1" with permissions 31
+		When transfering ownership of path "test" from "user0" to "user1"
+		And the command was successful
+		And As an "user1"
+		Then as "user1" the folder "/test" does not exist
+		And using received transfer folder of "user1" as dav path
+		And Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+
+	@no_encryption
+	Scenario: transfering ownership of folder doubly shared with third user
+		Given group "group1" exists
+		And user "user0" exists
+		And user "user1" exists
+		And user "user2" exists
+		And user "user2" belongs to group "group1"
+		And User "user0" created a folder "/test"
+		And User "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		And folder "/test" of user "user0" is shared with group "group1" with permissions 31
+		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
+		When transfering ownership of path "test" from "user0" to "user1"
+		And the command was successful
+		And As an "user2"
+		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+
+	@no_encryption
+	Scenario: transfering ownership does not transfer received shares
+		Given user "user0" exists
+		And user "user1" exists
+		And user "user2" exists
+		And User "user2" created a folder "/test"
+		And User "user0" created a folder "/sub"
+		And folder "/test" of user "user2" is shared with user "user0" with permissions 31
+		And User "user0" moved folder "/test" to "/sub/test"
+		When transfering ownership of path "sub" from "user0" to "user1"
+		And the command was successful
+		And As an "user1"
+		And using received transfer folder of "user1" as dav path
+		Then as "user1" the folder "/sub/test" does not exist
+
+	@no_encryption
+	@local_storage
+	Scenario: transfering ownership does not transfer external storage
+		Given user "user0" exists
+		And user "user1" exists
+		And User "user0" created a folder "/sub"
+		When transfering ownership of path "sub" from "user0" to "user1"
+		And the command was successful
+		And As an "user1"
+		And using received transfer folder of "user1" as dav path
+		Then as "user1" the folder "/local_storage" does not exist
+
+	Scenario: transfering ownership fails with invalid source user
+		Given user "user0" exists
+		And User "user0" created a folder "/sub"
+		When transfering ownership of path "sub" from "invalid_user" to "user0"
+		Then the command error output contains the text "Unknown source user"
+		And the command failed with exit code 1
+
+	Scenario: transfering ownership fails with invalid target user
+		Given user "user0" exists
+		And User "user0" created a folder "/sub"
+		When transfering ownership of path "sub" from "user0" to "invalid_user"
+		Then the command error output contains the text "Unknown target user"
+		And the command failed with exit code 1
+
+	Scenario: transfering ownership fails with invalid path
+		Given user "user0" exists
+		And user "user1" exists
+		When transfering ownership of path "test" from "user0" to "user1"
+		Then the command error output contains the text "Unknown target user"
+		And the command failed with exit code 1


### PR DESCRIPTION
This will help user to selectively move the folders
specified using --path option, instead of moving
entire folder under files directory.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
The change has been made for occ command's transfer-ownership. An additional --path argument has been added to support. This will help user to pass particular folder/file to move to destination user/target. So I have introduced an optional argument --path. I have deliberately made it optional, as its user choice to move entire folder under files or selectively.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This issue which this patch addresses is https://github.com/owncloud/platform/issues/91

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This helps the user to selectively transfer the ownership of the files/folders instead of moving entire folder under files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Below is the way I have tested:

The folder files/1/1a/1aa/ has 1aaa, 1aab and 1aac folders
root@silburyadmin-Inspiron-5567:/home/sujith/test/owncloud# sudo -u www-data ./occ  files:transfer-ownership --path "test1/files/1/1a/1aa" test1 test2 
Analysing files of test1 ...
    0 [>---------------------------]
Collecting all share information for files and folder of test1 ...
    0 [>---------------------------]
Transferring files to test2/files/transferred from test1 on 20170309_101206 ...
Restoring shares ...
    0 [>---------------------------]
root@silburyadmin-Inspiron-5567:/home/sujith/test/owncloud#

after the execution I was able to see in test2 user:

root@silburyadmin-Inspiron-5567:/home/sujith/test/owncloud# ls -lt data/test2/files/transferred\ from\ test1\ on\ 20170309_101206/
total 12
drwxr-xr-x 2 www-data www-data 4096 Mar  9 15:42 1aac
drwxr-xr-x 2 www-data www-data 4096 Mar  9 15:42 1aab
drwxr-xr-x 2 www-data www-data 4096 Mar  9 15:42 1aaa
root@silburyadmin-Inspiron-5567:/home/sujith/test/owncloud#

and in test1 user:

root@silburyadmin-Inspiron-5567:/home/sujith/test/owncloud# ls data/test1/files/1/1a/
1ab
root@silburyadmin-Inspiron-5567:/home/sujith/test/owncloud#

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

