### PR TITLE
Optimize join for sharedWith by moving logic to DB

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -725,6 +725,14 @@ class FederatedShareProvider implements IShareProvider {
 		return $shares;
 	}
 
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getAllSharedWith($userId, $node) {
+		return $this->getSharedWith($userId, self::SHARE_TYPE_REMOTE, $node, -1, 0);
+	}
+
 	/**
 	 * @inheritdoc
 	 */

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -462,6 +462,11 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		];
 	}
 
+	public function testGetAllSharedWith() {
+		$shares = $this->provider->getAllSharedWith('shared', null);
+		$this->assertCount(0, $shares);
+	}
+
 
 	public function testGetAllSharesByNodes() {
 		$node = $this->createMock('\OCP\Files\File');

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -68,8 +68,9 @@ class MountProvider implements IMountProvider {
 	 * @return \OCP\Files\Mount\IMountPoint[]
 	 */
 	public function getMountsForUser(IUser $user, IStorageFactory $storageFactory) {
-		$shares = $this->shareManager->getSharedWith($user->getUID(), \OCP\Share::SHARE_TYPE_USER, null, -1);
-		$shares = array_merge($shares, $this->shareManager->getSharedWith($user->getUID(), \OCP\Share::SHARE_TYPE_GROUP, null, -1));
+		$requiredShareTypes = [\OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_GROUP];
+		$shares = $this->shareManager->getAllSharedWith($user->getUID(), $requiredShareTypes, null);
+		
 		// filter out excluded shares and group shares that includes self
 		$shares = array_filter($shares, function (\OCP\Share\IShare $share) use ($user) {
 			return $share->getPermissions() > 0 && $share->getShareOwner() !== $user->getUID();

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -112,18 +112,19 @@ class MountProviderTest extends \Test\TestCase {
 			$this->makeMockShare(5, 100, 'user1', '/share4', 31), 
 		];
 
+		$userGroupUserShares = array_merge($userShares, $groupShares);
+
 		$this->user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('user1'));
 
-		$this->shareManager->expects($this->at(0))
-			->method('getSharedWith')
-			->with('user1', \OCP\Share::SHARE_TYPE_USER)
-			->will($this->returnValue($userShares));
-		$this->shareManager->expects($this->at(1))
-			->method('getSharedWith')
-			->with('user1', \OCP\Share::SHARE_TYPE_GROUP, null, -1)
-			->will($this->returnValue($groupShares));
+		$requiredShareTypes = [\OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_GROUP];
+		$this->shareManager->expects($this->once())
+			->method('getAllSharedWith')
+			->with('user1', $requiredShareTypes, null)
+			->will($this->returnValue($userGroupUserShares));
+		$this->shareManager->expects($this->never())
+			->method('getSharedWith');
 		$this->shareManager->expects($this->any())
 			->method('newShare')
 			->will($this->returnCallback(function() use ($rootFolder, $userManager) {
@@ -311,15 +312,17 @@ class MountProviderTest extends \Test\TestCase {
 		$this->user->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('user1'));
+		
+		$userGroupUserShares = array_merge($userShares, $groupShares);
+		$requiredShareTypes = [\OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_GROUP];
+		$this->shareManager->expects($this->once())
+			->method('getAllSharedWith')
+			->with('user1', $requiredShareTypes, null)
+			->will($this->returnValue($userGroupUserShares));
 
-		$this->shareManager->expects($this->at(0))
-			->method('getSharedWith')
-			->with('user1', \OCP\Share::SHARE_TYPE_USER)
-			->will($this->returnValue($userShares));
-		$this->shareManager->expects($this->at(1))
-			->method('getSharedWith')
-			->with('user1', \OCP\Share::SHARE_TYPE_GROUP, null, -1)
-			->will($this->returnValue($groupShares));
+		$this->shareManager->expects($this->never())
+			->method('getSharedWith');
+
 		$this->shareManager->expects($this->any())
 			->method('newShare')
 			->will($this->returnCallback(function() use ($rootFolder, $userManager) {

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -675,6 +675,116 @@ class DefaultShareProvider implements IShareProvider {
 		return true;
 	}
 
+	/*
+	 * Get shared with user shares for the given userId and node
+	 *
+	 * @param string $userId
+	 * @param Node|null $node
+	 * @return DB\QueryBuilder\IQueryBuilder $qb
+	 */
+	public function getSharedWithUserQuery($userId, $node) {
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->select('s.*', 'f.fileid', 'f.path')
+			->selectAlias('st.id', 'storage_string_id')
+			->from('share', 's')
+			->leftJoin('s', 'filecache', 'f', $qb->expr()->eq('s.file_source', 'f.fileid'))
+			->leftJoin('f', 'storages', 'st', $qb->expr()->eq('f.storage', 'st.numeric_id'));
+
+		// Order by id
+		$qb->orderBy('s.id');
+
+		$qb->where($qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_USER)))
+			->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($userId)))
+			->andWhere($qb->expr()->orX(
+				$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
+				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
+			));
+
+		// Filter by node if provided
+		if ($node !== null) {
+			$qb->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($node->getId())));
+		}
+
+		return $qb;
+	}
+
+	/*
+	 * Get shared with group shares for the given groups and node
+	 *
+	 * @param IGroup[] $groups
+	 * @param Node|null $node
+	 * @return DB\QueryBuilder\IQueryBuilder $qb
+	 */
+	private function getSharedWithGroupQuery($groups, $node) {
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->select('s.*', 'f.fileid', 'f.path')
+			->selectAlias('st.id', 'storage_string_id')
+			->from('share', 's')
+			->leftJoin('s', 'filecache', 'f', $qb->expr()->eq('s.file_source', 'f.fileid'))
+			->leftJoin('f', 'storages', 'st', $qb->expr()->eq('f.storage', 'st.numeric_id'))
+			->orderBy('s.id');
+
+		// Filter by node if provided
+		if ($node !== null) {
+			$qb->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($node->getId())));
+		}
+
+		$groups = array_map(function(IGroup $group) { return $group->getGID(); }, $groups);
+
+		$qb->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_GROUP)))
+			->andWhere($qb->expr()->in('share_with', $qb->createNamedParameter(
+				$groups,
+				IQueryBuilder::PARAM_STR_ARRAY
+			)))
+			->andWhere($qb->expr()->orX(
+				$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
+				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
+			));
+
+		return $qb;
+	}
+
+	/*
+	 * Get shared with group and shared with user shares for the given groups, userId and node
+	 *
+	 * @param IGroup[] $groups
+	 * @param string $userId
+	 * @param Node|null $node
+	 * @return DB\QueryBuilder\IQueryBuilder $qb
+	 */
+	private function getSharedWithUserGroupQuery($groups, $userId, $node) {
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->select('s.*', 'f.fileid', 'f.path')
+			->selectAlias('st.id', 'storage_string_id')
+			->from('share', 's')
+			->leftJoin('s', 'filecache', 'f', $qb->expr()->eq('s.file_source', 'f.fileid'))
+			->leftJoin('f', 'storages', 'st', $qb->expr()->eq('f.storage', 'st.numeric_id'))
+			->orderBy('s.id');
+
+		// Filter by node if provided
+		if ($node !== null) {
+			$qb->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($node->getId())));
+		}
+
+		$groups = array_map(function(IGroup $group) { return $group->getGID(); }, $groups);
+
+		$qb->andWhere($qb->expr()->orX(
+			$qb->expr()->andX(
+				$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_GROUP)),
+				$qb->expr()->in('share_with', $qb->createNamedParameter(
+					$groups,
+					IQueryBuilder::PARAM_STR_ARRAY
+				))
+			),
+			$qb->expr()->andX(
+				$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_USER)),
+				$qb->expr()->eq('share_with', $qb->createNamedParameter($userId))
+			)
+		));
+
+		return $qb;
+	}
+
 	/**
 	 * @inheritdoc
 	 */
