### PR TITLE
Add capability entry for multiple link share support

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -68,6 +68,7 @@ class Capabilities implements ICapability {
 
 				$public['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no') === 'yes';
 				$public['upload'] = $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes') === 'yes';
+				$public['multiple'] = true;
 			}
 			$res["public"] = $public;
 

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -297,4 +297,13 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertFalse($result['federation']['outgoing']);
 	}
 
+	public function testMultipleLinkShares() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertArrayHasKey('public', $result);
+		$this->assertTrue($result['public']['multiple']);
+	}
 }


### PR DESCRIPTION
## Description
See title

## Related Issue
Fixes https://github.com/owncloud/core/issues/27622

## Motivation and Context
Clients want it

## How Has This Been Tested?
`curl -u admin:admin -X GET 'http://localhost/owncloud/ocs/v1.php/cloud/capabilities?format=json' -D -`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review @jvillafanez @DeepDiver1975 @VicDeo 