### PR TITLE
search correct column when searching by displayname

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -244,7 +244,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return \OC\User\User[]
 	 */
 	public function searchDisplayName($pattern, $limit = null, $offset = null) {
-		$accounts = $this->accountMapper->search('user_id', $pattern, $limit, $offset);
+		$accounts = $this->accountMapper->search('display_name', $pattern, $limit, $offset);
 		return array_map(function(Account $account) {
 			return $this->getUserObject($account);
 		}, $accounts);


### PR DESCRIPTION
searching for users currently uses the user_id column. That is already problematic when you don't know the userid, but it is even more problematic when ldap is used and a unique id becomes the userid. searching for `000a9a30-d23c-1035-9df7-9bb74d28f7e6` is not what and users expect.

This PR uses the `display_name` column, which I consider more a workaround than a solution.

We should search in userid, displayname and email. and preferably make that configurable so we can omit the like query for the user_id in installations where a uuid is used. Then again, admins migh want to find users by that ID. Probably only allow admins to search by uuid / user_id?