### PR TITLE
Reorder the entries of the log for easier reading

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -486,7 +486,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		}
 
 		if(empty($this->requestId)) {
-			$this->requestId = $this->secureRandom->generate(20);
+			$validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+			$this->requestId = $this->secureRandom->generate(20, $validChars);
 		}
 
 		return $this->requestId;

--- a/lib/private/Log/Owncloud.php
+++ b/lib/private/Log/Owncloud.php
@@ -101,14 +101,14 @@ class Owncloud {
 		}
 		$entry = compact(
 			'reqId',
-			'remoteAddr',
-			'app',
-			'message',
 			'level',
 			'time',
+			'remoteAddr',
+			'user',
+			'app',
 			'method',
 			'url',
-			'user'
+			'message'
 		);
 		$entry = json_encode($entry);
 		if (!is_null($conditionalLogFile)) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Reorder log entries

## Related Issue
Fix https://github.com/owncloud/core/issues/27397 , related to https://github.com/owncloud/core/pull/27447

## Motivation and Context
Make the logs easier to read

## How Has This Been Tested?
Checked the logs manually

## Screenshots (if appropriate):
```
{"reqId":"heXNVIiTLeSrcxje601b","level":2,"time":"2017-04-04T07:19:16+00:00","remoteAddr":"10.0.2.4","user":"--","app":"core","method":"POST","url":"\/index.php\/login","message":"Login failed: 'admin' (Remote IP: '10.0.2.4')"}
{"reqId":"FqAaWU6uA5RAAJ7IwbNZ","level":2,"time":"2017-04-04T07:19:27+00:00","remoteAddr":"10.0.2.4","user":"--","app":"core","method":"POST","url":"\/index.php\/login?user=admin","message":"Login failed: 'admin' (Remote IP: '10.0.2.4')"}
{"reqId":"2FtXpg0TAg4qsffAzu6t","level":3,"time":"2017-04-04T07:19:48+00:00","remoteAddr":"10.0.2.4","user":"admin","app":"webdav","method":"PUT","url":"\/remote.php\/webdav\/SMB\/Circuit.png","message":"\\OC\\Files\\Filesystem::fopen() failed"}
{"reqId":"2FtXpg0TAg4qsffAzu6t","level":4,"time":"2017-04-04T07:19:48+00:00","remoteAddr":"10.0.2.4","user":"admin","app":"webdav","method":"PUT","url":"\/remote.php\/webdav\/SMB\/Circuit.png","message":"Exception: {\"Message\":\"Unknown error (30) for smb:\\\/\\\/10.0.2.6\\\/ro\\\/Circuit.png.ocTransferId1862609.part\",\"Exception\":\"Icewind\\\\SMB\\\\Exception\\\\Exception\",\"Code\":30,\"Trace\":\"#0 \\\/opt\\\/owncloud\\\/apps\\\/files_external\\\/3rdparty\\\/icewind\\\/smb\\\/src\\\/NativeState.php(72): Icewind\\\\SMB\\\\NativeState->handleError('smb:\\\/\\\/10.0.2.6\\\/...')\\n#1 \\\/opt\\\/owncloud\\\/apps\\\/files_external\\\/3rdparty\\\/icewind\\\/smb\\\/src\\\/NativeState.php(146): Icewind\\\\SMB\\\\NativeState->testResult(false, 'smb:\\\/\\\/10.0.2.6\\\/...')\\n#2 \\\/opt\\\/owncloud\\\/apps\\\/files_external\\\/3rdparty\\\/icewind\\\/smb\\\/src\\\/NativeShare.php(150): Icewind\\\\SMB\\\\NativeState->unlink('smb:\\\/\\\/10.0.2.6\\\/...')\\n#3 \\\/opt\\\/owncloud\\\/apps\\\/files_external\\\/lib\\\/Lib\\\/Storage\\\/SMB.php(352): Icewind\\\\SMB\\\\NativeShare->del('\\\/Circuit.png.oc...')\\n#4 \\\/opt\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/Wrapper.php(261): OCA\\\\Files_External\\\\Lib\\\\Storage\\\\SMB->unlink('\\\/Circuit.png.oc...')\\n#5 \\\/opt\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/PermissionsMask.php(107): OC\\\\Files\\\\Storage\\\\Wrapper\\\\Wrapper->unlink('Circuit.png.ocT...')\\n#6 \\\/opt\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/Wrapper.php(261): OC\\\\Files\\\\Storage\\\\Wrapper\\\\PermissionsMask->unlink('Circuit.png.ocT...')\\n#7 \\\/opt\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/Availability.php(284): OC\\\\Files\\\\Storage\\\\Wrapper\\\\Wrapper->unlink('Circuit.png.ocT...')\\n#8 \\\/opt\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/Encryption.php(254): OC\\\\Files\\\\Storage\\\\Wrapper\\\\Availability->unlink('Circuit.png.ocT...')\\n#9 \\\/opt\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/Wrapper.php(261): OC\\\\Files\\\\Storage\\\\Wrapper\\\\Encryption->unlink('Circuit.png.ocT...')\\n#10 [internal function]: OC\\\\Files\\\\Storage\\\\Wrapper\\\\Wrapper->unlink('Circuit.png.ocT...')\\n#11 \\\/opt\\\/owncloud\\\/apps\\\/files_trashbin\\\/lib\\\/Storage.php(169): call_user_func_array(Array, Array)\\n#12 \\\/opt\\\/owncloud\\\/apps\\\/files_trashbin\\\/lib\\\/Storage.php(120): OCA\\\\Files_Trashbin\\\\Storage->doDelete('Circuit.png.ocT...', 'unlink')\\n#13 \\\/opt\\\/owncloud\\\/apps\\\/workflow\\\/lib\\\/Engine\\\/Wrapper\\\/StorageWrapper.php(366): OCA\\\\Files_Trashbin\\\\Storage->unlink('Circuit.png.ocT...')\\n#14 \\\/opt\\\/owncloud\\\/apps\\\/dav\\\/lib\\\/Connector\\\/Sabre\\\/File.php(162): OCA\\\\Workflow\\\\Engine\\\\Wrapper\\\\StorageWrapper->unlink('Circuit.png.ocT...')\\n#15 \\\/opt\\\/owncloud\\\/apps\\\/dav\\\/lib\\\/Connector\\\/Sabre\\\/Directory.php(150): OCA\\\\DAV\\\\Connector\\\\Sabre\\\\File->put(Resource id #70)\\n#16 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(1095): OCA\\\\DAV\\\\Connector\\\\Sabre\\\\Directory->createFile('Circuit.png', Resource id #70)\\n#17 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/CorePlugin.php(525): Sabre\\\\DAV\\\\Server->createFile('SMB\\\/Circuit.png', Resource id #70, NULL)\\n#18 [internal function]: Sabre\\\\DAV\\\\CorePlugin->httpPut(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#19 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/event\\\/lib\\\/EventEmitterTrait.php(105): call_user_func_array(Array, Array)\\n#20 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(479): Sabre\\\\Event\\\\EventEmitter->emit('method:PUT', Array)\\n#21 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(254): Sabre\\\\DAV\\\\Server->invokeMethod(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#22 \\\/opt\\\/owncloud\\\/apps\\\/dav\\\/appinfo\\\/v1\\\/webdav.php(63): Sabre\\\\DAV\\\\Server->exec()\\n#23 \\\/opt\\\/owncloud\\\/remote.php(165): require_once('\\\/opt\\\/owncloud\\\/a...')\\n#24 {main}\",\"File\":\"\\\/opt\\\/owncloud\\\/apps\\\/files_external\\\/3rdparty\\\/icewind\\\/smb\\\/src\\\/NativeState.php\",\"Line\":66,\"User\":\"admin\"}"}
{"reqId":"uP2Bt0e3pXLMSCkIg8xl","level":3,"time":"2017-04-04T08:05:27+00:00","remoteAddr":"10.0.2.4","user":"qwerty","app":"webdav","method":"PUT","url":"\/remote.php\/webdav\/SMB\/iio.txt","message":"\\OC\\Files\\Filesystem::fopen() failed"}
{"reqId":"uP2Bt0e3pXLMSCkIg8xl","level":4,"time":"2017-04-04T08:05:27+00:00","remoteAddr":"10.0.2.4","user":"qwerty","app":"webdav","method":"PUT","url":"\/remote.php\/webdav\/SMB\/iio.txt","message":"Exception: {\"Message\":\"Unknown error (30) for smb:\\\/\\\/10.0.2.6\\\/ro\\\/iio.txt.ocTransferId1913855175.part\",\"Exception\":\"Icewind\\\\SMB\\\\Exception\\\\Exception\",\"Code\":30,\"Trace\":\"#0 \\\/opt\\\/owncloud\\\/apps\\\/files_external\\\/3rdparty\\\/icewind\\\/smb\\\/src\\\/NativeState.php(72): Icewind\\\\SMB\\\\NativeState->handleError('smb:\\\/\\\/10.0.2.6\\\/...')\\n#1 \\\/opt\\\/owncloud\\\/apps\\\/files_external\\\/3rdparty\\\/icewind\\\/smb\\\/src\\\/NativeState.php(146): Icewind\\\\SMB\\\\NativeState->testResult(false, 'smb:\\\/\\\/10.0.2.6\\\/...')\\n#2 \\\/opt\\\/owncloud\\\/apps\\\/files_external\\\/3rdparty\\\/icewind\\\/smb\\\/src\\\/NativeShare.php(150): Icewind\\\\SMB\\\\NativeState->unlink('smb:\\\/\\\/10.0.2.6\\\/...')\\n#3 \\\/opt\\\/owncloud\\\/apps\\\/files_external\\\/lib\\\/Lib\\\/Storage\\\/SMB.php(352): Icewind\\\\SMB\\\\NativeShare->del('\\\/iio.txt.ocTran...')\\n#4 \\\/opt\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/Wrapper.php(261): OCA\\\\Files_External\\\\Lib\\\\Storage\\\\SMB->unlink('\\\/iio.txt.ocTran...')\\n#5 \\\/opt\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/PermissionsMask.php(107): OC\\\\Files\\\\Storage\\\\Wrapper\\\\Wrapper->unlink('iio.txt.ocTrans...')\\n#6 \\\/opt\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/Wrapper.php(261): OC\\\\Files\\\\Storage\\\\Wrapper\\\\PermissionsMask->unlink('iio.txt.ocTrans...')\\n#7 \\\/opt\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/Availability.php(284): OC\\\\Files\\\\Storage\\\\Wrapper\\\\Wrapper->unlink('iio.txt.ocTrans...')\\n#8 \\\/opt\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/Encryption.php(254): OC\\\\Files\\\\Storage\\\\Wrapper\\\\Availability->unlink('iio.txt.ocTrans...')\\n#9 \\\/opt\\\/owncloud\\\/lib\\\/private\\\/Files\\\/Storage\\\/Wrapper\\\/Wrapper.php(261): OC\\\\Files\\\\Storage\\\\Wrapper\\\\Encryption->unlink('iio.txt.ocTrans...')\\n#10 [internal function]: OC\\\\Files\\\\Storage\\\\Wrapper\\\\Wrapper->unlink('iio.txt.ocTrans...')\\n#11 \\\/opt\\\/owncloud\\\/apps\\\/files_trashbin\\\/lib\\\/Storage.php(169): call_user_func_array(Array, Array)\\n#12 \\\/opt\\\/owncloud\\\/apps\\\/files_trashbin\\\/lib\\\/Storage.php(120): OCA\\\\Files_Trashbin\\\\Storage->doDelete('iio.txt.ocTrans...', 'unlink')\\n#13 \\\/opt\\\/owncloud\\\/apps\\\/workflow\\\/lib\\\/Engine\\\/Wrapper\\\/StorageWrapper.php(366): OCA\\\\Files_Trashbin\\\\Storage->unlink('iio.txt.ocTrans...')\\n#14 \\\/opt\\\/owncloud\\\/apps\\\/dav\\\/lib\\\/Connector\\\/Sabre\\\/File.php(162): OCA\\\\Workflow\\\\Engine\\\\Wrapper\\\\StorageWrapper->unlink('iio.txt.ocTrans...')\\n#15 \\\/opt\\\/owncloud\\\/apps\\\/dav\\\/lib\\\/Connector\\\/Sabre\\\/Directory.php(150): OCA\\\\DAV\\\\Connector\\\\Sabre\\\\File->put(Resource id #70)\\n#16 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(1095): OCA\\\\DAV\\\\Connector\\\\Sabre\\\\Directory->createFile('iio.txt', Resource id #70)\\n#17 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/CorePlugin.php(525): Sabre\\\\DAV\\\\Server->createFile('SMB\\\/iio.txt', Resource id #70, NULL)\\n#18 [internal function]: Sabre\\\\DAV\\\\CorePlugin->httpPut(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#19 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/event\\\/lib\\\/EventEmitterTrait.php(105): call_user_func_array(Array, Array)\\n#20 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(479): Sabre\\\\Event\\\\EventEmitter->emit('method:PUT', Array)\\n#21 \\\/opt\\\/owncloud\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(254): Sabre\\\\DAV\\\\Server->invokeMethod(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#22 \\\/opt\\\/owncloud\\\/apps\\\/dav\\\/appinfo\\\/v1\\\/webdav.php(63): Sabre\\\\DAV\\\\Server->exec()\\n#23 \\\/opt\\\/owncloud\\\/remote.php(165): require_once('\\\/opt\\\/owncloud\\\/a...')\\n#24 {main}\",\"File\":\"\\\/opt\\\/owncloud\\\/apps\\\/files_external\\\/3rdparty\\\/icewind\\\/smb\\\/src\\\/NativeState.php\",\"Line\":66,\"User\":\"qwerty\"}"}
{"reqId":"a5vzz2EBSUEEuYNXuPws","level":2,"time":"2017-04-04T08:06:29+00:00","remoteAddr":"10.0.2.4","user":"qwerty","app":"core","method":"POST","url":"\/index.php\/settings\/personal\/changepassword","message":"Login failed: 'qwerty' (Remote IP: '10.0.2.4')"}
{"reqId":"w5daBbCfcH1hT7B79IzG","level":3,"time":"2017-04-04T08:07:15+00:00","remoteAddr":"10.0.2.4","user":"qwerty","app":"no app in context","method":"POST","url":"\/ocs\/v2.php\/apps\/files_sharing\/api\/v1\/shares?format=json","message":"Failed to notify remote server of federated share, removing share (Sharing Photos failed, could not find user1@example.com, maybe the server is currently unreachable.)"}
{"reqId":"Ny0BwyfDItClXRn3SM94","level":2,"time":"2017-04-04T08:08:05+00:00","remoteAddr":"10.0.2.4","user":"--","app":"core","method":"POST","url":"\/index.php\/login","message":"Login failed: 'admin' (Remote IP: '10.0.2.4')"}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
