### PR TITLE
Use authType BASIC for Sabre client in integration tests

### DIFF
--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -141,7 +141,6 @@ trait WebDav {
 	public function downloadPublicFileWithRange($range){
 		$token = $this->lastShareData->data->token;
 		$fullUrl = substr($this->baseUrl, 0, -4) . "public.php/webdav";
-		$headers['Range'] = $range;
 
 		$client = new GClient();
 		$options = [];
@@ -160,7 +159,6 @@ trait WebDav {
 	public function downloadPublicFileInsideAFolderWithRange($path, $range){
 		$token = $this->lastShareData->data->token;
 		$fullUrl = substr($this->baseUrl, 0, -4) . "public.php/webdav" . "$path";
-		$headers['Range'] = $range;
 
 		$client = new GClient();
 		$options = [];
@@ -429,6 +427,7 @@ trait WebDav {
 		} else {
 			$settings['password'] = $this->regularUser;
 		}
+		$settings['authType'] = SClient::AUTH_BASIC;
 
 		return new SClient($settings);
 	}
@@ -686,6 +685,8 @@ trait WebDav {
 		} else {
 			$settings['password'] = $this->regularUser;
 		}
+		$settings['authType'] = SClient::AUTH_BASIC;
+
 		$client = new SClient($settings);
 		if (!$properties) {
 			$properties = [


### PR DESCRIPTION
This helps massively reduce the numerous useless 401 exceptions that
appears in the test log. These appear only because Sabre first connects
without any auth type to receive the challenge and then sends the
authentication data.

With this change it will directly use basic auth.

Thanks to @butonic for hinting at this here https://github.com/owncloud/core/pull/27216/files#diff-5c2150d9ba844c7e57f5de66708c7d78R72

Please review @owncloud/qa @DeepDiver1975 

I suggest backporting this, it makes logs from integration tests more readable.