### PR TITLE
Fix cross-storage move info when moving between two received shares

### DIFF
--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -311,4 +311,8 @@ class CacheJail extends CacheWrapper {
 		}
 		return $this->cache->moveFromCache($sourceCache, $sourcePath, $this->getSourcePath($targetPath));
 	}
+
+	protected function getMoveInfo($path) {
+		return [$this->getNumericStorageId(), $this->getSourcePath($path)];
+	}
 }

--- a/tests/integration/features/webdav-related-new-endpoint.feature
+++ b/tests/integration/features/webdav-related-new-endpoint.feature
@@ -543,3 +543,33 @@ Feature: webdav-related-new-endpoint
 		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
 		When user "user0" moves new chunk file with id "chunking-42" to "/existingFile.txt"
 		Then User "user0" checks id of file "/existingFile.txt"
+
+
+	Scenario: Checking file id after a move between received shares
+		Given using new dav path
+		And user "user0" exists
+		And user "user1" exists
+		And user "user0" created a folder "/folderA"
+		And user "user0" created a folder "/folderB"
+		And folder "/folderA" of user "user0" is shared with user "user1"
+		And folder "/folderB" of user "user0" is shared with user "user1"
+		And user "user1" created a folder "/folderA/ONE"
+		And user "user1" created a folder "/folderA/ONE/TWO"
+		And User "user1" stores id of file "/folderA/ONE"
+		And User "user1" moves folder "/folderA/ONE" to "/folderB"
+		When user "user1" created a folder "/folderB/ONE/TWO/THREE"
+		And using old dav path
+		Then user "user1" should see following elements
+			| /FOLDER/ |
+			| /PARENT/ |
+			| /PARENT/parent.txt |
+			| /textfile0.txt |
+			| /textfile1.txt |
+			| /textfile2.txt |
+			| /textfile3.txt |
+			| /textfile4.txt |
+			| /folderA |
+			| /folderB |
+			| /folderB/ONE |
+			| /folderB/ONE/TWO |
+			| /folderB/ONE/TWO/THREE |

--- a/tests/integration/features/webdav-related-new-endpoint.feature
+++ b/tests/integration/features/webdav-related-new-endpoint.feature
@@ -544,7 +544,6 @@ Feature: webdav-related-new-endpoint
 		When user "user0" moves new chunk file with id "chunking-42" to "/existingFile.txt"
 		Then User "user0" checks id of file "/existingFile.txt"
 
-
 	Scenario: Checking file id after a move between received shares
 		Given using new dav path
 		And user "user0" exists
@@ -554,22 +553,14 @@ Feature: webdav-related-new-endpoint
 		And folder "/folderA" of user "user0" is shared with user "user1"
 		And folder "/folderB" of user "user0" is shared with user "user1"
 		And user "user1" created a folder "/folderA/ONE"
-		And user "user1" created a folder "/folderA/ONE/TWO"
 		And User "user1" stores id of file "/folderA/ONE"
-		And User "user1" moves folder "/folderA/ONE" to "/folderB"
-		When user "user1" created a folder "/folderB/ONE/TWO/THREE"
-		And using old dav path
-		Then user "user1" should see following elements
-			| /FOLDER/ |
-			| /PARENT/ |
-			| /PARENT/parent.txt |
-			| /textfile0.txt |
-			| /textfile1.txt |
-			| /textfile2.txt |
-			| /textfile3.txt |
-			| /textfile4.txt |
-			| /folderA |
-			| /folderB |
-			| /folderB/ONE |
-			| /folderB/ONE/TWO |
-			| /folderB/ONE/TWO/THREE |
+		And user "user1" created a folder "/folderA/ONE/TWO"
+		When User "user1" moves folder "/folderA/ONE" to "/folderB/ONE"
+		Then as "user1" the folder "/folderA" exists
+		And as "user1" the folder "/folderA/ONE" does not exist
+		# yes, a weird bug used to make this one fail
+		And as "user1" the folder "/folderA/ONE/TWO" does not exist
+		And as "user1" the folder "/folderB/ONE" exists
+		And as "user1" the folder "/folderB/ONE/TWO" exists
+		And User "user1" checks id of file "/folderB/ONE"
+

--- a/tests/integration/features/webdav-related-old-endpoint.feature
+++ b/tests/integration/features/webdav-related-old-endpoint.feature
@@ -486,3 +486,24 @@ Feature: webdav-related-old-endpoint
 		When As an "user0"
 		And Downloading file "/myChunkedFile.txt"
 		Then Downloaded content should be "AAAAABBBBBCCCCC"
+
+	Scenario: Checking file id after a move between received shares
+		Given using old dav path
+		And user "user0" exists
+		And user "user1" exists
+		And user "user0" created a folder "/folderA"
+		And user "user0" created a folder "/folderB"
+		And folder "/folderA" of user "user0" is shared with user "user1"
+		And folder "/folderB" of user "user0" is shared with user "user1"
+		And user "user1" created a folder "/folderA/ONE"
+		And User "user1" stores id of file "/folderA/ONE"
+		And user "user1" created a folder "/folderA/ONE/TWO"
+		When User "user1" moves folder "/folderA/ONE" to "/folderB/ONE"
+		Then as "user1" the folder "/folderA" exists
+		And as "user1" the folder "/folderA/ONE" does not exist
+		# yes, a weird bug used to make this one fail
+		And as "user1" the folder "/folderA/ONE/TWO" does not exist
+		And as "user1" the folder "/folderB/ONE" exists
+		And as "user1" the folder "/folderB/ONE/TWO" exists
+		And User "user1" checks id of file "/folderB/ONE"
+


### PR DESCRIPTION
## Description
Need to properly resolve the given path to a source path in
`getMoveInfo`. This was missing when adding this new method.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28018

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] Manual test with the steps from the ticket.
- [x] Pending integration tests from @SergioBertolinSG, feel free to push them onto this branch.
- [ ] Will need regression testing of other cross-storage "move" scenarios

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

