### PR TITLE
get user email address from user account and not preferences table

### DIFF
--- a/settings/Controller/MailSettingsController.php
+++ b/settings/Controller/MailSettingsController.php
@@ -145,7 +145,7 @@ class MailSettingsController extends Controller {
 	 * @return array
 	 */
 	public function sendTestMail() {
-		$email = $this->config->getUserValue($this->userSession->getUser()->getUID(), $this->appName, 'email', '');
+		$email = $this->userSession->getUser()->getEMailAddress();
 		if (!empty($email)) {
 			try {
 				$message = $this->mailer->createMessage();

--- a/tests/Settings/Controller/MailSettingsControllerTest.php
+++ b/tests/Settings/Controller/MailSettingsControllerTest.php
@@ -192,10 +192,8 @@ class MailSettingsControllerTest extends \Test\TestCase {
 		$expectedResponse = ['data' => ['message' =>'You need to set your user email before being able to send test emails.'], 'status' => 'error'];
 		$this->assertSame($expectedResponse, $response);
 
-		// If no exception is thrown it should work
-		$this->container['Config']
-			->expects($this->any())
-			->method('getUserValue')
+		$user->expects($this->any())
+			->method('getEMailAddress')
 			->will($this->returnValue('mail@example.invalid'));
 		$response = $this->container['MailSettingsController']->sendTestMail();
 		$expectedResponse = ['data' => ['message' =>'Email sent'], 'status' => 'success'];


### PR DESCRIPTION
## Description
since commit 9489104cb3880f22d52bcf7b439a67dd3db60ccf / PR #27276
The email address is not stored in the preferences table any more but in the user account
https://github.com/owncloud/core/commit/9489104cb3880f22d52bcf7b439a67dd3db60ccf#diff-3030ca4989f892c50dea24eaa3f1ae38R151

So need to get it from there also

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#27554

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual test & updated unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

