### PR TITLE
Transfer ownership work with masterkey

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -194,6 +194,14 @@ class TransferOwnership extends Command {
 					$progress->advance();
 					$this->allFiles[] = $fileInfo;
 					if ($fileInfo->isEncrypted()) {
+						if (\OC::$server->getAppConfig()->getValue('encryption', 'useMasterKey', 0) !== 0) {
+							/**
+							 * We are not going to add this to encryptedFiles array.
+							 * Because its encrypted with masterKey and hence it doesn't
+							 * require user's specific password.
+							 */
+							return true;
+						}
 						$this->encryptedFiles[] = $fileInfo;
 					}
 					return true;

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -944,6 +944,9 @@ class Filesystem {
 	 * @return string
 	 */
 	public static function getPath($id) {
+		if (self::$defaultInstance === null) {
+			throw new NotFoundException("defaultInstance is null");
+		}
 		return self::$defaultInstance->getPath($id);
 	}
 

--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -115,7 +115,8 @@ class Encryption extends Wrapper {
 			'unencryptedSize',
 			'encryptionStorage',
 			'headerSize',
-			'signed'
+			'signed',
+			'sourceFileOfRename'
 		];
 	}
 
@@ -155,6 +156,7 @@ class Encryption extends Wrapper {
 								$unencryptedSize,
 								$headerSize,
 								$signed,
+								$sourceFileOfRename = null,
 								$wrapper =  'OC\Files\Stream\Encryption') {
 
 		$context = stream_context_create([
@@ -172,7 +174,8 @@ class Encryption extends Wrapper {
 				'unencryptedSize' => $unencryptedSize,
 				'encryptionStorage' => $encStorage,
 				'headerSize' => $headerSize,
-				'signed' => $signed
+				'signed' => $signed,
+				'sourceFileOfRename' => $sourceFileOfRename
 			]
 		]);
 
@@ -228,7 +231,7 @@ class Encryption extends Wrapper {
 	}
 
 	public function stream_open($path, $mode, $options, &$opened_path) {
-		$this->loadContext('ocencryption');
+		$context = $this->loadContext('ocencryption');
 
 		$this->position = 0;
 		$this->cache = '';
@@ -254,7 +257,7 @@ class Encryption extends Wrapper {
 		}
 
 		$accessList = $this->file->getAccessList($sharePath);
-		$this->newHeader = $this->encryptionModule->begin($this->fullPath, $this->uid, $mode, $this->header, $accessList);
+		$this->newHeader = $this->encryptionModule->begin($this->fullPath, $this->uid, $mode, $this->header, $accessList, $context['sourceFileOfRename']);
 
 		if (
 			$mode === 'w'

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -58,13 +58,15 @@ interface IEncryptionModule {
 	 * @param string $mode php stream open mode
 	 * @param array $header contains the header data read from the file
 	 * @param array $accessList who has access to the file contains the key 'users' and 'public'
+	 * @param string|null $sourceFileOfRename contains false or the rename source file. This is required
+	 * 						for version increment.
 	 *
 	 * $return array $header contain data as key-value pairs which should be
 	 *                       written to the header, in case of a write operation
 	 *                       or if no additional data is needed return a empty array
 	 * @since 8.1.0
 	 */
-	public function begin($path, $user, $mode, array $header, array $accessList);
+	public function begin($path, $user, $mode, array $header, array $accessList, $sourceFileOfRename);
 
 	/**
 	 * last chunk received. This is the place where you can perform some final

--- a/tests/integration/features/transfer-ownership.feature
+++ b/tests/integration/features/transfer-ownership.feature
@@ -1,7 +1,6 @@
 Feature: transfer-ownership
 
 	# TODO: change to @no_default_encryption once all this works with master key
-	@no_encryption
 	Scenario: transfering ownership of a file
 		Given user "user0" exists
 		And user "user1" exists
@@ -12,7 +11,19 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
 
-	@no_encryption
+	Scenario: transfering ownership of a file after updating the file
+		Given user "user0" exists
+		And user "user1" exists
+		And User "user0" uploads file "data/file_to_overwrite.txt" to "/PARENT/textfile0.txt"
+		And user "user0" uploads chunk file "1" of "3" with "AA" to "/PARENT/textfile0.txt"
+		And user "user0" uploads chunk file "2" of "3" with "BB" to "/PARENT/textfile0.txt"
+		And user "user0" uploads chunk file "3" of "3" with "CC" to "/PARENT/textfile0.txt"
+		When transfering ownership from "user0" to "user1"
+		Then the command was successful
+		And As an "user1"
+		And using received transfer folder of "user1" as dav path
+		Then Downloaded content when downloading file "/PARENT/textfile0.txt" with range "bytes=0-5" should be "AABBCC"
+
 	Scenario: transfering ownership of a folder
 		Given user "user0" exists
 		And user "user1" exists
@@ -24,7 +35,6 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
-	@no_encryption
 	Scenario: transfering ownership of file shares
 		Given user "user0" exists
 		And user "user1" exists
@@ -36,7 +46,6 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
 
-	@no_encryption
 	Scenario: transfering ownership of folder shared with third user
 		Given user "user0" exists
 		And user "user1" exists
@@ -49,7 +58,6 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
-	@no_encryption
 	Scenario: transfering ownership of folder shared with transfer recipient
 		Given user "user0" exists
 		And user "user1" exists
@@ -63,7 +71,6 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		And Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
-	@no_encryption
 	Scenario: transfering ownership of folder doubly shared with third user
 		Given group "group1" exists
 		And user "user0" exists
@@ -79,7 +86,6 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
-	@no_encryption
 	Scenario: transfering ownership does not transfer received shares
 		Given user "user0" exists
 		And user "user1" exists
@@ -92,7 +98,6 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then as "user1" the folder "/test" does not exist
 
-	@no_encryption
 	@local_storage
 	Scenario: transfering ownership does not transfer external storage
 		Given user "user0" exists
@@ -103,7 +108,6 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then as "user1" the folder "/local_storage" does not exist
 
-	@no_encryption
 	Scenario: transfering ownership does not fail with shared trashed files
 		Given user "user0" exists
 		And user "user1" exists
@@ -115,21 +119,18 @@ Feature: transfer-ownership
 		When transfering ownership from "user0" to "user1"
 		Then the command was successful
 
-	@no_encryption
 	Scenario: transfering ownership fails with invalid source user
 		Given user "user0" exists
 		When transfering ownership from "invalid_user" to "user0"
 		Then the command error output contains the text "Unknown source user"
 		And the command failed with exit code 1
 
-	@no_encryption
 	Scenario: transfering ownership fails with invalid target user
 		Given user "user0" exists
 		When transfering ownership from "user0" to "invalid_user"
 		Then the command error output contains the text "Unknown target user"
 		And the command failed with exit code 1
 
-	@no_encryption
 	Scenario: transfering ownership of a folder
 		Given user "user0" exists
 		And user "user1" exists
@@ -141,7 +142,6 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
-	@no_encryption
 	Scenario: transfering ownership of file shares
 		Given user "user0" exists
 		And user "user1" exists
@@ -154,7 +154,6 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
 
-	@no_encryption
 	Scenario: transfering ownership of folder shared with third user
 		Given user "user0" exists
 		And user "user1" exists
@@ -167,7 +166,6 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
-	@no_encryption
 	Scenario: transfering ownership of folder shared with transfer recipient
 		Given user "user0" exists
 		And user "user1" exists
@@ -181,7 +179,6 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		And Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
-	@no_encryption
 	Scenario: transfering ownership of folder doubly shared with third user
 		Given group "group1" exists
 		And user "user0" exists
@@ -197,7 +194,6 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
-	@no_encryption
 	Scenario: transfering ownership does not transfer received shares
 		Given user "user0" exists
 		And user "user1" exists
@@ -212,7 +208,6 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then as "user1" the folder "/sub/test" does not exist
 
-	@no_encryption
 	@local_storage
 	Scenario: transfering ownership does not transfer external storage
 		Given user "user0" exists
@@ -224,7 +219,6 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then as "user1" the folder "/local_storage" does not exist
 
-	@no_encryption
 	Scenario: transfering ownership fails with invalid source user
 		Given user "user0" exists
 		And User "user0" created a folder "/sub"
@@ -232,7 +226,6 @@ Feature: transfer-ownership
 		Then the command error output contains the text "Unknown source user"
 		And the command failed with exit code 1
 
-	@no_encryption
 	Scenario: transfering ownership fails with invalid target user
 		Given user "user0" exists
 		And User "user0" created a folder "/sub"
@@ -240,7 +233,6 @@ Feature: transfer-ownership
 		Then the command error output contains the text "Unknown target user"
 		And the command failed with exit code 1
 
-	@no_encryption
 	Scenario: transfering ownership fails with invalid path
 		Given user "user0" exists
 		And user "user1" exists


### PR DESCRIPTION
This change helps users to get transfer-ownership
command work when masterkey is enabled as mode
of encryption.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
This change will help users to transfer files using transfer-ownership command when masterkey mode is enabled for encryption.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/27427

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change would help user tranfer files between users using transfer-ownership command when masterkey mode is enabled for encryption.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Below are the steps executed for testing:
`sujith@sujith-Inspiron-5567 ~/test/owncloud $ ./occ files:transfer-ownership --path transferred\ from\ user1\ on\ 20170608_115804/1 admin user1
Cannot load Xdebug - it was already loaded
Analysing files of admin ...
    1 [->--------------------------]
Check if master key enabled 1
    1 [============================]
Collecting all share information for files and folder of admin ...
    0 [>---------------------------]
Transferring files to user1/files/transferred from admin on 20170608_032359 ...
Restoring shares ...
    0 [>---------------------------]
sujith@sujith-Inspiron-5567 ~/test/owncloud $ ./occ files:transfer-ownership --path transferred\ from\ admin\ on\ 20170608_032359/1 user1 admin
Cannot load Xdebug - it was already loaded
Analysing files of user1 ...
    1 [============================]
Collecting all share information for files and folder of user1 ...
    0 [>---------------------------]
Transferring files to admin/files/transferred from user1 on 20170608_033618 ...
Restoring shares ...
    0 [>---------------------------]
sujith@sujith-Inspiron-5567 ~/test/owncloud $

This has also been tested by running the test transfer-ownership.feature`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

