### PR TITLE
Scanner repairs invalid path

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -194,8 +194,22 @@ class Scanner extends BasicEmitter implements IScanner {
 							$data['etag'] = $etag;
 						}
 					}
+
+					// check if path / parent is inconsistent
+					if ($file !== $cacheData['path']) {
+						// fix path
+						\OCP\Util::writeLog(
+							'core',
+							'Repairing inconsistent file cache entry found for file id ' . $fileId . ', ' .
+							'path was "' . $cacheData['path'] . ' instead of "' . $file . '"',
+							\OCP\Util::WARN
+						);
+						$data['path'] = $file;
+					}
+
 					// Only update metadata that has changed
 					$newData = array_diff_assoc($data, $cacheData->getData());
+
 				} else {
 					$newData = $data;
 					$fileId = -1;


### PR DESCRIPTION
⚠️ EXPERIMENTAL ⚠️ 
## Description
Whenever the path doesn't match the parent/child relationship, the path
value is corrected in the oc_filecache table.

## Related Issue
Fixes the fallout created by the bug https://github.com/owncloud/core/issues/28018

## Motivation and Context
Because we hate filecache inconsistencies

## How Has This Been Tested?
Run the steps from https://github.com/owncloud/core/issues/28018.
Run the query from https://github.com/owncloud/core/issues/28018#issuecomment-311033479 to find the broken entry.
Run `occ files:scan --all`
Check the broken entry again: the path is corrected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODOs:

- [ ] add error handling in case we can't fix the path, for example if there is already an entry with that path
- [ ] check what happens if people continue using the broken folder, whether it's still repairable
- [ ] unit test
