### PR TITLE
Add public interface for managing sub admins

### DIFF
--- a/lib/private/SubAdmin.php
+++ b/lib/private/SubAdmin.php
@@ -32,8 +32,9 @@ use OCP\IUserManager;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IDBConnection;
+use OCP\ISubAdminManager;
 
-class SubAdmin extends PublicEmitter {
+class SubAdmin extends PublicEmitter implements ISubAdminManager {
 
 	/** @var IUserManager */
 	private $userManager;

--- a/lib/public/IGroupManager.php
+++ b/lib/public/IGroupManager.php
@@ -151,4 +151,13 @@ interface IGroupManager {
 	 * @since 8.0.0
 	 */
 	public function isInGroup($userId, $group);
+
+	/**
+	 * Returns the sub admin manager
+	 *
+	 * @since 10.1.0
+	 * @return ISubAdminManager
+	 */
+	public function getSubAdmin();
 }
+

--- a/lib/public/ISubAdminManager.php
+++ b/lib/public/ISubAdminManager.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP;
+
+use OCP\IUser;
+use OCP\IGroup;
+
+/**
+ * Sub admin manager
+ *
+ * @since 10.1.0
+ */
+interface ISubAdminManager {
+
+	/**
+	 * Make the given user a SubAdmin of the given group.
+	 *
+	 * @param IUser $user user to be SubAdmin
+	 * @param IGroup $group group $user becomes subadmin of
+	 * @return bool true if success, false otherwise
+ 	 * @since 10.1.0
+	 */
+	public function createSubAdmin(IUser $user, IGroup $group);
+
+	/**
+	 * Remove subadmin permission of the given user for the given group.
+	 *
+	 * @param IUser $user the user that is the SubAdmin
+	 * @param IGroup $group the group
+	 * @return bool true if success, false otherwise
+ 	 * @since 10.1.0
+	 */
+	public function deleteSubAdmin(IUser $user, IGroup $group);
+
+	/**
+	 * Returns groups managed by the given subadmin
+	 * @param IUser $user the SubAdmin
+	 * @return IGroup[] list of groups
+ 	 * @since 10.1.0
+	 */
+	public function getSubAdminsGroups(IUser $user);
+
+	/**
+	 * Returns SubAdmins of a group
+	 *
+	 * @param IGroup $group the group
+	 * @return IUser[] list of users who are subadmin
+ 	 * @since 10.1.0
+	 */
+	public function getGroupsSubAdmins(IGroup $group);
+
+	/**
+	 * Returns all SubAdmins
+	 *
+	 * @return array list of subadmin users
+ 	 * @since 10.1.0
+	 */
+	public function getAllSubAdmins();
+
+	/**
+	 * Checks whether a user is a SubAdmin of the given group
+	 *
+	 * @param IUser $user user to check
+	 * @param IGroup $group group to check
+	 * @return bool true if the given user is a subadmin of the group, false otherwise
+ 	 * @since 10.1.0
+	 */
+	public function isSubAdminofGroup(IUser $user, IGroup $group);
+
+	/**
+	 * Checks whether a user is a of at least one group
+	 *
+	 * @param IUser $user 
+	 * @return bool true if the given user is subadmin of at least one group, false otherwise
+ 	 * @since 10.1.0
+	 */
+	public function isSubAdmin(IUser $user);
+
+	/**
+	 * Checks whether a user is a accessible by a subadmin
+	 *
+	 * @param IUser $subadmin subadmin user
+	 * @param IUser $user user to check
+	 * @return bool true if accessible, false otherwise
+ 	 * @since 10.1.0
+	 */
+	public function isUserAccessible($subadmin, $user);
+}


### PR DESCRIPTION
## Description
Declare public interface for SubAdmin private class.

## Related Issue
None raised.

## Motivation and Context
Useful for some apps to provide subadmin specific functionality.
Required for custom groups enhancement: https://github.com/owncloud/customgroups/pull/70

## How Has This Been Tested?
Users page still works.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Note: I kept calling it `IGroupManager::getSubAdmin` because that's what it was called before instead of renaming the function to `getSubAdminManager` to avoid breaking old code that uses this private API.

@DeepDiver1975 @butonic @jvillafanez 