### PR TITLE
Added check for mtime to be integer

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -212,7 +212,7 @@ class File extends Node implements IFile {
 					}
 				}
 				else {
-					throw new BadRequest('expected mtime to be integer');
+					throw new BadRequest('X-OC-MTime header must be an integer');
 				}
 			}
 			
@@ -470,7 +470,7 @@ class File extends Node implements IFile {
 						}
 					}
 					else {
-						throw new BadRequest('expected mtime to be integer');
+						throw new BadRequest('X-OC-MTime header must be an integer');
 					}
 				}
 

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -206,8 +206,13 @@ class File extends Node implements IFile {
 			// allow sync clients to send the mtime along in a header
 			$request = \OC::$server->getRequest();
 			if (isset($request->server['HTTP_X_OC_MTIME'])) {
-				if ($this->fileView->touch($this->path, $request->server['HTTP_X_OC_MTIME'])) {
-					header('X-OC-MTime: accepted');
+				if( is_int($request->server['HTTP_X_OC_MTIME']) ) {
+					if ($this->fileView->touch($this->path, $request->server['HTTP_X_OC_MTIME'])) {
+						header('X-OC-MTime: accepted');
+					}
+				}
+				else {
+					throw new BadRequest('expected mtime to be integer');
 				}
 			}
 			
@@ -459,8 +464,13 @@ class File extends Node implements IFile {
 				// allow sync clients to send the mtime along in a header
 				$request = \OC::$server->getRequest();
 				if (isset($request->server['HTTP_X_OC_MTIME'])) {
-					if ($targetStorage->touch($targetInternalPath, $request->server['HTTP_X_OC_MTIME'])) {
-						header('X-OC-MTime: accepted');
+					if( is_int($request->server['HTTP_X_OC_MTIME']) ) {
+						if ($targetStorage->touch($targetInternalPath, $request->server['HTTP_X_OC_MTIME'])) {
+							header('X-OC-MTime: accepted');
+						}
+					}
+					else {
+						throw new BadRequest('expected mtime to be integer');
 					}
 				}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Added check in File.php of dav app in order to ensure that `$request->server['HTTP_X_OC_MTIME']` is an integer. If it is not then throws a `BadRequest` exception.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#27437](https://github.com/owncloud/core/issues/27437)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Have not tested it thoroughly. 
Chrome and Ubuntu 14.04

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

