### PR TITLE
mod_fcgid doesn't use `php_value`

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -36,18 +36,28 @@
 </IfModule>
 
 <IfModule mod_php5.c>
-  php_value always_populate_raw_post_data -1
+    php_value always_populate_raw_post_data -1
+    php_value upload_max_filesize 513M
+    php_value post_max_size 513M
+    php_value memory_limit 512M
+    php_value mbstring.func_overload 0
+    php_value default_charset 'UTF-8'
+    php_value output_buffering 0
+    <IfModule mod_env.c>
+      SetEnv htaccessWorking true
+    </IfModule>
 </IfModule>
 
-php_value upload_max_filesize 513M
-php_value post_max_size 513M
-php_value memory_limit 512M
-php_value mbstring.func_overload 0
-php_value default_charset 'UTF-8'
-php_value output_buffering 0
-
-<IfModule mod_env.c>
-  SetEnv htaccessWorking true
+<IfModule mod_php7.c>
+    php_value upload_max_filesize 513M
+    php_value post_max_size 513M
+    php_value memory_limit 512M
+    php_value mbstring.func_overload 0
+    php_value default_charset 'UTF-8'
+    php_value output_buffering 0
+    <IfModule mod_env.c>
+      SetEnv htaccessWorking true
+    </IfModule>
 </IfModule>
 
 <IfModule mod_rewrite.c>


### PR DESCRIPTION
## Description
mod_fcgid doesn't know `php_value`, specifically use it for mod_php5/7

## Related Issue
fixes https://github.com/owncloud/core/issues/27553

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

