### PR TITLE
UI tests - clear input before renaming

### DIFF
--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -62,7 +62,7 @@ class FeatureContext extends RawMinkContext implements Context
 	{
 		$notifications = $this->owncloudPage->getNotifications();
 		$tableRows=$table->getRows();
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
 			count($tableRows),
 			count($notifications)
 			);

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -280,7 +280,7 @@ class FilesPage extends OwnCloudPage
 		if ($inputField === null) {
 			throw new ElementNotFoundException("could not find input field");
 		}
-		$inputField->setValue($toFileName);
+		$this->cleanInputAndSetValue($inputField, $toFileName);
 		$inputField->blur();
 		$this->waitTillElementIsNull($this->fileBusyIndicatorXpath);
 	}

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -27,6 +27,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 use Behat\Mink\Session;
 use Behat\Mink\Element\NodeElement;
 use WebDriver\Exception as WebDriverException;
+use WebDriver\Key;
 
 class OwncloudPage extends Page
 {
@@ -244,5 +245,28 @@ class OwncloudPage extends Page
 		}
 
 		return $exists;
+	}
+	
+	/**
+	 * sends an END key and then BACKSPACEs to delete the current value
+	 * then sends the new value
+	 * checks the set value and sends the Escape key + throws an exception 
+	 * if  the value is not set corectly
+	 * 
+	 * @param NodeElement $inputField
+	 * @param string $value
+	 * @throws \Exception
+	 */
+	protected function cleanInputAndSetValue(NodeElement $inputField, $value) {
+		$resultValue = $inputField->getValue();
+		$existingValueLength = strlen($resultValue);
+		$deleteSequence = Key::END . str_repeat(Key::BACKSPACE, $existingValueLength);
+		$inputField->setValue($deleteSequence);
+		$inputField->setValue($value);
+		$resultValue = $inputField->getValue();
+		if ($resultValue !== $value) {
+			$inputField->keyUp(27); //send escape
+			throw new \Exception("value of input field is not what we expect");
+		}
 	}
 }

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -251,7 +251,7 @@ class OwncloudPage extends Page
 	 * sends an END key and then BACKSPACEs to delete the current value
 	 * then sends the new value
 	 * checks the set value and sends the Escape key + throws an exception 
-	 * if  the value is not set corectly
+	 * if the value is not set correctly
 	 * 
 	 * @param NodeElement $inputField
 	 * @param string $value


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
This PR makes sure the file name input is cleared before a new name is filled in

## Motivation and Context
In the tests sometimes the `setValue()` method does not remove the complete old value of the field but only the marked part. e.g. renaming file.txt to new-file.txt would become new-file.txt.txt
In this occasions tests fail even there is no problem in the code. I could not find out why and when its happening, seems only be a problem on Firefox. And it happens irregularly.
The only solution I found was to send an own delete-sequence and only then the real value. To make sure it works the value is double-checked and if its still wrong an exception is thrown. 

## How Has This Been Tested?
run several times on travis

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

