### PR TITLE
Untangle inter app dependencies

### DIFF
--- a/apps/federatedfilesharing/appinfo/app.php
+++ b/apps/federatedfilesharing/appinfo/app.php
@@ -2,6 +2,7 @@
 /**
  * @author Björn Schießle <bjoern@schiessle.org>
  * @author Joas Schilling <coding@schilljs.com>
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  *
  * @copyright Copyright (c) 2017, ownCloud GmbH
  * @license AGPL-3.0
@@ -36,3 +37,8 @@ $manager->registerNotifier(function() {
 		'name' => $l->t('Federated sharing'),
 	];
 });
+
+// add 'Add to your ownCloud' button to public pages
+// FIXME the OCA\Files::loadAdditionalScripts event is only fired by the ViewController of the files app ... but we are nowadays using webdav.
+// FIXME versions, comments, tags and sharing ui still uses it https://github.com/owncloud/core/search?utf8=%E2%9C%93&q=loadAdditionalScripts&type=
+OCP\Util::connectHook('OCP\Share', 'share_link_access', 'OCA\FederatedFileSharing\HookHandler', 'loadPublicJS');

--- a/apps/federatedfilesharing/appinfo/info.xml
+++ b/apps/federatedfilesharing/appinfo/info.xml
@@ -9,6 +9,9 @@
     <namespace>FederatedFileSharing</namespace>
     <use-migrations>true</use-migrations>
     <category>other</category>
+    <types>
+        <filesystem/>
+    </types>
     <dependencies>
 		<owncloud min-version="10.0.2.4" max-version="10.0" />
     </dependencies>

--- a/apps/federatedfilesharing/js/public.js
+++ b/apps/federatedfilesharing/js/public.js
@@ -1,0 +1,10 @@
+$(document).ready(function() {
+	$('#header #details').prepend(
+		'<span id="save">' +
+		'	<button id="save-button">'+t('files_sharing', 'Add to your ownCloud')+'</button>' +
+		'	<form class="save-form hidden" action="#">' +
+		'		<input type="text" id="remote_address" placeholder="example.com/owncloud"/>' +
+		'		<button id="save-button-confirm" class="icon-confirm svg" disabled></button>' +
+		'	</form>' +
+		'</span>');
+});

--- a/apps/federatedfilesharing/lib/HookHandler.php
+++ b/apps/federatedfilesharing/lib/HookHandler.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing;
+
+/**
+ * Class HookHandler
+ * 
+ * handles hooks
+ *
+ * @package OCA\FederatedFileSharing
+ */
+class HookHandler {
+
+	public static function loadPublicJS () {
+		\OCP\Util::addScript('federatedfilesharing', 'public');
+	}
+
+}

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -162,7 +162,7 @@ class Notifications {
 	 * @return bool
 	 */
 	public function sendRemoteUnShare($remote, $id, $token) {
-		$this->sendUpdateToRemote($remote, $id, $token, 'unshare');
+		return $this->sendUpdateToRemote($remote, $id, $token, 'unshare');
 	}
 
 	/**
@@ -174,7 +174,7 @@ class Notifications {
 	 * @return bool
 	 */
 	public function sendRevokeShare($remote, $id, $token) {
-		$this->sendUpdateToRemote($remote, $id, $token, 'revoke');
+		return $this->sendUpdateToRemote($remote, $id, $token, 'revoke');
 	}
 
 	/**
@@ -187,7 +187,7 @@ class Notifications {
 	 * @return bool
 	 */
 	public function sendPermissionChange($remote, $remoteId, $token, $permissions) {
-		$this->sendUpdateToRemote($remote, $remoteId, $token, 'permissions', ['permissions' => $permissions]);
+		return $this->sendUpdateToRemote($remote, $remoteId, $token, 'permissions', ['permissions' => $permissions]);
 	}
 
 	/**
@@ -257,7 +257,6 @@ class Notifications {
 
 		return false;
 	}
-
 
 	/**
 	 * return current timestamp

--- a/apps/federatedfilesharing/lib/RequestHandler.php
+++ b/apps/federatedfilesharing/lib/RequestHandler.php
@@ -147,9 +147,8 @@ class RequestHandler {
 					\OC::$server->getDatabaseConnection(),
 					\OC\Files\Filesystem::getMountManager(),
 					\OC\Files\Filesystem::getLoader(),
-					\OC::$server->getHTTPHelper(),
 					\OC::$server->getNotificationManager(),
-					$discoveryManager,
+					\OC::$server->getEventDispatcher(),
 					$shareWith
 				);
 

--- a/apps/federatedfilesharing/tests/RequestHandlerTest.php
+++ b/apps/federatedfilesharing/tests/RequestHandlerTest.php
@@ -249,9 +249,8 @@ class RequestHandlerTest extends TestCase {
 			\OC::$server->getDatabaseConnection(),
 			Filesystem::getMountManager(),
 			Filesystem::getLoader(),
-			\OC::$server->getHTTPHelper(),
 			\OC::$server->getNotificationManager(),
-			$discoveryManager,
+			\OC::$server->getEventDispatcher(),
 			$toDelete
 		);
 

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -261,10 +261,10 @@ OCA.Sharing.PublicApp = {
 
 			var remote = $(this).find('input[type="text"]').val();
 			var token = $('#sharingToken').val();
-			var owner = $('#save').data('owner');
-			var ownerDisplayName = $('#save').data('owner-display-name');
-			var name = $('#save').data('name');
-			var isProtected = $('#save').data('protected') ? 1 : 0;
+			var owner = $('#header').data('owner');
+			var ownerDisplayName = $('#header').data('owner-display-name');
+			var name = $('#header').data('name');
+			var isProtected = $('#header').data('protected') ? 1 : 0;
 			OCA.Sharing.PublicApp._saveToOwnCloud(remote, token, owner, ownerDisplayName, name, isProtected);
 		});
 
@@ -335,7 +335,7 @@ OCA.Sharing.PublicApp = {
 		
 		if(remote.substr(-1) !== '/') {
 			remote += '/'
-		};
+		}
 
 		var url = remote + 'index.php/apps/files#' + 'remote=' + encodeURIComponent(location) // our location is the remote for the other server
 			+ "&token=" + encodeURIComponent(token) + "&owner=" + encodeURIComponent(owner) +"&ownerDisplayName=" + encodeURIComponent(ownerDisplayName) + "&name=" + encodeURIComponent(name) + "&protected=" + isProtected;

--- a/apps/files_sharing/lib/API/Remote.php
+++ b/apps/files_sharing/lib/API/Remote.php
@@ -37,17 +37,12 @@ class Remote {
 	 * @return \OC_OCS_Result
 	 */
 	public static function getOpenShares($params) {
-		$discoveryManager = new DiscoveryManager(
-			\OC::$server->getMemCacheFactory(),
-			\OC::$server->getHTTPClientService()
-		);
 		$externalManager = new Manager(
 			\OC::$server->getDatabaseConnection(),
 			Filesystem::getMountManager(),
 			Filesystem::getLoader(),
-			\OC::$server->getHTTPHelper(),
 			\OC::$server->getNotificationManager(),
-			$discoveryManager,
+			\OC::$server->getEventDispatcher(),
 			\OC_User::getUser()
 		);
 
@@ -61,17 +56,12 @@ class Remote {
 	 * @return \OC_OCS_Result
 	 */
 	public static function acceptShare($params) {
-		$discoveryManager = new DiscoveryManager(
-			\OC::$server->getMemCacheFactory(),
-			\OC::$server->getHTTPClientService()
-		);
 		$externalManager = new Manager(
 			\OC::$server->getDatabaseConnection(),
 			Filesystem::getMountManager(),
 			Filesystem::getLoader(),
-			\OC::$server->getHTTPHelper(),
 			\OC::$server->getNotificationManager(),
-			$discoveryManager,
+			\OC::$server->getEventDispatcher(),
 			\OC_User::getUser()
 		);
 
@@ -103,17 +93,12 @@ class Remote {
 	 * @return \OC_OCS_Result
 	 */
 	public static function declineShare($params) {
-		$discoveryManager = new DiscoveryManager(
-			\OC::$server->getMemCacheFactory(),
-			\OC::$server->getHTTPClientService()
-		);
 		$externalManager = new Manager(
 			\OC::$server->getDatabaseConnection(),
 			Filesystem::getMountManager(),
 			Filesystem::getLoader(),
-			\OC::$server->getHTTPHelper(),
 			\OC::$server->getNotificationManager(),
-			$discoveryManager,
+			\OC::$server->getEventDispatcher(),
 			\OC_User::getUser()
 		);
 
@@ -162,17 +147,12 @@ class Remote {
 	 * @return \OC_OCS_Result
 	 */
 	public static function getShares($params) {
-		$discoveryManager = new DiscoveryManager(
-			\OC::$server->getMemCacheFactory(),
-			\OC::$server->getHTTPClientService()
-		);
 		$externalManager = new Manager(
 			\OC::$server->getDatabaseConnection(),
 			Filesystem::getMountManager(),
 			Filesystem::getLoader(),
-			\OC::$server->getHTTPHelper(),
 			\OC::$server->getNotificationManager(),
-			$discoveryManager,
+			\OC::$server->getEventDispatcher(),
 			\OC_User::getUser()
 		);
 
@@ -190,17 +170,12 @@ class Remote {
 	 * @return \OC_OCS_Result
 	 */
 	public static function getShare($params) {
-		$discoveryManager = new DiscoveryManager(
-			\OC::$server->getMemCacheFactory(),
-			\OC::$server->getHTTPClientService()
-		);
 		$externalManager = new Manager(
 			\OC::$server->getDatabaseConnection(),
 			Filesystem::getMountManager(),
 			Filesystem::getLoader(),
-			\OC::$server->getHTTPHelper(),
 			\OC::$server->getNotificationManager(),
-			$discoveryManager,
+			\OC::$server->getEventDispatcher(),
 			\OC_User::getUser()
 		);
 
@@ -221,17 +196,12 @@ class Remote {
 	 * @return \OC_OCS_Result
 	 */
 	public static function unshare($params) {
-		$discoveryManager = new DiscoveryManager(
-			\OC::$server->getMemCacheFactory(),
-			\OC::$server->getHTTPClientService()
-		);
 		$externalManager = new Manager(
 			\OC::$server->getDatabaseConnection(),
 			Filesystem::getMountManager(),
 			Filesystem::getLoader(),
-			\OC::$server->getHTTPHelper(),
 			\OC::$server->getNotificationManager(),
-			$discoveryManager,
+			\OC::$server->getEventDispatcher(),
 			\OC_User::getUser()
 		);
 

--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -4,6 +4,7 @@
  * @author Björn Schießle <bjoern@schiessle.org>
  * @author Georg Ehrke <georg@owncloud.com>
  * @author Joas Schilling <coding@schilljs.com>
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  * @author Lukas Reschke <lukas@statuscode.ch>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Piotr Filiciak <piotr@filiciak.pl>
@@ -34,7 +35,6 @@ namespace OCA\Files_Sharing\Controllers;
 use OC;
 use OC_Files;
 use OC_Util;
-use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCP;
 use OCP\Template;
 use OCP\Share;
@@ -49,8 +49,6 @@ use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\ISession;
 use OCP\IPreview;
-use OCA\Files_Sharing\Helper;
-use OCP\Util;
 use OCA\Files_Sharing\Activity;
 use \OCP\Files\NotFoundException;
 use OCP\Files\IRootFolder;
@@ -81,8 +79,6 @@ class ShareController extends Controller {
 	protected $previewManager;
 	/** @var IRootFolder */
 	protected $rootFolder;
-	/** @var FederatedShareProvider */
-	protected $federatedShareProvider;
 
 	/**
 	 * @param string $appName
@@ -96,7 +92,6 @@ class ShareController extends Controller {
 	 * @param ISession $session
 	 * @param IPreview $previewManager
 	 * @param IRootFolder $rootFolder
-	 * @param FederatedShareProvider $federatedShareProvider
 	 */
 	public function __construct($appName,
 								IRequest $request,
@@ -108,8 +103,7 @@ class ShareController extends Controller {
 								\OCP\Share\IManager $shareManager,
 								ISession $session,
 								IPreview $previewManager,
-								IRootFolder $rootFolder,
-								FederatedShareProvider $federatedShareProvider) {
+								IRootFolder $rootFolder) {
 		parent::__construct($appName, $request);
 
 		$this->config = $config;
@@ -121,7 +115,6 @@ class ShareController extends Controller {
 		$this->session = $session;
 		$this->previewManager = $previewManager;
 		$this->rootFolder = $rootFolder;
-		$this->federatedShareProvider = $federatedShareProvider;
 	}
 
 	/**
@@ -307,7 +300,6 @@ class ShareController extends Controller {
 		$shareTmpl['previewSupported'] = $this->previewManager->isMimeSupported($share->getNode()->getMimetype());
 		$shareTmpl['dirToken'] = $token;
 		$shareTmpl['sharingToken'] = $token;
-		$shareTmpl['server2serversharing'] = $this->federatedShareProvider->isOutgoingServer2serverShareEnabled();
 		$shareTmpl['protected'] = $share->getPassword() !== null ? 'true' : 'false';
 		$shareTmpl['dir'] = '';
 		$shareTmpl['nonHumanFileSize'] = $share->getNode()->getSize();

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -30,9 +30,11 @@
 namespace OCA\Files_Sharing\External;
 
 use OC\Files\Filesystem;
-use OCA\FederatedFileSharing\DiscoveryManager;
 use OCP\Files;
 use OCP\Notification\IManager;
+use OCP\Share\Events\AcceptShare;
+use OCP\Share\Events\DeclineShare;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class Manager {
 	const STORAGE = '\OCA\Files_Sharing\External\Storage';
@@ -58,40 +60,35 @@ class Manager {
 	private $storageLoader;
 
 	/**
-	 * @var \OC\HTTPHelper
-	 */
-	private $httpHelper;
-
-	/**
 	 * @var IManager
 	 */
 	private $notificationManager;
-	/** @var DiscoveryManager */
-	private $discoveryManager;
+
+	/**
+	 * @var EventDispatcherInterface
+	 */
+	private $eventDispatcher;
 
 	/**
 	 * @param \OCP\IDBConnection $connection
 	 * @param \OC\Files\Mount\Manager $mountManager
 	 * @param \OCP\Files\Storage\IStorageFactory $storageLoader
-	 * @param \OC\HTTPHelper $httpHelper
 	 * @param IManager $notificationManager
-	 * @param DiscoveryManager $discoveryManager
+	 * @param EventDispatcherInterface $eventDispatcher
 	 * @param string $uid
 	 */
 	public function __construct(\OCP\IDBConnection $connection,
 								\OC\Files\Mount\Manager $mountManager,
 								\OCP\Files\Storage\IStorageFactory $storageLoader,
-								\OC\HTTPHelper $httpHelper,
 								IManager $notificationManager,
-								DiscoveryManager $discoveryManager,
+								EventDispatcherInterface $eventDispatcher,
 								$uid) {
 		$this->connection = $connection;
 		$this->mountManager = $mountManager;
 		$this->storageLoader = $storageLoader;
-		$this->httpHelper = $httpHelper;
 		$this->uid = $uid;
 		$this->notificationManager = $notificationManager;
-		$this->discoveryManager = $discoveryManager;
+		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	/**
@@ -203,7 +200,10 @@ class Manager {
 					`mountpoint_hash` = ?
 				WHERE `id` = ? AND `user` = ?');
 			$acceptShare->execute([1, $mountPoint, $hash, $id, $this->uid]);
-			$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'accept');
+
+			$this->eventDispatcher->dispatch(
+				AcceptShare::class,	new AcceptShare($share)
+			);
 
 			\OC_Hook::emit('OCP\Share', 'federated_share_added', ['server' => $share['remote']]);
 
@@ -228,7 +228,11 @@ class Manager {
 			$removeShare = $this->connection->prepare('
 				DELETE FROM `*PREFIX*share_external` WHERE `id` = ? AND `user` = ?');
 			$removeShare->execute([$id, $this->uid]);
-			$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'decline');
+
+			$this->eventDispatcher->dispatch(
+				DeclineShare::class,
+				new DeclineShare($share)
+			);
 
 			$this->processNotification($id);
 			return true;
@@ -246,26 +250,6 @@ class Manager {
 			->setUser($this->uid)
 			->setObject('remote_share', (int) $remoteShare);
 		$this->notificationManager->markProcessed($filter);
-	}
-
-	/**
-	 * inform remote server whether server-to-server share was accepted/declined
-	 *
-	 * @param string $remote
-	 * @param string $token
-	 * @param int $remoteId Share id on the remote host
-	 * @param string $feedback
-	 * @return boolean
-	 */
-	private function sendFeedbackToRemote($remote, $token, $remoteId, $feedback) {
-
-		$url = rtrim($remote, '/') . $this->discoveryManager->getShareEndpoint($remote) . '/' . $remoteId . '/' . $feedback . '?format=' . \OCP\Share::RESPONSE_FORMAT;
-		$fields = ['token' => $token];
-
-		$result = $this->httpHelper->post($url, $fields);
-		$status = json_decode($result['result'], true);
-
-		return ($result['success'] && ($status['ocs']['meta']['statuscode'] === 100 || $status['ocs']['meta']['statuscode'] === 200));
 	}
 
 	/**
@@ -342,7 +326,10 @@ class Manager {
 
 		if ($result) {
 			$share = $getShare->fetch();
-			$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'decline');
+			$this->eventDispatcher->dispatch(
+				DeclineShare::class,
+				new DeclineShare($share)
+			);
 		}
 		$getShare->closeCursor();
 
@@ -399,7 +386,10 @@ class Manager {
 		if ($result) {
 			$shares = $getShare->fetchAll();
 			foreach($shares as $share) {
-				$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'decline');
+				$this->eventDispatcher->dispatch(
+					DeclineShare::class,
+					new DeclineShare($share)
+				);
 			}
 		}
 

--- a/apps/files_sharing/lib/Hooks.php
+++ b/apps/files_sharing/lib/Hooks.php
@@ -39,9 +39,8 @@ class Hooks {
 			\OC::$server->getDatabaseConnection(),
 			\OC\Files\Filesystem::getMountManager(),
 			\OC\Files\Filesystem::getLoader(),
-			\OC::$server->getHTTPHelper(),
 			\OC::$server->getNotificationManager(),
-			$discoveryManager,
+			\OC::$server->getEventDispatcher(),
 			$params['uid']);
 
 		$manager->removeUserShares($params['uid']);

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -51,9 +51,9 @@ OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $_['previewI
 <input type="hidden" name="filesize" value="<?php p($_['nonHumanFileSize']); ?>" id="filesize">
 <input type="hidden" name="maxSizeAnimateGif" value="<?php p($_['maxSizeAnimateGif']); ?>" id="maxSizeAnimateGif">
 
-
 <header>
-	<div id="header" class="<?php p((isset($_['folder']) ? 'share-folder' : 'share-file')) ?>">
+	<div id="header" class="<?php p((isset($_['folder']) ? 'share-folder' : 'share-file')) ?>" data-protected="<?php p($_['protected']) ?>"
+		 data-owner-display-name="<?php p($_['displayName']) ?>" data-owner="<?php p($_['owner']) ?>" data-name="<?php p($_['filename']) ?>">
 		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud">
 			<h1 class="logo-icon">
 				<span class="own">own</span><span class="cloud">Cloud</span>
@@ -66,18 +66,6 @@ OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $_['previewI
 		?>
 		<div class="header-right">
 			<span id="details">
-				<?php
-				if ($_['server2serversharing']) {
-					?>
-					<span id="save" data-protected="<?php p($_['protected']) ?>"
-						  data-owner-display-name="<?php p($_['displayName']) ?>" data-owner="<?php p($_['owner']) ?>" data-name="<?php p($_['filename']) ?>">
-					<button id="save-button"><?php p($l->t('Add to your ownCloud')) ?></button>
-					<form class="save-form hidden" action="#">
-						<input type="text" id="remote_address" placeholder="example.com/owncloud"/>
-						<button id="save-button-confirm" class="icon-confirm svg" disabled></button>
-					</form>
-				</span>
-				<?php } ?>
 				<a href="<?php p($_['downloadURL']); ?>" id="download" class="button">
 					<img class="svg" alt="" src="<?php print_unescaped(image_path("core", "actions/download.svg")); ?>"/>
 					<span id="download-text"><?php p($l->t('Download'))?></span>

--- a/apps/files_sharing/tests/Controllers/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controllers/ShareControllerTest.php
@@ -362,7 +362,6 @@ class ShareControllerTest extends \Test\TestCase {
 			'mimetype' => 'text/plain',
 			'dirToken' => 'token',
 			'sharingToken' => 'token',
-			'server2serversharing' => true,
 			'protected' => 'true',
 			'dir' => '',
 			'downloadURL' => null,

--- a/lib/public/Share/Events/AcceptShare.php
+++ b/lib/public/Share/Events/AcceptShare.php
@@ -21,5 +21,10 @@
 
 namespace OCP\Share\Events;
 
-
+/**
+ * Class AcceptShare
+ *
+ * @package OCP\Share\Events
+ * @since 10.0.2
+ */
 class AcceptShare extends ShareEvent {}

--- a/lib/public/Share/Events/AcceptShare.php
+++ b/lib/public/Share/Events/AcceptShare.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Share\Events;
+
+
+class AcceptShare extends ShareEvent {}

--- a/lib/public/Share/Events/DeclineShare.php
+++ b/lib/public/Share/Events/DeclineShare.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Share\Events;
+
+class DeclineShare extends ShareEvent {}

--- a/lib/public/Share/Events/DeclineShare.php
+++ b/lib/public/Share/Events/DeclineShare.php
@@ -21,4 +21,10 @@
 
 namespace OCP\Share\Events;
 
+/**
+ * Class DeclineShare
+ *
+ * @package OCP\Share\Events
+ * @since 10.0.2
+ */
 class DeclineShare extends ShareEvent {}

--- a/lib/public/Share/Events/ShareEvent.php
+++ b/lib/public/Share/Events/ShareEvent.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Share\Events;
+
+
+use Symfony\Component\EventDispatcher\Event;
+
+class ShareEvent extends Event {
+
+	// TODO when the sharing code uses a Share entity use that instead of an array
+	/** @var array */
+	private $share;
+
+	public function __construct($share) {
+		$this->share = $share;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getShare() {
+		return $this->share;
+	}
+
+	/**
+	 * @return string url
+	 */
+	public function getRemote() {
+		return $this->share['remote'];
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getRemoteId() {
+		return (int)$this->share['remote_id'];
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getShareToken() {
+		return $this->share['share_token'];
+	}
+}

--- a/lib/public/Share/Events/ShareEvent.php
+++ b/lib/public/Share/Events/ShareEvent.php
@@ -36,6 +36,12 @@ class ShareEvent extends Event {
 	/** @var array */
 	private $share;
 
+	/**
+	 * ShareEvent constructor.
+	 *
+	 * @param array $share
+	 * @since 10.0.2
+	 */
 	public function __construct($share) {
 		$this->share = $share;
 	}

--- a/lib/public/Share/Events/ShareEvent.php
+++ b/lib/public/Share/Events/ShareEvent.php
@@ -24,6 +24,12 @@ namespace OCP\Share\Events;
 
 use Symfony\Component\EventDispatcher\Event;
 
+/**
+ * Class ShareEvent
+ *
+ * @package OCP\Share\Events
+ * @since 10.0.2
+ */
 class ShareEvent extends Event {
 
 	// TODO when the sharing code uses a Share entity use that instead of an array
@@ -36,6 +42,7 @@ class ShareEvent extends Event {
 
 	/**
 	 * @return array
+	 * @since 10.0.2
 	 */
 	public function getShare() {
 		return $this->share;
@@ -43,6 +50,7 @@ class ShareEvent extends Event {
 
 	/**
 	 * @return string url
+	 * @since 10.0.2
 	 */
 	public function getRemote() {
 		return $this->share['remote'];
@@ -50,6 +58,7 @@ class ShareEvent extends Event {
 
 	/**
 	 * @return int
+	 * @since 10.0.2
 	 */
 	public function getRemoteId() {
 		return (int)$this->share['remote_id'];
@@ -57,6 +66,7 @@ class ShareEvent extends Event {
 
 	/**
 	 * @return string
+	 * @since 10.0.2
 	 */
 	public function getShareToken() {
 		return $this->share['share_token'];


### PR DESCRIPTION
fixes https://github.com/owncloud/core/issues/26297 by
- introducing public accept and decline share events
  - triggering them in files_sharing
  - listening to them in federatedfilesharing
  - use the existing Notifications class in federatedfilesharing which alread has the necessard methods and actually will retry sending the actions in a background job, making the whole process more robust
- make federatedfilesharing inject the 'Add to your ownCloud' button on public pages
  - by listening for the share_link_access hook triggered by files_sharing
- load federatedfilesharing  when the filesystem is initialized
- removing hard dependencies on federatedfilesharing in files_sharing

- [x] fix tests

@PVince81 @DeepDiver1975 should we use AcceptRemoteShare and DeclineRemoteShare. I am trying to think ahead because there might be accept / decline events for internal shares in the future...