### PR TITLE
Replace JS centering and sizing of dialog in favor of CSS

### DIFF
--- a/core/css/jquery.ocdialog.css
+++ b/core/css/jquery.ocdialog.css
@@ -9,6 +9,11 @@
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
 	min-width: 200px;
+
+	/* Center positioning */
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%,-50%);
 }
 .oc-dialog-title {
 	background: white;

--- a/core/js/jquery.ocdialog.js
+++ b/core/js/jquery.ocdialog.js
@@ -73,21 +73,7 @@
 					return false;
 				}
 			});
-			$(window).resize(function() {
-				self.parent = self.$dialog.parent().length > 0 ? self.$dialog.parent() : $('body');
-				var pos = self.parent.position();
-				self.$dialog.css({
-					left: pos.left + ($(window).innerWidth() - self.$dialog.outerWidth())/2,
-					top: pos.top + ($(window).innerHeight() - self.$dialog.outerHeight())/2,
-					width: Math.min(self.options.width, $(window).innerWidth() - 20 ),
-					height: Math.min(self.options.height, $(window).innerHeight() - 20)
-				});
-				// set sizes of content
-				self._setSizes();
-			});
-
 			this._setOptions(this.options);
-			$(window).trigger('resize');
 			this._createOverlay();
 		},
 		_init: function() {
@@ -106,7 +92,6 @@
 							+ '</h3>');
 						this.$title = $title.prependTo(this.$dialog);
 					}
-					this._setSizes();
 					break;
 				case 'buttons':
 					if(this.$buttonrow) {
@@ -141,7 +126,6 @@
 							self.$buttonrow.find('button').removeClass('primary');
 							$(this).addClass('primary');
 						});
-					this._setSizes();
 					break;
 				case 'closeButton':
 					if(value) {


### PR DESCRIPTION
## Description
Replace the faulty and legacy JS code for centering and sizing the oc-dialog modals and replace it with modern CSS code.

## Related Issue
Fixes https://github.com/owncloud/enterprise/issues/2063

## How Has This Been Tested?
_Only_ visual tests in latest Firefox and Google Chrome

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

FYI: @haukman