### PR TITLE
Handle inconsistent filecache reads 

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -135,12 +135,7 @@ class Cache implements ICache {
 		}
 
 		//merge partial data
-		if (!$data and is_string($file)) {
-			if (isset($this->partial[$file])) {
-				$data = $this->partial[$file];
-			}
-			return $data;
-		} else {
+		if($data) {
 			//fix types
 			$data['fileid'] = (int)$data['fileid'];
 			$data['parent'] = (int)$data['parent'];
@@ -157,6 +152,13 @@ class Cache implements ICache {
 			}
 			$data['permissions'] = (int)$data['permissions'];
 			return new CacheEntry($data);
+		} else if (!$data and is_string($file)) {
+			if (isset($this->partial[$file])) {
+				$data = $this->partial[$file];
+			}
+			return $data;
+		} else {
+			return false;
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
We have some reports of many undefined indexes in the owncloud logs generated when `->get()` is called with a fileid, but there is no database row. This PR fixes the cache logic to catch these cases properly and return a correct `false` response.

Should be backported to 10 and 9.1 as well.

## How Has This Been Tested?
Running the unit tests.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

