### PR TITLE
refactoring tag based integration tests

### DIFF
--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann
+ * @copyright 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace TestHelpers;
+
+class TagsHelper {
+	/**
+	 * tags a file
+	 * @param string $baseUrl
+	 * @param string $taggingUser
+	 * @param string $password
+	 * @param string $tagName
+	 * @param string $fileName
+	 * @param string $fileOwner
+	 * @param int $davPathVersionToUse (1|2)
+	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 */
+	public static function tag(
+		$baseUrl, $taggingUser, $password,
+		$tagName, $fileName, $fileOwner, $davPathVersionToUse = 1)
+	{
+		$fileID = WebDavHelper::getFileIdForPath(
+			$baseUrl, $fileOwner, $password, $fileName
+		);
+		
+		$tag = self::requestTagByDisplayName(
+			$baseUrl, $taggingUser, $password, $tagName
+		);
+		$tagID = ( int ) $tag ['{http://owncloud.org/ns}id'];
+		$path = '/systemtags-relations/files/' . $fileID . '/' . $tagID;
+		$response = WebDavHelper::makeDavRequest(
+			$baseUrl, $taggingUser, $password, "PUT",
+			$path, null, null, null, $davPathVersionToUse, "systemtags"
+		);
+		return $response;
+	}
+
+	/**
+	 * get all tags of a user
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $withGroups
+	 * @return array
+	 */
+	public static function requestTagsForUser(
+		$baseUrl, $user, $password, $withGroups = false)
+	{
+		$baseUrl = WebDavHelper::sanitizeUrl($baseUrl, true);
+		$client = WebDavHelper::getSabreClient($baseUrl, $user, $password);
+		$properties = [ 
+				'{http://owncloud.org/ns}id',
+				'{http://owncloud.org/ns}display-name',
+				'{http://owncloud.org/ns}user-visible',
+				'{http://owncloud.org/ns}user-assignable',
+				'{http://owncloud.org/ns}can-assign' 
+		];
+		if ($withGroups) {
+			array_push($properties, '{http://owncloud.org/ns}groups');
+		}
+		$appPath = '/systemtags/';
+		$fullUrl = $baseUrl . WebDavHelper::getDavPath($user, 2, "systemtags") . $appPath;
+		$response = $client->propfind($fullUrl, $properties, 1);
+		return $response;
+	}
+
+	/**
+	 * find a tag by its name
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $tagDisplayName
+	 * @param string $withGroups
+	 * @return array
+	 */
+	public static function requestTagByDisplayName(
+		$baseUrl,
+		$user,
+		$password,
+		$tagDisplayName,
+		$withGroups = false)
+	{
+		$tagList = self::requestTagsForUser($baseUrl, $user, $password, $withGroups);
+		foreach ($tagList as $path => $tagData) {
+			if (!empty($tagData) && $tagData['{http://owncloud.org/ns}display-name'] === $tagDisplayName) {
+				return $tagData;
+			}
+		}
+	}
+
+	/**
+	 *
+	 * @param string $baseUrl see: self::makeDavRequest()
+	 * @param string $user
+	 * @param string $password
+	 * @param string $name
+	 * @param bool $userVisible
+	 * @param bool $userAssignable
+	 * @param string $groups separated by "|"
+	 * @param int $davPathVersionToUse (1|2)
+	 * @return array ['lastTagId', 'HTTPResponse']
+	 * @throws \GuzzleHttp\Exception\ClientException
+	 * @link self::makeDavRequest()
+	 */
+	public static function createTag(
+		$baseUrl,
+		$user,
+		$password,
+		$name,
+		$userVisible = true,
+		$userAssignable = true,
+		$groups = null,
+		$davPathVersionToUse = 1)
+	{
+		$tagsPath = '/systemtags/';
+		$body = [
+				'name' => $name,
+				'userVisible' => $userVisible,
+				'userAssignable' => $userAssignable,
+		];
+		if ($groups !== null) {
+			$body['groups'] = $groups;
+		}
+		
+		$response = WebDavHelper::makeDavRequest(
+			$baseUrl,
+			$user,
+			$password,
+			"POST",
+			$tagsPath,
+			['Content-Type' => 'application/json',],
+			null,
+			json_encode($body),
+			$davPathVersionToUse,
+			"systemtags");
+
+		$responseHeaders =  $response->getHeaders();
+		$tagUrl = $responseHeaders['Content-Location'][0];
+		$lastTagId = substr($tagUrl, strrpos($tagUrl,'/')+1);
+		return ['lastTagId' => $lastTagId, 'HTTPResponse' => $response];
+	}
+
+	/**
+	 * 
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param int $tagID
+	 * @param int $davPathVersionToUse (1|2)
+	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @throws \GuzzleHttp\Exception\ClientException
+	 */
+	public static function deleteTag(
+		$baseUrl,
+		$user,
+		$password,
+		$tagID,
+		$davPathVersionToUse = 1)
+	{
+		$tagsPath = '/systemtags/' . $tagID;
+		$response = WebDavHelper::makeDavRequest(
+			$baseUrl, $user, $password,
+			"DELETE", $tagsPath, [ ], null, null, $davPathVersionToUse, "systemtags"
+		);
+		return $response;
+	}
+
+	/**
+	 * 
+	 * @param string $type
+	 * @throws \Exception
+	 * @return boolean[]
+	 */
+	public static function validateTypeOfTag($type) {
+		$userVisible = true;
+		$userAssignable = true;
+		switch ($type) {
+			case 'normal':
+				break;
+			case 'not user-assignable':
+				$userAssignable = false;
+				break;
+			case 'not user-visible':
+				$userVisible = false;
+				break;
+			default:
+				throw new \Exception('Unsupported type');
+		}
+		return array($userVisible, $userAssignable);
+	}
+}

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann
+ * @copyright 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace TestHelpers;
+
+use Exception;
+use GuzzleHttp\Client as GClient;
+use InvalidArgumentException;
+use Sabre\DAV\Client as SClient;
+use GuzzleHttp\Stream\StreamInterface;
+use GuzzleHttp\Stream\Stream;
+
+class WebDavHelper
+{
+	/**
+	 * returns the id of a file
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $path
+	 * @throws Exception
+	 * @return int
+	 */
+	public static function getFileIdForPath(
+		$baseUrl,
+		$user,
+		$password,
+		$path)
+	{
+		$body = Stream::factory('<?xml version="1.0"?>
+<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+  <d:prop>
+    <oc:fileid />
+  </d:prop>
+</d:propfind>');
+		$response = self::makeDavRequest($baseUrl, $user, $password, "PROPFIND", $path, null, $body);
+		preg_match('/\<oc:fileid\>(\d+)\<\/oc:fileid\>/', $response, $matches);
+		if (!isset($matches[1])) {
+			throw new Exception("could not find fileId of $path");
+		}
+		return $matches[1];
+	}
+
+	/**
+	 * namespace TestHelpers;
+
+	 * @param string $baseUrl
+	 * URL of owncloud e.g. http://localhost:8080
+	 * should include the subfolder if owncloud runs in a subfolder e.g. http://localhost:8080/owncloud-core
+	 * @param string $user
+	 * @param string $password
+	 * @param string $method PUT, GET, DELETE, etc.
+	 * @param string $path
+	 * @param array $headers
+	 * @param StreamInterface $body
+	 * @param string $requestBody
+	 * @param int $davPathVersionToUse (1|2)
+	 * @param string $type of request
+	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @throws \GuzzleHttp\Exception\BadResponseException
+	 */
+	public static function makeDavRequest(
+		$baseUrl,
+		$user,
+		$password,
+		$method,
+		$path,
+		$headers,
+		$body = null,
+		$requestBody = null,
+		$davPathVersionToUse = 1,
+		$type = "files")
+	{
+			$baseUrl = self::sanitizeUrl($baseUrl, true);
+			$davPath = self::getDavPath($user, $davPathVersionToUse, $type);
+			$fullUrl = self::sanitizeUrl($baseUrl . $davPath . $path);
+			$client = new GClient();
+			
+			$options = [];
+			if (!is_null($requestBody)){
+				$options['body'] = $requestBody;
+			}
+			$options['auth'] = [$user, $password];
+			
+			$request = $client->createRequest($method, $fullUrl, $options);
+			if (!is_null($headers)){
+				foreach ($headers as $key => $value) {
+					if ($request->hasHeader($key) === true) {
+						$request->setHeader($key, $value);
+					} else {
+						$request->addHeader($key, $value);
+					}
+				}
+			}
+			if (!is_null($body)) {
+				$request->setBody($body);
+			}
+			
+			return $client->send($request);
+	}
+
+	/**
+	 * get the dav path
+	 * @param string $user
+	 * @param int $davPathVersionToUse (1|2)
+	 * @param string $type
+	 * @throws InvalidArgumentException
+	 * @return string
+	 */
+	public static function getDavPath($user, $davPathVersionToUse = 1, $type = "files") 
+	{
+		if ($davPathVersionToUse === 1) {
+			return "remote.php/webdav/";
+		} elseif ($davPathVersionToUse === 2) {
+			if ($type === "files") {
+				return "remote.php/dav" . '/files/' . $user . "/";
+			} else {
+				return "remote.php/dav";
+			}
+		} else {
+			throw new InvalidArgumentException(
+				"DAV path version $davPathVersionToUse is unknown");
+		}
+	}
+
+	/**
+	 * returns a Sabre client
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @return \Sabre\DAV\Client
+	 */
+	public static function getSabreClient($baseUrl, $user, $password)
+	{
+		$settings = [
+				'baseUri' => $baseUrl,
+				'userName' => $user,
+				'password' => $password,
+				'authType' => SClient::AUTH_BASIC
+		];
+		
+		return new SClient($settings);
+	}
+
+	/**
+	 * make sure there are no double slash in the URL
+	 * 
+	 * @param string $url
+	 * @param bool $trailingSlash forces a trailing slash
+	 * @return string
+	 */
+	public static function sanitizeUrl($url, $trailingSlash = false)
+	{
+		if ($trailingSlash === true) {
+			$url = $url . "/";
+		} else {
+			$url = rtrim($url, "/");
+		}
+		$url = preg_replace("/([^:]\/)\/+/", '$1', $url);
+		return $url;
+	}
+}

--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -68,6 +68,10 @@ trait BasicStructure {
 		$this->baseUrlWithoutOCSAppendix = substr($this->baseUrl, 0, -4);
 	}
 
+	private function baseUrlWithoutOCSAppendix() {
+		return substr($this->baseUrl, 0, -4);
+	}
+
 	/**
 	 * @Given /^using api version "([^"]*)"$/
 	 * @param string $version
@@ -98,7 +102,6 @@ trait BasicStructure {
 			$this->baseUrl = $this->remoteBaseUrl;
 			$this->currentServer = 'REMOTE';
 		}
-		$this->baseUrlWithoutOCSAppendix = substr($this->baseUrl, 0, -4);
 		return $previousServer;
 	}
 
@@ -191,7 +194,7 @@ trait BasicStructure {
 	}
 
 	public function isExpectedUrl($possibleUrl, $finalPart){
-		$baseUrlChopped = substr($this->baseUrl, 0, -4);
+		$baseUrlChopped = $this->baseUrlWithoutOCSAppendix();
 		$endCharacter = strlen($baseUrlChopped) + strlen($finalPart);
 		return (substr($possibleUrl,0,$endCharacter) == "$baseUrlChopped" . "$finalPart");
 	}

--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -23,6 +23,12 @@ trait BasicStructure {
 	/** @var string */
 	private $baseUrl = '';
 
+	/**
+	 * base URL without the /ocs part
+	 * @var string
+	 */
+	private $baseUrlWithoutOCSAppendix = '';
+
 	/** @var int */
 	private $apiVersion = 1;
 
@@ -59,6 +65,7 @@ trait BasicStructure {
 		if ($testRemoteServerUrl !== false) {
 			$this->remoteBaseUrl = $testRemoteServerUrl;
 		}
+		$this->baseUrlWithoutOCSAppendix = substr($this->baseUrl, 0, -4);
 	}
 
 	/**
@@ -87,12 +94,12 @@ trait BasicStructure {
 		if ($server === 'LOCAL'){
 			$this->baseUrl = $this->localBaseUrl;
 			$this->currentServer = 'LOCAL';
-			return $previousServer;
 		} else {
 			$this->baseUrl = $this->remoteBaseUrl;
 			$this->currentServer = 'REMOTE';
-			return $previousServer;
 		}
+		$this->baseUrlWithoutOCSAppendix = substr($this->baseUrl, 0, -4);
+		return $previousServer;
 	}
 
 	/**
@@ -338,6 +345,18 @@ trait BasicStructure {
 	 */
 	public function fileIsCreatedInLocalStorageWithText($filename, $text) {
 		$this->createFileWithText("local_storage/$filename", $text);
+	}
+
+	/**
+	 * @param string $userName
+	 * @return string
+	 */
+	private function getPasswordForUser($userName) {
+		if ($userName === 'admin') {
+			return $this->adminUser[1];
+		} else {
+			return $this->regularUser;
+		}
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/Checksums.php
+++ b/tests/integration/features/bootstrap/Checksums.php
@@ -10,18 +10,6 @@ trait Checksums {
 	use Webdav;
 
 	/**
-	 * @param string $userName
-	 * @return string
-	 */
-	private function getPasswordForUser($userName) {
-		if ($userName === 'admin') {
-			return $this->adminUser;
-		} else {
-			return $this->regularUser;
-		}
-	}
-
-	/**
 	 * @When user :user uploads file :source to :destination with checksum :checksum
 	 * @param string $user
 	 * @param string $source

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -4,6 +4,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
+require_once 'bootstrap.php';
 
 
 /**

--- a/tests/integration/features/bootstrap/Tags.php
+++ b/tests/integration/features/bootstrap/Tags.php
@@ -40,7 +40,7 @@ trait Tags {
 	private function createTag($user, $userVisible, $userAssignable, $name, $groups = null) {
 		try {
 			$createdTag = TagsHelper::createTag(
-				$this->baseUrlWithoutOCSAppendix,
+				$this->baseUrlWithoutOCSAppendix(),
 				$user,
 				$this->getPasswordForUser($user),
 				$name, $userVisible, $userAssignable, $groups,
@@ -90,7 +90,7 @@ trait Tags {
 
 	public function requestTagsForUser($user, $withGroups = false) {
 		$this->response = TagsHelper:: requestTagsForUser(
-			$this->baseUrlWithoutOCSAppendix,
+			$this->baseUrlWithoutOCSAppendix(),
 			$user,
 			$this->getPasswordForUser($user),
 			$withGroups
@@ -196,7 +196,7 @@ trait Tags {
 		$appPath = '/systemtags/';
 		$tagID = $this->findTagIdByName($tagDisplayName);
 		PHPUnit_Framework_Assert::assertNotNull($tagID, "Tag wasn't found");
-		$fullUrl = $this->baseUrlWithoutOCSAppendix . $this->davPath . $appPath . $tagID;
+		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->davPath . $appPath . $tagID;
 		try {
 			$response = $client->proppatch($fullUrl, $properties, 1);
 			$this->response = $response;
@@ -244,7 +244,7 @@ trait Tags {
 		$tagID = $this->findTagIdByName($name);
 		try {
 			$this->response = TagsHelper::deleteTag(
-				$this->baseUrlWithoutOCSAppendix,
+				$this->baseUrlWithoutOCSAppendix(),
 				$user,
 				$this->getPasswordForUser($user), $tagID,
 				$this->getDavPathVersion()
@@ -259,7 +259,7 @@ trait Tags {
 	private function tag($taggingUser, $tagName, $fileName, $fileOwner) {
 		try {
 			$this->response = TagsHelper::tag(
-				$this->baseUrlWithoutOCSAppendix,
+				$this->baseUrlWithoutOCSAppendix(),
 				$taggingUser, 
 				$this->getPasswordForUser($taggingUser),
 				$tagName, $fileName, $fileOwner, $this->getDavPathVersion()
@@ -284,7 +284,7 @@ trait Tags {
 						'{http://owncloud.org/ns}can-assign'
 					  ];
 		$appPath = '/systemtags-relations/files/';
-		$fullUrl = $this->baseUrlWithoutOCSAppendix . $this->davPath . $appPath . $fileID;
+		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->davPath . $appPath . $fileID;
 		try{
 			$response = $client->propfind($fullUrl, $properties, 1);
 		}catch (Sabre\HTTP\ClientHttpException $e) {
@@ -377,7 +377,7 @@ trait Tags {
 		foreach($this->createdTags as $tagID) {
 			try {
 				$this->response = TagsHelper::deleteTag(
-					$this->baseUrlWithoutOCSAppendix,
+					$this->baseUrlWithoutOCSAppendix(),
 					"admin", $this->getPasswordForUser("admin"), $tagID, 2);
 			} catch (ClientException  $e) {
 				$this->response = $e->getResponse();

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -88,7 +88,7 @@ trait WebDav {
 		}
 
 		return WebDavHelper::makeDavRequest(
-			$this->baseUrlWithoutOCSAppendix,
+			$this->baseUrlWithoutOCSAppendix(),
 			$user, $this->getPasswordForUser($user), $method,
 			$path, $headers, $body, $requestBody, $this->getDavPathVersion(),
 			$type
@@ -102,7 +102,7 @@ trait WebDav {
 	 * @param string $fileDestination
 	 */
 	public function userMovedFile($user, $entry, $fileSource, $fileDestination){
-		$fullUrl = $this->baseUrlWithoutOCSAppendix . $this->getDavFilesPath($user);
+		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		$this->response = $this->makeDavRequest($user, "MOVE", $fileSource, $headers);
 		PHPUnit_Framework_Assert::assertEquals(201, $this->response->getStatusCode());
@@ -115,7 +115,7 @@ trait WebDav {
 	 * @param string $fileDestination
 	 */
 	public function userMovesFile($user, $entry, $fileSource, $fileDestination){
-		$fullUrl = $this->baseUrlWithoutOCSAppendix . $this->getDavFilesPath($user);
+		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		try {
 			$this->response = $this->makeDavRequest($user, "MOVE", $fileSource, $headers);
@@ -131,7 +131,7 @@ trait WebDav {
 	 * @param string $fileDestination
 	 */
 	public function userCopiesFile($user, $fileSource, $fileDestination){
-		$fullUrl = $this->baseUrlWithoutOCSAppendix . $this->getDavFilesPath($user);
+		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		try {
 			$this->response = $this->makeDavRequest($user, "COPY", $fileSource, $headers);
@@ -156,7 +156,7 @@ trait WebDav {
 	 */
 	public function downloadPublicFileWithRange($range){
 		$token = $this->lastShareData->data->token;
-		$fullUrl = $this->baseUrlWithoutOCSAppendix . "public.php/webdav";
+		$fullUrl = $this->baseUrlWithoutOCSAppendix() . "public.php/webdav";
 
 		$client = new GClient();
 		$options = [];
@@ -174,7 +174,7 @@ trait WebDav {
 	 */
 	public function downloadPublicFileInsideAFolderWithRange($path, $range){
 		$token = $this->lastShareData->data->token;
-		$fullUrl = $this->baseUrlWithoutOCSAppendix . "public.php/webdav" . "$path";
+		$fullUrl = $this->baseUrlWithoutOCSAppendix() . "public.php/webdav" . "$path";
 
 		$client = new GClient();
 		$options = [];
@@ -531,7 +531,7 @@ trait WebDav {
 
 	public function getSabreClient($user) {
 		return WebDavHelper::getSabreClient(
-			$this->baseUrlWithoutOCSAppendix,
+			$this->baseUrlWithoutOCSAppendix(),
 			$user,
 			$this->getPasswordForUser($user));
 	}
@@ -886,7 +886,7 @@ trait WebDav {
 	public function userMovesNewChunkFileWithIdToMychunkedfile($user, $id, $dest)
 	{
 		$source = '/uploads/' . $user . '/' . $id . '/.file';
-		$destination = $this->baseUrlWithoutOCSAppendix . $this->getDavFilesPath($user) . $dest;
+		$destination = $this->baseUrlWithoutOCSAppendix() . $this->getDavFilesPath($user) . $dest;
 		$this->makeDavRequest($user, 'MOVE', $source, [
 			'Destination' => $destination
 		], null, "uploads");
@@ -932,7 +932,7 @@ trait WebDav {
 	/*Set the elements of a proppatch, $folderDepth requires 1 to see elements without children*/
 	public function changeFavStateOfAnElement($user, $path, $favOrUnfav, $folderDepth, $properties = null){
 		$settings = [
-			'baseUri' => $this->baseUrlWithoutOCSAppendix,
+			'baseUri' => $this->baseUrlWithoutOCSAppendix(),
 			'userName' => $user,
 			'password' => $this->getPasswordForUser($user),
 			'authType' => SClient::AUTH_BASIC
@@ -1061,7 +1061,7 @@ trait WebDav {
 	private function getFileIdForPath($user, $path) {
 		try {
 			return WebDavHelper::getFileIdForPath(
-				$this->baseUrlWithoutOCSAppendix, $user,
+				$this->baseUrlWithoutOCSAppendix(), $user,
 				$this->getPasswordForUser($user), $path);
 		} catch ( Exception $e ) {
 			return null;

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -5,9 +5,9 @@ use GuzzleHttp\Message\ResponseInterface;
 use Sabre\DAV\Client as SClient;
 use Sabre\DAV\Xml\Property\ResourceType;
 use GuzzleHttp\Exception\ServerException;
+use TestHelpers\WebDavHelper;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
-
 
 trait WebDav {
 	use Sharing;
@@ -24,12 +24,20 @@ trait WebDav {
 	private $storedETAG = NULL;
 	/** @var integer */
 	private $storedFileID = NULL;
+	
+	/**
+	 * a variable that contains the dav path without "remote.php/(web)dav"
+	 * when setting $this->davPath directly by usingDavPath()
+	 * @var string
+	 */
+	private $customDavPath = null;
 
 	/**
 	 * @Given /^using dav path "([^"]*)"$/
 	 */
 	public function usingDavPath($davPath) {
 		$this->davPath = $davPath;
+		$this->customDavPath = preg_replace("/remote\.php\/(web)?dav\//", "", $davPath);
 	}
 
 	/**
@@ -38,6 +46,7 @@ trait WebDav {
 	public function usingOldDavPath() {
 		$this->davPath = "remote.php/webdav";
 		$this->usingOldDavPath = true;
+		$this->customDavPath = null;
 	}
 
 	/**
@@ -46,6 +55,7 @@ trait WebDav {
 	public function usingNewDavPath() {
 		$this->davPath = "remote.php/dav";
 		$this->usingOldDavPath = false;
+		$this->customDavPath = null;
 	}
 
 	public function getDavFilesPath($user){
@@ -56,42 +66,33 @@ trait WebDav {
 		}
 	}
 
+	private function getDavPathVersion ()
+	{
+		if ($this->usingOldDavPath === true) {
+			return 1;
+		} else {
+			return 2;
+		}
+	}
 	public function makeDavRequest($user,
 								   $method,
 								   $path,
 								   $headers,
 								   $body = null,
 								   $type = "files",
-								   $requestBody = null){
-		if ( $type === "files" ){
-			$fullUrl = substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user) . "$path";
-		} else if ( $type === "uploads" ){
-			$fullUrl = substr($this->baseUrl, 0, -4) . $this->davPath . "$path";
-		} 
-		$client = new GClient();
+								   $requestBody = null)
+	{
 
-		$options = [];
-		if (!is_null($requestBody)){
-			$options['body'] = $requestBody;
-		}
-		if ($user === 'admin') {
-			$options['auth'] = $this->adminUser;
-		} else {
-			$options['auth'] = [$user, $this->regularUser];
+		if ($this->customDavPath !== null) {
+			$path = $this->customDavPath . $path;
 		}
 
-		$request = $client->createRequest($method, $fullUrl, $options);
-		if (!is_null($headers)){
-			foreach ($headers as $key => $value) {
-				$request->addHeader($key, $value);
-			}
-		}
-
-		if (!is_null($body)) {
-			$request->setBody($body);
-		}
-
-		return $client->send($request);
+		return WebDavHelper::makeDavRequest(
+			$this->baseUrlWithoutOCSAppendix,
+			$user, $this->getPasswordForUser($user), $method,
+			$path, $headers, $body, $requestBody, $this->getDavPathVersion(),
+			$type
+		);
 	}
 
 	/**
@@ -101,7 +102,7 @@ trait WebDav {
 	 * @param string $fileDestination
 	 */
 	public function userMovedFile($user, $entry, $fileSource, $fileDestination){
-		$fullUrl = substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user);
+		$fullUrl = $this->baseUrlWithoutOCSAppendix . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		$this->response = $this->makeDavRequest($user, "MOVE", $fileSource, $headers);
 		PHPUnit_Framework_Assert::assertEquals(201, $this->response->getStatusCode());
@@ -114,7 +115,7 @@ trait WebDav {
 	 * @param string $fileDestination
 	 */
 	public function userMovesFile($user, $entry, $fileSource, $fileDestination){
-		$fullUrl = substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user);
+		$fullUrl = $this->baseUrlWithoutOCSAppendix . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		try {
 			$this->response = $this->makeDavRequest($user, "MOVE", $fileSource, $headers);
@@ -130,7 +131,7 @@ trait WebDav {
 	 * @param string $fileDestination
 	 */
 	public function userCopiesFile($user, $fileSource, $fileDestination){
-		$fullUrl = substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user);
+		$fullUrl = $this->baseUrlWithoutOCSAppendix . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		try {
 			$this->response = $this->makeDavRequest($user, "COPY", $fileSource, $headers);
@@ -155,7 +156,7 @@ trait WebDav {
 	 */
 	public function downloadPublicFileWithRange($range){
 		$token = $this->lastShareData->data->token;
-		$fullUrl = substr($this->baseUrl, 0, -4) . "public.php/webdav";
+		$fullUrl = $this->baseUrlWithoutOCSAppendix . "public.php/webdav";
 
 		$client = new GClient();
 		$options = [];
@@ -173,7 +174,7 @@ trait WebDav {
 	 */
 	public function downloadPublicFileInsideAFolderWithRange($path, $range){
 		$token = $this->lastShareData->data->token;
-		$fullUrl = substr($this->baseUrl, 0, -4) . "public.php/webdav" . "$path";
+		$fullUrl = $this->baseUrlWithoutOCSAppendix . "public.php/webdav" . "$path";
 
 		$client = new GClient();
 		$options = [];
@@ -529,21 +530,10 @@ trait WebDav {
 	}
 
 	public function getSabreClient($user) {
-		$fullUrl = substr($this->baseUrl, 0, -4);
-
-		$settings = [
-			'baseUri' => $fullUrl,
-			'userName' => $user,
-		];
-
-		if ($user === 'admin') {
-			$settings['password'] = $this->adminUser[1];
-		} else {
-			$settings['password'] = $this->regularUser;
-		}
-		$settings['authType'] = SClient::AUTH_BASIC;
-
-		return new SClient($settings);
+		return WebDavHelper::getSabreClient(
+			$this->baseUrlWithoutOCSAppendix,
+			$user,
+			$this->getPasswordForUser($user));
 	}
 
 	/**
@@ -896,8 +886,8 @@ trait WebDav {
 	public function userMovesNewChunkFileWithIdToMychunkedfile($user, $id, $dest)
 	{
 		$source = '/uploads/' . $user . '/' . $id . '/.file';
-		$destination = substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user) . $dest;
-		$this->response = $this->makeDavRequest($user, 'MOVE', $source, [
+		$destination = $this->baseUrlWithoutOCSAppendix . $this->getDavFilesPath($user) . $dest;
+		$this->makeDavRequest($user, 'MOVE', $source, [
 			'Destination' => $destination
 		], null, "uploads");
 	}
@@ -941,18 +931,12 @@ trait WebDav {
 
 	/*Set the elements of a proppatch, $folderDepth requires 1 to see elements without children*/
 	public function changeFavStateOfAnElement($user, $path, $favOrUnfav, $folderDepth, $properties = null){
-		$fullUrl = substr($this->baseUrl, 0, -4);
 		$settings = [
-			'baseUri' => $fullUrl,
+			'baseUri' => $this->baseUrlWithoutOCSAppendix,
 			'userName' => $user,
+			'password' => $this->getPasswordForUser($user),
+			'authType' => SClient::AUTH_BASIC
 		];
-		if ($user === 'admin') {
-			$settings['password'] = $this->adminUser[1];
-		} else {
-			$settings['password'] = $this->regularUser;
-		}
-		$settings['authType'] = SClient::AUTH_BASIC;
-
 		$client = new SClient($settings);
 		if (!$properties) {
 			$properties = [
@@ -1075,11 +1059,11 @@ trait WebDav {
 	 * @return int
 	 */
 	private function getFileIdForPath($user, $path) {
-		$propertiesTable = new \Behat\Gherkin\Node\TableNode([["{http://owncloud.org/ns}fileid"]]);
-		$this->asGetsPropertiesOfFolderWith($user, 'file', $path, $propertiesTable);
-		if (is_array($this->response)) {
-			return (int) $this->response['{http://owncloud.org/ns}fileid'];
-		} else {
+		try {
+			return WebDavHelper::getFileIdForPath(
+				$this->baseUrlWithoutOCSAppendix, $user,
+				$this->getPasswordForUser($user), $path);
+		} catch ( Exception $e ) {
 			return null;
 		}
 	}

--- a/tests/integration/features/bootstrap/bootstrap.php
+++ b/tests/integration/features/bootstrap/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+$classLoader = new \Composer\Autoload\ClassLoader();
+$classLoader->addPsr4("TestHelpers\\", __DIR__. "/../../../../tests/TestHelpers/", true);
+$classLoader->register();


### PR DESCRIPTION
## Description
This refactoring makes it easier to reuse test code across different tests suits.

## Related Issue
https://github.com/owncloud/QA/issues/467

## Motivation and Context
There is good code in the integration tests that would be very useful also for UI tests but its hard to reuse it. This is a proposal for a way forward to refactor code piece by piece to make it more reusable.

I've made the new helper functions static. This means a lot of parameter has to be passed around but also makes the function being independent.

## How Has This Been Tested?
Run integration tests locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

