### PR TITLE
make sure mtime is always an int

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -59,6 +59,24 @@ use Sabre\DAV\Exception\NotFound;
 
 class File extends Node implements IFile {
 
+	protected $request;
+	
+	/**
+	 * Sets up the node, expects a full path name
+	 *
+	 * @param \OC\Files\View $view
+	 * @param \OCP\Files\FileInfo $info
+	 * @param IManager $shareManager
+	 */
+	public function __construct($view, $info, IManager $shareManager = null, \OC\AppFramework\Http\Request $request = null) {
+		if (isset($request)) {
+			$this->request = $request;
+		} else {
+			$this->request = \OC::$server->getRequest();
+		}
+		parent::__construct($view, $info, $shareManager);
+	}
+	
 	/**
 	 * Updates the data
 	 *
@@ -210,9 +228,8 @@ class File extends Node implements IFile {
 			}
 
 			// allow sync clients to send the mtime along in a header
-			$request = \OC::$server->getRequest();
-			if (isset($request->server['HTTP_X_OC_MTIME'])) {
-				if ($this->fileView->touch($this->path, $request->server['HTTP_X_OC_MTIME'])) {
+			if (isset($this->request->server['HTTP_X_OC_MTIME'])) {
+				if ($this->fileView->touch($this->path, $this->request->server['HTTP_X_OC_MTIME'])) { 
 					header('X-OC-MTime: accepted');
 				}
 			}
@@ -473,9 +490,8 @@ class File extends Node implements IFile {
 				}
 
 				// allow sync clients to send the mtime along in a header
-				$request = \OC::$server->getRequest();
-				if (isset($request->server['HTTP_X_OC_MTIME'])) {
-					if ($targetStorage->touch($targetInternalPath, $request->server['HTTP_X_OC_MTIME'])) {
+				if (isset($this->request->server['HTTP_X_OC_MTIME'])) {
+					if ($targetStorage->touch($targetInternalPath, $this->request->server['HTTP_X_OC_MTIME'])) {
 						header('X-OC-MTime: accepted');
 					}
 				}

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -229,7 +229,15 @@ class File extends Node implements IFile {
 
 			// allow sync clients to send the mtime along in a header
 			if (isset($this->request->server['HTTP_X_OC_MTIME'])) {
-				if ($this->fileView->touch($this->path, $this->request->server['HTTP_X_OC_MTIME'])) { 
+				$mtime = (float) $this->request->server['HTTP_X_OC_MTIME'];
+				if ($mtime >= PHP_INT_MAX) {
+					$mtime = PHP_INT_MAX;
+				} elseif ($mtime <= (PHP_INT_MAX*-1)) {
+					$mtime = (PHP_INT_MAX*-1);
+				} else {
+					$mtime = (int) $this->request->server['HTTP_X_OC_MTIME'];
+				}
+				if ($this->fileView->touch($this->path, $mtime)) {
 					header('X-OC-MTime: accepted');
 				}
 			}

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -66,9 +66,9 @@ class File extends Node implements IFile {
 	 *
 	 * @param \OC\Files\View $view
 	 * @param \OCP\Files\FileInfo $info
-	 * @param IManager $shareManager
+	 * @param \OCP\Share\IManager $shareManager
 	 */
-	public function __construct($view, $info, IManager $shareManager = null, \OC\AppFramework\Http\Request $request = null) {
+	public function __construct($view, $info, $shareManager = null, \OC\AppFramework\Http\Request $request = null) {
 		if (isset($request)) {
 			$this->request = $request;
 		} else {

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -299,7 +299,7 @@ class FileTest extends TestCase {
 	 *
 	 * @return null|string of the PUT operaiton which is usually the etag
 	 */
-	private function doPut($path, $viewRoot = null) {
+	private function doPut($path, $viewRoot = null, \OC\AppFramework\Http\Request $request = null) {
 		$view = Filesystem::getView();
 		if (!is_null($viewRoot)) {
 			$view = new View($viewRoot);
@@ -315,7 +315,7 @@ class FileTest extends TestCase {
 			null
 		);
 
-		$file = new File($view, $info);
+		$file = new File($view, $info, null, $request);
 
 		// beforeMethod locks
 		$view->lockFile($path, ILockingProvider::LOCK_SHARED);

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -341,7 +341,8 @@ class FileTest extends TestCase {
 	}
 
 	public function legalMtimeProvider() {
-		return [ 
+		$primaryStorageConfig = getenv("PRIMARY_STORAGE_CONFIG");
+		$testValues = [
 				"string" => [ 
 						'HTTP_X_OC_MTIME' => "string",
 						'expected result' => 0
@@ -374,14 +375,6 @@ class FileTest extends TestCase {
 						'HTTP_X_OC_MTIME' => "2345asdf",
 						'expected result' => 2345
 				],
-				"negative int" => [
-						'HTTP_X_OC_MTIME' => -34,
-						'expected result' => -34
-				],
-				"negative float" => [
-						'HTTP_X_OC_MTIME' => -34.43,
-						'expected result' => -34
-				],
 				"string castable hex int" => [
 						'HTTP_X_OC_MTIME' => "0x45adf",
 						'expected result' => 0
@@ -390,7 +383,32 @@ class FileTest extends TestCase {
 						'HTTP_X_OC_MTIME' => "0x123g",
 						'expected result' => 0
 				]
-		];
+			];
+		
+		if ($primaryStorageConfig === "swift") {
+			$testValuesNegativeMtime = [
+				"negative int" => [
+						'HTTP_X_OC_MTIME' => -34,
+						'expected result' => 0
+				],
+				"negative float" => [
+						'HTTP_X_OC_MTIME' => -34.43,
+						'expected result' => 0
+				],
+			];
+		} else {
+			$testValuesNegativeMtime = [
+					"negative int" => [
+							'HTTP_X_OC_MTIME' => -34,
+							'expected result' => -34
+					],
+					"negative float" => [
+							'HTTP_X_OC_MTIME' => -34.43,
+							'expected result' => -34
+					],
+			];
+		}
+		return array_merge($testValues, $testValuesNegativeMtime);
 	}
 
 	/**

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -396,6 +396,7 @@ class FileTest extends TestCase {
 	/**
 	 * Test putting a file with string Mtime
 	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 * @dataProvider legalMtimeProvider
 	 */
 	public function testPutSingleFileLegalMtime($requestMtime, $resultMtime) {
@@ -407,6 +408,26 @@ class FileTest extends TestCase {
 		
 		$file = 'foo.txt';
 		$this->doPut($file, null, $request);
+		$this->assertEquals($resultMtime, $this->getFileInfos($file)['mtime']);
+	}
+
+	/**
+	 * Test putting a file with string Mtime using chunking
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 * @dataProvider legalMtimeProvider
+	 */
+	public function testChunkedPutLegalMtime($requestMtime, $resultMtime) {
+		$request = new \OC\AppFramework\Http\Request([
+				'server' => [
+						'HTTP_X_OC_MTIME' => $requestMtime,
+				]
+		], null, $this->config, null);
+		
+		$_SERVER['HTTP_OC_CHUNKED'] = true;
+		$file = 'foo.txt';
+		$this->doPut($file.'-chunking-12345-2-0', null, $request);
+		$this->doPut($file.'-chunking-12345-2-1', null, $request);
 		$this->assertEquals($resultMtime, $this->getFileInfos($file)['mtime']);
 	}
 

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -411,6 +411,7 @@ class FileTest extends TestCase {
 		return array_merge($testValues, $testValuesNegativeMtime);
 	}
 
+
 	/**
 	 * Test putting a file with string Mtime
 	 * @runInSeparateProcess

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -340,77 +340,67 @@ class FileTest extends TestCase {
 		$this->assertNotEmpty($this->doPut('/foo.txt'));
 	}
 
-	public function legalMtimeProvider() {
-		$primaryStorageConfig = getenv("PRIMARY_STORAGE_CONFIG");
-		$testValues = [
-				"string" => [ 
-						'HTTP_X_OC_MTIME' => "string",
-						'expected result' => 0
-				],
-				"castable string (int)" => [
-						'HTTP_X_OC_MTIME' => "34",
-						'expected result' => 34
-				],
-				"castable string (float)" => [ 
-						'HTTP_X_OC_MTIME' => "34.56",
-						'expected result' => 34
-				],
-				"float" => [
-						'HTTP_X_OC_MTIME' => 34.56,
-						'expected result' => 34
-				],
-				"zero" => [
-						'HTTP_X_OC_MTIME' => 0,
-						'expected result' => 0
-				],
-				"zero string" => [
-						'HTTP_X_OC_MTIME' => "0",
-						'expected result' => 0
-				],
-				"negative zero string" => [
-						'HTTP_X_OC_MTIME' => "-0",
-						'expected result' => 0
-				],
-				"string starting with number following by char" => [
-						'HTTP_X_OC_MTIME' => "2345asdf",
-						'expected result' => 2345
-				],
-				"string castable hex int" => [
-						'HTTP_X_OC_MTIME' => "0x45adf",
-						'expected result' => 0
-				],
-				"string that looks like invalid hex int" => [
-						'HTTP_X_OC_MTIME' => "0x123g",
-						'expected result' => 0
-				]
-			];
-		
-		if ($primaryStorageConfig === "swift") {
-			$testValuesNegativeMtime = [
-				"negative int" => [
-						'HTTP_X_OC_MTIME' => -34,
-						'expected result' => 0
-				],
-				"negative float" => [
-						'HTTP_X_OC_MTIME' => -34.43,
-						'expected result' => 0
-				],
-			];
-		} else {
-			$testValuesNegativeMtime = [
-					"negative int" => [
-							'HTTP_X_OC_MTIME' => -34,
-							'expected result' => -34
-					],
-					"negative float" => [
-							'HTTP_X_OC_MTIME' => -34.43,
-							'expected result' => -34
-					],
-			];
-		}
-		return array_merge($testValues, $testValuesNegativeMtime);
+	/**
+	 * Determine if the underlying storage supports a negative mtime value
+	 *
+	 * @return boolean true if negative mtime is supported
+	 */
+	private function supportsNegativeMtime() {
+		return (getenv("PRIMARY_STORAGE_CONFIG") !== "swift");
 	}
 
+	public function legalMtimeProvider() {
+		return [
+			"string" => [ 
+					'HTTP_X_OC_MTIME' => "string",
+					'expected result' => 0
+			],
+			"castable string (int)" => [
+					'HTTP_X_OC_MTIME' => "34",
+					'expected result' => 34
+			],
+			"castable string (float)" => [ 
+					'HTTP_X_OC_MTIME' => "34.56",
+					'expected result' => 34
+			],
+			"float" => [
+					'HTTP_X_OC_MTIME' => 34.56,
+					'expected result' => 34
+			],
+			"zero" => [
+					'HTTP_X_OC_MTIME' => 0,
+					'expected result' => 0
+			],
+			"zero string" => [
+					'HTTP_X_OC_MTIME' => "0",
+					'expected result' => 0
+			],
+			"negative zero string" => [
+					'HTTP_X_OC_MTIME' => "-0",
+					'expected result' => 0
+			],
+			"string starting with number following by char" => [
+					'HTTP_X_OC_MTIME' => "2345asdf",
+					'expected result' => 2345
+			],
+			"string castable hex int" => [
+					'HTTP_X_OC_MTIME' => "0x45adf",
+					'expected result' => 0
+			],
+			"string that looks like invalid hex int" => [
+					'HTTP_X_OC_MTIME' => "0x123g",
+					'expected result' => 0
+			],
+			"negative int" => [
+					'HTTP_X_OC_MTIME' => -34,
+					'expected result' => (supportsNegativeMtime() ? -34 : 0)
+			],
+			"negative float" => [
+					'HTTP_X_OC_MTIME' => -34.43,
+					'expected result' => (supportsNegativeMtime() ? -34 : 0)
+			],
+		];
+	}
 
 	/**
 	 * Test putting a file with string Mtime

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -393,11 +393,11 @@ class FileTest extends TestCase {
 			],
 			"negative int" => [
 					'HTTP_X_OC_MTIME' => -34,
-					'expected result' => (supportsNegativeMtime() ? -34 : 0)
+					'expected result' => ($this->supportsNegativeMtime() ? -34 : 0)
 			],
 			"negative float" => [
 					'HTTP_X_OC_MTIME' => -34.43,
-					'expected result' => (supportsNegativeMtime() ? -34 : 0)
+					'expected result' => ($this->supportsNegativeMtime() ? -34 : 0)
 			],
 		];
 	}

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -414,7 +414,6 @@ class FileTest extends TestCase {
 						'HTTP_X_OC_MTIME' => $requestMtime,
 				]
 		], null, $this->config, null);
-		
 		$file = 'foo.txt';
 		$this->doPut($file, null, $request);
 		$this->assertEquals($resultMtime, $this->getFileInfos($file)['mtime']);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
`HTTP_X_OC_MTIME` is cast to float, then checked if its outside the `int` range if yes it set to the max values and if not the original value is cast to `int`
That should make sure afterwards we have an `int` value that is in PHP range, in any PHP version
This is an alternative approach to #27615 , don't throw any errors but simply make sure the value is legal.

This fix partly fixes #23228. On a system that uses 32bit integer it would protect the database to receive a value that is too big, but on a 64bit system the value would still be given to the database.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#27960
#23228

## Motivation and Context
currently mtime can only be stored as `int`, but the server accepts also other types.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run new tests against pgsql, mysql & sqlite on PHP 7.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.