### PR TITLE
Catch session already closed exception in destructor

### DIFF
--- a/lib/private/Session/CryptoSessionData.php
+++ b/lib/private/Session/CryptoSessionData.php
@@ -63,7 +63,12 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 	 * Close session if class gets destructed
 	 */
 	public function __destruct() {
-		$this->close();
+		try {
+			$this->close();
+		} catch (SessionNotAvailableException $e){
+			// This exception can occur if session is already closed
+			// So it is safe to ignore it and let the garbage collector to proceed
+		}
 	}
 
 	protected function initializeSession() {

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -150,7 +150,7 @@ class Internal extends Session {
 	 */
 	private function validateSession() {
 		if ($this->sessionClosed) {
-			throw new \Exception('Session has been closed - no further changes to the session are allowed');
+			throw new SessionNotAvailableException('Session has been closed - no further changes to the session are allowed');
 		}
 	}
 }


### PR DESCRIPTION
## Description
Do not break while collecting garbage


## Related Issue
https://github.com/owncloud/QA/issues/409
https://github.com/owncloud/administration/issues/121

## Motivation and Context
```
[Wed Apr 12 10:15:25.737543 2017] [:error] [pid 1513] [client ::1:37856] PHP Fatal error:  Uncaught Exception: Session has been closed - no further changes to the session are allowed in /opt/owncloud/lib/private/Session/Internal.php:153
Stack trace:
#0 /opt/owncloud/lib/private/Session/Internal.php(63): OC\\Session\\Internal->validateSession()
#1 /opt/owncloud/lib/private/Session/CryptoSessionData.php(163): OC\\Session\\Internal->set('encrypted_sessi...', 'b1d49ce937c0001...')
#2 /opt/owncloud/lib/private/Session/CryptoSessionData.php(66): OC\\Session\\CryptoSessionData->close()
#3 [internal function]: OC\\Session\\CryptoSessionData->__destruct()
#4 {main}
  thrown in /opt/owncloud/lib/private/Session/Internal.php on line 153
```

## How Has This Been Tested?
Bashing /dev/head against /dev/wall
Myriads of docker containers were raised from dead and  squashed into dust

### Exact Steps to reproduce
1. Install 9.0.9rc
2. Enable encryption app
3. Enable encryption on admin page
4. Switch to beta channel
5. Update to 9.1.5 rc1
6. Nothing in owncloud.log but apache's error log is very motivating (See the `Motivation and Context` section)

![image](https://cloud.githubusercontent.com/assets/991300/24975777/8a494ff0-1fcf-11e7-934f-c621ab9b4337.png)

### `Note`: The patch should be applied to the zipped package and not to the installed instance. Otherwise the change will be rewritten.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

