### PR TITLE
64bit mtime

### DIFF
--- a/apps/dav/appinfo/Migrations/Version20170607100912.php
+++ b/apps/dav/appinfo/Migrations/Version20170607100912.php
@@ -1,0 +1,22 @@
+<?php
+namespace OCA\dav\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * changes mtime fields to be able to store 64bit time stamps
+ */
+class Version20170607100912 implements ISchemaMigration {
+
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+		$table = $schema->getTable("${prefix}filecache");
+		foreach ( ['mtime','storage_mtime'] as $column ) {
+			if ($table->getColumn($column)->getType()->getName() === Type::INTEGER) {
+				$table->getColumn($column)->setType(Type::getType(Type::BIGINT));
+			}
+		}
+	}
+}

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>ownCloud WebDAV endpoint</description>
 	<licence>AGPL</licence>
 	<author>owncloud.org</author>
-	<version>0.3.0</version>
+	<version>0.3.1</version>
 	<default_enable/>
 	<use-migrations>true</use-migrations>
 	<types>

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -399,6 +399,22 @@ class FileTest extends TestCase {
 					'HTTP_X_OC_MTIME' => -34.43,
 					'expected result' => -34
 			],
+			"long int" => [ 
+					'HTTP_X_OC_MTIME' => PHP_INT_MAX,
+					'expected result' => PHP_INT_MAX 
+			],
+			"too long int" => [ 
+					'HTTP_X_OC_MTIME' => PHP_INT_MAX + 1,
+					'expected result' => PHP_INT_MAX 
+			],
+			"long negative int" => [ 
+					'HTTP_X_OC_MTIME' => PHP_INT_MAX * - 1,
+					'expected result' => (PHP_INT_MAX * - 1)
+			],
+			"too long negative int" => [ 
+					'HTTP_X_OC_MTIME' => (PHP_INT_MAX * - 1) - 1,
+					'expected result' => (PHP_INT_MAX * - 1)
+			],
 		];
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
allow to store mtime as 64bit int
build on top of #28066

## Related Issue
#23228

## Motivation and Context
the database should hold 64bit int to be able to store dates after 2038

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run new tests against pgsql, mysql & sqlite on PHP 7.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

