### PR TITLE
Allow setting a null email

### DIFF
--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -145,7 +145,10 @@ class User implements IUser {
 	 * @since 9.0.0
 	 */
 	public function setEMailAddress($mailAddress) {
-		$mailAddress = trim($mailAddress);
+		if ($mailAddress !== null) {
+			$mailAddress = trim($mailAddress);
+		}
+
 		if ($mailAddress === $this->account->getEmail()) {
 			return;
 		}

--- a/lib/public/AppFramework/Db/Mapper.php
+++ b/lib/public/AppFramework/Db/Mapper.php
@@ -213,6 +213,8 @@ abstract class Mapper {
 				return \PDO::PARAM_INT;
 			case 'boolean':
 				return \PDO::PARAM_BOOL;
+			case 'NULL':
+				return \PDO::PARAM_NULL;
 			default:
 				return \PDO::PARAM_STR;
 		}

--- a/tests/lib/AppFramework/Db/MapperTestUtility.php
+++ b/tests/lib/AppFramework/Db/MapperTestUtility.php
@@ -76,6 +76,8 @@ abstract class MapperTestUtility extends \Test\TestCase {
 				return \PDO::PARAM_INT;
 			case 'boolean':
 				return \PDO::PARAM_BOOL;
+			case 'NULL':
+				return \PDO::PARAM_NULL;
 			default:
 				return \PDO::PARAM_STR;
 		}

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -341,4 +341,21 @@ class UserTest extends TestCase {
 		];
 	}
 
+	public function providesSetEmailAddress() {
+		return [
+			['aa1@example.com', 'aa1@example.com'],
+			['aa2@example.com ', 'aa2@example.com'],
+			[' wöt@example.com', 'wöt@example.com'],
+			['', ''],
+			[null, null],
+		];
+	}
+
+	/**
+	 * @dataProvider providesSetEmailAddress
+	 */
+	public function testSetEmailAddress($input, $expected) {
+		$this->user->setEMailAddress($input);
+		$this->assertEquals($expected, $this->user->getEMailAddress(), true);
+	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Allow setting a null email instead of an empty string

## Related Issue
https://github.com/owncloud/core/issues/27626#issuecomment-294946491

## Motivation and Context
Fix the above issue, which was crashing the sync process.

## How Has This Been Tested?
manually, syncing several LDAP users with the same email.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Notes (use with caution)
* Taking into account how deep the fix is, it's easy that it will affect several components. The amount of components affected are unknown at this moment.
* More issues could appear after this patch, depending on how each component handles null values.
* Only the user:sync command has been tested at the moment. More tests incomming.

@DeepDiver1975  @PVince81  ☝️ 