### PR TITLE
make syslog output configurable, introduce new default that includes the request id

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -628,6 +628,13 @@ $CONFIG = array(
 'syslog_tag' => 'ownCloud',
 
 /**
+ * The syslog format can be changed to remove or add information.
+ * In addition to the %replacements% below %level% can be used, but it is used
+ * as a dedicated parameter to the syslog logging facility anyway.
+ */
+'log.syslog.format' => '[%reqId%][%remoteAddr%][%user%][%app%][%method%][%url%] %message%',
+
+/**
  * Log condition for log level increase based on conditions. Once one of these
  * conditions is met, the required log level is set to debug. This allows to
  * debug specific requests, users or apps

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -96,7 +96,7 @@ class Log implements ILogger {
 	 * @param SystemConfig $config the system config object
 	 * @param null $normalizer
 	 */
-	public function __construct($logger=null, SystemConfig $config=null, $normalizer = null) {
+	public function __construct($logger = null, SystemConfig $config = null, $normalizer = null) {
 		// FIXME: Add this for backwards compatibility, should be fixed at some point probably
 		if($config === null) {
 			$config = \OC::$server->getSystemConfig();


### PR DESCRIPTION
admins using syslog or rsyslog currently don't get valuable debug information in the syslog entries when configuring `'log_type' => 'syslog',`

Before:
```
Jun 13 14:34:01 asylum ownCloud[9106]: {index} Exception: ...
Jun 13 14:34:02 asylum ownCloud[8508]: {cron} Started background job of class : OCA\Files\BackgroundJob\ScanFiles with arguments :
Jun 13 14:34:02 asylum ownCloud[8508]: {cron} Finished background job, the job took : 0 seconds, this job is an instance of class : OCA\Files\BackgroundJob\ScanFiles with arguments :
```

Now
```
Jun 13 14:33:09 asylum ownCloud[8508]: [WT-bhX8AAQEAACE8oAgAAAAs][127.0.0.1][jfd][index][GET][/oc/core/index.php/apps/files/] Exception: ...
Jun 13 14:33:10 asylum ownCloud[8593]: [WT-bhn8AAQEAACGRPdgAAAAt][127.0.0.1][--][cron][GET][/oc/core/cron.php] Started background job of class : OCA\Files_Sharing\DeleteOrphanedSharesJob with arguments :
Jun 13 14:33:10 asylum ownCloud[8593]: [WT-bhn8AAQEAACGRPdgAAAAt][127.0.0.1][--][DeleteOrphanedSharesJob][GET][/oc/core/cron.php] 0 orphaned share(s) deleted
Jun 13 14:33:10 asylum ownCloud[8593]: [WT-bhn8AAQEAACGRPdgAAAAt][127.0.0.1][--][cron][GET][/oc/core/cron.php] Finished background job, the job took : 0 seconds, this job is an instance of class : OCA\Files_Sharing\DeleteOrphanedSharesJob with arguments :
```

* order of params is same as in owncloud.log
* syslog format string is configurable, example given in config.sample.php
* includes requestid by default, which allows correlating the apache log entries if `mod_unique_id` is enabled
  * see https://github.com/owncloud/documentation/issues/2967 for mod_unique_id 
  * see https://github.com/owncloud/documentation/issues/2968 for json based apache log format 