### PR TITLE
Removed before and after scenarios to speed up tests

### DIFF
--- a/tests/integration/features/bootstrap/AppConfiguration.php
+++ b/tests/integration/features/bootstrap/AppConfiguration.php
@@ -4,6 +4,7 @@ use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use GuzzleHttp\Message\ResponseInterface;
 
+
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 trait AppConfiguration {
@@ -66,42 +67,9 @@ trait AppConfiguration {
 	abstract protected function resetAppConfigs();
 
 	/**
-	 * @BeforeScenario
-	 *
-	 * Enable the testing app before the first scenario of the feature and
-	 * reset the configs before each scenario
-	 * @param BeforeScenarioScope $event
+	 * @BeforeScenario @AfterScenario
 	 */
-	public function prepareParameters(BeforeScenarioScope $event){
-		$user = $this->currentUser;
-		$this->currentUser = 'admin';
-
-		$scenarios = $event->getFeature()->getScenarios();
-		if ($event->getScenario() === reset($scenarios)) {
-			$this->setStatusTestingApp(true);
-		}
-
+	public function prepareParametersForScenario() {
 		$this->resetAppConfigs();
-
-		$this->currentUser = $user;
-	}
-
-	/**
-	 * @AfterScenario
-	 *
-	 * Reset the values after the last scenario of the feature and disable the testing app
-	 * @param AfterScenarioScope $event
-	 */
-	public function undoChangingParameters(AfterScenarioScope $event) {
-		$scenarios = $event->getFeature()->getScenarios();
-		if ($event->getScenario() === end($scenarios)) {
-			$user = $this->currentUser;
-			$this->currentUser = 'admin';
-
-			$this->resetAppConfigs();
-
-			$this->setStatusTestingApp(false);
-			$this->currentUser = $user;
-		}
 	}
 }

--- a/tests/integration/features/bootstrap/AppConfiguration.php
+++ b/tests/integration/features/bootstrap/AppConfiguration.php
@@ -67,9 +67,12 @@ trait AppConfiguration {
 	abstract protected function resetAppConfigs();
 
 	/**
-	 * @BeforeScenario @AfterScenario
+	 * @BeforeScenario
 	 */
-	public function prepareParametersForScenario() {
+	public function prepareParametersBeforeScenario() {
+		$user = $this->currentUser;
+		$this->currentUser = 'admin';
 		$this->resetAppConfigs();
+		$this->currentUser = $user;
 	}
 }

--- a/tests/integration/features/bootstrap/AppConfiguration.php
+++ b/tests/integration/features/bootstrap/AppConfiguration.php
@@ -69,7 +69,7 @@ trait AppConfiguration {
 	/**
 	 * @BeforeScenario
 	 */
-	public function prepareParametersBeforeScenario() {
+	public function prepareParametersBeforeScenario(){
 		$user = $this->currentUser;
 		$this->currentUser = 'admin';
 		$this->resetAppConfigs();

--- a/tests/integration/features/bootstrap/CalDavContext.php
+++ b/tests/integration/features/bootstrap/CalDavContext.php
@@ -47,13 +47,13 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 		}
 	}
 
-	/** @BeforeScenario */
+	/** @BeforeScenario @caldav */
 	public function setUpScenario() {
 		$this->client = new Client();
 		$this->responseXml = '';
 	}
 
-	/** @AfterScenario */
+	/** @AfterScenario @caldav */
 	public function afterScenario() {
 		$davUrl = $this->baseUrl. '/remote.php/dav/calendars/admin/MyCalendar';
 		try {

--- a/tests/integration/features/bootstrap/CardDavContext.php
+++ b/tests/integration/features/bootstrap/CardDavContext.php
@@ -47,14 +47,14 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 		}
 	}
 
-	/** @BeforeScenario */
+	/** @BeforeScenario @carddav*/
 	public function setUpScenario() {
 		$this->client = new Client();
 		$this->responseXml = '';
 	}
 
 
-	/** @AfterScenario */
+	/** @AfterScenario @carddav*/
 	public function afterScenario() {
 		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/admin/MyAddressbook';
 		try {

--- a/tests/integration/features/caldav.feature
+++ b/tests/integration/features/caldav.feature
@@ -1,31 +1,34 @@
 Feature: caldav
-  Scenario: Accessing a not existing calendar of another user
-    Given user "user0" exists
-    When "admin" requests calendar "user0/MyCalendar"
-    Then The CalDAV HTTP status code should be "404"
-    And The exception is "Sabre\DAV\Exception\NotFound"
-    And The error message is "Node with name 'MyCalendar' could not be found"
 
-  # Blocked by https://github.com/php/php-src/pull/1417
-  #Scenario: Accessing a not shared calendar of another user
-  #  Given user "user0" exists
-  #  Given "admin" creates a calendar named "MyCalendar"
-  #  Given The CalDAV HTTP status code should be "201"
-  #  When "user0" requests calendar "admin/MyCalendar"
-  #  Then The CalDAV HTTP status code should be "404"
-  #  And The exception is "Sabre\DAV\Exception\NotFound"
-  #  And The error message is "Node with name 'MyCalendar' could not be found"
+	@caldav
+	Scenario: Accessing a not existing calendar of another user
+		Given user "user0" exists
+		When "admin" requests calendar "user0/MyCalendar"
+		Then The CalDAV HTTP status code should be "404"
+		And The exception is "Sabre\DAV\Exception\NotFound"
+		And The error message is "Node with name 'MyCalendar' could not be found"
 
-  Scenario: Accessing a not existing calendar of myself
-    Given user "user0" exists
-    When "user0" requests calendar "admin/MyCalendar"
-    Then The CalDAV HTTP status code should be "404"
-    And The exception is "Sabre\DAV\Exception\NotFound"
-    And The error message is "Node with name 'MyCalendar' could not be found"
+	@caldav
+	Scenario: Accessing a not shared calendar of another user
+		Given user "user0" exists
+		Given "admin" creates a calendar named "MyCalendar"
+		Given The CalDAV HTTP status code should be "201"
+		When "user0" requests calendar "admin/MyCalendar"
+		Then The CalDAV HTTP status code should be "404"
+		And The exception is "Sabre\DAV\Exception\NotFound"
+		And The error message is "Node with name 'MyCalendar' could not be found"
 
-  # Blocked by https://github.com/php/php-src/pull/1417
-  #Scenario: Creating a new calendar
-  #  When "admin" creates a calendar named "MyCalendar"
-  #  Then The CalDAV HTTP status code should be "201"
-  #  And "admin" requests calendar "admin/MyCalendar"
-  #  Then The CalDAV HTTP status code should be "200"
+	@caldav
+	Scenario: Accessing a not existing calendar of myself
+		Given user "user0" exists
+		When "user0" requests calendar "admin/MyCalendar"
+		Then The CalDAV HTTP status code should be "404"
+		And The exception is "Sabre\DAV\Exception\NotFound"
+		And The error message is "Node with name 'MyCalendar' could not be found"
+
+	@caldav
+	Scenario: Creating a new calendar
+		When "admin" creates a calendar named "MyCalendar"
+		Then The CalDAV HTTP status code should be "201"
+		And "admin" requests calendar "admin/MyCalendar"
+		Then The CalDAV HTTP status code should be "200"

--- a/tests/integration/features/carddav.feature
+++ b/tests/integration/features/carddav.feature
@@ -1,10 +1,12 @@
 Feature: carddav
+  @carddav
   Scenario: Accessing a not existing addressbook of another user
     Given user "user0" exists
     When "admin" requests addressbook "user0/MyAddressbook" with statuscode "404"
     And The CardDAV exception is "Sabre\DAV\Exception\NotFound"
     And The CardDAV error message is "Addressbook with name 'MyAddressbook' could not be found"
 
+  @carddav
   Scenario: Accessing a not shared addressbook of another user
     Given user "user0" exists
     Given "admin" creates an addressbook named "MyAddressbook" with statuscode "201"
@@ -12,12 +14,14 @@ Feature: carddav
     And The CardDAV exception is "Sabre\DAV\Exception\NotFound"
     And The CardDAV error message is "Addressbook with name 'MyAddressbook' could not be found"
 
+  @carddav
   Scenario: Accessing a not existing addressbook of myself
     Given user "user0" exists
     When "user0" requests addressbook "admin/MyAddressbook" with statuscode "404"
     And The CardDAV exception is "Sabre\DAV\Exception\NotFound"
     And The CardDAV error message is "Addressbook with name 'MyAddressbook' could not be found"
 
+  @carddav
   Scenario: Creating a new addressbook
     When "admin" creates an addressbook named "MyAddressbook" with statuscode "201"
     Then "admin" requests addressbook "admin/MyAddressbook" with statuscode "200"

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -16,7 +16,6 @@ SCENARIO_TO_RUN=$1
 HIDE_OC_LOGS=$2
 
 function env_alt_home_enable {
-	$OCC app:enable testing
 	$OCC config:app:set testing enable_alt_user_backend --value yes
 }
 
@@ -79,6 +78,8 @@ $OCC config:system:set skeletondirectory --value="$(pwd)/skeleton"
 #Enable external storage app
 $OCC config:app:set core enable_external_storage --value=yes
 
+$OCC app:enable testing
+
 mkdir -p work/local_storage || { echo "Unable to create work folder" >&2; exit 1; }
 OUTPUT_CREATE_STORAGE=`$OCC files_external:create local_storage local null::null -c datadir=$SCRIPT_PATH/work/local_storage` 
 
@@ -122,6 +123,9 @@ $OCC files_external:delete -y $ID_STORAGE
 
 #Disable external storage app
 $OCC config:app:set core enable_external_storage --value=no
+
+$OCC app:disable testing
+
 
 # Clear storage folder
 rm -Rf work/local_storage/*


### PR DESCRIPTION
Integration tests are starting to get too slow. Removing the code executed before and after scenarios when not needed will speed them.
