### PR TITLE
Add market app to shipped.json

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -25,6 +25,7 @@
     "firewall",
     "firstrunwizard",
     "gallery",
+    "market",
     "notifications",
     "objectstore",
     "password_policy",


### PR DESCRIPTION
Will be needed once we actually ship it...

Currently I don't want to bundle it because it looks totally broken.

@DeepDiver1975 @tomneedham @VicDeo 