### PR TITLE
Improved remote user search

### DIFF
--- a/apps/dav/lib/CardDAV/AddressBookImpl.php
+++ b/apps/dav/lib/CardDAV/AddressBookImpl.php
@@ -86,11 +86,13 @@ class AddressBookImpl implements IAddressBook {
 	 * @param string $pattern which should match within the $searchProperties
 	 * @param array $searchProperties defines the properties within the query pattern should match
 	 * @param array $options - for future use. One should always have options!
+	 * @param int $limit
+	 * @param int $offset
 	 * @return array an array of contacts which are arrays of key-value-pairs
 	 * @since 5.0.0
 	 */
-	public function search($pattern, $searchProperties, $options) {
-		$results = $this->backend->search($this->getKey(), $pattern, $searchProperties);
+	public function search($pattern, $searchProperties, $options, $limit, $offset) {
+		$results = $this->backend->search($this->getKey(), $pattern, $searchProperties, $limit, $offset);
 
 		$vCards = [];
 		foreach ($results as $result) {

--- a/apps/dav/lib/CardDAV/AddressBookImpl.php
+++ b/apps/dav/lib/CardDAV/AddressBookImpl.php
@@ -91,7 +91,7 @@ class AddressBookImpl implements IAddressBook {
 	 * @return array an array of contacts which are arrays of key-value-pairs
 	 * @since 5.0.0
 	 */
-	public function search($pattern, $searchProperties, $options, $limit, $offset) {
+	public function search($pattern, $searchProperties, $options, $limit = null, $offset = null) {
 		$results = $this->backend->search($this->getKey(), $pattern, $searchProperties, $limit, $offset);
 
 		$vCards = [];

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -790,9 +790,11 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 * @param int $addressBookId
 	 * @param string $pattern which should match within the $searchProperties
 	 * @param array $searchProperties defines the properties within the query pattern should match
+	 * @param int $limit
+	 * @param int $offset
 	 * @return array an array of contacts which are arrays of key-value-pairs
 	 */
-	public function search($addressBookId, $pattern, $searchProperties) {
+	public function search($addressBookId, $pattern, $searchProperties, $limit = 100, $offset = 0) {
 		$query = $this->db->getQueryBuilder();
 		$query2 = $this->db->getQueryBuilder();
 		$query2->selectDistinct('cp.cardid')->from($this->dbCardsPropertiesTable, 'cp');
@@ -808,6 +810,8 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 
 		$query->select('c.carddata', 'c.uri')->from($this->dbCardsTable, 'c')
 			->where($query->expr()->in('c.id', $query->createFunction($query2->getSQL())));
+
+		$query->setFirstResult($limit)->setMaxResults($offset);
 
 		$result = $query->execute();
 		$cards = $result->fetchAll();

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -811,7 +811,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		$query->select('c.carddata', 'c.uri')->from($this->dbCardsTable, 'c')
 			->where($query->expr()->in('c.id', $query->createFunction($query2->getSQL())));
 
-		$query->setFirstResult($limit)->setMaxResults($offset);
+		$query->setFirstResult($offset)->setMaxResults($limit);
 
 		$result = $query->execute();
 		$cards = $result->fetchAll();

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -812,6 +812,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 			->where($query->expr()->in('c.id', $query->createFunction($query2->getSQL())));
 
 		$query->setFirstResult($offset)->setMaxResults($limit);
+		$query->orderBy('c.uri');
 
 		$result = $query->execute();
 		$cards = $result->fetchAll();

--- a/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
@@ -102,10 +102,10 @@ class AddressBookImplTest extends TestCase {
 			->getMock();
 
 		$pattern = 'pattern';
-		$searchProperties = 'properties';
+		$searchProperties = ['properties'];
 
 		$this->backend->expects($this->once())->method('search')
-			->with($this->addressBookInfo['id'], $pattern, $searchProperties)
+			->with($this->addressBookInfo['id'], $pattern, $searchProperties, 10, 0)
 			->willReturn(
 				[
 					['uri' => 'foo.vcf', 'carddata' => 'cardData1'],
@@ -121,7 +121,7 @@ class AddressBookImplTest extends TestCase {
 				['bar.vcf', $this->vCard]
 			)->willReturn('vCard');
 
-		$result = $addressBookImpl->search($pattern, $searchProperties, []);
+		$result = $addressBookImpl->search($pattern, $searchProperties, [], 10, 0);
 		$this->assertTrue((is_array($result)));
 		$this->assertSame(2, count($result));
 	}

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -466,7 +466,7 @@ class CardDavBackendTest extends TestCase {
 	 * @param array $properties
 	 * @param array $expected
 	 */
-	public function testSearch($pattern, $properties, $expected) {
+	public function testSearch($pattern, $properties, $expected, $limit, $offset) {
 		/** @var VCard $vCards */
 		$vCards = [];
 		$vCards[0] = new VCard();
@@ -529,7 +529,7 @@ class CardDavBackendTest extends TestCase {
 			);
 		$query->execute();
 
-		$result = $this->backend->search(0, $pattern, $properties);
+		$result = $this->backend->search(0, $pattern, $properties, $limit, $offset);
 
 		// check result
 		$this->assertSame(count($expected), count($result));
@@ -548,11 +548,13 @@ class CardDavBackendTest extends TestCase {
 
 	public function dataTestSearch() {
 		return [
-				['John', ['FN'], [['uri0', 'John Doe'], ['uri1', 'John M. Doe']]],
-				['M. Doe', ['FN'], [['uri1', 'John M. Doe']]],
-				['Do', ['FN'], [['uri0', 'John Doe'], ['uri1', 'John M. Doe']]],
-				'check if duplicates are handled correctly' => ['John', ['FN', 'CLOUD'], [['uri0', 'John Doe'], ['uri1', 'John M. Doe']]],
-				'case insensitive' => ['john', ['FN'], [['uri0', 'John Doe'], ['uri1', 'John M. Doe']]]
+				['John', ['FN'], [['uri0', 'John Doe'], ['uri1', 'John M. Doe']], 100, 0],
+				['M. Doe', ['FN'], [['uri1', 'John M. Doe']], 100, 0],
+				['Do', ['FN'], [['uri0', 'John Doe'], ['uri1', 'John M. Doe']], 100, 0],
+				'check if duplicates are handled correctly' => ['John', ['FN', 'CLOUD'], [['uri0', 'John Doe'], ['uri1', 'John M. Doe']], 100, 0],
+				'case insensitive' => ['john', ['FN'], [['uri0', 'John Doe'], ['uri1', 'John M. Doe']], 100, 0],
+				'search limit' => ['John', ['FN'], [['uri0', 'John Doe']], 1, 0],
+				'search offset' => ['John', ['FN'], [['uri1', 'John M. Doe']], 1, 1],
 		];
 	}
 

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -296,8 +296,7 @@ class ShareesController extends OCSController  {
 		$searchProperties = explode(',', $this->config->getAppValue('dav', 'remote_search_properties', 'CLOUD,FN'));
 
 		// Search in contacts
-		//@todo Pagination missing
-		$addressBookContacts = $this->contactsManager->search($search, $searchProperties);
+		$addressBookContacts = $this->contactsManager->search($search, $searchProperties, $this->limit, $this->offset);
 		$foundRemoteById = false;
 		foreach ($addressBookContacts as $contact) {
 			if (isset($contact['isLocalSystemBook'])) {

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -292,9 +292,12 @@ class ShareesController extends OCSController  {
 	protected function getRemote($search) {
 		$this->result['remotes'] = [];
 
+		// Fetch remote search properties from app config
+		$searchProperties = explode(',', $this->config->getAppValue('dav', 'remote_search_properties', 'CLOUD,FN'));
+
 		// Search in contacts
 		//@todo Pagination missing
-		$addressBookContacts = $this->contactsManager->search($search, ['CLOUD', 'FN']);
+		$addressBookContacts = $this->contactsManager->search($search, $searchProperties);
 		$foundRemoteById = false;
 		foreach ($addressBookContacts as $contact) {
 			if (isset($contact['isLocalSystemBook'])) {

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -296,7 +296,7 @@ class ShareesController extends OCSController  {
 		$searchProperties = explode(',', $this->config->getAppValue('dav', 'remote_search_properties', 'CLOUD,FN'));
 
 		// Search in contacts
-		$addressBookContacts = $this->contactsManager->search($search, $searchProperties, $this->limit, $this->offset);
+		$addressBookContacts = $this->contactsManager->search($search, $searchProperties, [], $this->limit, $this->offset);
 		$foundRemoteById = false;
 		foreach ($addressBookContacts as $contact) {
 			if (isset($contact['isLocalSystemBook'])) {

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -291,60 +291,102 @@ class ShareesController extends OCSController  {
 	 */
 	protected function getRemote($search) {
 		$this->result['remotes'] = [];
-
 		// Fetch remote search properties from app config
 		$searchProperties = explode(',', $this->config->getAppValue('dav', 'remote_search_properties', 'CLOUD,FN'));
-
 		// Search in contacts
 		$addressBookContacts = $this->contactsManager->search($search, $searchProperties, [], $this->limit, $this->offset);
 		$foundRemoteById = false;
 		foreach ($addressBookContacts as $contact) {
+
 			if (isset($contact['isLocalSystemBook'])) {
+				// We only want remote users
 				continue;
 			}
-			if (isset($contact['CLOUD'])) {
-				$cloudIds = $contact['CLOUD'];
-				if (!is_array($cloudIds)) {
-					$cloudIds = [$cloudIds];
+			if (!isset($contact['CLOUD'])) {
+				// we need a cloud id to setup a remote share
+				continue;
+			}
+
+			// we can have multiple cloud domains, always convert to an array
+			$cloudIds = $contact['CLOUD'];
+			if (!is_array($cloudIds)) {
+				$cloudIds = [$cloudIds];
+			}
+
+			$lowerSearch = strtolower($search);
+			foreach ($cloudIds as $cloudId) {
+				list(, $serverUrl) = $this->splitUserRemote($cloudId);
+
+
+				if (strtolower($cloudId) === $lowerSearch) {
+					$foundRemoteById = true;
+					// Save this as an exact match and continue with next CLOUD
+					$this->result['exact']['remotes'][] = [
+						'label' => $contact['FN'],
+						'value' => [
+							'shareType' => Share::SHARE_TYPE_REMOTE,
+							'shareWith' => $cloudId,
+							'server' => $serverUrl,
+						],
+					];
+					continue;
 				}
-				$lowerSearch = strtolower($search);
-				foreach ($cloudIds as $cloudId) {
-					list(, $serverUrl) = $this->splitUserRemote($cloudId);
-					if (strtolower($contact['FN']) === $lowerSearch || strtolower($cloudId) === $lowerSearch) {
-						if (strtolower($cloudId) === $lowerSearch) {
-							$foundRemoteById = true;
+
+				// CLOUD matching is done above
+				unset($searchProperties['CLOUD']);
+				foreach($searchProperties as $property) {
+					// do we even have this property for this contact/
+					if(!isset($contact[$property])) {
+						// Skip this property since our contact doesnt have it
+						continue;
+					}
+					// check if we have a match
+					$values = $contact[$property];
+					if(!is_array($values)) {
+						$values = [$values];
+					}
+					foreach($values as $value) {
+						// check if we have an exact match
+						if(strtolower($value) === $lowerSearch) {
+							$this->result['exact']['remotes'][] = [
+								'label' => $contact['FN'],
+								'value' => [
+									'shareType' => Share::SHARE_TYPE_REMOTE,
+									'shareWith' => $cloudId,
+									'server' => $serverUrl,
+								],
+							];
+
+							// Now skip to next CLOUD
+							continue 3;
 						}
-						$this->result['exact']['remotes'][] = [
-							'label' => $contact['FN'],
-							'value' => [
-								'shareType' => Share::SHARE_TYPE_REMOTE,
-								'shareWith' => $cloudId,
-								'server' => $serverUrl,
-							],
-						];
-					} else {
-						$this->result['remotes'][] = [
-							'label' => $contact['FN'],
-							'value' => [
-								'shareType' => Share::SHARE_TYPE_REMOTE,
-								'shareWith' => $cloudId,
-								'server' => $serverUrl,
-							],
-						];
 					}
 				}
+
+				// If we get here, we didnt find an exact match, so add to other matches
+				$this->result['remotes'][] = [
+					'label' => $contact['FN'],
+					'value' => [
+						'shareType' => Share::SHARE_TYPE_REMOTE,
+						'shareWith' => $cloudId,
+						'server' => $serverUrl,
+					],
+				];
+
 			}
 		}
 
+		// remove the exact user results if we dont allow autocomplete
 		if (!$this->shareeEnumeration) {
 			$this->result['remotes'] = [];
 		}
+
 
 		if (!$foundRemoteById && substr_count($search, '@') >= 1 && $this->offset === 0
 			// if an exact local user is found, only keep the remote entry if
 			// its domain does not matches the trusted domains
 			// (if it does, it is a user whose local login domain matches the ownCloud
-			// instance domain) 
+			// instance domain)
 			&& (empty($this->result['exact']['users'])
 				|| !$this->isInstanceDomain($search))
 		) {

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -1248,6 +1248,11 @@ class ShareesTest extends TestCase {
 	 * @param array $previousExact
 	 */
 	public function testGetRemote($searchTerm, $contacts, $shareeEnumeration, $exactExpected, $expected, $reachedEnd, $previousExact = []) {
+
+		// Set the limit and offset for remote user searching
+		$this->invokePrivate($this->sharees, 'limit', [2]);
+		$this->invokePrivate($this->sharees, 'offset', [0]);
+
 		$this->config->expects($this->any())
 			->method('getSystemValue')
 			->with('trusted_domains')
@@ -1267,7 +1272,7 @@ class ShareesTest extends TestCase {
 		$this->invokePrivate($this->sharees, 'shareeEnumeration', [$shareeEnumeration]);
 		$this->contactsManager->expects($this->any())
 			->method('search')
-			->with($searchTerm, ['CLOUD', 'FN'])
+			->with($searchTerm, ['CLOUD', 'FN'], [], 2, 0)
 			->willReturn($contacts);
 
 		$this->invokePrivate($this->sharees, 'getRemote', [$searchTerm]);

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -1259,6 +1259,11 @@ class ShareesTest extends TestCase {
 			$this->invokePrivate($this->sharees, 'result', [$result]);
 		}
 
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('dav', 'remote_search_properties')
+			->willReturn('CLOUD,FN');
+
 		$this->invokePrivate($this->sharees, 'shareeEnumeration', [$shareeEnumeration]);
 		$this->contactsManager->expects($this->any())
 			->method('search')

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -1233,6 +1233,34 @@ class ShareesTest extends TestCase {
 					]
 				]
 			],
+			// #16 check email property is matched for remote users
+			[
+				'user@example.com',
+				[
+					[
+						'FN' => 'User3 @ Localhost',
+					],
+					[
+						'FN' => 'User2 @ Localhost',
+						'CLOUD' => [
+						],
+					],
+					[
+						'FN' => 'User @ Localhost',
+						'CLOUD' => [
+							'username@localhost',
+						],
+						'EMAIL' => 'user@example.com'
+					],
+				],
+				true,
+				[
+					['label' => 'User @ Localhost', 'value' => ['shareType' => Share::SHARE_TYPE_REMOTE, 'shareWith' => 'username@localhost', 'server' => 'localhost']],
+					['label' => 'user@example.com', 'value' => ['shareType' => Share::SHARE_TYPE_REMOTE, 'shareWith' => 'user@example.com']]
+				],
+				[],
+				true,
+			],
 		];
 	}
 
@@ -1267,12 +1295,12 @@ class ShareesTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('getAppValue')
 			->with('dav', 'remote_search_properties')
-			->willReturn('CLOUD,FN');
+			->willReturn('EMAIL,CLOUD,FN');
 
 		$this->invokePrivate($this->sharees, 'shareeEnumeration', [$shareeEnumeration]);
 		$this->contactsManager->expects($this->any())
 			->method('search')
-			->with($searchTerm, ['CLOUD', 'FN'], [], 2, 0)
+			->with($searchTerm, ['EMAIL', 'CLOUD', 'FN'], [], 2, 0)
 			->willReturn($contacts);
 
 		$this->invokePrivate($this->sharees, 'getRemote', [$searchTerm]);

--- a/lib/private/ContactsManager.php
+++ b/lib/private/ContactsManager.php
@@ -26,7 +26,9 @@
 
 namespace OC {
 
-	class ContactsManager implements \OCP\Contacts\IManager {
+	use OCP\Contacts\IManager;
+
+	class ContactsManager implements IManager {
 
 		/**
 		 * This function is used to search and find contacts within the users address books.
@@ -35,13 +37,15 @@ namespace OC {
 		 * @param string $pattern which should match within the $searchProperties
 		 * @param array $searchProperties defines the properties within the query pattern should match
 		 * @param array $options - for future use. One should always have options!
+		 * @param int $limit
+		 * @param int $offset
 		 * @return array an array of contacts which are arrays of key-value-pairs
 		 */
-		public function search($pattern, $searchProperties = [], $options = []) {
+		public function search($pattern, $searchProperties = [], $options = [], $limit = null, $offset = null) {
 			$this->loadAddressBooks();
 			$result = [];
 			foreach($this->addressBooks as $addressBook) {
-				$r = $addressBook->search($pattern, $searchProperties, $options);
+				$r = $addressBook->search($pattern, $searchProperties, $options, $limit, $offset);
 				$contacts = [];
 				foreach($r as $c){
 					$c['addressbook-key'] = $addressBook->getKey();

--- a/lib/private/ContactsManager.php
+++ b/lib/private/ContactsManager.php
@@ -41,7 +41,7 @@ namespace OC {
 		 * @param int $offset
 		 * @return array an array of contacts which are arrays of key-value-pairs
 		 */
-		public function search($pattern, $searchProperties = [], $options = [], $limit = null, $offset = null) {
+		public function search($pattern, $searchProperties = [], $options = [], $limit = 100, $offset = 0) {
 			$this->loadAddressBooks();
 			$result = [];
 			foreach($this->addressBooks as $addressBook) {

--- a/lib/public/Contacts/IManager.php
+++ b/lib/public/Contacts/IManager.php
@@ -92,10 +92,12 @@ namespace OCP\Contacts {
 		 * @param string $pattern which should match within the $searchProperties
 		 * @param array $searchProperties defines the properties within the query pattern should match
 		 * @param array $options - for future use. One should always have options!
+		 * @param int $limit
+		 * @param int $offset
 		 * @return array an array of contacts which are arrays of key-value-pairs
 		 * @since 6.0.0
 		 */
-		function search($pattern, $searchProperties = [], $options = []);
+		function search($pattern, $searchProperties = [], $options = [], $limit = null, $offset = null);
 
 		/**
 		 * This function can be used to delete the contact identified by the given id

--- a/lib/public/IAddressBook.php
+++ b/lib/public/IAddressBook.php
@@ -55,10 +55,12 @@ namespace OCP {
 		 * @param string $pattern which should match within the $searchProperties
 		 * @param array $searchProperties defines the properties within the query pattern should match
 		 * @param array $options - for future use. One should always have options!
+		 * @param int $limit
+		 * @param int $offset
 		 * @return array an array of contacts which are arrays of key-value-pairs
 		 * @since 5.0.0
 		 */
-		public function search($pattern, $searchProperties, $options);
+		public function search($pattern, $searchProperties, $options, $limit, $offset);
 		//	// dummy results
 		//	return array(
 		//		array('id' => 0, 'FN' => 'Thomas Müller', 'EMAIL' => 'a@b.c', 'GEO' => '37.386013;-122.082932'),

--- a/lib/public/IAddressBook.php
+++ b/lib/public/IAddressBook.php
@@ -60,7 +60,7 @@ namespace OCP {
 		 * @return array an array of contacts which are arrays of key-value-pairs
 		 * @since 5.0.0
 		 */
-		public function search($pattern, $searchProperties, $options, $limit, $offset);
+		public function search($pattern, $searchProperties, $options, $limit = null, $offset = null);
 		//	// dummy results
 		//	return array(
 		//		array('id' => 0, 'FN' => 'Thomas Müller', 'EMAIL' => 'a@b.c', 'GEO' => '37.386013;-122.082932'),


### PR DESCRIPTION
## Description
Implemented paginated searching of (local|remote)addressbooks for improved search performance when searching through (multiple) very large addressbooks.

Also added configurable search properites for remote addressbook contact search - used for shareelookup on remote servers.

## Motivation and Context
 - When connected to federated servers with large addressbooks, this search method is extremely slow and can use large amount of memory due to the lack of search limits and offsets.

## How Has This Been Tested?
So far: unit tests


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

