### PR TITLE
better waiting for the filesPage to be loaded during UI tests

### DIFF
--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -46,6 +46,7 @@ class FeatureContext extends RawMinkContext implements Context
 	{
 		$this->loginPage->open();
 		$this->filesPage = $this->loginPage->loginAs("admin", "admin");
+		$this->filesPage->waitTillPageIsloaded(10);
 	}
 	
 	/**

--- a/tests/ui/features/bootstrap/LoginContext.php
+++ b/tests/ui/features/bootstrap/LoginContext.php
@@ -53,7 +53,7 @@ class LoginContext extends RawMinkContext implements Context
 	public function iLoginWithUsernameAndPassword($username, $password)
 	{
 		$this->filesPage = $this->loginPage->loginAs($username, $password);
-		$this->loginPage->waitTillPageIsloaded(10);
+		$this->filesPage->waitTillPageIsloaded(10);
 	}
 	
 	/**

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -32,8 +32,28 @@ class FilesPage extends OwnCloudPage
 	 * @var string $path
 	 */
 	protected $path = '/index.php/apps/files/';
+	
+	protected $emptyContentXpath = ".//*[@id='emptycontent']";
 	public function findFileInList($filename)
 	{
 		return $this->findLink($filename);
+	}
+	
+	//there is no reliable loading indicator on the files page, so waiting for
+	//the table or the Emplty Folder message to be shown
+	public function waitTillPageIsloaded($timeout)
+	{
+		for ($counter = 0; $counter <= $timeout; $counter ++) {
+			
+			$fileList = $this->findById("fileList");
+			
+			if ($fileList !== null && 
+				($fileList->has("xpath", "//a") || ! $this->find("xpath", 
+				$this->emptyContentXpath)->hasClass("hidden"))) {
+				break;
+			}
+			
+			sleep(1);
+		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
This should make the UI tests more robust. It makes selenium to wait more reliable for the files Page to be fully loaded before doing the next operation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the Server/Browser reacts too slow Selenium would try to execute the next test step before the page is fully loaded. In that case tests would fail.
As there is no reliable loading indicator on the files page, or better to say, there are multiple, I suggest to wait till the table has links or the empty folder message is shown.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run selenium tests locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

