### PR TITLE
Encode any non-ASCII chars to produce valid XHTML.

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1108,6 +1108,8 @@ class OC_Util {
 		} else {
 			// Specify encoding for PHP<5.4
 			$value = htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
+			// Encode any non-ASCII chars to produce valid X(HT)ML.
+			$value = preg_replace_callback('/[^\x20-\x7E]/', function($char) { return ord($char) < 32 ? "" : "&#".str_pad(ord($char), 3, '0', STR_PAD_LEFT).";"; }, (string)$value);
 		}
 		return $value;
 	}


### PR DESCRIPTION
## Description
sanitizeHTML function now encodes non ASCII chars to &#(charcode);

## Related Issue
None.

## Motivation and Context
When using the Ampache music app the resulting XML will sometimes contain non ASCII chars, which may be included in the ID3 Tags.
To take care of the correct encoding in any other app also, I added the additional line in sanitizeHTML().

## How Has This Been Tested?
I have 35k MP3s in my cloud with several ID3 Tags. The output now generates valid XML.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

