### PR TITLE
Ignore runtime changes to .htaccess using .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ Vagrantfile
 /config/config-autotest-backup.php
 /config/autoconfig.php
 clover.xml
+
+# Ignore changes to .htacces made by ownCloud on runtime
+.htaccess


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
During development `.htaccess` is modified by ownCloud which causes git to pickup this change all the time and block changing branches until it is reset. I find myself constantly having to reset the `.htaccess` using `git checkout .htaccess`.

With this change, `.htaccess` is ignored, but still included in the repo, much like the `apps` folder. If we need to modify the `.htaccess` then it can be added to a commit using `git add --force .htaccess`.

## Motivation and Context
Personal annoyance...

## How Has This Been Tested?
Running ownCloud with this alteration - it does not seem to trigger a git notification about the change. But please help me test, I am not sure if this works exactly as we need.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
