### PR TITLE
Separate audit logs from server logs.

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -602,13 +602,25 @@ $CONFIG = array(
  *                this condition is met
  *  - ``apps``:   if the log message is invoked by one of the specified apps,
  *                this condition is met
+ *  - ``logfile``: the log message invoked by the specified apps get redirected to
+ *		   this logfile, this condition is met
+ *		   Note: Not applicapable when using syslog.
  *
  * Defaults to an empty array.
  */
-'log.condition' => [
-	'shared_secret' => '57b58edb6637fe3059b3595cf9c41b9',
-	'users' => ['sample-user'],
-	'apps' => ['files'],
+'log.conditions' => [
+        [
+		'shared_secret' => '57b58edb6637fe3059b3595cf9c41b9',
+		'users' => ['user1'],
+		'apps' => ['files_texteditor'],
+		'logfile' => '/tmp/test.log'
+        ],
+        [
+		'shared_secret' => '57b58edb6637fe3059b3595cf9c41b9',
+		'users' => ['user1'],
+		'apps' => ['gallery'],
+		'logfile' => '/tmp/gallery.log'
+        ],
 ],
 
 /**

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -230,7 +230,11 @@ class Log implements ILogger {
 	 */
 	public function log($level, $message, array $context = []) {
 		$minLevel = min($this->config->getValue('loglevel', Util::WARN), Util::FATAL);
-		$logCondition = $this->config->getValue('log.condition', []);
+		$logConditions = $this->config->getValue('log.conditions', []);
+		if (empty($logConditions)) {
+			$logConditions[] = $this->config->getValue('log.condition', []);
+		}
+		$logConditionFile = null;
 
 		array_walk($context, [$this->normalizer, 'format']);
 
@@ -241,10 +245,17 @@ class Log implements ILogger {
 			 * check log condition based on the context of each log message
 			 * once this is met -> change the required log level to debug
 			 */
-			if(!empty($logCondition)
-				&& isset($logCondition['apps'])
-				&& in_array($app, $logCondition['apps'], true)) {
-				$minLevel = Util::DEBUG;
+			if(!empty($logConditions)) {
+				foreach ($logConditions as $logCondition) {
+					if(!empty($logCondition['apps'])
+					   && in_array($app, $logCondition['apps'], true)) {
+						$minLevel = Util::DEBUG;
+						if (!empty($logCondition['logfile'])) {
+							$logConditionFile = $logCondition['logfile'];
+							break;
+						}
+					}
+				}
 			}
 
 		} else {
@@ -266,25 +277,29 @@ class Log implements ILogger {
 		if($this->logConditionSatisfied === null) {
 			// default to false to just process this once per request
 			$this->logConditionSatisfied = false;
-			if(!empty($logCondition)) {
+			if(!empty($logConditions)) {
+				foreach ($logConditions as $logCondition) {
 
-				// check for secret token in the request
-				if(isset($logCondition['shared_secret'])) {
-					$request = \OC::$server->getRequest();
+					// check for secret token in the request
+					if (!empty($logCondition['shared_secret'])) {
+						$request = \OC::$server->getRequest();
 
-					// if token is found in the request change set the log condition to satisfied
-					if($request && hash_equals($logCondition['shared_secret'], $request->getParam('log_secret'))) {
-						$this->logConditionSatisfied = true;
+						// if token is found in the request change set the log condition to satisfied
+						if ($request && hash_equals($logCondition['shared_secret'], $request->getParam('log_secret'))) {
+							$this->logConditionSatisfied = true;
+							break;
+						}
 					}
-				}
 
-				// check for user
-				if(isset($logCondition['users'])) {
-					$user = \OC::$server->getUserSession()->getUser();
+					// check for user
+					if (!empty($logCondition['users'])) {
+						$user = \OC::$server->getUserSession()->getUser();
 
-					// if the user matches set the log condition to satisfied
-					if($user !== null && in_array($user->getUID(), $logCondition['users'], true)) {
-						$this->logConditionSatisfied = true;
+						// if the user matches set the log condition to satisfied
+						if ($user !== null && in_array($user->getUID(), $logCondition['users'], true)) {
+							$this->logConditionSatisfied = true;
+							break;
+						}
 					}
 				}
 			}
@@ -297,7 +312,7 @@ class Log implements ILogger {
 
 		if ($level >= $minLevel) {
 			$logger = $this->logger;
-			call_user_func([$logger, 'write'], $app, $message, $level);
+			call_user_func([$logger, 'write'], $app, $message, $level, $logConditionFile);
 		}
 	}
 

--- a/lib/private/Log/Owncloud.php
+++ b/lib/private/Log/Owncloud.php
@@ -67,8 +67,9 @@ class Owncloud {
 	 * @param string $app
 	 * @param string $message
 	 * @param int $level
+	 * @param string conditionalLogFile
 	 */
-	public static function write($app, $message, $level) {
+	public static function write($app, $message, $level, $conditionalLogFile = null) {
 		$config = \OC::$server->getSystemConfig();
 
 		// default to ISO8601
@@ -110,8 +111,13 @@ class Owncloud {
 			'user'
 		);
 		$entry = json_encode($entry);
-		$handle = @fopen(self::$logFile, 'a');
-		@chmod(self::$logFile, 0640);
+		if (!is_null($conditionalLogFile)) {
+			$handle = @fopen($conditionalLogFile, 'a');
+			@chmod($conditionalLogFile, 0640);
+		} else {
+			$handle = @fopen(self::$logFile, 'a');
+			@chmod(self::$logFile, 0640);
+		}
 		if ($handle) {
 			fwrite($handle, $entry."\n");
 			fclose($handle);

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -59,6 +59,24 @@ class LoggerTest extends TestCase {
 		$this->assertEquals($expected, $this->getLogs());
 	}
 
+	public function testAppLogCondition() {
+		$this->config->expects($this->any())
+			->method('getValue')
+			->will(($this->returnValueMap([
+				['loglevel', Util::WARN, Util::WARN],
+				['log.conditions', [], [['apps' => ['files'], 'logfile' => '/tmp/test.log']]]
+			])));
+		$logger = $this->logger;
+
+		$logger->info('Don\'t display info messages');
+		$logger->info('Show info messages of files app', ['app' => 'files']);
+
+		$expected = [
+			'1 Show info messages of files app',
+		];
+		$this->assertEquals($expected, $this->getLogs());
+	}
+
 	private function getLogs() {
 		return self::$logs;
 	}


### PR DESCRIPTION
This change will help users to separate logs
for each apps based on conditional logging.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
This change will help users to separate the audit logs from the server log. So lets say for each apps we can have conditional logs having separate log files.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will help users to have separate logs for each apps. Instead of searching the entire server log, it would be better to separate the logs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Made the modifications in the files_texteditor and gallary app as follows:

https://paste.fedoraproject.org/paste/MF7RzFfirSFFfKYciC1UYl5M1UNdIGYhyRLivL9gydE=
Modify the config.php as follows:
```php
  'log.condition' => [
    [
      'users' => ['user1'],
      'apps' => ['files_texteditor'],
      'logfile' => '/tmp/test.log'
    ],
    [
      'users' => ['user1'],
      'apps' => ['gallery'],
      'logfile' => '/tmp/gallery.log'
    ],
  ], 
```

After this try to open a text file in the files app. User should be able to see the logs written in /tmp/test.log
Similarly try to open the gallery with photos. User should be able to see the logs written in /tmp/gallery.log

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

