### PR TITLE
Use shorter webdav.org when getting litmus tar

### DIFF
--- a/apps/dav/tests/travis/litmus-v1/install.sh
+++ b/apps/dav/tests/travis/litmus-v1/install.sh
@@ -3,7 +3,7 @@
 # compile litmus
 if [ ! -f /tmp/litmus/litmus-0.13.tar.gz ]; then
   mkdir -p /tmp/litmus
-  wget -O /tmp/litmus/litmus-0.13.tar.gz http://www.webdav.org/neon/litmus/litmus-0.13.tar.gz
+  wget -O /tmp/litmus/litmus-0.13.tar.gz http://webdav.org/neon/litmus/litmus-0.13.tar.gz
   cd /tmp/litmus
   tar -xzf litmus-0.13.tar.gz
   cd /tmp/litmus/litmus-0.13

--- a/apps/dav/tests/travis/litmus-v2/install.sh
+++ b/apps/dav/tests/travis/litmus-v2/install.sh
@@ -3,7 +3,7 @@
 # compile litmus
 if [ ! -f /tmp/litmus/litmus-0.13.tar.gz ]; then
   mkdir -p /tmp/litmus
-  wget -O /tmp/litmus/litmus-0.13.tar.gz http://www.webdav.org/neon/litmus/litmus-0.13.tar.gz
+  wget -O /tmp/litmus/litmus-0.13.tar.gz http://webdav.org/neon/litmus/litmus-0.13.tar.gz
   cd /tmp/litmus
   tar -xzf litmus-0.13.tar.gz
   cd /tmp/litmus/litmus-0.13


### PR DESCRIPTION
Signed-off-by: Phil Davis <phil@jankaritech.com>


## Description
Use shorter name for webdav.org

## Related Issue
#28104 
## Motivation and Context
At least for the last hours (and how long???) www.webdav.org does not resolve on the internet, but webdav.org does. The litmus tests were failing because they could not wget the litmus tar.

## How Has This Been Tested?
Travis will tell.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

