### PR TITLE
Fix unique email address handling

### DIFF
--- a/lib/private/User/AccountMapper.php
+++ b/lib/private/User/AccountMapper.php
@@ -34,8 +34,10 @@ class AccountMapper extends Mapper {
 	}
 
 	/**
-	 * @param string $email
-	 * @return Account[]
+	 * Return account matching the given email address
+	 *
+	 * @param string $email email address
+	 * @return Account|null account matching the address or null
 	 */
 	public function getByEmail($email) {
 		$qb = $this->db->getQueryBuilder();
@@ -43,7 +45,11 @@ class AccountMapper extends Mapper {
 			->from($this->getTableName())
 			->where($qb->expr()->eq('email', $qb->createNamedParameter($email)));
 
-		return $this->findEntities($qb->getSQL(), $qb->getParameters());
+		$results = $this->findEntities($qb->getSQL(), $qb->getParameters());
+		if (empty($results)) {
+			return null;
+		}
+		return $results[0];
 	}
 
 	/**

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -367,10 +367,8 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @since 9.1.0
 	 */
 	public function getByEmail($email) {
-		$accounts = $this->accountMapper->getByEmail($email);
-		return array_map(function(Account $account) {
-			return $this->getUserObject($account);
-		}, $accounts);
+		$account = $this->accountMapper->getByEmail($email);
+		return [$this->getUserObject($account)];
 	}
 
 	/**

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -368,6 +368,9 @@ class Manager extends PublicEmitter implements IUserManager {
 	 */
 	public function getByEmail($email) {
 		$account = $this->accountMapper->getByEmail($email);
+		if ($account === null) {
+			return null;
+		}
 		return [$this->getUserObject($account)];
 	}
 


### PR DESCRIPTION
## Description
Fixes upgrade and user:sync issues when one user backend provides multiple users with the same email address, or multiple backends provide different users with the same email address.

## Related Issue
Fixes critical part of https://github.com/owncloud/core/issues/27626

## Motivation and Context
See ticket

## How Has This Been Tested?
- [x] TEST: upgrade with duplicate email => second user must have empty email, no failures
- [ ] TEST: user:sync of new users where LDAP has duplicate email => second user has empty email
- [ ] TEST: user:sync of existing users where one's email is changed to a duplicate in LDAP => user with modified email receives an empty email address instead of failing
- [x] TEST: same as above with two backends where the second user is in a separate backend

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## TODOs
- [x] testing (see above)
- [x] test with multiple 
- [ ] add / adjust unit tests
- [ ] integration test if possible ?
