### PR TITLE
Fix failing share integration tests related to permissions

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -283,6 +283,10 @@ class Share20OCS {
 			return new \OC\OCS\Result(null, 404, 'invalid permissions');
 		}
 
+		if ($permissions === 0) {
+			return new \OC\OCS\Result(null, 400, $this->l->t('Cannot remove all permissions'));
+		}
+
 		$shareType = (int)$this->request->getParam('shareType', '-1');
 
 		// link shares can have create-only without read (anonymous upload)
@@ -730,6 +734,9 @@ class Share20OCS {
 			}
 		}
 
+		if ($share->getPermissions() === 0) {
+			return new \OC\OCS\Result(null, 400, $this->l->t('Cannot remove all permissions'));
+		}
 
 		try {
 			$share = $this->shareManager->updateShare($share);

--- a/tests/integration/features/sharing-v1.feature
+++ b/tests/integration/features/sharing-v1.feature
@@ -1065,6 +1065,31 @@ Feature: sharing
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
+	Scenario: Cannot create share with zero permissions
+		Given user "user0" exists
+		And user "user1" exists
+		And As an "user0"
+		When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+			| path | welcome.txt |
+			| shareWith | user1 |
+			| shareType | 0 |
+			| permissions | 0 |
+		Then the OCS status code should be "400"
+
+	Scenario: Cannot set permissions to zero
+		Given As an "admin"
+		And user "user0" exists
+		And user "user1" exists
+		And group "new-group" exists
+		And user "user0" belongs to group "new-group"
+		And user "user1" belongs to group "new-group"
+		And Assure user "user0" is subadmin of group "new-group"
+		And As an "user0"
+		And folder "/FOLDER" of user "user0" is shared with group "new-group"
+		And Updating last share with
+			| permissions | 0 |
+		Then the OCS status code should be "400"
+
 	Scenario: Adding public upload to a read only shared folder as recipient is not allowed
 		Given As an "admin"
 		And user "user0" exists

--- a/tests/integration/features/sharing-v1.feature
+++ b/tests/integration/features/sharing-v1.feature
@@ -1059,7 +1059,7 @@ Feature: sharing
 		And As an "user0"
 		And folder "/FOLDER" of user "user0" is shared with group "new-group"
 		And Updating last share with
-			| permissions | 0 |
+			| permissions | 1 |
 		When Updating last share with
 			| permissions | 31 |
 		Then the OCS status code should be "100"


### PR DESCRIPTION
## Description
**Fixes failing integration tests on master.**

Some integration tests set permissions to 0 instead of 1.
The old behavior allowed that and internally remapped to 1.
Since https://github.com/owncloud/core/pull/27548 the behavior changed.

This PR fixes that one test (see first commit) and also enhances the API to forbid setting permissions to 0 completely. Doing so has a special meaning due to "opted-out" shares.

## Related Issue
None raised.

## Motivation and Context
We want tests on master to pass!

## How Has This Been Tested?
Ran the automated tests locally (partial).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

