### PR TITLE
Tests maintenancemode endpoint

### DIFF
--- a/tests/integration/features/bootstrap/CommandLineContext.php
+++ b/tests/integration/features/bootstrap/CommandLineContext.php
@@ -110,4 +110,24 @@ class CommandLineContext implements \Behat\Behat\Context\Context {
 		$davPath = rtrim($davPath, '/') . $this->lastTransferPath;
 		$this->featureContext->usingDavPath($davPath);
 	}
+
+	/**
+	 * @When /^maintenance mode is (enabled|disabled)$/
+	 */
+	public function maintenanceModeIs($state) {
+		if ($state === 'enabled') {
+			$this->runOcc(['maintenance:mode', '--on']);
+		} else {
+			$this->runOcc(['maintenance:mode', '--off']);
+		}
+	}
+
+	/**
+	 * @AfterScenario
+	 *
+	 * Disables maintenance mode in case it was enabled.
+	 */
+	public function disableMaintenanceModeAfterScenario() {
+		$this->runOcc(['maintenance:mode', '--off']);
+	}
 }

--- a/tests/integration/features/bootstrap/CommandLineContext.php
+++ b/tests/integration/features/bootstrap/CommandLineContext.php
@@ -123,7 +123,7 @@ class CommandLineContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @AfterScenario
+	 * @AfterScenario @maintenance_mode
 	 *
 	 * Disables maintenance mode in case it was enabled.
 	 */

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -981,8 +981,10 @@ trait WebDav {
 	 */
 	public function connectingToDavEndpoint() {
 		try {
-			$this->response = $this->makeDavRequest(null, 'PROPFIND', '', []);
+			$this->response = $this->makeDavRequest('admin', 'PROPFIND', '', []);
 		} catch (\GuzzleHttp\Exception\ClientException $e) {
+			$this->response = $e->getResponse();
+		} catch (\GuzzleHttp\Exception\ServerException $e) {
 			$this->response = $e->getResponse();
 		}
 	}

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -981,7 +981,20 @@ trait WebDav {
 	 */
 	public function connectingToDavEndpoint() {
 		try {
-			$this->response = $this->makeDavRequest('admin', 'PROPFIND', '', []);
+			$this->response = $this->makeDavRequest(null, 'PROPFIND', '', []);
+		} catch (\GuzzleHttp\Exception\ClientException $e) {
+			$this->response = $e->getResponse();
+		} catch (\GuzzleHttp\Exception\ServerException $e) {
+			$this->response = $e->getResponse();
+		}
+	}
+
+	/**
+	 * @When Connecting to dav endpoint as user :user
+	 */
+	public function connectingToDavEndpointAsUser($user) {
+		try {
+			$this->response = $this->makeDavRequest($user, 'PROPFIND', '', []);
 		} catch (\GuzzleHttp\Exception\ClientException $e) {
 			$this->response = $e->getResponse();
 		} catch (\GuzzleHttp\Exception\ServerException $e) {

--- a/tests/integration/features/maintenance-mode.feature
+++ b/tests/integration/features/maintenance-mode.feature
@@ -1,0 +1,16 @@
+Feature: maintenance-mode
+	Background:
+		Given using api version "1"
+		And maintenance mode is enabled
+
+	@maintenance_mode
+	Scenario: Maintenance mode new dav path
+		Given using new dav path
+		When Connecting to dav endpoint as user "admin"
+ 		Then the HTTP status code should be "503"
+
+ 	@maintenance_mode
+	Scenario: Maintenance mode old dav path
+		Given using old dav path
+		When Connecting to dav endpoint as user "admin"
+ 		Then the HTTP status code should be "503"

--- a/tests/integration/features/webdav-related-new-endpoint.feature
+++ b/tests/integration/features/webdav-related-new-endpoint.feature
@@ -511,3 +511,10 @@ Feature: webdav-related-new-endpoint
 		And as "user1" the folder "/folderB/ONE/TWO" exists
 		And User "user1" checks id of file "/folderB/ONE"
 
+	Scenario: Maintenance mode
+		Given using new dav path
+		And maintenance mode is enabled
+		When Connecting to dav endpoint
+ 		Then the HTTP status code should be "503"
+
+

--- a/tests/integration/features/webdav-related-new-endpoint.feature
+++ b/tests/integration/features/webdav-related-new-endpoint.feature
@@ -514,7 +514,7 @@ Feature: webdav-related-new-endpoint
 	Scenario: Maintenance mode
 		Given using new dav path
 		And maintenance mode is enabled
-		When Connecting to dav endpoint
+		When Connecting to dav endpoint as user "admin"
  		Then the HTTP status code should be "503"
 
 

--- a/tests/integration/features/webdav-related-new-endpoint.feature
+++ b/tests/integration/features/webdav-related-new-endpoint.feature
@@ -516,5 +516,3 @@ Feature: webdav-related-new-endpoint
 		And maintenance mode is enabled
 		When Connecting to dav endpoint as user "admin"
  		Then the HTTP status code should be "503"
-
-

--- a/tests/integration/features/webdav-related-old-endpoint.feature
+++ b/tests/integration/features/webdav-related-old-endpoint.feature
@@ -481,3 +481,8 @@ Feature: webdav-related-old-endpoint
 		And as "user1" the folder "/folderB/ONE/TWO" exists
 		And User "user1" checks id of file "/folderB/ONE"
 
+	Scenario: Maintenance mode
+		Given maintenance mode is enabled
+		When Connecting to dav endpoint
+ 		Then the HTTP status code should be "503"
+

--- a/tests/integration/features/webdav-related-old-endpoint.feature
+++ b/tests/integration/features/webdav-related-old-endpoint.feature
@@ -483,6 +483,6 @@ Feature: webdav-related-old-endpoint
 
 	Scenario: Maintenance mode
 		Given maintenance mode is enabled
-		When Connecting to dav endpoint
+		When Connecting to dav endpoint as user "admin"
  		Then the HTTP status code should be "503"
 


### PR DESCRIPTION
Add integration tests for maintenance mode.

Currently they fail randomly on Jenkins and some environments but not others, see details here https://github.com/owncloud/core/pull/27821#issuecomment-300522184

Needs further research.