### PR TITLE
Don't disable third party apps on upgrade

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -85,12 +85,6 @@ class Upgrade extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
 
-		$skip3rdPartyAppsDisable = false;
-
-		if ($input->getOption('no-app-disable')) {
-			$skip3rdPartyAppsDisable = true;
-		}
-
 		if(\OC::checkUpgrade(false)) {
 			if (OutputInterface::VERBOSITY_NORMAL < $output->getVerbosity()) {
 				// Prepend each line with a little timestamp
@@ -105,7 +99,6 @@ class Upgrade extends Command {
 					$this->logger
 			);
 
-			$updater->setSkip3rdPartyAppsDisable($skip3rdPartyAppsDisable);
 			$dispatcher = \OC::$server->getEventDispatcher();
 			$progress = new ProgressBar($output);
 			$progress->setFormat(" %message%\n %current%/%max% [%bar%] %percent:3s%%");
@@ -218,9 +211,6 @@ class Upgrade extends Command {
 			});
 			$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use($output) {
 				$output->writeln('<info>Disabled incompatible app: ' . $app . '</info>');
-			});
-			$updater->listen('\OC\Updater', 'thirdPartyAppDisabled', function ($app) use ($output) {
-				$output->writeln('<info>Disabled 3rd-party app: ' . $app . '</info>');
 			});
 			$updater->listen('\OC\Updater', 'upgradeAppStoreApp', function ($app) use($output) {
 				$output->writeln('<info>Update 3rd-party app: ' . $app . '</info>');

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -168,9 +168,6 @@ if (OC::checkUpgrade(false)) {
 	$updater->listen('\OC\Updater', 'incompatibleAppDisabled', function ($app) use (&$incompatibleApps) {
 		$incompatibleApps[]= $app;
 	});
-	$updater->listen('\OC\Updater', 'thirdPartyAppDisabled', function ($app) use (&$disabledThirdPartyApps) {
-		$disabledThirdPartyApps[]= $app;
-	});
 	$updater->listen('\OC\Updater', 'failure', function ($message) use ($eventSource, $config) {
 		$eventSource->send('failure', $message);
 		$eventSource->close();

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -58,9 +58,6 @@ class Updater extends BasicEmitter {
 	/** @var Checker */
 	private $checker;
 
-	/** @var bool */
-	private $skip3rdPartyAppsDisable;
-
 	private $logLevelNames = [
 		0 => 'Debug',
 		1 => 'Info',
@@ -80,16 +77,6 @@ class Updater extends BasicEmitter {
 		$this->log = $log;
 		$this->config = $config;
 		$this->checker = $checker;
-	}
-
-	/**
-	 * Sets whether the update disables 3rd party apps.
-	 * This can be set to true to skip the disable.
-	 *
-	 * @param bool $flag false to not disable, true otherwise
-	 */
-	public function setSkip3rdPartyAppsDisable($flag) {
-		$this->skip3rdPartyAppsDisable = $flag;
 	}
 
 	/**
@@ -360,13 +347,6 @@ class Updater extends BasicEmitter {
 			if (OC_App::isType($app, ['session', 'authentication'])) {
 				continue;
 			}
-
-			// disable any other 3rd party apps if not overriden
-			if(!$this->skip3rdPartyAppsDisable) {
-				\OC_App::disable($app);
-				$disabledApps[]= $app;
-				$this->emit('\OC\Updater', 'thirdPartyAppDisabled', [$app]);
-			};
 		}
 		return $disabledApps;
 	}

--- a/tests/lib/UpdaterTest.php
+++ b/tests/lib/UpdaterTest.php
@@ -161,11 +161,4 @@ class UpdaterTest extends TestCase {
 		$this->assertSame($result, $this->updater->isUpgradePossible($oldVersion, $newVersion, $allowedVersion));
 	}
 
-	public function testSetSkip3rdPartyAppsDisable() {
-		$this->updater->setSkip3rdPartyAppsDisable(true);
-		$this->assertSame(true, $this->invokePrivate($this->updater, 'skip3rdPartyAppsDisable'));
-		$this->updater->setSkip3rdPartyAppsDisable(false);
-		$this->assertSame(false, $this->invokePrivate($this->updater, 'skip3rdPartyAppsDisable'));
-	}
-
 }


### PR DESCRIPTION
## Description
Stop disabling them.

## Related Issue
The market will update apps earlier in the upgrade process, it doesn't make much sense to disable them afterwards still: https://github.com/owncloud/market/issues/39

## Motivation and Context
Let's hope the market brings higher quality apps that don't break the upgrade process.

## How Has This Been Tested?
Install contacts app, upgrade, app is still enabled.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @VicDeo @butonic @cdamken 