### PR TITLE
Allow to configure the chredentials last_check by adding minutes to database

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -86,7 +86,7 @@ class Session implements IUserSession, Emitter {
 	private $session;
 
 	/** @var ITimeFactory */
-	private $timeFacory;
+	private $timeFactory;
 
 	/** @var IProvider */
 	private $tokenProvider;
@@ -100,14 +100,14 @@ class Session implements IUserSession, Emitter {
 	/**
 	 * @param IUserManager $manager
 	 * @param ISession $session
-	 * @param ITimeFactory $timeFacory
+	 * @param ITimeFactory $timeFactory
 	 * @param IProvider $tokenProvider
 	 * @param IConfig $config
 	 */
-	public function __construct(IUserManager $manager, ISession $session, ITimeFactory $timeFacory, $tokenProvider, IConfig $config) {
+	public function __construct(IUserManager $manager, ISession $session, ITimeFactory $timeFactory, $tokenProvider, IConfig $config) {
 		$this->manager = $manager;
 		$this->session = $session;
-		$this->timeFacory = $timeFacory;
+		$this->timeFactory = $timeFactory;
 		$this->tokenProvider = $tokenProvider;
 		$this->config = $config;
 	}
@@ -345,7 +345,7 @@ class Session implements IUserSession, Emitter {
 		if (!is_null($request->getCookie('cookie_test'))) {
 			return true;
 		}
-		setcookie('cookie_test', 'test', $this->timeFacory->getTime() + 3600);
+		setcookie('cookie_test', 'test', $this->timeFactory->getTime() + 3600);
 		return false;
 	}
 
@@ -607,7 +607,7 @@ class Session implements IUserSession, Emitter {
 		// However, we try to read last_check_timeout from the appconfig table so the
 		// administrator could change this 5 minutes timeout
 		$lastCheck = $dbToken->getLastCheck() ? : 0;
-		$now = $this->timeFacory->getTime();
+		$now = $this->timeFactory->getTime();
 		$last_check_timeout = intval($this->config->getAppValue('last_check_timeout', 5));
 		if ($lastCheck > ($now - 60 * $last_check_timeout)) {
 			// Checked performed recently, nothing to do now

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -603,10 +603,13 @@ class Session implements IUserSession, Emitter {
 	 */
 	private function checkTokenCredentials(IToken $dbToken, $token) {
 		// Check whether login credentials are still valid and the user was not disabled
-		// This check is performed each 5 minutes
+		// This check is performed each 5 minutes per default
+		// However, we try to read last_check_timeout from the appconfig table so the
+		// administrator could change this 5 minutes timeout
 		$lastCheck = $dbToken->getLastCheck() ? : 0;
 		$now = $this->timeFacory->getTime();
-		if ($lastCheck > ($now - 60 * 5)) {
+		$last_check_timeout = intval($this->config->getAppValue('last_check_timeout', 5));
+		if ($lastCheck > ($now - 60 * $last_check_timeout)) {
 			// Checked performed recently, nothing to do now
 			return true;
 		}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -608,7 +608,7 @@ class Session implements IUserSession, Emitter {
 		// administrator could change this 5 minutes timeout
 		$lastCheck = $dbToken->getLastCheck() ? : 0;
 		$now = $this->timeFactory->getTime();
-		$last_check_timeout = intval($this->config->getAppValue('last_check_timeout', 5));
+		$last_check_timeout = intval($this->config->getAppValue('core', 'last_check_timeout', 5));
 		if ($lastCheck > ($now - 60 * $last_check_timeout)) {
 			// Checked performed recently, nothing to do now
 			return true;


### PR DESCRIPTION
 
## Description

It reads the timeout for re-checking credentials from the database.

## Related Issue

#28252 

## Motivation and Context

This causes unneccessary load on the LDAP server.
Also, when using one time passwords, the 2nd authentication after 5 minutes will not work anymore!
So we need to set this to lets say 8 hours.

## How Has This Been Tested?

It has been manually tested with OC 10.0.2

1. tested without the DB setting "last_check_timeout". This successfully falls back to 5 minutes.
2. tested with a DB setting of last_check_timeout=1. This checks passwords every minute.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

