### PR TITLE
Do not verify email address for admins

### DIFF
--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -599,7 +599,8 @@ class UsersController extends Controller {
 			);
 		}
 
-		if ($mailAddress === '') {
+		// admins can set email without verification
+		if ($mailAddress === '' || $this->isAdmin) {
 			$this->setEmailAddress($userId, $mailAddress);
 			return new DataResponse(
 				[


### PR DESCRIPTION
## Description
Do not verify email address for admins.
For non-admins, send the email verification mail.

## Related Issue
Fixes https://github.com/owncloud/core/issues/27916

## Motivation and Context
See ticket, solves confusion.

## How Has This Been Tested?
- [x] TEST: set email as admin, set directly
- [x] TEST: set email as regular user, email gets sent

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

