### PR TITLE
Fix app enable of not existing app

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -3,7 +3,6 @@
     "encryption",
     "configreport",
     "dav",
-    "enterprise_key",
     "federation",
     "federatedfilesharing",
     "files",

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -429,16 +429,17 @@ class Installer {
 	public static function removeApp($appId) {
 
 		if(Installer::isDownloaded( $appId )) {
-			$appDir=OC_App::getInstallPath() . '/' . $appId;
+			$appDir = OC_App::getAppPath($appId);
+			if ($appDir === false) {
+				return false;
+			}
 			OC_Helper::rmdirr($appDir);
 
 			return true;
-		}else{
-			\OCP\Util::writeLog('core', 'can\'t remove app '.$appId.'. It is not installed.', \OCP\Util::ERROR);
-
-			return false;
 		}
+		\OCP\Util::writeLog('core', 'can\'t remove app '.$appId.'. It is not installed.', \OCP\Util::ERROR);
 
+		return false;
 	}
 
 	/**

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -433,6 +433,10 @@ class Installer {
 			if ($appDir === false) {
 				return false;
 			}
+			if(is_dir("$appDir/.git")) {
+				throw new AppAlreadyInstalledException("App <$appId> is a git clone - it will not be deleted.");
+			}
+
 			OC_Helper::rmdirr($appDir);
 
 			return true;

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -369,6 +369,9 @@ class OC_App {
 		$config = \OC::$server->getConfig();
 		$l = \OC::$server->getL10N('core');
 		$info = self::getAppInfo($app);
+		if ($info === null) {
+			throw new \Exception("$app can't be enabled since it is not installed.");
+		}
 
 		self::checkAppDependencies($config, $l, $info);
 

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -116,10 +116,11 @@ interface IAppManager {
 
 	/**
 	 * @param string $package
+	 * @param bool $skipMigrations whether to skip migrations, which would only install the code
 	 * @return mixed
 	 * @since 10.0
 	 */
-	public function installApp($package);
+	public function installApp($package, $skipMigrations = false);
 
 	/**
 	 * @param string $package


### PR DESCRIPTION
## Description
Actually fixes to issues:
 - one related to enabling an app which is removed from the system (rm -rf apps/$APPNAME)
 - allow uninstall of the enterprise key app

## Related Issue
https://github.com/owncloud/market/issues/94

## How Has This Been Tested?
- install an app
- enable it
- remove the folder
- call ./occ app:enable
- EXPECTATION it shall not break on php7

- install enterprise key app
- try to uninstall it
- EXPECTATION: one can uninstall it

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

