### PR TITLE
[Example] Report skipped scenarios

### DIFF
--- a/tests/travis/start_behat_tests.sh
+++ b/tests/travis/start_behat_tests.sh
@@ -99,9 +99,20 @@ lib/composer/bin/behat -c $BEHAT_YML $BEHAT_TAG_OPTION $BEHAT_TAGS $BEHAT_FEATUR
 if [ "$BEHAT_TAGS_OPTION_FOUND" != true ]
 then
 	# The behat run above specified to skip scenarios tagged @skip
-	# so report them in a dry-run so they can be seen
-	echo "The following tests were skipped because they are tagged @skip:"
-	lib/composer/bin/behat --dry-run -c $BEHAT_YML --tags '@skip' $BEHAT_FEATURE -v
+	# Report them in a dry-run so they can be seen
+	# Big red error output is displayed if there are no matching scenarios - send it to null
+	DRY_RUN_FILE=$(mktemp)
+	lib/composer/bin/behat --dry-run --colors -c $BEHAT_YML --tags '@skip' $BEHAT_FEATURE 1>$DRY_RUN_FILE 2>/dev/null
+	if grep -q -m 1 'No scenarios' "$DRY_RUN_FILE"
+	then
+		# If there are no skip scenarios, then no need to report that
+		:
+	else
+		echo ""
+		echo "The following tests were skipped because they are tagged @skip:"
+		cat "$DRY_RUN_FILE"
+	fi
+	rm -f "$DRY_RUN_FILE"
 fi
 
 if [ $? -eq 0 ]

--- a/tests/travis/start_behat_tests.sh
+++ b/tests/travis/start_behat_tests.sh
@@ -96,6 +96,13 @@ export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"browser_name": 
 
 lib/composer/bin/behat -c $BEHAT_YML $BEHAT_TAG_OPTION $BEHAT_TAGS $BEHAT_FEATURE -v
 
+if [ $? -eq 0 ]
+then
+	PASSED=true
+else
+	PASSED=false
+fi
+
 if [ "$BEHAT_TAGS_OPTION_FOUND" != true ]
 then
 	# The behat run above specified to skip scenarios tagged @skip
@@ -113,13 +120,6 @@ then
 		cat "$DRY_RUN_FILE"
 	fi
 	rm -f "$DRY_RUN_FILE"
-fi
-
-if [ $? -eq 0 ]
-then
-	PASSED=true
-else
-	PASSED=false
 fi
 
 if [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && [ -e /tmp/saucelabs_sessionid ]

--- a/tests/travis/start_behat_tests.sh
+++ b/tests/travis/start_behat_tests.sh
@@ -96,6 +96,14 @@ export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"browser_name": 
 
 lib/composer/bin/behat -c $BEHAT_YML $BEHAT_TAG_OPTION $BEHAT_TAGS $BEHAT_FEATURE -v
 
+if [ "$BEHAT_TAGS_OPTION_FOUND" != true ]
+then
+	# The behat run above specified to skip scenarios tagged @skip
+	# so report them in a dry-run so they can be seen
+	echo "The following tests were skipped because they are tagged @skip:"
+	lib/composer/bin/behat --dry-run -c $BEHAT_YML --tags '@skip' $BEHAT_FEATURE -v
+fi
+
 if [ $? -eq 0 ]
 then
 	PASSED=true

--- a/tests/ui/features/renameFiles.feature
+++ b/tests/ui/features/renameFiles.feature
@@ -14,7 +14,7 @@ Feature: renameFiles
 		|'"quotes1"'   |
 		|"'quotes2'"   |
 
-		
+	@skip @because-this-test-is-annoying
 	Scenario Outline: Rename a file that has special characters in its name
 		When I rename the file <from_name> to <to_name>
 		Then the file <to_name> should be listed
@@ -34,6 +34,7 @@ Feature: renameFiles
 		And the page is reloaded
 		Then the file "no-double-quotes.txt" should be listed
 
+	@skip @renaming-to-forbidden-characters-is-broken-see-issue-1234
 	Scenario: Rename a file using forbidden characters
 		When I rename the file "data.zip" to one of these names
 		|lorem/txt  |

--- a/tests/ui/features/users.feature
+++ b/tests/ui/features/users.feature
@@ -1,5 +1,6 @@
 Feature: users
 
+	@skip @this-takes-a-long-time-to-run-and-we-cannot-be-bothered
 	Scenario Outline: change quota to a valid value
 		Given I am logged in as admin
 		And quota of user "admin" is set to "<start_quota>"


### PR DESCRIPTION
## Description
The behat UI tests will do a dry-run report of skipped scenarios after doing the real scenarios.
That will help people to be able to see skipped tests, and thus be annoyed enough by it to do something
about fixing the bugs.

The dry-run report is only done if the default set of tests are run (i.e. the @skip tags have been skipped by default)

This PR is a demo - it marks a few tests with @skip so the Travis log will have something to show.

It gives the example that you can put some other tag after @skip that is like an explanation of why it is skipped. People can see that in the output, and if you are testing in future while fixing the bug you could run behat specifying just that tag to run that particular test.

## Related Issue

## Motivation and Context
Help people see what tests exist that need bugs fixed.

## How Has This Been Tested?
We are about to see.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

It will need some developer doc enhancement to explain what it does.
