### PR TITLE
fix probably devastating typo

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -111,7 +111,7 @@ class Installer {
 			throw new \Exception($l->t("App directory already exists"));
 		}
 
-		if(!empty($data['pretent'])) {
+		if(!empty($data['pretend'])) {
 			return false;
 		}
 		OC_App::clearAppCache($info['id']);


### PR DESCRIPTION
pretend ... not preten**t**

I don't know where this code is called, but it looks rather nasty. php doc says `pretend`: https://github.com/owncloud/core/pull/27938/files#diff-ad8c79933f6e78c27903df782afaf76cL65