### PR TITLE
fix caret inconsistency

### DIFF
--- a/core/css/header.css
+++ b/core/css/header.css
@@ -97,16 +97,16 @@
 
 /* hover effect for app switcher label */
 .header-appname-container .header-appname,
-.menutoggle .icon-caret {
+.menutoggle .caret {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=75)";
 	opacity: .75;
 }
 .menutoggle:hover .header-appname,
-.menutoggle:hover .icon-caret,
+.menutoggle:hover .caret,
 .menutoggle:focus .header-appname,
-.menutoggle:focus .icon-caret,
+.menutoggle:focus .caret,
 .menutoggle.active .header-appname,
-.menutoggle.active .icon-caret {
+.menutoggle.active .caret {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
 	opacity: 1;
 }
@@ -124,17 +124,14 @@
 	vertical-align: middle;
 }
 /* show caret indicator next to logo to make clear it is tappable */
-#header .icon-caret {
-	display: inline-block;
-	width: 12px;
-	height: 12px;
-	margin: 0;
-	margin-top: -21px;
-	padding: 0;
+#header .caret {
+	width: 10px;
+	height: 10px;
+	margin: -21px 0 0 3px;
 	vertical-align: middle;
 }
 /* do not show menu toggle on public share links as there is no menu */
-#body-public #header .icon-caret {
+#body-public #header .caret {
 	display: none;
 }
 

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1562,11 +1562,11 @@ function initCore() {
 	// 2 is the additional offset between the triangles
 	if ($('#navigation').length) {
 		$('#header #owncloud + .menutoggle').one('click', function () {
-			var caretPosition = $('.header-appname + .icon-caret').offset().left - 2;
-			if (caretPosition > 255) {
-				// if the app name is longer than the menu, just put the triangle in the middle
-				return;
-			} else {
+			var caret = $('.header-appname + .caret');
+			var caretPosition = caret.offset().left - caret.width() / 2;
+
+			// only position the menu arrow if the caret is in its reach
+			if (caretPosition <= 255) {
 				$('head').append('<style>#navigation:after { left: ' + caretPosition + 'px; }</style>');
 			}
 		});

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -57,7 +57,7 @@
 						}
 					?>
 				</h1>
-				<div class="icon-caret"></div>
+				<img alt="" class="caret" src="<?php print_unescaped(image_path('', 'actions/caret.svg')); ?>">
 			</a>
 
 			<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>


### PR DESCRIPTION
## Description
Users wanted to theme the carets besides the application name and the username. One of those is a div which is getting a background through css, the other one is an image. The image is easily overwritten with a theme, the css one would require additional steps.

It has been a little inconsistent, i fixed that by replacing the div with an image. Also the menu arrow positioning was quite bound to the specific image and size we where using. I fixed that to always point at the middle of the image. As long as it is symmetric, the size and image doesn't matter anymore.

## Related Issue
https://github.com/owncloud/enterprise/issues/1904

## How Has This Been Tested?
There are no tests for the positioning part of the menu arrow. Probably because it depends on the image content that might change. That's why i didn't test it automatically either.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

