### PR TITLE
Create missing field in dav_shares

### DIFF
--- a/apps/dav/appinfo/Migrations/Version20170427182800.php
+++ b/apps/dav/appinfo/Migrations/Version20170427182800.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @author Victor Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Migrations;
+
+use OCP\Migration\ISchemaMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/*
+ * Fixes missed  `publicuri` field on update from 9.1.x
+ */
+
+class Version20170427182800 implements ISchemaMigration {
+
+	/** @var  string */
+	private $prefix;
+
+	/**
+	 * @param Schema $schema
+	 * @param [] $options
+	 */
+	public function changeSchema(Schema $schema, array $options) {
+		$this->prefix = $options['tablePrefix'];
+		$table = $schema->getTable("{$this->prefix}dav_shares");
+		if (!$table->hasColumn('publicuri')) {
+			$table->addColumn('publicuri', 'string', [
+				'length' => 255,
+				'notnull' => false,
+			]);
+			$table->dropIndex('dav_shares_index');
+			$table->addUniqueIndex(
+				['principaluri', 'resourceid', 'type', 'publicuri'],
+				'dav_shares_index'
+			);
+		}
+	}
+}

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>ownCloud WebDAV endpoint</description>
 	<licence>AGPL</licence>
 	<author>owncloud.org</author>
-	<version>0.2.8</version>
+	<version>0.2.9</version>
 	<default_enable/>
 	<use-migrations>true</use-migrations>
 	<types>


### PR DESCRIPTION
## Description
the `publicuri` field  was added for 9.2 only
https://github.com/owncloud/core/commit/83083488815e51a0e46cf2dd5a6a23f6e352f66a#diff-d53df64924cb593d19a757e011413c8b


## Related Issue
https://github.com/owncloud/core/issues/27754

## Motivation and Context
Fixes broken calendar app when updating from 9.1.x (see issue)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

