### PR TITLE
Sync the users after processing any missing account

### DIFF
--- a/core/Command/User/SyncBackend.php
+++ b/core/Command/User/SyncBackend.php
@@ -118,21 +118,6 @@ class SyncBackend extends Command {
 
 		$syncService = new SyncService($this->accountMapper, $backend, $this->config, $this->logger);
 
-		// insert/update known users
-		$output->writeln("Insert new and update existing users ...");
-		$p = new ProgressBar($output);
-		$max = null;
-		if ($backend->implementsActions(\OC_User_Backend::COUNT_USERS)) {
-			$max = $backend->countUsers();
-		}
-		$p->start($max);
-		$syncService->run(function () use ($p) {
-			$p->advance();
-		});
-		$p->finish();
-		$output->writeln('');
-		$output->writeln('');
-
 		// analyse unknown users
 		$output->writeln("Analyse unknown users ...");
 		$p = new ProgressBar($output);
@@ -213,6 +198,22 @@ class SyncBackend extends Command {
 					break;
 			}
 		}
+
+		// insert/update known users
+		$output->writeln("Insert new and update existing users ...");
+		$p = new ProgressBar($output);
+		$max = null;
+		if ($backend->implementsActions(\OC_User_Backend::COUNT_USERS)) {
+			$max = $backend->countUsers();
+		}
+		$p->start($max);
+		$syncService->run(function () use ($p) {
+			$p->advance();
+		});
+		$p->finish();
+		$output->writeln('');
+		$output->writeln('');
+
 		return 0;
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Sync the backend after processing any missing account

## Related Issue
https://github.com/owncloud/user_ldap/issues/73

## Motivation and Context
The LDAP app has code to handle duplicated names. Some existing accounts could collide with new ones. By processing the missing accounts first we avoid unneeded calls to that functions when the old accounts are going to be deleted.

## How Has This Been Tested?
Manually tested with LDAP app.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@DeepDiver1975 