### PR TITLE
[stable10] Use shorter webdav.org when getting litmus tar

### DIFF
--- a/apps/dav/tests/travis/litmus-v1/install.sh
+++ b/apps/dav/tests/travis/litmus-v1/install.sh
@@ -3,7 +3,7 @@
 # compile litmus
 if [ ! -f /tmp/litmus/litmus-0.13.tar.gz ]; then
   mkdir -p /tmp/litmus
-  wget -O /tmp/litmus/litmus-0.13.tar.gz http://www.webdav.org/neon/litmus/litmus-0.13.tar.gz
+  wget -O /tmp/litmus/litmus-0.13.tar.gz http://webdav.org/neon/litmus/litmus-0.13.tar.gz
   cd /tmp/litmus
   tar -xzf litmus-0.13.tar.gz
   cd /tmp/litmus/litmus-0.13

--- a/apps/dav/tests/travis/litmus-v2/install.sh
+++ b/apps/dav/tests/travis/litmus-v2/install.sh
@@ -3,7 +3,7 @@
 # compile litmus
 if [ ! -f /tmp/litmus/litmus-0.13.tar.gz ]; then
   mkdir -p /tmp/litmus
-  wget -O /tmp/litmus/litmus-0.13.tar.gz http://www.webdav.org/neon/litmus/litmus-0.13.tar.gz
+  wget -O /tmp/litmus/litmus-0.13.tar.gz http://webdav.org/neon/litmus/litmus-0.13.tar.gz
   cd /tmp/litmus
   tar -xzf litmus-0.13.tar.gz
   cd /tmp/litmus/litmus-0.13


### PR DESCRIPTION
Signed-off-by: Phil Davis <phil@jankaritech.com>

Backport #28103 

just in case this webdav.org name resolution issue happens again, and to reduce unnecessary noise in diffs between master and stable10.