### PR TITLE
Fix missing translation of built-in section names

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -119,7 +119,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerService('SettingsManager', function(Server $c) {
 			return new SettingsManager(
-				$c->getL10N('core'),
+				$c->getL10N('lib'),
 				$c->getAppManager(),
 				$c->getUserSession(),
 				$c->getLogger(),


### PR DESCRIPTION
## Description
Changed translation resource from 'core' to 'lib', because translation of section names was not happening even though the code does translate it here: https://github.com/owncloud/core/blob/master/lib/private/Settings/SettingsManager.php#L195

## Related Issue
App provided sections with translations and icons? #27327

## Motivation and Context
Translation of section names was not happening on the Settings page. See screenshot of Norwegian installation below.

## How Has This Been Tested?
Tested in private installation. Manual regression testing: 
* The modified translation resource is used exclusively for translating sections in SettingsManager.php. This works after the fix.
* The modified translation resource is passed to SecurityWarning.php to [translate memcache names](https://github.com/owncloud/core/blob/master/settings/Panels/Admin/SecurityWarning.php#L84). This design was already broken before the fix, because those names are in the 'settings' resource, neither in 'core' nor 'lib'. _I leave it to others to decide how this separate issue is best fixed._

## Screenshots (if appropriate):
![oc-nontrans-a](https://cloud.githubusercontent.com/assets/4960432/25069944/99989264-228f-11e7-8b80-eb36287669a3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

EDIT: Corrected link to SecurityWarning.php.