### PR TITLE
Properly quote column names when adding columns to an existing table

### DIFF
--- a/lib/private/DB/NoCheckMigrator.php
+++ b/lib/private/DB/NoCheckMigrator.php
@@ -30,9 +30,4 @@ use Doctrine\DBAL\Schema\Schema;
  * @package OC\DB
  */
 class NoCheckMigrator extends Migrator {
-	/**
-	 * @param \Doctrine\DBAL\Schema\Schema $targetSchema
-	 * @throws \OC\DB\MigrationException
-	 */
-	public function checkMigrate(Schema $targetSchema) {}
 }

--- a/lib/private/DB/SQLiteMigrator.php
+++ b/lib/private/DB/SQLiteMigrator.php
@@ -30,43 +30,6 @@ use Doctrine\DBAL\Types\BigIntType;
 use Doctrine\DBAL\Types\Type;
 
 class SQLiteMigrator extends Migrator {
-
-	/**
-	 * @param \Doctrine\DBAL\Schema\Schema $targetSchema
-	 * @throws \OC\DB\MigrationException
-	 *
-	 * For sqlite we simple make a copy of the entire database, and test the migration on that
-	 */
-	public function checkMigrate(\Doctrine\DBAL\Schema\Schema $targetSchema) {
-		$dbFile = $this->connection->getDatabase();
-		$tmpFile = $this->buildTempDatabase();
-		copy($dbFile, $tmpFile);
-
-		$connectionParams = [
-			'path' => $tmpFile,
-			'driver' => 'pdo_sqlite',
-		];
-		$conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams);
-		try {
-			$this->applySchema($targetSchema, $conn);
-			$conn->close();
-			unlink($tmpFile);
-		} catch (DBALException $e) {
-			$conn->close();
-			unlink($tmpFile);
-			throw new MigrationException('', $e->getMessage());
-		}
-	}
-
-	/**
-	 * @return string
-	 */
-	private function buildTempDatabase() {
-		$dataDir = $this->config->getSystemValue("datadirectory", \OC::$SERVERROOT . '/data');
-		$tmpFile = uniqid("oc_");
-		return "$dataDir/$tmpFile.db";
-	}
-
 	/**
 	 * @param Schema $targetSchema
 	 * @param \Doctrine\DBAL\Connection $connection

--- a/tests/lib/DB/MigratorTest.php
+++ b/tests/lib/DB/MigratorTest.php
@@ -102,8 +102,8 @@ class MigratorTest extends \Test\TestCase {
 		$this->connection->insert($this->tableName, ['id' => 2, 'name' => 'bar']);
 		$this->connection->insert($this->tableName, ['id' => 2, 'name' => 'qwerty']);
 
-		$migrator->checkMigrate($endSchema);
-		$this->fail('checkMigrate should have failed');
+		$migrator->migrate($endSchema);
+		$this->fail('migrate should have failed');
 	}
 
 	public function testUpgrade() {
@@ -115,7 +115,6 @@ class MigratorTest extends \Test\TestCase {
 		$this->connection->insert($this->tableName, ['id' => 2, 'name' => 'bar']);
 		$this->connection->insert($this->tableName, ['id' => 3, 'name' => 'qwerty']);
 
-		$migrator->checkMigrate($endSchema);
 		$migrator->migrate($endSchema);
 		$this->assertTrue(true);
 	}
@@ -134,7 +133,6 @@ class MigratorTest extends \Test\TestCase {
 		$this->connection->insert($this->tableName, ['id' => 2, 'name' => 'bar']);
 		$this->connection->insert($this->tableName, ['id' => 3, 'name' => 'qwerty']);
 
-		$migrator->checkMigrate($endSchema);
 		$migrator->migrate($endSchema);
 		$this->assertTrue(true);
 
@@ -173,7 +171,6 @@ class MigratorTest extends \Test\TestCase {
 		$migrator = $this->manager->getMigrator();
 		$migrator->migrate($startSchema);
 
-		$migrator->checkMigrate($endSchema);
 		$migrator->migrate($endSchema);
 
 		$this->assertTrue(true);
@@ -195,7 +192,6 @@ class MigratorTest extends \Test\TestCase {
 		$migrator = $this->manager->getMigrator();
 		$migrator->migrate($startSchema);
 
-		$migrator->checkMigrate($endSchema);
 		$migrator->migrate($endSchema);
 
 		$this->assertTrue(true);


### PR DESCRIPTION
## Description
- get rid of unused `checkMigrate` which was from the update simulation which is removed in 10.0
- fix OracleMigrator to quote column names when adding columns to an existing table
- open up MigratorTest for Oracle tests, but only slightly because some other tests fail
- add unit test for the column names quoting (when not quoted properly by the fix, Oracle would create the columns all capitalized instead of lower case)

## Related Issue
- BLOCKS: https://github.com/owncloud/core/pull/27448
- BLOCKS: https://github.com/owncloud/core/pull/27337

## Motivation and Context
Because now that we're using manual migration code, some scenarios aren't covered properly yet for Oracle.

## How Has This Been Tested?
```
% make test-php TEST_DATABASE=oci TEST_PHP_SUITE=tests/lib/DB/MigratorTest.php
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @butonic please review