### PR TITLE
[stable9]  Fix cross-storage move info when moving between two received shares

### DIFF
--- a/apps/files_sharing/lib/cache.php
+++ b/apps/files_sharing/lib/cache.php
@@ -71,14 +71,6 @@ class Shared_Cache extends CacheJail {
 		);
 	}
 
-	public function getNumericStorageId() {
-		if (isset($this->numericId)) {
-			return $this->numericId;
-		} else {
-			return false;
-		}
-	}
-
 	protected function formatCacheEntry($entry) {
 		$path = $entry['path'];
 		$entry = parent::formatCacheEntry($entry);

--- a/apps/files_sharing/tests/cache.php
+++ b/apps/files_sharing/tests/cache.php
@@ -505,4 +505,28 @@ class Test_Files_Sharing_Cache extends TestCase {
 		$this->assertEquals('', $sharedCache->getPathById($folderInfo->getId()));
 		$this->assertEquals('bar/test.txt', $sharedCache->getPathById($fileInfo->getId()));
 	}
+
+	public function testNumericStorageId() {
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+		\OC\Files\Filesystem::mkdir('foo');
+
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1);
+		$node = $rootFolder->get('foo');
+		$share = $this->shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(\OCP\Share::SHARE_TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$this->shareManager->createShare($share);
+		\OC_Util::tearDownFS();
+
+		list($sourceStorage) = \OC\Files\Filesystem::resolvePath('/' . self::TEST_FILES_SHARING_API_USER1 . '/files/foo');
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+		$this->assertTrue(\OC\Files\Filesystem::file_exists('/foo'));
+		list($sharedStorage) = \OC\Files\Filesystem::resolvePath('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/foo');
+
+		$this->assertEquals($sourceStorage->getCache()->getNumericStorageId(), $sharedStorage->getCache()->getNumericStorageId());
+	}
 }

