### PR TITLE
[stable9.1] Add maintenance mode plugin to new dav endpoint

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -35,6 +35,7 @@ use OCA\DAV\Connector\Sabre\DummyGetResponsePlugin;
 use OCA\DAV\Connector\Sabre\FakeLockerPlugin;
 use OCA\DAV\Connector\Sabre\FilesPlugin;
 use OCA\DAV\Connector\Sabre\QuotaPlugin;
+use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCA\DAV\Files\BrowserErrorPagePlugin;
 use OCA\DAV\Files\CustomPropertiesBackend;
 use OCA\DAV\SystemTag\SystemTagPlugin;
@@ -70,7 +71,9 @@ class Server {
 		$this->server->httpRequest->setUrl($this->request->getRequestUri());
 		$this->server->setBaseUri($this->baseUri);
 
-		$this->server->addPlugin(new BlockLegacyClientPlugin(\OC::$server->getConfig()));
+		$config = \OC::$server->getConfig();
+		$this->server->addPlugin(new MaintenancePlugin($config));
+		$this->server->addPlugin(new BlockLegacyClientPlugin($config));
 		$authPlugin = new Plugin();
 		$this->server->addPlugin($authPlugin);
 


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/27821 to stable9.1

I've retested this without and with maintenance mode enabled on the new endpoint.
Before fix: files can be listed with cadaver.
After fix: 503

Note: the desktop client will not sure the new endpoint on 9.1 because the capability isn't set. But we don't know about possible third party clients which might already be using the new endpoint, so better be safe.

Please review @DeepDiver1975 @SergioBertolinSG 