### PR TITLE
[stable9.1] Fix user deletion for LDAP users

### DIFF
--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -322,7 +322,12 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 		if(is_null($user)) {
 			throw new NoUserException($uid . ' is not a valid user anymore');
 		}
+
 		$path = $user->getHomePath();
+		if ($path === null) {
+			$path = false;
+		}
+
 		$this->access->cacheUserHome($uid, $path);
 
 		return $path;

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -275,12 +275,18 @@ class User_LDAPTest extends \Test\TestCase {
 		$mapping->expects($this->once())
 			->method('unmap')
 			->will($this->returnValue(true));
-		$access->expects($this->once())
+		$access->expects($this->exactly(2))
 			->method('getUserMapper')
 			->will($this->returnValue($mapping));
+		$access->connection->expects($this->any())
+			->method('getConnectionResource')
+			->will($this->returnCallback(function() {
+				return true;
+			}));
+
 
 		$config = $this->getMock('\OCP\IConfig');
-		$config->expects($this->exactly(2))
+		$config->expects($this->exactly(1))
 			->method('getUserValue')
 			->will($this->onConsecutiveCalls('1', '/var/vhome/jdings/'));
 
@@ -290,7 +296,7 @@ class User_LDAPTest extends \Test\TestCase {
 		$this->assertTrue($result);
 
 		$home = $backend->getHome('jeremy');
-		$this->assertSame($home, '/var/vhome/jdings/');
+		$this->assertFalse($home);
 	}
 
 	/**
@@ -674,9 +680,6 @@ class User_LDAPTest extends \Test\TestCase {
 		$this->assertFalse($result);
 	}
 
-	/**
-	 * @expectedException \OC\User\NoUserException
-	 */
 	public function testGetHomeDeletedUser() {
 		$access = $this->getAccessMock();
 		$backend = new UserLDAP($access, $this->getMock('\OCP\IConfig'));


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
ownCloud's user deletion fails for LDAP users who have been deleted in the LDAP server. This PR fixes that.

## Related Issue
https://github.com/owncloud/core/issues/27861

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested:
* Try to delete an existing user -> failed (expected)
* Delete the user from LDAP, try to delete from ownCloud -> failed (expected, user not marked as deleteable)
* Delete the user from LDAP, check user existence (occ ldap:check-user), try to delete -> success

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

To be checked the behaviour in 10.0.x (the behaviour changed so we might need to review it), and possible backport to 9.0.x

@felixboehm @PVince81 To be evaluated if this can be in 9.1.6. Setting for 9.1.7 for now.