### PR TITLE
[WIP] unify config log options

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -592,27 +592,27 @@ $CONFIG = array(
  * Setting this parameter to ``errorlog`` will use the PHP error_log function
  * for logging.
  */
-'log_type' => 'owncloud',
+'log.type' => 'owncloud',
 
 /**
  * Log file path for the ownCloud logging type.
  * Defaults to ``[datadirectory]/owncloud.log``
  */
-'logfile' => '/var/log/owncloud.log',
+'log.file' => '/var/log/owncloud.log',
 
 /**
- * Loglevel to start logging at. Valid values are: 0 = Debug, 1 = Info, 2 =
+ * Log level to start logging at. Valid values are: 0 = Debug, 1 = Info, 2 =
  * Warning, 3 = Error, and 4 = Fatal. The default value is Warning.
  */
-'loglevel' => 2,
+'log.level' => 2,
 
 /**
  * If you maintain different instances and aggregate the logs, you may want
- * to distinguish between them. ``syslog_tag`` can be set per instance
- * with a unique id. Only available if ``log_type`` is set to ``syslog``.
+ * to distinguish between them. ``log.syslog.tag`` can be set per instance
+ * with a unique id. Only available if ``log.type`` is set to ``syslog``.
  * The default value is ``ownCloud``.
  */
-'syslog_tag' => 'ownCloud',
+'log.syslog.tag' => 'ownCloud',
 
 /**
  * Log condition for log level increase based on conditions. Once one of these
@@ -650,24 +650,24 @@ $CONFIG = array(
 /**
  * This uses PHP.date formatting; see http://php.net/manual/en/function.date.php
  */
-'logdateformat' => 'F d, Y H:i:s',
+'log.dateformat' => 'F d, Y H:i:s',
 
 /**
  * The default timezone for logfiles is UTC. You may change this; see
  * http://php.net/manual/en/timezones.php
  */
-'logtimezone' => 'Europe/Berlin',
+'log.timezone' => 'Europe/Berlin',
 
 /**
  * Append all database queries and parameters to the log file. Use this only for
  * debugging, as your logfile will become huge.
  */
-'log_query' => false,
+'log.query' => false, // FIXME unused?
 
 /**
  * Log successful cron runs.
  */
-'cron_log' => true,
+'log.cron' => true,
 
 /**
  * Enables log rotation and limits the total size of logfiles. The default is 0,
@@ -676,7 +676,7 @@ $CONFIG = array(
  * old logfile reaches your limit. If a rotated log file is already present, it
  * will be overwritten.
  */
-'log_rotate_size' => false,
+'log.rotate.size' => false,
 
 
 /**

--- a/core/Command/Log/Manage.php
+++ b/core/Command/Log/Manage.php
@@ -76,7 +76,7 @@ class Manage extends Command {
 
 		if ($backend = $input->getOption('backend')) {
 			$this->validateBackend($backend);
-			$toBeSet['log_type'] = $backend;
+			$toBeSet['log.type'] = $backend;
 		}
 
 		$level = $input->getOption('level');
@@ -88,12 +88,12 @@ class Manage extends Command {
 			} else {
 				$levelNum = $this->convertLevelString($level);
 			}
-			$toBeSet['loglevel'] = $levelNum;
+			$toBeSet['log.level'] = $levelNum;
 		}
 
 		if ($timezone = $input->getOption('timezone')) {
 			$this->validateTimezone($timezone);
-			$toBeSet['logtimezone'] = $timezone;
+			$toBeSet['log.timezone'] = $timezone;
 		}
 
 		// set config
@@ -102,14 +102,14 @@ class Manage extends Command {
 		}
 
 		// display configuration
-		$backend = $this->config->getSystemValue('log_type', self::DEFAULT_BACKEND);
+		$backend = $this->config->getSystemValue('log.type', self::DEFAULT_BACKEND);
 		$output->writeln('Enabled logging backend: '.$backend);
 
-		$levelNum = $this->config->getSystemValue('loglevel', self::DEFAULT_LOG_LEVEL);
+		$levelNum = $this->config->getSystemValue('log.level', self::DEFAULT_LOG_LEVEL);
 		$level = $this->convertLevelNumber($levelNum);
 		$output->writeln('Log level: '.$level.' ('.$levelNum.')');
 
-		$timezone = $this->config->getSystemValue('logtimezone', self::DEFAULT_TIMEZONE);
+		$timezone = $this->config->getSystemValue('log.timezone', self::DEFAULT_TIMEZONE);
 		$output->writeln('Log timezone: '.$timezone);
 	}
 

--- a/core/Command/Log/OwnCloud.php
+++ b/core/Command/Log/OwnCloud.php
@@ -68,17 +68,17 @@ class OwnCloud extends Command {
 		$toBeSet = [];
 
 		if ($input->getOption('enable')) {
-			$toBeSet['log_type'] = 'owncloud';
+			$toBeSet['log.type'] = 'owncloud';
 		}
 
 		if ($file = $input->getOption('file')) {
-			$toBeSet['logfile'] = $file;
+			$toBeSet['log.file'] = $file;
 		}
 
 		if (($rotateSize = $input->getOption('rotate-size')) !== null) {
 			$rotateSize = \OCP\Util::computerFileSize($rotateSize);
 			$this->validateRotateSize($rotateSize);
-			$toBeSet['log_rotate_size'] = $rotateSize;
+			$toBeSet['log.rotate.size'] = $rotateSize;
 		}
 
 		// set config
@@ -87,7 +87,7 @@ class OwnCloud extends Command {
 		}
 
 		// display config
-		if ($this->config->getSystemValue('log_type', 'owncloud') === 'owncloud') {
+		if ($this->config->getSystemValue('log.type', 'owncloud') === 'owncloud') {
 			$enabledText = 'enabled';
 		} else {
 			$enabledText = 'disabled';
@@ -96,9 +96,9 @@ class OwnCloud extends Command {
 
 		$dataDir = $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT.'/data');
 		$defaultLogFile = rtrim($dataDir, '/').'/owncloud.log';
-		$output->writeln('Log file: '.$this->config->getSystemValue('logfile', $defaultLogFile));
+		$output->writeln('Log file: '.$this->config->getSystemValue('log.file', $defaultLogFile));
 
-		$rotateSize = $this->config->getSystemValue('log_rotate_size', 0);
+		$rotateSize = $this->config->getSystemValue('log.rotate.size', 0);
 		if ($rotateSize) {
 			$rotateString = \OCP\Util::humanFileSize($rotateSize);
 		} else {

--- a/cron.php
+++ b/cron.php
@@ -149,7 +149,7 @@ try {
 	}
 
 	// Log the successful cron execution
-	if (\OC::$server->getConfig()->getSystemValue('cron_log', true)) {
+	if (\OC::$server->getConfig()->getSystemValue('log.cron', true)) {
 		\OC::$server->getConfig()->setAppValue('core', 'lastcron', time());
 	}
 	exit();

--- a/lib/base.php
+++ b/lib/base.php
@@ -767,10 +767,10 @@ class OC {
 	 */
 	public static function registerLogRotate() {
 		$systemConfig = \OC::$server->getSystemConfig();
-		if ($systemConfig->getValue('installed', false) && $systemConfig->getValue('log_rotate_size', false) && !self::checkUpgrade(false)) {
+		if ($systemConfig->getValue('installed', false) && $systemConfig->getValue('log.rotate.size', false) && !self::checkUpgrade(false)) {
 			//don't try to do this before we are properly setup
 			//use custom logfile path if defined, otherwise use default of owncloud.log in data directory
-			\OCP\BackgroundJob::registerJob('OC\Log\Rotate', $systemConfig->getValue('logfile', $systemConfig->getValue('datadirectory', OC::$SERVERROOT . '/data') . '/owncloud.log'));
+			\OCP\BackgroundJob::registerJob('OC\Log\Rotate', $systemConfig->getValue('log.file', $systemConfig->getValue('datadirectory', OC::$SERVERROOT . '/data') . '/owncloud.log'));
 		}
 	}
 

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -91,6 +91,7 @@ class Config {
 			return $envValue;
 		}
 
+		$key = $this->updateConfigKey($key);
 		if (isset($this->cache[$key])) {
 			return $this->cache[$key];
 		}
@@ -107,6 +108,7 @@ class Config {
 	public function setValues(array $configs) {
 		$needsUpdate = false;
 		foreach ($configs as $key => $value) {
+			$key = $this->updateConfigKey($key);
 			if ($value !== null) {
 				$needsUpdate |= $this->set($key, $value);
 			} else {
@@ -127,6 +129,7 @@ class Config {
 	 * @param mixed $value value
 	 */
 	public function setValue($key, $value) {
+		$key = $this->updateConfigKey($key);
 		if ($this->set($key, $value)) {
 			// Write changes
 			$this->writeData();
@@ -155,6 +158,7 @@ class Config {
 	 * @param string $key
 	 */
 	public function deleteKey($key) {
+		$key = $this->updateConfigKey($key);
 		if ($this->delete($key)) {
 			// Write changes
 			$this->writeData();
@@ -213,6 +217,7 @@ class Config {
 			unset($CONFIG);
 			include $file;
 			if(isset($CONFIG) && is_array($CONFIG)) {
+				$CONFIG = $this->updateConfigKeys($CONFIG);
 				$this->cache = array_merge($this->cache, $CONFIG);
 			}
 
@@ -220,6 +225,54 @@ class Config {
 			flock($filePointer, LOCK_UN);
 			fclose($filePointer);
 		}
+	}
+
+	private function updateConfigKeys(array $config) {
+		if (isset($config['log_type'])) {
+			$config['log.type'] = $config['log_type'];
+		}
+		if (isset($config['logfile'])) {
+			$config['log.file'] = $config['logfile'];
+		}
+		if (isset($config['loglevel'])) {
+			$config['log.level'] = $config['loglevel'];
+		}
+		if (isset($config['syslog_tag'])) {
+			$config['log.syslog.tag'] = $config['syslog_tag'];
+		}
+		if (isset($config['logdateformat'])) {
+			$config['log.dateformat'] = $config['logdateformat'];
+		}
+		if (isset($config['logtimezone'])) {
+			$config['log.timezone'] = $config['logtimezone'];
+		}
+		if (isset($config['log_query'])) {
+			$config['log.query'] = $config['log_query'];
+		}
+		if (isset($config['cron_log'])) {
+			$config['log.cron'] = $config['cron_log'];
+		}
+		if (isset($config['log_rotate_size'])) {
+			$config['log.rotate.size'] = $config['log_rotate_size'];
+		}
+
+		return $config;
+	}
+
+	private function updateConfigKey($key) {
+		switch ($key) {
+			case 'log_type':		return 'log.type';
+			case 'logfile':			return 'log.file';
+			case 'loglevel':		return 'log.level';
+			case 'syslog_tag':		return 'log.syslog.tag';
+			case 'logdateformat':	return 'log.dateformat';
+			case 'logtimezone':		return 'log.timezone';
+			case 'log_query':		return 'log.query';
+			case 'cron_log':		return 'log.cron';
+			case 'log_rotate_size':	return 'log.rotate.size';
+		}
+
+		return $key;
 	}
 
 	/**

--- a/lib/private/Console/TimestampFormatter.php
+++ b/lib/private/Console/TimestampFormatter.php
@@ -96,11 +96,11 @@ class TimestampFormatter implements OutputFormatterInterface {
 	 */
 	public function format($message) {
 
-		$timeZone = $this->config->getSystemValue('logtimezone', null);
+		$timeZone = $this->config->getSystemValue('log.timezone', null);
 		$timeZone = $timeZone !== null ? new \DateTimeZone($timeZone) : null;
 
 		$time = new \DateTime('now', $timeZone);
-		$timestampInfo = $time->format($this->config->getSystemValue('logdateformat', 'c'));
+		$timestampInfo = $time->format($this->config->getSystemValue('log.dateformat', 'c'));
 
 		return $timestampInfo . ' ' . $this->formatter->format($message);
 	}

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -107,7 +107,7 @@ class Log implements ILogger {
 
 		// FIXME: Add this for backwards compatibility, should be fixed at some point probably
 		if($logger === null) {
-			$this->logger = 'OC\\Log\\'.ucfirst($this->config->getValue('log_type', 'owncloud'));
+			$this->logger = 'OC\\Log\\'.ucfirst($this->config->getValue('log.type', 'owncloud'));
 			call_user_func([$this->logger, 'init']);
 		} else {
 			$this->logger = $logger;
@@ -229,7 +229,7 @@ class Log implements ILogger {
 	 * @return void
 	 */
 	public function log($level, $message, array $context = []) {
-		$minLevel = min($this->config->getValue('loglevel', Util::WARN), Util::FATAL);
+		$minLevel = min($this->config->getValue('log.level', Util::WARN), Util::FATAL);
 		$logConditions = $this->config->getValue('log.conditions', []);
 		if (empty($logConditions)) {
 			$logConditions[] = $this->config->getValue('log.condition', []);

--- a/lib/private/Log/Owncloud.php
+++ b/lib/private/Log/Owncloud.php
@@ -44,8 +44,8 @@ class Owncloud {
 	 */
 	public static function init() {
 		$systemConfig = \OC::$server->getSystemConfig();
-		$defaultLogFile = $systemConfig->getValue("datadirectory", \OC::$SERVERROOT.'/data').'/owncloud.log';
-		self::$logFile = $systemConfig->getValue("logfile", $defaultLogFile);
+		$defaultLogFile = $systemConfig->getValue('datadirectory', \OC::$SERVERROOT.'/data').'/owncloud.log';
+		self::$logFile = $systemConfig->getValue('log.file', $defaultLogFile);
 
 		/**
 		 * Fall back to default log file if specified logfile does not exist
@@ -73,8 +73,8 @@ class Owncloud {
 		$config = \OC::$server->getSystemConfig();
 
 		// default to ISO8601
-		$format = $config->getValue('logdateformat', 'c');
-		$logTimeZone = $config->getValue( "logtimezone", 'UTC' );
+		$format = $config->getValue('log.dateformat', 'c');
+		$logTimeZone = $config->getValue( 'log.timezone', 'UTC' );
 		try {
 			$timezone = new \DateTimeZone($logTimeZone);
 		} catch (\Exception $e) {

--- a/lib/private/Log/Rotate.php
+++ b/lib/private/Log/Rotate.php
@@ -32,7 +32,7 @@ namespace OC\Log;
 class Rotate extends \OC\BackgroundJob\Job {
 	private $max_log_size;
 	public function run($logFile) {
-		$this->max_log_size = \OC::$server->getConfig()->getSystemValue('log_rotate_size', false);
+		$this->max_log_size = \OC::$server->getConfig()->getSystemValue('log.rotate.size', false);
 		if ($this->max_log_size) {
 			$filesize = @filesize($logFile);
 			if ($filesize >= $this->max_log_size) {

--- a/lib/private/Log/Syslog.php
+++ b/lib/private/Log/Syslog.php
@@ -37,7 +37,7 @@ class Syslog {
 	 * Init class data
 	 */
 	public static function init() {
-		openlog(\OC::$server->getSystemConfig()->getValue("syslog_tag", "ownCloud"), LOG_PID | LOG_CONS, LOG_USER);
+		openlog(\OC::$server->getSystemConfig()->getValue('log.syslog.tag', 'ownCloud'), LOG_PID | LOG_CONS, LOG_USER);
 		// Close at shutdown
 		register_shutdown_function('closelog');
 	}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -408,7 +408,7 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 		});
 		$this->registerService('Logger', function (Server $c) {
-			$logClass = $c->query('AllConfig')->getSystemValue('log_type', 'owncloud');
+			$logClass = $c->query('AllConfig')->getSystemValue('log.type', 'owncloud');
 			$logger = 'OC\\Log\\' . ucfirst($logClass);
 			call_user_func([$logger, 'init']);
 

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -367,7 +367,7 @@ class Setup {
 
 			//try to write logtimezone
 			if (date_default_timezone_get()) {
-				$config->setSystemValue('logtimezone', date_default_timezone_get());
+				$config->setSystemValue('log.timezone', date_default_timezone_get());
 			}
 
 			self::installBackgroundJobs();

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -88,9 +88,9 @@ class Updater extends BasicEmitter {
 	public function upgrade() {
 		$this->emitRepairEvents();
 
-		$logLevel = $this->config->getSystemValue('loglevel', Util::WARN);
+		$logLevel = $this->config->getSystemValue('log.level', Util::WARN);
 		$this->emit('\OC\Updater', 'setDebugLogLevel', [ $logLevel, $this->logLevelNames[$logLevel] ]);
-		$this->config->setSystemValue('loglevel', Util::DEBUG);
+		$this->config->setSystemValue('log.level', Util::DEBUG);
 
 		$wasMaintenanceModeEnabled = $this->config->getSystemValue('maintenance', false);
 
@@ -122,7 +122,7 @@ class Updater extends BasicEmitter {
 		}
 
 		$this->emit('\OC\Updater', 'resetLogLevel', [ $logLevel, $this->logLevelNames[$logLevel] ]);
-		$this->config->setSystemValue('loglevel', $logLevel);
+		$this->config->setSystemValue('log.level', $logLevel);
 		$this->config->setSystemValue('installed', true);
 
 		return $success;

--- a/settings/Controller/LogSettingsController.php
+++ b/settings/Controller/LogSettingsController.php
@@ -76,7 +76,7 @@ class LogSettingsController extends Controller {
 			], Http::STATUS_BAD_REQUEST);
 		}
 
-		$this->config->setSystemValue('loglevel', $level);
+		$this->config->setSystemValue('log.level', $level);
 		return new JSONResponse([
 			'level' => $level,
 		]);

--- a/settings/Panels/Admin/BackgroundJobs.php
+++ b/settings/Panels/Admin/BackgroundJobs.php
@@ -39,7 +39,7 @@ class BackgroundJobs implements ISettings {
 
 	public function getPanel() {
 		$tmpl = new Template('settings', 'panels/admin/backgroundjobs');
-		$tmpl->assign('cron_log', $this->config->getSystemValue('cron_log', true));
+		$tmpl->assign('log.cron', $this->config->getSystemValue('log.cron', true));
 		$tmpl->assign('lastcron', $this->config->getAppValue('core', 'lastcron', false));
 		$tmpl->assign('backgroundjobs_mode', $this->config->getAppValue('core', 'backgroundjobs_mode', 'ajax'));
 		return $tmpl;

--- a/settings/Panels/Admin/Logging.php
+++ b/settings/Panels/Admin/Logging.php
@@ -56,11 +56,11 @@ class Logging implements ISettings {
 		if($doesLogFileExist) {
 			$logFileSize = filesize($logFilePath);
 		}
-		$tmpl->assign('loglevel', $this->config->getSystemValue("loglevel", 2));
+		$tmpl->assign('log.level', $this->config->getSystemValue('log.level', 2));
 		$tmpl->assign('doesLogFileExist', $doesLogFileExist);
 		$tmpl->assign('urlGenerator', $this->urlGenerator);
 		$tmpl->assign('logFileSize', $logFileSize);
-		$tmpl->assign('showLog', $this->config->getSystemValue('log_type', 'owncloud') === 'owncloud');
+		$tmpl->assign('showLog', $this->config->getSystemValue('log.type', 'owncloud') === 'owncloud');
 		return $tmpl;
 	}
 

--- a/settings/Panels/Admin/Mail.php
+++ b/settings/Panels/Admin/Mail.php
@@ -47,7 +47,7 @@ class Mail implements ISettings {
 		$template = new Template('settings', 'panels/admin/mail');
 		// Should we display sendmail as an option?
 		$template->assign('sendmail_is_available', $this->helper->findBinaryPath('sendmail'));
-		$template->assign('loglevel', $this->config->getSystemValue("loglevel", 2));
+		$template->assign('log.level', $this->config->getSystemValue('log.level', 2));
 		$template->assign('mail_domain', $this->config->getSystemValue("mail_domain", ''));
 		$template->assign('mail_from_address', $this->config->getSystemValue("mail_from_address", ''));
 		$template->assign('mail_smtpmode', $this->config->getSystemValue("mail_smtpmode", ''));

--- a/settings/templates/panels/admin/backgroundjobs.php
+++ b/settings/templates/panels/admin/backgroundjobs.php
@@ -7,7 +7,7 @@ script('settings', 'panels/backgroundjobs');
 ?>
 <div class="section" id="backgroundjobs">
 	<h2 class="app-name has-documentation"><?php p($l->t('Cron'));?></h2>
-	<?php if ($_['cron_log']): ?>
+	<?php if ($_['log.cron']): ?>
 	<p class="cronlog inlineblock">
 		<?php if ($_['lastcron'] !== false):
 			$relative_time = relative_modified_date($_['lastcron']);

--- a/settings/templates/panels/admin/logging.php
+++ b/settings/templates/panels/admin/logging.php
@@ -18,7 +18,7 @@ $levelLabels = [
 			<p><?php p($l->t('What to log'));?> <select name='loglevel' id='loglevel'>
 			<?php for ($i = 0; $i < 5; $i++):
 				$selected = '';
-				if ($i == $_['loglevel']):
+				if ($i == $_['log.level']):
 					$selected = 'selected="selected"';
 				endif; ?>
 					<option value='<?php p($i)?>' <?php p($selected) ?>><?php p($levelLabels[$i])?></option>

--- a/tests/Core/Command/Log/ManageTest.php
+++ b/tests/Core/Command/Log/ManageTest.php
@@ -55,7 +55,7 @@ class ManageTest extends TestCase {
 			]));
 		$this->config->expects($this->once())
 			->method('setSystemValue')
-			->with('log_type', 'syslog');
+			->with('log.type', 'syslog');
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
@@ -67,7 +67,7 @@ class ManageTest extends TestCase {
 			]));
 		$this->config->expects($this->once())
 			->method('setSystemValue')
-			->with('loglevel', 0);
+			->with('log.level', 0);
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
@@ -79,7 +79,7 @@ class ManageTest extends TestCase {
 			]));
 		$this->config->expects($this->once())
 			->method('setSystemValue')
-			->with('logtimezone', 'UTC');
+			->with('log.timezone', 'UTC');
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
@@ -154,15 +154,15 @@ class ManageTest extends TestCase {
 	public function testGetConfiguration() {
 		$this->config->expects($this->at(0))
 			->method('getSystemValue')
-			->with('log_type', 'owncloud')
+			->with('log.type', 'owncloud')
 			->willReturn('log_type_value');
 		$this->config->expects($this->at(1))
 			->method('getSystemValue')
-			->with('loglevel', 2)
+			->with('log.level', 2)
 			->willReturn(0);
 		$this->config->expects($this->at(2))
 			->method('getSystemValue')
-			->with('logtimezone', 'UTC')
+			->with('log.timezone', 'UTC')
 			->willReturn('logtimezone_value');
 
 		$this->consoleOutput->expects($this->at(0))

--- a/tests/Core/Command/Log/OwnCloudTest.php
+++ b/tests/Core/Command/Log/OwnCloudTest.php
@@ -55,7 +55,7 @@ class OwnCloudTest extends TestCase {
 			]));
 		$this->config->expects($this->once())
 			->method('setSystemValue')
-			->with('log_type', 'owncloud');
+			->with('log.type', 'owncloud');
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
@@ -67,7 +67,7 @@ class OwnCloudTest extends TestCase {
 			]));
 		$this->config->expects($this->once())
 			->method('setSystemValue')
-			->with('logfile', '/foo/bar/file.log');
+			->with('log.file', '/foo/bar/file.log');
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
@@ -91,7 +91,7 @@ class OwnCloudTest extends TestCase {
 			]));
 		$this->config->expects($this->once())
 			->method('setSystemValue')
-			->with('log_rotate_size', $configValue);
+			->with('log.rotate.size', $configValue);
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
@@ -99,10 +99,10 @@ class OwnCloudTest extends TestCase {
 	public function testGetConfiguration() {
 		$this->config->method('getSystemValue')
 			->will($this->returnValueMap([
-				['log_type', 'owncloud', 'log_type_value'],
+				['log.type', 'owncloud', 'log_type_value'],
 				['datadirectory', \OC::$SERVERROOT.'/data', '/data/directory/'],
-				['logfile', '/data/directory/owncloud.log', '/var/log/owncloud.log'],
-				['log_rotate_size', 0, 5 * 1024 * 1024],
+				['log.file', '/data/directory/owncloud.log', '/var/log/owncloud.log'],
+				['log.rotate.size', 0, 5 * 1024 * 1024],
 			]));
 
 		$this->consoleOutput->expects($this->at(0))

--- a/tests/Settings/Controller/LogSettingsControllerTest.php
+++ b/tests/Settings/Controller/LogSettingsControllerTest.php
@@ -41,7 +41,7 @@ class LogSettingsControllerTest extends \Test\TestCase {
 			$this->container['Config']
 				->expects($this->once())
 				->method('setSystemValue')
-				->with('loglevel', $level);
+				->with('log.level', $level);
 		}
 
 		$response = $this->logSettingsController->setLogLevel($level)->getData();

--- a/tests/Settings/Panels/Admin/LoggingTest.php
+++ b/tests/Settings/Panels/Admin/LoggingTest.php
@@ -62,8 +62,8 @@ class LoggingTest extends \Test\TestCase {
 			->method('getLogFilePath')
 			->willReturn(__FILE__);
 		$this->config->expects($this->exactly(2))->method('getSystemValue')->will($this->returnValueMap([
-			['loglevel', 2, 2],
-			['log_type', 'owncloud', 'owncloud'],
+			['log.level', 2, 2],
+			['log.type', 'owncloud', 'owncloud'],
 		]));
 		$templateHtml = $this->panel->getPanel()->fetchPage();
 		$this->assertContains('<div class="section">', $templateHtml);

--- a/tests/lib/Log/OwncloudTest.php
+++ b/tests/lib/Log/OwncloudTest.php
@@ -33,21 +33,21 @@ class OwncloudTest extends TestCase
 	protected function setUp() {
 		parent::setUp();
 		$config = \OC::$server->getConfig();
-		$this->restore_logfile = $config->getSystemValue("logfile");
-		$this->restore_logdateformat = $config->getSystemValue('logdateformat');
+		$this->restore_logfile = $config->getSystemValue("log.file");
+		$this->restore_logdateformat = $config->getSystemValue('log.dateformat');
 		
-		$config->setSystemValue("logfile", $config->getSystemValue('datadirectory') . "/logtest");
+		$config->setSystemValue("log.file", $config->getSystemValue('datadirectory') . "/logtest");
 		Owncloud::init();
 	}
 	protected function tearDown() {
 		$config = \OC::$server->getConfig();
 		if (isset($this->restore_logfile)) {
-			$config->getSystemValue("logfile", $this->restore_logfile);
+			$config->getSystemValue("log.file", $this->restore_logfile);
 		} else {
-			$config->deleteSystemValue("logfile");
+			$config->deleteSystemValue("log.file");
 		}		
 		if (isset($this->restore_logdateformat)) {
-			$config->getSystemValue("logdateformat", $this->restore_logdateformat);
+			$config->getSystemValue("log.dateformat", $this->restore_logdateformat);
 		} else {
 			$config->deleteSystemValue("restore_logdateformat");
 		}		
@@ -58,14 +58,14 @@ class OwncloudTest extends TestCase
 	public function testMicrosecondsLogTimestamp() {
 		$config = \OC::$server->getConfig();
 		# delete old logfile
-		unlink($config->getSystemValue('logfile'));
+		unlink($config->getSystemValue('log.file'));
 
 		# set format & write log line
-		$config->setSystemValue('logdateformat', 'u');
+		$config->setSystemValue('log.dateformat', 'u');
 		Owncloud::write('test', 'message', \OCP\Util::ERROR);
 		
 		# read log line
-		$handle = @fopen($config->getSystemValue('logfile'), 'r');
+		$handle = @fopen($config->getSystemValue('log.file'), 'r');
 		$line = fread($handle, 1000);
 		fclose($handle);
 		

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -43,7 +43,7 @@ class LoggerTest extends TestCase {
 		$this->config->expects($this->any())
 			->method('getValue')
 			->will(($this->returnValueMap([
-				['loglevel', Util::WARN, Util::WARN],
+				['log.level', Util::WARN, Util::WARN],
 				['log.condition', [], ['apps' => ['files']]]
 			])));
 		$logger = $this->logger;
@@ -63,8 +63,8 @@ class LoggerTest extends TestCase {
 		$this->config->expects($this->any())
 			->method('getValue')
 			->will(($this->returnValueMap([
-				['loglevel', Util::WARN, Util::WARN],
-				['log.conditions', [], [['apps' => ['files'], 'logfile' => '/tmp/test.log']]]
+				['log.level', Util::WARN, Util::WARN],
+				['log.conditions', [], [['apps' => ['files'], 'log.file' => '/tmp/test.log']]]
 			])));
 		$logger = $this->logger;
 

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -118,7 +118,7 @@ cat > ./tests/autoconfig-oracle.php <<DELIM
   'dbname' => 'XE',
   'dbhost' => 'localhost',
   'dbpass' => 'owncloud',
-  'loglevel' => 0,
+  'log.level' => 0,
 );
 DELIM
 


### PR DESCRIPTION
The current config option naming is a grown mess. This pr changes the logging options and introducas fallback code. I did not yet add logging, because during config reading the logger is not yet initialized ... might add a shutdown function to do that.

Any other logging related options I should add?