### PR TITLE
Keep share link name if not specified in update call

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -356,7 +356,10 @@ class Share20OCS {
 				$share->setPermissions(\OCP\Constants::PERMISSION_READ);
 			}
 
-			$share->setName($name);
+			// set name only if passed as parameter, empty string is allowed
+			if ($name !== null) {
+				$share->setName($name);
+			}
 
 			// Set password
 			$password = $this->request->getParam('password', '');
@@ -594,7 +597,7 @@ class Share20OCS {
 		 * expirationdate, password and publicUpload only make sense for link shares
 		 */
 		if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
-			if ($permissions === null && $password === null && $publicUpload === null && $expireDate === null) {
+			if ($permissions === null && $password === null && $publicUpload === null && $expireDate === null && $name === null) {
 				$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 				return new \OC\OCS\Result(null, 400, 'Wrong or no update parameter given');
 			}
@@ -641,7 +644,10 @@ class Share20OCS {
 				$newPermissions = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE;
 			}
 
-			$share->setName($name);
+			// set name only if passed as parameter, empty string is allowed
+			if ($name !== null) {
+				$share->setName($name);
+			}
 
 			if ($newPermissions !== null) {
 				$share->setPermissions($newPermissions);


### PR DESCRIPTION
## Description
Keep share link name if not specified in update call.
Also make it possible to only change the name alone to avoid "Wrong or no update parameter given" error.

## Related Issue
Fixes https://github.com/owncloud/core/issues/27517

## Motivation and Context
Clients use the API this way.

## How Has This Been Tested?
Unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review @SamuAlfageme @SergioBertolinSG @jvillafanez 