### PR TITLE
don´t change folders with --repair-filecache

### DIFF
--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -158,11 +158,15 @@ class Loader implements IMimeTypeLoader {
 	 * @return int number of changed rows
 	 */
 	public function updateFilecache($ext, $mimetypeId) {
+		$is_folderId = $this->getId('httpd/unix-directory');
 		$update = $this->dbConnection->getQueryBuilder();
 		$update->update('filecache')
 			->set('mimetype', $update->createNamedParameter($mimetypeId))
 			->where($update->expr()->neq(
 				'mimetype', $update->createNamedParameter($mimetypeId)
+			))
+			->andwhere($update->expr()->neq(
+				'mimetype', $update->createNamedParameter($is_folderId)
 			))
 			->andWhere($update->expr()->like(
 				$update->createFunction('LOWER(`name`)'), $update->createNamedParameter($ext)


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
check if folder is "httpd/unix-directory" and don´t perform `--repair-filecache` there

## Related Issue

- #27585
- create a folder "WAV"
- check filecache: mimetype 1 (unix directory)
- execute occ maintenance:mimetype:update-db --repair-filecache
- check filecache: mimetype "audio/wav"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
WAV folder is not changed anymore

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
