### PR TITLE
Fix links to settings admin panels in JS and PHP

### DIFF
--- a/apps/updatenotification/lib/Notification/BackgroundJob.php
+++ b/apps/updatenotification/lib/Notification/BackgroundJob.php
@@ -96,7 +96,7 @@ class BackgroundJob extends TimedJob {
 
 		$status = $updater->check();
 		if (isset($status['version'])) {
-			$url = $this->urlGenerator->linkToRouteAbsolute('settings_admin') . '#updater';
+			$url = $this->urlGenerator->linkToRouteAbsolute('settings.SettingsPage.getAdmin') . '#updater';
 			$this->createNotifications('core', $status['version'], $url);
 		}
 	}

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -17,7 +17,7 @@
 	
 ?>
 <form id="oca_updatenotification_section" class="section">
-	<h2 class="app-name"><?php p($l->t('Updater')); ?></h2>
+	<h2 id="updater" class="app-name"><?php p($l->t('Updater')); ?></h2>
 
 	<?php if($isNewVersionAvailable === true): ?>
 		<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>

--- a/apps/updatenotification/tests/Notification/BackgroundJobTest.php
+++ b/apps/updatenotification/tests/Notification/BackgroundJobTest.php
@@ -159,7 +159,7 @@ class BackgroundJobTest extends TestCase {
 		} else {
 			$this->urlGenerator->expects($this->once())
 				->method('linkToRouteAbsolute')
-				->with('settings_admin')
+				->with('settings.SettingsPage.getAdmin')
 				->willReturn('admin-url');
 
 			$job->expects($this->once())

--- a/core/templates/untrustedDomain.php
+++ b/core/templates/untrustedDomain.php
@@ -10,7 +10,7 @@
 			<?php p($l->t('Depending on your configuration, as an administrator you might also be able to use the button below to trust this domain.')); ?>
 			<br><br>
 			<p style="text-align:center;">
-				<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->getAbsoluteURL(\OCP\Util::linkToRoute('settings_admin'))); ?>?trustDomain=<?php p($_['domain']); ?>" class="button">
+				<a href="<?php print_unescaped(\OC::$server->getURLGenerator()->getAbsoluteURL(\OCP\Util::linkToRoute('settings.SettingsPage.getAdmin'))); ?>?trustDomain=<?php p($_['domain']); ?>" class="button">
 					<?php p($l->t('Add "%s" as trusted domain', [$_['domain']])); ?>
 				</a>
 			</p>

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -258,7 +258,7 @@ class CheckSetupController extends Controller {
 	public function rescanFailedIntegrityCheck() {
 		$this->checker->runInstanceVerification();
 		return new RedirectResponse(
-			$this->urlGenerator->linkToRoute('settings_admin')
+			$this->urlGenerator->linkToRoute('settings.SettingsPage.getAdmin')
 		);
 	}
 

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -608,7 +608,7 @@ class CheckSetupControllerTest extends TestCase {
 		$this->urlGenerator
 			->expects($this->once())
 			->method('linkToRoute')
-			->with('settings_admin')
+			->with('settings.SettingsPage.getAdmin')
 			->will($this->returnValue('/admin'));
 
 		$expected = new RedirectResponse('/admin');


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Fixes several calls to linkToRoute which still use the old `settings_admin` named route. Instead, they now call `SettingsPage#getAdmin` with the correct additional parameters to ensure users arrive at the correct location.

## Related Issue
Fixes https://github.com/owncloud/core/issues/27251

## Motivation and Context
Links pointing the user to settings pages will currently receive errors if the url generation is not updated.

## How Has This Been Tested?
Updated tests + tested in UI.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

