### PR TITLE
Fix checksum check when uploading to external storage

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Checksum.php
+++ b/lib/private/Files/Storage/Wrapper/Checksum.php
@@ -25,6 +25,7 @@ use OC\Cache\CappedMemoryCache;
 use OC\Files\Stream\Checksum as ChecksumStream;
 use OC\OCS\Exception;
 use OCP\ILogger;
+use OCP\Files\IHomeStorage;
 
 /**
  * Class Checksum
@@ -91,7 +92,11 @@ class Checksum extends Wrapper {
 	 * @return int
 	 */
 	private function getChecksumRequirement($path, $mode) {
-		$isNormalFile = substr($path, 0, 6) === 'files/';
+		$isNormalFile = true;
+		if ($this->instanceOfStorage(IHomeStorage::class)) {
+			// home storage stores files in "files"
+			$isNormalFile = substr($path, 0, 6) === 'files/';
+		}
 		$fileIsWritten = $mode !== 'r' && $mode !== 'rb';
 
 		if ($isNormalFile && $fileIsWritten) {

--- a/tests/integration/features/checksums.feature
+++ b/tests/integration/features/checksums.feature
@@ -54,6 +54,7 @@ Feature: checksums
     When user "user0" downloads the file "/myChecksumFile.txt"
     Then The header checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8"
 
+  @local_storage
   Scenario: Downloading a file from local storage has correct checksum
     Given using old dav path
     And user "user0" exists
@@ -132,6 +133,7 @@ Feature: checksums
     When user "user0" downloads the file "/myChecksumFile.txt"
     Then The header checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8"
 
+  @local_storage
   Scenario: Downloading a file from local storage has correct checksum using new dav path
     Given using new dav path
     And user "user0" exists
@@ -172,3 +174,14 @@ Feature: checksums
     When Downloading file "/chksumtst.txt" as "user0"
     Then The following headers should be set
             | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
+
+  @local_storage
+  Scenario: Uploaded file to external storage should have the same checksum when downloaded
+    Given using old dav path
+    Given user "user0" exists
+    And file "/local_storage/chksumtst.txt"  does not exist for user "user0"
+    And user "user0" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/local_storage/chksumtst.txt"
+    When Downloading file "/local_storage/chksumtst.txt" as "user0"
+    Then The following headers should be set
+            | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
+


### PR DESCRIPTION
## Description
Don't exclude files outside of "/files" when dealing with non-home storages.

## Related Issue
Fixes https://github.com/owncloud/core/issues/27686

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@davitol 