### PR TITLE
Use "sharing" scope when sending notification

### DIFF
--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -2864,7 +2864,7 @@ class Share extends Constants {
 	 * @return Group[]
 	 */
 	private static function getGroupsForUser($user) {
-		$groups = \OC::$server->getGroupManager()->getUserIdGroups($user);
+		$groups = \OC::$server->getGroupManager()->getUserIdGroups($user, 'sharing');
 		return array_values(array_map(function(Group $g) {
 			return $g->getGID();
 		}, $groups));


### PR DESCRIPTION
## Description
Wire up old share api with group manager sharing scope. Required to make customgroup work with "notify user" checkbox.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@jvillafanez please review