### PR TITLE
Be more careful about not needed test dirs

### DIFF
--- a/tests/apps.php
+++ b/tests/apps.php
@@ -7,10 +7,10 @@
  */
 
 function loadDirectory($path) {
-	if (strpos($path, 'integration')) {
+	if (stripos(basename($path), 'integration') !== false) {
 		return;
 	}
-	if (strpos($path, 'Integration')) {
+	if (strcasecmp(basename($path), 'ui') === 0) {
 		return;
 	}
 	if ($dh = opendir($path)) {


### PR DESCRIPTION
for the unit tests

## Description
The existing code would match any path with "integration" anywhere in it - e.g. if there is an app called files_integration_thing and not "require" anything in it.

I think we really want just folders down the tree that have "integration" in their name.

And with the coming of UI tests, we should similarly exclude those here - they should not be needed in this "unit testing" framework. The UI tests have their own way of loading the stuff they need with Behat.

## Related Issue

## Motivation and Context
Unnecessary stuff being loaded, potentially stuff could be missed from being loaded, when firing up unit tests,

## How Has This Been Tested?
Travis and Jenkins will tell.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
