### PR TITLE
[stable9.1] Catch session already closed exception in destructor

### DIFF
--- a/lib/private/Session/CryptoSessionData.php
+++ b/lib/private/Session/CryptoSessionData.php
@@ -63,7 +63,12 @@ class CryptoSessionData implements \ArrayAccess, ISession {
 	 * Close session if class gets destructed
 	 */
 	public function __destruct() {
-		$this->close();
+		try {
+			$this->close();
+		} catch (SessionNotAvailableException $e){
+			// This exception can occur if session is already closed
+			// So it is safe to ignore it and let the garbage collector to proceed
+		}
 	}
 
 	protected function initializeSession() {

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -150,7 +150,7 @@ class Internal extends Session {
 	 */
 	private function validateSession() {
 		if ($this->sessionClosed) {
-			throw new \Exception('Session has been closed - no further changes to the session are allowed');
+			throw new SessionNotAvailableException('Session has been closed - no further changes to the session are allowed');
 		}
 	}
 }


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/27638
Fixes https://github.com/owncloud/administration/issues/121