### PR TITLE
[stable9] Fix quota behaviour

### DIFF
--- a/apps/user_ldap/lib/user/user.php
+++ b/apps/user_ldap/lib/user/user.php
@@ -165,6 +165,10 @@ class User {
 		$attr = strtolower($this->connection->ldapQuotaAttribute);
 		if(isset($ldapEntry[$attr])) {
 			$this->updateQuota($ldapEntry[$attr][0]);
+		} else {
+			if ($this->connection->ldapQuotaDefault !== '') {
+				$this->updateQuota();
+			}
 		}
 		unset($attr);
 
@@ -448,6 +452,20 @@ class User {
 	}
 
 	/**
+	 * Overall process goes as follow:
+	 * 1. fetch the quota from LDAP and check if it's parseable with the "verifyQuotaValue" function
+	 * 2. if the value can't be fetched, is empty or not parseable, use the default LDAP quota
+	 * 3. if the default LDAP quota can't be parsed, use the ownCloud's default quota (use 'default')
+	 * 4. check if the target user exists and set the quota for the user.
+	 *
+	 * In order to improve performance and prevent an unwanted extra LDAP call, the $valueFromLDAP
+	 * parameter can be passed with the value of the attribute. This value will be considered as the
+	 * quota for the user coming from the LDAP server (step 1 of the process) It can be useful to
+	 * fetch all the user's attributes in one call and use the fetched values in this function.
+	 * The expected value for that parameter is a string describing the quota for the user. Valid
+	 * values are 'none' (unlimited), 'default' (the ownCloud's default quota), '1234' (quota in
+	 * bytes), '1234 MB' (quota in MB - check the \OC_Helper::computerFileSize method for more info)
+	 *
 	 * fetches the quota from LDAP and stores it as ownCloud user value
 	 * @param string $valueFromLDAP the quota attribute's value can be passed,
 	 * to save the readAttribute request
@@ -457,23 +475,49 @@ class User {
 		if($this->wasRefreshed('quota')) {
 			return;
 		}
-		//can be null
-		$quotaDefault = $this->connection->ldapQuotaDefault;
-		$quota = $quotaDefault !== '' ? $quotaDefault : null;
-		$quota = !is_null($valueFromLDAP) ? $valueFromLDAP : $quota;
 
+		$quota = false;
 		if(is_null($valueFromLDAP)) {
 			$quotaAttribute = $this->connection->ldapQuotaAttribute;
-			if(!empty($quotaAttribute)) {
+			if ($quotaAttribute !== '') {
 				$aQuota = $this->access->readAttribute($this->dn, $quotaAttribute);
 				if($aQuota && (count($aQuota) > 0)) {
-					$quota = $aQuota[0];
+					if ($this->verifyQuotaValue($aQuota[0])) {
+						$quota = $aQuota[0];
+					} else {
+						$this->log->log('not suitable LDAP quota found for user ' . $this->uid . ': [' . $aQuota[0] . ']', \OCP\Util::WARN);
+					}
 				}
 			}
+		} else {
+			if ($this->verifyQuotaValue($valueFromLDAP)) {
+				$quota = $valueFromLDAP;
+			} else {
+				$this->log->log('not suitable LDAP quota found for user ' . $this->uid . ': [' . $valueFromLDAP . ']', \OCP\Util::WARN);
+			}
 		}
-		if(!is_null($quota)) {
-			$user = $this->userManager->get($this->uid)->setQuota($quota);
+		if ($quota === false) {
+			// quota not found using the LDAP attribute (or not parseable). Try the default quota
+			$defaultQuota = $this->connection->ldapQuotaDefault;
+			if ($this->verifyQuotaValue($defaultQuota)) {
+				$quota = $defaultQuota;
+			}
 		}
+		$targetUser = $this->userManager->get($this->uid);
+		if ($targetUser) {
+			if($quota !== false) {
+				$targetUser->setQuota($quota);
+			} else {
+				$this->log->log('not suitable default quota found for user ' . $this->uid . ': [' . $defaultQuota . ']', \OCP\Util::WARN);
+				$targetUser->setQuota('default');
+			}
+		} else {
+			$this->log->log('trying to set a quota for user ' . $this->uid . ' but the user is missing', \OCP\Util::ERROR);
+		}
+	}
+
+	private function verifyQuotaValue($quotaValue) {
+		return $quotaValue === 'none' || $quotaValue === 'default' || \OC_Helper::computerFileSize($quotaValue) !== false;
 	}
 
 	/**

--- a/apps/user_ldap/tests/user/user.php
+++ b/apps/user_ldap/tests/user/user.php
@@ -193,15 +193,17 @@ class Test_User_User extends \Test\TestCase {
 
 		$connection->expects($this->at(0))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
-			->will($this->returnValue('23 GB'));
-
-		$connection->expects($this->at(1))
-			->method('__get')
 			->with($this->equalTo('ldapQuotaAttribute'))
 			->will($this->returnValue('myquota'));
 
-		$connection->expects($this->exactly(2))
+		/* Having a quota defined, the ldapQuotaDefault won't be used
+		$connection->expects($this->at(1))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue('23 GB'));
+		*/
+
+		$connection->expects($this->exactly(1))
 			->method('__get');
 
 		$access->expects($this->once())
@@ -229,6 +231,86 @@ class Test_User_User extends \Test\TestCase {
 		$user->updateQuota();
 	}
 
+	public function testUpdateQuotaToDefaultAllProvided() {
+		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
+			$this->getTestInstances();
+
+		list($access, $connection) =
+			$this->getAdvancedMocks($config, $filesys, $log, $avaMgr, $dbc);
+
+		$connection->expects($this->at(0))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
+
+		$connection->expects($this->exactly(1))
+			->method('__get');
+
+		$access->expects($this->once())
+			->method('readAttribute')
+			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+				$this->equalTo('myquota'))
+			->will($this->returnValue(array('default')));
+
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('default');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
+		$uid = 'alice';
+		$dn  = 'uid=alice,dc=foo,dc=bar';
+
+		$user = new User(
+			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
+
+		$user->updateQuota();
+	}
+
+	public function testUpdateQuotaToNoneAllProvided() {
+		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
+			$this->getTestInstances();
+
+		list($access, $connection) =
+			$this->getAdvancedMocks($config, $filesys, $log, $avaMgr, $dbc);
+
+		$connection->expects($this->at(0))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
+
+		$connection->expects($this->exactly(1))
+			->method('__get');
+
+		$access->expects($this->once())
+			->method('readAttribute')
+			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+				$this->equalTo('myquota'))
+			->will($this->returnValue(array('none')));
+
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('none');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
+		$uid = 'alice';
+		$dn  = 'uid=alice,dc=foo,dc=bar';
+
+		$user = new User(
+			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
+
+		$user->updateQuota();
+	}
+
 	public function testUpdateQuotaDefaultProvided() {
 		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
 			$this->getTestInstances();
@@ -238,13 +320,13 @@ class Test_User_User extends \Test\TestCase {
 
 		$connection->expects($this->at(0))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
-			->will($this->returnValue('25 GB'));
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
 
 		$connection->expects($this->at(1))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaAttribute'))
-			->will($this->returnValue('myquota'));
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue('25 GB'));
 
 		$connection->expects($this->exactly(2))
 			->method('__get');
@@ -283,15 +365,17 @@ class Test_User_User extends \Test\TestCase {
 
 		$connection->expects($this->at(0))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
-			->will($this->returnValue(''));
-
-		$connection->expects($this->at(1))
-			->method('__get')
 			->with($this->equalTo('ldapQuotaAttribute'))
 			->will($this->returnValue('myquota'));
 
-		$connection->expects($this->exactly(2))
+		/* Having a quota set this won't be used
+		$connection->expects($this->at(1))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue(''));
+		*/
+
+		$connection->expects($this->exactly(1))
 			->method('__get');
 
 		$access->expects($this->once())
@@ -328,13 +412,13 @@ class Test_User_User extends \Test\TestCase {
 
 		$connection->expects($this->at(0))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
-			->will($this->returnValue(''));
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
 
 		$connection->expects($this->at(1))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaAttribute'))
-			->will($this->returnValue('myquota'));
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue(''));
 
 		$connection->expects($this->exactly(2))
 			->method('__get');
@@ -344,6 +428,16 @@ class Test_User_User extends \Test\TestCase {
 			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
 				$this->equalTo('myquota'))
 			->will($this->returnValue(false));
+
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('default');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
 
 		$config->expects($this->never())
 			->method('setUserValue');
@@ -366,16 +460,27 @@ class Test_User_User extends \Test\TestCase {
 
 		$connection->expects($this->at(0))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
+			->with($this->equalTo('ldapQuotaAttribute'))
 			->will($this->returnValue(''));
 
 		$connection->expects($this->at(1))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaAttribute'))
+			->with($this->equalTo('ldapQuotaDefault'))
 			->will($this->returnValue(''));
 
 		$connection->expects($this->exactly(2))
 			->method('__get');
+
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('default');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
 
 		$access->expects($this->never())
 			->method('readAttribute');
@@ -401,15 +506,9 @@ class Test_User_User extends \Test\TestCase {
 
 		$readQuota = '19 GB';
 
-		$connection->expects($this->at(0))
+		$connection->expects($this->never())
 			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
-			->will($this->returnValue(''));
-
-		$connection->expects($this->once(1))
-			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
-			->will($this->returnValue(null));
+			->with($this->equalTo('ldapQuotaDefault'));
 
 		$access->expects($this->never())
 			->method('readAttribute');
@@ -431,6 +530,195 @@ class Test_User_User extends \Test\TestCase {
 			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
 
 		$user->updateQuota($readQuota);
+	}
+
+	/**
+	 * Unparseable quota will fallback to use the LDAP default
+	 */
+	public function testUpdateWrongQuotaAllProvided() {
+		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
+			$this->getTestInstances();
+
+		list($access, $connection) =
+			$this->getAdvancedMocks($config, $filesys, $log, $avaMgr, $dbc);
+
+		$connection->expects($this->at(0))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
+
+		$connection->expects($this->at(1))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue('23 GB'));
+
+		$connection->expects($this->exactly(2))
+			->method('__get');
+
+		$access->expects($this->once())
+			->method('readAttribute')
+			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+				$this->equalTo('myquota'))
+			->will($this->returnValue(array('42 GBwos')));
+
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('23 GB');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
+		$uid = 'alice';
+		$dn  = 'uid=alice,dc=foo,dc=bar';
+
+		$user = new User(
+			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
+
+		$user->updateQuota();
+	}
+
+	/**
+	 * No user quota and wrong default will set 'default' as quota
+	 */
+	public function testUpdateWrongDefaultQuotaProvided() {
+		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
+			$this->getTestInstances();
+
+		list($access, $connection) =
+			$this->getAdvancedMocks($config, $filesys, $log, $avaMgr, $dbc);
+
+		$connection->expects($this->at(0))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
+
+		$connection->expects($this->at(1))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue('23 GBwowowo'));
+
+		$connection->expects($this->exactly(2))
+			->method('__get');
+
+		$access->expects($this->once())
+			->method('readAttribute')
+			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+				$this->equalTo('myquota'))
+			->will($this->returnValue(false));
+
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('default');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
+		$uid = 'alice';
+		$dn  = 'uid=alice,dc=foo,dc=bar';
+
+		$user = new User(
+			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
+
+		$user->updateQuota();
+	}
+
+	/**
+	 * Wrong user quota and wrong default will set 'default' as quota
+	 */
+	public function testUpdateWrongQuotaAndDefaultAllProvided() {
+		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
+			$this->getTestInstances();
+
+		list($access, $connection) =
+			$this->getAdvancedMocks($config, $filesys, $log, $avaMgr, $dbc);
+
+		$connection->expects($this->at(0))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
+
+		$connection->expects($this->at(1))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue('23 GBwowowo'));
+
+		$connection->expects($this->exactly(2))
+			->method('__get');
+
+		$access->expects($this->once())
+			->method('readAttribute')
+			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+				$this->equalTo('myquota'))
+			->will($this->returnValue(array('23 flush')));
+
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('default');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
+		$uid = 'alice';
+		$dn  = 'uid=alice,dc=foo,dc=bar';
+
+		$user = new User(
+			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
+
+		$user->updateQuota();
+	}
+
+	/**
+	 * No quota attribute set and wrong default will set 'default' as quota
+	 */
+	public function testUpdateWrongDefaultQuotaNotProvided() {
+		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
+			$this->getTestInstances();
+
+		list($access, $connection) =
+			$this->getAdvancedMocks($config, $filesys, $log, $avaMgr, $dbc);
+
+		$connection->expects($this->at(0))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue(''));
+
+		$connection->expects($this->at(1))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue('23 GBwowowo'));
+
+		$connection->expects($this->exactly(2))
+			->method('__get');
+
+		$access->expects($this->never())
+			->method('readAttribute');
+
+		$user = $this->getMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('default');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
+		$uid = 'alice';
+		$dn  = 'uid=alice,dc=foo,dc=bar';
+
+		$user = new User(
+			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
+
+		$user->updateQuota();
 	}
 
 	//the testUpdateAvatar series also implicitely tests getAvatarImage


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
backport of https://github.com/owncloud/user_ldap/pull/64 to stable9

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

