### PR TITLE
Addresses #27910: reflected cross site scripting for 8.x latest.

### DIFF
--- a/apps/files/ajax/download.php
+++ b/apps/files/ajax/download.php
@@ -31,12 +31,16 @@ OCP\User::checkLoggedIn();
 \OC::$server->getSession()->close();
 
 $files = isset($_GET['files']) ? (string)$_GET['files'] : '';
-$dir = isset($_GET['dir']) ? (string)$_GET['dir'] : '';
+$dir = isset($_GET['dir']) ? htmlspecialchars($_GET['dir'], ENT_QUOTES) : '';
 
 $files_list = json_decode($files);
 // in case we get only a single file
 if (!is_array($files_list)) {
-	$files_list = array($files);
+	$files_list = array(htmlspecialchars($files_list, ENT_QUOTES));
+} else {
+	$files_list = array_map(function($file) {
+		return htmlspecialchars($file, ENT_QUOTES);
+	}, $files_list);
 }
 
 /**


### PR DESCRIPTION
will also need a 9.x

The private disclosure to hackerone was seemingly ignored by owncloud and has now been made public. (https://hackerone.com/reports/215410)

http://seclists.org/fulldisclosure/2017/May/56

This PR attempts to fix this for 8.x stable.