### PR TITLE
Respect RFC2616 Section 5.1.2 and allow absoluteURI

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -75,7 +75,10 @@ class Server {
 		);
 
 		// Set URL explicitly due to reverse-proxy situations
-		$this->server->httpRequest->setUrl($this->request->getRequestUri());
+		$uri = $this->request->getRequestUri();
+		$components = parse_url($uri);
+		$url = $components['path'].'?'.$components['query'].'#'.$components['fragment'];
+		$this->server->httpRequest->setUrl($url);
 		$this->server->setBaseUri($this->baseUri);
 
 		$config = \OC::$server->getConfig();

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -75,10 +75,7 @@ class Server {
 		);
 
 		// Set URL explicitly due to reverse-proxy situations
-		$uri = $this->request->getRequestUri();
-		$components = parse_url($uri);
-		$url = $components['path'].'?'.$components['query'].'#'.$components['fragment'];
-		$this->server->httpRequest->setUrl($url);
+		$this->server->httpRequest->setUrl($this->request->getRequestUri());
 		$this->server->setBaseUri($this->baseUri);
 
 		$config = \OC::$server->getConfig();

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -613,6 +613,15 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		$uri = isset($this->server['REQUEST_URI']) ? $this->server['REQUEST_URI'] : '';
 		if($this->config->getSystemValue('overwritewebroot') !== '' && $this->isOverwriteCondition()) {
 			$uri = $this->getScriptName() . substr($uri, strlen($this->server['SCRIPT_NAME']));
+		} else {
+			$components = parse_url($uri);
+			$uri = $components['path'];
+			if (isset($components['query'])) {
+				$uri .= '?'.$components['query'];
+			}
+			if (isset($components['fragment'])) {
+				$uri .= '#'.$components['fragment'];
+			}
 		}
 		return $uri;
 	}

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -615,6 +615,11 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			$uri = $this->getScriptName() . substr($uri, strlen($this->server['SCRIPT_NAME']));
 		} else {
 			$components = parse_url($uri);
+			if ($components === false) {
+				// due to https://bugs.php.net/bug.php?id=70942 we have to add a
+				// fake schema and host to successfully extract path, query and fragment
+				$components = parse_url("http://localhost$uri");
+			}
 			$uri = $components['path'];
 			if (isset($components['query'])) {
 				$uri .= '?'.$components['query'];

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -16,13 +16,14 @@ use OC\Security\CSRF\CsrfTokenManager;
 use OCP\IRequest;
 use OCP\Security\ISecureRandom;
 use OCP\IConfig;
+use Test\TestCase;
 
 /**
  * Class RequestTest
  *
  * @package OC\AppFramework\Http
  */
-class RequestTest extends \Test\TestCase {
+class RequestTest extends TestCase {
 	/** @var string */
 	protected $stream = 'fakeinput://data';
 	/** @var ISecureRandom | \PHPUnit_Framework_MockObject_MockObject */

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -1338,7 +1338,22 @@ class RequestTest extends TestCase {
 		];
 	}
 
-	public function testGetRequestUriWithoutOverwrite() {
+	public function providesUri() {
+		return[
+			['/test.php', '/test.php'],
+			['/remote.php/dav/files/user0/test_folder:5', '/remote.php/dav/files/user0/test_folder:5'],
+			['/remote.php/dav/files/admin/welcome.txt', 'http://localhost:8080/remote.php/dav/files/admin/welcome.txt'],
+			['/path?arg=value#anchor', 'http://username:password@hostname:9090/path?arg=value#anchor'],
+			['/path:5?arg=value#anchor', 'http://username:password@hostname:9090/path:5?arg=value#anchor'],
+			['', ''],
+			['/test.php', '/test.php'],
+		];
+	}
+
+	/**
+	 * @dataProvider providesUri
+	 */
+	public function testGetRequestUriWithoutOverwrite($expectedUri, $requestUri) {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
@@ -1348,7 +1363,7 @@ class RequestTest extends TestCase {
 		$request = new Request(
 			[
 				'server' => [
-					'REQUEST_URI' => '/test.php'
+					'REQUEST_URI' => $requestUri
 				]
 			],
 			$this->secureRandom,
@@ -1357,7 +1372,7 @@ class RequestTest extends TestCase {
 			$this->stream
 		);
 
-		$this->assertSame('/test.php', $request->getRequestUri());
+		$this->assertSame($expectedUri, $request->getRequestUri());
 	}
 
 	public function providesGetRequestUriWithOverwriteData() {


### PR DESCRIPTION
From https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2

> To allow for transition to absoluteURIs in all requests in future versions of HTTP, all HTTP/1.1 servers MUST accept the absoluteURI form in requests, even though HTTP/1.1 clients will only generate them in requests to proxies.

Currently, this happens:
```json
{"Message":"Requested uri (http:\/\/localhost\/owncloud\/remote.php\/webdav\/) is out of base uri (\/owncloud\/remote.php\/webdav\/)","Code":0,"Trace":"
#0 \/var\/www\/owncloud\/3rdparty\/sabre\/dav\/lib\/DAV\/Server.php(1279): Sabre\\HTTP\\Request->getPath()
#1 \/var\/www\/owncloud\/3rdparty\/sabre\/dav\/lib\/DAV\/Server.php(464): Sabre\\DAV\\Server->checkPreconditions(Object(Sabre\\HTTP\\Request), Object(Sabre\\HTTP\\Response))
#2 \/var\/www\/owncloud\/3rdparty\/sabre\/dav\/lib\/DAV\/Server.php(254): Sabre\\DAV\\Server->invokeMethod(Object(Sabre\\HTTP\\Request), Object(Sabre\\HTTP\\Response))
#3 \/var\/www\/owncloud\/apps\/files\/appinfo\/remote.php(83): Sabre\\DAV\\Server->exec()
#4 \/var\/www\/owncloud\/remote.php(132): require_once('\/var\/www\/ownclo...')
#5 {main}","File":"\/var\/www\/owncloud\/3rdparty\/sabre\/http\/lib\/Request.php","Line":210}
```
Also see client Issue: https://github.com/owncloud/client/issues/3881

Test with absolute.php (adjust `$host`, `$user`, `$password` and `$path` as necessary, only works against http )
```php
<?php
$host = 'localhost';
$user = 'user';
$password = 'password';
$path = "http://localhost/owncloud/remote.php/dav/files/$user/welcome.txt";
#$path = "/owncloud/remote.php/dav/files/$user/welcome.txt";

$fp = fsockopen($host, 80);

fputs($fp, "GET $path HTTP/1.1\r\n");
fputs($fp, "Host: $host\r\n");
fputs($fp, "Authorization: Basic ".base64_encode("$user:$password")."\r\n");
fputs($fp, "Accept: */*\r\n");
fputs($fp, "\r\n");

$result = '';
while(!feof($fp)) {
    $result .= fgets($fp, 128);
}

fclose($fp);

echo $result;
```

This PR ignores the host, as the OC::$WEBROOT ignores it as well.