### PR TITLE
loginController now emitting failedLogin hook after failed login attempts

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -3,6 +3,7 @@
  * @author Christoph Wurst <christoph@owncloud.com>
  * @author Joas Schilling <coding@schilljs.com>
  * @author Lukas Reschke <lukas@statuscode.ch>
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
  * @copyright Copyright (c) 2017, ownCloud GmbH
@@ -182,11 +183,16 @@ class LoginController extends Controller {
 	public function tryLogin($user, $password, $redirect_url) {
 		$originalUser = $user;
 		// TODO: Add all the insane error handling
-		$emailUsers = $this->userManager->getByEmail($user);
-		if (count($emailUsers) === 1) {
-			$user = $emailUsers[0]->getUID();
+		$loginResult = $this->userSession->login($user, $password);
+		if ($loginResult !== true) {
+			$users = $this->userManager->getByEmail($user);
+			// we only allow login by email if unique
+			if (count($users) === 1) {
+				$user = $users[0]->getUID();
+				$loginResult = $this->userSession->login($user, $password);
+			}
 		}
-		if ($this->userSession->login($user, $password) !== true) {
+		if ($loginResult !== true) {
 			$this->session->set('loginMessages', [
 				['invalidpassword'], []
 			]);

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -9,6 +9,7 @@
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Robin Appelman <icewind@owncloud.com>
  * @author Robin McCorkell <robin@mccorkell.me.uk>
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
  *
@@ -70,6 +71,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * - postCreateUser(\OC\User\User $user)
  * - preLogin(string $user, string $password)
  * - postLogin(\OC\User\User $user, string $password)
+ * - failedLogin(string $user)
  * - preRememberedLogin(string $uid)
  * - postRememberedLogin(\OC\User\User $user)
  * - logout()
@@ -464,7 +466,7 @@ class Session implements IUserSession, Emitter {
 		$this->manager->emit('\OC\User', 'preLogin', [$uid, $password]);
 		$user = $this->manager->checkPassword($uid, $password);
 		if ($user === false) {
-			// Password check failed
+			$this->manager->emit('\OC\User', 'failedLogin', [$uid]);
 			return false;
 		}
 

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -290,8 +290,8 @@ class LoginControllerTest extends TestCase {
 		$password = 'secret';
 		$loginPageUrl = 'some url';
 
-		$this->userManager->expects($this->once())
-			->method('checkPassword')
+		$this->userSession->expects($this->once())
+			->method('login')
 			->will($this->returnValue(false));
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
@@ -311,12 +311,14 @@ class LoginControllerTest extends TestCase {
 		$password = 'secret';
 		$indexPageUrl = 'some url';
 
-		$this->userManager->expects($this->once())
-			->method('checkPassword')
-			->will($this->returnValue($user));
 		$this->userSession->expects($this->once())
 			->method('login')
-			->with($user, $password);
+			->with($user, $password)
+			->will($this->returnValue(true));
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with($user)
+			->will($this->returnValue($user));
 		$this->userSession->expects($this->once())
 			->method('createSessionToken')
 			->with($this->request, $user->getUID(), $user, $password);
@@ -357,9 +359,13 @@ class LoginControllerTest extends TestCase {
 		$originalUrl = 'another%20url';
 		$redirectUrl = 'http://localhost/another url';
 
-		$this->userManager->expects($this->once())
-			->method('checkPassword')
+		$this->userSession->expects($this->once())
+			->method('login')
 			->with('Jane', $password)
+			->will($this->returnValue(true));
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('Jane')
 			->will($this->returnValue($user));
 		$this->userSession->expects($this->once())
 			->method('createSessionToken')
@@ -386,8 +392,11 @@ class LoginControllerTest extends TestCase {
 		$password = 'secret';
 		$challengeUrl = 'challenge/url';
 
+		$this->userSession->expects($this->once())
+			->method('login')
+			->will($this->returnValue(true));
 		$this->userManager->expects($this->once())
-			->method('checkPassword')
+			->method('get')
 			->will($this->returnValue($user));
 		$this->userSession->expects($this->once())
 			->method('login')
@@ -418,12 +427,9 @@ class LoginControllerTest extends TestCase {
 			->method('getUID')
 			->will($this->returnValue('john'));
 
-		$this->userManager->expects($this->exactly(2))
-			->method('checkPassword')
-			->withConsecutive(
-				['john@doe.com', 'just wrong'],
-				['john', 'just wrong']
-				)
+		$this->userSession->expects($this->once())
+			->method('login')
+			->with('john', 'just wrong')
 			->willReturn(false);
 		
 		$this->userManager->expects($this->once())

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @author Lukas Reschke <lukas@owncloud.com>
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
  *
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  * @license AGPL-3.0
@@ -427,9 +428,12 @@ class LoginControllerTest extends TestCase {
 			->method('getUID')
 			->will($this->returnValue('john'));
 
-		$this->userSession->expects($this->once())
+		$this->userSession->expects($this->exactly(2))
 			->method('login')
-			->with('john', 'just wrong')
+			->withConsecutive(
+				['john@doe.com', 'just wrong'],
+				['john', 'just wrong']
+			)
 			->willReturn(false);
 		
 		$this->userManager->expects($this->once())


### PR DESCRIPTION
## Description
There is an error in the logic of emitting preLogin signal in the LoginController. UserSession's login function is checking password and emitting preLogin signal, but loginController is either checking password before UserSession and returning view response without hook signal when failed login attempts.

With this change, unnecessary checkPassword functions are removed. Code simplified and now we are emitting preLogin hook also before failed login attempts.
## Motivation and Context
preLogin hook is not emitting on failed login attempts. To resolve following issue 
https://github.com/owncloud/security/issues/1

## How Has This Been Tested?
Unit tests are working

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

