### PR TITLE
If not logged in -> 401 and bye-bye

### DIFF
--- a/core/js/config.php
+++ b/core/js/config.php
@@ -44,6 +44,10 @@ header("Content-type: text/javascript");
 header("Cache-Control: no-cache, must-revalidate");
 header("Expires: Sat, 26 Jul 1997 05:00:00 GMT");
 
+if (\OC::$server->getUserSession() === null || !\OC::$server->getUserSession()->isLoggedIn()) {
+	header('HTTP/1.0 401 Unauthorized');
+	return;
+}
 // Enable l10n support
 $l = \OC::$server->getL10N('core');
 


### PR DESCRIPTION
## Description
In case of an unauthorized request no config values are exposed.

## Related Issue
https://github.com/owncloud/core/pull/27473

## Motivation and Context
Disallow information disclosure

## How Has This Been Tested?
- installation
- login/logout
- public link share
- federated sharing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

