### PR TITLE
Optimize any request by eliminating redundant query for rootInfo and its contents

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -188,7 +188,6 @@ class Server {
 				$this->server->addPlugin(new SharesPlugin(
 					$this->server->tree,
 					$userSession,
-					$userFolder,
 					\OC::$server->getShareManager()
 				));
 				$this->server->addPlugin(new CommentPropertiesPlugin(

--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -69,12 +69,9 @@ class SharesPluginTest extends \Test\TestCase {
 			->method('getUser')
 			->will($this->returnValue($user));
 
-		$this->userFolder = $this->createMock('\OCP\Files\Folder');
-
 		$this->plugin = new \OCA\DAV\Connector\Sabre\SharesPlugin(
 			$this->tree,
 			$userSession,
-			$this->userFolder,
 			$this->shareManager
 		);
 		$this->plugin->initialize($this->server);
@@ -90,20 +87,6 @@ class SharesPluginTest extends \Test\TestCase {
 		$sabreNode->expects($this->any())
 			->method('getId')
 			->will($this->returnValue(123));
-		$sabreNode->expects($this->once())
-			->method('getPath')
-			->will($this->returnValue('/subdir'));
-
-		// node API nodes
-		$node = $this->createMock('\OCP\Files\Folder');
-		$node->expects($this->any())
-			->method('getId')
-			->will($this->returnValue(123));
-
-		$this->userFolder->expects($this->once())
-			->method('get')
-			->with('/subdir')
-			->will($this->returnValue($node));
 
 		$requestedShareTypes = [
 			\OCP\Share::SHARE_TYPE_USER,
@@ -179,33 +162,12 @@ class SharesPluginTest extends \Test\TestCase {
 			->method('getId')
 			->will($this->returnValue(123));
 		// never, because we use getDirectoryListing from the Node API instead
-		$sabreNode->expects($this->never())
-			->method('getChildren');
+		$sabreNode->expects($this->once())
+			->method('getChildren')
+		->will($this->returnValue([$sabreNode1,$sabreNode2]));
 		$sabreNode->expects($this->any())
 			->method('getPath')
 			->will($this->returnValue('/subdir'));
-
-		// node API nodes
-		$node = $this->createMock('\OCP\Files\Folder');
-		$node->expects($this->any())
-			->method('getId')
-			->will($this->returnValue(123));
-		$node1 = $this->createMock('\OCP\Files\File');
-		$node1->expects($this->any())
-			->method('getId')
-			->will($this->returnValue(111));
-		$node2 = $this->createMock('\OCP\Files\File');
-		$node2->expects($this->any())
-			->method('getId')
-			->will($this->returnValue(222));
-		$node->expects($this->once())
-			->method('getDirectoryListing')
-			->will($this->returnValue([$node1, $node2]));
-
-		$this->userFolder->expects($this->once())
-			->method('get')
-			->with('/subdir')
-			->will($this->returnValue($node));
 
 		$requestedShareTypes = [
 			\OCP\Share::SHARE_TYPE_USER,


### PR DESCRIPTION
#I found out that `\OC::$server->getUserFolder();` will finish up calling `$view->getFileInfo('');` and storing this information in its `protected $fileInfo;`, so we can get rid of one redundant FileInfo query here. 

- [x] Optimisation
- [x] Unit tests

Effect of not calling `$view->getFileInfo('')` once again:
**Non-shared:**
![selection_063](https://cloud.githubusercontent.com/assets/13368647/23848919/8e9f5fc6-07d9-11e7-95e4-23ba0d66a171.jpg)


**With shared files of various types:**
![selection_071](https://cloud.githubusercontent.com/assets/13368647/23854967/2929fb72-07f4-11e7-9d1a-2459cffb1a8b.jpg)
![selection_086](https://cloud.githubusercontent.com/assets/13368647/23955031/0734ddc4-0999-11e7-82e1-cd76c4ab840b.jpg)


On my local machine all tests passed. @DeepDiver1975 @PVince81 @butonic @felixboehm 