### PR TITLE
Return no user when uid is null

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -151,6 +151,9 @@ class Manager extends PublicEmitter implements IUserManager {
 		if (isset($this->cachedUsers[$uid])) { //check the cache first to prevent having to loop over the backends
 			return $this->cachedUsers[$uid];
 		}
+		if (is_null($uid)){
+			return null;
+		}
 		try {
 			$account = $this->accountMapper->getByUid($uid);
 			if (is_null($account)) {


### PR DESCRIPTION

## Description
Do not execute SQL query when looking for user with uid `NULL`

## Related Issue
https://github.com/owncloud/updater/issues/424

## Motivation and Context
`oc_accounts` doesn't exist in 9.1.5
While upgrading to 10.0.x we are trying to search user with uid `NULL` in this table

## How Has This Been Tested?
1. Install 9.1.5
2. Override `updater.server.url` to point to 10.0.1rc3
3. Do web update

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

