### PR TITLE
Add header handing in ocs controllers

### DIFF
--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -32,6 +32,7 @@
 
 namespace OCP\AppFramework;
 
+use OC\OCS\Result;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\OCSResponse;
 use OCP\AppFramework\Http\Response;
@@ -81,6 +82,11 @@ abstract class OCSController extends ApiController {
 	 * @since 8.1.0
 	 */
 	private function buildOCSResponse($format, $data) {
+		if ($data instanceof Result) {
+			$headers = $data->getHeaders();
+			$data = $data->getMeta();
+			$data['headers'] = $headers;
+		}
 		if ($data instanceof DataResponse) {
 			$data = $data->getData();
 		}
@@ -97,11 +103,18 @@ abstract class OCSController extends ApiController {
 			$params[$key] = $value;
 		}
 
-		return new OCSResponse(
+		$resp = new OCSResponse(
 			$format, $params['statuscode'],
 			$params['message'], $params['data'],
 			$params['itemscount'], $params['itemsperpage']
 		);
+		if (isset($data['headers'])) {
+			foreach ($data['headers'] as $key => $value) {
+				$resp->addHeader($key, $value);
+			}
+		}
+
+		return $resp;
 	}
 
 	/**


### PR DESCRIPTION
## Description
Old OCS result did allow to set http headers in the response.
The app framework approach did not allow this.

## Motivation and Context
Allow moving to app framework approach - e.g. in notifications app

## How Has This Been Tested?
With a modified notifications app ...

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

