### PR TITLE
Rename "local link" to "private link"

### DIFF
--- a/apps/files/js/mainfileinfodetailview.js
+++ b/apps/files/js/mainfileinfodetailview.js
@@ -162,7 +162,7 @@
 					starAltText: isFavorite ? t('files', 'Favorited') : t('files', 'Favorite'),
 					starClass: isFavorite ? 'icon-starred' : 'icon-star',
 					permalink: this._makePermalink(this.model.get('id')),
-					permalinkTitle: t('files', 'Local link')
+					permalinkTitle: t('files', 'Private link:  Only people who have access to the file/folder can use it. Use it as a permanent link for yourself or to point others to files within shares')
 				}));
 
 				// TODO: we really need OC.Previews


### PR DESCRIPTION
@pmaier1 @felixheidecke please review

![private_link](https://cloud.githubusercontent.com/assets/277525/24793221/7e419d4a-1b81-11e7-8ec6-fa7ab1b4175f.png)

Fixes https://github.com/owncloud/core/issues/27593