### PR TITLE
Fix new DAV quota check target path

### DIFF
--- a/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
@@ -28,6 +28,8 @@ use OCP\Files\StorageNotAvailableException;
 use Sabre\DAV\Exception\InsufficientStorage;
 use Sabre\DAV\Exception\ServiceUnavailable;
 use Sabre\HTTP\URLUtil;
+use OCA\DAV\Upload\FutureFile;
+use Sabre\DAV\INode;
 
 /**
  * This plugin check user quota and deny creating files when they exceeds the quota.
@@ -50,11 +52,14 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 	 */
 	private $server;
 
+	private $newDavEndpoint;
+
 	/**
 	 * @param \OC\Files\View $view
 	 */
-	public function __construct($view) {
+	public function __construct($view, $newDavEndpoint = false) {
 		$this->view = $view;
+		$this->newDavEndpoint = $newDavEndpoint;
 	}
 
 	/**
@@ -72,22 +77,81 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 
 		$this->server = $server;
 
-		$server->on('beforeWriteContent', [$this, 'checkQuota'], 10);
-		$server->on('beforeCreateFile', [$this, 'checkQuota'], 10);
+		$server->on('beforeWriteContent', [$this, 'handleBeforeWriteContent'], 10);
+		$server->on('beforeCreateFile', [$this, 'handleBeforeCreateFile'], 10);
+		if ($this->newDavEndpoint) {
+			$server->on('beforeMove', [$this, 'handleBeforeMove'], 10);
+		}
+	}
+
+	/**
+	 * Check if we're moving a Futurefile in which case we need to check
+	 * the quota on the target destination.
+	 *
+	 * @param string $source source path
+	 * @param string $destination destination path
+	 */
+	public function handleBeforeMove($source, $destination) {
+		$sourceNode = $this->server->tree->getNodeForPath($source);
+		if (!$sourceNode instanceof FutureFile) {
+			return;
+		}
+
+		return $this->checkQuota($destination, $sourceNode->getSize());
+	}
+
+	/**
+	 * Check quota before writing content
+	 *
+	 * @param string $uri target file URI
+	 * @param INode $node Sabre Node
+	 * @param resource $data data
+	 * @param bool $modified modified
+	 */
+	public function handleBeforeWriteContent($uri, $node, $data, $modified) {
+		return $this->checkQuota($uri);
+	}
+
+	/**
+	 * Check quota before creating file
+	 *
+	 * @param string $uri target file URI
+	 * @param resource $data data
+	 * @param INode $parent Sabre Node
+	 * @param bool $modified modified
+	 */
+	public function handleBeforeCreateFile($uri, $data, $parent, $modified) {
+		return $this->checkQuota($uri);
 	}
 
 	/**
 	 * This method is called before any HTTP method and validates there is enough free space to store the file
 	 *
 	 * @param string $uri
+	 * @param int $length size to check whether it fits
 	 * @throws InsufficientStorage
 	 * @return bool
 	 */
-	public function checkQuota($uri) {
-		$length = $this->getLength();
+	public function checkQuota($uri, $length = null) {
+		if ($length === null) {
+			$length = $this->getLength();
+		}
 		if ($length) {
+			// TODO: should really use the getNodeForPath() and the node instead...
 			if (substr($uri, 0, 1) !== '/') {
 				$uri = '/' . $uri;
+			}
+			if ($this->newDavEndpoint) {
+				// need to remove the prefix "/files/$user"
+				// note: duplicate slashes have been taken care of by Sabre already
+				$uri = explode('/', trim($uri, '/'));
+				if (count($uri) < 2 || $uri[0] !== 'files') {
+					// not the "files" endpoint
+					return;
+				}
+				array_shift($uri);
+				array_shift($uri);
+				$uri = '/' . implode('/', $uri);
 			}
 			list($parentUri, $newName) = URLUtil::splitPath($uri);
 			if(is_null($parentUri)) {

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -179,7 +179,7 @@ class Server {
 				);
 				if (!is_null($view)) {
 					$this->server->addPlugin(
-						new QuotaPlugin($view, true));
+						new QuotaPlugin($view));
 				}
 				$this->server->addPlugin(
 					new TagsPlugin(

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -179,7 +179,7 @@ class Server {
 				);
 				if (!is_null($view)) {
 					$this->server->addPlugin(
-						new QuotaPlugin($view));
+						new QuotaPlugin($view, true));
 				}
 				$this->server->addPlugin(
 					new TagsPlugin(

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -4,6 +4,7 @@ use GuzzleHttp\Client as GClient;
 use GuzzleHttp\Message\ResponseInterface;
 use Sabre\DAV\Client as SClient;
 use Sabre\DAV\Xml\Property\ResourceType;
+use GuzzleHttp\Exception\ServerException;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
@@ -17,6 +18,8 @@ trait WebDav {
 	private $usingOldDavPath = true;
 	/** @var ResponseInterface */
 	private $response;
+	/** @var ResponseInterface[] */
+	private $uploadResponses;
 	/** @var map with user as key and another map as value, which has path as key and etag as value */
 	private $storedETAG = NULL;
 	/** @var integer */
@@ -568,14 +571,164 @@ trait WebDav {
 	 * @param string $source
 	 * @param string $destination
 	 */
-	public function userUploadsAFileTo($user, $source, $destination)
-	{
+	public function userUploadsAFileTo($user, $source, $destination) {
 		$file = \GuzzleHttp\Stream\Stream::factory(fopen($source, 'r'));
 		try {
 			$this->response = $this->makeDavRequest($user, "PUT", $destination, [], $file);
 		} catch (\GuzzleHttp\Exception\BadResponseException $e) {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
+		}
+	}
+
+	/**
+	 * @When User :user uploads file :source to :destination with chunks
+	 * @param string $user
+	 * @param string $source
+	 * @param string $destination
+	 * @param string $chunkingVersion null for autodetect, "old" with old style, "new" for new style
+	 */
+	public function userUploadsAFileToWithChunks($user, $source, $destination, $chunkingVersion = null) {
+		$size = filesize($source);
+		$contents = file_get_contents($source);
+
+		// use two chunks for the sake of testing
+		$chunks = [];
+		$chunks[] = substr($contents, 0, $size / 2);
+		$chunks[] = substr($contents, $size / 2);
+
+		$this->uploadChunks($user, $chunks, $destination, $chunkingVersion);
+	}
+
+	public function uploadChunks($user, $chunks, $destination, $chunkingVersion = null) {
+		if ($chunkingVersion === null) {
+			if ($this->usingOldDavPath) {
+				$chunkingVersion = 'old';
+			} else {
+				$chunkingVersion = 'new';
+			}
+		}
+		if ($chunkingVersion === 'old') {
+			foreach ($chunks as $index => $chunk) {
+				$this->userUploadsChunkedFile($user, $index + 1, count($chunks), $chunk, $destination);
+			}
+		} else {
+			$id = 'chunking-43';
+			$this->userCreatesANewChunkingUploadWithId($user, $id);
+			foreach ($chunks as $index => $chunk) {
+				$this->userUploadsNewChunkFileOfWithToId($user, $index + 1, $chunk, $id);
+			}
+			$this->userMovesNewChunkFileWithIdToMychunkedfile($user, $id, $destination);
+		}
+	}
+
+	/**
+	 * Uploading with old/new dav and chunked/non-chunked.
+	 *
+	 * @When User :user uploads file :source to :destination with all mechanisms
+	 * @param string $user
+	 * @param string $source
+	 * @param string $destination
+	 */
+	public function userUploadsAFileToWithAllMechanisms($user, $source, $destination) {
+		$this->uploadResponses = $this->uploadWithAllMechanisms($user, $source, $destination, false); 
+	}
+
+	/**
+	 * Overwriting with old/new dav and chunked/non-chunked.
+	 *
+	 * @When User :user overwrites file :source to :destination with all mechanisms
+	 * @param string $user
+	 * @param string $source
+	 * @param string $destination
+	 */
+	public function userOverwritesAFileToWithAllMechanisms($user, $source, $destination) {
+		$this->uploadResponses = $this->uploadWithAllMechanisms($user, $source, $destination, true); 
+	}
+
+	/**
+	 * Upload the same file multiple times with different mechanisms.
+	 *
+	 * @param string $user user who uploads
+	 * @param string $source source file path
+	 * @param string $destination destination path on the server
+	 * @param bool $overwriteMode when false creates separate files to test uploading brand new files,
+	 * when true it just overwrites the same file over and over again with the same name
+	 */
+	public function uploadWithAllMechanisms($user, $source, $destination, $overwriteMode = false) {
+		$responses = [];
+		foreach (['old', 'new'] as $dav) {
+			if ($dav === 'old') {
+				$this->usingOldDavPath();
+			} else {
+				$this->usingNewDavPath();
+			}
+
+			$suffix = '';
+
+			// regular upload
+			try {
+				if (!$overwriteMode) {
+					$suffix = '-' . $dav . 'dav-regular';
+				}
+				$this->userUploadsAFileTo($user, $source, $destination . $suffix);
+				$responses[] = $this->response;
+			} catch (ServerException $e) {
+				$responses[] = $e->getResponse();
+			}
+
+			// old chunking upload
+			if ($dav === 'old') {
+				if (!$overwriteMode) {
+					$suffix = '-' . $dav . 'dav-oldchunking';
+				}
+				try {
+					$this->userUploadsAFileToWithChunks($user, $source, $destination . $suffix, 'old');
+					$responses[] = $this->response;
+				} catch (ServerException $e) {
+					$responses[] = $e->getResponse();
+				}
+			}
+			if ($dav === 'new') {
+				// old chunking style applied to new endpoint 🙈
+				if (!$overwriteMode) {
+					$suffix = '-' . $dav . 'dav-oldchunking';
+				}
+				try {
+					// FIXME: prepending new dav path because the chunking utility functions are messed up
+					$this->userUploadsAFileToWithChunks($user, $source, '/files/' . $user . '/' . ltrim($destination, '/') . $suffix, 'old');
+					$responses[] = $this->response;
+				} catch (ServerException $e) {
+					$responses[] = $e->getResponse();
+				}
+
+				// new chunking style applied to new endpoint
+				if (!$overwriteMode) {
+					$suffix = '-' . $dav . 'dav-newchunking';
+				}
+				try {
+					$this->userUploadsAFileToWithChunks($user, $source, $destination . $suffix, 'new');
+					$responses[] = $this->response;
+				} catch (ServerException $e) {
+					$responses[] = $e->getResponse();
+				}
+			}
+		}
+
+		return $responses;
+	}
+
+	/**
+	 * @Then /^the HTTP status code of all upload responses should be "([^"]*)"$/
+	 * @param int $statusCode
+	 */
+	public function theHTTPStatusCodeOfAllUploadResponsesShouldBe($statusCode) {
+		foreach ($this->uploadResponses as $response) {
+			PHPUnit_Framework_Assert::assertEquals(
+				$statusCode,
+				$response->getStatusCode(),
+				'Response for ' . $response->getEffectiveUrl() . ' did not return expected status code'
+			);
 		}
 	}
 
@@ -680,6 +833,8 @@ trait WebDav {
 	}
 
 	/**
+	 * Old style chunking upload
+	 *
 	 * @Given user :user uploads chunk file :num of :total with :data to :destination
 	 * @param string $user
 	 * @param int $num
@@ -742,7 +897,7 @@ trait WebDav {
 	{
 		$source = '/uploads/' . $user . '/' . $id . '/.file';
 		$destination = substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user) . $dest;
-		$this->makeDavRequest($user, 'MOVE', $source, [
+		$this->response = $this->makeDavRequest($user, 'MOVE', $source, [
 			'Destination' => $destination
 		], null, "uploads");
 	}

--- a/tests/integration/features/checksums.feature
+++ b/tests/integration/features/checksums.feature
@@ -148,8 +148,6 @@ Feature: checksums
     And user "user0" creates a new chunking upload with id "chunking-42"
     And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
     And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" with checksum "SHA1:f005ba11"
-    And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
-    And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt"
     Then the HTTP status code should be "400"
 
   Scenario: Upload a file where checksum does not match

--- a/tests/integration/features/quota.feature
+++ b/tests/integration/features/quota.feature
@@ -1,0 +1,133 @@
+Feature: quota
+	Background:
+		Given using api version "1"
+
+	# Owner
+
+	Scenario: Uploading a file as owner having enough quota
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user0" has a quota of "10 MB"
+		When User "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms
+		Then the HTTP status code of all upload responses should be "201"
+
+	Scenario: Uploading a file as owner having insufficient quota
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user0" has a quota of "20 B"
+		When User "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms
+		Then the HTTP status code of all upload responses should be "507"
+		And as "user0" the file "/testquota.txt" does not exist
+
+	Scenario: Overwriting a file as owner having enough quota
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user0" has a quota of "10 MB"
+		And User "user0" uploads file with content "test" to "/testquota.txt"
+		When User "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms
+		Then the HTTP status code of all upload responses should be "204"
+
+	Scenario: Overwriting a file as owner having insufficient quota
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user0" has a quota of "20 B"
+		And User "user0" uploads file with content "test" to "/testquota.txt"
+		When User "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms
+		Then the HTTP status code of all upload responses should be "507"
+		And as "user0" the file "/testquota.txt" does not exist
+
+	# Received shared folder
+
+	Scenario: Uploading a file in received folder having enough quota
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user1" exists
+		And user "user0" has a quota of "20 B"
+		And user "user1" has a quota of "10 MB"
+		And As an "user1"
+		And user "user1" created a folder "/testquota"
+		And folder "/testquota" of user "user1" is shared with user "user0" with permissions 31
+		And As an "user0"
+		When User "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms
+		Then the HTTP status code of all upload responses should be "201"
+
+	Scenario: Uploading a file in received folder having insufficient quota
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user1" exists
+		And user "user0" has a quota of "10 MB"
+		And user "user1" has a quota of "20 B"
+		And As an "user1"
+		And user "user1" created a folder "/testquota"
+		And folder "/testquota" of user "user1" is shared with user "user0" with permissions 31
+		And As an "user0"
+		When User "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms
+		Then the HTTP status code of all upload responses should be "507"
+		And as "user0" the file "/testquota/testquota.txt" does not exist
+
+	Scenario: Overwriting a file in received folder having enough quota
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user1" exists
+		And user "user0" has a quota of "20 B"
+		And user "user1" has a quota of "10 MB"
+		And As an "user1"
+		And user "user1" created a folder "/testquota"
+		And User "user1" uploads file with content "test" to "/testquota/testquota.txt"
+		And folder "/testquota" of user "user1" is shared with user "user0" with permissions 31
+		And As an "user0"
+		When User "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms
+		Then the HTTP status code of all upload responses should be "204"
+
+	Scenario: Overwriting a file in received folder having insufficient quota
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user1" exists
+		And user "user0" has a quota of "10 MB"
+		And user "user1" has a quota of "20 B"
+		And As an "user1"
+		And user "user1" created a folder "/testquota"
+		And User "user1" uploads file with content "test" to "/testquota/testquota.txt"
+		And folder "/testquota" of user "user1" is shared with user "user0" with permissions 31
+		And As an "user0"
+		When User "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms
+		Then the HTTP status code of all upload responses should be "507"
+		And as "user0" the file "/testquota/testquota.txt" does not exist
+
+	# Received shared file
+
+	Scenario: Overwriting a received file having enough quota
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user1" exists
+		And user "user0" has a quota of "20 B"
+		And user "user1" has a quota of "10 MB"
+		And As an "user1"
+		And User "user1" uploads file with content "test" to "/testquota.txt"
+		And file "/testquota.txt" of user "user1" is shared with user "user0" with permissions 19
+		And As an "user0"
+		When User "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms
+		Then the HTTP status code of all upload responses should be "204"
+
+	Scenario: Overwriting a received file having insufficient quota
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user1" exists
+		And user "user0" has a quota of "10 MB"
+		And user "user1" has a quota of "20 B"
+		And As an "user1"
+		And User "user1" moves file "/textfile0.txt" to "/testquota.txt"
+		And file "/testquota.txt" of user "user1" is shared with user "user0" with permissions 19
+		When User "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms
+		Then the HTTP status code of all upload responses should be "507"
+

--- a/tests/integration/features/webdav-related-new-endpoint.feature
+++ b/tests/integration/features/webdav-related-new-endpoint.feature
@@ -124,14 +124,6 @@ Feature: webdav-related-new-endpoint
 		When Downloading file "/welcome.txt" with range "bytes=51-77"
 		Then Downloaded content should be "example file for developers"
 
-	Scenario: Upload forbidden if quota is 0
-		Given using new dav path
-		And As an "admin"
-		And user "user0" exists
-		And user "user0" has a quota of "0"
-		When User "user0" uploads file "data/textfile.txt" to "/asdf.txt"
-		Then the HTTP status code should be "507"
-
 	Scenario: Retrieving folder quota when no quota is set
 		Given using new dav path
 		And As an "admin"
@@ -167,24 +159,6 @@ Feature: webdav-related-new-endpoint
 		Then as "user0" gets properties of folder "/testquota" with
 		  |{DAV:}quota-available-bytes|
 		And the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
-
-	Scenario: Uploading a file as recipient using webdav having quota
-		Given using new dav path
-		And As an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" has a quota of "10 MB"
-		And user "user1" has a quota of "10 MB"
-		And As an "user1"
-		And user "user1" created a folder "/testquota"
-		And as "user1" creating a share with
-		  | path | testquota |
-		  | shareType | 0 |
-		  | permissions | 31 |
-		  | shareWith | user0 |
-		And As an "user0"
-		When User "user0" uploads file "data/textfile.txt" to "/testquota/asdf.txt"
-		Then the HTTP status code should be "201"
 
 	Scenario: Retrieving folder quota when quota is set and a file was uploaded
 		Given using new dav path
@@ -428,33 +402,6 @@ Feature: webdav-related-new-endpoint
 		Given Logging in using web as "admin"
 		When Sending a "PROPFIND" to "/remote.php/dav/files/admin/welcome.txt" with requesttoken
 		Then the HTTP status code should be "207"
-
-	Scenario: Uploading a file having 0B as quota
-		Given using new dav path
-		And As an "admin"
-		And user "user0" exists
-		And user "user0" has a quota of "0 B"
-		And As an "user0"
-		When User "user0" uploads file "data/textfile.txt" to "/asdf.txt"
-		Then the HTTP status code should be "507"
-
-	Scenario: Uploading a file as recipient using webdav new endpoint having quota
-		Given using new dav path
-		And As an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" has a quota of "10 MB"
-		And user "user1" has a quota of "10 MB"
-		And As an "user1"
-		And user "user1" created a folder "/testquota"
-		And as "user1" creating a share with
-		  | path | testquota |
-		  | shareType | 0 |
-		  | permissions | 31 |
-		  | shareWith | user0 |
-		And As an "user0"
-		When User "user0" uploads file "data/textfile.txt" to "/testquota/asdf.txt"
-		Then the HTTP status code should be "201"
 
 	Scenario: Setting custom DAV property and reading it
 		Given using new dav path

--- a/tests/integration/features/webdav-related-old-endpoint.feature
+++ b/tests/integration/features/webdav-related-old-endpoint.feature
@@ -124,14 +124,6 @@ Feature: webdav-related-old-endpoint
 		When Downloading file "/welcome.txt" with range "bytes=51-77"
 		Then Downloaded content should be "example file for developers"
 
-	Scenario: Upload forbidden if quota is 0
-		Given using old dav path
-		And As an "admin"
-		And user "user0" exists
-		And user "user0" has a quota of "0"
-		When User "user0" uploads file "data/textfile.txt" to "/asdf.txt"
-		Then the HTTP status code should be "507"
-
 	Scenario: Retrieving folder quota when no quota is set
 		Given using old dav path
 		And As an "admin"
@@ -167,24 +159,6 @@ Feature: webdav-related-old-endpoint
 		Then as "user0" gets properties of folder "/testquota" with
 		  |{DAV:}quota-available-bytes|
 		And the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
-
-	Scenario: Uploading a file as recipient using webdav having quota
-		Given using old dav path
-		And As an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" has a quota of "10 MB"
-		And user "user1" has a quota of "10 MB"
-		And As an "user1"
-		And user "user1" created a folder "/testquota"
-		And as "user1" creating a share with
-		  | path | testquota |
-		  | shareType | 0 |
-		  | permissions | 31 |
-		  | shareWith | user0 |
-		And As an "user0"
-		When User "user0" uploads file "data/textfile.txt" to "/testquota/asdf.txt"
-		Then the HTTP status code should be "201"
 
 	Scenario: Retrieving folder quota when quota is set and a file was uploaded
 		Given using old dav path


### PR DESCRIPTION
## Description
Fixes the following:
- use correct actual path in `QuotaPlugin` when coming from the new DAV endpoint
- add quota check when moving FutureFile using chunked upload to new DAV endpoint

Also adds quota test hypercube to make sure we didn't forget anything, from https://github.com/owncloud/QA/issues/461

## Related Issue
Fixes https://github.com/owncloud/core/issues/28159
Fixes https://github.com/owncloud/QA/issues/461

## Motivation and Context
One **must not** be able to bypass quotas

## How Has This Been Tested?
Automated tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODO:
- [x] integration tests (test first!)
- [ ] the actual fix

cc @SergioBertolinSG 