### PR TITLE
remove double test

### DIFF
--- a/tests/ui/features/users.feature
+++ b/tests/ui/features/users.feature
@@ -10,7 +10,6 @@ Feature: users
 		Examples:
 		|start_quota|wished_quota|expected_quota|
 		|Unlimited  |5 GB        |5 GB          |
-		|Unlimited  |5 GB        |5 GB          |
 		|1 GB       |5 GB        |5 GB          |
 		|5 GB       |Unlimited   |Unlimited     |
 		|1 GB       |Unlimited   |Unlimited     |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The removed tests was run double. In the beginning it used to be a test to set from "Unlimited to 1GB" then somehow I made a mistake and made double "Unlimited to 5GB" tests
I guess even the "Unlimited to 1GB" is not really needed

## How Has This Been Tested?
travis will test it for me

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.