### PR TITLE
Option to mount a new local storage disabled

### DIFF
--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -87,10 +87,7 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 			$container->query('OCA\Files_External\Lib\Backend\SMB_OC'),
 		];
 
-		$this->allowLocalMounts = \OC::$server->getConfig()->getSystemValue('files_external_allow_local', true);
-		if ($this->allowLocalMounts === true) {
-			$backends[] = $container->query('OCA\Files_External\Lib\Backend\Local');
-		};
+		$backends[] = $container->query('OCA\Files_External\Lib\Backend\Local');
 
 		return $backends;
 	}

--- a/apps/files_external/lib/Controller/StoragesController.php
+++ b/apps/files_external/lib/Controller/StoragesController.php
@@ -111,30 +111,26 @@ abstract class StoragesController extends Controller {
 		$applicableGroups = null,
 		$priority = null
 	) {
-		$canCreateNewLocalStorage = \OC::$server->getConfig()->getSystemValue('files_external_allow_create_new_local', false);
-
-		if ($canCreateNewLocalStorage === true) {
-			try {
-				return $this->service->createStorage(
-					$mountPoint,
-					$backend,
-					$authMechanism,
-					$backendOptions,
-					$mountOptions,
-					$applicableUsers,
-					$applicableGroups,
-					$priority
-				);
-			} catch (\InvalidArgumentException $e) {
-				$this->logger->logException($e);
-				return new DataResponse(
-					[
-						'message' => (string)$this->l10n->t('Invalid backend or authentication mechanism class')
-					],
-					Http::STATUS_UNPROCESSABLE_ENTITY
-				);
-			}
-		};
+		try {
+			return $this->service->createStorage(
+				$mountPoint,
+				$backend,
+				$authMechanism,
+				$backendOptions,
+				$mountOptions,
+				$applicableUsers,
+				$applicableGroups,
+				$priority
+			);
+		} catch (\InvalidArgumentException $e) {
+			$this->logger->logException($e);
+			return new DataResponse(
+				[
+					'message' => (string)$this->l10n->t('Invalid backend or authentication mechanism class')
+				],
+				Http::STATUS_UNPROCESSABLE_ENTITY
+			);
+		}
 	}
 
 	/**

--- a/apps/files_external/lib/Controller/StoragesController.php
+++ b/apps/files_external/lib/Controller/StoragesController.php
@@ -111,26 +111,30 @@ abstract class StoragesController extends Controller {
 		$applicableGroups = null,
 		$priority = null
 	) {
-		try {
-			return $this->service->createStorage(
-				$mountPoint,
-				$backend,
-				$authMechanism,
-				$backendOptions,
-				$mountOptions,
-				$applicableUsers,
-				$applicableGroups,
-				$priority
-			);
-		} catch (\InvalidArgumentException $e) {
-			$this->logger->logException($e);
-			return new DataResponse(
-				[
-					'message' => (string)$this->l10n->t('Invalid backend or authentication mechanism class')
-				],
-				Http::STATUS_UNPROCESSABLE_ENTITY
-			);
-		}
+		$canCreateNewLocalStorage = \OC::$server->getConfig()->getSystemValue('files_external_allow_create_new_local', false);
+
+		if ($canCreateNewLocalStorage === true) {
+			try {
+				return $this->service->createStorage(
+					$mountPoint,
+					$backend,
+					$authMechanism,
+					$backendOptions,
+					$mountOptions,
+					$applicableUsers,
+					$applicableGroups,
+					$priority
+				);
+			} catch (\InvalidArgumentException $e) {
+				$this->logger->logException($e);
+				return new DataResponse(
+					[
+						'message' => (string)$this->l10n->t('Invalid backend or authentication mechanism class')
+					],
+					Http::STATUS_UNPROCESSABLE_ENTITY
+				);
+			}
+		};
 	}
 
 	/**

--- a/apps/files_external/lib/Controller/UserStoragesController.php
+++ b/apps/files_external/lib/Controller/UserStoragesController.php
@@ -126,29 +126,40 @@ class UserStoragesController extends StoragesController {
 		$backendOptions,
 		$mountOptions
 	) {
-		$newStorage = $this->createStorage(
-			$mountPoint,
-			$backend,
-			$authMechanism,
-			$backendOptions,
-			$mountOptions
-		);
-		if ($newStorage instanceOf DataResponse) {
-			return $newStorage;
+		$canCreateNewLocalStorage = \OC::$server->getConfig()->getSystemValue('files_external_allow_create_new_local', false);
+
+		if ($canCreateNewLocalStorage === true) {
+			$newStorage = $this->createStorage(
+				$mountPoint,
+				$backend,
+				$authMechanism,
+				$backendOptions,
+				$mountOptions
+			);
+			if ($newStorage instanceOf DataResponse) {
+				return $newStorage;
+			}
+
+			$response = $this->validate($newStorage);
+			if (!empty($response)) {
+				return $response;
+			}
+
+			$newStorage = $this->service->addStorage($newStorage);
+			$this->updateStorageStatus($newStorage);
+
+			return new DataResponse(
+				$newStorage,
+				Http::STATUS_CREATED
+			);
 		}
 
-		$response = $this->validate($newStorage);
-		if (!empty($response)) {
-			return $response;
+		else {
+			return new DataResponse(
+				null,
+				Http::STATUS_FORBIDDEN
+			);
 		}
-
-		$newStorage = $this->service->addStorage($newStorage);
-		$this->updateStorageStatus($newStorage);
-
-		return new DataResponse(
-			$newStorage,
-			Http::STATUS_CREATED
-		);
 	}
 
 	/**

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -88,8 +88,12 @@
 								return strcasecmp($a->getText(), $b->getText());
 							});
 						?>
+						<?php
+							$canCreateNewLocalStorage = \OC::$server->getConfig()->getSystemValue('files_external_allow_create_new_local', false);
+						?>
 						<?php foreach ($sortedBackends as $backend): ?>
 							<?php if ($backend->getDeprecateTo()) continue; // ignore deprecated backends ?>
+							<?php if (!$canCreateNewLocalStorage && $backend->getIdentifier() == "local") continue; // if the "files_external_allow_create_new_local" config param isn't set to to true ?>
 							<option value="<?php p($backend->getIdentifier()); ?>"><?php p($backend->getText()); ?></option>
 						<?php endforeach; ?>
 					</select>

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1380,13 +1380,6 @@ $CONFIG = array(
 'data-fingerprint' => '',
 
 /**
- * Set this property to false if you want to disable the files_external local mount Option.
- * Default: true
- *
- */
-'files_external_allow_local' => true,
-
-/**
  * This entry is just here to show a warning in case somebody copied the sample
  * configuration. DO NOT ADD THIS SWITCH TO YOUR CONFIGURATION!
  *
@@ -1394,5 +1387,12 @@ $CONFIG = array(
  * modify *ANY* settings in this file without reading the documentation.
  */
 'copied_sample_config' => true,
+
+/**
+ * Set this property to true if you want to enable the files_external local mount Option.
+ * Default: false
+ *
+ */
+'files_external_allow_create_new_local' => false,
 
 );


### PR DESCRIPTION
Fixes #26653 

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Option to mount a new local storage removed unless ```files_external_allow_create_new_local``` variable specifically set to ```true``` in config.php

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/26653

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Included the ```files_external_allow_create_new_local``` option and set to ```true``` and ```false```, works as desired

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@PVince81 