### PR TITLE
[stable9.1] fix objectstore rename

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -506,7 +506,8 @@ class File extends Node implements IFile {
 		// TODO: in the future use ChunkHandler provided by storage
 		// and/or add method on Storage called "needsPartFile()"
 		return !$storage->instanceOfStorage('OCA\Files_Sharing\External\Storage') &&
-		!$storage->instanceOfStorage('OC\Files\Storage\OwnCloud');
+			!$storage->instanceOfStorage('OC\Files\Storage\OwnCloud') &&
+			!$storage->instanceOfStorage('OC\Files\ObjectStore\ObjectStoreStorage');
 	}
 
 	/**

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -517,7 +517,12 @@ class FileTest extends \Test\TestCase {
 			$thrown = true;
 		}
 
-		$this->assertTrue($thrown);
+		// objectstore does not use partfiles -> no move after upload -> no exception
+		if (getenv('RUN_OBJECTSTORE_TESTS')) {
+			$this->assertFalse($thrown);
+		} else {
+			$this->assertTrue($thrown);
+		}
 		$this->assertEmpty($this->listPartFiles(), 'No stray part files');
 	}
 

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -305,9 +305,8 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	public function rename($source, $target) {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
-		$sourceEntry = $this->getCache()->get($source);
-		$this->getCache()->copyFromCache($this->getCache(), $sourceEntry, $target);
-		$this->remove($source);
+		$this->remove($target);
+		$this->getCache()->move($source, $target);
 		$this->touch(dirname($target));
 		return true;
 	}

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -305,8 +305,9 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	public function rename($source, $target) {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
-		$this->remove($target);
-		$this->getCache()->move($source, $target);
+		$sourceEntry = $this->getCache()->get($source);
+		$this->getCache()->copyFromCache($this->getCache(), $sourceEntry, $target);
+		$this->remove($source);
 		$this->touch(dirname($target));
 		return true;
 	}


### PR DESCRIPTION
backport of https://github.com/owncloud/core/pull/27281 to stable9.1