### PR TITLE
[stable9.1] Add check for empty result in storage memcache

### DIFF
--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -109,7 +109,7 @@ class Storage {
 			self::$localCache = new CappedMemoryCache();
 		}
 		$result = self::$localCache->get($storageId);
-		if ($result === null) {
+		if ($result === null || empty($result) || !isset($result['numeric_id'])) {
 			$result = self::getStorageByIdFromCache($storageId);
 			self::$localCache->set($storageId, $result);
 		}
@@ -134,7 +134,7 @@ class Storage {
 	 */
 	private static function getStorageByIdFromCache($storageId) {
 		$result = self::getDistributedCache()->get($storageId);
-		if ($result === null) {
+		if ($result === null || empty($result) || !isset($result['numeric_id'])) {
 			$result = self::getStorageByIdFromDb($storageId);
 			self::getDistributedCache()->set(
 				$storageId,	$result, self::$distributedCacheTTL

--- a/lib/private/Files/Cache/Storage.php
+++ b/lib/private/Files/Cache/Storage.php
@@ -109,7 +109,7 @@ class Storage {
 			self::$localCache = new CappedMemoryCache();
 		}
 		$result = self::$localCache->get($storageId);
-		if ($result === null || empty($result) || !isset($result['numeric_id'])) {
+		if ($result === null || !isset($result['numeric_id'])) {
 			$result = self::getStorageByIdFromCache($storageId);
 			self::$localCache->set($storageId, $result);
 		}
@@ -134,7 +134,7 @@ class Storage {
 	 */
 	private static function getStorageByIdFromCache($storageId) {
 		$result = self::getDistributedCache()->get($storageId);
-		if ($result === null || empty($result) || !isset($result['numeric_id'])) {
+		if ($result === null || !isset($result['numeric_id'])) {
 			$result = self::getStorageByIdFromDb($storageId);
 			self::getDistributedCache()->set(
 				$storageId,	$result, self::$distributedCacheTTL


### PR DESCRIPTION
## Description
It was observed that sometimes the row data is empty which could be due to memcache returning empty arrays instead of null.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@tomneedham 
