### PR TITLE
Newdav maintenancemode

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -49,6 +49,7 @@ use Sabre\CardDAV\VCFExportPlugin;
 use Sabre\DAV\Auth\Plugin;
 use OCA\DAV\Connector\Sabre\TagsPlugin;
 use OCA\DAV\AppInfo\PluginManager;
+use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 
 class Server {
 
@@ -77,7 +78,9 @@ class Server {
 		$this->server->httpRequest->setUrl($this->request->getRequestUri());
 		$this->server->setBaseUri($this->baseUri);
 
-		$this->server->addPlugin(new BlockLegacyClientPlugin(\OC::$server->getConfig()));
+		$config = \OC::$server->getConfig();
+		$this->server->addPlugin(new MaintenancePlugin($config));
+		$this->server->addPlugin(new BlockLegacyClientPlugin($config));
 		$authPlugin = new Plugin();
 		$authPlugin->addBackend(new PublicAuth());
 		$this->server->addPlugin($authPlugin);


### PR DESCRIPTION
## Description
Enable maintenance mode plugin also for the new DAV endpoint.

## Related Issue
Fixes https://github.com/owncloud/client/issues/5738

## How Has This Been Tested?
Integration tests.
Local test with a simple PROPFIND with maintenance mode enabled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


Tagged as critical because it causes data loss with "Local" external storage and potentially other system-wide storages.

Needs backport to stable9.1.

@SergioBertolinSG I need your help with behat: the `@AfterScenario` that disables maintenance mode after the test runs too late. So while the tests pass, the other `@AfterScenario` code fails because maintenance mode is still active at this point. Any ideas how to change the priority ?

@DeepDiver1975 please review the fix