### PR TITLE
Convert the group limit to match the same behaviour as the user search

### DIFF
--- a/apps/user_ldap/lib/Command/Search.php
+++ b/apps/user_ldap/lib/Command/Search.php
@@ -113,6 +113,11 @@ class Search extends Command {
 			$proxy = new Group_Proxy($configPrefixes, $ldapWrapper);
 			$getMethod = 'getGroups';
 			$printID = false;
+			// convert the limit of groups to null. This will show all the groups available instead of
+			// nothing, and will match the same behaviour the search for users has.
+			if ($limit === 0) {
+				$limit = null;
+			}
 		} else {
 			$proxy = new User_Proxy($configPrefixes, $ldapWrapper, $this->ocConfig);
 			$getMethod = 'getDisplayNames';


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Backport of https://github.com/owncloud/user_ldap/pull/9 to stable9.1

## Related Issue
https://github.com/owncloud/core/issues/14248

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

