### PR TITLE
Add optional warning in share panel about link share recipients

### DIFF
--- a/core/js/config.php
+++ b/core/js/config.php
@@ -168,7 +168,8 @@ $array = [
 				'remoteShareAllowed' => $outgoingServer2serverShareEnabled,
 				'allowGroupSharing' => \OC::$server->getShareManager()->allowGroupSharing(),
 				'previewsEnabled' => \OC::$server->getConfig()->getSystemValue('enable_previews', true) === true,
-				'enabledPreviewProviders' => \OC::$server->getPreviewManager()->getSupportedMimes()
+				'enabledPreviewProviders' => \OC::$server->getPreviewManager()->getSupportedMimes(),
+				'shareLinksDisplayPrivacyWarning' => $config->getAppValue('core', 'share_links_display_privacy_warning', 'no') === 'yes'
 			]
 		],
 	"oc_defaults" => [

--- a/core/js/shareconfigmodel.js
+++ b/core/js/shareconfigmodel.js
@@ -27,7 +27,8 @@
 			isRemoteShareAllowed: oc_appconfig.core.remoteShareAllowed,
 			defaultExpireDate: oc_appconfig.core.defaultExpireDate,
 			isResharingAllowed: oc_appconfig.core.resharingAllowed,
-			allowGroupSharing: oc_appconfig.core.allowGroupSharing
+			allowGroupSharing: oc_appconfig.core.allowGroupSharing,
+			shareLinksDisplayPrivacyWarning: oc_appconfig.core.shareLinksDisplayPrivacyWarning
 		},
 
 		/**

--- a/core/js/sharedialoglinklistview.js
+++ b/core/js/sharedialoglinklistview.js
@@ -14,6 +14,9 @@
 	}
 
 	var TEMPLATE =
+		'{{#if isDisplayPrivacyWarning}}' +
+		'<div class="warning privacyWarningMessage">{{privacyWarningMessage}}</div>' +
+		'{{/if}}' +
 		'<span class="icon-loading-small hidden"></span>' +
 		'<ul class="link-shares">' +
 		'{{#each shares}}' +
@@ -245,6 +248,8 @@
 				socialShareEnabled: this.configModel.isSocialShareEnabled(),
 				noShares: !this.collection.length,
 				noSharesMessage: t('core', 'There are currently no link shares, you can create one'),
+				isDisplayPrivacyWarning: this.configModel.get('shareLinksDisplayPrivacyWarning'),
+				privacyWarningMessage: t('core', 'If you share public links the recipient may forward them to anyone on the internet'),
 				shares: this.collection.map(_.bind(this._formatItem, this))
 			}));
 

--- a/settings/Panels/Admin/FileSharing.php
+++ b/settings/Panels/Admin/FileSharing.php
@@ -48,6 +48,7 @@ class FileSharing implements ISettings {
 		$template->assign('shareAPIEnabled', $this->config->getAppValue('core', 'shareapi_enabled', 'yes'));
 		$template->assign('allowLinks', $this->config->getAppValue('core', 'shareapi_allow_links', 'yes'));
 		$template->assign('allowPublicUpload', $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes'));
+		$template->assign('displayPrivacyWarning', $this->config->getAppValue('core', 'share_links_display_privacy_warning', 'no'));
 		$template->assign('enforceLinkPassword', $this->helper->isPublicLinkPasswordRequired());
 		$template->assign('shareDefaultExpireDateSet', $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no'));
 		$template->assign('allowPublicMailNotification', $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no'));

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -39,6 +39,10 @@
 			   value="1" <?php if ($_['allowSocialShare'] == 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="allowSocialShare"><?php p($l->t('Allow users to share file via social media'));?></label><br/>
 
+		<input type="checkbox" name="share_links_display_privacy_warning" id="shareLinksDisplayPrivateWarning" class="checkbox"
+			   value="1" <?php if ($_['displayPrivacyWarning'] == 'yes') print_unescaped('checked="checked"'); ?> />
+		<label for="shareLinksDisplayPrivateWarning"><?php p($l->t('Display privacy warning about recipients resharing with anyone on the internet'));?></label><br/>
+
 	</p>
 	<p id="setDefaultExpireDate" class="double-indent <?php if ($_['allowLinks'] !== 'yes' || $_['shareDefaultExpireDateSet'] === 'no' || $_['shareAPIEnabled'] === 'no') p('hidden');?>">
 		<?php p($l->t( 'Expire after ' )); ?>


### PR DESCRIPTION
## Description
The message warns about the fact that link share recipients may reshare
with anyone on the internet.
It's disabled by default.

## Related Issue
https://github.com/owncloud/enterprise/issues/1914

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] TEST: it's disabled by default
- [x] TEST: no warning displayed when disabled
- [x] TEST: warning appears in link share panel when enabled

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

![share-link-warning](https://cloud.githubusercontent.com/assets/277525/25690941/968288ae-3096-11e7-9782-3b203e28f416.png)

@michaelstingl @pmaier1 feel free to modify the texts in this PR.

@felixheidecke I used the existing "warning" CSS class which seems to be designed to be used in such contexts.

Please review