### PR TITLE
Introduce OWNCLOUD_CONFIG_DIR environment variable

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -128,6 +128,8 @@ class OC {
 			self::$configDir = OC::$SERVERROOT . '/' . PHPUNIT_CONFIG_DIR . '/';
 		} elseif(defined('PHPUNIT_RUN') and PHPUNIT_RUN and is_dir(OC::$SERVERROOT . '/tests/config/')) {
 			self::$configDir = OC::$SERVERROOT . '/tests/config/';
+		} elseif($dir = getenv('OWNCLOUD_CONFIG_DIR')) {
+			self::$configDir = rtrim($dir, '/') . '/';
 		} else {
 			self::$configDir = OC::$SERVERROOT . '/config/';
 		}


### PR DESCRIPTION


## Description
The environment variable `OWNCLOUD_CONFIG_DIR` allows to move the config out of the source tree. This is usefull to make the rest read-only.

## Motivation and Context
Allow to have the source directory read-only.
Nextcloud has a similar variable called `NEXTCLOUD_CONFIG_DIR` so there it is already working.

## How Has This Been Tested?
Running an Owncloud server 9.1.5 with a read only source directory.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

