### PR TITLE
Always use ALT_HOME mode for integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,28 +132,11 @@ timestampedNode('SLAVE') {
 			rm -rf config/config.php data/*
 			./occ maintenance:install --admin-pass=admin
 			make clean-test-integration
-			make test-integration
+			make test-integration OC_TEST_ALT_HOME=1
 		   '''
 		}
 
 		if (isOnReleaseBranch()) {
-
-			executeAndReport('tests/integration/output/*.xml') {
-				sh '''phpenv local 7.0
-				rm -rf config/config.php data/*
-				./occ maintenance:install --admin-pass=admin
-				make clean-test-integration
-				make test-integration OC_TEST_ALT_HOME=1
-			   '''
-			}
-			executeAndReport('tests/integration/output/*.xml') {
-				sh '''phpenv local 7.0
-				rm -rf config/config.php data/*
-				./occ maintenance:install --admin-pass=admin
-				make clean-test-integration
-				make test-integration OC_TEST_ENCRYPTION_ENABLED=1
-			   '''
-			}
 			executeAndReport('tests/integration/output/*.xml') {
 				sh '''phpenv local 7.0
 				rm -rf config/config.php data/*


### PR DESCRIPTION
Because the results for this test also cover the non-alt-home case
indirectly, so no need to spend more time testing.

@DeepDiver1975 @SergioBertolinSG this should reduce the testing time on master hopefully.