### PR TITLE
Ui tests multiple browsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,19 @@ matrix:
     - php: 5.6
       env: DB=sqlite;TC=carddav-old-endpoint
     - php: 5.6
-      env: DB=pgsql;TC=selenium;TEST_DAV=0
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="48.0" PLATFORM=Linux TEST_DAV=0
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" PLATFORM="Windows 10" TEST_DAV=0
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" PLATFORM="Windows 10" TEST_DAV=0
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="26" PLATFORM="Windows 10" TEST_DAV=0
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" PLATFORM="Windows 10" TEST_DAV=0
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="14.0" PLATFORM="Windows 10" TEST_DAV=0
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" PLATFORM="Windows 7" TEST_DAV=0
     - php: 5.6
       env: DB=sqlite;TC=syntax;TEST_DAV=0
     - php: 7.0

--- a/tests/travis/start_behat_tests.sh
+++ b/tests/travis/start_behat_tests.sh
@@ -12,6 +12,7 @@ then
 else
 	BASE_URL="http://$SRV_HOST_NAME:$SRV_HOST_PORT/$SRV_HOST_URL"
 fi
+echo "Running tests on '$BROWSER' ($BROWSER_VERSION) on $PLATFORM"
+export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"browser_name": "'$BROWSER'", "base_url" : "'$BASE_URL'","selenium2":{"capabilities": {"browser": "'$BROWSER'", "version": "'$BROWSER_VERSION'", "platform": "'$PLATFORM'"}, "wd_host":"http://'$SAUCE_USERNAME:$SAUCE_ACCESS_KEY'@localhost:4445/wd/hub"}}}}' 
 
-export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "'$BASE_URL'","selenium2":{"wd_host":"http://'$SAUCE_USERNAME:$SAUCE_ACCESS_KEY'@localhost:4445/wd/hub"}}}}'
 lib/composer/bin/behat -c tests/ui/config/behat.yml

--- a/tests/travis/start_behat_tests.sh
+++ b/tests/travis/start_behat_tests.sh
@@ -15,4 +15,9 @@ fi
 echo "Running tests on '$BROWSER' ($BROWSER_VERSION) on $PLATFORM"
 export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"browser_name": "'$BROWSER'", "base_url" : "'$BASE_URL'","selenium2":{"capabilities": {"browser": "'$BROWSER'", "version": "'$BROWSER_VERSION'", "platform": "'$PLATFORM'"}, "wd_host":"http://'$SAUCE_USERNAME:$SAUCE_ACCESS_KEY'@localhost:4445/wd/hub"}}}}' 
 
-lib/composer/bin/behat -c tests/ui/config/behat.yml
+if [ "$BROWSER" == "internet explorer" ]
+then
+	lib/composer/bin/behat -c tests/ui/config/behat.yml --tags '~@skipOnIE'
+else
+	lib/composer/bin/behat -c tests/ui/config/behat.yml
+fi

--- a/tests/ui/config/behat.yml
+++ b/tests/ui/config/behat.yml
@@ -2,10 +2,8 @@ default:
   autoload:
     '': %paths.base%/../features/bootstrap
   extensions:
-    Behat\MinkExtension:
-      browser_name: 'chrome'
     SensioLabs\Behat\PageObjectExtension: ~
-    
+
   suites:
     default:
       paths:
@@ -16,5 +14,3 @@ default:
         - UsersContext:
         - FilesContext:
         - PersonalSecuritySettingsContext:
-
-

--- a/tests/ui/features/files.feature
+++ b/tests/ui/features/files.feature
@@ -1,6 +1,6 @@
 Feature: files
 
-	@AdminLogin
+	@AdminLogin @skipOnIE
 	Scenario: scroll fileactionsmenu into view
 		Given I am on the files page
 		And the list of files/folders does not fit in one browser page


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
This makes every UI test run in multiple browser.

**What tests are run now:**

- Chrome 48 on Linux, the newest Chrome that Saucelabs supports on Linux

- latest Chrome on Windows 10 (currently 57)

- latest-1 Chrome on Windows 10 (currently 56)

- oldest available Chrome (26) on Windows 10, as oC [claims to run on Chrome 18+ ](https://doc.owncloud.com/server/10.0/admin_manual/installation/system_requirements.html#web-browser)

- Firefox 47 on Windows 10 
webdriver for current Firefox is actually not ready, so we need to test on 47.0. see https://github.com/SeleniumHQ/selenium/issues/3693 & https://stackoverflow.com/questions/38746148/behat-mink-force-selenium-driver-to-use-chrome-instead-of-firefox#38764599

- oldest available Firefox (14) on Windows 10, as oC [claims to run on FF 14+ ](https://doc.owncloud.com/server/10.0/admin_manual/installation/system_requirements.html#web-browser)

- IE 11
IE has a problem with one test, getBoundingClientRect() throws an error. This is a known bug but I don't expect MS to fix it :-)
so I just skip this test for IE

Because the tests are run now multiple times it takes them much longer to pass. This time will increase again as we add UI tests.
to discuss

1. **what  browser/OS combinations do we want to run.**
e.g. do we really want to support ancient browsers like FF 14 or Chrome 26? Or should the [documentation](https://doc.owncloud.com/server/10.0/admin_manual/installation/system_requirements.html#web-browser) just be changed to support only the latest versions of browsers, versions on ESR and maybe latest-1
2. **do we want to run all UI tests on every PR?**
we could run only a part of the tests (limited by browser and/or test suits) on PRs and then run all tests on "master" or periodically. Then in case somebody thinks a special change should run all UI tests there can be a test-special branch that runs all tests.


_Side note: The first problem, and that took me a while to figure out, was the fact that the setting of env. variables does not work as expected in travis when separating them by a semicolon. They were somehow not correctly set. Need to separate them by a space (according to travis documentation)_


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently all UI tests are only run inside Chrome 48 on Linux, its better to test multiple browsers to catch bugs that only happen in a certain browser

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It is the test  :-) http://www.commitstrip.com/en/2017/01/03/developer-bedtime-paradox/
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

