### PR TITLE
[stable9.1] unlink test image - pollutes ci server

### DIFF
--- a/tests/lib/ImageTest.php
+++ b/tests/lib/ImageTest.php
@@ -336,6 +336,7 @@ class ImageTest extends \Test\TestCase {
 
 		$img->save($tempFile, $mimeType);
 		$actualMimeType = \OC_Image::getMimeTypeForFile($tempFile);
+		unlink($tempFile);
 		$this->assertEquals($mimeType, $actualMimeType);
 	}
 }


### PR DESCRIPTION
backport of #26891 