### PR TITLE
Delete appstoreurl config value when enabling market

### DIFF
--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -112,6 +112,10 @@ class Apps implements IRepairStep {
 		if($isCoreUpdate && $requiresMarketEnable) {
 			// Then we need to enable the market app to support app updates / downloads during upgrade
 			$output->info('Enabling market app to assist with update');
+			// delete old value that might influence old APIs
+			if ($this->config->getSystemValue('appstoreenabled', null) !== null) {
+				$this->config->deleteSystemValue('appstoreenabled');
+			}
 			$this->appManager->enableApp('market');
 		}
 


### PR DESCRIPTION
## Description
To avoid side effects with old APIs still using it.

## Related Issue
Workaround for https://github.com/owncloud/core/issues/27951

## How Has This Been Tested?

1. Setup stable9.1.
1. Set "appstoreenabled" to "false" in config.php
1. Upgrade to this branch `occ upgrade`
1. Check config.php and see that the value is gone
1. Install an app with `occ market:install guests` and see it works

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 