### PR TITLE
Optimize PUT - Dont fetch info of not existing file

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -147,12 +147,10 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node
 			$this->fileView->verifyPath($this->path, $name);
 
 			$path = $this->fileView->getAbsolutePath($this->path) . '/' . $name;
-			// in case the file already exists/overwriting
-			$info = $this->fileView->getFileInfo($this->path . '/' . $name);
-			if (!$info) {
-				// use a dummy FileInfo which is acceptable here since it will be refreshed after the put is complete
-				$info = new \OC\Files\FileInfo($path, null, null, [], null);
-			}
+
+			// use a dummy FileInfo which is acceptable here since it will be refreshed after the put is complete
+			$info = new \OC\Files\FileInfo($path, null, null, [], null);
+
 			$node = new \OCA\DAV\Connector\Sabre\File($this->fileView, $info);
 			$node->acquireLock(ILockingProvider::LOCK_SHARED);
 			return $node->put($data);

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -120,7 +120,7 @@ class File extends Node implements IFile {
 		$this->verifyPath();
 
 		// chunked handling
-		if (isset($_SERVER['HTTP_OC_CHUNKED'])) {
+		if (\OC_FileChunking::isWebdavChunk()) {
 			try {
 				return $this->createFileChunked($data);
 			} catch (\Exception $e) {

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -398,7 +398,7 @@ class FilesPlugin extends ServerPlugin {
 	 */
 	public function sendFileIdHeader($filePath, \Sabre\DAV\INode $node = null) {
 		// chunked upload handling
-		if (isset($_SERVER['HTTP_OC_CHUNKED'])) {
+		if (\OC_FileChunking::isWebdavChunk()) {
 			list($path, $name) = \Sabre\HTTP\URLUtil::splitPath($filePath);
 			$info = \OC_FileChunking::decodeName($name);
 			if (!empty($info)) {

--- a/apps/dav/lib/Connector/Sabre/LockPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/LockPlugin.php
@@ -51,7 +51,7 @@ class LockPlugin extends ServerPlugin {
 	public function getLock(RequestInterface $request) {
 		// we can't listen on 'beforeMethod:PUT' due to order of operations with setting up the tree
 		// so instead we limit ourselves to the PUT method manually
-		if ($request->getMethod() !== 'PUT' || isset($_SERVER['HTTP_OC_CHUNKED'])) {
+		if ($request->getMethod() !== 'PUT' || \OC_FileChunking::isWebdavChunk()) {
 			return;
 		}
 		try {
@@ -69,7 +69,7 @@ class LockPlugin extends ServerPlugin {
 	}
 
 	public function releaseLock(RequestInterface $request) {
-		if ($request->getMethod() !== 'PUT' || isset($_SERVER['HTTP_OC_CHUNKED'])) {
+		if ($request->getMethod() !== 'PUT' || \OC_FileChunking::isWebdavChunk()) {
 			return;
 		}
 		try {

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -76,7 +76,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 	 * @return string path to real file
 	 */
 	private function resolveChunkFile($path) {
-		if (isset($_SERVER['HTTP_OC_CHUNKED'])) {
+		if (\OC_FileChunking::isWebdavChunk()) {
 			// resolve to real file name to find the proper node
 			list($dir, $name) = \Sabre\HTTP\URLUtil::splitPath($path);
 			if ($dir == '/' || $dir == '.') {

--- a/apps/dav/lib/Upload/FutureFile.php
+++ b/apps/dav/lib/Upload/FutureFile.php
@@ -40,6 +40,23 @@ class FutureFile implements \Sabre\DAV\IFile {
 	/** @var string */
 	private $name;
 
+	static public function getFutureFileName() {
+		return '.file';
+	}
+
+	static public function isFutureFile() {
+		$davUploadsTarget = '/dav/uploads';
+
+		// Check if pathinfo starts with dav uploads target and basename is future file basename
+		if (isset($_SERVER['PATH_INFO'])
+			&& pathinfo($_SERVER['PATH_INFO'], PATHINFO_BASENAME) === FutureFile::getFutureFileName()
+			&& (strpos($_SERVER['PATH_INFO'], $davUploadsTarget) === 0)) {
+			return true;
+		}
+
+		return false;
+	}
+
 	/**
 	 * @param Directory $root
 	 * @param string $name

--- a/apps/dav/lib/Upload/UploadFolder.php
+++ b/apps/dav/lib/Upload/UploadFolder.php
@@ -43,20 +43,20 @@ class UploadFolder implements ICollection {
 	}
 
 	function getChild($name) {
-		if ($name === '.file') {
-			return new FutureFile($this->node, '.file');
+		if ($name === FutureFile::getFutureFileName()) {
+			return new FutureFile($this->node, FutureFile::getFutureFileName());
 		}
 		return $this->node->getChild($name);
 	}
 
 	function getChildren() {
 		$children = $this->node->getChildren();
-		$children[] = new FutureFile($this->node, '.file');
+		$children[] = new FutureFile($this->node, FutureFile::getFutureFileName());
 		return $children;
 	}
 
 	function childExists($name) {
-		if ($name === '.file') {
+		if ($name === FutureFile::getFutureFileName()) {
 			return true;
 		}
 		return $this->node->childExists($name);

--- a/lib/private/legacy/filechunking.php
+++ b/lib/private/legacy/filechunking.php
@@ -39,6 +39,13 @@ class OC_FileChunking {
 	 */
 	protected $ttl;
 
+	static public function isWebdavChunk() {
+		if (isset($_SERVER['HTTP_OC_CHUNKED'])) {
+			return true;
+		}
+		return false;
+	}
+
 	static public function decodeName($name) {
 		preg_match('/(?P<name>.*)-chunking-(?P<transferid>\d+)-(?P<chunkcount>\d+)-(?P<index>\d+)/', $name, $matches);
 		return $matches;


### PR DESCRIPTION
"in case the file already exists/overwriting" ? In createFile() function which from composer is used only for new files, and there is specific one called updateFile() ?

-1 query plus Locking/Releasing because each getFileInfo needs to do that
![selection_295](https://cloud.githubusercontent.com/assets/13368647/26495558/5c60fc10-4224-11e7-964e-b8bb97a68db1.jpg)

