### PR TITLE
adding note to ensure having all servers down

### DIFF
--- a/core/Command/Maintenance/Mode.php
+++ b/core/Command/Maintenance/Mode.php
@@ -61,6 +61,7 @@ class Mode extends Command {
 		if ($input->getOption('on')) {
 			$this->config->setSystemValue('maintenance', true);
 			$output->writeln('Maintenance mode enabled');
+			$output->writeln('Please also consider to stop the web server on all ownCloud instances');
 		} elseif ($input->getOption('off')) {
 			$this->config->setSystemValue('maintenance', false);
 			$output->writeln('Maintenance mode disabled');


### PR DESCRIPTION
## Description
Adding note, when enabling maintenance mode.

## Motivation and Context
Shutdown servers is considered as best practice for maintenance.

