### PR TITLE
Add inactive user command

### DIFF
--- a/core/Command/User/Inactive.php
+++ b/core/Command/User/Inactive.php
@@ -55,15 +55,17 @@ class Inactive extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$days = $input->getArgument('days');
-		if($days < 1) {
-			throw new InvalidArgumentException('Days must be above zero');
+		if(!is_int($days) || $days < 1) {
+			throw new InvalidArgumentException('Days must be integer and above zero');
 		}
 
+		$now = time();
+
 		$inactive = [];
-		$this->userManager->callForSeenUsers(function(IUser $user) use (&$inactive, $days) {
+		$this->userManager->callForSeenUsers(function(IUser $user) use (&$inactive, $days, $now) {
 			$lastLogin = $user->getLastLogin();
 			// Difference between now and last login, into days, and rounded down
-			$daysSinceLastLogin = floor((time() - $lastLogin) / (60*60*24));
+			$daysSinceLastLogin = floor(($now - $lastLogin) / (60*60*24));
 			if($daysSinceLastLogin >= $days) {
 				$inactive[] = [
 					'uid' => $user->getUID(),

--- a/core/Command/User/Inactive.php
+++ b/core/Command/User/Inactive.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\User;
+
+use OC\Core\Command\Base;
+use OCP\IUser;
+use OCP\IUserManager;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Inactive extends Base {
+	/** @var \OCP\IUserManager */
+	protected $userManager;
+
+	/**
+	 * @param IUserManager $userManager
+	 */
+	public function __construct(IUserManager $userManager) {
+		parent::__construct();
+		$this->userManager = $userManager;
+	}
+
+	protected function configure() {
+		$this
+			->setName('user:inactive')
+			->setDescription('reports users who are known to owncloud, but have not logged in for a certain number of days')
+			->addArgument(
+				'days',
+				InputArgument::REQUIRED,
+				'Integer number of days that the user has not logged in since'
+			);
+		parent::configure();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$days = $input->getArgument('days');
+		if($days < 1) {
+			throw new InvalidArgumentException('Days must be above zero');
+		}
+
+		$inactive = [];
+		$this->userManager->callForSeenUsers(function(IUser $user) use (&$inactive, $days) {
+			$lastLogin = $user->getLastLogin();
+			// Difference between now and last login, into days, and rounded down
+			$daysSinceLastLogin = floor((time() - $lastLogin) / (60*60*24));
+			if($daysSinceLastLogin >= $days) {
+				$inactive[] = [
+					'uid' => $user->getUID(),
+					'displayName' => $user->getDisplayName(),
+					'inactiveSinceDays' => $daysSinceLastLogin
+				];
+			}
+		});
+
+		$this->writeArrayInOutputFormat($input, $output, $inactive);
+
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -144,6 +144,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig(), \OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\User\SyncBackend(\OC::$server->getAccountMapper(), \OC::$server->getConfig(), \OC::$server->getUserManager(), \OC::$server->getLogger()));
+	$application->add(new \OC\Core\Command\User\Inactive(\OC::$server->getUserManager()));
 
 	$application->add(new OC\Core\Command\Security\ListCertificates(\OC::$server->getCertificateManager(null), \OC::$server->getL10N('core')));
 	$application->add(new OC\Core\Command\Security\ImportCertificate(\OC::$server->getCertificateManager(null)));

--- a/tests/Core/Command/User/InactiveTest.php
+++ b/tests/Core/Command/User/InactiveTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\User;
+
+use OC\Core\Command\Base;
+use OC\Core\Command\User\Inactive;
+use OCP\IUser;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Test\TestCase;
+
+class InactiveTest extends TestCase {
+
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $userManager;
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $consoleInput;
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $consoleOutput;
+
+	/** @var \Symfony\Component\Console\Command\Command */
+	protected $command;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$userManager = $this->userManager = $this->getMockBuilder('OCP\IUserManager')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->consoleInput = $this->createMock('Symfony\Component\Console\Input\InputInterface');
+		$this->consoleOutput = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
+
+		/** @var \OCP\IUserManager $userManager */
+		$this->command = new Inactive($userManager);
+	}
+
+	public function invalidDays() {
+		return [
+			[0],
+			['test'],
+			[-1]
+		];
+	}
+
+	/**
+	 * @dataProvider invalidDays
+	 */
+	public function testWithInvalidDays($days) {
+		$this->consoleInput->expects($this->once())
+			->method('getArgument')
+			->with('days')
+			->willReturn($days);
+
+		$this->expectException(InvalidArgumentException::class);
+
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+
+	public function testWithValidDays() {
+		$this->consoleInput->expects($this->once())
+			->method('getArgument')
+			->with('days')
+			->willReturn(1);
+
+		// Work with json output
+		$this->consoleInput->expects($this->once())
+			->method('getOption')
+			->with('output')
+			->willReturn(Base::OUTPUT_FORMAT_JSON);
+
+		$this->userManager->expects($this->once())
+			->method('callForSeenUsers');
+
+		$this->consoleOutput->expects($this->once())
+			->method('writeLn')
+			->with($this->stringContains('['));
+
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Allows admins to retrieve a parsable list of users that have been seen at least once, but have been inactive for a certain amount of days (no login since then). Scriptable because json output is supported with `--output-json`.

Usage:
`./occ user:inactive 30` for all users who have no logged in for 30 days.

## Motivation and Context
Admins wanting reports on inactive users in their instances.

## How Has This Been Tested?
 - Created several users in the web UI
 - Ran the command and checked none of these users showed up
 - Altered the last_login times in the accounts table
 - Ran command and checked they appeared correctly


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

