### PR TITLE
Add permanent link share privacy warning

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -97,6 +97,10 @@
   background-size: 16px 16px;
 }
 
+.shareTabView .privacyWarningMessage {
+  margin-top: 20px;
+}
+
 .subTabHeaders .tabHeaders {
   margin-left: 0px;
   margin-right: 0px;

--- a/core/js/sharedialoglinklistview.js
+++ b/core/js/sharedialoglinklistview.js
@@ -246,7 +246,7 @@
 				socialShareEnabled: this.configModel.isSocialShareEnabled(),
 				noShares: !this.collection.length,
 				noSharesMessage: t('core', 'There are currently no link shares, you can create one'),
-				privacyWarningMessage: t('core', 'Warning: Anyone with the link has access to the file/folder'),
+				privacyWarningMessage: t('core', 'Anyone with the link has access to the file/folder'),
 				shares: this.collection.map(_.bind(this._formatItem, this))
 			}));
 

--- a/core/js/sharedialoglinklistview.js
+++ b/core/js/sharedialoglinklistview.js
@@ -50,7 +50,8 @@
 		'{{/if}}' +
 		'<div class="clear-both">' +
 		'	<button class="addLink">{{addLinkText}}</button>' +
-		'</div>';
+		'</div>' +
+		'<div class="privacyWarningMessage">{{privacyWarningMessage}}</div>';
 
 	/**
 	 * @class OCA.Share.ShareDialogLinkListView
@@ -245,6 +246,7 @@
 				socialShareEnabled: this.configModel.isSocialShareEnabled(),
 				noShares: !this.collection.length,
 				noSharesMessage: t('core', 'There are currently no link shares, you can create one'),
+				privacyWarningMessage: t('core', 'Warning: Anyone with the link has access to the file/folder'),
 				shares: this.collection.map(_.bind(this._formatItem, this))
 			}));
 


### PR DESCRIPTION
## Description
Add permanent link share privacy warning in the share tab view.

## Related Issue
https://github.com/owncloud/enterprise/issues/1914

## Motivation and Context
Some people want it

## How Has This Been Tested?
Open the public link section in the share tab in the sidebar

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

