### PR TITLE
[Stable9] Backport fixed output in error pages

### DIFF
--- a/core/templates/error.php
+++ b/core/templates/error.php
@@ -3,7 +3,7 @@
 		<li class='error'>
 			<?php p($error['error']) ?><br>
 			<?php if(isset($error['hint']) && $error['hint']): ?>
-				<p class='hint'><?php print_unescaped($error['hint']) ?></p>
+				<p class='hint'><?php p($error['hint']) ?></p>
 			<?php endif;?>
 		</li>
 	<?php endforeach ?>

--- a/lib/private/template.php
+++ b/lib/private/template.php
@@ -314,7 +314,7 @@ class OC_Template extends \OC\Template\Base {
 	public static function printErrorPage( $error_msg, $hint = '' ) {
 		try {
 			$content = new \OC_Template( '', 'error', 'error', false );
-			$errors = array(array('error' => $error_msg, 'hint' => $hint));
+			$errors = array(array('error' => \OCP\Util::sanitizeHTML($error_msg), 'hint' => \OCP\Util::sanitizeHTML($hint)));
 			$content->assign( 'errors', $errors );
 			$content->printPage();
 		} catch (\Exception $e) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Backport Escape output in error pages

## Related Issue
fixes https://github.com/owncloud/core/issues/27807

## Motivation and Context
Now downloading files or folder with quotes is possible

## How Has This Been Tested?
Download File with quotes and there is no error page

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

