### PR TITLE
Properly filter out encryption tests

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -83,10 +83,10 @@ fi
 # Enable encryption if requested
 if test "$OC_TEST_ENCRYPTION_ENABLED" = "1"; then
 	env_encryption_enable
-	BEHAT_FILTER_TAGS="~@no_encryption ~@no_default_encryption"
+	BEHAT_FILTER_TAGS="~@no_encryption&&~@no_default_encryption"
 elif test "$OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED" = "1"; then
 	env_encryption_enable_master_key
-	BEHAT_FILTER_TAGS="~@no_encryption ~@no_masterkey_encryption"
+	BEHAT_FILTER_TAGS="~@no_encryption&&~@no_masterkey_encryption"
 fi
 
 if test "$BEHAT_FILTER_TAGS"; then


### PR DESCRIPTION
Fixed behat command tags filter condition to properly exclude tests that
have "@no_encryption" set.

This should fix the tests on master where transfer ownership integration tests were still running even though they were supposed to be excluded.

@owncloud/qa @DeepDiver1975 