### PR TITLE
Ensure that get user with uid null returns null without querying DB

### DIFF
--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -274,4 +274,10 @@ class ManagerTest extends TestCase {
 		$user3->delete();
 		$user4->delete();
 	}
+	
+	public function testNullUidMakesNoQueryToAccountsTable() {
+		// migration from versions below 10.0. accounts table hasn't been created yet.
+		$this->accountMapper->expects($this->never())->method('getByUid');
+		$this->assertNull($this->manager->get(null));
+	}
 }


### PR DESCRIPTION


## Description
A unit test requested in #27965 

## Related Issue
already fixed :)

## Motivation and Context
to be on a safe side

## How Has This Been Tested?
By running PHPUnit on master (pass)
 running it with on master with  #27965 reverted  (fail)


## Types of changes
- [x] Just a unit test
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

