### PR TITLE
Groups for occ command and UI testing

### DIFF
--- a/core/Command/Group/Add.php
+++ b/core/Command/Group/Add.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Group;
+
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class Add extends Command {
+	/** @var \OCP\IGroupManager */
+	protected $groupManager;
+
+	/**
+	 * @param IGroupManager $groupManager
+	 */
+	public function __construct(IGroupManager $groupManager, IUserManager $userManager) {
+		parent::__construct();
+		$this->groupManager = $groupManager;
+		$this->userManager = $userManager;
+	}
+
+	protected function configure() {
+		$this
+			->setName('group:add')
+			->setDescription('adds a group')
+			->addArgument(
+				'group',
+				InputArgument::REQUIRED,
+				'Name of the group'
+			)
+			->addOption(
+				'user',
+				'u',
+				InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+				'existing users that should be added to the group'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$groupName = $input->getArgument('group');
+		$group = $this->groupManager->get($groupName);
+		if (!$group) {
+			$this->groupManager->createGroup($groupName);
+			$group = $this->groupManager->get($groupName);
+			if ($group) {
+				$output->writeln('Created group "' . $group->getGID() . '"');
+			} else {
+				$output->writeln('<error>Group "' . $groupName . '" could not be created</error>');
+				return 1;
+			}
+		} else {
+			$output->writeln('The group "' . $group->getGID() . '" already exists');
+		}
+
+		$users = $input->getOption('user');
+
+		foreach ($users as $userName) {
+			$user = $this->userManager->get($userName);
+			if ($user) {
+				if ($group->inGroup($user)) {
+					$output->writeln('User "' . $user->getUID() . '" is already a member of group "' . $group->getGID() . '"');
+				} else {
+					$group->addUser($user);
+					$output->writeln('User "' . $user->getUID() . '" added to group "' . $group->getGID() . '"');
+				}
+			} else {
+				$output->writeln('<error>User "' . $userName . '" could not be found - not added to group "' . $group->getGID() . '"</error>');
+			}
+		}
+	}
+}

--- a/core/Command/Group/AddMember.php
+++ b/core/Command/Group/AddMember.php
@@ -29,7 +29,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 
-class Add extends Command {
+class AddMember extends Command {
 	/** @var \OCP\IGroupManager */
 	protected $groupManager;
 

--- a/core/Command/Group/Delete.php
+++ b/core/Command/Group/Delete.php
@@ -55,7 +55,7 @@ class Delete extends Command {
 		$group = $this->groupManager->get($groupName);
 		if (is_null($group)) {
 			$output->writeln('<error>Group does not exist</error>');
-			return;
+			return 1;
 		}
 
 		if ($group->delete()) {
@@ -64,5 +64,6 @@ class Delete extends Command {
 		}
 
 		$output->writeln('<error>The specified group could not be deleted. Please check the logs.</error>');
+		return 1;
 	}
 }

--- a/core/Command/Group/Delete.php
+++ b/core/Command/Group/Delete.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Group;
+
+use OCP\IGroupManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class Delete extends Command {
+	/** @var IGroupManager */
+	protected $groupManager;
+
+	/**
+	 * @param IGroupManager $groupManager
+	 */
+	public function __construct(IGroupManager $groupManager) {
+		$this->groupManager = $groupManager;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('group:delete')
+			->setDescription('deletes the specified group')
+			->addArgument(
+				'group',
+				InputArgument::REQUIRED,
+				'the group name'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$groupName = $input->getArgument('group');
+		$group = $this->groupManager->get($groupName);
+		if (is_null($group)) {
+			$output->writeln('<error>Group does not exist</error>');
+			return;
+		}
+
+		if ($group->delete()) {
+			$output->writeln('<info>The specified group was deleted</info>');
+			return;
+		}
+
+		$output->writeln('<error>The specified group could not be deleted. Please check the logs.</error>');
+	}
+}

--- a/core/Command/Group/RemoveMember.php
+++ b/core/Command/Group/RemoveMember.php
@@ -22,32 +22,40 @@
 namespace OC\Core\Command\Group;
 
 use OCP\IGroupManager;
+use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 
-class Add extends Command {
+class RemoveMember extends Command {
 	/** @var \OCP\IGroupManager */
 	protected $groupManager;
 
 	/**
 	 * @param IGroupManager $groupManager
 	 */
-	public function __construct(IGroupManager $groupManager) {
+	public function __construct(IGroupManager $groupManager, IUserManager $userManager) {
 		parent::__construct();
 		$this->groupManager = $groupManager;
+		$this->userManager = $userManager;
 	}
 
 	protected function configure() {
 		$this
-			->setName('group:add')
-			->setDescription('adds a group')
+			->setName('group:removemember')
+			->setDescription('remove member(s) from a group')
 			->addArgument(
 				'group',
 				InputArgument::REQUIRED,
 				'Name of the group'
+			)
+			->addOption(
+				'member',
+				'm',
+				InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+				'member that should be removed from the group'
 			);
 	}
 
@@ -55,16 +63,35 @@ class Add extends Command {
 		$groupName = $input->getArgument('group');
 		$group = $this->groupManager->get($groupName);
 		if (!$group) {
-			$this->groupManager->createGroup($groupName);
-			$group = $this->groupManager->get($groupName);
-			if ($group) {
-				$output->writeln('<info>Created group "' . $group->getGID() . '"</info>');
+			$output->writeln('<error>Group "' . $groupName . '" does not exist</error>');
+			return 1;
+		}
+
+		$members = $input->getOption('member');
+
+		if (!count($members)) {
+			$output->writeln('<error>No members specified</error>');
+			return 1;
+		}
+
+		$memberExistsError = false;
+
+		foreach ($members as $userName) {
+			$user = $this->userManager->get($userName);
+			if ($user) {
+				if ($group->inGroup($user)) {
+					$group->removeUser($user);
+					$output->writeln('<info>Member "' . $user->getUID() . '" removed from group "' . $group->getGID() . '"</info>');
+				} else {
+					$output->writeln('<info>Member "' . $userName . '" could not be found in group "' . $group->getGID() . '"</info>');
+				}
 			} else {
-				$output->writeln('<error>Group "' . $groupName . '" could not be created</error>');
-				return 1;
+				$output->writeln('<error>Member "' . $userName . '" does not exist - not removed from group "' . $group->getGID() . '"</error>');
+				$memberExistsError = true;
 			}
-		} else {
-			$output->writeln('<error>The group "' . $group->getGID() . '" already exists</error>');
+		}
+		
+		if ($memberExistsError) {
 			return 1;
 		}
 	}

--- a/core/Command/Group/RemoveUser.php
+++ b/core/Command/Group/RemoveUser.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Group;
+
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class RemoveUser extends Command {
+	/** @var \OCP\IGroupManager */
+	protected $groupManager;
+
+	/**
+	 * @param IGroupManager $groupManager
+	 */
+	public function __construct(IGroupManager $groupManager, IUserManager $userManager) {
+		parent::__construct();
+		$this->groupManager = $groupManager;
+		$this->userManager = $userManager;
+	}
+
+	protected function configure() {
+		$this
+			->setName('group:removeuser')
+			->setDescription('remove user(s) from a group')
+			->addArgument(
+				'group',
+				InputArgument::REQUIRED,
+				'Name of the group'
+			)
+			->addOption(
+				'user',
+				'u',
+				InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+				'user that should be removed from the group'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$groupName = $input->getArgument('group');
+		$group = $this->groupManager->get($groupName);
+		if (!$group) {
+			$output->writeln('<error>Group "' . $groupName . '" does not exist</error>');
+			return 1;
+		}
+
+		$users = $input->getOption('user');
+
+		if (!count($users)) {
+			$output->writeln('<error>No users specified</error>');
+			return 1;
+		}
+
+		foreach ($users as $userName) {
+			$user = $this->userManager->get($userName);
+			if ($user) {
+				if ($group->inGroup($user)) {
+					$group->removeUser($user);
+					$output->writeln('User "' . $user->getUID() . '" removed from group "' . $group->getGID() . '"');
+				} else {
+					$output->writeln('<error>User "' . $userName . '" could not be found in group "' . $group->getGID() . '"</error>');
+				}
+			} else {
+				$output->writeln('<error>User "' . $userName . '" could not be found - not removed from group "' . $group->getGID() . '"</error>');
+			}
+		}
+	}
+}

--- a/core/Command/User/Delete.php
+++ b/core/Command/User/Delete.php
@@ -57,7 +57,7 @@ class Delete extends Command {
 		$user = $this->userManager->get($input->getArgument('uid'));
 		if (is_null($user)) {
 			$output->writeln('<error>User does not exist</error>');
-			return;
+			return 1;
 		}
 
 		if ($user->delete()) {
@@ -66,5 +66,6 @@ class Delete extends Command {
 		}
 
 		$output->writeln('<error>The specified user could not be deleted. Please check the logs.</error>');
+		return 1;
 	}
 }

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -145,9 +145,10 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig(), \OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\User\SyncBackend(\OC::$server->getAccountMapper(), \OC::$server->getConfig(), \OC::$server->getUserManager(), \OC::$server->getLogger()));
 
-	$application->add(new OC\Core\Command\Group\Add(\OC::$server->getGroupManager(), \OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\Group\Add(\OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\Group\Delete(\OC::$server->getGroupManager()));
-	$application->add(new OC\Core\Command\Group\RemoveUser(\OC::$server->getGroupManager(), \OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\Group\AddMember(\OC::$server->getGroupManager(), \OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\Group\RemoveMember(\OC::$server->getGroupManager(), \OC::$server->getUserManager()));
 
 	$application->add(new OC\Core\Command\Security\ListCertificates(\OC::$server->getCertificateManager(null), \OC::$server->getL10N('core')));
 	$application->add(new OC\Core\Command\Security\ImportCertificate(\OC::$server->getCertificateManager(null)));

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -145,6 +145,10 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig(), \OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\User\SyncBackend(\OC::$server->getAccountMapper(), \OC::$server->getConfig(), \OC::$server->getUserManager(), \OC::$server->getLogger()));
 
+	$application->add(new OC\Core\Command\Group\Add(\OC::$server->getGroupManager(), \OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\Group\Delete(\OC::$server->getGroupManager()));
+	$application->add(new OC\Core\Command\Group\RemoveUser(\OC::$server->getGroupManager(), \OC::$server->getUserManager()));
+
 	$application->add(new OC\Core\Command\Security\ListCertificates(\OC::$server->getCertificateManager(null), \OC::$server->getL10N('core')));
 	$application->add(new OC\Core\Command\Security\ImportCertificate(\OC::$server->getCertificateManager(null)));
 	$application->add(new OC\Core\Command\Security\RemoveCertificate(\OC::$server->getCertificateManager(null)));

--- a/tests/Core/Command/Group/DeleteTest.php
+++ b/tests/Core/Command/Group/DeleteTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\Group;
+
+use OC\Core\Command\Group\Delete;
+use Test\TestCase;
+
+class DeleteTest extends TestCase {
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $groupManager;
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $consoleInput;
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $consoleOutput;
+
+	/** @var \Symfony\Component\Console\Command\Command */
+	protected $command;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$groupManager = $this->groupManager = $this->getMockBuilder('OCP\IGroupManager')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->consoleInput = $this->createMock('Symfony\Component\Console\Input\InputInterface');
+		$this->consoleOutput = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
+
+		/** @var \OCP\IGroupManager $groupManager */
+		$this->command = new Delete($groupManager);
+	}
+
+
+	public function validGroupLastSeen() {
+		return [
+			[true, 'The specified group was deleted'],
+			[false, 'The specified group could not be deleted'],
+		];
+	}
+
+	/**
+	 * @dataProvider validGroupLastSeen
+	 *
+	 * @param bool $deleteSuccess
+	 * @param string $expectedString
+	 */
+	public function testValidGroup($deleteSuccess, $expectedString) {
+		$group = $this->createMock('OCP\IGroup');
+		$group->expects($this->once())
+			->method('delete')
+			->willReturn($deleteSuccess);
+
+		$this->groupManager->expects($this->once())
+			->method('get')
+			->with('group')
+			->willReturn($group);
+
+		$this->consoleInput->expects($this->once())
+			->method('getArgument')
+			->with('group')
+			->willReturn('group');
+
+		$this->consoleOutput->expects($this->once())
+			->method('writeln')
+			->with($this->stringContains($expectedString));
+
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+
+	public function testInvalidGroup() {
+		$this->groupManager->expects($this->once())
+			->method('get')
+			->with('group')
+			->willReturn(null);
+
+		$this->consoleInput->expects($this->once())
+			->method('getArgument')
+			->with('group')
+			->willReturn('group');
+
+		$this->consoleOutput->expects($this->once())
+			->method('writeln')
+			->with($this->stringContains('Group does not exist'));
+
+		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+}

--- a/tests/ui/config/behat.yml
+++ b/tests/ui/config/behat.yml
@@ -13,7 +13,9 @@ default:
           ocPath: ./
           regularUserPassword: 123456
           regularUserName: regularuser
-          regularUserNames: user1,user2,user3,user4,user5
+          regularUserNames: user1,user2,user3,usergrp,grpuser
+          regularGroupName: regulargrp
+          regularGroupNames: grp1,grp2,grp3,usergrp,grpuser
       contexts:
         - FeatureContext:
         - LoginContext:

--- a/tests/ui/features/lib/setupHelper.php
+++ b/tests/ui/features/lib/setupHelper.php
@@ -71,7 +71,7 @@ class SetupHelper
 	 */
 	public static function addUserToGroup($ocPath, $groupName, $userName)
 	{
-		return self::runOcc(['group:add', '--user '.$userName, $groupName], $ocPath);
+		return self::runOcc(['group:addmember', '--member '.$userName, $groupName], $ocPath);
 	}
 
 	/**
@@ -83,7 +83,7 @@ class SetupHelper
 	 */
 	public static function removeUserFromGroup($ocPath, $groupName, $userName)
 	{
-		return self::runOcc(['group:removeuser', '--user '.$userName, $groupName], $ocPath);
+		return self::runOcc(['group:removemember', '--member '.$userName, $groupName], $ocPath);
 	}
 
 	/**

--- a/tests/ui/features/lib/setupHelper.php
+++ b/tests/ui/features/lib/setupHelper.php
@@ -52,6 +52,52 @@ class SetupHelper
 	}
 
 	/**
+	 * creates a group
+	 * @param string $ocPath
+	 * @param string $groupName
+	 * @return string[] associated array with "code", "stdOut", "stdErr"
+	 */
+	public static function createGroup($ocPath, $groupName)
+	{
+		return self::runOcc(['group:add', $groupName], $ocPath);
+	}
+
+	/**
+	 * adds an existing user to a group, creating the group if it does not exist
+	 * @param string $ocPath
+	 * @param string $groupName
+	 * @param string $userName
+	 * @return string[] associated array with "code", "stdOut", "stdErr"
+	 */
+	public static function addUserToGroup($ocPath, $groupName, $userName)
+	{
+		return self::runOcc(['group:add', '--user '.$userName, $groupName], $ocPath);
+	}
+
+	/**
+	 * removes a user from a group
+	 * @param string $ocPath
+	 * @param string $groupName
+	 * @param string $userName
+	 * @return string[] associated array with "code", "stdOut", "stdErr"
+	 */
+	public static function removeUserFromGroup($ocPath, $groupName, $userName)
+	{
+		return self::runOcc(['group:removeuser', '--user '.$userName, $groupName], $ocPath);
+	}
+
+	/**
+	 * deletes a group
+	 * @param string $ocPath
+	 * @param string $groupName
+	 * @return string[] associated array with "code", "stdOut", "stdErr"
+	 */
+	public static function deleteGroup($ocPath, $groupName)
+	{
+		return self::runOcc(['group:delete', $groupName], $ocPath);
+	}
+
+	/**
 	 * invokes an OCC command
 	 *
 	 * @param array $args anything behind "occ". For example: "files:transfer-ownership"

--- a/tests/ui/features/shareeAutocompletion.feature
+++ b/tests/ui/features/shareeAutocompletion.feature
@@ -3,13 +3,21 @@ Feature: Sharee - autocompletion
 	Background:
 		Given regular users exist
 		And a regular user exists
+		And regular groups exist
+		And a regular group exists
 		And I am logged in as a regular user
 		And I am on the files page
 		
 	Scenario: autocompletion of regular existing users
 		And the share dialog for the folder "simple-folder" is open
 		And I type "user" in the share-with-field
-		Then all users that contain the string "user" in their username should be listed in the autocomplete list
+		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list
+		And my own name should not be listed in the autocomplete list
+		
+	Scenario: autocompletion of regular existing groups
+		And the share dialog for the folder "simple-folder" is open
+		And I type "grp" in the share-with-field
+		Then all users and groups that contain the string "grp" in their name should be listed in the autocomplete list
 		And my own name should not be listed in the autocomplete list
 		
 	Scenario: autocompletion for a pattern that does not match any user or group
@@ -22,12 +30,26 @@ Feature: Sharee - autocompletion
 		And the folder "simple-folder" is shared with the user "user1"
 		And the share dialog for the folder "simple-folder" is open
 		And I type "user" in the share-with-field
-		Then all users that contain the string "user" in their username should be listed in the autocomplete list except "user1"
+		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list except user "user1"
 		And my own name should not be listed in the autocomplete list
 
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user whith whom the item is already shared (file)
-		And the file "data.zip" is shared with the user "user1"
+		And the file "data.zip" is shared with the user "usergrp"
 		And the share dialog for the file "data.zip" is open
 		And I type "user" in the share-with-field
-		Then all users that contain the string "user" in their username should be listed in the autocomplete list except "user1"
+		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list except user "usergrp"
+		And my own name should not be listed in the autocomplete list
+		
+	Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
+		And the folder "simple-folder" is shared with the group "grp1"
+		And the share dialog for the folder "simple-folder" is open
+		And I type "grp" in the share-with-field
+		Then all users and groups that contain the string "grp" in their name should be listed in the autocomplete list except group "grp1"
+		And my own name should not be listed in the autocomplete list
+
+	Scenario: autocompletion of a pattern that matches regular existing groups but also a group whith whom the item is already shared (file)
+		And the file "data.zip" is shared with the group "grpuser"
+		And the share dialog for the file "data.zip" is open
+		And I type "grp" in the share-with-field
+		Then all users and groups that contain the string "grp" in their name should be listed in the autocomplete list except group "grpuser"
 		And my own name should not be listed in the autocomplete list


### PR DESCRIPTION
## Description
- Add group add, delete and removeuser to occ command (group add can also add users to a group)
- Add support for creating and removing groups withing the UI testing framework
- Use this to change/add some sharing autocompletion tests to include sharing with groups as well as users

## Related Issue
Addresses https://github.com/owncloud/core/issues/20629 to provide occ group command
for which some initial work happened in https://github.com/owncloud/core/pull/21627

Also part of providing base infrastructure for UI testing #27858 

## Motivation and Context
- It is useful to be able to manage groups from occ as well as users
- UI testing needs to be able to easily create groups and put users into groups during scenario setup
- File Firewall needs this to be able to test group rules

## How Has This Been Tested?
Self-testing - Travis does it

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Once this is accepted, the documentation of the occ group command needs to be done.