### PR TITLE
[stable10] UI tests - clear input before renaming

### DIFF
--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -62,7 +62,7 @@ class FeatureContext extends RawMinkContext implements Context
 	{
 		$notifications = $this->owncloudPage->getNotifications();
 		$tableRows=$table->getRows();
-		PHPUnit_Framework_Assert::assertEquals(
+		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
 			count($tableRows),
 			count($notifications)
 			);

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -263,7 +263,7 @@ class FilesPage extends OwnCloudPage
 		if ($inputField === null) {
 			throw new ElementNotFoundException("could not find input field");
 		}
-		$inputField->setValue($toFileName);
+		$this->cleanInputAndSetValue($inputField, $toFileName);
 		$inputField->blur();
 		$this->waitTillElementIsNull($this->fileBusyIndicatorXpath);
 	}

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -27,6 +27,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 use Behat\Mink\Session;
 use Behat\Mink\Element\NodeElement;
 use WebDriver\Exception as WebDriverException;
+use WebDriver\Key;
 
 class OwncloudPage extends Page
 {
@@ -196,5 +197,28 @@ class OwncloudPage extends Page
 		}
 
 		return $exists;
+	}
+	
+	/**
+	 * sends an END key and then BACKSPACEs to delete the current value
+	 * then sends the new value
+	 * checks the set value and sends the Escape key + throws an exception 
+	 * if  the value is not set corectly
+	 * 
+	 * @param NodeElement $inputField
+	 * @param string $value
+	 * @throws \Exception
+	 */
+	protected function cleanInputAndSetValue(NodeElement $inputField, $value) {
+		$resultValue = $inputField->getValue();
+		$existingValueLength = strlen($resultValue);
+		$deleteSequence = Key::END . str_repeat(Key::BACKSPACE, $existingValueLength);
+		$inputField->setValue($deleteSequence);
+		$inputField->setValue($value);
+		$resultValue = $inputField->getValue();
+		if ($resultValue !== $value) {
+			$inputField->keyUp(27); //send escape
+			throw new \Exception("value of input field is not what we expect");
+		}
 	}
 }

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -203,7 +203,7 @@ class OwncloudPage extends Page
 	 * sends an END key and then BACKSPACEs to delete the current value
 	 * then sends the new value
 	 * checks the set value and sends the Escape key + throws an exception 
-	 * if  the value is not set corectly
+	 * if the value is not set correctly
 	 * 
 	 * @param NodeElement $inputField
 	 * @param string $value


### PR DESCRIPTION
Backport #28175 

Makes the rename tests more reliable.