### PR TITLE
Optimize PUT - with custom mtime, use storage instead of view

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -81,7 +81,30 @@ class File extends Node implements IFile, IFileNode {
 		}
 		parent::__construct($view, $info, $shareManager);
 	}
-	
+
+	/**
+	 * Handles metadata updates for the target storage (mtime, propagation)
+	 *
+	 * @param Storage $targetStorage
+	 * @param $targetInternalPath
+	 */
+	private function handleMetadataUpdate(\OC\Files\Storage\Storage $targetStorage, $targetInternalPath) {
+		// since we skipped the view we need to scan and emit the hooks ourselves
+		
+		// allow sync clients to send the mtime along in a header
+		if (isset($this->request->server['HTTP_X_OC_MTIME'])) {
+			$mtime = $this->sanitizeMtime(
+				$this->request->server ['HTTP_X_OC_MTIME']
+			);
+			if ($targetStorage->touch($targetInternalPath, $mtime)) {
+				$this->header('X-OC-MTime: accepted');
+			}
+			$targetStorage->getUpdater()->update($targetInternalPath, $mtime);
+		} else {
+			$targetStorage->getUpdater()->update($targetInternalPath);
+		}
+	}
+
 	/**
 	 * Updates the data
 	 *
@@ -232,21 +255,12 @@ class File extends Node implements IFile, IFileNode {
 				}
 			}
 
-			// since we skipped the view we need to scan and emit the hooks ourselves
-			$storage->getUpdater()->update($internalPath);
+			$this->handleMetadataUpdate($storage, $internalPath);
 
 			try {
 				$this->changeLock(ILockingProvider::LOCK_SHARED);
 			} catch (LockedException $e) {
 				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
-			}
-
-			// allow sync clients to send the mtime along in a header
-			if (isset($this->request->server['HTTP_X_OC_MTIME'])) {
-				$mtime = $this->sanitizeMtime($this->request->server ['HTTP_X_OC_MTIME']);
-				if ($this->fileView->touch($this->path, $mtime)) {
-					$this->header('X-OC-MTime: accepted');
-				}
 			}
 
 			if ($view) {
@@ -524,18 +538,7 @@ class File extends Node implements IFile, IFileNode {
 					$chunk_handler->file_assemble($targetStorage, $targetInternalPath);
 				}
 
-				// allow sync clients to send the mtime along in a header
-				if (isset($this->request->server['HTTP_X_OC_MTIME'])) {
-					$mtime = $this->sanitizeMtime(
-						$this->request->server ['HTTP_X_OC_MTIME']
-					);
-					if ($targetStorage->touch($targetInternalPath, $mtime)) {
-						$this->header('X-OC-MTime: accepted');
-					}
-				}
-
-				// since we skipped the view we need to scan and emit the hooks ourselves
-				$targetStorage->getUpdater()->update($targetInternalPath);
+				$this->handleMetadataUpdate($targetStorage, $targetInternalPath);
 
 				$this->fileView->changeLock($targetPath, ILockingProvider::LOCK_SHARED);
 

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -378,6 +378,8 @@ abstract class Node implements \Sabre\DAV\INode {
 
 	/**
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 *
+	 * @throws \OCP\Lock\LockedException
 	 */
 	public function changeLock($type) {
 		$this->fileView->changeLock($this->path, $type);


### PR DESCRIPTION
### Description
As in the title, I am trying to avoid unnecessarily queries delivering this information different way then just querying the database twice. 

This PR saves few queries in the tested example, 4 READ and 4 WRITE (!), needs 2 aditional LOCK updates, so +2 WRITE.

- [x] Integrations tests in place for this feature
- [x] Might need some unit test update?
- [x] In other PR, I am doing the same with checksum, and this PR might need adjustment after merge of https://github.com/owncloud/core/pull/27532

PR reduces the number of queries from 92 to 82 for new, and from 111 to 101 for edited file (SELECTS and UPDATES)

### How did I test

Smashbox basic test

```
docker run -e SMASHBOX_URL=172.42.16.124:80/octest -e SMASHBOX_USERNAME=admin -e SMASHBOX_ACCOUNT_PASSWORD=admin -e SMASHBOX_PASSWORD=admin owncloud/smashbox lib/test_basicSync.py
```

Using diagnostic, compared number of queries

##### Previous impl - single put new file

{"type":"SUMMARY","reqId":"0S1oOpIXAOJaU7i66fAL","time":"2018-05-16T15:19:45+00:00","remoteAddr":"::1","user":"admin","method":"PUT","url":"\/octest\/remote.php\/dav\/files\/admin\/testnew.txt","diagnostics":{**"totalSQLQueries":92**,"totalSQLDurationmsec":15.33818244934082,"totalSQLParams":205,"totalEvents":16,"totalEventsDurationmsec":44.87967491149902}}

##### Previous impl - single put edit file

{"type":"SUMMARY","reqId":"QxoT5rglLIWSHBJl3XRb","time":"2018-05-16T15:19:45+00:00","remoteAddr":"::1","user":"admin","method":"PUT","url":"\/octest\/remote.php\/dav\/files\/admin\/testnew.txt","diagnostics":{**"totalSQLQueries":111,**"totalSQLDurationmsec":17.354965209960938,"totalSQLParams":259,"totalEvents":16,"totalEventsDurationmsec":59.42058563232422}}

##### Current impl - single put new file

{"type":"SUMMARY","reqId":"5L9J79Am5wkkeqfKY7Wr","time":"2018-05-16T15:21:18+00:00","remoteAddr":"::1","user":"admin","method":"PUT","url":"\/octest\/remote.php\/dav\/files\/admin\/testnew.txt","diagnostics":{**"totalSQLQueries":82**,"totalSQLDurationmsec":13.219833374023438,"totalSQLParams":175,"totalEvents":16,"totalEventsDurationmsec":58.83908271789551}}

##### Current impl - single put edit file

{"type":"SUMMARY","reqId":"AWPSyMmw8aCWHDmHnKZ0","time":"2018-05-16T15:21:18+00:00","remoteAddr":"::1","user":"admin","method":"PUT","url":"\/octest\/remote.php\/dav\/files\/admin\/testnew.txt","diagnostics":{**"totalSQLQueries":101,**"totalSQLDurationmsec":15.613555908203125,"totalSQLParams":223,"totalEvents":16,"totalEventsDurationmsec":50.08506774902344}}

