### PR TITLE
Oracle quote delete column

### DIFF
--- a/build/autotest.sh
+++ b/build/autotest.sh
@@ -35,6 +35,10 @@ if test -z "$PHPUNIT"; then
 	PHPUNIT=$(which phpunit)
 fi
 
+if [ -z "$SQLPLUS" ]; then
+	SQLPLUS=$(which sqlplus 2>/dev/null)
+fi
+
 set -e
 
 _XDEBUG_CONFIG=$XDEBUG_CONFIG
@@ -293,14 +297,19 @@ function execute_tests {
 
 		echo "Waiting for Oracle initialization ... "
 
-		# Try to connect to the OCI host via sqlplus to ensure that the connection is already running
+		if [ ! -z "$SQLPLUS" ]; then
+			# Try to connect to the OCI host via sqlplus to ensure that the connection is already running
       		for i in {1..48}
                 do
-                        if sqlplus "autotest/owncloud@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(Host=$DATABASEHOST)(Port=1521))(CONNECT_DATA=(SID=XE)))" < /dev/null | grep 'Connected to'; then
+                        if "$SQLPLUS" "autotest/owncloud@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(Host=$DATABASEHOST)(Port=1521))(CONNECT_DATA=(SID=XE)))" < /dev/null | grep 'Connected to'; then
                                 break;
                         fi
                         sleep 5
                 done
+		else
+			echo "sqlplus not found, using sleep to wait for Oracle initialization"
+			sleep 120
+		fi
 
 		DATABASEUSER=autotest
 		DATABASENAME='XE'

--- a/tests/lib/DB/MigratorTest.php
+++ b/tests/lib/DB/MigratorTest.php
@@ -234,6 +234,33 @@ class MigratorTest extends \Test\TestCase {
 		$this->assertTrue(true);
 	}
 
+	public function testDeletingColumn() {
+		$schema = new Schema([], [], $this->getSchemaConfig());
+		$table = $schema->createTable($this->tableName);
+		$table->addColumn('id', 'integer');
+		$table->addColumn('name', 'string');
+		$table->addColumn('to_delete', 'string');
+
+		$migrator = $this->manager->getMigrator();
+		$migrator->migrate($schema);
+
+		$table->dropColumn('to_delete');
+
+		$migrator->migrate($schema);
+
+		$schemaManager = $this->connection->getSchemaManager();
+		$actualSchema = $schemaManager->createSchema();
+
+		// Oracle might change casing if double quotes were missing, so verify
+		// that the column names still match
+		$table = $actualSchema->getTable($this->tableName);
+		$this->assertEquals('id', $table->getColumn('id')->getName());
+		$this->assertEquals('name', $table->getColumn('name')->getName());
+		$this->assertFalse($table->hasColumn('to_delete'));
+
+		$this->assertTrue(true);
+	}
+
 	public function testReservedKeywords() {
 		$startSchema = new Schema([], [], $this->getSchemaConfig());
 		$table = $startSchema->createTable($this->tableName);


### PR DESCRIPTION
For https://github.com/owncloud/core/issues/27466.

- Adds a test for dropping columns to confirm that no extra quoting is needed for Oracle.
- Small tweak to autotest.sh to be able to run it without a local sqlplus instance.

@DeepDiver1975 