### PR TITLE
Catch no admin additional panels

### DIFF
--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -199,7 +199,7 @@ class SettingsManager implements ISettingsManager {
 				new Section('general', $this->l->t('General'), 100),
 				new Section('storage', $this->l->t('Storage'), 95, 'folder'),
 				new Section('security', $this->l->t('Security'), 90, 'password'),
-				new Section('authentication', $this->l->t('Authentication'), 87, 'user'),
+				new Section('authentication', $this->l->t('User Authentication'), 87, 'user'),
 				new Section('encryption', $this->l->t('Encryption'), 85, 'password'),
 				new Section('workflow', $this->l->t('Workflows & Tags'), 85, 'workflows'),
 				new Section('sharing', $this->l->t('Sharing'), 80, 'share'),

--- a/settings/templates/settingsPage.php
+++ b/settings/templates/settingsPage.php
@@ -61,8 +61,10 @@ style('settings', 'settings');
         </div>
 	<?php }
 	$numPanels = count($_['panels']);
-	$legacyClass = OC\Settings\Panels\Personal\Legacy::class;
-	if($numPanels === 0 || ($numPanels === 1 && $_['panels'][0]['id'] === $legacyClass && empty(trim($_['panels'][0]['content'])))) { ?>
+	$legacyClassPersonal = OC\Settings\Panels\Personal\Legacy::class;
+	$legacyClassAdmin = \OC\Settings\Panels\Admin\Legacy::class;
+	$legacyClass = $_['panels'][0]['id'] === $legacyClassPersonal || $_['panels'][0]['id'] === $legacyClassAdmin;
+	if($numPanels === 0 || ($numPanels === 1 && $legacyClass && empty(trim($_['panels'][0]['content'])))) { ?>
 		<div class="section">
 			<h2><?php p($l->t('Error')); ?></h2>
 			<p><?php p($l->t('No panels for this section.')); ?></p>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Catches when the 'Additional' section is loaded but actually there are none to show so displays the nice error message like the personal section does.



## Motivation and Context
 - Otherwise you get a blank page like this 
![screen shot 2017-05-17 at 16 04 31](https://cloud.githubusercontent.com/assets/660805/26160986/8b92baca-3b1a-11e7-9ab5-b777cc8bd2bf.png)


## How Has This Been Tested?
- manual

## Screenshots (if appropriate):
 - more error much message
![screen shot 2017-05-17 at 16 04 20](https://cloud.githubusercontent.com/assets/660805/26161003/9a3a574a-3b1a-11e7-9028-ad23abd02488.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
