### PR TITLE
Add email option to user:add command

### DIFF
--- a/core/Command/User/Add.php
+++ b/core/Command/User/Add.php
@@ -73,6 +73,12 @@ class Add extends Command {
 				'User name used in the web UI (can contain any characters)'
 			)
 			->addOption(
+				'email',
+				null,
+				InputOption::VALUE_OPTIONAL,
+				'Email address for the user'
+			)
+			->addOption(
 				'group',
 				'g',
 				InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
@@ -127,6 +133,11 @@ class Add extends Command {
 		if ($input->getOption('display-name')) {
 			$user->setDisplayName($input->getOption('display-name'));
 			$output->writeln('Display name set to "' . $user->getDisplayName() . '"');
+		}
+
+		if ($input->getOption('email')) {
+			$user->setEMailAddress($input->getOption('email'));
+			$output->writeln('Email address set to  "' . $user->getEMailAddress() . '"');
 		}
 
 		$groups = $input->getOption('group');


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
In the `user:add` command you can now specify the email for a user.

I would consider this a regression in functionality, assigned 10.0.3 to reintroduce this feature.

## Related Issue
https://central.owncloud.org/t/setting-email-with-occ-doesnt-show-in-gui/7987/3

## Motivation and Context
Now that emails are stored in the accounts table there is no way to set the email of a user via occ. Since it is metadata stored alongside users in the accounts table I thought it made sense to add this to the user:add command.

## How Has This Been Tested?
Local command line.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [] I have updated the documentation accordingly. https://github.com/owncloud/documentation/issues/3152#issuecomment-308095641
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
