### PR TITLE
Fix column lengths on migrations table to fix index

### DIFF
--- a/core/Migrations/Version20170605143658.php
+++ b/core/Migrations/Version20170605143658.php
@@ -1,0 +1,27 @@
+<?php
+namespace OC\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Updates the column lengths for the migrations table to reflect changes in its schema
+ */
+class Version20170605143658 implements ISchemaMigration {
+
+	public function changeSchema(Schema $schema, array $options) {
+		// Get the table
+		$prefix = $options['tablePrefix'];
+		$table = $schema->getTable("{$prefix}migrations");
+
+		// Check column length to see if migration is necessary necessary
+		if($table->getColumn('app')->getLength() === 177) {
+			// then this server was installed after the fix
+			return;
+		}
+
+		// Need to shorten columns
+		$table->getColumn('app')->setLength(177);
+		$table->getColumn('version')->setLength(14);
+	}
+}

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -114,8 +114,10 @@ class MigrationService {
 		$tableName = $this->connection->getDatabasePlatform()->quoteIdentifier($tableName);
 
 		$columns = [
-			'app' => new Column($this->connection->getDatabasePlatform()->quoteIdentifier('app'), Type::getType('string'), ['length' => 255]),
-			'version' => new Column($this->connection->getDatabasePlatform()->quoteIdentifier('version'), Type::getType('string'), ['length' => 255]),
+			// Length = max indexable char length - length of other columns = 191 - 14
+			'app' => new Column($this->connection->getDatabasePlatform()->quoteIdentifier('app'), Type::getType('string'), ['length' => 177]),
+			// Datetime string. Eg: 20172605104128
+			'version' => new Column($this->connection->getDatabasePlatform()->quoteIdentifier('version'), Type::getType('string'), ['length' => 14]),
 		];
 		$table = new Table($tableName, $columns);
 		$table->setPrimaryKey([


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Reduces the lengths of the app and version columns in the migrations table so that the index that is created is not too long when using 4 byte database encodings and you have strict mode enabled.

Altered the create table method to use the new lengths (for new installs) and added a migration step to alter the existing table if it is already created (on upgrades)

## Related Issue
Install is blocked when using 4 byte support with strict mode enabled.
https://github.com/owncloud/core/issues/28030

## Motivation and Context
Broken installs.

## How Has This Been Tested?
New installs. Upgrades. Strict mode. mb4 encoding with MySQL.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
