### PR TITLE
Sending event after mountConfig object is set

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -945,6 +945,7 @@ MountConfigListView.prototype = _.extend({
 						}
 					});
 					onCompletion.resolve();
+					$("#body-settings").trigger("mountConfigLoaded");
 				}
 			});
 		}
@@ -965,6 +966,7 @@ MountConfigListView.prototype = _.extend({
 					self.recheckStorageConfig($tr);
 				});
 				onCompletion.resolve();
+				$("#body-settings").trigger("mountConfigLoaded");
 			}
 		});
 	},


### PR DESCRIPTION
## Description
Sending an event when mountConfig object is set, in order to use it in js files without failing

## Related Issue
https://github.com/owncloud/platform/issues/94

## Motivation and Context
When .js is executed moungConfig object is not always set, so it has to wait until that. A way to do that it's waiting for an event sent by core when object has been set.

## How Has This Been Tested?
The event has been received in a .js file in the settings part.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

