### PR TITLE
External files oauth callback url should include settings sectionid

### DIFF
--- a/apps/files_external/js/oauth1.js
+++ b/apps/files_external/js/oauth1.js
@@ -59,7 +59,7 @@ $(document).ready(function() {
 			var configured = $(this).parent().find('[data-parameter="configured"]');
 			var token = $(this).parent().find('[data-parameter="token"]');
 			var token_secret = $(this).parent().find('[data-parameter="token_secret"]');
-			$.post(OC.filePath('files_external', 'ajax', 'oauth1.php'), { step: 1, app_key: app_key, app_secret: app_secret, callback: location.protocol + '//' + location.host + location.pathname }, function(result) {
+			$.post(OC.filePath('files_external', 'ajax', 'oauth1.php'), { step: 1, app_key: app_key, app_secret: app_secret, callback: location.protocol + '//' + location.host + location.pathname + '?sectionid=storage' }, function(result) {
 				if (result && result.status == 'success') {
 					$(configured).val('false');
 					$(token).val(result.data.request_token);

--- a/apps/files_external/js/oauth2.js
+++ b/apps/files_external/js/oauth2.js
@@ -37,7 +37,7 @@ $(document).ready(function() {
 										step: 2,
 										client_id: client_id,
 										client_secret: client_secret,
-										redirect: location.protocol + '//' + location.host + location.pathname,
+										redirect: location.protocol + '//' + location.host + location.pathname + '?sectionid=storage',
 										code: params['code'],
 									}, function(result) {
 										if (result && result.status == 'success') {
@@ -75,7 +75,7 @@ $(document).ready(function() {
 					step: 1,
 					client_id: client_id,
 					client_secret: client_secret,
-					redirect: location.protocol + '//' + location.host + location.pathname,
+					redirect: location.protocol + '//' + location.host + location.pathname + '?sectionid=storage',
 				}, function(result) {
 					if (result && result.status == 'success') {
 						$(configured).val('false');


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
appended `?sectionid=storage` to the callback urls to ensure they are hooked up correctly on return to OC.

## Related Issue
https://github.com/owncloud/core/issues/27456

## How Has This Been Tested?
 - Setup oauth with google
 - Tested was brokne
 - Implemented fix
 - Works, without alteration to google credentials / callback URI settings

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
