### PR TITLE
Fix theme overwrite for subdir deployments

### DIFF
--- a/core/js/mimetype.js
+++ b/core/js/mimetype.js
@@ -82,7 +82,7 @@ OC.MimeType = {
 
 		// First try to get the correct icon from the current theme
 		if (OC.currentTheme.name !== '' && $.isArray(OC.MimeTypeList.themes[OC.currentTheme.name])) {
-			path = '/' + OC.currentTheme.directory + 'core/img/filetypes/';
+			path = '/' + OC.currentTheme.directory + '/core/img/filetypes/';
 			icon = OC.MimeType._getFile(mimeType, OC.MimeTypeList.themes[OC.currentTheme.name]);
 		}
 

--- a/core/js/tests/specs/mimeTypeSpec.js
+++ b/core/js/tests/specs/mimeTypeSpec.js
@@ -129,7 +129,7 @@ describe('MimeType tests', function() {
 			beforeEach(function() {
 				_themeFolder = OC.currentTheme.name;
 				OC.currentTheme.name = 'abc';
-				OC.currentTheme.directory = 'themes/abc/';
+				OC.currentTheme.directory = 'themes/abc';
 				//Clear mimetypeIcons caches
 				OC.MimeType._mimeTypeIcons = {};
 			});

--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -85,12 +85,12 @@ class Base {
 		// Check if the app is in the app folder or in the root
 		if( file_exists($app_dir.'/templates/' )) {
 			return [
-				$serverRoot.'/'.$theme->getDirectory().'apps/'.$app.'/templates/',
+				$serverRoot.'/'.$theme->getDirectory().'/apps/'.$app.'/templates/',
 				$app_dir.'/templates/',
 			];
 		}
 		return [
-			$serverRoot.'/'.$theme->getDirectory().$app.'/templates/',
+			$serverRoot.'/'.$theme->getDirectory().'/'.$app.'/templates/',
 			$serverRoot.'/'.$app.'/templates/',
 		];
 	}
@@ -102,7 +102,7 @@ class Base {
 	 */
 	protected function getCoreTemplateDirs($theme, $serverRoot) {
 		return [
-			$serverRoot.'/'.$theme->getDirectory().'core/templates/',
+			$serverRoot.'/'.$theme->getDirectory().'/core/templates/',
 			$serverRoot.'/core/templates/',
 		];
 	}

--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -54,8 +54,8 @@ class CSSResourceLocator extends ResourceLocator {
 	public function doFindTheme($style) {
 		$themeDirectory = $this->theme->getDirectory();
 
-		$this->appendOnceIfExist($this->serverroot, $themeDirectory.'apps/'.$style.'.css')
-			|| $this->appendOnceIfExist($this->serverroot, $themeDirectory.$style.'.css')
-			|| $this->appendOnceIfExist($this->serverroot, $themeDirectory.'core/'.$style.'.css');
+		$this->appendOnceIfExist($this->serverroot, $themeDirectory . '/apps/' . $style . '.css')
+			|| $this->appendOnceIfExist($this->serverroot, $themeDirectory . '/' . $style . '.css')
+			|| $this->appendOnceIfExist($this->serverroot, $themeDirectory . '/core/' . $style . '.css');
 	}
 }

--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -43,18 +43,18 @@ class JSResourceLocator extends ResourceLocator {
 			// single l10n strings without having to translate all of them.
 			$found = 0;
 			$found += $this->appendOnceIfExist($this->serverroot, 'core/'.$script.'.js');
-			$found += $this->appendOnceIfExist($this->serverroot, $themeDirectory.'core/'.$script.'.js');
+			$found += $this->appendOnceIfExist($this->serverroot, $themeDirectory.'/core/'.$script.'.js');
 			$found += $this->appendOnceIfExist($this->serverroot, $script.'.js');
-			$found += $this->appendOnceIfExist($this->serverroot, $themeDirectory.$script.'.js');
-			$found += $this->appendOnceIfExist($this->serverroot, $themeDirectory.'apps/'.$script.'.js');
+			$found += $this->appendOnceIfExist($this->serverroot, $themeDirectory.'/'.$script.'.js');
+			$found += $this->appendOnceIfExist($this->serverroot, $themeDirectory.'/apps/'.$script.'.js');
 
 			if ($found) {
 				return;
 			}
-		} else if ($this->appendOnceIfExist($this->serverroot, $themeDirectory.'apps/'.$script.'.js')
-			|| $this->appendOnceIfExist($this->serverroot, $themeDirectory.$script.'.js')
+		} else if ($this->appendOnceIfExist($this->serverroot, $themeDirectory.'/apps/'.$script.'.js')
+			|| $this->appendOnceIfExist($this->serverroot, $themeDirectory.'/'.$script.'.js')
 			|| $this->appendOnceIfExist($this->serverroot, $script.'.js')
-			|| $this->appendOnceIfExist($this->serverroot, $themeDirectory.'core/'.$script.'.js')
+			|| $this->appendOnceIfExist($this->serverroot, $themeDirectory.'/core/'.$script.'.js')
 			|| $this->appendOnceIfExist($this->serverroot, 'core/'.$script.'.js')
 		) {
 			return;

--- a/lib/private/Theme/Theme.php
+++ b/lib/private/Theme/Theme.php
@@ -80,7 +80,7 @@ class Theme {
 	/**
 	 * @return string
 	 */
-	public function getWebPath(): string {
+	public function getWebPath() {
 		return $this->webPath;
 	}
 

--- a/lib/private/Theme/Theme.php
+++ b/lib/private/Theme/Theme.php
@@ -87,7 +87,7 @@ class Theme {
 	/**
 	 * @param string $webPath
 	 */
-	public function setWebPath(string $webPath) {
+	public function setWebPath($webPath) {
 		$this->webPath = $webPath;
 	}
 }

--- a/lib/private/Theme/Theme.php
+++ b/lib/private/Theme/Theme.php
@@ -34,6 +34,11 @@ class Theme {
 	private $directory;
 
 	/**
+	 * @var string
+	 */
+	private $webPath;
+
+	/**
 	 * Theme constructor.
 	 *
 	 * @param string $name
@@ -70,5 +75,19 @@ class Theme {
 	 */
 	public function setDirectory($directory) {
 		$this->directory = $directory;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getWebPath(): string {
+		return $this->webPath;
+	}
+
+	/**
+	 * @param string $webPath
+	 */
+	public function setWebPath(string $webPath) {
+		$this->webPath = $webPath;
 	}
 }

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -100,8 +100,9 @@ class ThemeService {
 	public function setAppTheme($appName = '') {
 		if ($appName !== '') {
 			$this->theme->setDirectory(
-				ltrim(\OC_App::getAppWebPath($appName), '/') . '/'
+				substr(\OC_App::getAppPath($appName), strlen(\OC::$SERVERROOT) + 1)
 			);
+			$this->theme->setWebPath(\OC_App::getAppWebPath($appName));
 			$this->theme->setName($appName);
 		}
 	}

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -102,7 +102,8 @@ class ThemeService {
 			$this->theme->setDirectory(
 				substr(\OC_App::getAppPath($appName), strlen(\OC::$SERVERROOT) + 1)
 			);
-			$this->theme->setWebPath(\OC_App::getAppWebPath($appName));
+			$appWebPath = \OC_App::getAppWebPath($appName);
+			$this->theme->setWebPath($appWebPath ? $appWebPath : '');
 			$this->theme->setName($appName);
 		}
 	}

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -187,7 +187,7 @@ class URLGenerator implements IURLGenerator {
 			$file = $directory . $imageName;
 
 			if (!empty($themeDirectory)) {
-				if ($imagePath = $this->getImagePathOrFallback('/' . substr($this->theme->getDirectory(), 0, -1) . $file)) {
+				if ($imagePath = $this->getImagePathOrFallback('/' . $this->theme->getDirectory() . '/' . $file)) {
 					return $imagePath;
 				}
 			}

--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -67,10 +67,9 @@ class OC_Defaults {
 		$this->defaultLogoClaim = '';
 		$this->defaultMailHeaderColor = '#1d2d44'; /* header color of mail notifications */
 
-
 		$themePath = OC_Util::getTheme()->getDirectory();
 
-		$defaultsPath = OC::$SERVERROOT . '/' .$themePath . 'defaults.php';
+		$defaultsPath = OC::$SERVERROOT . '/' . $themePath . '/defaults.php';
 		if (file_exists($defaultsPath)) {
 			// prevent defaults.php from printing output
 			ob_start();

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -189,7 +189,7 @@ class OC_Template extends \OC\Template\Base {
 	 */
 	protected function findTemplate($theme, $app, $name) {
 		// Check if it is a app template or not.
-		if( $app !== '' ) {
+		if( $app !== '' && $app !== 'core' ) {
 			$dirs = $this->getAppTemplateDirs($theme, $app, OC::$SERVERROOT, OC_App::getAppPath($app));
 		} else {
 			$dirs = $this->getCoreTemplateDirs($theme, OC::$SERVERROOT);


### PR DESCRIPTION
## Description
Because of a confusion with `webroot`, `serverroot`, `relative/absolute` paths and a mixture of adding and removing trailing and leading slashes, an app theme could not overwrite resources when the owncloud instance was configured like described in #27630. This change fixes this.

## Related Issue
#27630


## How Has This Been Tested?
Overwriting resources has to be tested excessively, here is a list of all scenarios that have to work:

Regular deployment - app theme:
- [x] css
- [x] js
- [x] images
- [x] templates
- [x] mimetype icons

Subdir deployment - app theme:
- [x] css
- [x] js
- [x] images
- [x] templates
- [x] mimetype icons

Regular deployment - legacy theme:
- [x] css
- [x] js
- [x] images
- [x] templates
- [x] mimetype icons

Subdir deployment - legacy theme:
- [x] css
- [x] js
- [x] images
- [x] templates
- [x] mimetype icons

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

