### PR TITLE
Do not load previews for unsupported mimes

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1732,6 +1732,9 @@
 			var mime = options.mime;
 			var ready = options.callback;
 			var etag = options.etag;
+			var enabledPreviewProviders = oc_appconfig.core.enabledPreviewProviders || [];
+			// We join all supported mimes into a single regex
+			var allMimesPattern = new RegExp(enabledPreviewProviders.join('|'));
 
 			// get mime icon url
 			var iconURL = OC.MimeType.getIconUrl(mime);
@@ -1741,7 +1744,7 @@
 
 			var img = new Image();
 
-			if (oc_appconfig.core.previewsEnabled) {
+			if (oc_appconfig.core.previewsEnabled && allMimesPattern.test(mime)) {
 				urlSpec.file = OCA.Files.Files.fixPath(path);
 				if (options.x) {
 					urlSpec.x = options.x;

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -174,6 +174,7 @@ $array = [
 				'federatedCloudShareDoc' => \OC::$server->getURLGenerator()->linkToDocs('user-sharing-federated'),
 				'allowGroupSharing' => \OC::$server->getShareManager()->allowGroupSharing(),
 				'previewsEnabled' => \OC::$server->getConfig()->getSystemValue('enable_previews', true) === true,
+				'enabledPreviewProviders' => \OC::$server->getPreviewManager()->getSupportedMimes()
 			]
 		]
 	),

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -147,6 +147,22 @@ class PreviewManager implements IPreview {
 		$this->mimeTypeSupportMap[$mimeType] = false;
 		return false;
 	}
+	
+	/**
+	 * Returns all registered MimeTypes as an array
+	 *
+	 * @return string[]
+	 */
+	public function getSupportedMimes(){
+		$supportedMimes = [];
+		$this->registerCoreProviders();
+		$mimeRegexArray = array_keys($this->providers);
+		// Now trim start/stop regexp delimiters
+		foreach ($mimeRegexArray as $mimeRegex){
+			$supportedMimes[] = trim($mimeRegex, '/');
+		}
+		return $supportedMimes;
+	}
 
 	/**
 	 * Check if a preview can be generated for a file


### PR DESCRIPTION
## Description
~- As suggested, set response to 204 instead of 404 if there is no preview~
- Pass supported mimetypes via `oc_appconfig.core.enabledPreviewProviders` and test mime against this list on js side.

## Related Issue
Fixes https://github.com/owncloud/core/issues/24216

## Motivation and Context
https://github.com/owncloud/core/issues/24216#issue-150533780

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



