### PR TITLE
if external storage has been disabled, a full screen error is not shown

### DIFF
--- a/apps/files_external/templates/list.php
+++ b/apps/files_external/templates/list.php
@@ -7,7 +7,25 @@
 <div id="emptycontent" class="hidden">
 	<div class="icon-external"></div>
 	<h2><?php p($l->t('No external storage configured')); ?></h2>
-	<p><a href="<?php p(link_to('', 'index.php/settings/admin?sectionid=storage' )); ?>"><?php p($l->t('You can add external storages in the personal settings')); ?></a></p>
+
+	<?php
+		$userId = \OC::$server->getUserSession()->getUser()->getUID();
+		if (\OC::$server->getGroupManager()->isAdmin($userId)) {
+			echo 	'<p><a href="' .
+				link_to('', 'index.php/settings/admin?sectionid=storage' ) .
+				'">' .
+				$l->t('You can add external storages in storage settings') .
+				'</a></p>';
+		}
+
+		else {
+			echo 	'<p><a href="' .
+				link_to('', 'index.php/settings/personal?sectionid=storage' ) .
+				'">' .
+				$l->t('You can add external storages in storage settings') .
+				'</a></p>';
+		}
+	?>
 </div>
 
 <input type="hidden" name="dir" value="" id="dir">

--- a/apps/files_external/templates/list.php
+++ b/apps/files_external/templates/list.php
@@ -14,7 +14,7 @@
 			echo 	'<p><a href="' .
 				link_to('', 'index.php/settings/admin?sectionid=storage' ) .
 				'">' .
-				$l->t('You can add external storages in storage settings') .
+				$l->t('You can add external storages in the storage settings') .
 				'</a></p>';
 		}
 
@@ -22,7 +22,7 @@
 			echo 	'<p><a href="' .
 				link_to('', 'index.php/settings/personal?sectionid=storage' ) .
 				'">' .
-				$l->t('You can add external storages in storage settings') .
+				$l->t('You can add external storages in the storage settings') .
 				'</a></p>';
 		}
 	?>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Fixes #27285 

if external storage has been disabled, a full screen error is not shown

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/27285

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
if external storage has been disabled, a full screen error is not shown

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with both admin and non-admin user.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

