### PR TITLE
Preserve 15 permissions when creating link shares

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -365,7 +365,8 @@ class Share20OCS {
 					\OCP\Constants::PERMISSION_UPDATE |
 					\OCP\Constants::PERMISSION_DELETE
 				);
-			} else if ($permissions === \OCP\Constants::PERMISSION_CREATE) {
+			} else if ($permissions === \OCP\Constants::PERMISSION_CREATE ||
+					$permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE)) {
 				$share->setPermissions($permissions);
 			} else {
 				// because when "publicUpload" is passed usually no permissions are set,

--- a/tests/integration/features/sharing-v1.feature
+++ b/tests/integration/features/sharing-v1.feature
@@ -1189,6 +1189,22 @@ Feature: sharing
 			| share_type | 3 |
 			| permissions | 1 |
 
+	Scenario: Creating link share with edit permissions keeps it
+		Given As an "admin"
+		And user "user0" exists
+		And user "user0" created a folder "/afolder"
+		And As an "user0"
+		And creating a share with
+			| path | /afolder |
+			| shareType | 3 |
+			| permissions | 15 |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And Share fields of last share match with
+			| id | A_NUMBER |
+			| share_type | 3 |
+			| permissions | 15 |
+
 	Scenario: resharing using a public link with read only permissions is not allowed
 		Given As an "admin"
 		And user "user0" exists


### PR DESCRIPTION
## Description
Preserve 15 permissions when creating link shares

## Related Issue
Fixes https://github.com/owncloud/core/issues/28057

## Motivation and Context

## How Has This Been Tested?
Integration test and unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Please review @SamuAlfageme @jvillafanez @DeepDiver1975.

Yes, this code is super-ugly, there are two separate methods for create and update... needs refactoring one day.