### PR TITLE
only trigger changeUser if account object really changed

### DIFF
--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -434,7 +434,7 @@ class User implements IUser {
 	}
 
 	public function triggerChange($feature, $value = null) {
-		if ($this->emitter) {
+		if ($this->emitter && in_array($feature, $this->account->getUpdatedFields())) {
 			$this->emitter->emit('\OC\User', 'changeUser', [$this, $feature, $value]);
 		}
 	}


### PR DESCRIPTION
While working on #28212 I was profiling the performance for user:sync and this actually made a measurable difference because it was causing the filesystem to be setup repeatedly.