### PR TITLE
use divs for header carets

### DIFF
--- a/core/css/header.css
+++ b/core/css/header.css
@@ -97,16 +97,16 @@
 
 /* hover effect for app switcher label */
 .header-appname-container .header-appname,
-.menutoggle .caret {
+.menutoggle .icon-caret {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=75)";
 	opacity: .75;
 }
 .menutoggle:hover .header-appname,
-.menutoggle:hover .caret,
+.menutoggle:hover .icon-caret,
 .menutoggle:focus .header-appname,
-.menutoggle:focus .caret,
+.menutoggle:focus .icon-caret,
 .menutoggle.active .header-appname,
-.menutoggle.active .caret {
+.menutoggle.active .icon-caret {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
 	opacity: 1;
 }
@@ -123,19 +123,23 @@
 	padding: 7px 0 7px 5px;
 	vertical-align: middle;
 }
-/* show caret indicator next to logo to make clear it is tappable */
-#header .caret {
-	width: 10px;
-	height: 10px;
-	margin: -21px 0 0 3px;
+
+#header .icon-caret {
+	display: inline-block;
+	width: 12px;
+	height: 12px;
+	padding: 0;
 	vertical-align: middle;
 }
-/* do not show menu toggle on public share links as there is no menu */
-#body-public #header .caret {
-	display: none;
+
+#header .header-appname-container .icon-caret {
+	margin: -21px 0 0;
 }
 
-
+/* do not show menu toggle on public share links as there is no menu */
+#body-public #header .icon-caret {
+	display: none;
+}
 
 /* NAVIGATION --------------------------------------------------------------- */
 

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -51,7 +51,7 @@
 				<h1 class="header-appname">
 					<?php p(!empty($_['application']) ? $_['application'] : $l->t('Apps')); ?>
 				</h1>
-				<img alt="" class="caret" src="<?php print_unescaped(image_path('', 'actions/caret.svg')); ?>">
+				<div class="icon-caret"></div>
 			</a>
 
 			<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
@@ -68,7 +68,8 @@
 					</div>
 					<?php endif; ?>
 					<span id="expandDisplayName"><?php  p(trim($_['user_displayname']) != '' ? $_['user_displayname'] : $_['user_uid']) ?></span>
-					<img alt="" src="<?php print_unescaped(image_path('', 'actions/caret.svg')); ?>">
+
+					<div class="icon-caret"></div>
 				</div>
 				<div id="expanddiv">
 				<ul>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
This switches out the header caret images with divs that are styled via css.

## Motivation and Context
This makes it possible to style each caret individually, rather than both by overwriting an image. Overwriting both by overwriting an image is still possible like this. So we got the best of both.

## How has this been tested?
Tested for the default and the enterprise theme. Both now look like expected. Screenshot for enterprise and default themes below.

## Screenshots (if appropriate):
Carets individually styled:
![2017-05-19-152257_767x40_scrot](https://cloud.githubusercontent.com/assets/1282767/26249611/91e569ca-3ca7-11e7-9107-f192081b3f47.png)

Default theme:
![2017-05-19-153257_767x40_scrot](https://cloud.githubusercontent.com/assets/1282767/26249992/d739eef0-3ca8-11e7-9797-c01d281ac987.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

