### PR TITLE
Remove sharing subtab headers if no link share is allowed

### DIFF
--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -16,10 +16,12 @@
 	var TEMPLATE_BASE =
 		'<div class="resharerInfoView subView"></div>' +
 		'{{#if isSharingAllowed}}' +
+		'{{#if isLinkSharingAllowed}}' +
 		'<ul class="subTabHeaders">' +
 		'    <li class="subTabHeader selected subtab-localshare">{{localSharesLabel}}</li>' +
 		'    <li class="subTabHeader subtab-publicshare">{{publicSharesLabel}}</li>' +
 		'</ul>' +
+		'{{/if}}' +
 		'<div class="tabsContainer">' +
 		// TODO: this really should be a separate view class
 		'    <div class="localShareView tab" style="padding-left:0;padding-right:0;">' +
@@ -378,6 +380,7 @@
 				sharePlaceholder: this._renderSharePlaceholderPart(),
 				remoteShareInfo: this._renderRemoteShareInfoPart(),
 				isSharingAllowed: this.model.sharePermissionPossible(),
+				isLinkSharingAllowed: this.configModel.isShareWithLinkAllowed(),
 				localSharesLabel: t('core', 'User and Groups'),
 				publicSharesLabel: t('core', 'Public Links'),
 				noSharingPlaceholder: t('core', 'Resharing is not allowed')

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -818,6 +818,15 @@ describe('OC.Share.ShareDialogView', function() {
 			expect(dialog.$('.subTabHeaders').length).toEqual(0);
 			expect(dialog.$('.tabsContainer').length).toEqual(0);
 		});
+		it('does not render tab headers is link sharing is not allowed', function() {
+			$('#allowShareWithLink').val('no');
+
+			dialog.render();
+
+			// only hide headers
+			expect(dialog.$('.subTabHeaders').length).toEqual(0);
+			expect(dialog.$('.tabsContainer').length).toEqual(1);
+		});
 		it('initially selects first tab', function() {
 			expect(dialog.$('.subTabHeaders>.subTabHeader:eq(0)').hasClass('selected')).toEqual(true);
 			expect(dialog.$('.subTabHeaders>.subTabHeader:eq(1)').hasClass('selected')).toEqual(false);


### PR DESCRIPTION
## Description
Because then there is only one tab to select, so only keep its body.

## Related Issue
None (I thought there was one but can't find it any more)

## Motivation and Context
It looks bad to have an empty "Public link" subtab.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@felixheidecke please review