### PR TITLE
Update the integration test for transfer-ownership

### DIFF
--- a/tests/integration/features/bootstrap/CommandLineContext.php
+++ b/tests/integration/features/bootstrap/CommandLineContext.php
@@ -89,6 +89,20 @@ class CommandLineContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
+	 * @When /^transfering ownership path from path "([^"]+)" "([^"]+)" to "([^"]+)"/
+	 */
+	public function transferingOwnershipPath($path, $user1, $user2) {
+		$path = '--path ' . $path;
+		if($this->runOcc(['files:transfer-ownership', $path, $user1, $user2]) == 0) {
+			$this->lastTransferPath = $this->findLastTransferFolderForUser($user1, $user2);
+		} else {
+			// failure
+			$this->lastTransferPath = null;
+		}
+	}
+
+
+	/**
 	 * @When /^using received transfer folder of "([^"]+)" as dav path$/
 	 */
 	public function usingTransferFolderAsDavPath($user) {

--- a/tests/integration/features/transfer-ownership.feature
+++ b/tests/integration/features/transfer-ownership.feature
@@ -114,6 +114,16 @@ Feature: transfer-ownership
 		When transfering ownership from "user0" to "user1"
 		Then the command was successful
 
+	@no_encryption
+	Scenario: transfering ownership of a folder
+		Given user "user0" exists
+		And user "user1" exists
+		And User "user0" created a folder "/test"
+		When transfering ownership path from path "test" "user0" to "user1"
+		And the command was successful
+		And As an "user1"
+		And using received transfer folder of "user1" as dav path
+
 	Scenario: transfering ownership fails with invalid source user
 		Given user "user0" exists
 		When transfering ownership from "invalid_user" to "user0"


### PR DESCRIPTION
Update the integration test for transfer-ownership
as the new option --path is introduced in the command.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
This is the integration test changes made to include the change from #27343.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
It helps to automate and test the the --path option added for transfer-ownership.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

