### PR TITLE
Add repair step to load missing apps before upgrade

### DIFF
--- a/core/templates/update.admin.php
+++ b/core/templates/update.admin.php
@@ -16,16 +16,6 @@
 			</ul>
 		</div>
 		<?php } ?>
-		<?php if (!empty($_['incompatibleAppsList'])) { ?>
-		<div class="infogroup">
-			<span><?php p($l->t('These incompatible apps will be disabled:')) ?></span>
-			<ul class="content appList">
-				<?php foreach ($_['incompatibleAppsList'] as $appInfo) { ?>
-				<li><?php p($appInfo['name']) ?> (<?php p($appInfo['id']) ?>)</li>
-				<?php } ?>
-			</ul>
-		</div>
-		<?php } ?>
 		<?php if (!empty($_['oldTheme'])) { ?>
 		<div class="infogroup">
 			<?php p($l->t('The theme %s has been disabled.', [$_['oldTheme']])) ?>

--- a/lib/base.php
+++ b/lib/base.php
@@ -400,7 +400,6 @@ class OC {
 		// get third party apps
 		$ocVersion = \OCP\Util::getVersion();
 		$tmpl->assign('appsToUpgrade', $appManager->getAppsNeedingUpgrade($ocVersion));
-		$tmpl->assign('incompatibleAppsList', $appManager->getIncompatibleApps($ocVersion));
 		$tmpl->assign('productName', 'ownCloud'); // for now
 		$tmpl->assign('oldTheme', $oldTheme);
 		$tmpl->printPage();

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -181,7 +181,7 @@ class Repair implements IOutput{
 			new Collation(\OC::$server->getConfig(), $connection),
 			new SqliteAutoincrement($connection),
 			new SearchLuceneTables(),
-			new Apps(\OC::$server->getAppManager(), \OC::$server->getEventDispatcher()),
+			new Apps(\OC::$server->getAppManager(), \OC::$server->getEventDispatcher(), \OC::$server->getConfig()),
 		];
 
 		//There is no need to delete all previews on every single update

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -29,6 +29,7 @@
 
 namespace OC;
 
+use OC\Repair\Apps;
 use OC\Repair\AvatarPermissions;
 use OC\Repair\CleanTags;
 use OC\Repair\Collation;
@@ -180,6 +181,7 @@ class Repair implements IOutput{
 			new Collation(\OC::$server->getConfig(), $connection),
 			new SqliteAutoincrement($connection),
 			new SearchLuceneTables(),
+			new Apps(\OC::$server->getAppManager(), \OC::$server->getEventDispatcher()),
 		];
 
 		//There is no need to delete all previews on every single update

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -94,12 +94,12 @@ class Apps implements IRepairStep {
 				);
 				$hasNotUpdatedCompatibleApps = count($failedCompatibleApps);
 
-				// TODO: find why/where these apps are disabled
+				// Apps with no deleted code are restored as disabled 
+				// This is a fixup for this
 				$appsToEnable = array_diff(
 					$appsToUpgrade[self::KEY_MISSING],
 					$failedMissingApps
 				);
-
 				foreach ($appsToEnable as $app){
 					$this->appManager->enableApp($app);
 				}

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -89,6 +89,7 @@ class Apps implements IRepairStep {
 		$failedCompatibleApps = [];
 		$failedMissingApps = $appsToUpgrade[self::KEY_MISSING];
 		$failedIncompatibleApps = $appsToUpgrade[self::KEY_INCOMPATIBLE];
+		$hasNotUpdatedCompatibleApps = 0;
 
 		if ($isMarketEnabled && $isCoreUpdate) {
 			$this->loadApp('market');
@@ -110,7 +111,7 @@ class Apps implements IRepairStep {
 				);
 				$hasNotUpdatedCompatibleApps = count($failedCompatibleApps);
 			} catch (AppManagerException $e) {
-				$output->warning('No connection to marketplace');
+				$output->warning('No connection to marketplace: ' . $e->getPrevious());
 				$isMarketEnabled = false;
 			}
 		}

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -77,11 +77,6 @@ class Apps implements IRepairStep {
 		if ($isMarketEnabled) {
 			$this->loadApp('market');
 			try {
-				$failedCompatibleApps = $this->getAppsFromMarket(
-					$output,
-					$appsToUpgrade[self::KEY_COMPATIBLE],
-					'upgradeAppStoreApp'
-				);
 				$failedIncompatibleApps = $this->getAppsFromMarket(
 					$output,
 					$appsToUpgrade[self::KEY_INCOMPATIBLE],
@@ -91,6 +86,11 @@ class Apps implements IRepairStep {
 					$output,
 					$appsToUpgrade[self::KEY_MISSING],
 					'reinstallAppStoreApp'
+				);
+				$failedCompatibleApps = $this->getAppsFromMarket(
+					$output,
+					$appsToUpgrade[self::KEY_COMPATIBLE],
+					'upgradeAppStoreApp'
 				);
 				$hasNotUpdatedCompatibleApps = count($failedCompatibleApps);
 			} catch (AppManagerException $e) {

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -93,17 +93,6 @@ class Apps implements IRepairStep {
 					'reinstallAppStoreApp'
 				);
 				$hasNotUpdatedCompatibleApps = count($failedCompatibleApps);
-
-				// Apps with no deleted code are restored as disabled 
-				// This is a fixup for this
-				$appsToEnable = array_diff(
-					$appsToUpgrade[self::KEY_MISSING],
-					$failedMissingApps
-				);
-				foreach ($appsToEnable as $app){
-					$this->appManager->enableApp($app);
-				}
-
 			} catch (AppManagerException $e) {
 				$output->warning('No connection to marketplace');
 				$isMarketEnabled = false;

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @author Victor Dubiniuk <dubiniuk@aheadworks.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Repair;
+
+use OC_App;
+use OCP\App\IAppManager;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class Apps implements IRepairStep {
+
+	/** @var  IAppManager */
+	private $appManager;
+
+	/** @var  EventDispatcher */
+	private $eventDispatcher;
+
+	/**
+	 * Apps constructor.
+	 *
+	 * @param IAppManager $appManager
+	 */
+	public function __construct(IAppManager $appManager, EventDispatcher $eventDispatcher) {
+		$this->appManager = $appManager;
+		$this->eventDispatcher = $eventDispatcher;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getName() {
+		return 'Put back missing apps';
+	}
+
+	/**
+	 * @param IOutput $output
+	 */
+	public function run(IOutput $output) {
+		$missingApps = $this->getMissingApps();
+		if (count($missingApps)){
+			$isMarketEnabled = $this->appManager->isEnabledForUser('market');
+			if ($isMarketEnabled){
+				$this->loadApp('market');
+				foreach ($missingApps as $app) {
+					$output->info("Repairing missing app: $app");
+					$this->eventDispatcher->dispatch(
+						IRepairStep::class . '::repairAppStoreApps',
+						new GenericEvent($app)
+					);
+					$this->appManager->enableApp($app);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	private function getMissingApps(){
+		$installedApps = $this->appManager->getInstalledApps();
+		$missingApps = [];
+		foreach ($installedApps as $appId){
+			$info = $this->appManager->getAppInfo($appId);
+			if (!isset($info['id']) || is_null($info['id'])){
+				$missingApps[] = $appId;
+			}
+		}
+		return $missingApps;
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 * @param $app
+	 * @throws NeedsUpdateException
+	 */
+	protected function loadApp($app) {
+		OC_App::loadApp($app, false);
+	}
+}

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -27,6 +27,7 @@ use OCP\App\AppAlreadyInstalledException;
 use OCP\App\AppManagerException;
 use OCP\App\AppNotFoundException;
 use OCP\App\AppNotInstalledException;
+use OCP\App\AppUpdateNotFoundException;
 use OCP\App\IAppManager;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -159,6 +160,8 @@ class Apps implements IRepairStep {
 			} catch (AppNotInstalledException $e) {
 				$failedApps[] = $app;
 			} catch (AppNotFoundException $e) {
+				$failedApps[] = $app;
+			} catch (AppUpdateNotFoundException $e) {
 				$failedApps[] = $app;
 			} catch (AppManagerException $e) {
 				// No connection to market. Abort.

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -71,8 +71,8 @@ class Apps implements IRepairStep {
 		$appsToUpgrade = $this->getAppsToUpgrade();
 		$isMarketEnabled = $this->appManager->isEnabledForUser('market');
 		$failedCompatibleApps = [];
-		$failedIncompatibleApps = [];
-		$failedMissingApps = [];
+		$failedMissingApps = $appsToUpgrade[self::KEY_MISSING];
+		$failedIncompatibleApps = $appsToUpgrade[self::KEY_INCOMPATIBLE];
 
 		if ($isMarketEnabled) {
 			$this->loadApp('market');
@@ -110,13 +110,6 @@ class Apps implements IRepairStep {
 			}
 		}
 
-		// Do not put this in else
-		if (!$isMarketEnabled) {
-			$hasNotUpdatedCompatibleApps = false;
-			$failedMissingApps = $appsToUpgrade[self::KEY_MISSING];
-			$failedIncompatibleApps = $appsToUpgrade[self::KEY_INCOMPATIBLE];
-		}
-
 		$hasBlockingMissingApps = count($failedMissingApps);
 		$hasBlockingIncompatibleApps = count($failedIncompatibleApps);
 
@@ -130,7 +123,10 @@ class Apps implements IRepairStep {
 
 			throw new RepairException('Upgrade is not possible');
 		} elseif ($hasNotUpdatedCompatibleApps) {
-			// warn?
+			foreach ($failedCompatibleApps as $app) {
+				// TODO: Show reason
+				$output->info("App was not updated: $app");
+			}
 		}
 	}
 

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -1051,6 +1051,7 @@ class OC_App {
 		self::executeRepairSteps($appId, $appData['repair-steps']['post-migration']);
 		self::setupLiveMigrations($appId, $appData['repair-steps']['live-migration']);
 		unset(self::$appVersion[$appId]);
+		unset(self::$appInfo[$appId]);
 		// run upgrade code
 		if (file_exists($appPath . '/appinfo/update.php')) {
 			self::loadApp($appId, false);


### PR DESCRIPTION
## Description
Before update repair step

## Related Issue
owncloud/market#39
https://github.com/owncloud/core/issues/26227

## Motivation and Context
Allow seamless app unbundling  for the next releases

## How Has This Been Tested?
Testing in progress

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

