### PR TITLE
use efficient startsWith implementation, don't check if key exists twice

### DIFF
--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -107,9 +107,9 @@ class SimpleContainer extends Container implements IContainer {
 	 */
 	public function query($name) {
 		$name = $this->sanitizeName($name);
-		if ($this->offsetExists($name)) {
+		try {
 			return $this->offsetGet($name);
-		} else {
+		} catch (\InvalidArgumentException $ex) {
 			$object = $this->resolve($name);
 			$this->registerService($name, function () use ($object) {
 				return $object;

--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -73,7 +73,7 @@ class ServerContainer extends SimpleContainer {
 
 		// In case the service starts with OCA\ we try to find the service in
 		// the apps container first.
-		if (strpos($name, 'OCA\\') === 0 && substr_count($name, '\\') >= 2) {
+		if (strrpos($name, 'OCA\\', -strlen($name)) !== false && substr_count($name, '\\') >= 2) {
 			$segments = explode('\\', $name);
 			$appContainer = $this->getAppContainer(strtolower($segments[1]));
 			try {


### PR DESCRIPTION
While working on https://github.com/owncloud/core/pull/28212 I was profiling the performance for user:sync and this actually made a measurable difference. 