### PR TITLE
enable app theme with `default_enable` during installation/update

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -842,6 +842,15 @@ class OC {
 			$setupHelper = new OC\Setup(\OC::$server->getConfig(), \OC::$server->getIniWrapper(),
 				\OC::$server->getL10N('lib'), new \OC_Defaults(), \OC::$server->getLogger(),
 				\OC::$server->getSecureRandom());
+
+			$defaultEnabledAppTheme = \OC_App::getDefaultEnabledAppTheme();
+
+			if ($defaultEnabledAppTheme !== false) {
+				/** @var \OC\Theme\ThemeService $themeService */
+				$themeService = \OC::$server->query('ThemeService');
+				$themeService->setAppTheme($defaultEnabledAppTheme);
+			}
+
 			$controller = new OC\Core\Controller\SetupController($setupHelper);
 			$controller->run($_POST);
 			exit();

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -637,6 +637,23 @@ class OC_App {
 		return isset($appData['version']) ? $appData['version'] : '';
 	}
 
+	/**
+	 * @return false|string
+	 */
+	public static function getDefaultEnabledAppTheme() {
+		$apps = self::getAllApps();
+		$parser = new InfoParser();
+		foreach ($apps as $app) {
+			$info = $parser->parse(self::getAppPath($app) . '/appinfo/info.xml');
+			if (is_array($info)) {
+				$info = OC_App::parseAppInfo($info);
+			}
+			if (isset($info['default_enable']) && in_array('theme', $info['types'])) {
+				return $app;
+			}
+		}
+		return false;
+	}
 
 	/**
 	 * Read all app metadata from the info.xml file


### PR DESCRIPTION
## Description
Apps are disabled during the installation and update wizard. Thats why we have to find and enable the app theme manually. This PR provides functionality to find the first app that has the type `theme` and is `default_enable`. We can't use existing functions for that, because they always check the database which is not setup at this point yet.

## Related Issue
https://github.com/owncloud/enterprise/issues/1956

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

