### PR TITLE
Separate documentation url about federation and cloudID

### DIFF
--- a/apps/federatedfilesharing/lib/PersonalPanel.php
+++ b/apps/federatedfilesharing/lib/PersonalPanel.php
@@ -67,7 +67,7 @@ class PersonalPanel implements ISettings {
 			$isIE8 = true;
 		}
 		$cloudID = $this->userSession->getUser()->getCloudId();
-		$url = 'https://owncloud.org/federation#' . $cloudID;
+		$url = 'https://owncloud.org/federation ' . $cloudID;
 		$ownCloudLogoPath = $this->urlGenerator->imagePath('core', 'logo-icon.svg');
 		$tmpl = new Template('federatedfilesharing', 'settings-personal');
 		$tmpl->assign('outgoingServer2serverShareEnabled', $this->shareProvider->isOutgoingServer2serverShareEnabled());


### PR DESCRIPTION
Previously:

```
Share with me through my #ownCloud Federated Cloud ID, see https://owncloud.org/federation#grant@hidden.domain.es:62606 
```

After this PR:

```
Share with me through my #ownCloud Federated Cloud ID, see https://owncloud.org/federation grant@hidden.domain.es:62606 
```