### PR TITLE
Also mount share owner mounts for recipient

### DIFF
--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -117,7 +117,8 @@ class Application extends App {
 			return new MountProvider(
 				$server->getConfig(),
 				$server->getShareManager(),
-				$server->getLogger()
+				$server->getLogger(),
+				$server->getMountManager()
 			);
 		});
 
@@ -126,7 +127,7 @@ class Application extends App {
 			$server = $c->query('ServerContainer');
 			return new \OCA\Files_Sharing\External\MountProvider(
 				$server->getDatabaseConnection(),
-				function() use ($c) {
+				function () use ($c) {
 					return $c->query('ExternalManager');
 				}
 			);

--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -32,6 +32,7 @@ use \OC\Files\Filesystem;
 use OC\Files\Storage\StorageFactory;
 use OC\Files\Storage\Storage;
 use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Storage\IStorageFactory;
 
 class MountPoint implements IMountPoint {
 	/**
@@ -249,5 +250,21 @@ class MountPoint implements IMountPoint {
 	 */
 	public function getStorageRootId() {
 		return (int)$this->getStorage()->getCache()->getId('');
+	}
+
+	/**
+	 * Get all arguments for the storage
+	 *
+	 * @return array
+	 */
+	public function getStorageArguments() {
+		return $this->arguments;
+	}
+
+	/**
+	 * @return IStorageFactory
+	 */
+	public function getStorageFactory() {
+		return $this->loader;
 	}
 }

--- a/lib/public/Files/Mount/IMountPoint.php
+++ b/lib/public/Files/Mount/IMountPoint.php
@@ -21,6 +21,7 @@
  */
 
 namespace OCP\Files\Mount;
+use OCP\Files\Storage\IStorageFactory;
 
 /**
  * A storage mounted to folder on the filesystem
@@ -102,4 +103,18 @@ interface IMountPoint {
 	 * @since 9.1.0
 	 */
 	public function getStorageRootId();
+
+	/**
+	 * Get all arguments for the storage
+	 *
+	 * @return array
+	 * @since 10.0.0
+	 */
+	public function getStorageArguments();
+
+	/**
+	 * @return IStorageFactory
+	 * @since 10.0.0
+	 */
+	public function getStorageFactory();
 }


### PR DESCRIPTION
## Description
Whenever a share owner has mount points (external storage) inside
the shared folder, also mount these for the share recipient.

Revival of https://github.com/owncloud/core/pull/20953 ported to the new code.

## Related Issue
Fixes https://github.com/owncloud/core/issues/20990

## Motivation and Context
See issue

## How Has This Been Tested?
Manually in web UI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## TODOs
- [ ] add unit tests
- [ ] make a decision about including or excluding the shared mounts, if any (normally this kind of situation cannot be created directly so it might be ok to not exclude it in code)

I'm not sure about other possible consequences or performance impact from this.

@jvillafanez @mrow4a @DeepDiver1975 
