### PR TITLE
quote index columns on oracle, handle all index changes, minor phpdoc…

### DIFF
--- a/tests/lib/DB/MigratorTest.php
+++ b/tests/lib/DB/MigratorTest.php
@@ -125,9 +125,6 @@ class MigratorTest extends \Test\TestCase {
 	}
 
 	public function testUpgrade() {
-		if ($this->isOracle()) {
-			$this->markTestSkipped('Does not work yet with Oracle, needs fixing index quoting');
-		}
 		list($startSchema, $endSchema) = $this->getDuplicateKeySchemas();
 		$migrator = $this->manager->getMigrator();
 		$migrator->migrate($startSchema);
@@ -141,9 +138,6 @@ class MigratorTest extends \Test\TestCase {
 	}
 
 	public function testUpgradeDifferentPrefix() {
-		if ($this->isOracle()) {
-			$this->markTestSkipped('Does not work yet with Oracle, needs fixing index quoting');
-		}
 		$oldTablePrefix = $this->config->getSystemValue('dbtableprefix', 'oc_');
 
 		$this->config->setSystemValue('dbtableprefix', 'ownc_');
@@ -164,9 +158,6 @@ class MigratorTest extends \Test\TestCase {
 	}
 
 	public function testInsertAfterUpgrade() {
-		if ($this->isOracle()) {
-			$this->markTestSkipped('Does not work yet with Oracle, needs fixing index quoting');
-		}
 		list($startSchema, $endSchema) = $this->getDuplicateKeySchemas();
 		$migrator = $this->manager->getMigrator();
 		$migrator->migrate($startSchema);
@@ -184,9 +175,6 @@ class MigratorTest extends \Test\TestCase {
 	}
 
 	public function testAddingPrimaryKeyWithAutoIncrement() {
-		if ($this->isOracle()) {
-			$this->markTestSkipped('Does not work yet with Oracle, needs fixing index quoting');
-		}
 		$startSchema = new Schema([], [], $this->getSchemaConfig());
 		$table = $startSchema->createTable($this->tableName);
 		$table->addColumn('id', 'integer');


### PR DESCRIPTION
supersedes https://github.com/owncloud/core/pull/27649

It will leave index names unquoted. added a TODO for a future migration from UPPERCASE index identifiers to lowercase identifiers. As index identifiers are suffixed I dont think we will ever hit a reserved identifier ... so I wouldn't bother. Not for esthetic reasons only.