### PR TITLE
Add missing entry in trash for recipient

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -183,6 +183,11 @@ class Trashbin {
 		$target = $user . '/files_trashbin/files/' . $targetFilename . '.d' . $timestamp;
 		$source = $owner . '/files_trashbin/files/' . $sourceFilename . '.d' . $timestamp;
 		self::copy_recursive($source, $target, $view);
+
+		if ($view->file_exists($target)) {
+			self::insertTrashEntry($user, $targetFilename, $targetLocation, $timestamp);
+			self::scheduleExpire($user);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
Fix regression by properly creating user entry in trash table for shared recipient.
This used to be in the old code but got discarded by mistake.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28121

## Motivation and Context
We hate regressions

## How Has This Been Tested?
Tested manually with steps from the ticket.
Integration tests are in another PR: https://github.com/owncloud/core/pull/28111

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

