### PR TITLE
Don't overwrite a git clone of an app with code from the marketplace

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -44,6 +44,7 @@ use OC\App\CodeChecker\PrivateCheck;
 use OC_App;
 use OC_DB;
 use OC_Helper;
+use OCP\App\AppAlreadyInstalledException;
 
 /**
  * This class provides the functionality needed to install, update and remove plugins/apps
@@ -221,6 +222,9 @@ class Installer {
 
 		if($currentDir !== false && is_writable($currentDir)) {
 			$basedir = $currentDir;
+		}
+		if(is_dir("$basedir/.git")) {
+			throw new AppAlreadyInstalledException("App <{$info['id']}> is a git clone - it will not be updated.");
 		}
 		if(is_dir($basedir)) {
 			OC_Helper::rmdirr($basedir);


### PR DESCRIPTION
## Description
It is very annoying when ./occ upgrade grabs an app from the marketplace and kills a local app installation.

## Motivation and Context
Don't annoy developers

## How Has This Been Tested?
- grab e.g. the market app from github
- run occ upgrade
- see that the local clone is not killed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

