### PR TITLE
[Stable10] fix trashbin mimetypes

### DIFF
--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -114,6 +114,7 @@ class Helper {
 			$entry['id'] = $id++;
 			$entry['etag'] = $entry['mtime']; // add fake etag, it is only needed to identify the preview image
 			$entry['permissions'] = \OCP\Constants::PERMISSION_READ;
+			$entry['mimetype'] = \OC::$server->getMimeTypeDetector()->detectPath($entry['name']);
 			$files[] = $entry;
 		}
 		return $files;


### PR DESCRIPTION
Backport of #28091

## Related Issue
Fixes https://github.com/owncloud/core/issues/27932

## Motivation and Context
Any trashbin item has a mimetype "application/octet-stream"

## How Has This Been Tested?
By deleting  items with a preview / browsing into trashbin

stable10: No preview in trashbin
this branch: There is a preview in trashbin
