### PR TITLE
Only VEVENT for birthday calendar and default order to 1

### DIFF
--- a/apps/dav/appinfo/Migrations/Version20170526100342.php
+++ b/apps/dav/appinfo/Migrations/Version20170526100342.php
@@ -19,44 +19,26 @@
  *
  */
 
-namespace OCA\DAV\Migration;
+namespace OCA\DAV\Migrations;
 
-use OCA\DAV\CalDAV\BirthdayService;
-use OCP\IDBConnection;
 use OCP\Migration\IOutput;
-use OCP\Migration\IRepairStep;
+use OCP\Migration\ISimpleMigration;
 
-class FixBirthdayCalendarComponent implements IRepairStep {
+/**
+ * Fix the calendar components of the system contact birthday calendar
+ */
+class Version20170526100342 implements ISimpleMigration {
 
-	/** @var IDBConnection */
-	private $connection;
-
-	/**
-	 * FixBirthdayCalendarComponent constructor.
-	 *
-	 * @param IDBConnection $connection
-	 */
-	public function __construct(IDBConnection $connection) {
-		$this->connection = $connection;
-	}
-
-	/**
-	 * @inheritdoc
-	 */
-	public function getName() {
-		return 'Fix component of birthday calendars';
-	}
-
-	/**
-	 * @inheritdoc
-	 */
-	public function run(IOutput $output) {
-		$query = $this->connection->getQueryBuilder();
+	public function run(IOutput $out) {
+		$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
 		$updated = $query->update('calendars')
 			->set('components', $query->createNamedParameter('VEVENT'))
-			->where($query->expr()->eq('uri', $query->createNamedParameter(BirthdayService::BIRTHDAY_CALENDAR_URI)))
+			->set('calendarorder', $query->createNamedParameter('100'))
+			->where($query->expr()->eq(
+				'uri',
+				$query->createNamedParameter('contact_birthdays')))
 			->execute();
 
-		$output->info("$updated birthday calendars updated.");
+		$out->info("$updated birthday calendars updated.");
 	}
 }

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>ownCloud WebDAV endpoint</description>
 	<licence>AGPL</licence>
 	<author>owncloud.org</author>
-	<version>0.2.9</version>
+	<version>0.3.0</version>
 	<default_enable/>
 	<use-migrations>true</use-migrations>
 	<types>
@@ -21,11 +21,6 @@
 	<background-jobs>
 		<job>OCA\DAV\CardDAV\SyncJob</job>
 	</background-jobs>
-	<repair-steps>
-		<post-migration>
-			<step>OCA\DAV\Migration\FixBirthdayCalendarComponent</step>
-		</post-migration>
-	</repair-steps>
 	<commands>
 		<command>OCA\DAV\Command\CreateAddressBook</command>
 		<command>OCA\DAV\Command\CreateCalendar</command>

--- a/apps/dav/lib/CalDAV/BirthdayService.php
+++ b/apps/dav/lib/CalDAV/BirthdayService.php
@@ -25,6 +25,7 @@ namespace OCA\DAV\CalDAV;
 use Exception;
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\DAV\GroupPrincipalBackend;
+use Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Component\VCard;
 use Sabre\VObject\DateTimeParser;
@@ -106,7 +107,8 @@ class BirthdayService {
 		$this->calDavBackEnd->createCalendar($principal, self::BIRTHDAY_CALENDAR_URI, [
 			'{DAV:}displayname' => 'Contact birthdays',
 			'{http://apple.com/ns/ical/}calendar-color' => '#FFFFCA',
-			'components'   => 'VEVENT',
+			'{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set'   => new SupportedCalendarComponentSet(['VEVENT']),
+			'{http://apple.com/ns/ical/}calendar-order' => 100
 		]);
 
 		return $this->calDavBackEnd->getCalendarByUri($principal, self::BIRTHDAY_CALENDAR_URI);

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -532,7 +532,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 *
 	 * @param string $principalUri
 	 * @param string $calendarUri
-	 * @param array $properties
+	 * @param array $properties (keys must be CalDAV properties not db names)
 	 * @return int
 	 * @throws DAV\Exception
 	 */
@@ -544,7 +544,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			'synctoken'    => 1,
 			'transparent'  => 0,
 			'components'   => 'VEVENT,VTODO',
-			'displayname'  => $calendarUri
+			'displayname'  => $calendarUri,
 		];
 
 		// Default value

--- a/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
@@ -26,6 +26,7 @@ use OCA\DAV\CalDAV\BirthdayService;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\DAV\GroupPrincipalBackend;
+use Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Reader;
 use Test\TestCase;
@@ -199,7 +200,8 @@ class BirthdayServiceTest extends TestCase {
 			->with('principal001', 'contact_birthdays', [
 				'{DAV:}displayname' => 'Contact birthdays',
 				'{http://apple.com/ns/ical/}calendar-color' => '#FFFFCA',
-				'components'   => 'VEVENT',
+				'{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set' => new SupportedCalendarComponentSet(['VEVENT']),
+				'{http://apple.com/ns/ical/}calendar-order' => 100
 			]);
 		$this->service->ensureCalendarExists('principal001');
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
New calendars are given a default order of 1, to always be after the default birthday calendar.

The system birthday calendar is created with VEVENT only, not VTODO as this is not possible.

## Motivation and Context
Causes issues when the birthday calendar is used for accepting events or if TODOs are created in that calendar.

## How Has This Been Tested?
 - New install and observing the created calendars
before:
![screen shot 2017-05-25 at 14 17 58](https://cloud.githubusercontent.com/assets/660805/26451849/9e82ea88-4155-11e7-8f87-d5702c93f004.png)
after:
![screen shot 2017-05-25 at 14 43 50](https://cloud.githubusercontent.com/assets/660805/26452639/9b0cb41c-4158-11e7-8784-47059af04ed1.png)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

