### PR TITLE
Reduce the elapsed time of the various Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,16 @@ addons:
     - owncloud
 
 before_install:
-  - sh -c "if [ '$TC' = 'syntax' ] || [ '$TEST_DAV' = '1' ] || { [ '$TC' = 'selenium' ] && [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && { [ '$CRON_ONLY' = '0' ] || [ '$TRAVIS_EVENT_TYPE' = 'cron' ]; }; }; then make; fi"
-  - sh -c "if [ '$TEST_DAV' = '1' ] || { [ '$TC' = 'selenium' ] && [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && { [ '$CRON_ONLY' = '0' ] || [ '$TRAVIS_EVENT_TYPE' = 'cron' ]; }; }; then bash tests/travis/before_install.sh $DB; fi"
+  - if [ "$TC" = "syntax" ] || [ "$TEST_DAV" = "1" ] || { [ "$TC" = "selenium" ] && [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && { [ "$CRON_ONLY" = "0" ] || [ "$TRAVIS_EVENT_TYPE" = "cron" ]; }; }; then echo "There is real work to do"; else exit 0; fi
+  - make
+  - sh -c "if [ '$TEST_DAV' = '1' ] || [ '$TC' = 'selenium' ]; then bash tests/travis/before_install.sh $DB; fi"
 
 install:
-  - sh -c "if [ '$TEST_DAV' = '1' ] || { [ '$TC' = 'selenium' ] && [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && { [ '$CRON_ONLY' = '0' ] || [ '$TRAVIS_EVENT_TYPE' = 'cron' ]; }; }; then bash tests/travis/install.sh $DB; fi"
+  - sh -c "if [ '$TEST_DAV' = '1' ] || [ '$TC' = 'selenium' ]; then bash tests/travis/install.sh $DB; fi"
   - sh -c "if [ '$TEST_DAV' = '1' ]; then bash apps/dav/tests/travis/$TC/install.sh; fi"
 
 before_script:
-  - sh -c "if [ '$TC' = 'selenium' ] && [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && { [ '$CRON_ONLY' = '0' ] || [ '$TRAVIS_EVENT_TYPE' = 'cron' ]; }; then bash tests/travis/start_php_dev_server.sh; fi"
+  - sh -c "if [ '$TC' = 'selenium' ]; then bash tests/travis/start_php_dev_server.sh; fi"
 
 script:
   - sh -c "if [ '$TC' = 'syntax' ]; then make test-php-lint ; fi"
@@ -49,7 +50,7 @@ script:
   - sh -c "if [ '$TEST_DAV' = '1' ]; then echo \"Testing DAV\"; fi"
 
   - sh -c "if [ '$TEST_DAV' = '1' ]; then bash apps/dav/tests/travis/$TC/script.sh; fi"
-  - sh -c "if [ '$TC' = 'selenium' ] && [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && { [ '$CRON_ONLY' = '0' ] || [ '$TRAVIS_EVENT_TYPE' = 'cron' ]; }; then bash tests/travis/start_behat_tests.sh; fi"
+  - sh -c "if [ '$TC' = 'selenium' ]; then bash tests/travis/start_behat_tests.sh; fi"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,24 +25,23 @@ branches:
     - /^stable\d+(\.\d+)?$/
 
 addons:
-  apt:
+  apt: &common_apt
     packages:
     - realpath
     - net-tools
-  hosts:
+  hosts: &common_hosts
     - owncloud
-  sauce_connect:
 
 before_install:
-  - make
-  - sh -c "if [ '$TEST_DAV' = '1' ] || [ '$TC' = 'selenium' ]; then bash tests/travis/before_install.sh $DB; fi"
+  - sh -c "if [ '$TC' = 'syntax' ] || [ '$TEST_DAV' = '1' ] || { [ '$TC' = 'selenium' ] && [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && { [ '$CRON_ONLY' = '0' ] || [ '$TRAVIS_EVENT_TYPE' = 'cron' ]; }; }; then make; fi"
+  - sh -c "if [ '$TEST_DAV' = '1' ] || { [ '$TC' = 'selenium' ] && [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && { [ '$CRON_ONLY' = '0' ] || [ '$TRAVIS_EVENT_TYPE' = 'cron' ]; }; }; then bash tests/travis/before_install.sh $DB; fi"
 
 install:
-  - sh -c "if [ '$TEST_DAV' = '1' ] || [ '$TC' = 'selenium' ]; then bash tests/travis/install.sh $DB; fi"
+  - sh -c "if [ '$TEST_DAV' = '1' ] || { [ '$TC' = 'selenium' ] && [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && { [ '$CRON_ONLY' = '0' ] || [ '$TRAVIS_EVENT_TYPE' = 'cron' ]; }; }; then bash tests/travis/install.sh $DB; fi"
   - sh -c "if [ '$TEST_DAV' = '1' ]; then bash apps/dav/tests/travis/$TC/install.sh; fi"
 
 before_script:
-  - sh -c "if [ '$TC' = 'selenium' ]; then bash tests/travis/start_php_dev_server.sh; fi"
+  - sh -c "if [ '$TC' = 'selenium' ] && [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && { [ '$CRON_ONLY' = '0' ] || [ '$TRAVIS_EVENT_TYPE' = 'cron' ]; }; then bash tests/travis/start_php_dev_server.sh; fi"
 
 script:
   - sh -c "if [ '$TC' = 'syntax' ]; then make test-php-lint ; fi"
@@ -50,10 +49,28 @@ script:
   - sh -c "if [ '$TEST_DAV' = '1' ]; then echo \"Testing DAV\"; fi"
 
   - sh -c "if [ '$TEST_DAV' = '1' ]; then bash apps/dav/tests/travis/$TC/script.sh; fi"
-  - sh -c "if [ '$TC' = 'selenium' ] && [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ]; then bash tests/travis/start_behat_tests.sh; fi"
+  - sh -c "if [ '$TC' = 'selenium' ] && [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && { [ '$CRON_ONLY' = '0' ] || [ '$TRAVIS_EVENT_TYPE' = 'cron' ]; }; then bash tests/travis/start_behat_tests.sh; fi"
 
 matrix:
   include:
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" PLATFORM="Windows 7" TEST_DAV=0 CRON_ONLY=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
     - php: 5.6
       env: DB=pgsql TC=litmus-v1
     - php: 5.6
@@ -65,16 +82,32 @@ matrix:
     - php: 5.6
       env: DB=sqlite TC=carddav-old-endpoint
     - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" PLATFORM="Windows 10" TEST_DAV=0
-    - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" PLATFORM="Windows 10" TEST_DAV=0
-    - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" PLATFORM="Windows 10" TEST_DAV=0
-    - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" PLATFORM="Windows 7" TEST_DAV=0
-    - php: 5.6
       env: DB=sqlite TC=syntax TEST_DAV=0
     - php: 7.0
       env: DB=sqlite TC=syntax TEST_DAV=0
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=1
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="26" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=1
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="48.0" PLATFORM=Linux TEST_DAV=0 CRON_ONLY=1
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="14.0" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=1
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
 
   fast_finish: true


### PR DESCRIPTION
## Description
1) Pull out sauce_connect from the global addons and put it just in the selenium jobs that need it. The addons section is not able to have a global section, and then add to it in each matrix include, so YAML anchors http://www.yaml.org/spec/1.2/spec.html#id2785586 are used to minimize code duplication.
This makes each of the other "little" jobs in the matrix run >30 seconds faster, as they do not waste time connecting to sauce labs and disconnecting.

2) Make each of the before_install, install, before_script and script lines only execute if it is really a step for the given combination of environment variables. This saves a bit of time e.g. for cases like when $TEST_DAV=0 so there is no point even bothering to do "make".

3) Add a CRON_ONLY environment variable to flag jobs in the matrix to only be run when in a Travis cron job. When a build is run as a Travis cron job, Travis kindly sets the env var $TRAVIS_EVENT_TYPE to 'cron'.
I added back older browser/OS combinations that could be just run in the Travis cron job. I also made the chrome latest-1 to be cron-only. Thus there are only 3 browsers that will be run for every PR... - chrome latest, latest working Firefox and IE on Win7.

4) Put the selenium jobs at the top. That way they start straight away, taking 3 job slots out of 5. The other 2 jobs slots will run the other quicker jobs, which will all end up finishing in about the time of the 3 parallel selenium jobs. We will get an example of total elapsed time when this PR builds.

## Related Issue
#27858 

## Motivation and Context
Optimize the elapsed time for a regular Travis build/test run, thus giving quicker feedback to devs.

## How Has This Been Tested?
Running test runs in a separated forked repo.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

