### PR TITLE
Add flag to skip migrations on install

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -378,17 +378,20 @@ class AppManager implements IAppManager {
 	}
 
 	/**
-	 * @param string $package
-	 * @return mixed
+	 * @param string $package package path
+	 * @param bool whether to skip migrations, which would only install the code
+	 * @return string|false app id or false in case of error
 	 * @since 10.0
 	 */
-	public function installApp($package) {
+	public function installApp($package, $skipMigrations = false) {
 		$appId = Installer::installApp([
 			'source' => 'local',
 			'path' => $package
 		]);
-		// HACK: this will run the migration and related code
-		Installer::installShippedApp($appId);
+		if (!$skipMigrations && $appId !== false) {
+			// HACK: this will run the migration and related code
+			Installer::installShippedApp($appId);
+		}
 		return $appId;
 	}
 


### PR DESCRIPTION
## Description
Fixes upgrade process: when `occ upgrade` reinstalls code from a missing app which at the same time changes version, the reinstallation *must not* run the migrations because they will be run again later in the upgrade process through app version change.

Fixes issue when upgrading user_ldap from 9.1.5 to 10.0.1 RC1 (requires https://github.com/owncloud/core/pull/27930)

## Related Issue
Discovered while testing https://github.com/owncloud/core/pull/27930

## Motivation and Context
See description

## How Has This Been Tested?
Needs market PR which uses this, see that PR https://github.com/owncloud/market/pull/76

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

