### PR TITLE
test scripts shall not fail if the docker image cannot be stopped or …

### DIFF
--- a/build/autotest.sh
+++ b/build/autotest.sh
@@ -129,8 +129,8 @@ function cleanup_config {
 
 	if [ ! -z "$DOCKER_CONTAINER_ID" ]; then
 		echo "Kill the docker $DOCKER_CONTAINER_ID"
-		docker stop "$DOCKER_CONTAINER_ID"
-		docker rm -f "$DOCKER_CONTAINER_ID"
+		docker stop "$DOCKER_CONTAINER_ID" || true
+		docker rm -f "$DOCKER_CONTAINER_ID" || true
 	fi
 
 	cd "$BASEDIR"

--- a/tests/objectstore/stop-swift-ceph.sh
+++ b/tests/objectstore/stop-swift-ceph.sh
@@ -31,8 +31,8 @@ if [ -e $thisFolder/dockerContainerCeph.$EXECUTOR_NUMBER.swift ]; then
         fi
         echo "Stopping and removing docker container $container"
         # kills running container and removes it
-        docker stop $container
-        docker rm -f $container
+        docker stop $container || true
+        docker rm -f $container || true
     done;
 fi;
 


### PR DESCRIPTION
…removed - test job can still continue

````
12:23:03 Kill the docker 2d61f9d1e520057261e1f9ab81de2779574336ff2ae84f2c6eb4651f4cb7de54
12:23:15 2d61f9d1e520057261e1f9ab81de2779574336ff2ae84f2c6eb4651f4cb7de54
12:23:15 Error response from daemon: Driver aufs failed to remove root filesystem 2d61f9d1e520057261e1f9ab81de2779574336ff2ae84f2c6eb4651f4cb7de54: rename /var/lib/docker/aufs/mnt/30d8be69d42474836424b17b132f64e23033ef73fb8e04a82e2b289bee9f4831 /var/lib/docker/aufs/mnt/30d8be69d42474836424b17b132f64e23033ef73fb8e04a82e2b289bee9f4831-removing: device or resource busy
12:23:15 Kill the docker 2d61f9d1e520057261e1f9ab81de2779574336ff2ae84f2c6eb4651f4cb7de54
12:23:15 Error response from daemon: No such container: 2d61f9d1e520057261e1f9ab81de2779574336ff2ae84f2c6eb4651f4cb7de54
12:23:15 Makefile:179: recipe for target 'test-php' failed
12:23:15 make: *** [test-php] Error 1
