### PR TITLE
UI tests default timeout constant and accurate timer calculations

### DIFF
--- a/tests/ui/features/bootstrap/bootstrap.php
+++ b/tests/ui/features/bootstrap/bootstrap.php
@@ -10,3 +10,6 @@ $classLoader->register();
 // Sleep for 10 milliseconds
 const STANDARDSLEEPTIMEMILLISEC = 10;
 const STANDARDSLEEPTIMEMICROSEC = STANDARDSLEEPTIMEMILLISEC * 1000;
+
+// Default timeout for use in code that needs to wait for the UI
+const STANDARDUIWAITTIMEOUTMILLISEC = 10000;

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -164,7 +164,7 @@ class FilesPage extends OwnCloudPage
 	 * @param Session $session
 	 * @param int $timeout_msec
 	 */
-	public function scrollDownAppContent ($numberOfFilesOld, Session $session, $timeout_msec=5000)
+	public function scrollDownAppContent ($numberOfFilesOld, Session $session, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
 		$session->evaluateScript(
 			'$("#' . $this->appContentId . '").scrollTop($("#' . $this->appContentId . '")[0].scrollHeight);'
@@ -172,7 +172,9 @@ class FilesPage extends OwnCloudPage
 
 		// there is no loading indicator here, so we are going to wait until we have
 		// more files than before
-		for ($counter = 0; $counter <= $timeout_msec; $counter += STANDARDSLEEPTIMEMILLISEC) {
+		$currentTime = microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
 			$this->waitForOutstandingAjaxCalls($session);
 			$fileNameSpans = $this->find("xpath", $this->fileListXpath)->findAll(
 				"xpath", $this->fileNamesXpath
@@ -181,6 +183,7 @@ class FilesPage extends OwnCloudPage
 				break;
 			}
 			usleep(STANDARDSLEEPTIMEMICROSEC);
+			$currentTime = microtime(true);
 		}
 	}
 
@@ -292,15 +295,18 @@ class FilesPage extends OwnCloudPage
 
 	//there is no reliable loading indicator on the files page, so wait for
 	//the table or the Empty Folder message to be shown
-	public function waitTillPageIsLoaded(Session $session, $timeout_msec=10000)
+	public function waitTillPageIsLoaded(Session $session, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
-		for ($counter = 0; $counter <= $timeout_msec; $counter += STANDARDSLEEPTIMEMILLISEC) {
+		$currentTime = microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
 			$fileList = $this->findById("fileList");
 			if ($fileList !== null && ($fileList->has("xpath", "//a") || ! $this->find("xpath",
 				$this->emptyContentXpath)->hasClass("hidden"))) {
 				break;
 			}
 			usleep(STANDARDSLEEPTIMEMICROSEC);
+			$currentTime = microtime(true);
 		}
 		$this->waitForOutstandingAjaxCalls($session);
 	}

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -31,9 +31,11 @@ use WebDriver\Exception as WebDriverException;
 class OwncloudPage extends Page
 {
 	protected $userNameDispayId = "expandDisplayName";
-	public function waitTillPageIsLoaded(Session $session, $timeout_msec=10000)
+	public function waitTillPageIsLoaded(Session $session, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
-		for ($counter = 0; $counter <= $timeout_msec; $counter += STANDARDSLEEPTIMEMILLISEC) {
+		$currentTime = microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
 			$loadingIndicator=$this->find("css", '.loading');
 			$visibility = $this->elementHasCSSValue(
 				$loadingIndicator, 'visibility', 'visible'
@@ -42,6 +44,7 @@ class OwncloudPage extends Page
 				break;
 			}
 			usleep(STANDARDSLEEPTIMEMICROSEC);
+			$currentTime = microtime(true);
 		}
 		$this->waitForOutstandingAjaxCalls($session);
 	}
@@ -51,9 +54,11 @@ class OwncloudPage extends Page
 	 * @param string $xpath
 	 * @param int $timeout_msec
 	 */
-	public function waitTillElementIsNull ($xpath, $timeout_msec=10000)
+	public function waitTillElementIsNull ($xpath, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
-		for ($counter = 0; $counter <= $timeout_msec; $counter += STANDARDSLEEPTIMEMILLISEC) {
+		$currentTime = microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
 			try {
 				$element = $this->find("xpath",$xpath);
 			} catch (WebDriverException $e) {
@@ -63,6 +68,7 @@ class OwncloudPage extends Page
 				break;
 			}
 			usleep(STANDARDSLEEPTIMEMICROSEC);
+			$currentTime = microtime(true);
 		}
 	}
 
@@ -71,9 +77,11 @@ class OwncloudPage extends Page
 	 * @param string $xpath
 	 * @param int $timeout_msec
 	 */
-	public function waitTillElementIsNotNull ($xpath, $timeout_msec=10000)
+	public function waitTillElementIsNotNull ($xpath, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
-		for ($counter = 0; $counter <= $timeout_msec; $counter += STANDARDSLEEPTIMEMILLISEC) {
+		$currentTime = microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
 			try {
 				$element = $this->find("xpath",$xpath);
 				if ($element === null || !$element->isValid()) {
@@ -83,6 +91,7 @@ class OwncloudPage extends Page
 				}
 			} catch (WebDriverException $e) {
 				usleep(STANDARDSLEEPTIMEMICROSEC);
+				$currentTime = microtime(true);
 			}
 		}
 	}
@@ -144,7 +153,7 @@ class OwncloudPage extends Page
 	 * @param number $timeout_msec
 	 * @throws \Exception
 	 */
-	public function waitForOutstandingAjaxCalls (Session $session, $timeout_msec=5000)
+	public function waitForOutstandingAjaxCalls (Session $session, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
 		$timeout_msec = (int) $timeout_msec;
 		if ($timeout_msec <= 0) {
@@ -203,7 +212,7 @@ class OwncloudPage extends Page
 	 * @param Session $session
 	 * @param int $timeout_msec
 	 */
-	public function waitForAjaxCallsToStartAndFinish (Session $session, $timeout_msec=5000)
+	public function waitForAjaxCallsToStartAndFinish (Session $session, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
 		$start = microtime(true);
 		$this->waitForAjaxCallsToStart($session);

--- a/tests/ui/features/lib/SharingDialog.php
+++ b/tests/ui/features/lib/SharingDialog.php
@@ -61,7 +61,7 @@ class SharingDialog extends OwnCloudPage
 	 * @return \Behat\Mink\Element\NodeElement AutocompleteElement
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 */
-	public function fillShareWithField ($input, Session $session, $timeout_msec = 10000)
+	public function fillShareWithField ($input, Session $session, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC)
 	{
 		$shareWithField = $this->_findShareWithField();
 		$shareWithField->setValue($input);


### PR DESCRIPTION
Signed-off-by: Phil Davis <phil@jankaritech.com>

## Description
1) Use a constant for the default timeout of functions that wait for something to complete in the browser.
2) Set this to 10 seconds (10000msec) - there was actually no good reason that some places used 5000msec and others 10000msec.
3) Implement code to more accurately calculate and compare the timeout end time against the current time in remaining places that should have it. (This was done already in some places by another PR)

## Related Issue
#27858 

## Motivation and Context
1) Clean up repeated use of magic numbers 5000 and 10000.
2) Make timeouts on page-loading-type more accurately reflect the specified timeout.

## How Has This Been Tested?
Manual run of the tests, and running in a separate repo with Travis/Saucelabs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

