### PR TITLE
Auto enable market app on update and improve app update logging

### DIFF
--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -98,6 +98,8 @@ class Util {
 		$this->config = $config;
 
 		$this->excludedPaths[] = 'files_encryption';
+		// contains certificates
+		$this->excludedPaths[] = 'files_external';
 		$this->excludedPaths[] = 'avatars';
 		$this->excludedPaths[] = 'avatar.png';
 		$this->excludedPaths[] = 'avatar.jpg';

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -179,12 +179,16 @@ class Apps implements IRepairStep {
 					new GenericEvent($app)
 				);
 			} catch (AppAlreadyInstalledException $e) {
+				$output->info($e->getMessage());
 				$failedApps[] = $app;
 			} catch (AppNotInstalledException $e) {
+				$output->info($e->getMessage());
 				$failedApps[] = $app;
 			} catch (AppNotFoundException $e) {
+				$output->info($e->getMessage());
 				$failedApps[] = $app;
 			} catch (AppUpdateNotFoundException $e) {
+				$output->info($e->getMessage());
 				$failedApps[] = $app;
 			} catch (AppManagerException $e) {
 				// No connection to market. Abort.

--- a/tests/lib/Encryption/UtilTest.php
+++ b/tests/lib/Encryption/UtilTest.php
@@ -134,6 +134,7 @@ class UtilTest extends TestCase {
 			['/keyStorage/user1/files/foo.txt', 'keyStorage', true],
 			['/keyStorage/files_encryption', '/keyStorage', true],
 			['keyStorage/user1/files_encryption', '/keyStorage/', true],
+			['/files_external/rootcerts.crt', '', true],
 
 		];
 	}

--- a/tests/lib/Repair/AppsTest.php
+++ b/tests/lib/Repair/AppsTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace Test\Repair;
+use OCP\App\IAppManager;
+use OCP\IConfig;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * Tests to check version comparison
+ *
+ * @see \OC\Repair\AppsTest
+ */
+class AppsTest extends \Test\TestCase {
+
+	/** @var \OC\Repair\AvatarPermissions */
+	protected $repair;
+
+	/** @var IAppManager */
+	protected $appManager;
+	/** @var  EventDispatcher */
+	protected $eventDispatcher;
+	/** @var  IConfig */
+	protected $config;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->appManager = $this->getMockBuilder(IAppManager::class)->getMock();
+		$this->eventDispatcher = $this->getMockBuilder(EventDispatcher::class)->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->repair = new \OC\Repair\Apps($this->appManager, $this->eventDispatcher, $this->config);
+	}
+
+	public function testMarketEnableVersionCompare10() {
+		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->will($this->returnValue('10.0.0'));
+		$this->assertTrue($this->invokePrivate($this->repair, 'requiresMarketEnable'));
+	}
+
+	public function testMarketEnableVersionCompare9() {
+		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->will($this->returnValue('9.1.5'));
+		$this->assertTrue($this->invokePrivate($this->repair, 'requiresMarketEnable'));
+	}
+
+	public function testMarketEnableVersionCompareFuture() {
+		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->will($this->returnValue('10.0.2'));
+		$this->assertFalse($this->invokePrivate($this->repair, 'requiresMarketEnable'));
+	}
+
+	public function testMarketEnableVersionCompareCurrent() {
+		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->will($this->returnValue('10.0.1'));
+		$this->assertFalse($this->invokePrivate($this->repair, 'requiresMarketEnable'));
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
 - Enables the market app when upgrading to use it for updating apps and finding apps that are unbundled to the marketplace now but are still in use.

## Related Issue
 - Upgrading to 10.0.1 from 9.x

## Motivation and Context
Otherwise we get this: 
![screen shot 2017-05-18 at 10 28 04](https://cloud.githubusercontent.com/assets/660805/26199908/b748ea1e-3bc3-11e7-97d3-8b8ac420f2cc.png)
which is actually caused by the market app not being enabled


## How Has This Been Tested?
 - tests with 9.1.4 updating to 10.0.x with user_ldap installed and enabled

## Screenshots (if appropriate):
current output with additional messages:
![screen shot 2017-05-18 at 12 09 33](https://cloud.githubusercontent.com/assets/660805/26199956/fc115a00-3bc3-11e7-88c4-c78550d0e82f.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# TODO
 - [ ] testing & thinking

