### PR TITLE
Node: Define relationship between id and fileid

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -213,6 +213,17 @@ abstract class Node implements \Sabre\DAV\INode {
 	}
 
 	/**
+	 * Returns the node's full id
+	 *
+	 * The full id is the numerical id padded with zeroes concatenated with
+	 * the instance id.
+	 *
+	 * Warning: Users of the full id may depend on its particular format, be
+	 * careful about changes.
+	 *
+	 * The contract is that taking the substring up until the first character
+	 * and converting to an integer yields the numerical id.
+	 *
 	 * @return string|null
 	 */
 	public function getFileId() {

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1138,6 +1138,9 @@ class OC_Util {
 	/**
 	 * get an id unique for this instance
 	 *
+	 * The instance id must begin with a letter. It's typically used as the
+	 * session name and appears in a file or directory's 'id' property.
+	 *
 	 * @return string
 	 */
 	public static function getInstanceId() {


### PR DESCRIPTION
Users of the 'id' property would like to be able to deduce the 'fileid'
property from it. To allow that the 'id' property is now required to
be made up from two parts: a purely numeric one, plus one that starts
with a letter. The first part shall be the (potentially padded) fileid.

The background is that clients need the fileid to be able to create
private link urls, but they currently only have the full 'id' property
available.

See owncloud/client#5763. This would be desirable for the desktop client as well as for mobile clients @davivel 

This is a pure documentation-and-test change and will not affect behavior.