### PR TITLE
Fix reset password button in link share dialog

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -293,7 +293,7 @@
 			if (this.model.isNew()) {
 				title = t('files_sharing', 'Create link share: {name}', {name: this.itemModel.getFileInfo().getFullPath()});
 			}
-			else if (this.model.get('encryptedPassword') !== undefined) {
+			else if (this.model.get('encryptedPassword')) {
 				buttons.push({
 					classes: 'removePassword -float-left',
 					text: t('core', 'Remove password'),


### PR DESCRIPTION
Steps to reproduce:

1. Create public link share, Save
1. Edit public link share

Before fix: "Reset password" button still visible even though there is none
After fix: button is gone.

I tested that the button still appears only when a password was set.

@felixheidecke quick review please