### PR TITLE
Remove server-side htaccess test

### DIFF
--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -25,16 +25,6 @@ script('core', [
 		<?php endforeach; ?>
 	</fieldset>
 	<?php endif; ?>
-	<?php if(!$_['htaccessWorking']): ?>
-	<fieldset class="warning">
-		<legend><strong><?php p($l->t('Security warning'));?></strong></legend>
-		<p><?php p($l->t('Your data directory and files are probably accessible from the internet because the .htaccess file does not work.'));?><br>
-		<?php print_unescaped($l->t(
-			'For information how to properly configure your server, please see the <a href="%s" target="_blank" rel="noreferrer">documentation</a>.',
-			link_to_docs('admin-install')
-		)); ?></p>
-	</fieldset>
-	<?php endif; ?>
 	<fieldset id="adminaccount">
 		<legend><?php print_unescaped($l->t( 'Create an <strong>admin account</strong>' )); ?></legend>
 		<p class="grouptop">

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -198,21 +198,9 @@ class Setup {
 		if(!file_exists($dataDir)) {
 			@mkdir($dataDir);
 		}
-		$htAccessWorking = true;
 		if (is_dir($dataDir) && is_writable($dataDir)) {
 			// Protect data directory here, so we can test if the protection is working
 			\OC\Setup::protectDataDirectory();
-
-			try {
-				$util = new \OC_Util();
-				$htAccessWorking = $util->isHtaccessWorking(\OC::$server->getConfig());
-			} catch (\OC\HintException $e) {
-				$errors[] = [
-					'error' => $e->getMessage(),
-					'hint' => $e->getHint()
-				];
-				$htAccessWorking = false;
-			}
 		}
 
 		if (\OC_Util::runningOnMac()) {
@@ -244,7 +232,6 @@ class Setup {
 			'hasOracle' => isset($databases['oci']),
 			'databases' => $databases,
 			'directory' => $dataDir,
-			'htaccessWorking' => $htAccessWorking,
 			'errors' => $errors,
 		];
 	}

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1209,45 +1209,6 @@ class OC_Util {
 	}
 
 	/**
-	 * Check if the .htaccess file is working
-	 * @param \OCP\IConfig $config
-	 * @return bool
-	 * @throws Exception
-	 * @throws \OC\HintException If the test file can't get written.
-	 */
-	public function isHtaccessWorking(\OCP\IConfig $config) {
-
-		if (\OC::$CLI || !$config->getSystemValue('check_for_working_htaccess', true)) {
-			return true;
-		}
-
-		$testContent = $this->createHtaccessTestFile($config);
-		if ($testContent === false) {
-			return false;
-		}
-
-		$fileName = '/htaccesstest.txt';
-		$testFile = $config->getSystemValue('datadirectory', OC::$SERVERROOT . '/data') . '/' . $fileName;
-
-		// accessing the file via http
-		$url = \OC::$server->getURLGenerator()->getAbsoluteURL(OC::$WEBROOT . '/data' . $fileName);
-		try {
-			$content = \OC::$server->getHTTPClientService()->newClient()->get($url)->getBody();
-		} catch (\Exception $e) {
-			$content = false;
-		}
-
-		// cleanup
-		@unlink($testFile);
-
-		/*
-		 * If the content is not equal to test content our .htaccess
-		 * is working as required
-		 */
-		return $content !== $testContent;
-	}
-
-	/**
 	 * Check if the setlocal call does not work. This can happen if the right
 	 * local packages are not available on the server.
 	 *

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1186,6 +1186,9 @@ class OC_Util {
 		if (php_sapi_name() === 'cli-server') {
 			return false;
 		}
+		if (\OC::$CLI) {
+			return false;
+		}
 
 		// testdata
 		$fileName = '/htaccesstest.txt';

--- a/settings/Panels/Admin/SecurityWarning.php
+++ b/settings/Panels/Admin/SecurityWarning.php
@@ -60,6 +60,10 @@ class SecurityWarning implements ISettings {
 	}
 
 	public function getPanel() {
+		// create htaccess test file
+		$util = new \OC_Util();
+		$util->createHtaccessTestFile($this->config);
+
 		$template = new Template('settings', 'panels/admin/securitywarning');
 		// warn if php is not setup properly to get system variables with getenv
 		$path = getenv('PATH');


### PR DESCRIPTION
## Description
To test htaccess, one would try accessing a file in the data folder.
The old code does this call from the server side instead of client side.
Recently we've added a client-side check instead https://github.com/owncloud/core/pull/25014.
But also we seem to have another check based on an env variable present within the ".htaccess" file here: https://github.com/owncloud/core/blob/master/apps/files/lib/Panels/Admin.php#L50

Obsoleted by client-side and env checks on the settings page.

## Related Issue
https://github.com/owncloud/core/issues/27475

## Motivation and Context
Solves the issue that the `isHtAccessWorking` is using the `View` which itself requires a `UserManager` object, and this is happening much too early before the setup could be completed and cause side effects. See https://github.com/owncloud/core/issues/27475#issuecomment-288972174

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


I wonder if we should redirect to the settings page directly after setup to make sure the setup checks are visible ?

@DeepDiver1975 @jvillafanez @VicDeo @butonic please review
