### PR TITLE
Allow app to register multiple settings panels of same type

### DIFF
--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -315,10 +315,12 @@ class SettingsManager implements ISettingsManager {
 		$panels = [];
 		foreach($this->appManager->getEnabledAppsForUser($this->userSession->getUser()) as $app) {
 			if(isset($this->appManager->getAppInfo($app)['settings'])) {
-				foreach($this->appManager->getAppInfo($app)['settings'] as $t => $panel) {
+				foreach($this->appManager->getAppInfo($app)['settings'] as $t => $detected) {
 					if($t === $type)
 					{
-						$panels[] = (string) $panel;
+						// Allow app to register multiple panels of the same type
+						$detected = is_array($detected) ? $detected : [$detected];
+						$panels = array_merge($panels, $detected);
 					}
 				}
 			}

--- a/tests/lib/Settings/ManagerTest.php
+++ b/tests/lib/Settings/ManagerTest.php
@@ -90,6 +90,52 @@ class SettingsManagerTest extends TestCase {
 		$this->assertContains('OC\Settings\Panels\Personal\Profile', $list);
 	}
 
+	public function testFindRegisteredPanelsAdmin() {
+		// Return a mock user
+		$user = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$this->userSession->expects($this->any())->method('getUser')->willReturn($user);
+		// Return encryption as example app with
+		$this->appManager->expects($this->exactly(1))->method('getEnabledAppsForUser')->with($user)->willReturn(['encryption']);
+		$settingsInfo = [
+			'settings' =>
+				['admin' => 'OCA\Encryption\TestPanel']
+		];
+		$this->appManager->expects($this->exactly(2))->method('getAppInfo')->with('encryption')->willReturn($settingsInfo);
+		$panels = $this->invokePrivate($this->settingsManager, 'findRegisteredPanels', ['admin']);
+		$this->assertCount(1, $panels);
+	}
+
+	public function testFindRegisteredPanelsPersonal() {
+		// Return a mock user
+		$user = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$this->userSession->expects($this->any())->method('getUser')->willReturn($user);
+		// Return encryption as example app with
+		$this->appManager->expects($this->exactly(1))->method('getEnabledAppsForUser')->with($user)->willReturn(['encryption']);
+		$settingsInfo = [
+			'settings' =>
+				['personal' => 'OCA\Encryption\TestPanel']
+		];
+		$this->appManager->expects($this->exactly(2))->method('getAppInfo')->with('encryption')->willReturn($settingsInfo);
+		$panels = $this->invokePrivate($this->settingsManager, 'findRegisteredPanels', ['personal']);
+		$this->assertCount(1, $panels);
+		$this->assertEquals('OCA\Encryption\TestPanel', array_shift($panels));
+	}
+
+	public function testFindRegisteredPanelsPersonalMultiple() {
+		// Return a mock user
+		$user = $this->getMockBuilder('\OCP\IUser')->getMock();
+		$this->userSession->expects($this->any())->method('getUser')->willReturn($user);
+		// Return encryption as example app with
+		$this->appManager->expects($this->exactly(1))->method('getEnabledAppsForUser')->with($user)->willReturn(['encryption']);
+		$settingsInfo = [
+			'settings' =>
+				['personal' => ['OCA\Encryption\TestPanel', 'OCA\Encryption\TestPanel2']]
+		];
+		$this->appManager->expects($this->exactly(2))->method('getAppInfo')->with('encryption')->willReturn($settingsInfo);
+		$panels = $this->invokePrivate($this->settingsManager, 'findRegisteredPanels', ['personal']);
+		$this->assertCount(2, $panels);
+	}
+
 	public function testLoadPersonalPanels() {
 		$user = $this->getMockBuilder('\OCP\IUser')->getMock();
 		$this->userSession->expects($this->any())->method('getUser')->willReturn($user);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Apps can now register multiple settings panels of the same type

## How Has This Been Tested?
 - With an app and unit tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

