### PR TITLE
find instead of search

### DIFF
--- a/lib/private/User/AccountMapper.php
+++ b/lib/private/User/AccountMapper.php
@@ -148,11 +148,11 @@ class AccountMapper extends Mapper {
 	 * @param integer $offset
 	 * @return Account[]
 	 */
-	public function find($pattern, $limit, $offset) {
+	public function find($pattern, $limit = null, $offset = null) {
 		$lowerPattern = strtolower($pattern);
 		$qb = $this->db->getQueryBuilder();
-		$qb->select(['user_id', 'lower_user_id', 'display_name', 'email', 'last_login', 'backend', 'state', 'quota', 'home'])
-			->selectAlias('a.id', 'id')
+		$qb->selectAlias('DISTINCT a.id', 'id')
+			->addSelect(['user_id', 'lower_user_id', 'display_name', 'email', 'last_login', 'backend', 'state', 'quota', 'home'])
 			->from($this->getTableName(), 'a')
 			->leftJoin('a', 'account_terms', 't', $qb->expr()->eq('a.id', 't.account_id'))
 			->orderBy('display_name')
@@ -160,7 +160,6 @@ class AccountMapper extends Mapper {
 			->orWhere($qb->expr()->iLike('display_name', $qb->createNamedParameter($this->db->escapeLikeParameter($pattern) . '%')))
 			->orWhere($qb->expr()->iLike('email', $qb->createNamedParameter($this->db->escapeLikeParameter($pattern) . '%')))
 			->orWhere($qb->expr()->like('t.term', $qb->createNamedParameter($this->db->escapeLikeParameter($lowerPattern) . '%')));
-
 
 		return $this->findEntities($qb->getSQL(), $qb->getParameters(), $limit, $offset);
 	}

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -263,7 +263,7 @@ class UsersController extends Controller {
 	 * @param int $offset
 	 * @param int $limit
 	 * @param string $gid GID to filter for
-	 * @param string $pattern Pattern to find in the account table (usenid, displayname, email, additional search terms)
+	 * @param string $pattern Pattern to find in the account table (userid, displayname, email, additional search terms)
 	 * @param string $backend Backend to filter for (class-name)
 	 * @return DataResponse
 	 *

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -263,7 +263,7 @@ class UsersController extends Controller {
 	 * @param int $offset
 	 * @param int $limit
 	 * @param string $gid GID to filter for
-	 * @param string $pattern Pattern to search for in the username
+	 * @param string $pattern Pattern to find in the account table (usenid, displayname, email, additional search terms)
 	 * @param string $backend Backend to filter for (class-name)
 	 * @return DataResponse
 	 *
@@ -293,7 +293,7 @@ class UsersController extends Controller {
 			if($gid !== '') {
 				$batch = $this->getUsersForUID($this->groupManager->displayNamesInGroup($gid, $pattern, $limit, $offset));
 			} else {
-				$batch = $this->userManager->search($pattern, $limit, $offset);
+				$batch = $this->userManager->find($pattern, $limit, $offset);
 			}
 
 			foreach ($batch as $user) {

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -620,7 +620,7 @@ class UsersControllerTest extends \Test\TestCase {
 
 		$this->container['UserManager']
 			->expects($this->once())
-			->method('search')
+			->method('find')
 			->with('pattern', 10, 0)
 			->will($this->returnValue([$foo, $admin, $bar]));
 		$this->container['GroupManager']
@@ -733,7 +733,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->method('clearBackends');
 		$this->container['UserManager']
 			->expects($this->once())
-			->method('search')
+			->method('find')
 			->with('')
 			->will($this->returnValue([$user]));
 
@@ -779,7 +779,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->will($this->returnValue([new \OC\User\Database()]));
 		$this->container['UserManager']
 			->expects($this->once())
-			->method('search')
+			->method('find')
 			->with('')
 			->will($this->returnValue([]));
 

--- a/tests/lib/User/AccountMapperTest.php
+++ b/tests/lib/User/AccountMapperTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\User;
+
+
+use OC\User\Account;
+use OC\User\AccountMapper;
+use OC\User\AccountTermMapper;
+use OCP\IDBConnection;
+use Test\TestCase;
+
+/**
+ * Class AccountMapperTest
+ *
+ * @group DB
+ *
+ * @package Test\User
+ */
+class AccountMapperTest extends TestCase {
+
+	/**
+	 * @var IDBConnection
+	 */
+	protected $connection;
+	/**
+	 * @var AccountMapper
+	 */
+	protected $mapper;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		$mapper = \OC::$server->getAccountMapper();
+
+		\OC::$server->getDatabaseConnection()->beginTransaction();
+
+		// create test users
+		for ($i = 1; $i <= 4; $i++) {
+
+			$account = $mapper->find("TestFind$i");
+			if ($account) {
+				$mapper->delete($account);
+			}
+
+			$account = new Account();
+			$account->setUserId("TestFind$i");
+			$account->setDisplayName("Test Find $i");
+			$account->setEmail("test$i@find.tld");
+			$account->setBackend(self::class);
+			$account->setHome("/foo/TestFind$i");
+
+			$mapper->insert($account);
+
+			$mapper->setTermsForAccount($account->getId(), ["Term $i A","Term $i B","Term $i C"]);
+
+		}
+	}
+
+	public function setUp() {
+		parent::setUp();
+		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->mapper = new AccountMapper($this->connection, new AccountTermMapper($this->connection));
+	}
+
+	public static function tearDownAfterClass () {
+		\OC::$server->getDatabaseConnection()->rollBack();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * find all, use lower case
+	 */
+	public function testFindAll() {
+		$result = $this->mapper->find("testfind");
+		$this->assertEquals(4, count($result));
+
+	}
+
+	/**
+	 * find by userid, use lower case
+	 */
+	public function testFindByUserId() {
+		$result = $this->mapper->find("testfind1");
+		$this->assertEquals(1, count($result));
+		$this->assertEquals("TestFind1", array_shift($result)->getUserId());
+
+	}
+
+	/**
+	 * find by display name, use lower case
+	 */
+	public function testFindByDisplayName() {
+		$result = $this->mapper->find('test find 2');
+		$this->assertEquals(1, count($result));
+		$this->assertEquals("TestFind2", array_shift($result)->getUserId());
+
+	}
+
+	/**
+	 * find by email
+	 */
+	public function testFindByEmail() {
+		$result= $this->mapper->find('test3@find.tld');
+		$this->assertEquals(1, count($result));
+		$this->assertEquals("TestFind3", array_shift($result)->getUserId());
+
+	}
+
+	/**
+	 * find by search term, use lower case
+	 */
+	public function testFindBySearchTerm() {
+		$result = $this->mapper->find('term 4 b');
+		$this->assertEquals(1, count($result));
+		$this->assertEquals("TestFind4", array_shift($result)->getUserId());
+
+	}
+
+	/**
+	 * find with limit and offset, use lower case
+	 */
+	public function testFindLimitAndOffset() {
+		$result = $this->mapper->find('Term', 2, 2);
+		$this->assertEquals(2, count($result));
+		//results are ordered by display name
+		$this->assertEquals("TestFind3", array_shift($result)->getUserId());
+		$this->assertEquals("TestFind4", array_shift($result)->getUserId());
+
+	}
+}

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -135,58 +135,16 @@ class ManagerTest extends TestCase {
 
 	public function testFind() {
 		$a0 = new Account();
-		$a0->setUserId('afoo');
+		$a0->setUserId('foo');
 		$a1 = new Account();
-		$a1->setUserId('foo');
+		$a1->setUserId('foob');
 		$this->accountMapper->expects($this->once())->method('find')
 			->with('fo')->willReturn([$a0, $a1]);
 		$result = $this->manager->find('fo');
 		$this->assertEquals(2, count($result));
-		$this->assertEquals('afoo', array_shift($result)->getUID());
 		$this->assertEquals('foo', array_shift($result)->getUID());
+		$this->assertEquals('foob', array_shift($result)->getUID());
 	}
-
-	public function testFindWithLimit() {
-		$a0 = new Account();
-		$a0->setUserId('afoo');
-		$a1 = new Account();
-		$a1->setUserId('foo');
-		$this->accountMapper->expects($this->once())->method('find')
-			->with('fo', 1)->willReturn([$a0]);
-		$result = $this->manager->find('fo', 1);
-		$this->assertEquals(1, count($result));
-		$this->assertEquals('afoo', array_shift($result)->getUID());
-	}
-
-	public function testFindWithDisplayName() {
-		$a0 = new Account();
-		$a0->setUserId('afoo');
-		$a0->setDisplayName('display1');
-		$a1 = new Account();
-		$a1->setUserId('foo');
-		$a0->setDisplayName('display2');
-		$this->accountMapper->expects($this->once())->method('find')
-			->with('display2')->willReturn([$a1]);
-		$result = $this->manager->find('display2');
-		$this->assertEquals(1, count($result));
-		$this->assertEquals('foo', array_shift($result)->getUID());
-	}
-
-	public function testFindWithEmail() {
-		$a0 = new Account();
-		$a0->setUserId('afoo');
-		$a0->setEmail('test@test.com');
-		$a1 = new Account();
-		$a1->setUserId('foo');
-		$a0->setEmail('test2@test.com');
-		$this->accountMapper->expects($this->once())->method('find')
-			->with('@test.com')->willReturn([$a0, $a1]);
-		$result = $this->manager->find('@test.com');
-		$this->assertEquals(2, count($result));
-		$this->assertEquals('afoo', array_shift($result)->getUID());
-		$this->assertEquals('foo', array_shift($result)->getUID());
-	}
-
 
 	public function testSearch() {
 		$a0 = new Account();


### PR DESCRIPTION
currently only searching by userid is possible. This PR allows finding users by userid, displayname, email and additional search terms. 

related:
- https://github.com/owncloud/core/issues/27171
- https://github.com/owncloud/core/issues/27013