@@ -683,34 +793,14 @@ class DefaultShareProvider implements IShareProvider {
 		$shares = [];
 
 		if ($shareType === \OCP\Share::SHARE_TYPE_USER) {
-			//Get shares directly with this user
-			$qb = $this->dbConn->getQueryBuilder();
-			$qb->select('s.*', 'f.fileid', 'f.path')
-				->selectAlias('st.id', 'storage_string_id')
-				->from('share', 's')
-				->leftJoin('s', 'filecache', 'f', $qb->expr()->eq('s.file_source', 'f.fileid'))
-				->leftJoin('f', 'storages', 'st', $qb->expr()->eq('f.storage', 'st.numeric_id'));
-
-			// Order by id
-			$qb->orderBy('s.id');
+			// Create SharedWithUser query
+			$qb = $this->getSharedWithUserQuery($userId, $node);
 
 			// Set limit and offset
 			if ($limit !== -1) {
 				$qb->setMaxResults($limit);
 			}
 			$qb->setFirstResult($offset);
-
-			$qb->where($qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_USER)))
-				->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($userId)))
-				->andWhere($qb->expr()->orX(
-					$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
-					$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
-				));
-
-			// Filter by node if provided
-			if ($node !== null) {
-				$qb->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($node->getId())));
-			}
 
 			$cursor = $qb->execute();
 
