### PR TITLE
Fix env setting syntax in travis matrix entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,20 +55,20 @@ script:
 matrix:
   include:
     - php: 5.6
-      env: DB=pgsql;TC=litmus-v1
+      env: DB=pgsql TC=litmus-v1
     - php: 5.6
-      env: DB=sqlite;TC=carddav
+      env: DB=sqlite TC=carddav
     - php: 5.6
-      env: DB=sqlite;TC=caldav
+      env: DB=sqlite TC=caldav
     - php: 5.6
-      env: DB=sqlite;TC=caldav-old-endpoint
+      env: DB=sqlite TC=caldav-old-endpoint
     - php: 5.6
-      env: DB=sqlite;TC=carddav-old-endpoint
+      env: DB=sqlite TC=carddav-old-endpoint
     - php: 5.6
       env: DB=pgsql;TC=selenium;TEST_DAV=0
     - php: 5.6
-      env: DB=sqlite;TC=syntax;TEST_DAV=0
+      env: DB=sqlite TC=syntax TEST_DAV=0
     - php: 7.0
-      env: DB=sqlite;TC=syntax;TEST_DAV=0
+      env: DB=sqlite TC=syntax TEST_DAV=0
 
   fast_finish: true


### PR DESCRIPTION
## Description
The command strings in .travis.xml with a semi-colon like:
```
env: DB=sqlite;TC=syntax;TEST_DAV=0
```
are actually setting the first var (DB) as an export (env var). Then the semi-colon ends that command, and TC is set just as a local var, then TEST_DAV is also set just as a local var.
That is an odd and I'm sure unintended thing.
We get away with it here, because the "global" section further up already has exported env vars TC and TEST_DAV.
In bash, once you have exported a var as an env var, you get it "local" for free. And when you change the value of the local var, bash kindly updates the value of the env var for you also.
But if you were to use a new var name that was not already an env var (set from elsewhere), then it would just get set as a local var. If you then later try to use it inside some script or some program that is a child process, you will not see the var.

Putting spaces between the vars sends them all to the "export" command, which happily takes a space-separated list.

## Related Issue
#27842

## Motivation and Context
This change will make life easier for future maintainers, by not having the accidental env var followed by local var definitions.

## How Has This Been Tested?
This effects the running of tests in Travis, so success from Travis will be the criteria.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

