### PR TITLE
Count space of the mounted directories

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -293,6 +293,21 @@ class Local extends \OC\Files\Storage\Common {
 		if ($space === false || is_null($space)) {
 			return \OCP\Files\FileInfo::SPACE_UNKNOWN;
 		}
+		$mounts = shell_exec("mount | grep $sourcePath");
+		$mounts = preg_split('/\n/', $mounts);
+		array_pop($mounts);
+		if (count($mounts) > 0) {
+			foreach ($mounts as &$value) {
+				$dir = preg_split('/ /', $value)[0];
+				do {
+					$size = @disk_free_space($dir);
+					$dir = preg_split('/\//', $dir);
+					array_pop($dir);
+					$dir = join('/', $dir);
+				} while(count($dir) > 0 and $size == null);
+				$space += $size;
+			}
+		}
 		return $space;
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description, Motivation and Context
Since the symlinks are disabled the only possibility to keep the files in the different filesystems on the server is to mount those filesystems onto the some subdirectory of data directrory.
In this case the available space is calculated incorrectly and the application decides that no space is left.
This patch fixes the problem but ONLY for ***nix** systems.

## How Has This Been Tested?
It was tested on the working instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

