### PR TITLE
Setting the active navigation entry to 'files_index' is so wrong ...

### DIFF
--- a/apps/files/lib/AppInfo/Application.php
+++ b/apps/files/lib/AppInfo/Application.php
@@ -25,10 +25,10 @@
 namespace OCA\Files\AppInfo;
 
 use OCA\Files\Controller\ApiController;
+use OCA\Files\Controller\ViewController;
 use OCP\AppFramework\App;
 use \OCA\Files\Service\TagService;
 use \OCP\IContainer;
-use OCA\Files\Controller\ViewController;
 
 class Application extends App {
 	public function __construct(array $urlParams= []) {
@@ -56,7 +56,6 @@ class Application extends App {
 				$c->query('AppName'),
 				$c->query('Request'),
 				$server->getURLGenerator(),
-				$server->getNavigationManager(),
 				$c->query('L10N'),
 				$server->getConfig(),
 				$server->getEventDispatcher(),

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -73,7 +73,6 @@ class ViewController extends Controller {
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param IURLGenerator $urlGenerator
-	 * @param INavigationManager $navigationManager
 	 * @param IL10N $l10n
 	 * @param IConfig $config
 	 * @param EventDispatcherInterface $eventDispatcherInterface
@@ -84,7 +83,6 @@ class ViewController extends Controller {
 	public function __construct($appName,
 								IRequest $request,
 								IURLGenerator $urlGenerator,
-								INavigationManager $navigationManager,
 								IL10N $l10n,
 								IConfig $config,
 								EventDispatcherInterface $eventDispatcherInterface,
@@ -96,7 +94,6 @@ class ViewController extends Controller {
 		$this->appName = $appName;
 		$this->request = $request;
 		$this->urlGenerator = $urlGenerator;
-		$this->navigationManager = $navigationManager;
 		$this->l10n = $l10n;
 		$this->config = $config;
 		$this->eventDispatcher = $eventDispatcherInterface;
@@ -254,7 +251,6 @@ class ViewController extends Controller {
 		$params['fileNotFound'] = $fileNotFound ? 1 : 0;
 		$params['appNavigation'] = $nav;
 		$params['appContents'] = $contentItems;
-		$this->navigationManager->setActiveEntry('files_index');
 
 		$response = new TemplateResponse(
 			$this->appName,

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -33,7 +33,6 @@ use Test\TestCase;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\AppFramework\Http\RedirectResponse;
-use OCP\INavigationManager;
 use OCP\IL10N;
 use OCP\IConfig;
 use OCP\IUserSession;
@@ -51,8 +50,6 @@ class ViewControllerTest extends TestCase {
 	private $request;
 	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
 	private $urlGenerator;
-	/** @var INavigationManager */
-	private $navigationManager;
 	/** @var IL10N */
 	private $l10n;
 	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
@@ -74,7 +71,6 @@ class ViewControllerTest extends TestCase {
 		parent::setUp();
 		$this->request = $this->createMock('\OCP\IRequest');
 		$this->urlGenerator = $this->createMock('\OCP\IURLGenerator');
-		$this->navigationManager = $this->createMock('\OCP\INavigationManager');
 		$this->l10n = $this->createMock('\OCP\IL10N');
 		$this->config = $this->createMock('\OCP\IConfig');
 		$this->eventDispatcher = $this->createMock('\Symfony\Component\EventDispatcher\EventDispatcherInterface');
@@ -93,7 +89,6 @@ class ViewControllerTest extends TestCase {
 			'files',
 			$this->request,
 			$this->urlGenerator,
-			$this->navigationManager,
 			$this->l10n,
 			$this->config,
 			$this->eventDispatcher,


### PR DESCRIPTION
## Description
The app name of files should be files ... how magical ...

## Related Issue
fixes https://github.com/owncloud/core/issues/27839

## How Has This Been Tested?
- switch between files app and settings
- choose different language to make sure translations work as well

## Screenshots (if appropriate):
![bildschirmfoto von 2017-05-09 15-31-22](https://cloud.githubusercontent.com/assets/1005065/25853288/967af23a-34cc-11e7-8d51-e1837626c3e5.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

