### PR TITLE
OCC scanner commit in batches

### DIFF
--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -85,6 +85,7 @@ class Scanner extends PublicEmitter {
 		$this->logger = $logger;
 		$this->user = $user;
 		$this->db = $db;
+		// when DB locking is used, no DB transactions will be used
 		$this->useTransaction = !(\OC::$server->getLockingProvider() instanceof DBLockingProvider);
 	}
 
@@ -255,10 +256,10 @@ class Scanner extends PublicEmitter {
 
 	private function postProcessEntry(IStorage $storage, $internalPath) {
 		$this->triggerPropagator($storage, $internalPath);
-		$this->entriesToCommit++;
 		if ($this->useTransaction) {
-			$propagator = $storage->getPropagator();
+			$this->entriesToCommit++;
 			if ($this->entriesToCommit >= self::MAX_ENTRIES_TO_COMMIT) {
+				$propagator = $storage->getPropagator();
 				$this->entriesToCommit = 0;
 				$this->db->commit();
 				$propagator->commitBatch();

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -45,6 +45,8 @@ use OCP\ILogger;
  * @package OC\Files\Utils
  */
 class Scanner extends PublicEmitter {
+	const MAX_ENTRIES_TO_COMMIT = 10000;
+
 	/**
 	 * @var string $user
 	 */
@@ -61,6 +63,20 @@ class Scanner extends PublicEmitter {
 	protected $logger;
 
 	/**
+	 * Whether to use a DB transaction
+	 *
+	 * @var bool
+	 */
+	protected $useTransaction;
+
+	/**
+	 * Number of entries scanned to commit
+	 *
+	 * @var int
+	 */
+	protected $entriesToCommit;
+
+	/**
 	 * @param string $user
 	 * @param \OCP\IDBConnection $db
 	 * @param ILogger $logger
@@ -69,6 +85,7 @@ class Scanner extends PublicEmitter {
 		$this->logger = $logger;
 		$this->user = $user;
 		$this->db = $db;
+		$this->useTransaction = !(\OC::$server->getLockingProvider() instanceof DBLockingProvider);
 	}
 
 	/**
@@ -197,19 +214,18 @@ class Scanner extends PublicEmitter {
 			$scanner = $storage->getScanner();
 			$scanner->setUseTransactions(false);
 			$this->attachListener($mount);
-			$isDbLocking = \OC::$server->getLockingProvider() instanceof DBLockingProvider;
 
 			$scanner->listen('\OC\Files\Cache\Scanner', 'removeFromCache', function ($path) use ($storage) {
-				$this->triggerPropagator($storage, $path);
+				$this->postProcessEntry($storage, $path);
 			});
 			$scanner->listen('\OC\Files\Cache\Scanner', 'updateCache', function ($path) use ($storage) {
-				$this->triggerPropagator($storage, $path);
+				$this->postProcessEntry($storage, $path);
 			});
 			$scanner->listen('\OC\Files\Cache\Scanner', 'addToCache', function ($path) use ($storage) {
-				$this->triggerPropagator($storage, $path);
+				$this->postProcessEntry($storage, $path);
 			});
 
-			if (!$isDbLocking) {
+			if ($this->useTransaction) {
 				$this->db->beginTransaction();
 			}
 			try {
@@ -227,7 +243,7 @@ class Scanner extends PublicEmitter {
 				$this->logger->logException($e);
 				$this->emit('\OC\Files\Utils\Scanner', 'StorageNotAvailable', [$e]);
 			}
-			if (!$isDbLocking) {
+			if ($this->useTransaction) {
 				$this->db->commit();
 			}
 		}
@@ -235,6 +251,21 @@ class Scanner extends PublicEmitter {
 
 	private function triggerPropagator(IStorage $storage, $internalPath) {
 		$storage->getPropagator()->propagateChange($internalPath, time());
+	}
+
+	private function postProcessEntry(IStorage $storage, $internalPath) {
+		$this->triggerPropagator($storage, $internalPath);
+		$this->entriesToCommit++;
+		if ($this->useTransaction) {
+			$propagator = $storage->getPropagator();
+			if ($this->entriesToCommit >= self::MAX_ENTRIES_TO_COMMIT) {
+				$this->entriesToCommit = 0;
+				$this->db->commit();
+				$propagator->commitBatch();
+				$this->db->beginTransaction();
+				$propagator->beginBatch();
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
Autocommit after 10k entries when running occ scanner to avoid excessive memory usage.

## Related Issue
Fixes https://github.com/owncloud/core/issues/27516

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@jvillafanez @butonic 

also see https://github.com/owncloud/core/issues/27516#issuecomment-289793918 for potential concerns.