### PR TITLE
Increase phantomjs timeout

### DIFF
--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -288,6 +288,9 @@ module.exports = function(config) {
 
 		// If browser does not capture in given timeout [ms], kill it
 		captureTimeout: 60000,
+		browserNoActivityTimeout: 60000,
+		browserDisconnectTimeout: 30000,
+		captureTimeout: 60000,
 
 		// Continuous Integration mode
 		// if true, it capture browsers, run tests and exit


### PR DESCRIPTION
I had the timeout happening locally, changing these values seemed to fix it.

We might need to backport these in case the same happens on 9.1 at some point.

@DeepDiver1975 