### PR TITLE
Workaround for admin user to be able to login with objectstore

### DIFF
--- a/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
@@ -37,6 +37,10 @@ class HomeObjectStoreStorage extends ObjectStoreStorage implements \OCP\Files\IH
 		}
 		$this->user = $params['user'];
 		parent::__construct($params);
+		//initialize home storage cache with files directory in cache
+		if (!$this->is_dir('files')) {
+			$this->mkdir('files');
+		}
 	}
 
 	public function getId () {


### PR DESCRIPTION
## Description
When using home object store, for some reason the home folder "files" of the admin doesn't get created and no skeleton is copied. This causes trouble and the admin cannot login.

This workaround pre-creates some of the missing folders to allow logging in.
This however doesn't fix the skeleton issue, so the admin has no skeleton files.
Still, this is an important fix to avoid blocking admins. Skeleton issue to be investigated separately.

## Related Issue
Fixes https://github.com/owncloud/objectstore/issues/56

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
By @davitol manually and it worked

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@butonic @DeepDiver1975 