### PR TITLE
Add repair step to repair mismatch filecache paths

### DIFF
--- a/apps/files/appinfo/app.php
+++ b/apps/files/appinfo/app.php
@@ -29,6 +29,9 @@
 
 \OC::$server->getSearch()->registerProvider('OC\Search\Provider\File', ['apps' => ['files']]);
 
+// instantiate to make sure services get registered
+$app = new \OCA\Files\AppInfo\Application();
+
 $templateManager = \OC_Helper::getFileTemplateManager();
 $templateManager->registerTemplate('text/html', 'core/templates/filetemplates/template.html');
 $templateManager->registerTemplate('application/vnd.oasis.opendocument.presentation', 'core/templates/filetemplates/template.odp');

--- a/apps/files/lib/AppInfo/Application.php
+++ b/apps/files/lib/AppInfo/Application.php
@@ -87,6 +87,13 @@ class Application extends App {
 			);
 		});
 
+		$container->registerService('OCP\Lock\ILockingProvider', function(IContainer $c)  {
+			return $c->query('ServerContainer')->getLockingProvider();
+		});
+		$container->registerService('OCP\Files\IMimeTypeLoader', function(IContainer $c)  {
+			return $c->query('ServerContainer')->getMimeTypeLoader();
+		});
+
 		/*
 		 * Register capabilities
 		 */

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -238,9 +238,7 @@ class Scan extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$inputPath = $input->getOption('path');
-		if ($input->getOption('repair')) {
-			$shouldRepairStoragesIndividually = true;
-		}
+		$shouldRepairStoragesIndividually = (bool) $input->getOption('repair');
 
 		if ($inputPath) {
 			$inputPath = '/' . trim($inputPath, '/');
@@ -304,7 +302,8 @@ class Scan extends Base {
 			if ($this->userManager->userExists($user)) {
 				# add an extra line when verbose is set to optical separate users
 				if ($verbose) {$output->writeln(""); }
-				$output->writeln("Starting scan for user $user_count out of $users_total ($user)");
+				$r = $shouldRepairStoragesIndividually ? ' (and repair)' : '';
+				$output->writeln("Starting scan$r for user $user_count out of $users_total ($user)");
 				# full: printout data if $verbose was set
 				$this->scanFiles($user, $path, $verbose, $output, $input->getOption('unscanned'), $shouldRepairStoragesIndividually);
 			} else {

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -254,8 +254,8 @@ class Scan extends Base {
 				// don't fix individually
 				$shouldRepairStoragesIndividually = false;
 			} else {
-				$output->writeln("<error>Repairing every storage individually is slower than repairing in bulk</error>");
-				$output->writeln("<error>To repair in bulk, please switch to single user mode first: occ maintenance:singleuser --on</error>");
+				$output->writeln("<comment>Repairing every storage individually is slower than repairing in bulk</comment>");
+				$output->writeln("<comment>To repair in bulk, please switch to single user mode first: occ maintenance:singleuser --on</comment>");
 			}
 			$users = $this->userManager->search('');
 		} else {

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -196,7 +196,8 @@ class Scanner extends PublicEmitter {
 			}
 
 			// if the home storage isn't writable then the scanner is run as the wrong user
-			if ($storage->instanceOfStorage('\OC\Files\Storage\Home') and
+			$isHome = $storage->instanceOfStorage('\OC\Files\Storage\Home');
+			if ($isHome and
 				(!$storage->isCreatable('') or !$storage->isCreatable('files'))
 			) {
 				if ($storage->file_exists('') or $storage->getCache()->inCache('')) {
@@ -211,6 +212,9 @@ class Scanner extends PublicEmitter {
 			if ($storage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
 				continue;
 			}
+
+			$this->emit('\OC\Files\Utils\Scanner', 'beforeScanStorage', [$storage]);
+
 			$relativePath = $mount->getInternalPath($dir);
 			$scanner = $storage->getScanner();
 			$scanner->setUseTransactions(false);
@@ -247,6 +251,7 @@ class Scanner extends PublicEmitter {
 			if ($this->useTransaction) {
 				$this->db->commit();
 			}
+			$this->emit('\OC\Files\Utils\Scanner', 'afterScanStorage', [$storage]);
 		}
 	}
 

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -196,8 +196,7 @@ class Scanner extends PublicEmitter {
 			}
 
 			// if the home storage isn't writable then the scanner is run as the wrong user
-			$isHome = $storage->instanceOfStorage('\OC\Files\Storage\Home');
-			if ($isHome and
+			if ($storage->instanceOfStorage('\OC\Files\Storage\Home') and
 				(!$storage->isCreatable('') or !$storage->isCreatable('files'))
 			) {
 				if ($storage->file_exists('') or $storage->getCache()->inCache('')) {

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -53,6 +53,7 @@ use OCP\Migration\IRepairStep;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use OC\Repair\MoveAvatarOutsideHome;
+use OC\Repair\RepairMismatchFileCachePath;
 
 class Repair implements IOutput{
 	/* @var IRepairStep[] */
@@ -126,6 +127,7 @@ class Repair implements IOutput{
 	public static function getRepairSteps() {
 		return [
 			new RepairMimeTypes(\OC::$server->getConfig()),
+			new RepairMismatchFileCachePath(\OC::$server->getDatabaseConnection(), \OC::$server->getMimeTypeLoader()),
 			new FillETags(\OC::$server->getDatabaseConnection()),
 			new CleanTags(\OC::$server->getDatabaseConnection(), \OC::$server->getUserManager()),
 			new DropOldTables(\OC::$server->getDatabaseConnection()),

--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -1,0 +1,407 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Repair;
+
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use OCP\Files\IMimeTypeLoader;
+use OCP\IDBConnection;
+
+/**
+ * Repairs file cache entry which path do not match the parent-child relationship
+ */
+class RepairMismatchFileCachePath implements IRepairStep {
+
+	const CHUNK_SIZE = 10000;
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	/** @var IMimeTypeLoader */
+	protected $mimeLoader;
+
+	/** @var int */
+	protected $dirMimeTypeId;
+
+	/** @var int */
+	protected $dirMimePartId;
+
+	/**
+	 * @param \OCP\IDBConnection $connection
+	 */
+	public function __construct(IDBConnection $connection, IMimeTypeLoader $mimeLoader) {
+		$this->connection = $connection;
+		$this->mimeLoader = $mimeLoader;
+	}
+
+	public function getName() {
+		return 'Repair file cache entries with path that does not match parent-child relationships';
+	}
+
+	/**
+	 * Fixes the broken entry's path.
+	 *
+	 * @param IOutput $out repair output
+	 * @param int $fileId file id of the entry to fix
+	 * @param string $wrongPath wrong path of the entry to fix
+	 * @param int $correctStorageNumericId numeric idea of the correct storage
+	 * @param string $correctPath value to which to set the path of the entry 
+	 * @return bool true for success
+	 */
+	private function fixEntryPath(IOutput $out, $fileId, $wrongPath, $correctStorageNumericId, $correctPath) {
+		// delete target if exists
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('filecache')
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($correctStorageNumericId)))
+			->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($correctPath)));
+		$entryExisted = $qb->execute() > 0;
+
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('filecache')
+			->set('path', $qb->createNamedParameter($correctPath))
+			->set('path_hash', $qb->createNamedParameter(md5($correctPath)))
+			->set('storage', $qb->createNamedParameter($correctStorageNumericId))
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)));
+		$qb->execute();
+
+		$text = "Fixed file cache entry with fileid $fileId, set wrong path \"$wrongPath\" to \"$correctPath\"";
+		if ($entryExisted) {
+			$text = " (replaced an existing entry)";
+		}
+		$out->advance(1, $text);
+	}
+
+	private function addQueryConditions($qb) {
+		// thanks, VicDeo!
+		if ($this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
+			$concatFunction = $qb->createFunction("CONCAT(fcp.path, '/', fc.name)");
+		} else {
+			$concatFunction = $qb->createFunction("(fcp.`path` || '/' || fc.`name`)");
+		}
+
+		if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+			$emptyPathExpr = $qb->expr()->isNotNull('fcp.path');
+		} else {
+			$emptyPathExpr = $qb->expr()->neq('fcp.path', $qb->expr()->literal(''));
+		}
+
+		$qb
+			->from('filecache', 'fc')
+			->from('filecache', 'fcp')
+			->where($qb->expr()->eq('fc.parent', 'fcp.fileid'))
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->neq(
+						$qb->createFunction($concatFunction),
+						'fc.path'
+					),
+					$qb->expr()->neq('fc.storage', 'fcp.storage')
+				)
+			)
+			->andWhere($emptyPathExpr)
+			// yes, this was observed in the wild...
+			->andWhere($qb->expr()->neq('fc.fileid', 'fcp.fileid'));
+	}
+
+	private function countResultsToProcess() {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select($qb->createFunction('COUNT(*)'));
+		$this->addQueryConditions($qb);
+		$results = $qb->execute();
+		$count = $results->fetchColumn(0);
+		$results->closeCursor();
+		return $count;
+	}
+
+	/**
+	 * Repair all entries for which the parent entry exists but the path
+	 * value doesn't match the parent's path.
+	 *
+	 * @param IOutput $out
+	 * @return int number of results that were fixed
+	 */
+	private function fixEntriesWithCorrectParentIdButWrongPath(IOutput $out) {
+		$totalResultsCount = 0;
+
+		// find all entries where the path entry doesn't match the path value that would
+		// be expected when following the parent-child relationship, basically
+		// concatenating the parent's "path" value with the name of the child
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('fc.storage', 'fc.fileid', 'fc.name')
+			->selectAlias('fc.path', 'path')
+			->selectAlias('fc.parent', 'wrongparentid')
+			->selectAlias('fcp.storage', 'parentstorage')
+			->selectAlias('fcp.path', 'parentpath');
+		$this->addQueryConditions($qb);
+		$qb->setMaxResults(self::CHUNK_SIZE);
+
+		do {
+			$results = $qb->execute();
+			// since we're going to operate on fetched entry, better cache them
+			// to avoid DB lock ups
+			$rows = $results->fetchAll();
+			$results->closeCursor();
+
+			$this->connection->beginTransaction();
+			$lastResultsCount = 0;
+			foreach ($rows as $row) {
+				$wrongPath = $row['path'];
+				$correctPath = $row['parentpath'] . '/' . $row['name'];
+				// make sure the target is on a different subtree
+				if (substr($correctPath, 0, strlen($wrongPath)) === $wrongPath) {
+					// the path based parent entry is referencing one of its own children, skipping
+					// fix the entry's parent id instead
+					// note: fixEntryParent cannot fail to find the parent entry by path
+					// here because the reason we reached this code is because we already
+					// found it
+					$this->fixEntryParent(
+						$out,
+						$row['storage'],
+						$row['fileid'],
+						$row['path'],
+						$row['wrongparentid'],
+						true
+					);
+				} else {
+					$this->fixEntryPath(
+						$out,
+						$row['fileid'],
+						$wrongPath,
+						$row['parentstorage'],
+						$correctPath
+					);
+				}
+				$lastResultsCount++;
+			}
+			$this->connection->commit();
+
+			$totalResultsCount += $lastResultsCount;
+
+			// note: this is not pagination but repeating the query over and over again
+			// until all possible entries were fixed
+		} while ($lastResultsCount > 0);
+
+		if ($totalResultsCount > 0) {
+			$out->info("Fixed $totalResultsCount file cache entries with wrong path");
+		}
+
+		return $totalResultsCount;
+	}
+
+	/**
+	 * Gets the file id of the entry. If none exists, create it
+	 * up to the root if needed.
+	 *
+	 * @param int $storageId storage id
+	 * @param string $path path for which to create the parent entry
+	 * @return int file id of the newly created parent
+	 */
+	private function getOrCreateEntry($storageId, $path, $reuseFileId = null) {
+		if ($path === '.') {
+			$path = '';
+		}
+		// find the correct parent
+		$qb = $this->connection->getQueryBuilder();
+		// select fileid as "correctparentid"
+		$qb->select('fileid')
+			// from oc_filecache
+			->from('filecache')
+			// where storage=$storage and path='$parentPath'
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($storageId)))
+			->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($path)));
+		$results = $qb->execute();
+		$rows = $results->fetchAll();
+		$results->closeCursor();
+
+		if (!empty($rows)) {
+			return $rows[0]['fileid'];
+		}
+
+		if ($path !== '') {
+			$parentId = $this->getOrCreateEntry($storageId, dirname($path));
+		} else {
+			// root entry missing, create it
+			$parentId = -1;
+		}
+
+		$qb = $this->connection->getQueryBuilder();
+		$values = [
+			'storage' => $qb->createNamedParameter($storageId),
+			'path' => $qb->createNamedParameter($path),
+			'path_hash' => $qb->createNamedParameter(md5($path)),
+			'name' => $qb->createNamedParameter(basename($path)),
+			'parent' => $qb->createNamedParameter($parentId),
+			'size' => $qb->createNamedParameter(-1),
+			'etag' => $qb->createNamedParameter('zombie'),
+			'mimetype' => $qb->createNamedParameter($this->dirMimeTypeId),
+			'mimepart' => $qb->createNamedParameter($this->dirMimePartId),
+		];
+
+		if ($reuseFileId !== null) {
+			// purpose of reusing the fileid of the parent is to salvage potential
+			// metadata that might have previously been linked to this file id
+			$values['fileid'] = $qb->createNamedParameter($reuseFileId);
+		}
+		$qb->insert('filecache')->values($values);
+		$qb->execute();
+		return $this->connection->lastInsertId('*PREFIX*filecache');
+	}
+
+	/**
+	 * Fixes the broken entry's path.
+	 *
+	 * @param IOutput $out repair output
+	 * @param int $storageId storage id of the entry to fix
+	 * @param int $fileId file id of the entry to fix
+	 * @param string $path path from the entry to fix
+	 * @param int $wrongParentId wrong parent id
+	 * @param bool $parentIdExists true if the entry from the $wrongParentId exists (but is the wrong one),
+	 * false if it doesn't
+	 * @return bool true if the entry was fixed, false otherwise
+	 */
+	private function fixEntryParent(IOutput $out, $storageId, $fileId, $path, $wrongParentId, $parentIdExists = false) {
+		if (!$parentIdExists) {
+			// if the parent doesn't exist, let us reuse its id in case there is metadata to salvage
+			$correctParentId = $this->getOrCreateEntry($storageId, dirname($path), $wrongParentId);
+		} else {
+			// parent exists and is the wrong one, so recreating would need a new fileid
+			$correctParentId = $this->getOrCreateEntry($storageId, dirname($path));
+		}
+
+		$this->connection->beginTransaction();
+
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('filecache')
+			->set('parent', $qb->createNamedParameter($correctParentId))
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)));
+		$qb->execute();
+
+		$text = "Fixed file cache entry with fileid $fileId, set wrong parent \"$wrongParentId\" to \"$correctParentId\"";
+		$out->advance(1, $text);
+
+		$this->connection->commit();
+
+		return true;
+	}
+
+	/**
+	 * Repair entries where the parent id doesn't point to any existing entry
+	 * by finding the actual parent entry matching the entry's path dirname.
+	 * 
+	 * @param IOutput $out output
+	 * @return int number of results that were fixed
+	 */
+	private function fixEntriesWithNonExistingParentIdEntry(IOutput $out) {
+		// Subquery for parent existence
+		$qbe = $this->connection->getQueryBuilder();
+		$qbe->select($qbe->expr()->literal('1'))
+			->from('filecache', 'fce')
+			->where($qbe->expr()->eq('fce.fileid', 'fc.parent'));
+
+		$qb = $this->connection->getQueryBuilder();
+
+		// Find entries to repair
+		// select fc.storage,fc.fileid,fc.parent as "wrongparent",fc.path,fc.etag
+		// and not exists (select 1 from oc_filecache fc2 where fc2.fileid = fc.parent)
+		$qb->select('storage', 'fileid', 'path', 'parent')
+			// from oc_filecache fc
+			->from('filecache', 'fc')
+			// where fc.parent <> -1
+			->where($qb->expr()->neq('fc.parent', $qb->createNamedParameter(-1)))
+			// and not exists (select 1 from oc_filecache fc2 where fc2.fileid = fc.parent)
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->eq('fc.fileid', 'fc.parent'),
+					$qb->createFunction('NOT EXISTS (' . $qbe->getSQL() . ')'))
+				);
+		$qb->setMaxResults(self::CHUNK_SIZE);
+
+		$totalResultsCount = 0;
+		do {
+			$results = $qb->execute();
+			// since we're going to operate on fetched entry, better cache them
+			// to avoid DB lock ups
+			$rows = $results->fetchAll();
+			$results->closeCursor();
+
+			$lastResultsCount = 0;
+			foreach ($rows as $row) {
+				$this->fixEntryParent(
+					$out,
+					$row['storage'],
+					$row['fileid'],
+					$row['path'],
+					$row['parent'],
+					// in general the parent doesn't exist except
+					// for the one condition where parent=fileid
+					$row['parent'] === $row['fileid']
+				);
+				$lastResultsCount++;
+			}
+
+			$totalResultsCount += $lastResultsCount;
+
+			// note: this is not pagination but repeating the query over and over again
+			// until all possible entries were fixed
+		} while ($lastResultsCount > 0);
+
+		if ($totalResultsCount > 0) {
+			$out->info("Fixed $totalResultsCount file cache entries with wrong path");
+		}
+
+		return $totalResultsCount;
+	}
+
+	/**
+	 * Run the repair step
+	 *
+	 * @param IOutput $out output
+	 */
+	public function run(IOutput $out) {
+
+		$this->dirMimeTypeId = $this->mimeLoader->getId('httpd/unix-directory');
+		$this->dirMimePartId = $this->mimeLoader->getId('httpd');
+
+		$out->startProgress($this->countResultsToProcess());
+
+		$totalFixed = 0;
+
+		/*
+		 * This repair itself might overwrite existing target parent entries and create
+		 * orphans where the parent entry of the parent id doesn't exist but the path matches.
+		 * This needs to be repaired by fixEntriesWithNonExistingParentIdEntry(), this is why
+		 * we need to keep this specific order of repair.
+		 */
+		$totalFixed += $this->fixEntriesWithCorrectParentIdButWrongPath($out);
+
+		$totalFixed += $this->fixEntriesWithNonExistingParentIdEntry($out);
+
+		$out->finishProgress();
+
+		if ($totalFixed > 0) {
+			$out->warning('Please run `occ files:scan --all` once to complete the repair');
+		}
+	}
+}

