### PR TITLE
this fixes a bug where resources could be loaded with prepended doubl…

### DIFF
--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -85,7 +85,7 @@ abstract class ResourceLocator {
 				$this->logger->error('Could not find resource file "' . $e->getResourcePath() . '"', ['app' => $resourceApp]);
 			}
 		}
-		if (!empty($this->theme)) {
+		if (!empty($this->theme->getName())) {
 			foreach ($resources as $resource) {
 				try {
 					$this->doFindTheme($resource);
@@ -106,7 +106,7 @@ abstract class ResourceLocator {
 	 * @return bool True if the resource was found, false otherwise
 	 */
 	protected function appendOnceIfExist($root, $file, $webRoot = null) {
-
+		$file = ltrim($file, '/');
 		$path = $this->buildPath([$root, $file]);
 		
 		if (!isset( $this->resources[$path] ) && is_file($path)) {

--- a/tests/lib/Template/ResourceLocatorTest.php
+++ b/tests/lib/Template/ResourceLocatorTest.php
@@ -45,15 +45,18 @@ class ResourceLocatorTest extends \Test\TestCase {
 	 * @return \PHPUnit_Framework_MockObject_MockObject
 	 */
 	public function getResourceLocator($theme, $core_map, $party_map, $appsRoots) {
+		$themeInstance = $this->createMock('OC\Theme\Theme');
+		$themeInstance->method('getName')->willReturn($theme);
+
 		return $this->getMockForAbstractClass('OC\Template\ResourceLocator',
-			[$this->logger, $theme, $core_map, $party_map, $appsRoots],
+			[$this->logger, $themeInstance, $core_map, $party_map, $appsRoots],
 			'', true, true, true, []);
 	}
 
 	public function testConstructor() {
 		$locator = $this->getResourceLocator('theme',
 			['core'=>'map'], ['3rd'=>'party'], ['foo'=>'bar']);
-		$this->assertAttributeEquals('theme', 'theme', $locator);
+		$this->assertAttributeInstanceOf('OC\Theme\Theme', 'theme', $locator);
 		$this->assertAttributeEquals('core', 'serverroot', $locator);
 		$this->assertAttributeEquals(['core'=>'map','3rd'=>'party'], 'mapping', $locator);
 		$this->assertAttributeEquals('3rd', 'thirdpartyroot', $locator);


### PR DESCRIPTION
…e slashes and one where resources would be loaded twice if no theme is set

## Description
Whenever no theme is set, some resources could be loaded twice, because the check for a theme was faulty. Also CSS and JS files are provided differently to the append method, which led to double prepended slashes for scripts.

## Related Issue
#27670

## How Has This Been Tested?
Tested with and without themes, in a root deployment and subdir deployment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

