### PR TITLE
Add option to restrict share autocomplete to group members

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -76,6 +76,9 @@ class ShareesController extends OCSController  {
 	/** @var bool */
 	protected $shareeEnumeration = true;
 
+	/** @var bool */
+	protected $shareeEnumerationGroupMembers = false;
+
 	/** @var int */
 	protected $offset = 0;
 
@@ -137,7 +140,7 @@ class ShareesController extends OCSController  {
 		$this->result['users'] = $this->result['exact']['users'] = $users = [];
 
 		$userGroups = [];
-		if ($this->shareWithGroupOnly) {
+		if ($this->shareWithGroupOnly || $this->shareeEnumerationGroupMembers) {
 			// Search in all the groups this user is part of
 			$userGroups = $this->groupManager->getUserGroupIds($this->userSession->getUser());
 			foreach ($userGroups as $userGroup) {
@@ -228,7 +231,7 @@ class ShareesController extends OCSController  {
 		}
 
 		$userGroups =  [];
-		if (!empty($groups) && $this->shareWithGroupOnly) {
+		if (!empty($groups) && ($this->shareWithGroupOnly || $this->shareeEnumerationGroupMembers)) {
 			// Intersect all the groups that match with the groups this user is a member of
 			$userGroups = $this->groupManager->getUserGroups($this->userSession->getUser(), 'sharing');
 			$userGroups = array_map(function (IGroup $group) { return $group->getGID(); }, $userGroups);
@@ -469,6 +472,11 @@ class ShareesController extends OCSController  {
 
 		$this->shareWithGroupOnly = $this->config->getAppValue('core', 'shareapi_only_share_with_group_members', 'no') === 'yes';
 		$this->shareeEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
+		if ($this->shareeEnumeration) {
+			$this->shareeEnumerationGroupMembers = $this->config->getAppValue('core', 'shareapi_share_dialog_user_enumeration_group_members', 'no') === 'yes';
+		} else {
+			$this->shareeEnumerationGroupMembers = false;
+		}
 		$this->limit = (int) $perPage;
 		$this->offset = $perPage * ($page - 1);
 

--- a/settings/Panels/Admin/FileSharing.php
+++ b/settings/Panels/Admin/FileSharing.php
@@ -56,6 +56,7 @@ class FileSharing implements ISettings {
 		$template->assign('onlyShareWithGroupMembers', $this->helper->shareWithGroupMembersOnly());
 		$template->assign('allowMailNotification', $this->config->getAppValue('core', 'shareapi_allow_mail_notification', 'no'));
 		$template->assign('allowShareDialogUserEnumeration', $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'));
+		$template->assign('shareDialogUserEnumerationGroupMembers', $this->config->getAppValue('core', 'shareapi_share_dialog_user_enumeration_group_members', 'no'));
 		$excludeGroups = $this->config->getAppValue('core', 'shareapi_exclude_groups', 'no') === 'yes' ? true : false;
 		$template->assign('shareExcludeGroups', $excludeGroups);
 		$excludedGroupsList = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -84,4 +84,9 @@
 			<?php if ($_['allowShareDialogUserEnumeration'] === 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="shareapi_allow_share_dialog_user_enumeration"><?php p($l->t('Allow username autocompletion in share dialog. If this is disabled the full username needs to be entered.'));?></label><br />
 	</p>
+	<p class="indent <?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
+		<input type="checkbox" name="shareapi_share_dialog_user_enumeration_group_members" value="1" id="shareapi_share_dialog_user_enumeration_group_members" class="checkbox"
+			<?php if ($_['shareDialogUserEnumerationGroupMembers'] === 'yes') print_unescaped('checked="checked"'); ?> />
+		<label for="shareapi_share_dialog_user_enumeration_group_members"><?php p($l->t('Restrict enumeration to group members'));?></label><br />
+	</p>
 </div>

--- a/tests/integration/features/bootstrap/ShareesContext.php
+++ b/tests/integration/features/bootstrap/ShareesContext.php
@@ -68,6 +68,7 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 	protected function resetAppConfigs() {
 		$this->modifyServerConfig('core', 'shareapi_only_share_with_group_members', 'no');
 		$this->modifyServerConfig('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
+		$this->modifyServerConfig('core', 'shareapi_share_dialog_user_enumeration_group_members', 'no');
 		$this->modifyServerConfig('core', 'shareapi_allow_group_sharing', 'yes');
 	}
 }

--- a/tests/integration/sharees_features/sharees.feature
+++ b/tests/integration/sharees_features/sharees.feature
@@ -1,240 +1,241 @@
 Feature: sharees
-  Background:
-    Given using api version "1"
-    And user "test" exists
-    And user "Sharee1" exists
-    And group "ShareeGroup" exists
-    And user "test" belongs to group "ShareeGroup"
+	Background:
+		Given using api version "1"
+		And user "test" exists
+		And user "Sharee1" exists
+		And group "ShareeGroup" exists
+		And user "test" belongs to group "ShareeGroup"
 
-  Scenario: Search without exact match
-    Given As an "test"
-    When getting sharees for
-      | search | Sharee |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned are
-      | Sharee1 | 0 | Sharee1 |
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned are
-      | ShareeGroup | 1 | ShareeGroup |
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+	Scenario: Search without exact match
+		Given As an "test"
+		When getting sharees for
+			| search | Sharee |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned is empty
+		And "users" sharees returned are
+			| Sharee1 | 0 | Sharee1 |
+		And "exact groups" sharees returned is empty
+		And "groups" sharees returned are
+			| ShareeGroup | 1 | ShareeGroup |
+		And "exact remotes" sharees returned is empty
+		And "remotes" sharees returned is empty
 
-  Scenario: Search without exact match not-exact casing
-    Given As an "test"
-    When getting sharees for
-      | search | sharee |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned are
-      | Sharee1 | 0 | Sharee1 |
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned are
-      | ShareeGroup | 1 | ShareeGroup |
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+	Scenario: Search without exact match not-exact casing
+		Given As an "test"
+		When getting sharees for
+			| search | sharee |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned is empty
+		And "users" sharees returned are
+			| Sharee1 | 0 | Sharee1 |
+		And "exact groups" sharees returned is empty
+		And "groups" sharees returned are
+			| ShareeGroup | 1 | ShareeGroup |
+		And "exact remotes" sharees returned is empty
+		And "remotes" sharees returned is empty
 
-  Scenario: Search only with group members - denied
-    Given As an "test"
-    And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
-    When getting sharees for
-      | search | sharee |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned is empty
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned are
-      | ShareeGroup | 1 | ShareeGroup |
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+	Scenario: Search only with group members - denied
+		Given As an "test"
+		And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
+		When getting sharees for
+			| search | sharee |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned is empty
+		And "users" sharees returned is empty
+		And "exact groups" sharees returned is empty
+		And "groups" sharees returned are
+			| ShareeGroup | 1 | ShareeGroup |
+		And "exact remotes" sharees returned is empty
+		And "remotes" sharees returned is empty
 
-  Scenario: Search only with group members - allowed
-    Given As an "test"
-    And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
-    And user "Sharee1" belongs to group "ShareeGroup"
-    When getting sharees for
-      | search | sharee |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned are
-      | Sharee1 | 0 | Sharee1 |
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned are
-      | ShareeGroup | 1 | ShareeGroup |
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+	Scenario: Search only with group members - allowed
+		Given As an "test"
+		And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
+		And user "Sharee1" belongs to group "ShareeGroup"
+		When getting sharees for
+			| search | sharee |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned is empty
+		And "users" sharees returned are
+			| Sharee1 | 0 | Sharee1 |
+		And "exact groups" sharees returned is empty
+		And "groups" sharees returned are
+			| ShareeGroup | 1 | ShareeGroup |
+		And "exact remotes" sharees returned is empty
+		And "remotes" sharees returned is empty
 
-  Scenario: Search only with group members - no group as non-member
-    Given As an "Sharee1"
-    And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
-    When getting sharees for
-      | search | sharee |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned is empty
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned is empty
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+	Scenario: Search only with group members - no group as non-member
+		Given As an "Sharee1"
+		And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
+		When getting sharees for
+			| search | sharee |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned is empty
+		And "users" sharees returned is empty
+		And "exact groups" sharees returned is empty
+		And "groups" sharees returned is empty
+		And "exact remotes" sharees returned is empty
+		And "remotes" sharees returned is empty
 
-  Scenario: Search without exact match no iteration allowed
-    Given As an "test"
-    And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
-    When getting sharees for
-      | search | Sharee |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned is empty
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned is empty
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+	Scenario: Search without exact match no iteration allowed
+		Given As an "test"
+		And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
+		When getting sharees for
+			| search | Sharee |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned is empty
+		And "users" sharees returned is empty
+		And "exact groups" sharees returned is empty
+		And "groups" sharees returned is empty
+		And "exact remotes" sharees returned is empty
+		And "remotes" sharees returned is empty
 
-  Scenario: Search with exact match no iteration allowed
-    Given As an "test"
-    And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
-    When getting sharees for
-      | search | Sharee1 |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And "exact users" sharees returned are
-      | Sharee1 | 0 | Sharee1 |
-    And "users" sharees returned is empty
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned is empty
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+	Scenario: Search with exact match no iteration allowed
+		Given As an "test"
+		And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
+		When getting sharees for
+			| search | Sharee1 |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned are
+			| Sharee1 | 0 | Sharee1 |
+		And "users" sharees returned is empty
+		And "exact groups" sharees returned is empty
+		And "groups" sharees returned is empty
+		And "exact remotes" sharees returned is empty
+		And "remotes" sharees returned is empty
 
-  Scenario: Search with exact match group no iteration allowed
-    Given As an "test"
-    And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
-    When getting sharees for
-      | search | ShareeGroup |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned is empty
-    And "exact groups" sharees returned are
-      | ShareeGroup | 1 | ShareeGroup |
-    And "groups" sharees returned is empty
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+	Scenario: Search with exact match group no iteration allowed
+		Given As an "test"
+		And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
+		When getting sharees for
+			| search | ShareeGroup |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned is empty
+		And "users" sharees returned is empty
+		And "exact groups" sharees returned are
+			| ShareeGroup | 1 | ShareeGroup |
+		And "groups" sharees returned is empty
+		And "exact remotes" sharees returned is empty
+		And "remotes" sharees returned is empty
 
-  Scenario: Search with exact match
-    Given As an "test"
-    When getting sharees for
-      | search | Sharee1 |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    Then "exact users" sharees returned are
-      | Sharee1 | 0 | Sharee1 |
-    Then "users" sharees returned is empty
-    Then "exact groups" sharees returned is empty
-    Then "groups" sharees returned is empty
-    Then "exact remotes" sharees returned is empty
-    Then "remotes" sharees returned is empty
+	Scenario: Search with exact match
+		Given As an "test"
+		When getting sharees for
+			| search | Sharee1 |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		Then "exact users" sharees returned are
+			| Sharee1 | 0 | Sharee1 |
+		Then "users" sharees returned is empty
+		Then "exact groups" sharees returned is empty
+		Then "groups" sharees returned is empty
+		Then "exact remotes" sharees returned is empty
+		Then "remotes" sharees returned is empty
 
-  Scenario: Search with exact match not-exact casing
-    Given As an "test"
-    When getting sharees for
-      | search | sharee1 |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    Then "exact users" sharees returned are
-      | Sharee1 | 0 | Sharee1 |
-    Then "users" sharees returned is empty
-    Then "exact groups" sharees returned is empty
-    Then "groups" sharees returned is empty
-    Then "exact remotes" sharees returned is empty
-    Then "remotes" sharees returned is empty
+	Scenario: Search with exact match not-exact casing
+		Given As an "test"
+		When getting sharees for
+			| search | sharee1 |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		Then "exact users" sharees returned are
+			| Sharee1 | 0 | Sharee1 |
+		Then "users" sharees returned is empty
+		Then "exact groups" sharees returned is empty
+		Then "groups" sharees returned is empty
+		Then "exact remotes" sharees returned is empty
+		Then "remotes" sharees returned is empty
 
-  Scenario: Search with exact match not-exact casing group
-    Given As an "test"
-    When getting sharees for
-      | search | shareegroup |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    Then "exact users" sharees returned is empty
-    Then "users" sharees returned is empty
-    Then "exact groups" sharees returned are
-      | ShareeGroup | 1 | ShareeGroup |
-    Then "groups" sharees returned is empty
-    Then "exact remotes" sharees returned is empty
-    Then "remotes" sharees returned is empty
+	Scenario: Search with exact match not-exact casing group
+		Given As an "test"
+		When getting sharees for
+			| search | shareegroup |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		Then "exact users" sharees returned is empty
+		Then "users" sharees returned is empty
+		Then "exact groups" sharees returned are
+			| ShareeGroup | 1 | ShareeGroup |
+		Then "groups" sharees returned is empty
+		Then "exact remotes" sharees returned is empty
+		Then "remotes" sharees returned is empty
 
-  Scenario: Search with "self"
-    Given As an "Sharee1"
-    When getting sharees for
-      | search | Sharee1 |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    Then "exact users" sharees returned are
-      | Sharee1 | 0 | Sharee1 |
-    Then "users" sharees returned is empty
-    Then "exact groups" sharees returned is empty
-    Then "groups" sharees returned is empty
-    Then "exact remotes" sharees returned is empty
-    Then "remotes" sharees returned is empty
+	Scenario: Search with "self"
+		Given As an "Sharee1"
+		When getting sharees for
+			| search | Sharee1 |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		Then "exact users" sharees returned are
+			| Sharee1 | 0 | Sharee1 |
+		Then "users" sharees returned is empty
+		Then "exact groups" sharees returned is empty
+		Then "groups" sharees returned is empty
+		Then "exact remotes" sharees returned is empty
+		Then "remotes" sharees returned is empty
 
-  Scenario: Remote sharee for files
-    Given As an "test"
-    When getting sharees for
-      | search | test@localhost |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    Then "exact users" sharees returned is empty
-    Then "users" sharees returned is empty
-    Then "exact groups" sharees returned is empty
-    Then "groups" sharees returned is empty
-    Then "exact remotes" sharees returned are
-      | test@localhost | 6 | test@localhost |
-    Then "remotes" sharees returned is empty
+	Scenario: Remote sharee for files
+		Given As an "test"
+		When getting sharees for
+			| search | test@localhost |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		Then "exact users" sharees returned is empty
+		Then "users" sharees returned is empty
+		Then "exact groups" sharees returned is empty
+		Then "groups" sharees returned is empty
+		Then "exact remotes" sharees returned are
+			| test@localhost | 6 | test@localhost |
+		Then "remotes" sharees returned is empty
 
-  Scenario: Remote sharee for calendars not allowed
-    Given As an "test"
-    When getting sharees for
-      | search | test@localhost |
-      | itemType | calendar |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    Then "exact users" sharees returned is empty
-    Then "users" sharees returned is empty
-    Then "exact groups" sharees returned is empty
-    Then "groups" sharees returned is empty
-    Then "exact remotes" sharees returned is empty
-    Then "remotes" sharees returned is empty
+	Scenario: Remote sharee for calendars not allowed
+		Given As an "test"
+		When getting sharees for
+			| search | test@localhost |
+			| itemType | calendar |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		Then "exact users" sharees returned is empty
+		Then "users" sharees returned is empty
+		Then "exact groups" sharees returned is empty
+		Then "groups" sharees returned is empty
+		Then "exact remotes" sharees returned is empty
+		Then "remotes" sharees returned is empty
 
-  Scenario: Group sharees not returned when group sharing is disabled
-    Given As an "test"
-    And parameter "shareapi_allow_group_sharing" of app "core" is set to "no"
-    When getting sharees for
-      | search | sharee |
-      | itemType | file |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned are
-      | Sharee1 | 0 | Sharee1 |
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned is empty
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+	Scenario: Group sharees not returned when group sharing is disabled
+		Given As an "test"
+		And parameter "shareapi_allow_group_sharing" of app "core" is set to "no"
+		When getting sharees for
+			| search | sharee |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned is empty
+		And "users" sharees returned are
+			| Sharee1 | 0 | Sharee1 |
+		And "exact groups" sharees returned is empty
+		And "groups" sharees returned is empty
+		And "exact remotes" sharees returned is empty
+		And "remotes" sharees returned is empty
+

--- a/tests/integration/sharees_features/sharees.feature
+++ b/tests/integration/sharees_features/sharees.feature
@@ -239,3 +239,70 @@ Feature: sharees
 		And "exact remotes" sharees returned is empty
 		And "remotes" sharees returned is empty
 
+	Scenario: Enumerate only group members - only show partial results from member groups
+		Given As an "test"
+		And user "Another" exists
+		And user "Another" belongs to group "ShareeGroup"
+		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" is set to "yes"
+		When getting sharees for
+			| search | ano |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned is empty
+		And "users" sharees returned are
+			| Another | 0 | Another |
+		And "exact groups" sharees returned is empty
+		And "groups" sharees returned is empty
+		And "exact remotes" sharees returned is empty
+		And "remotes" sharees returned is empty
+
+	Scenario: Enumerate only group members - accept exact match from non-member groups
+		Given As an "test"
+		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" is set to "yes"
+		When getting sharees for
+			| search | Sharee1 |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned are
+			| Sharee1 | 0 | Sharee1 |
+		And "users" sharees returned is empty
+		And "exact groups" sharees returned is empty
+		And "groups" sharees returned is empty
+		And "exact remotes" sharees returned is empty
+		And "remotes" sharees returned is empty
+
+	Scenario: Enumerate only group members - only show partial results from member groups
+		Given As an "test"
+		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" is set to "yes"
+		When getting sharees for
+			| search | ShareeG |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned is empty
+		And "users" sharees returned is empty
+		And "exact groups" sharees returned is empty
+		And "groups" sharees returned are
+			| ShareeGroup | 1 | ShareeGroup |
+		And "exact remotes" sharees returned is empty
+		And "remotes" sharees returned is empty
+
+	Scenario: Enumerate only group members - only accept exact group match from non-memberships
+		Given As an "test"
+		And group "ShareeGroupNonMember" exists
+		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" is set to "yes"
+		When getting sharees for
+			| search | ShareeGroupNonMember |
+			| itemType | file |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And "exact users" sharees returned is empty
+		And "users" sharees returned is empty
+		And "exact groups" sharees returned are
+			| ShareeGroupNonMember | 1 | ShareeGroupNonMember |
+		And "groups" sharees returned is empty
+		And "exact remotes" sharees returned is empty
+		And "remotes" sharees returned is empty
+


### PR DESCRIPTION
## Description
When set, the autocomplete only displays user or group results matching
the current user's group memberships.

Typing a full user or group name not in the result list will still allow
sharing with these entries.

## Related Issue
Fixes https://github.com/owncloud/core/issues/27849

## Motivation and Context
See issue

## How Has This Been Tested?
When the new option is set:
- [x] TEST: autocomplete only show current user's user results
- [x] TEST: autocomplete only show current user's group results
- [x] TEST: typing full recipient user name not in result list still allows sharing
- [x] TEST: typing full recipient group name not in result list still allows sharing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODOs:

- [ ] beware of potential conflict with https://github.com/owncloud/core/pull/27832, might need rebase/retesting after that one
- [x] add unit tests
- [x] add integration tests

@jvillafanez @tomneedham @pmaier1 