### PR TITLE
modal parameter added while showing confirmation alert

### DIFF
--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -184,14 +184,14 @@ OCA.External.StatusManager = {
 							if (e === true) {
 								OC.redirect(OC.generateUrl('/settings/admin?sectionid=storage'));
 							}
-						});
+						}, true);
 					}
 				} else {
 					OC.dialogs.confirm(t('files_external', 'There was an error with message: ') + mountData.error + '. Do you want to review mount point config in personal settings page?', t('files_external', 'External mount error'), function (e) {
 						if (e === true) {
 							OC.redirect(OC.generateUrl('/settings/personal?sectionid=storage'));
 						}
-					});
+					}, true);
 				}
 			}
 		}, this));

--- a/apps/files_external/js/statusmanager.js
+++ b/apps/files_external/js/statusmanager.js
@@ -182,7 +182,12 @@ OCA.External.StatusManager = {
 					} else {
 						OC.dialogs.confirm(t('files_external', 'There was an error with message: ') + mountData.error + '. Do you want to review mount point config in admin settings page?', t('files_external', 'External mount error'), function (e) {
 							if (e === true) {
-								OC.redirect(OC.generateUrl('/settings/admin?sectionid=storage'));
+								if (OC.isUserAdmin()) {
+									OC.redirect(OC.generateUrl('/settings/admin?sectionid=storage'));
+								}
+								else {
+									OC.redirect(OC.generateUrl('/settings/personal?sectionid=storage'));
+								}
 							}
 						}, true);
 					}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Fixes #27357 

Single pop-up shown if keep clicking wrongly mounted external storage

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/27357

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested both as admin and non-admin user.

Even added that if user is non-admin, and at the alert "Yes" is pressed, a full page non-admin error wouldn't be shown ( in reference to #27285 ).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@PVince81 