### PR TITLE
Update the minimum desktop version to 2.2.4

### DIFF
--- a/apps/dav/lib/Connector/Sabre/BlockLegacyClientPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/BlockLegacyClientPlugin.php
@@ -67,7 +67,7 @@ class BlockLegacyClientPlugin extends ServerPlugin {
 			return;
 		}
 
-		$minimumSupportedDesktopVersion = $this->config->getSystemValue('minimum.supported.desktop.version', '2.0.0');
+		$minimumSupportedDesktopVersion = $this->config->getSystemValue('minimum.supported.desktop.version', '2.2.4');
 
 		// Match on the mirall version which is in scheme "Mozilla/5.0 (%1) mirall/%2" or
 		// "mirall/%1" for older releases

--- a/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
@@ -77,8 +77,8 @@ class BlockLegacyClientPluginTest extends TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
-			->with('minimum.supported.desktop.version', '2.0.0')
-			->will($this->returnValue('1.7.0'));
+			->with('minimum.supported.desktop.version', '2.2.4')
+			->will($this->returnValue('2.2.4'));
 
 		$this->blockLegacyClientVersionPlugin->beforeHandler($request);
 	}
@@ -88,11 +88,11 @@ class BlockLegacyClientPluginTest extends TestCase {
 	 */
 	public function newAndAlternateDesktopClientProvider() {
 		return [
-			['Mozilla/5.0 (1.7.0) mirall/1.7.0'],
-			['mirall/1.8.3'],
-			['mirall/1.7.2'],
-			['mirall/1.7.0'],
-			['Mozilla/5.0 (Bogus Text) mirall/1.9.3'],
+			['Mozilla/5.0 (2.2.4) mirall/2.2.4'],
+			['mirall/2.8.3'],
+			['mirall/2.7.2'],
+			['mirall/2.7.0'],
+			['Mozilla/5.0 (Bogus Text) mirall/3.0.1'],
 		];
 	}
 
@@ -112,8 +112,8 @@ class BlockLegacyClientPluginTest extends TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
-			->with('minimum.supported.desktop.version', '2.0.0')
-			->will($this->returnValue('1.7.0'));
+			->with('minimum.supported.desktop.version', '2.2.4')
+			->will($this->returnValue('2.2.4'));
 
 		$this->blockLegacyClientVersionPlugin->beforeHandler($request);
 	}

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1253,7 +1253,7 @@ $CONFIG = array(
  * client may not function as expected, and could lead to permanent data loss for
  * clients or other unexpected results.
  */
-'minimum.supported.desktop.version' => '2.0.0',
+'minimum.supported.desktop.version' => '2.2.4',
 
 /**
  * EXPERIMENTAL: option whether to include external storage in quota


### PR DESCRIPTION
As per the request in #27978, this PR was created to resolve it, setting the minimum ownCloud client version to 2.2.4. 

## Relates To 

- #27978 
- owncloud/documentation/issues/3079