--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -523,6 +523,7 @@ class RepairMismatchFileCachePath implements IRepairStep {
 				$this->fixEntriesWithNonExistingParentIdEntry($out);
 			}
 			$out->finishProgress();
+			$out->info('');
 		}
 	}
 }

--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -232,7 +232,9 @@ class RepairMismatchFileCachePath implements IRepairStep {
 
 		if (!empty($storageIds)) {
 			$out->warning('The file cache contains entries with invalid path values for the following storage numeric ids: ' . implode(' ', $storageIds));
-			$out->warning('Please run `occ files:scan --all --repair` to repair all affected storages');
+			$out->warning('Please run `occ files:scan --all --repair` to repair'
+			.'all affected storages or run `occ files:scan userid --repair for '
+			.'each user with affected storages');
 		}
 	}
 

--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -413,6 +413,20 @@ class RepairMismatchFileCachePath implements IRepairStep {
 
 		// If we reused the fileid then this is the id to return
 		if($reuseFileId !== null) {
+			// with Oracle, the trigger gets in the way and does not let us specify
+			// a fileid value on insert
+			if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+				$lastFileId = $this->connection->lastInsertId('*PREFIX*filecache');
+				if ($reuseFileId !== $lastFileId) {
+					// use update to set it directly
+					$qb = $this->connection->getQueryBuilder();
+					$qb->update('filecache')
+						->set('fileid', $qb->createNamedParameter($reuseFileId))
+						->where($qb->expr()->eq('fileid', $qb->createNamedParameter($lastFileId)));
+					$qb->execute();
+				}
+			}
+
 			return $reuseFileId;
 		} else {
 			// Else we inserted a new row with auto generated id, use that

--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -103,8 +103,13 @@ class RepairMismatchFileCachePath implements IRepairStep {
 		// delete target if exists
 		$qb = $this->connection->getQueryBuilder();
 		$qb->delete('filecache')
-			->where($qb->expr()->eq('storage', $qb->createNamedParameter($correctStorageNumericId)))
-			->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($correctPath)));
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($correctStorageNumericId)));
+
+		if ($correctPath === '' && $this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+			$qb->andWhere($qb->expr()->isNull('path'));
+		} else {
+			$qb->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($correctPath)));
+		}
 		$entryExisted = $qb->execute() > 0;
 
 		$qb = $this->connection->getQueryBuilder();
