### PR TITLE
Test that the most recent app version is loaded for multi app dir config

### DIFF
--- a/tests/integration/config/behat.yml
+++ b/tests/integration/config/behat.yml
@@ -20,6 +20,7 @@ default:
         - CommandLineContext:
             baseUrl: http://localhost:8080
             ocPath: ../../
+        - AppManagementContext:
     federation:
       paths:
         - %paths.base%/../federation_features

--- a/tests/integration/features/appmanagement.feature
+++ b/tests/integration/features/appmanagement.feature
@@ -1,0 +1,17 @@
+Feature: AppManagement
+
+  Background:
+    Given apps are in two directories "apps" and "apps2"
+
+  Scenario: Two app instances exist the first is more recent
+    Given App "multidirtest" with version "1.0.1" exists in dir "apps"
+    And App "multidirtest" with version "1.0.0" exists in dir "apps2"
+    When App "multidirtest" is loaded
+    Then path to "multidirtest" should be "apps"
+
+  Scenario: Two app instances exist the second is more recent
+    Given App "multidirtest" with version "1.0.0" exists in dir "apps"
+    And App "multidirtest" with version "1.0.5" exists in dir "apps2"
+    When App "multidirtest" is loaded
+    Then path to "multidirtest" should be "apps2"
+    

--- a/tests/integration/features/bootstrap/AppManagementContext.php
+++ b/tests/integration/features/bootstrap/AppManagementContext.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * @author Victor Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+ 
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+
+require __DIR__ . '/../../../../lib/composer/autoload.php';
+
+/**
+ * App Management context.
+ */
+class AppManagementContext implements  Context {
+	
+	/** @var string[] */
+	private $appInfo;
+	
+	private $oldAppPath;
+	
+	/** @var string stdout of last command */
+	private $cmdOutput;
+	
+	/**
+	 * @BeforeScenario
+	 *
+	 * Enable the testing app before the first scenario of the feature and
+	 * reset the configs before each scenario
+	 * @param BeforeScenarioScope $event
+	 */
+	public function prepareParameters(BeforeScenarioScope $event){
+		include_once __DIR__ . '/../../../../lib/base.php';
+		$this->oldAppPath = \OC::$server->getConfig()->getSystemValue('apps_paths', null);
+	}
+	
+	/**
+	 * @AfterScenario
+	 *
+	 * Reset the values after the last scenario of the feature and disable the testing app
+	 * @param AfterScenarioScope $event
+	 */
+	public function undoChangingParameters(AfterScenarioScope $event) {
+		if (!is_null($this->oldAppPath)){
+			\OC::$server->getConfig()->setSystemValue('apps_paths', $this->oldAppPath);
+		} else {
+			\OC::$server->getConfig()->deleteSystemValue('apps_paths');
+		}
+	}
+	
+	/**
+	 * @Given apps are in two directories :dir1 and :dir2
+	 * @param string $dir1
+	 * @param string $dir2
+	 */
+	public function setAppDirectories($dir1, $dir2){
+		$fullpath1 = \OC::$SERVERROOT . '/' . $dir1;
+		$fullpath2 = \OC::$SERVERROOT . '/' . $dir2;
+		\OC::$server->getConfig()->setSystemValue(
+			'apps_paths',
+			[
+				['path' => $fullpath1, 'url' => $dir1, 'writable' => true], 
+				['path' => $fullpath2, 'url' => $dir2, 'writable' => true]
+			]
+		);
+	}
+	
+	/**
+	 * @Given App :appId with version :version exists in dir :dir
+	 * @param string $appId app id
+	 * @param string $version app version
+	 * @param string $dir app directory
+	 */
+	public function appExistsInDir($appId, $version, $dir){
+		$ocVersion = \OC::$server->getConfig()->getSystemValue('version', '0.0.0');
+		$appInfo = sprintf('<?xml version="1.0"?>
+			<info>
+				<id>%s</id>
+				<name>%s</name>
+				<description>description</description>
+				<licence>AGPL</licence>
+				<author>Author</author>
+				<version>%s</version>
+				<category>collaboration</category>
+				<website>https://github.com/owncloud/</website>
+				<bugs>https://github.com/owncloud/</bugs>
+				<repository type="git">https://github.com/owncloud/</repository>
+				<screenshot>https://raw.githubusercontent.com/owncloud/screenshots/</screenshot>
+				<dependencies>
+					<owncloud min-version="%s" max-version="%s" />
+				</dependencies>
+			</info>',
+			$appId,
+			$appId,
+			$version,
+			$ocVersion,
+			$ocVersion
+		);
+		$appsDir = \OC::$SERVERROOT . '/' . $dir;
+		if (!file_exists($appsDir)){
+			mkdir($appsDir);
+		}
+		if (!file_exists($appsDir . '/' . $appId)){
+			mkdir($appsDir . '/' . $appId);
+		}
+		
+		$fullpath = $appsDir . '/' . $appId;
+		
+		if (!file_exists($fullpath . '/appinfo')){
+			mkdir($fullpath . '/appinfo');
+		}
+		
+		file_put_contents($fullpath . '/appinfo/info.xml', $appInfo);
+	}
+	
+	/**
+	 * @When App :appId is loaded
+	 * @param string $appId app id
+	 */
+	public function loadApp($appId){
+		$args = explode(' ', "app:getpath $appId");
+		$args = array_map(function($arg) {
+			return escapeshellarg($arg);
+		}, $args);
+		$args[] = '--no-ansi';
+		$args = implode(' ', $args);
+
+		$descriptor = [
+			0 => ['pipe', 'r'],
+			1 => ['pipe', 'w'],
+			2 => ['pipe', 'w'],
+		];
+		$process = proc_open('php console.php ' . $args, $descriptor, $pipes, \OC::$SERVERROOT);
+		$this->cmdOutput = stream_get_contents($pipes[1]);
+		proc_close($process);
+	}
+	
+	/**
+	 * @Then path to :appId should be :dir
+	 * @param string $appId
+	 * @param string $dir
+	 */
+	 public function appVersionIs($appId, $dir){
+		PHPUnit_Framework_Assert::assertEquals(\OC::$SERVERROOT . '/' . $dir . '/' . $appId, trim($this->cmdOutput));
+	}
+}


### PR DESCRIPTION
## Attention: 
The fix was merged into 10.0.2 https://github.com/owncloud/core/pull/28002
This PR contains integration test to detect future regressions


## Description
App version was loaded incorrectly

## Motivation and Context
When there are several app directories the app is always loaded from the very first due to the bug in logic

## How Has This Been Tested?
config.php
```
  "apps_paths" =>  [
    0 => 
   [
      'path' => '/1001/apps/',
      'url' => '/apps',
      'writable' => false,
   ],
    1 => 
   [
      'path' => '/1001/apps2/',
      'url' => '/apps2',
      'writable' => true,
    ],
  ],
```

1. Put the same app into  `/1001/apps/` and `/1001/apps2/`
2. Increase version of the app in `/1001/apps2/` 

Expected: the change is detected and the app is updated
Actual: it's not 

3. Apply patch - everything works as expected
4. Keep the patch and increase version of the app in `/1001/apps/` just to be sure it doesn't break anything

Expected & Actual: the change is detected and the app is updated


## Types of changes
- [ ] Integration test
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

