### PR TITLE
MySQL 4 byte is now detected during setup in any case.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -74,3 +74,7 @@ Options -Indexes
 <IfModule pagespeed_module>
   ModPagespeed Off
 </IfModule>
+#### DO NOT CHANGE ANYTHING ABOVE THIS LINE ####
+
+ErrorDocument 403 //core/templates/403.php
+ErrorDocument 404 //core/templates/404.php

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1082,8 +1082,12 @@ $CONFIG = array(
 'sqlite.journal_mode' => 'DELETE',
 
 /**
- * If this setting is set to true MySQL can handle 4 byte characters instead of
- * 3 byte characters
+ * If requirements are met (see below) this setting is set to true during setup
+ * and MySQL can handle 4 byte characters instead of 3 byte characters.
+ *
+ * If you want to convert a 3-byte setup into a 4-byte setup please run the
+ * migration command:
+ * ./occ db:convert-mysql-charset
  *
  * MySQL requires a special setup for longer indexes (> 767 bytes) which are
  * needed:

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -40,12 +40,10 @@ class MySQL extends AbstractDatabase {
 		$connection = $this->connect();
 
 		// detect mb4
-		if (is_null($this->config->getSystemValue('mysql.utf8mb4', null))) {
-			$tools = new MySqlTools();
-			if ($tools->supports4ByteCharset($connection)) {
-				$this->config->setSystemValue('mysql.utf8mb4', true);
-				$connection = $this->connect();
-			}
+		$tools = new MySqlTools();
+		if ($tools->supports4ByteCharset($connection)) {
+			$this->config->setSystemValue('mysql.utf8mb4', true);
+			$connection = $this->connect();
 		}
 
 		$this->createSpecificUser($username, $connection);


### PR DESCRIPTION
config.sample.php was updated to explicitly state that there detection in place to set mysql.utf8mb4

## Description
<!--- Describe your changes in detail -->

## Related Issue
fixes #27221

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

