### PR TITLE
quote index columns to make oracle happy for now

### DIFF
--- a/apps/dav/appinfo/Migrations/Version20170116170538.php
+++ b/apps/dav/appinfo/Migrations/Version20170116170538.php
@@ -56,7 +56,7 @@ class Version20170116170538 implements ISchemaMigration {
 			'length' => 255,
 		]);
 		$table->setPrimaryKey(['id']);
-		$table->addIndex(['fileid'], 'fileid_index');
+		$table->addIndex(['`fileid`'], 'fileid_index');
 	}
 
 	/**
@@ -81,7 +81,7 @@ class Version20170116170538 implements ISchemaMigration {
 				]);
 			}
 			if (!$table->hasIndex('fileid_index')){
-				$table->addIndex(['fileid'], 'fileid_index');
+				$table->addIndex(['`fileid`'], 'fileid_index');
 			}
 		}
 	}


### PR DESCRIPTION
This is only a workaround that allows the migration from 9.1.4 to 10.0 to complete. Without this oracle complains:

```json
{"reqId":"mBuwxqTILuAsZOesm3ic","level":0,"time":"2017-04-18T08:42:33+00:00","remoteAddr":"","user":"--","app":"core","method":"--","url":"--","message":"starting upgrade from 9.1.4.2 to 10.0.0.6"}
{"reqId":"mBuwxqTILuAsZOesm3ic","level":1,"time":"2017-04-18T08:46:23+00:00","remoteAddr":"","user":"--","app":"core","method":"--","url":"--","message":"Insert new users ..."}
{"reqId":"mBuwxqTILuAsZOesm3ic","level":3,"time":"2017-04-18T08:54:30+00:00","remoteAddr":"","user":"--","app":"core","method":"--","url":"--","message":"Exception: {\"Exception\":\"Doctrine\DBAL\Exception\InvalidFieldNameException\",\"Message\":\"An exception occurred while executing 'CREATE INDEX fileid_index ON \\\"oc_properties\\\" (fileid)':

ORA-00904: \\\"FILEID\\\": invalid identifier\",\"Code\":0,\"Trace\":\"#0 /home/jfd/www/owncloud-10.0.0beta2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php(128): Doctrine\DBAL\Driver\AbstractOracleDriver->convertException('An exception oc...', Object(Doctrine\DBAL\Driver\OCI8\OCI8Exception))
#1 /home/jfd/www/owncloud-10.0.0beta2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(964): Doctrine\DBAL\DBALException::driverExceptionDuringQuery(Object(Doctrine\DBAL\Driver\OCI8\Driver), Object(Doctrine\DBAL\Driver\OCI8\OCI8Exception), 'CREATE INDEX fi...')
#2 /home/jfd/www/owncloud-10.0.0beta2/lib/private/DB/Migrator.php(199): Doctrine\DBAL\Connection->query('CREATE INDEX fi...')
#3 /home/jfd/www/owncloud-10.0.0beta2/lib/private/DB/Migrator.php(81): OC\DB\Migrator->applySchema(Object(Doctrine\DBAL\Schema\Schema))
#4 /home/jfd/www/owncloud-10.0.0beta2/lib/private/DB/Connection.php(429): OC\DB\Migrator->migrate(Object(Doctrine\DBAL\Schema\Schema))
#5 /home/jfd/www/owncloud-10.0.0beta2/lib/private/DB/MigrationService.php(388): OC\DB\Connection->migrateToSchema(Object(Doctrine\DBAL\Schema\Schema))
#6 /home/jfd/www/owncloud-10.0.0beta2/lib/private/DB/MigrationService.php(346): OC\DB\MigrationService->executeStep(20170116170538)
#7 /home/jfd/www/owncloud-10.0.0beta2/lib/private/legacy/app.php(1044): OC\DB\MigrationService->migrate()
#8 /home/jfd/www/owncloud-10.0.0beta2/lib/private/Updater.php(315): OC_App::updateApp('dav')
#9 /home/jfd/www/owncloud-10.0.0beta2/lib/private/Updater.php(238): OC\Updater->doAppUpgrade()
#10 /home/jfd/www/owncloud-10.0.0beta2/lib/private/Updater.php(121): OC\Updater->doUpgrade('10.0.0.6', '9.1.4.2')
#11 /home/jfd/www/owncloud-10.0.0beta2/core/Command/Upgrade.php(259): OC\Updater->upgrade()
#12 /home/jfd/www/owncloud-10.0.0beta2/lib/composer/symfony/console/Command/Command.php(262): OC\Core\Command\Upgrade->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /home/jfd/www/owncloud-10.0.0beta2/lib/composer/symfony/console/Application.php(826): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /home/jfd/www/owncloud-10.0.0beta2/lib/composer/symfony/console/Application.php(189): Symfony\Component\Console\Application->doRunCommand(Object(OC\Core\Command\Upgrade), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 /home/jfd/www/owncloud-10.0.0beta2/lib/composer/symfony/console/Application.php(120): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 /home/jfd/www/owncloud-10.0.0beta2/lib/private/Console/Application.php(160): Symfony\Component\Console\Application->run(NULL, NULL)
#17 /home/jfd/www/owncloud-10.0.0beta2/console.php(99): OC\Console\Application->run()
#18 /home/jfd/www/owncloud-10.0.0beta2/occ(11): require_once('/home/jfd/www/o...')
#19 {main}\",\"File\":\"/home/jfd/www/owncloud-10.0.0beta2/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractOracleDriver.php\",\"Line\":48}"}
```

Caused by Doctrine generating unquoted identifiers:
```SQL
CREATE INDEX fileid_index ON "oc_properties" (fileid)
```

The correct fix is to generate quoted columns ... but we might want to get rid of the quotation mess and instead forbid reserved identifiers? But that is a different topic.

Related: https://github.com/owncloud/core/issues/27466