@@ -737,35 +827,13 @@ class DefaultShareProvider implements IShareProvider {
 					break;
 				}
 
-				$qb = $this->dbConn->getQueryBuilder();
-				$qb->select('s.*', 'f.fileid', 'f.path')
-					->selectAlias('st.id', 'storage_string_id')
-					->from('share', 's')
-					->leftJoin('s', 'filecache', 'f', $qb->expr()->eq('s.file_source', 'f.fileid'))
-					->leftJoin('f', 'storages', 'st', $qb->expr()->eq('f.storage', 'st.numeric_id'))
-					->orderBy('s.id')
-					->setFirstResult(0);
+				// Create SharedWithGroups query
+				$qb = $this->getSharedWithGroupQuery($groups, $node);
+				$qb->setFirstResult(0);
 
 				if ($limit !== -1) {
 					$qb->setMaxResults($limit - count($shares));
 				}
-
-				// Filter by node if provided
-				if ($node !== null) {
-					$qb->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($node->getId())));
-				}
-
-				$groups = array_map(function(IGroup $group) { return $group->getGID(); }, $groups);
-
-				$qb->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_GROUP)))
-					->andWhere($qb->expr()->in('share_with', $qb->createNamedParameter(
-						$groups,
-						IQueryBuilder::PARAM_STR_ARRAY
-					)))
-					->andWhere($qb->expr()->orX(
-						$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
-						$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
-					));
 
 				$cursor = $qb->execute();
 				while($data = $cursor->fetch()) {
@@ -794,101 +862,53 @@ class DefaultShareProvider implements IShareProvider {
 	}
 
 	/**
-	 * Performs DB call to obtain all shared with specific groups or user for specific node predicate (if any)
-	 * It also segregates results in chunks of result(array) batches e.g. { { array, array, ...}[100], { array, array, array }[3] }[2]
-	 *
-	 * @param IGroup[] $sharedWithGroup
-	 * @param string $userId
-	 * @param Node|null $node
-	 * @return array $chunkedResults
-	 */
-	private function getChunkedAllSharedWith($sharedWithGroup, $userId, $node) {
-		$sharedWithGroupChunks = array_chunk($sharedWithGroup, 100);
-
-		// Check how many group chunks do we need
-		$sharedWithGroupChunksNo = count($sharedWithGroupChunks);
-
-		// Check that if there are no groups for users, we still query for a shared with user
-		$chunkNoRequired = $sharedWithGroupChunksNo > 0 ? $sharedWithGroupChunksNo : 1;
-
-		for ($chunkNo = 0; $chunkNo < $chunkNoRequired; $chunkNo++) {
-			// Query for user/group shares
-			$qb = $this->dbConn->getQueryBuilder();
-			$qb->select('s.*', 'f.fileid', 'f.path')
-				->selectAlias('st.id', 'storage_string_id')
-				->from('share', 's')
-				->leftJoin('s', 'filecache', 'f', $qb->expr()->eq('s.file_source', 'f.fileid'))
-				->leftJoin('f', 'storages', 'st', $qb->expr()->eq('f.storage', 'st.numeric_id'))
-				->orderBy('s.id');
-
-			// Apply predicate on item_type
-			$qb->where($qb->expr()->orX(
-				$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
-				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
-			));
-
-			// Apply predicate on node if provided
-			if ($node !== null) {
-				$qb->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($node->getId())));
-			}
-
-			// Handle chunking logic
-			if ($chunkNo === 0 && $sharedWithGroupChunksNo > 0) {
-				// There are groups to be checked and this is first chunk
-				// In the first chunk, check for shared with user along with groups
-				$groups = $sharedWithGroupChunks[$chunkNo];
-				$qb->andWhere($qb->expr()->orX(
-					$qb->expr()->andX(
-						$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_GROUP)),
-						$qb->expr()->in('share_with', $qb->createNamedParameter(
-							$groups,
-							IQueryBuilder::PARAM_STR_ARRAY
-						))
-					),
-					$qb->expr()->andX(
-						$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_USER)),
-						$qb->expr()->eq('share_with', $qb->createNamedParameter($userId))
-					)
-				));
-			} else if ($chunkNo > 0 && $sharedWithGroupChunksNo > 0) {
-				// There are groups to be checked and this is consecutive chunk
-				$groups = $sharedWithGroupChunks[$chunkNo];
-				$qb->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_GROUP)));
-				$qb->andWhere($qb->expr()->in('share_with', $qb->createNamedParameter(
-					$groups,
-					IQueryBuilder::PARAM_STR_ARRAY
-				))
-				);
-			} else {
-				// There are no groups to be checked
-				$qb->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share::SHARE_TYPE_USER)));
-				$qb->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($userId)));
-			}
-
-			$cursor = $qb->execute();
-			$chunkedResults[] = $cursor->fetchAll();
-			$cursor->closeCursor();
-		}
-		return $chunkedResults;
-	}
-
-	/**
 	 * @inheritdoc
 	 */
 	public function getAllSharedWith($userId, $node) {
 		// Create array of sharedWith objects (target user -> $userId or group of which user is a member
 		$user = $this->userManager->get($userId);
-		$allGroups = $this->groupManager->getUserGroups($user, 'sharing');
-
-		/** @var Share[] $resolvedShares */
-		$resolvedShares = [];
-		$groupShares = [];
 
 		// Check if user is member of some groups and chunk them
-		$sharedWithGroup = array_map(function(IGroup $group) { return $group->getGID(); }, $allGroups);
+		$allGroups = $this->groupManager->getUserGroups($user, 'sharing');
 
-		$chunkedResults = $this->getChunkedAllSharedWith($sharedWithGroup, $userId, $node);
+		// Make chunks
+		$sharedWithGroupChunks = array_chunk($allGroups, 100);
 
+		// Check how many group chunks do we need
+		$sharedWithGroupChunksNo = count($sharedWithGroupChunks);
+
+		// If there are not groups, query only user, if there are groups, query both
+		$chunkedResults = [];
+		if ($sharedWithGroupChunksNo === 0) {
+			// There are no groups, query only for user
+			$qb = $this->getSharedWithUserQuery($userId, $node);
+			$cursor = $qb->execute();
+			$chunkedResults[] = $cursor->fetchAll();
+			$cursor->closeCursor();
+		} else {
+			// There are groups, query both for user and for groups
+			$userSharesRetrieved = false;
+			for ($chunkNo = 0; $chunkNo < $sharedWithGroupChunksNo; $chunkNo++) {
+				// Get respective group chunk
+				$groups = $sharedWithGroupChunks[$chunkNo];
+
+				// Check if user shares were already retrieved
+				// One cannot retrieve user shares multiple times, since it will result in duplicated
+				// user shares with each query
+				if ($userSharesRetrieved === false) {
+					$qb = $this->getSharedWithUserGroupQuery($groups, $userId, $node);
+					$userSharesRetrieved = true;
+				} else {
+					$qb = $this->getSharedWithGroupQuery($groups, $node);
+				}
+				$cursor = $qb->execute();
+				$chunkedResults[] = $cursor->fetchAll();
+				$cursor->closeCursor();
+			}
+		}
+
+		$resolvedShares = [];
+		$groupShares = [];
 		foreach($chunkedResults as $resultBatch) {
 			foreach($resultBatch as $data) {
 				if ($this->isAccessibleResult($data)) {

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -90,7 +90,7 @@ interface IManager {
 	 * Get all shares shared by (initiated) by the provided user for specific node IDs.
 	 *
 	 * @param string $userId
-	 * @param int[] $shareTypes
+	 * @param int[] $shareTypes - ref \OC\Share\Constants[]
 	 * @param int[] $nodeIDs
 	 * @param bool $reshares
 	 * @return IShare[]
@@ -112,6 +112,19 @@ interface IManager {
 	 */
 	public function getSharesBy($userId, $shareType, $path = null, $reshares = false, $limit = 50, $offset = 0);
 
+
+	/**
+	 * Get shares shared with $userId for specified share types.
+	 * Filter by $node if provided
+	 * 
+	 * @param string $userId
+	 * @param int[] $shareTypes - ref \OC\Share\Constants[]
+	 * @param Node|null $node
+	 * @return IShare[]
+	 * @since 10.0.0
+	 */
+	public function getAllSharedWith($userId, $shareTypes, $node = null);
+	
 	/**
 	 * Get shares shared with $user.
 	 * Filter by $node if provided

--- a/lib/public/Share/IShareProvider.php
+++ b/lib/public/Share/IShareProvider.php
@@ -105,7 +105,7 @@ interface IShareProvider {
 	public function getSharesBy($userId, $shareType, $node, $reshares, $limit, $offset);
 
 	/**
-	 * Get all shares by the given user for specified shareTypes array
+	 * Get all shares by the given user for specified shareTypes array (ref. \OC\Share\Constants)
 	 *
 	 * @param string $userId
 	 * @param int[] $shareTypes
@@ -137,8 +137,21 @@ interface IShareProvider {
 	 */
 	public function getSharesByPath(Node $path);
 
+
 	/**
-	 * Get shared with the given user
+	 * Get shared with the given user for shares of all supported share types for this share provider,
+	 * with file_source predicate specified ($node is Node) or
+	 * without ($node is null and scan over file_source is performed).
+	 *
+	 * @param string $userId get shares where this user is the recipient
+	 * @param Node|null $node
+	 * @return \OCP\Share\IShare[]
+	 * @since 10.0.0
+	 */
+	public function getAllSharedWith($userId, $node);
+	
+	/**
+	 * Get shared with the given user specifying share type predicate for this specific share provider
 	 *
 	 * @param string $userId get shares where this user is the recipient
 	 * @param int $shareType

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2735,6 +2735,41 @@ class ManagerTest extends \Test\TestCase {
 
 		$this->manager->moveShare($share, 'recipient');
 	}
+	
+	public function testGetSharedWith() {
+		$user = $this->createMock(IUser::class);
+
+		$share = $this->manager->newShare();
+		$share->setShareType(\OCP\Share::SHARE_TYPE_GROUP)
+			->setId('42')
+			->setProviderId('foo');
+		$this->defaultProvider->method('getSharedWith')->with($user, \OCP\Share::SHARE_TYPE_GROUP, null, -1, 0)->willReturn([$share]);
+
+		$shares = $this->manager->getSharedWith($user, \OCP\Share::SHARE_TYPE_GROUP, null, -1, 0);
+		$this->assertCount(1, $shares);
+		$returnedShare = $shares[0];
+		$this->assertSame($returnedShare->getId(), $share->getId());
+	}
+
+	public function testGetAllSharedWith() {
+		$user = $this->createMock(IUser::class);
+
+		$share1 = $this->manager->newShare();
+		$share1->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setId('42')
+			->setProviderId('foo');
+		$share2 = $this->manager->newShare();
+		$share2->setShareType(\OCP\Share::SHARE_TYPE_GROUP)
+			->setId('43')
+			->setProviderId('foo');
+		$this->defaultProvider->method('getAllSharedWith')
+			->with($user, null)
+			->willReturn([$share1, $share2]);
+
+		$shares = $this->manager->getAllSharedWith($user, [\OCP\Share::SHARE_TYPE_GROUP, \OCP\Share::SHARE_TYPE_USER]);
+		$this->assertCount(2, $shares);
+		$this->assertSame($shares, [$share1, $share2]);
+	}
 }
 
 class DummyPassword {


### PR DESCRIPTION
In best case it gets rid of doubled queries `$shares, $this->shareManager->getSharedWith` for both GROUP and USER shares, as in the PR body. Currently, if there are both user and group shares, we need to do 2 queries. With this PR, if we have both group and user shares, we need to do 1 query. If we have only user shares, old and new implementation will do 1 query per user. 

![selection_102](https://cloud.githubusercontent.com/assets/13368647/24110812/c442a988-0d94-11e7-9df2-d6f3293d39ee.jpg)

Anyways, it is big win, since this query does... 2 Left Joins! These are very expensive operations in DBMS for enterprise scale tables. 

- [x] Unit tests 
- [x] Needs to use $this->resolveGroupShares https://github.com/owncloud/core/pull/27434
