### PR TITLE
Report skipped scenarios

### DIFF
--- a/tests/travis/start_behat_tests.sh
+++ b/tests/travis/start_behat_tests.sh
@@ -96,6 +96,13 @@ export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"browser_name": 
 
 lib/composer/bin/behat -c $BEHAT_YML $BEHAT_TAG_OPTION $BEHAT_TAGS $BEHAT_FEATURE -v
 
+if [ $? -eq 0 ]
+then
+	PASSED=true
+else
+	PASSED=false
+fi
+
 if [ "$BEHAT_TAGS_OPTION_FOUND" != true ]
 then
 	# The behat run above specified to skip scenarios tagged @skip
@@ -113,13 +120,6 @@ then
 		cat "$DRY_RUN_FILE"
 	fi
 	rm -f "$DRY_RUN_FILE"
-fi
-
-if [ $? -eq 0 ]
-then
-	PASSED=true
-else
-	PASSED=false
 fi
 
 if [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && [ -e /tmp/saucelabs_sessionid ]

--- a/tests/travis/start_behat_tests.sh
+++ b/tests/travis/start_behat_tests.sh
@@ -96,6 +96,25 @@ export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"browser_name": 
 
 lib/composer/bin/behat -c $BEHAT_YML $BEHAT_TAG_OPTION $BEHAT_TAGS $BEHAT_FEATURE -v
 
+if [ "$BEHAT_TAGS_OPTION_FOUND" != true ]
+then
+	# The behat run above specified to skip scenarios tagged @skip
+	# Report them in a dry-run so they can be seen
+	# Big red error output is displayed if there are no matching scenarios - send it to null
+	DRY_RUN_FILE=$(mktemp)
+	lib/composer/bin/behat --dry-run --colors -c $BEHAT_YML --tags '@skip' $BEHAT_FEATURE 1>$DRY_RUN_FILE 2>/dev/null
+	if grep -q -m 1 'No scenarios' "$DRY_RUN_FILE"
+	then
+		# If there are no skip scenarios, then no need to report that
+		:
+	else
+		echo ""
+		echo "The following tests were skipped because they are tagged @skip:"
+		cat "$DRY_RUN_FILE"
+	fi
+	rm -f "$DRY_RUN_FILE"
+fi
+
 if [ $? -eq 0 ]
 then
 	PASSED=true


### PR DESCRIPTION
## Description
The behat UI tests will do a dry-run report of skipped scenarios after doing the real scenarios.
That will help people to be able to see skipped tests, and thus be annoyed enough by it to do something
about fixing the bugs.

The dry-run report is only done if the default set of tests are run (i.e. the @skip tags have been skipped by default)

You can add a "description" of why a scenario is skipped, by simply adding an extra tag that effectively contains the reason, for example:

@skip @special-file-upload-broken-due-to-issue-1234
Scenario: Upload a special sort of file in a special way

See #28195 for an example test run with some scenarios skipped.

## Related Issue
Issue #27858 

## Motivation and Context
Help people see what tests exist that are waiting for bugs to be fixed.

## How Has This Been Tested?
Local runs of UI tests with and without @skip scenarios

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

It will need some developer doc enhancement to explain what it does, as well as how best to use @skip tags.
