### PR TITLE
27347 fixed message display error

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -1355,6 +1355,7 @@ $(document).ready(function() {
 			var value = checked ? 'yes' : 'no';
 			OC.AppConfig.setValue('core', 'enable_external_storage', value);
 			$('#files_external_settings').toggleClass('hidden', !checked);
+			$("#files_external_message").toggleClass('hidden', checked);
 		};
 
 		if (checked === false) {

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -1376,6 +1376,10 @@ $(document).ready(function() {
 		}
 	});
 
+	$('body').on('click', 'a.oc-dialog-close', function () {
+		$('#files_external input[name=enableExternalStorage]').prop('checked', true);
+	});
+
 	// global instance
 	OCA.External.Settings.mountConfig = mountConfigListView;
 

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -42,10 +42,11 @@
 		</label>
 	</p>
 	<?php endif; ?>
-	<p
-	<?php if ($_['enableExternalStorage']): ?>
-		style="display: none;"
-	<?php endif; ?>
+	<p class="
+		<?php if ($_['enableExternalStorage']): ?> 
+			hidden 
+		<?php endif; ?>
+		files_external_message"
 	>
 		<?php p($l->t('External storage has been disabled by the administrator')); ?>
 	</p>

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -42,9 +42,13 @@
 		</label>
 	</p>
 	<?php endif; ?>
-	<?php if (!$_['enableExternalStorage']): ?>
-	<p><?php p($l->t('External storage has been disabled by the administrator')); ?></p>
+	<p
+	<?php if ($_['enableExternalStorage']): ?>
+		style="display: none;"
 	<?php endif; ?>
+	>
+		<?php p($l->t('External storage has been disabled by the administrator')); ?>
+	</p>
 
 	<div id="files_external_settings" class=" <?php if (!$_['enableExternalStorage']) print('hidden'); ?>">
 

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -42,11 +42,11 @@
 		</label>
 	</p>
 	<?php endif; ?>
-	<p class="
-		<?php if ($_['enableExternalStorage']): ?> 
-			hidden 
+	<p
+		<?php if ($_['enableExternalStorage']): ?>
+			class="hidden"
 		<?php endif; ?>
-		files_external_message"
+		id="files_external_message"
 	>
 		<?php p($l->t('External storage has been disabled by the administrator')); ?>
 	</p>

--- a/settings/js/settings.js
+++ b/settings/js/settings.js
@@ -96,3 +96,13 @@ OC.Settings = _.extend(OC.Settings, {
 		}
 	}
 });
+
+$(document).ready(function () {
+	$("#enableExternalStorageCheckbox").change(function() {
+		if($(this).is(":checked")) {
+			$("#files_external p:nth-of-type(2)").hide();
+		} else {
+			$("#files_external p:nth-of-type(2)").show();
+		}
+	});
+});

--- a/settings/js/settings.js
+++ b/settings/js/settings.js
@@ -96,13 +96,3 @@ OC.Settings = _.extend(OC.Settings, {
 		}
 	}
 });
-
-$(document).ready(function () {
-	$("#enableExternalStorageCheckbox").change(function() {
-		if($(this).is(":checked")) {
-			$("#files_external p:nth-of-type(2)").hide();
-		} else {
-			$("#files_external p:nth-of-type(2)").show();
-		}
-	});
-});


### PR DESCRIPTION
## Description
- Modified the settings template to add the information message even if `external storage` is enabled, but hidden;
- Added the required javascript to display/hide the information message.

## Related Issue
External Storage has been disabled by administrator" doesn't disappear until full page refresh if enabled. #27347

## Motivation and Context
Solves the front-end display problem described in the issue

## How Has This Been Tested?
Passed all the javascript tests. Also, no functionality has been affected.

## Screenshots (if appropriate):
http://recordit.co/Hk6lYCI9iB

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

P.S.: This is my first pull request and contribution, please correct me if I did something wrong.
