### PR TITLE
Allow user backends to provide quotas

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -393,6 +393,12 @@ class Manager extends PublicEmitter implements IUserManager {
 				$account->setEmail($email);
 			}
 		}
+		if ($backend instanceof IProvidesQuotaBackend) {
+			$quota = $backend->getQuota($uid);
+			if ($quota !== null) {
+				$account->setQuota($quota);
+			}
+		}
 		$home = false;
 		if ($backend->implementsActions(Backend::GET_HOME)) {
 			$home = $backend->getHome($uid);

--- a/lib/public/User/IProvidesQuotaBackend.php
+++ b/lib/public/User/IProvidesQuotaBackend.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+// use OCP namespace for all classes that are considered public.
+// This means that they should be used by apps instead of the internal ownCloud classes
+namespace OCP\User;
+
+/**
+ * Interface IProvidesQuotaBackend
+ *
+ * @package OCP\User
+ * @since 10.0
+ */
+interface IProvidesQuotaBackend {
+
+	/**
+	 * Get a users quota
+	 *
+	 * @param string $uid The username
+	 * @return string
+	 * @since 10.0
+	 */
+	public function getQuota($uid);
+}
+


### PR DESCRIPTION
## Description
Because user backends must not call set methods on IUser instances directly.

## Related Issue
Required for fixing LDAP here https://github.com/owncloud/user_ldap/issues/72

## Motivation and Context
Because user backends must not call set methods on IUser instances directly.

## How Has This Been Tested?
I just tested that regular user creation still works. There is no implementation out there yet to test properly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @jvillafanez review please