### PR TITLE
Add events for password validation

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -167,7 +167,11 @@ class Users {
 			return new Result(null, 100);
 		} catch (\Exception $e) {
 			$this->logger->error('Failed addUser attempt with exception: '.$e->getMessage(), ['app' => 'ocs_api']);
-			return new Result(null, 101, 'Bad request');
+			$message = $e->getMessage();
+			if (empty($message)) {
+				$message = 'Bad request';
+			}
+			return new Result(null, 101, $e->getMessage());
 		}
 	}
 
@@ -293,7 +297,11 @@ class Users {
 				$targetUser->setQuota($quota);
 				break;
 			case 'password':
-				$targetUser->setPassword($parameters['_put']['value']);
+				try {
+					$targetUser->setPassword($parameters['_put']['value']);
+				} catch (\Exception $e) {
+					return new Result(null, 403, $e->getMessage());
+				}
 				break;
 			case 'two_factor_auth_enabled':
 				if ($parameters['_put']['value'] === true) {

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -440,7 +440,7 @@ class UsersTest extends OriginalTest {
 			->with('adminUser')
 			->willReturn(true);
 
-		$expected = new Result(null, 101, 'Bad request');
+		$expected = new Result(null, 101, 'User backend not found.');
 		$this->assertEquals($expected, $this->api->addUser());
 	}
 

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -49,6 +49,7 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\IDBConnection;
 use OCP\IConfig;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * This class provides the ability for apps to share their content between users.
@@ -2851,6 +2852,11 @@ class Share extends Constants {
 		if (!$accepted) {
 			throw new \Exception($message);
 		}
+
+		\OC::$server->getEventDispatcher()->dispatch(
+			'OCP\Share::validatePassword',
+			new GenericEvent(null, ['password' => $password])
+		);
 	}
 
 	/**

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -44,6 +44,7 @@ use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * This class is the communication hub for all sharing related operations.
@@ -151,6 +152,11 @@ class Manager implements IManager {
 		if (!$accepted) {
 			throw new \Exception($message);
 		}
+
+		\OC::$server->getEventDispatcher()->dispatch(
+			'OCP\Share::validatePassword',
+			new GenericEvent(null, ['password' => $password])
+		);
 	}
 
 	/**

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -40,6 +40,7 @@ use OCP\IUserManager;
 use OCP\IConfig;
 use OCP\User\IProvidesEMailBackend;
 use OCP\UserInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Class Manager
@@ -288,6 +289,11 @@ class Manager extends PublicEmitter implements IUserManager {
 		}
 
 		$this->emit('\OC\User', 'preCreateUser', [$uid, $password]);
+		\OC::$server->getEventDispatcher()->dispatch(
+			'OCP\User::validatePassword',
+			new GenericEvent(null, ['password' => $password])
+		);
+
 		if (empty($this->backends)) {
 			$this->registerBackend(new Database());
 		}

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -228,6 +228,10 @@ class User implements IUser {
 	public function setPassword($password, $recoveryPassword = null) {
 		if ($this->emitter) {
 			$this->emitter->emit('\OC\User', 'preSetPassword', [$this, $password, $recoveryPassword]);
+			\OC::$server->getEventDispatcher()->dispatch(
+				'OCP\User::validatePassword',
+				new GenericEvent(null, ['password' => $password])
+			);
 		}
 		if ($this->canChangePassword()) {
 			/** @var IChangePasswordBackend $backend */

--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -52,14 +52,18 @@ class Controller {
 			\OC_JSON::error(["data" => ["message" => $l->t("The new password can not be the same as the previous one")]]);
 			exit();
 	        }
-		if (!is_null($password) && \OC_User::setPassword($username, $password)) {
-			\OC::$server->getUserSession()->updateSessionTokenPassword($password);
+		try {
+			if (!is_null($password) && \OC_User::setPassword($username, $password)) {
+				\OC::$server->getUserSession()->updateSessionTokenPassword($password);
 
-			self::sendNotificationMail($username);
+				self::sendNotificationMail($username);
 
-			\OC_JSON::success();
-		} else {
-			\OC_JSON::error();
+				\OC_JSON::success();
+			} else {
+				\OC_JSON::error();
+			}
+		} catch (\Exception $e) {
+			\OC_JSON::error(['data' => ['message' => $e->getMessage()]]);
 		}
 	}
 
@@ -161,11 +165,15 @@ class Controller {
 
 			}
 		} else { // if encryption is disabled, proceed
-			if (!is_null($password) && \OC_User::setPassword($username, $password)) {
-				self::sendNotificationMail($username);
-				\OC_JSON::success(['data' => ['username' => $username]]);
-			} else {
-				\OC_JSON::error(['data' => ['message' => $l->t('Unable to change password')]]);
+			try {
+				if (!is_null($password) && \OC_User::setPassword($username, $password)) {
+					self::sendNotificationMail($username);
+					\OC_JSON::success(['data' => ['username' => $username]]);
+				} else {
+					\OC_JSON::error(['data' => ['message' => $l->t('Unable to change password')]]);
+				}
+			} catch (\Exception $e) {
+				\OC_JSON::error(['data' => ['message' => $e->getMessage()]]);
 			}
 		}
 	}


### PR DESCRIPTION
## Description
Makes it possible for apps to implement validation.
Also added code to properly throw exceptions and convert them into
messages to display in the UI.

## Related Issue


## Motivation and Context
To allow for password policies

## How Has This Been Tested?
With a quick test app, throw an exception in the hooks and check that the message is properly displayed in the following cases:

- [x] TEST: when setting a password in the link share dialog
- [x] TEST: when a user sets a password in the personal page
- [x] TEST: when a user sets a password after password reset
- [x] TEST: when an admin sets a password in the users page
- [x] TEST: when creating a user with OCC: `occ user:add user1`
- [x] TEST: when resetting a password with OCC `occ user:resetpassword user1`
- [x] TEST: when creating a user with provisioning API: `curl -X POST --user admin:admin "http://localhost/owncloud/ocs/v1.php/cloud/users" -d userid="userx" -d password="y"`
- [x] TEST: when setting a password with provisioning API: `curl -X PUT --user admin:admin "http://localhost/owncloud/ocs/v1.php/cloud/users/user1" -d key="password" -d value="x"`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 