--- a/build/integration/features/bootstrap/WebDav.php
+++ b/build/integration/features/bootstrap/WebDav.php
@@ -19,6 +19,8 @@ trait WebDav {
 	private $response;
 	/** @var map with user as key and another map as value, which has path as key and etag as value */
 	private $storedETAG = NULL;
+	/** @var integer */
+	private $storedFileID = NULL;
 
 	/**
 	 * @Given /^using dav path "([^"]*)"$/
@@ -652,4 +654,42 @@ trait WebDav {
 			}
 		}
     }
+
+	/**
+	 * @param string $user
+	 * @param string $path
+	 * @return int
+	 */
+	private function getFileIdForPath($user, $path) {
+		$propertiesTable = new \Behat\Gherkin\Node\TableNode([["{http://owncloud.org/ns}fileid"]]);
+		$this->asGetsPropertiesOfFolderWith($user, 'file', $path, $propertiesTable);
+		if (is_array($this->response)) {
+			return (int) $this->response['{http://owncloud.org/ns}fileid'];
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * @Given /^User "([^"]*)" stores id of file "([^"]*)"$/
+	 * @param string $user
+	 * @param string $path
+	 * @param string $fileid
+	 * @return int
+	 */
+	public function userStoresFileIdForPath($user, $path) {
+		$this->storedFileID = $this->getFileIdForPath($user, $path);
+	}
+
+	/**
+	 * @Given /^User "([^"]*)" checks id of file "([^"]*)"$/
+	 * @param string $user
+	 * @param string $path
+	 * @param string $fileid
+	 * @return int
+	 */
+	public function userChecksFileIdForPath($user, $path) {
+		$currentFileID = $this->getFileIdForPath($user, $path);
+		PHPUnit_Framework_Assert::assertEquals($currentFileID, $this->storedFileID);
+	}
 }

--- a/build/integration/features/external-storage.feature
+++ b/build/integration/features/external-storage.feature
@@ -23,4 +23,27 @@ Feature: external-storage
       | token | A_TOKEN |
       | mimetype | httpd/unix-directory |
 
+  @local_storage
+  @no_encryption
+  Scenario: Move a file into storage works
+    Given user "user0" exists
+    And user "user1" exists
+    And As an "user0"
+    And user "user0" created a folder "/local_storage/foo1"
+    When User "user0" moved file "/textfile0.txt" to "/local_storage/foo1/textfile0.txt"
+    Then as "user1" the file "/local_storage/foo1/textfile0.txt" exists
+    And as "user0" the file "/local_storage/foo1/textfile0.txt" exists
+
+  @local_storage
+  @no_encryption
+  Scenario: Move a file out of the storage works
+    Given user "user0" exists
+    And user "user1" exists
+    And As an "user0"
+    And user "user0" created a folder "/local_storage/foo2"
+    And User "user0" moved file "/textfile0.txt" to "/local_storage/foo2/textfile0.txt"
+    When User "user1" moved file "/local_storage/foo2/textfile0.txt" to "/local.txt"
+    Then as "user1" the file "/local_storage/foo2/textfile0.txt" does not exist
+    And as "user0" the file "/local_storage/foo2/textfile0.txt" does not exist
+    And as "user1" the file "/local.txt" exists
 

--- a/build/integration/features/sharing-v1.feature
+++ b/build/integration/features/sharing-v1.feature
@@ -977,3 +977,13 @@ Feature: sharing
     And the HTTP status code should be "200"
     And last share_id is not included in the answer
 
+  Scenario: moving a file into a share as recipient
+    Given As an "admin"
+    And user "user0" exists
+    And user "user1" exists
+    And user "user0" created a folder "/shared"
+    And folder "/shared" of user "user0" is shared with user "user1"
+    When User "user1" moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    Then as "user1" the file "/shared/shared_file.txt" exists
+    And as "user0" the file "/shared/shared_file.txt" exists
+

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -386,3 +386,32 @@ Feature: webdav-related
 		When as "user0" gets properties of folder "/test_folder:5" with
 		  |{DAV:}resourcetype|
 		Then the single response should contain a property "{DAV:}resourcetype" with value "{DAV:}collection"
+
+	Scenario: Checking file id after a move between received shares
+		Given using old dav path
+		And user "user0" exists
+		And user "user1" exists
+		And user "user0" created a folder "/folderA"
+		And user "user0" created a folder "/folderB"
+		And folder "/folderA" of user "user0" is shared with user "user1"
+		And folder "/folderB" of user "user0" is shared with user "user1"
+		And user "user1" created a folder "/folderA/ONE"
+		And user "user1" created a folder "/folderA/ONE/TWO"
+		And User "user1" stores id of file "/folderA/ONE"
+		And User "user1" moves folder "/folderA/ONE" to "/folderB"
+		When user "user1" created a folder "/folderB/ONE/TWO/THREE"
+		And using old dav path
+		Then user "user1" should see following elements
+			| /FOLDER/ |
+			| /PARENT/ |
+			| /PARENT/parent.txt |
+			| /textfile0.txt |
+			| /textfile1.txt |
+			| /textfile2.txt |
+			| /textfile3.txt |
+			| /textfile4.txt |
+			| /folderA |
+			| /folderB |
+			| /folderB/ONE |
+			| /folderB/ONE/TWO |
+			| /folderB/ONE/TWO/THREE |

--- a/build/integration/features/webdav-related.feature
+++ b/build/integration/features/webdav-related.feature
@@ -396,22 +396,13 @@ Feature: webdav-related
 		And folder "/folderA" of user "user0" is shared with user "user1"
 		And folder "/folderB" of user "user0" is shared with user "user1"
 		And user "user1" created a folder "/folderA/ONE"
-		And user "user1" created a folder "/folderA/ONE/TWO"
 		And User "user1" stores id of file "/folderA/ONE"
-		And User "user1" moves folder "/folderA/ONE" to "/folderB"
-		When user "user1" created a folder "/folderB/ONE/TWO/THREE"
-		And using old dav path
-		Then user "user1" should see following elements
-			| /FOLDER/ |
-			| /PARENT/ |
-			| /PARENT/parent.txt |
-			| /textfile0.txt |
-			| /textfile1.txt |
-			| /textfile2.txt |
-			| /textfile3.txt |
-			| /textfile4.txt |
-			| /folderA |
-			| /folderB |
-			| /folderB/ONE |
-			| /folderB/ONE/TWO |
-			| /folderB/ONE/TWO/THREE |
+		And user "user1" created a folder "/folderA/ONE/TWO"
+		When User "user1" moves folder "/folderA/ONE" to "/folderB/ONE"
+		Then as "user1" the folder "/folderA" exists
+		And as "user1" the folder "/folderA/ONE" does not exist
+		# yes, a weird bug used to make this one fail
+		And as "user1" the folder "/folderA/ONE/TWO" does not exist
+		And as "user1" the folder "/folderB/ONE" exists
+		And as "user1" the folder "/folderB/ONE/TWO" exists
+		And User "user1" checks id of file "/folderB/ONE"

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -88,6 +88,9 @@ $OCC files_external:delete -y $ID_STORAGE
 #Disable external storage app
 $OCC app:disable files_external
 
+# Clear storage folder
+rm -Rf work/local_storage/*
+
 if test "$OC_TEST_ALT_HOME" = "1"; then
 	env_alt_home_clear
 fi

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -491,6 +491,7 @@ class Cache implements ICache {
 	 * @param string $sourcePath
 	 * @param string $targetPath
 	 * @throws \OC\DatabaseException
+	 * @throws \Exception if the given storages have an invalid id
 	 */
 	public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath) {
 		if ($sourceCache instanceof Cache) {
@@ -504,6 +505,13 @@ class Cache implements ICache {
 
 			list($sourceStorageId, $sourcePath) = $sourceCache->getMoveInfo($sourcePath);
 			list($targetStorageId, $targetPath) = $this->getMoveInfo($targetPath);
+
+			if (is_null($sourceStorageId) || $sourceStorageId === false) {
+				throw new \Exception('Invalid source storage id: ' . $sourceStorageId);
+			}
+			if (is_null($targetStorageId) || $targetStorageId === false) {
+				throw new \Exception('Invalid target storage id: ' . $targetStorageId);
+			}
 
 			// sql for final update
 			$moveSql = 'UPDATE `*PREFIX*filecache` SET `storage` =  ?, `path` = ?, `path_hash` = ?, `name` = ?, `parent` =? WHERE `fileid` = ?';

--- a/lib/private/files/cache/wrapper/cachejail.php
+++ b/lib/private/files/cache/wrapper/cachejail.php
@@ -292,4 +292,8 @@ class CacheJail extends CacheWrapper {
 		$path = $this->cache->getPathById($id);
 		return $this->getJailedPath($path);
 	}
+
+	protected function getMoveInfo($path) {
+		return [$this->getNumericStorageId(), $this->getSourcePath($path)];
+	}
 }

--- a/lib/private/files/cache/wrapper/cachejail.php
+++ b/lib/private/files/cache/wrapper/cachejail.php
@@ -293,6 +293,22 @@ class CacheJail extends CacheWrapper {
 		return $this->getJailedPath($path);
 	}
 
+	/**
+	 * Move a file or folder in the cache
+	 *
+	 * Note that this should make sure the entries are removed from the source cache
+	 *
+	 * @param \OCP\Files\Cache\ICache $sourceCache
+	 * @param string $sourcePath
+	 * @param string $targetPath
+	 */
+	public function moveFromCache(\OCP\Files\Cache\ICache $sourceCache, $sourcePath, $targetPath) {
+		if ($sourceCache === $this) {
+			return $this->move($sourcePath, $targetPath);
+		}
+		return $this->cache->moveFromCache($sourceCache, $sourcePath, $targetPath);
+	}
+
 	protected function getMoveInfo($path) {
 		return [$this->getNumericStorageId(), $this->getSourcePath($path)];
 	}

--- a/lib/private/files/cache/wrapper/cachejail.php
+++ b/lib/private/files/cache/wrapper/cachejail.php
@@ -306,7 +306,7 @@ class CacheJail extends CacheWrapper {
 		if ($sourceCache === $this) {
 			return $this->move($sourcePath, $targetPath);
 		}
-		return $this->cache->moveFromCache($sourceCache, $sourcePath, $targetPath);
+		return $this->cache->moveFromCache($sourceCache, $sourcePath, $this->getSourcePath($targetPath));
 	}
 
 	protected function getMoveInfo($path) {


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/28238 to stable9 which is based on https://github.com/owncloud/core/pull/28022 and https://github.com/owncloud/core/pull/27172.

This prevents the inconsistency to happen when moving between two received shares or moving something out of a received share. (tested manually)

@jvillafanez @tomneedham 