### PR TITLE
Don't login user after setup, doesn't work any way

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -374,15 +374,6 @@ class Setup {
 
 			//and we are done
 			$config->setSystemValue('installed', true);
-
-			// Create a session token for the newly created user
-			// The token provider requires a working db, so it's not injected on setup
-			/* @var $userSession User\Session */
-			$userSession = \OC::$server->getUserSession();
-			$defaultTokenProvider = \OC::$server->query('OC\Authentication\Token\DefaultTokenProvider');
-			$userSession->setTokenProvider($defaultTokenProvider);
-			$userSession->login($username, $password);
-			$userSession->createSessionToken($request, $userSession->getUser()->getUID(), $username, $password);
 		}
 
 		return $error;


### PR DESCRIPTION
## Description
Remove code that automatically logs in the admin user after setting up
ownCloud. This doesn't work anyway.

## Related Issue

## Motivation and Context
Unneeded code triggers more app loading at setup time through the extra login, which can cause other side effects or even have the setup command look like it failed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@SergioBertolinSG @DeepDiver1975