### PR TITLE
[stable10] Data is not properly set in case of OCS Result object - no…

### DIFF
--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -84,8 +84,10 @@ abstract class OCSController extends ApiController {
 	private function buildOCSResponse($format, $data) {
 		if ($data instanceof Result) {
 			$headers = $data->getHeaders();
+			$d = $data->getData();
 			$data = $data->getMeta();
 			$data['headers'] = $headers;
+			$data['data'] = $d;
 		}
 		if ($data instanceof DataResponse) {
 			$data = $data->getData();

--- a/tests/lib/AppFramework/Controller/OCSControllerTest.php
+++ b/tests/lib/AppFramework/Controller/OCSControllerTest.php
@@ -25,6 +25,7 @@
 namespace Test\AppFramework\Controller;
 
 use OC\AppFramework\Http\Request;
+use OC\OCS\Result;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
 use OCP\IConfig;
@@ -135,8 +136,11 @@ class OCSControllerTest extends TestCase {
 		$this->assertEquals($expected, $out);
 	}
 
-
-	public function testJSON() {
+	/**
+	 * @dataProvider providesData
+	 * @param $params
+	 */
+	public function testJSON($params) {
 		$controller = new ChildOCSController('app', new Request(
 			[
 				'urlParams' => [
@@ -152,17 +156,24 @@ class OCSControllerTest extends TestCase {
 		));
 		$expected = '{"ocs":{"meta":{"status":"failure","statuscode":400,"message":"OK",' .
 		            '"totalitems":"","itemsperpage":""},"data":{"test":"hi"}}}';
-		$params = [
-			'data' => [
-				'test' => 'hi'
-			],
-			'statuscode' => 400
-		];
 
 		$out = $controller->buildResponse($params, 'json')->render();
 		$this->assertEquals($expected, $out);
 	}
 
+	public function providesData() {
+		return [
+			'array' => [[
+				'data' => [
+					'test' => 'hi'
+				],
+				'statuscode' => 400]
+			],
+			'ocs-resuls' => [new Result([
+				'test' => 'hi'
+			], 400, 'OK')]
+		];
+	}
 
 	public function testStatusCodeMapping() {
 		$configMock = $this->createMock(IConfig::class);


### PR DESCRIPTION
…w with tests

backport of https://github.com/owncloud/core/pull/28183/ to stable1p