### PR TITLE
Truncate mtime passed to X-OC-Mtime in web UI uploads

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -241,7 +241,7 @@ OC.FileUpload.prototype = {
 
 		if (file.lastModified) {
 			// preserve timestamp
-			this.data.headers['X-OC-Mtime'] = file.lastModified / 1000;
+			this.data.headers['X-OC-Mtime'] = Math.floor(file.lastModified / 1000);
 		}
 
 		var userName = this.uploader.filesClient.getUserName();


### PR DESCRIPTION
## Description
Some envs seem to have a higher timer resolution which would cause
a float value to be sent, which isn't supported by the server.

## Related Issue
Fixes https://github.com/owncloud/core/issues/27960

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested locally with a debugger to see that the mtime still looks good.
But I don't have an env to reproduce the decimal issue to really confirm.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

