### PR TITLE
Prevent empty username or email when authenticating

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -109,6 +109,9 @@ class Auth extends AbstractBasic {
 	 * @return bool
 	 */
 	protected function validateUserPass($username, $password) {
+		if (trim($username) === '') {
+			return false;
+		}
 		if ($this->userSession->isLoggedIn() &&
 			$this->isDavAuthenticated($this->userSession->getUser()->getUID())
 		) {

--- a/lib/private/User/AccountMapper.php
+++ b/lib/private/User/AccountMapper.php
@@ -38,6 +38,9 @@ class AccountMapper extends Mapper {
 	 * @return Account[]
 	 */
 	public function getByEmail($email) {
+		if ($email === null || trim($email) === '') {
+			throw new \InvalidArgumentException('$email must be defined');
+		}
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from($this->getTableName())

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -372,6 +372,9 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @since 9.1.0
 	 */
 	public function getByEmail($email) {
+		if ($email === null || trim($email) === '') {
+			throw new \InvalidArgumentException('$email cannot be empty');
+		}
 		$accounts = $this->accountMapper->getByEmail($email);
 		return array_map(function(Account $account) {
 			return $this->getUserObject($account);

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -314,6 +314,9 @@ class Session implements IUserSession, Emitter {
 	 */
 	public function logClientIn($user, $password, IRequest $request) {
 		$isTokenPassword = $this->isTokenPassword($password);
+		if ($user === null || trim($user) === '') {
+			throw new \InvalidArgumentException('$user cannot be empty');
+		}
 		if (!$isTokenPassword && $this->isTokenAuthEnforced()) {
 			throw new PasswordLoginForbiddenException();
 		}


### PR DESCRIPTION
## Description
Add more checks for empty user names or empty email search.

## Related Issue
None raised, see test steps.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

1. Setup OC
1. Go to personal settings
1. Set an email address
1. Set it back to empty string (this will set the email field in oc_accounts to an empty string instead of "null")
1. Using cadaver, use an empty string as "username" and type in the admin user's password (or whichever user appears first in the oc_accounts table).

Before this fix: successful login as the first user in the list
After this fix: 401 error

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@Peter-Prochaska even though it accesses the first entry in oc_accounts I don't think it's critical because it still requires you to know the password of that one user.
So consider this more as hardening.
