### PR TITLE
[stable10] Preserve 15 permissions when creating link shares

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -365,7 +365,8 @@ class Share20OCS {
 					\OCP\Constants::PERMISSION_UPDATE |
 					\OCP\Constants::PERMISSION_DELETE
 				);
-			} else if ($permissions === \OCP\Constants::PERMISSION_CREATE) {
+			} else if ($permissions === \OCP\Constants::PERMISSION_CREATE ||
+					$permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE)) {
 				$share->setPermissions($permissions);
 			} else {
 				// because when "publicUpload" is passed usually no permissions are set,

--- a/tests/integration/features/sharing-v1.feature
+++ b/tests/integration/features/sharing-v1.feature
@@ -1189,6 +1189,22 @@ Feature: sharing
 			| share_type | 3 |
 			| permissions | 1 |
 
+	Scenario: Creating link share with edit permissions keeps it
+		Given As an "admin"
+		And user "user0" exists
+		And user "user0" created a folder "/afolder"
+		And As an "user0"
+		And creating a share with
+			| path | /afolder |
+			| shareType | 3 |
+			| permissions | 15 |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And Share fields of last share match with
+			| id | A_NUMBER |
+			| share_type | 3 |
+			| permissions | 15 |
+
 	Scenario: resharing using a public link with read only permissions is not allowed
 		Given As an "admin"
 		And user "user0" exists


### PR DESCRIPTION
Backport https://github.com/owncloud/core/pull/28060 to stable10.

Tests will tell.

@butonic @michaelstingl @SamuAlfageme 