@@ -363,8 +368,13 @@ class RepairMismatchFileCachePath implements IRepairStep {
 			// from oc_filecache
 			->from('filecache')
 			// where storage=$storage and path='$parentPath'
-			->where($qb->expr()->eq('storage', $qb->createNamedParameter($storageId)))
-			->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($path)));
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($storageId)));
+
+		if ($path === '' && $this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+			$qb->andWhere($qb->expr()->isNull('path'));
+		} else {
+			$qb->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($path)));
+		}
 		$results = $qb->execute();
 		$rows = $results->fetchAll();
 		$results->closeCursor();

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -652,6 +652,7 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 			return new NoopLockingProvider();
 		});
+		$this->registerAlias('OCP\Lock\ILockingProvider', 'LockingProvider');
 		$this->registerService('MountManager', function () {
 			return new \OC\Files\Mount\Manager();
 		});
@@ -667,6 +668,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getDatabaseConnection()
 			);
 		});
+		$this->registerAlias('OCP\Files\IMimeTypeLoader', 'MimeTypeLoader');
 		$this->registerService('NotificationManager', function () {
 			return new Manager();
 		});

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -92,6 +92,9 @@ interface IDBConnection {
 
 	/**
 	 * Used to get the id of the just inserted element
+	 * Note: On postgres platform, this will return the last sequence id which
+	 * may not be the id last inserted if you were reinserting a previously
+	 * used auto_increment id.
 	 * @param string $table the name of the table where we inserted the item
 	 * @return int the id of the inserted element
 	 * @since 6.0.0

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -42,6 +42,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 				['httpd/unix-directory', 2],
 			]));
 		$this->repair = new RepairMismatchFileCachePath($this->connection, $mimeLoader);
+		$this->repair->setCountOnly(false);
 	}
 
 	protected function tearDown() {

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -1,0 +1,495 @@
+<?php
+/**
+ * Copyright (c) 2017 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Repair;
+
+
+use OC\Repair\RepairMismatchFileCachePath;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Test\TestCase;
+use OCP\Files\IMimeTypeLoader;
+
+/**
+ * Tests for repairing mismatch file cache paths
+ *
+ * @group DB
+ *
+ * @see \OC\Repair\RepairMismatchFileCachePath
+ */
+class RepairMismatchFileCachePathTest extends TestCase {
+
+	/** @var IRepairStep */
+	private $repair;
+
+	/** @var \OCP\IDBConnection */
+	private $connection;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+
+		$mimeLoader = $this->createMock(IMimeTypeLoader::class);
+		$mimeLoader->method('getId')
+			->will($this->returnValueMap([
+				['httpd', 1],
+				['httpd/unix-directory', 2],
+			]));
+		$this->repair = new RepairMismatchFileCachePath($this->connection, $mimeLoader);
+	}
+
+	protected function tearDown() {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('filecache')->execute();
+		parent::tearDown();
+	}
+
+	private function createFileCacheEntry($storage, $path, $parent = -1) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert('filecache')
+			->values([
+				'storage' => $qb->createNamedParameter($storage),
+				'path' => $qb->createNamedParameter($path),
+				'path_hash' => $qb->createNamedParameter(md5($path)),
+				'name' => $qb->createNamedParameter(basename($path)),
+				'parent' => $qb->createNamedParameter($parent),
+			]);
+		$qb->execute();
+		return $this->connection->lastInsertId('*PREFIX*filecache');
+	}
+
+	/**
+	 * Returns autoincrement compliant fileid for an entry that might
+	 * have existed
+	 *
+	 * @return int fileid
+	 */
+	private function createNonExistingId() {
+		// why are we doing this ? well, if we just pick an arbitrary
+		// value ahead of the autoincrement, this will not reflect real scenarios
+		// and also will likely cause potential collisions as some newly inserted entries
+		// might receive said arbitrary id through autoincrement
+		//
+		// So instead, we insert a dummy entry and delete it afterwards so we have
+		// "reserved" the fileid and also somehow simulated whatever might have happened
+		// on a real system when a file cache entry suddenly disappeared for whatever
+		// mysterious reasons
+		$entryId = $this->createFileCacheEntry(1, 'goodbye-entry');
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('filecache')
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($entryId)));
+		$qb->execute();
+		return $entryId;
+	}
+
+	private function getFileCacheEntry($fileId) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('*')
+			->from('filecache')
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)));
+		$results = $qb->execute();
+		$result = $results->fetch();
+		$results->closeCursor();
+		return $result;
+	}
+
+	/**
+	 * Sets the parent of the given file id to the given parent id
+	 *
+	 * @param int $fileId file id of the entry to adjust
+	 * @param int $parentId parent id to set to
+	 */
+	private function setFileCacheEntryParent($fileId, $parentId) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('filecache')
+			->set('parent', $qb->createNamedParameter($parentId))
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)));
+		$qb->execute();
+	}
+
+	public function repairCasesProvider() {
+		return [
+			// same storage, different target dir
+			[1, 1, 'target'],
+			// different storage, same target dir name
+			[1, 2, 'source'],
+			// different storage, different target dir
+			[1, 2, 'target'],
+
+			// same storage, different target dir, target exists
+			[1, 1, 'target', true],
+			// different storage, same target dir name, target exists
+			[1, 2, 'source', true],
+			// different storage, different target dir, target exists
+			[1, 2, 'target', true],
+		];
+	}
+
+	/**
+	 * Test repair
+	 *
+	 * @dataProvider repairCasesProvider
+	 */
+	public function testRepairEntry($sourceStorageId, $targetStorageId, $targetDir, $targetExists = false) {
+		/*
+		 * Tree:
+		 *
+		 * source storage:
+		 *     - files/
+		 *     - files/source/
+		 *     - files/source/to_move (not created as we simulate that it was already moved)
+		 *     - files/source/to_move/content_to_update (bogus entry to fix)
+		 *     - files/source/to_move/content_to_update/sub (bogus subentry to fix)
+		 *     - files/source/do_not_touch (regular entry outside of the repair scope)
+		 *
+		 * target storage:
+		 *     - files/
+		 *     - files/target/
+		 *     - files/target/moved_renamed (already moved target)
+		 *     - files/target/moved_renamed/content_to_update (missing until repair)
+		 *
+		 * if $targetExists: pre-create these additional entries:
+		 *     - files/target/moved_renamed/content_to_update (will be overwritten)
+		 *     - files/target/moved_renamed/content_to_update/sub (will be overwritten)
+		 *     - files/target/moved_renamed/content_to_update/unrelated (will be reparented)
+		 *
+		 */
+
+		// source storage entries
+		$rootId1 = $this->createFileCacheEntry($sourceStorageId, '');
+		$baseId1 = $this->createFileCacheEntry($sourceStorageId, 'files', $rootId1);
+		if ($sourceStorageId !== $targetStorageId) {
+			$rootId2 = $this->createFileCacheEntry($targetStorageId, '');
+			$baseId2 = $this->createFileCacheEntry($targetStorageId, 'files', $rootId2);
+		} else {
+			$rootId2 = $rootId1;
+			$baseId2 = $baseId1;
+		}
+		$sourceId = $this->createFileCacheEntry($sourceStorageId, 'files/source', $baseId1);
+
+		// target storage entries
+		$targetParentId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir, $baseId2);
+
+		// the move does create the parent in the target
+		$targetId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir . '/moved_renamed', $targetParentId);
+
+		// bogus entry: any children of the source are not properly updated
+		$movedId = $this->createFileCacheEntry($sourceStorageId, 'files/source/to_move/content_to_update', $targetId);
+		$movedSubId = $this->createFileCacheEntry($sourceStorageId, 'files/source/to_move/content_to_update/sub', $movedId);
+
+		if ($targetExists) {
+			// after the bogus move happened, some code path recreated the parent under a
+			// different file id
+			$existingTargetId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir . '/moved_renamed/content_to_update', $targetId);
+			$existingTargetSubId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir . '/moved_renamed/content_to_update/sub', $existingTargetId);
+			$existingTargetUnrelatedId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir . '/moved_renamed/content_to_update/unrelated', $existingTargetId);
+		}
+
+		$doNotTouchId = $this->createFileCacheEntry($sourceStorageId, 'files/source/do_not_touch', $sourceId);
+
+		$outputMock = $this->createMock(IOutput::class);
+		$this->repair->run($outputMock);
+
+		$entry = $this->getFileCacheEntry($movedId);
+		$this->assertEquals($targetId, $entry['parent']);
+		$this->assertEquals((string)$targetStorageId, $entry['storage']);
+		$this->assertEquals('files/' . $targetDir . '/moved_renamed/content_to_update', $entry['path']);
+		$this->assertEquals(md5('files/' . $targetDir . '/moved_renamed/content_to_update'), $entry['path_hash']);
+
+		$entry = $this->getFileCacheEntry($movedSubId);
+		$this->assertEquals($movedId, $entry['parent']);
+		$this->assertEquals((string)$targetStorageId, $entry['storage']);
+		$this->assertEquals('files/' . $targetDir . '/moved_renamed/content_to_update/sub', $entry['path']);
+		$this->assertEquals(md5('files/' . $targetDir . '/moved_renamed/content_to_update/sub'), $entry['path_hash']);
+
+		if ($targetExists) {
+			$this->assertFalse($this->getFileCacheEntry($existingTargetId));
+			$this->assertFalse($this->getFileCacheEntry($existingTargetSubId));
+
+			// unrelated folder has been reparented
+			$entry = $this->getFileCacheEntry($existingTargetUnrelatedId);
+			$this->assertEquals($movedId, $entry['parent']);
+			$this->assertEquals((string)$targetStorageId, $entry['storage']);
+			$this->assertEquals('files/' . $targetDir . '/moved_renamed/content_to_update/unrelated', $entry['path']);
+			$this->assertEquals(md5('files/' . $targetDir . '/moved_renamed/content_to_update/unrelated'), $entry['path_hash']);
+		}
+
+		// root entries left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$sourceStorageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+
+		$entry = $this->getFileCacheEntry($rootId2);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$targetStorageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+
+		// "do not touch" entry left untouched
+		$entry = $this->getFileCacheEntry($doNotTouchId);
+		$this->assertEquals($sourceId, $entry['parent']);
+		$this->assertEquals((string)$sourceStorageId, $entry['storage']);
+		$this->assertEquals('files/source/do_not_touch', $entry['path']);
+		$this->assertEquals(md5('files/source/do_not_touch'), $entry['path_hash']);
+
+		// root entry left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$sourceStorageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+	}
+
+	/**
+	 * Test repair self referencing entries
+	 */
+	public function testRepairSelfReferencing() {
+		/**
+		 * Self-referencing:
+		 *     - files/all_your_zombies (parent=fileid must be reparented)
+		 *
+		 * Referencing child one level:
+		 *     - files/ref_child1 (parent=fileid of the child)
+		 *     - files/ref_child1/child (parent=fileid of the child)
+		 *
+		 * Referencing child two levels:
+		 *     - files/ref_child2/ (parent=fileid of the child's child)
+		 *     - files/ref_child2/child
+		 *     - files/ref_child2/child/child
+		 *
+		 * Referencing child two levels detached:
+		 *     - detached/ref_child3/ (parent=fileid of the child, "detached" has no entry)
+		 *     - detached/ref_child3/child
+		 */
+		$storageId = 1;
+		$rootId1 = $this->createFileCacheEntry($storageId, '');
+		$baseId1 = $this->createFileCacheEntry($storageId, 'files', $rootId1);
+
+		$selfRefId = $this->createFileCacheEntry($storageId, 'files/all_your_zombies', $baseId1);
+		$this->setFileCacheEntryParent($selfRefId, $selfRefId);
+
+		$refChild1Id = $this->createFileCacheEntry($storageId, 'files/ref_child1', $baseId1);
+		$refChild1ChildId = $this->createFileCacheEntry($storageId, 'files/ref_child1/child', $refChild1Id);
+		// make it reference its own child
+		$this->setFileCacheEntryParent($refChild1Id, $refChild1ChildId);
+
+		$refChild2Id = $this->createFileCacheEntry($storageId, 'files/ref_child2', $baseId1);
+		$refChild2ChildId = $this->createFileCacheEntry($storageId, 'files/ref_child2/child', $refChild2Id);
+		$refChild2ChildChildId = $this->createFileCacheEntry($storageId, 'files/ref_child2/child/child', $refChild2ChildId);
+		// make it reference its own sub child
+		$this->setFileCacheEntryParent($refChild2Id, $refChild2ChildChildId);
+
+		$refChild3Id = $this->createFileCacheEntry($storageId, 'detached/ref_child3', $baseId1);
+		$refChild3ChildId = $this->createFileCacheEntry($storageId, 'detached/ref_child3/child', $refChild3Id);
+		// make it reference its own child
+		$this->setFileCacheEntryParent($refChild3Id, $refChild3ChildId);
+
+		$outputMock = $this->createMock(IOutput::class);
+		$this->repair->run($outputMock);
+
+		// self-referencing updated
+		$entry = $this->getFileCacheEntry($selfRefId);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/all_your_zombies', $entry['path']);
+		$this->assertEquals(md5('files/all_your_zombies'), $entry['path_hash']);
+
+		// ref child 1 case was reparented to "files"
+		$entry = $this->getFileCacheEntry($refChild1Id);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child1', $entry['path']);
+		$this->assertEquals(md5('files/ref_child1'), $entry['path_hash']);
+
+		// ref child 1 child left alone
+		$entry = $this->getFileCacheEntry($refChild1ChildId);
+		$this->assertEquals($refChild1Id, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child1/child', $entry['path']);
+		$this->assertEquals(md5('files/ref_child1/child'), $entry['path_hash']);
+
+		// ref child 2 case was reparented to "files"
+		$entry = $this->getFileCacheEntry($refChild2Id);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child2', $entry['path']);
+		$this->assertEquals(md5('files/ref_child2'), $entry['path_hash']);
+
+		// ref child 2 child left alone
+		$entry = $this->getFileCacheEntry($refChild2ChildId);
+		$this->assertEquals($refChild2Id, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child2/child', $entry['path']);
+		$this->assertEquals(md5('files/ref_child2/child'), $entry['path_hash']);
+
+		// ref child 2 child child left alone
+		$entry = $this->getFileCacheEntry($refChild2ChildChildId);
+		$this->assertEquals($refChild2ChildId, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child2/child/child', $entry['path']);
+		$this->assertEquals(md5('files/ref_child2/child/child'), $entry['path_hash']);
+
+		// root entry left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+
+		// ref child 3 child left alone
+		$entry = $this->getFileCacheEntry($refChild3ChildId);
+		$this->assertEquals($refChild3Id, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('detached/ref_child3/child', $entry['path']);
+		$this->assertEquals(md5('detached/ref_child3/child'), $entry['path_hash']);
+
+		// ref child 3 case was reparented to a new "detached" entry
+		$entry = $this->getFileCacheEntry($refChild3Id);
+		$this->assertTrue(isset($entry['parent']));
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('detached/ref_child3', $entry['path']);
+		$this->assertEquals(md5('detached/ref_child3'), $entry['path_hash']);
+
+		// entry "detached" was restored
+		$entry = $this->getFileCacheEntry($entry['parent']);
+		$this->assertEquals($rootId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('detached', $entry['path']);
+		$this->assertEquals(md5('detached'), $entry['path_hash']);
+	}
+
+	/**
+	 * Test repair wrong parent id
+	 */
+	public function testRepairParentIdPointingNowhere() {
+		/**
+		 * Wrong parent id
+		 *     - wrongparentroot
+		 *     - files/wrongparent
+		 */
+		$storageId = 1;
+		$rootId1 = $this->createFileCacheEntry($storageId, '');
+		$baseId1 = $this->createFileCacheEntry($storageId, 'files', $rootId1);
+
+		$nonExistingParentId = $this->createNonExistingId();
+		$wrongParentRootId = $this->createFileCacheEntry($storageId, 'wrongparentroot', $nonExistingParentId);
+		$wrongParentId = $this->createFileCacheEntry($storageId, 'files/wrongparent', $nonExistingParentId);
+
+		$outputMock = $this->createMock(IOutput::class);
+		$this->repair->run($outputMock);
+
+		// wrong parent root reparented to actual root
+		$entry = $this->getFileCacheEntry($wrongParentRootId);
+		$this->assertEquals($rootId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('wrongparentroot', $entry['path']);
+		$this->assertEquals(md5('wrongparentroot'), $entry['path_hash']);
+
+		// wrong parent subdir reparented to "files"
+		$entry = $this->getFileCacheEntry($wrongParentId);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/wrongparent', $entry['path']);
+		$this->assertEquals(md5('files/wrongparent'), $entry['path_hash']);
+
+		// root entry left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+	}
+
+	/**
+	 * Test repair detached subtree
+	 */
+	public function testRepairDetachedSubtree() {
+		/**
+		 * other:
+		 *     - files/missingdir/orphaned1 (orphaned entry as "missingdir" is missing)
+		 *     - missingdir/missingdir1/orphaned2 (orphaned entry two levels up to root)
+		 *     - noroot (orphaned entry on a storage that has no root entry)
+		 */
+		$storageId = 1;
+		$storageId2 = 2;
+		$rootId1 = $this->createFileCacheEntry($storageId, '');
+		$baseId1 = $this->createFileCacheEntry($storageId, 'files', $rootId1);
+
+		$nonExistingParentId = $this->createNonExistingId();
+		$orphanedId1 = $this->createFileCacheEntry($storageId, 'files/missingdir/orphaned1', $nonExistingParentId);
+
+		$nonExistingParentId2 = $this->createNonExistingId();
+		$orphanedId2 = $this->createFileCacheEntry($storageId, 'missingdir/missingdir1/orphaned2', $nonExistingParentId2);
+
+		$nonExistingParentId3 = $this->createNonExistingId();
+		$orphanedId3 = $this->createFileCacheEntry($storageId2, 'noroot', $nonExistingParentId3);
+
+		$outputMock = $this->createMock(IOutput::class);
+		$this->repair->run($outputMock);
+
+		// orphaned entry reattached
+		$entry = $this->getFileCacheEntry($orphanedId1);
+		$this->assertEquals($nonExistingParentId, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/missingdir/orphaned1', $entry['path']);
+		$this->assertEquals(md5('files/missingdir/orphaned1'), $entry['path_hash']);
+
+		// non existing id exists now
+		$entry = $this->getFileCacheEntry($entry['parent']);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/missingdir', $entry['path']);
+		$this->assertEquals(md5('files/missingdir'), $entry['path_hash']);
+
+		// orphaned entry reattached
+		$entry = $this->getFileCacheEntry($orphanedId2);
+		$this->assertEquals($nonExistingParentId2, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('missingdir/missingdir1/orphaned2', $entry['path']);
+		$this->assertEquals(md5('missingdir/missingdir1/orphaned2'), $entry['path_hash']);
+
+		// non existing id exists now
+		$entry = $this->getFileCacheEntry($entry['parent']);
+		$this->assertTrue(isset($entry['parent']));
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('missingdir/missingdir1', $entry['path']);
+		$this->assertEquals(md5('missingdir/missingdir1'), $entry['path_hash']);
+
+		// non existing id parent exists now
+		$entry = $this->getFileCacheEntry($entry['parent']);
+		$this->assertEquals($rootId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('missingdir', $entry['path']);
+		$this->assertEquals(md5('missingdir'), $entry['path_hash']);
+
+		// root entry left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+
+		// orphaned entry with no root reattached
+		$entry = $this->getFileCacheEntry($orphanedId3);
+		$this->assertTrue(isset($entry['parent']));
+		$this->assertEquals((string)$storageId2, $entry['storage']);
+		$this->assertEquals('noroot', $entry['path']);
+		$this->assertEquals(md5('noroot'), $entry['path_hash']);
+
+		// recreated root entry
+		$entry = $this->getFileCacheEntry($entry['parent']);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$storageId2, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+	}
+}
+

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -599,7 +599,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		// orphaned entry reattached
 		$entry = $this->getFileCacheEntry($orphanedId1);
-		$this->assertEquals($nonExistingParentId, $entry['parent']); // this row fails, $entry['parent'] seems to equal a similar but different value
+		$this->assertEquals($nonExistingParentId, $entry['parent']);
 		$this->assertEquals((string)$storageId, $entry['storage']);
 		$this->assertEquals('files/missingdir/orphaned1', $entry['path']);
 		$this->assertEquals(md5('files/missingdir/orphaned1'), $entry['path_hash']);
@@ -713,7 +713,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		// recreated root entry
 		$entry = $this->getFileCacheEntry($entry['parent']);
-		$this->assertEquals(-1, $entry['parent']); // this row fails, it appears to get attached to another entry, not the root (fileid ~ 4000)
+		$this->assertEquals(-1, $entry['parent']);
 		$this->assertEquals((string)$storageId, $entry['storage']);
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -583,6 +583,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		// end corrupt storage
 
 		// Parallel test storage
+		/*
 		$storageId_parallel = 2;
 		$rootId1_parallel = $this->createFileCacheEntry($storageId_parallel, '');
 		$baseId1_parallel = $this->createFileCacheEntry($storageId_parallel, 'files', $rootId1_parallel);
@@ -592,6 +593,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$notOrphanedFolderChild2_parallel = $this->createFileCacheEntry($storageId_parallel, 'missingdir/missingdir1', $notOrphanedFolder2_parallel);
 		$notOrphanedId2_parallel = $this->createFileCacheEntry($storageId_parallel, 'missingdir/missingdir1/orphaned2', $notOrphanedFolder2_parallel);
 		// end parallel test storage
+		*/
 
 		$outputMock = $this->createMock(IOutput::class);
 		$this->repair->setStorageNumericId($storageId);
@@ -599,7 +601,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		// orphaned entry reattached
 		$entry = $this->getFileCacheEntry($orphanedId1);
-		$this->assertEquals($nonExistingParentId, $entry['parent']);
+		$this->assertEquals($nonExistingParentId, $entry['parent']); // this row fails, $entry['parent'] seems to equal a similar but different value
 		$this->assertEquals((string)$storageId, $entry['storage']);
 		$this->assertEquals('files/missingdir/orphaned1', $entry['path']);
 		$this->assertEquals(md5('files/missingdir/orphaned1'), $entry['path_hash']);
@@ -640,6 +642,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals(md5(''), $entry['path_hash']);
 
 		// now check the parallel storage is intact
+		/*
 		// orphaned entry reattached
 		$entry = $this->getFileCacheEntry($notOrphanedId1_parallel);
 		$this->assertEquals($notOrphanedFolder_parallel, $entry['parent']);
@@ -681,6 +684,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals((string)$storageId_parallel, $entry['storage']);
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);
+		*/
 	}
 
 	/**
@@ -695,9 +699,11 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$orphanedId = $this->createFileCacheEntry($storageId, 'noroot', $nonExistingParentId);
 
 		// Test parallel storage which should be untouched by the repair operation
+		/*
 		$testStorageId = 2;
 		$baseId = $this->createFileCacheEntry($testStorageId, '');
 		$noRootid = $this->createFileCacheEntry($testStorageId, 'noroot', $baseId);
+		*/
 
 
 		$outputMock = $this->createMock(IOutput::class);
@@ -713,11 +719,12 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		// recreated root entry
 		$entry = $this->getFileCacheEntry($entry['parent']);
-		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals(-1, $entry['parent']); // this row fails, it appears to get attached to another entry, not the root (fileid ~ 4000)
 		$this->assertEquals((string)$storageId, $entry['storage']);
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);
 
+		/*
 		// Check that the parallel test storage is still intact
 		$entry = $this->getFileCacheEntry($noRootid);
 		$this->assertEquals($baseId, $entry['parent']);
@@ -729,6 +736,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals((string)$testStorageId, $entry['storage']);
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);
+		*/
 	}
 }
 

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -583,7 +583,6 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		// end corrupt storage
 
 		// Parallel test storage
-		/*
 		$storageId_parallel = 2;
 		$rootId1_parallel = $this->createFileCacheEntry($storageId_parallel, '');
 		$baseId1_parallel = $this->createFileCacheEntry($storageId_parallel, 'files', $rootId1_parallel);
@@ -593,7 +592,6 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$notOrphanedFolderChild2_parallel = $this->createFileCacheEntry($storageId_parallel, 'missingdir/missingdir1', $notOrphanedFolder2_parallel);
 		$notOrphanedId2_parallel = $this->createFileCacheEntry($storageId_parallel, 'missingdir/missingdir1/orphaned2', $notOrphanedFolder2_parallel);
 		// end parallel test storage
-		*/
 
 		$outputMock = $this->createMock(IOutput::class);
 		$this->repair->setStorageNumericId($storageId);
@@ -642,7 +640,6 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals(md5(''), $entry['path_hash']);
 
 		// now check the parallel storage is intact
-		/*
 		// orphaned entry reattached
 		$entry = $this->getFileCacheEntry($notOrphanedId1_parallel);
 		$this->assertEquals($notOrphanedFolder_parallel, $entry['parent']);
@@ -684,7 +681,6 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals((string)$storageId_parallel, $entry['storage']);
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);
-		*/
 	}
 
 	/**
@@ -699,11 +695,9 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$orphanedId = $this->createFileCacheEntry($storageId, 'noroot', $nonExistingParentId);
 
 		// Test parallel storage which should be untouched by the repair operation
-		/*
 		$testStorageId = 2;
 		$baseId = $this->createFileCacheEntry($testStorageId, '');
 		$noRootid = $this->createFileCacheEntry($testStorageId, 'noroot', $baseId);
-		*/
 
 
 		$outputMock = $this->createMock(IOutput::class);
@@ -724,7 +718,6 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);
 
-		/*
 		// Check that the parallel test storage is still intact
 		$entry = $this->getFileCacheEntry($noRootid);
 		$this->assertEquals($baseId, $entry['parent']);
@@ -736,7 +729,6 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals((string)$testStorageId, $entry['storage']);
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);
-		*/
 	}
 }
 

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -221,7 +221,11 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		}
 		$dataDir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data-autotest');
 		if (self::$wasDatabaseAllowed && \OC::$server->getDatabaseConnection()) {
-			$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+			$connection = \OC::$server->getDatabaseConnection();
+			if ($connection->inTransaction()) {
+				throw new \Exception('Stray transaction in test class ' . get_called_class());
+			}
+			$queryBuilder = $connection->getQueryBuilder();
 
 			self::tearDownAfterClassCleanShares($queryBuilder);
 			self::tearDownAfterClassCleanStorages($queryBuilder);

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -223,7 +223,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		if (self::$wasDatabaseAllowed && \OC::$server->getDatabaseConnection()) {
 			$connection = \OC::$server->getDatabaseConnection();
 			if ($connection->inTransaction()) {
-				throw new \Exception('Stray transaction in test class ' . get_called_class());
+				//throw new \Exception('Stray transaction in test class ' . get_called_class());
 			}
 			$queryBuilder = $connection->getQueryBuilder();
 

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -222,9 +222,6 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		$dataDir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data-autotest');
 		if (self::$wasDatabaseAllowed && \OC::$server->getDatabaseConnection()) {
 			$connection = \OC::$server->getDatabaseConnection();
-			if ($connection->inTransaction()) {
-				//throw new \Exception('Stray transaction in test class ' . get_called_class());
-			}
 			$queryBuilder = $connection->getQueryBuilder();
 
 			self::tearDownAfterClassCleanShares($queryBuilder);


### PR DESCRIPTION
## Description
Whenever a parent-child relationship describes a specific path but the
entry's actual path is different, this new repair step will adjust it.

In the event where another entry already exists under that name, the
latter is deleted and replaced by the above entry. This should help
preserve the metadata associated with the original entry.

This kind of situation can be create through the bug from https://github.com/owncloud/core/issues/28018

This is a better fix than https://github.com/owncloud/core/pull/28217

The cases that this repair step fixes:
- current path doesn't match the one from the parent on same storage: reproducible before https://github.com/owncloud/core/pull/28022 by moving a file between two received shares from the same user or by moving a file out of a received share.
- current path doesn't match the one from the parent on a different storage: reproducible before https://github.com/owncloud/core/pull/28022 by moving a file between two received shares where each share comes from a different user (two storages)
- parentid pointing to a non-existing entry: not reproducible in the wild, however the first phase of the repair step will create such entries which the second phase fixes. I assume that there might be such cases existing out there so this would fix them too.
- `parent = fileid`: not reproducible at all, was reported by @butonic as seen in the wild (clustered env). I added it because such entries would have caused an infinite loop in the repair step which is bad.

This repair step **does not**:
- repair mismatch path_hashes
- mime types

Here are the queries that are run to find broken entries, could be used to pre-check an instance:

```sql
select fc.storage,fc.fileid,fc.parent as "wrongparent",fc3.fileid "correctparent",fc.path,fc.etag from oc_filecache fc, oc_filecache fc3 where fc.parent <> -1 and fc.parent != fc3.fileid and fc3.storage=fc.storage and fc3.path = substring(fc.path, 1, length(fc.path) - length(substring_index(fc.path, '/', -1)) - 1) and not exists (select 1 from oc_filecache fc2 where fc2.fileid = fc.parent) order by path;
SELECT fc.`storage`, fc.`fileid`, fc.`path` as `path`, fc.`name`, fcp.`storage` as `parentstorage`, fcp.`path` as `parentpath`     FROM `oc_filecache` fc, `oc_filecache` fcp     WHERE (fc.`parent` = fcp.`fileid`)     AND (         (CONCAT(fcp.`path`, '/', fc.`name`) <> fc.`path`)         OR (fc.`storage` <> fcp.`storage`)     )     AND (fcp.`path` <> '')     AND (fc.`fileid` <> fcp.`fileid`);
select fc.storage,fc.fileid,fc.parent as "wrongparent",fc.path,fc.etag from oc_filecache fc where fc.parent <> -1 and not exists (select 1 from oc_filecache fc2 where fc2.fileid = fc.parent) order by path;
select * from oc_filecache where parent=fileid;
```

## Related Issue
Fixes the fallout created by https://github.com/owncloud/core/issues/28018

## Motivation and Context
Because we hate filecache inconsistencies.

## How Has This Been Tested?
- [x] TEST: Unit test (some pending)
- [x] TEST: manual test

⚠️ Use the test steps from here: https://github.com/owncloud/core/pull/28253#issuecomment-311781465

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

