### PR TITLE
Don't send password notification email if null

### DIFF
--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -178,7 +178,7 @@ class Controller {
 		$mailer = \OC::$server->getMailer();
 		$lion = \OC::$server->getL10N('lib');
 
-		if ($email !== '') {
+		if ($email !== null && $email !== '') {
 			$tmpl = new \OC_Template('core', 'lostpassword/notify');
 			$msg = $tmpl->fetchPage();
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/27654

- [x] TEST: admin can change password of user who has no email
- [x] TEST: user can change own password when no email set

@SergioBertolinSG @jvillafanez please review