### PR TITLE
fix header caret and js error

### DIFF
--- a/core/css/header.css
+++ b/core/css/header.css
@@ -177,7 +177,7 @@
 }
 /* position of dropdown arrow */
 #navigation:after {
-	left: 47%;
+	margin-left: -20px;
 }
 #expanddiv:after {
 	right: 15px;

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1561,11 +1561,10 @@ function initCore() {
 
 	// move triangle of apps dropdown to align with app name triangle
 	// 2 is the additional offset between the triangles
-	if ($('#navigation').length) {
+	if ($('#navigation').length && $('.header-appname + .icon-caret').length) {
 		$('#header #owncloud + .menutoggle').one('click', function () {
-			var caret = $('.header-appname + .caret');
-			var caretPosition = caret.offset().left - caret.width() / 2;
-
+			var caret = $('.header-appname + .icon-caret');
+			var caretPosition = caret.offset().left + caret.width() / 2;
 			// only position the menu arrow if the caret is in its reach
 			if (caretPosition <= 255) {
 				$('head').append('<style>#navigation:after { left: ' + caretPosition + 'px; }</style>');


### PR DESCRIPTION
add half caret to arrow position so it can subtract half of its own width in css
can't get its width in js because it is a pseudo element
also subtract half width via negative css margin

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
We are currently getting a js error because the class used in css doesn't exist anymore. This uses the new class, and also checks if it exists, so this doesn't appear again if we change the class.

Also the position of the caret wasn't correct and can't be calculated with js purely because the arrow is a pseudo element. The element gets now pre positioned so it only needs to add a negative margin of half its width in css. Also fixed that in css.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
We had an error, now we don't.

## How Has This Been Tested?
Optical test with the default theme and the current enterprise theme.

## Screenshots (if appropriate):
![2017-05-26-100812_287x147_scrot](https://cloud.githubusercontent.com/assets/1282767/26486542/d11bc842-41fb-11e7-8178-59fc6523efe5.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

