### PR TITLE
reenable medial search, default to true

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -259,9 +259,10 @@ $CONFIG = array(
 /**
  * Allow medial search on account properties like display name, user id, email,
  * and other search terms. Allows finding 'Alice' when searching for 'lic'.
- * May slow down user search.
+ * May slow down user search. Disable this if you encounter slow username search
+ * in the sharing dialog.
  */
-'accounts.enable_medial_search' => false,
+'accounts.enable_medial_search' => true,
 
 /**
  * Mail Parameters

--- a/core/Migrations/Version20170221114437.php
+++ b/core/Migrations/Version20170221114437.php
@@ -6,6 +6,7 @@ use OC\User\AccountMapper;
 use OC\User\AccountTermMapper;
 use OC\User\Database;
 use OC\User\SyncService;
+use OCP\IConfig;
 use OCP\Migration\ISimpleMigration;
 use OCP\Migration\IOutput;
 
@@ -19,7 +20,7 @@ class Version20170221114437 implements ISimpleMigration {
 		$config = \OC::$server->getConfig();
 		$logger = \OC::$server->getLogger();
 		$connection = \OC::$server->getDatabaseConnection();
-		$accountMapper = new AccountMapper($connection, new AccountTermMapper($connection));
+		$accountMapper = new AccountMapper($config, $connection, new AccountTermMapper($connection));
 		$syncService = new SyncService($accountMapper, $backend, $config, $logger);
 
 		// insert/update known users

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -222,7 +222,7 @@ class Server extends ServerContainer implements IServerContainer {
 			});
 		});
 		$this->registerService('AccountMapper', function(Server $c) {
-			return new AccountMapper($c->getDatabaseConnection(), new AccountTermMapper($c->getDatabaseConnection()));
+			return new AccountMapper($c->getConfig(), $c->getDatabaseConnection(), new AccountTermMapper($c->getDatabaseConnection()));
 		});
 		$this->registerService('UserManager', function (Server $c) {
 			$config = $c->getConfig();

--- a/tests/lib/Traits/UserTrait.php
+++ b/tests/lib/Traits/UserTrait.php
@@ -10,6 +10,7 @@ namespace Test\Traits;
 
 use OC\User\AccountTermMapper;
 use OC\User\User;
+use OCP\IConfig;
 use Test\Util\User\Dummy;
 use Test\Util\User\MemoryAccountMapper;
 
@@ -39,7 +40,8 @@ trait UserTrait {
 	protected function setUpUserTrait() {
 
 		$db = \OC::$server->getDatabaseConnection();
-		$accountMapper = new MemoryAccountMapper($db, new AccountTermMapper($db));
+		$config = $this->createMock(IConfig::class);
+		$accountMapper = new MemoryAccountMapper($config, $db, new AccountTermMapper($db));
 		$accountMapper->testCaseName = get_class($this);
 		$this->previousUserManagerInternals = \OC::$server->getUserManager()
 			->reset($accountMapper, [Dummy::class => new Dummy()]);

--- a/tests/lib/User/AccountMapperTest.php
+++ b/tests/lib/User/AccountMapperTest.php
@@ -25,6 +25,7 @@ namespace Test\User;
 use OC\User\Account;
 use OC\User\AccountMapper;
 use OC\User\AccountTermMapper;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use Test\TestCase;
 
@@ -37,13 +38,13 @@ use Test\TestCase;
  */
 class AccountMapperTest extends TestCase {
 
-	/**
-	 * @var IDBConnection
-	 */
+	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	protected $config;
+
+	/** @var IDBConnection */
 	protected $connection;
-	/**
-	 * @var AccountMapper
-	 */
+
+	/** @var AccountMapper */
 	protected $mapper;
 
 	public static function setUpBeforeClass() {
@@ -76,8 +77,16 @@ class AccountMapperTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+
 		$this->connection = \OC::$server->getDatabaseConnection();
-		$this->mapper = new AccountMapper($this->connection, new AccountTermMapper($this->connection));
+
+		$this->mapper = new AccountMapper(
+			$this->config,
+			$this->connection,
+			new AccountTermMapper($this->connection)
+		);
 	}
 
 	public static function tearDownAfterClass () {
@@ -91,7 +100,6 @@ class AccountMapperTest extends TestCase {
 	public function testFindAll() {
 		$result = $this->mapper->find("testfind");
 		$this->assertEquals(4, count($result));
-
 	}
 
 	/**
@@ -101,7 +109,6 @@ class AccountMapperTest extends TestCase {
 		$result = $this->mapper->find("testfind1");
 		$this->assertEquals(1, count($result));
 		$this->assertEquals("TestFind1", array_shift($result)->getUserId());
-
 	}
 
 	/**
@@ -111,7 +118,6 @@ class AccountMapperTest extends TestCase {
 		$result = $this->mapper->find('test find 2');
 		$this->assertEquals(1, count($result));
 		$this->assertEquals("TestFind2", array_shift($result)->getUserId());
-
 	}
 
 	/**
@@ -121,7 +127,6 @@ class AccountMapperTest extends TestCase {
 		$result= $this->mapper->find('test3@find.tld');
 		$this->assertEquals(1, count($result));
 		$this->assertEquals("TestFind3", array_shift($result)->getUserId());
-
 	}
 
 	/**
@@ -131,7 +136,6 @@ class AccountMapperTest extends TestCase {
 		$result = $this->mapper->find('term 4 b');
 		$this->assertEquals(1, count($result));
 		$this->assertEquals("TestFind4", array_shift($result)->getUserId());
-
 	}
 
 	/**
@@ -143,6 +147,5 @@ class AccountMapperTest extends TestCase {
 		//results are ordered by display name
 		$this->assertEquals("TestFind3", array_shift($result)->getUserId());
 		$this->assertEquals("TestFind4", array_shift($result)->getUserId());
-
 	}
 }


### PR DESCRIPTION
This reverts commit d9fc93c694fa46bc7cbb1cf090271394a99f9897 and enables medial search for users by default, as was the case for all backends except ldap. restores pre oc10.0.1 behavior.