### PR TITLE
extended theme service

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -808,6 +808,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('ThemeService', function ($c) {
 			return new ThemeService($this->getSystemConfig()->getValue('theme'));
 		});
+		$this->registerAlias('IThemeService', 'ThemeService');
 		$this->registerAlias('OCP\IUserSession', 'UserSession');
 		$this->registerAlias('OCP\Security\ICrypto', 'Crypto');
 	}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -808,7 +808,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService('ThemeService', function ($c) {
 			return new ThemeService($this->getSystemConfig()->getValue('theme'));
 		});
-		$this->registerAlias('IThemeService', 'ThemeService');
+		$this->registerAlias('OCP\Theme\IThemeService', 'ThemeService');
 		$this->registerAlias('OCP\IUserSession', 'UserSession');
 		$this->registerAlias('OCP\Security\ICrypto', 'Crypto');
 	}

--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -30,7 +30,7 @@
 
 namespace OC\Template;
 
-use OC\Theme\Theme;
+use OCP\Theme\ITheme;
 
 class Base {
 	/**
@@ -49,7 +49,7 @@ class Base {
 	private $l10n;
 
 	/**
-	 * @var Theme
+	 * @var ITheme
 	 */
 	protected $theme;
 
@@ -62,7 +62,7 @@ class Base {
 	 * @param string $template
 	 * @param string $requestToken
 	 * @param \OCP\IL10N $l10n
-	 * @param Theme $theme
+	 * @param ITheme $theme
 	 * @param \OC_Defaults $themeDefaults
 	 */
 	public function __construct($template, $requestToken, $l10n, $theme, $themeDefaults) {
@@ -77,7 +77,7 @@ class Base {
 	/**
 	 * @param string $serverRoot
 	 * @param string|false $app_dir
-	 * @param Theme $theme
+	 * @param ITheme $theme
 	 * @param string $app
 	 * @return string[]
 	 */
@@ -97,7 +97,7 @@ class Base {
 
 	/**
 	 * @param string $serverRoot
-	 * @param Theme $theme
+	 * @param ITheme $theme
 	 * @return string[]
 	 */
 	protected function getCoreTemplateDirs($theme, $serverRoot) {

--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -28,11 +28,11 @@
 
 namespace OC\Template;
 
-use OC\Theme\Theme;
+use OCP\Theme\ITheme;
 
 abstract class ResourceLocator {
 	/**
-	 * @var Theme
+	 * @var ITheme
 	 */
 	protected $theme;
 
@@ -48,7 +48,7 @@ abstract class ResourceLocator {
 
 	/**
 	 * @param \OCP\ILogger $logger
-	 * @param Theme $theme
+	 * @param ITheme $theme
 	 * @param array $core_map
 	 * @param array $party_map
 	 */

--- a/lib/private/Theme/Theme.php
+++ b/lib/private/Theme/Theme.php
@@ -39,14 +39,14 @@ class Theme {
 	private $webPath;
 
 	/**
-	 * Theme constructor.
-	 *
 	 * @param string $name
 	 * @param string $directory
+	 * @param string $webPath
 	 */
-	public function __construct($name = '', $directory = '') {
+	public function __construct($name = '', $directory = '', $webPath = '') {
 		$this->name = $name;
 		$this->directory = $directory;
+		$this->webPath = $webPath;
 	}
 
 	/**
@@ -57,13 +57,6 @@ class Theme {
 	}
 
 	/**
-	 * @param $name
-	 */
-	public function setName($name) {
-		$this->name = $name;
-	}
-
-	/**
 	 * @return string
 	 */
 	public function getDirectory() {
@@ -71,17 +64,24 @@ class Theme {
 	}
 
 	/**
-	 * @param string $directory
-	 */
-	public function setDirectory($directory) {
-		$this->directory = $directory;
-	}
-
-	/**
 	 * @return string
 	 */
 	public function getWebPath() {
 		return $this->webPath;
+	}
+
+	/**
+	 * @param string $name
+	 */
+	public function setName($name) {
+		$this->name = $name;
+	}
+
+	/**
+	 * @param string $directory
+	 */
+	public function setDirectory($directory) {
+		$this->directory = $directory;
 	}
 
 	/**

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -1,6 +1,5 @@
 <?php
 /**
- * @author Philipp Schaffrath <github@philippschaffrath.de>
  * @author Philipp Schaffrath <github@philipp.schaffrath.email>
  *
  * @copyright Copyright (c) 2017, ownCloud GmbH
@@ -17,11 +16,12 @@
  *
  * You should have received a copy of the GNU Affero General Public License, version 3,
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *
  */
 namespace OC\Theme;
 
-class ThemeService {
+use OCP\Theme\IThemeService;
+
+class ThemeService implements IThemeService {
 
 	/**
 	 * @var Theme

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -187,7 +187,7 @@ class URLGenerator implements IURLGenerator {
 			$file = $directory . $imageName;
 
 			if (!empty($themeDirectory)) {
-				if ($imagePath = $this->getImagePathOrFallback('/' . $this->theme->getDirectory() . '/' . $file)) {
+				if ($imagePath = $this->getImagePathOrFallback('/' . $this->theme->getDirectory() . $file)) {
 					return $imagePath;
 				}
 			}

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -30,7 +30,7 @@
  */
 
 namespace OC;
-use OC\Theme\Theme;
+use OCP\Theme\ITheme;
 use OC_Defaults;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -48,7 +48,7 @@ class URLGenerator implements IURLGenerator {
 	private $cacheFactory;
 	/** @var IRouter */
 	private $router;
-	/** @var Theme */
+	/** @var ITheme */
 	private $theme;
 
 	/**

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -189,9 +189,9 @@ class OC_App {
 	 */
 	private static function enableThemeIfApplicable($app) {
 		if (self::isType($app, 'theme')) {
-			/** @var \OC\Theme\ThemeService $themeManager */
-			$themeManager = \OC::$server->query('ThemeService');
-			$themeManager->setAppTheme($app);
+			/** @var \OCP\Theme\IThemeService $themeService */
+			$themeService = \OC::$server->query('ThemeService');
+			$themeService->setAppTheme($app);
 		}
 	}
 

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -37,7 +37,7 @@
  */
 
 use OC\TemplateLayout;
-use OC\Theme\Theme;
+use OCP\Theme\ITheme;
 
 require_once __DIR__.'/template/functions.php';
 
@@ -183,7 +183,7 @@ class OC_Template extends \OC\Template\Base {
 	 *
 	 * Will select the template file for the selected theme.
 	 * Checking all the possible locations.
-	 * @param Theme $theme
+	 * @param ITheme $theme
 	 * @param string $app
 	 * @return string
 	 */

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1274,10 +1274,10 @@ class OC_Util {
 	 * Handles the case that there may not be a theme, then check if a "default"
 	 * theme exists and take that one
 	 *
-	 * @return \OC\Theme\Theme the theme
+	 * @return \OCP\Theme\ITheme the theme
 	 */
 	public static function getTheme() {
-		/** @var \OC\Theme\ThemeService $themeService */
+		/** @var \OCP\Theme\IThemeService $themeService */
 		$themeService = \OC::$server->query('ThemeService');
 		return $themeService->getTheme();
 	}

--- a/lib/public/Theme/ITheme.php
+++ b/lib/public/Theme/ITheme.php
@@ -17,77 +17,48 @@
  * You should have received a copy of the GNU Affero General Public License, version 3,
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
-namespace OC\Theme;
+namespace OCP\Theme;
 
-use OCP\Theme\ITheme;
-
-class Theme implements ITheme {
-
-	/**
-	 * @var string
-	 */
-	private $name;
+/**
+ * The representation of a Theme.
+ * @package OCP\Theme
+ * @since 10.0.1
+ */
+interface ITheme {
 
 	/**
-	 * @var string
+	 * @return string
+	 * @since 10.0.1
 	 */
-	private $directory;
+	public function getName();
 
 	/**
-	 * @var string
+	 * @return string
+	 * @since 10.0.1
 	 */
-	private $webPath;
+	public function getDirectory();
+
+	/**
+	 * @return string
+	 * @since 10.0.1
+	 */
+	public function getWebPath();
 
 	/**
 	 * @param string $name
-	 * @param string $directory
-	 * @param string $webPath
+	 * @since 10.0.1
 	 */
-	public function __construct($name = '', $directory = '', $webPath = '') {
-		$this->name = $name;
-		$this->directory = $directory;
-		$this->webPath = $webPath;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getName() {
-		return $this->name;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getDirectory() {
-		return $this->directory;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getWebPath() {
-		return $this->webPath;
-	}
-
-	/**
-	 * @param string $name
-	 */
-	public function setName($name) {
-		$this->name = $name;
-	}
+	public function setName($name);
 
 	/**
 	 * @param string $directory
+	 * @since 10.0.1
 	 */
-	public function setDirectory($directory) {
-		$this->directory = $directory;
-	}
+	public function setDirectory($directory);
 
 	/**
 	 * @param string $webPath
+	 * @since 10.0.1
 	 */
-	public function setWebPath($webPath) {
-		$this->webPath = $webPath;
-	}
+	public function setWebPath($webPath);
 }

--- a/lib/public/Theme/IThemeService.php
+++ b/lib/public/Theme/IThemeService.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @author Philipp Schaffrath <github@philipp.schaffrath.email>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+namespace OCP\Theme;
+
+/**
+ * @package OCP\Theme
+ * @since 10.0.1
+ */
+interface IThemeService {
+
+	/**
+	 * Returns the currently active theme.
+	 * @return ITheme
+	 * @since 10.0.1
+	 */
+	public function getTheme();
+
+	/**
+	 * Sets an app as the active theme.
+	 * @param string $themeName
+	 * @since 10.0.1
+	 */
+	public function setAppTheme($themeName = '');
+
+	/**
+	 * Gets legacy and app themes as an array of ITheme's.
+	 * @return ITheme[]
+	 * @since 10.0.1
+	 */
+	public function getAllThemes();
+
+	/**
+	 * Returns an ITheme by its name, or false if there is no theme
+	 * with that name.
+	 * @param string $themeName
+	 * @return ITheme|false
+	 * @since 10.0.1
+	 */
+	public function findTheme($themeName);
+}

--- a/tests/lib/Theme/ThemeServiceTest.php
+++ b/tests/lib/Theme/ThemeServiceTest.php
@@ -22,7 +22,7 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 		$themeService = new ThemeService('theme-name');
 		$theme = $themeService->getTheme();
 		$this->assertEquals('theme-name', $theme->getName());
-		$this->assertEquals('themes/theme-name/', $theme->getDirectory());
+		$this->assertEquals('themes/theme-name', $theme->getDirectory());
 	}
 
 	public function testCreatesEmptyThemeIfDefaultDoesNotExist() {
@@ -49,7 +49,7 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 		$theme = $themeService->getTheme();
 
 		$this->assertEquals('default', $theme->getName());
-		$this->assertEquals('themes/default/', $theme->getDirectory());
+		$this->assertEquals('themes/default', $theme->getDirectory());
 	}
 
 	public function testSetAppThemeSetsName() {

--- a/tests/lib/Theme/ThemeTest.php
+++ b/tests/lib/Theme/ThemeTest.php
@@ -16,12 +16,14 @@ class ThemeTest extends \PHPUnit\Framework\TestCase {
 		parent::setUp();
 	}
 
-	public function testConstructorSetsNameAndDirectory() {
+	public function testConstructorSetsNameDirectoryAndWebPath() {
 		$this->assertEmpty($this->sut->getName());
 		$this->assertEmpty($this->sut->getDirectory());
-		$this->sut = new Theme('name', 'directory/directory');
+		$this->assertEmpty($this->sut->getWebPath());
+		$this->sut = new Theme('name', 'directory/directory', 'directory/web-directory');
 		$this->assertEquals('name', $this->sut->getName());
 		$this->assertEquals('directory/directory', $this->sut->getDirectory());
+		$this->assertEquals('directory/web-directory', $this->sut->getWebPath());
 	}
 
 	public function testDirectoryCanBeSet() {
@@ -34,5 +36,11 @@ class ThemeTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEmpty($this->sut->getName());
 		$this->sut->setName('some-name');
 		$this->assertEquals('some-name', $this->sut->getName());
+	}
+
+	public function testWebPathCanBeSet() {
+		$this->assertEmpty($this->sut->getWebPath());
+		$this->sut->setWebPath('test/web-directory');
+		$this->assertEquals('test/web-directory', $this->sut->getWebPath());
 	}
 }


### PR DESCRIPTION
## Description
This adds the functionality to get a list of all available themes or search for one through the ThemeService.

## Related Issue
Templateditor PR https://github.com/owncloud/templateeditor/pull/52, which fixes https://github.com/owncloud/core/issues/27628, has a hard dependency on this extension

## Motivation and Context
The mail template editor needs to know which themes there are, and i don't want too much theme logic it its repository, this way we can keep it clean.

## How Has This Been Tested?
Partially tested through unittests. Fully tested by hand.
The usual overwrites: css, js, img, templates, translations, mimetype icons all work for legacy and app themes, for subdir and normal deployments.

Tested the following overwrites:

app theme - regular deployment:
- [x] css
- [x] js
- [x] img
- [x] template
- [x] mimetype icons
- [x] translations

app theme - subdir deployment:
- [x] css
- [x] js
- [x] img
- [x] template
- [x] mimetype icons
- [x] translations

legacy theme - regular deployment:
- [x] css
- [x] js
- [x] img
- [x] template
- [x] mimetype icons
- [x] translations

legacy theme - sub dir deployment:
- [x] css
- [x] js
- [x] img
- [x] template
- [x] mimetype icons
- [x] translations

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

