### PR TITLE
redirect to new location for app passwords

### DIFF
--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -64,12 +64,18 @@ jQuery.fn.enter = function (callback, allowEmptyValue) {
 $(document).ready(function () {
 	// 'redirect' to anchor sections
 	// anchors are lost on redirects (e.g. while solving the 2fa challenge) otherwise
-	// example: /settings/person?section=devices will result in /settings/person?#devices
+	// example: /settings/personal?section=devices will result in /settings/personal?#devices
 	if (!window.location.hash) {
 		var query = OC.parseQueryString(location.search);
 		if (query && query.section) {
 			OC.Util.History.replaceState({});
 			window.location.hash = query.section;
 		}
+	} else {
+		if(window.location.hash === '#apppasswords' && window.location.pathname === '/settings/personal') {
+			// Handle old apppasswords links from desktop apps
+			window.location = OC.generateUrl('/settings/personal?sectionid=security#apppasswords');
+		}
 	}
+
 });

--- a/settings/js/personal.js
+++ b/settings/js/personal.js
@@ -74,7 +74,7 @@ $(document).ready(function () {
 	} else {
 		if(window.location.hash === '#apppasswords' && window.location.pathname === '/settings/personal') {
 			// Handle old apppasswords links from desktop apps
-			window.location = OC.generateUrl('/settings/personal?sectionid=security#apppasswords');
+			OC.redirect(OC.generateUrl('/settings/personal?sectionid=security#apppasswords'));
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Older dekstop clients currently link to `/settings/personal#apppasswords` to create a new password but this is incorrect with the new settings panels. Since we cannot detect the anchor in PHP this JS catches the route and anchor and redirects to the correct page. This does cause a second page load.

Another option could be to just show a notification saying that in OC 10 these settings have moved and give a link?

Desktop guys have already patched the client with the new URL.

## Related Issue
https://github.com/owncloud/core/issues/27360

## Motivation and Context
Users getting lost from the desktop client who are directed to the UI to create a new password.

## How Has This Been Tested?
Visiting `/settings/personal#apppasswords`.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

