### PR TITLE
Fix mimetype detection for trashbin items

### DIFF
--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -114,6 +114,7 @@ class Helper {
 			$entry['id'] = $id++;
 			$entry['etag'] = $entry['mtime']; // add fake etag, it is only needed to identify the preview image
 			$entry['permissions'] = \OCP\Constants::PERMISSION_READ;
+			$entry['mimetype'] = \OC::$server->getMimeTypeDetector()->detectPath($entry['name']);
 			$files[] = $entry;
 		}
 		return $files;


### PR DESCRIPTION
## Description


## Related Issue
Fixes https://github.com/owncloud/core/issues/27932

## Motivation and Context
Any trashbin item has a mimetype "application/octet-stream"

## How Has This Been Tested?
By deleting  items with a preview / browsing into trashbin

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

