### PR TITLE
Remove oracle workaround leftovers for limit

### DIFF
--- a/lib/public/AppFramework/Db/Mapper.php
+++ b/lib/public/AppFramework/Db/Mapper.php
@@ -334,6 +334,7 @@ abstract class Mapper {
 	 * @since 7.0.0
 	 */
 	protected function mapRowToEntity($row) {
+		unset($row['DOCTRINE_ROWNUM']); // Remove oracle workaround for limit
 		return call_user_func($this->entityClass .'::fromRow', $row);
 	}
 


### PR DESCRIPTION
Doctrine has to use a workaround to provide limit and offset for oracle. That workaround leaves a 'DOCTRINE_ROWNUM' column in the result set for queries that use limit and offset. One example is the users page. The initial page works fine. Scrolling down triggers fetching the next page, which leads to:
```json
{"reqId":"g0RlZMNhplquuAjiMfDh","level":3,"time":"2017-04-19T09:07:35+00:00","remoteAddr":"127.0.0.1","user":"admin","app":"index","method":"GET","url":"\/oc\/owncloud-10.0.0beta2\/index.php\/settings\/users\/users?offset=50&limit=10&gid=&pattern=","message":"Exception: {\"Exception\":\"BadFunctionCallException\",\"Message\":\"dOCTRINEROWNUM is not a valid attribute\",\"Code\":0,\"Trace\":\"#0 /home/jfd/www/owncloud-10.0.0beta2/lib/public/AppFramework/Db/Entity.php(146): OCP\AppFramework\Db\Entity->setter('dOCTRINEROWNUM', Array)
#1 /home/jfd/www/owncloud-10.0.0beta2/lib/public/AppFramework/Db/Entity.php(70): OCP\AppFramework\Db\Entity->__call('setDOCTRINEROWN...', Array)
#2 /home/jfd/www/owncloud-10.0.0beta2/lib/public/AppFramework/Db/Entity.php(70): OC\User\Account->setDOCTRINEROWNUM('51')
#3 [internal function]: OCP\AppFramework\Db\Entity::fromRow(Array)
#4 /home/jfd/www/owncloud-10.0.0beta2/lib/public/AppFramework/Db/Mapper.php(337): call_user_func('OC\\User\\Account...', Array)
#5 /home/jfd/www/owncloud-10.0.0beta2/lib/public/AppFramework/Db/Mapper.php(356): OCP\AppFramework\Db\Mapper->mapRowToEntity(Array)
#6 /home/jfd/www/owncloud-10.0.0beta2/lib/private/User/AccountMapper.php(76): OCP\AppFramework\Db\Mapper->findEntities('SELECT * FROM `...', Array, 10, 50)
#7 /home/jfd/www/owncloud-10.0.0beta2/lib/private/User/Manager.php(228): OC\User\AccountMapper->search('user_id', '', 10, 50)
#8 /home/jfd/www/owncloud-10.0.0beta2/settings/Controller/UsersController.php(296): OC\User\Manager->search('', 10, 50)
#9 [internal function]: OC\Settings\Controller\UsersController->index(50, 10, '', '', '')
#10 /home/jfd/www/owncloud-10.0.0beta2/lib/private/AppFramework/Http/Dispatcher.php(159): call_user_func_array(Array, Array)
#11 /home/jfd/www/owncloud-10.0.0beta2/lib/private/AppFramework/Http/Dispatcher.php(89): OC\AppFramework\Http\Dispatcher->executeController(Object(OC\Settings\Controller\UsersController), 'index')
#12 /home/jfd/www/owncloud-10.0.0beta2/lib/private/AppFramework/App.php(98): OC\AppFramework\Http\Dispatcher->dispatch(Object(OC\Settings\Controller\UsersController), 'index')
#13 /home/jfd/www/owncloud-10.0.0beta2/lib/private/AppFramework/Routing/RouteActionHandler.php(46): OC\AppFramework\App::main('UsersController', 'index', Object(OC\AppFramework\DependencyInjection\DIContainer), Array)
#14 [internal function]: OC\AppFramework\Routing\RouteActionHandler->__invoke(Array)
#15 /home/jfd/www/owncloud-10.0.0beta2/lib/private/Route/Router.php(299): call_user_func(Object(OC\AppFramework\Routing\RouteActionHandler), Array)
#16 /home/jfd/www/owncloud-10.0.0beta2/lib/base.php(910): OC\Route\Router->match('/settings/users...')
#17 /home/jfd/www/owncloud-10.0.0beta2/index.php(49): OC::handleRequest()
#18 {main}\",\"File\":\"/home/jfd/www/owncloud-10.0.0beta2/lib/public/AppFramework/Db/Entity.php\",\"Line\":115}"}
```

This PR unsets the 'DOCTRINE_ROWNUM' when mapping the row to an entity before making the actual call. We could also ignore DOCTRINE_ROWNUM in the Entities fromRow() or setter() methods. I think mapRowToEntity is the least likely to be overwritten ... 

@DeepDiver1975 @PVince81 any other good ideas how to solve this?