### PR TITLE
Make new text file tooltip messages update

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2102,6 +2102,7 @@
 				} catch (error) {
 					input.attr('title', error);
 					input.tooltip({placement: 'right', trigger: 'manual'});
+					input.tooltip('fixTitle');
 					input.tooltip('show');
 					input.addClass('error');
 				}

--- a/apps/files/js/newfilemenu.js
+++ b/apps/files/js/newfilemenu.js
@@ -153,6 +153,7 @@
 				} catch (error) {
 					$input.attr('title', error);
 					$input.tooltip({placement: 'right', trigger: 'manual'});
+					$input.tooltip('fixTitle');
 					$input.tooltip('show');
 					$input.addClass('error');
 				}


### PR DESCRIPTION
## Description

## Related Issue
#27864 

## Motivation and Context
As the reason that the new text file name is invalid changes, the displayed text does not change.
The user needs to see an up-to-date error reason.

## How Has This Been Tested?
1) Create a folder with a file in it - e.g. file.txt
2) Click "+", New text file, first blank out the whole file name and file type. "File name cannot be empty" is displayed in the tooltip -good.
3) Now type a name that exactly matches the name of the other file in the folder - file.txt. The tooltip displays again, but it still says "File name cannot be empty".

After this fix, at step (3) the tooltip pops up and says "file.txt already exists"
and as you blank out the filename, put a single "." etc, the tooltip text changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

These are the other places that this type of tooltip code happens where the tooltip text gets updated on-the-fly. The same fix as in #27958 applies.