### PR TITLE
load default enabled theme during error messages

### DIFF
--- a/index.php
+++ b/index.php
@@ -49,18 +49,22 @@ try {
 	OC::handleRequest();
 
 } catch(\OC\ServiceUnavailableException $ex) {
+	\OC::loadDefaultEnabledAppTheme();
 	\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 
 	//show the user a detailed error page
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 	OC_Template::printExceptionErrorPage($ex);
 } catch (\OC\HintException $ex) {
+	\OC::loadDefaultEnabledAppTheme();
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 	OC_Template::printErrorPage($ex->getMessage(), $ex->getHint());
 } catch (\OC\User\LoginException $ex) {
+	\OC::loadDefaultEnabledAppTheme();
 	OC_Response::setStatus(OC_Response::STATUS_FORBIDDEN);
 	OC_Template::printErrorPage($ex->getMessage());
 } catch (Exception $ex) {
+	\OC::loadDefaultEnabledAppTheme();
 	try {
 		\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 
@@ -76,6 +80,7 @@ try {
 		echo('</body></html>');
 	}
 } catch (Error $ex) {
+	\OC::loadDefaultEnabledAppTheme();
 	\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 	OC_Template::printExceptionErrorPage($ex);

--- a/lib/base.php
+++ b/lib/base.php
@@ -826,6 +826,22 @@ class OC {
 	}
 
 	/**
+	 * Enables the defaultEnabled app theme
+	 * __do not__ call this for every request, as this parses all apps info.xml
+	 * files in order to determine which app is a default enabled theme while
+	 * not accessing the database which might not be available.
+	 */
+	public static function loadDefaultEnabledAppTheme() {
+		$defaultEnabledAppTheme = \OC_App::getDefaultEnabledAppTheme();
+
+		if ($defaultEnabledAppTheme !== false) {
+			/** @var \OC\Theme\ThemeService $themeService */
+			$themeService = \OC::$server->query('ThemeService');
+			$themeService->setAppTheme($defaultEnabledAppTheme);
+		}
+	}
+
+	/**
 	 * Handle the request
 	 */
 	public static function handleRequest() {
@@ -843,13 +859,7 @@ class OC {
 				\OC::$server->getL10N('lib'), new \OC_Defaults(), \OC::$server->getLogger(),
 				\OC::$server->getSecureRandom());
 
-			$defaultEnabledAppTheme = \OC_App::getDefaultEnabledAppTheme();
-
-			if ($defaultEnabledAppTheme !== false) {
-				/** @var \OC\Theme\ThemeService $themeService */
-				$themeService = \OC::$server->query('ThemeService');
-				$themeService->setAppTheme($defaultEnabledAppTheme);
-			}
+			self::loadDefaultEnabledAppTheme();
 
 			$controller = new OC\Core\Controller\SetupController($setupHelper);
 			$controller->run($_POST);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
As themes are now apps, and no apps are loaded during errors, the error messages are shown with the default theme. This loads any theme that has the `default_enable` tag active for all error pages (not requests without errors). I reused the functionality that was used for the installation/update screen.

## Related Issue
https://github.com/owncloud/enterprise/issues/1984

## How Has This Been Tested?
This has been tested by hand. I manually triggered all exceptions that run into error pages, and the theme loads successfully.

Sadly this brought my attention to another bug that was undetected until now:
Any theme that does not have the `default_enable` tag, that is activated during an error, is not loaded.

For 10.0.2 we should find a solution for this problem. We cannot rely on any database connection or whatever here. So the only way we can guarantee theme loading in every case, is if we save the enabled theme into the config file and use this one to enable the theme, and use the enabled apps (through database) as fallback.

I will create  a tech-debt ticket for that with 10.0.2 milestone.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

