### PR TITLE
Properly decode id from URI

### DIFF
--- a/core/js/oc-backbone-webdav.js
+++ b/core/js/oc-backbone-webdav.js
@@ -128,7 +128,7 @@
 			// so we take the part before that
 		} while (!result && parts.length > 0);
 
-		return result;
+		return decodeURIComponent(result);
 	}
 
 	function isSuccessStatus(status) {


### PR DESCRIPTION
## Description
When parsing an href to get the id of a WebdavNode, make sure to also
decode it.

## Related Issue
None raised.

## How Has This Been Tested?

1. Install the customgroup v0.1 app
1. Create a custom group with a space in the name like "Group One"
1. Refresh the page
1. Click on the group "Group One"

Before the fix: error in console, wrongly encoded URL in network console.
After the fix: sidebar opens and group members appear.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review @felixheidecke @jvillafanez @VicDeo 