### PR TITLE
[stable10] UI Test redirect from personal settings to login page

### DIFF
--- a/tests/ui/features/bootstrap/LoginContext.php
+++ b/tests/ui/features/bootstrap/LoginContext.php
@@ -35,6 +35,7 @@ class LoginContext extends RawMinkContext implements Context
 {
 	private $loginPage;
 	private $filesPage;
+	private $expectedPage;
 	private $featureContext;
 
 	public function __construct(LoginPage $loginPage)
@@ -57,6 +58,24 @@ class LoginContext extends RawMinkContext implements Context
 	{
 		$this->filesPage = $this->loginPage->loginAs($username, $password);
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
+	}
+
+	/**
+	 * @When I login with username :username and invalid password :password
+	 */
+	public function iLoginWithUsernameAndInvalidPassword($username, $password)
+	{
+		$this->loginPage->loginAs($username, $password, 'LoginPage');
+		$this->loginPage->waitTillPageIsLoaded($this->getSession());
+	}
+
+	/**
+	 * @When I login with username :username and password :password after a redirect from the :page page
+	 */
+	public function iLoginWithUsernameAndPasswordAfterRedirectFromThePage($username, $password, $page)
+	{
+		$this->expectedPage = $this->loginPage->loginAs($username, $password, str_replace(' ', '', ucwords($page)) . 'Page');
+		$this->expectedPage->waitTillPageIsLoaded($this->getSession());
 	}
 
 	/**

--- a/tests/ui/features/bootstrap/PersonalGeneralSettingsContext.php
+++ b/tests/ui/features/bootstrap/PersonalGeneralSettingsContext.php
@@ -48,6 +48,15 @@ class PersonalGeneralSettingsContext extends RawMinkContext implements Context
 	}
 	
 	/**
+	 * @Given I go to the personal general settings page
+	 */
+	public function iGoToThePersonalGeneralSettingsPage()
+	{
+		$this->visitPath($this->personalGeneralSettingsPage->getPagePath());
+		$this->personalGeneralSettingsPage->waitForOutstandingAjaxCalls($this->getSession());
+	}
+	
+	/**
 	 * @When I change the language to :language
 	 */
 	public function iChangeTheLanguageTo($language)

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -38,11 +38,13 @@ class OwncloudPage extends Page
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
 			$loadingIndicator=$this->find("css", '.loading');
-			$visibility = $this->elementHasCSSValue(
-				$loadingIndicator, 'visibility', 'visible'
-			);
-			if ($visibility===FALSE) {
-				break;
+			if (!is_null($loadingIndicator)) {
+				$visibility = $this->elementHasCSSValue(
+					$loadingIndicator, 'visibility', 'visible'
+				);
+				if ($visibility===FALSE) {
+					break;
+				}
 			}
 			usleep(STANDARDSLEEPTIMEMICROSEC);
 			$currentTime = microtime(true);
@@ -116,6 +118,14 @@ class OwncloudPage extends Page
 	 */
 	public function getMyUsername() {
 		return $this->findById($this->userNameDispayId)->getText();
+	}
+
+	/**
+	 * return the path to the relevant page
+	 * @return string
+	 */
+	public function getPagePath() {
+		return $this->getPath();
 	}
 
 	/**

--- a/tests/ui/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/ui/features/lib/PersonalGeneralSettingsPage.php
@@ -23,6 +23,7 @@
 namespace Page;
 
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
+use Behat\Mink\Session;
 
 class PersonalGeneralSettingsPage extends OwncloudPage
 {
@@ -32,9 +33,26 @@ class PersonalGeneralSettingsPage extends OwncloudPage
 	 */
 	protected $path = '/index.php/settings/personal?sectionid=general';
 	protected $languageSelectId = "languageinput";
+	protected $personalProfilePanelId = "OC\Settings\Panels\Personal\Profile";
 	
 	public function changeLanguage($language)
 	{
 		$this->selectFieldOption($this->languageSelectId, $language);
+	}
+
+	//there is no reliable loading indicator on the personal general settings page, so just wait for
+	//the personal profile panel to be there.
+	public function waitTillPageIsLoaded(Session $session, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
+	{
+		$currentTime = microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
+			if ($this->findById($this->personalProfilePanelId) !== null) {
+				break;
+			}
+			usleep(STANDARDSLEEPTIMEMICROSEC);
+			$currentTime = microtime(true);
+		}
+		$this->waitForOutstandingAjaxCalls($session);
 	}
 }

--- a/tests/ui/features/login.feature
+++ b/tests/ui/features/login.feature
@@ -10,3 +10,23 @@ Feature: login
 		Given I am on the login page
 		When I login with username "admin" and password "admin"
 		Then I should be redirected to a page with the title "Files - ownCloud"
+
+	Scenario: admin login with invalid password
+		Given I am on the login page
+		When I login with username "admin" and invalid password "invalidpassword"
+		Then I should be redirected to a page with the title "ownCloud"
+
+	Scenario: access the personal general settings page when not logged in
+		Given I go to the personal general settings page
+		Then I should be redirected to a page with the title "ownCloud"
+		When I login with username "admin" and password "admin" after a redirect from the "personal general settings" page
+		Then I should be redirected to a page with the title "Settings - ownCloud"
+
+	@skip @entering-the-wrong-password-breaks-the-redirect-issue-28129
+	Scenario: access the personal general settings page when not logged in using incorrect then correct password
+		Given I go to the personal general settings page
+		Then I should be redirected to a page with the title "ownCloud"
+		When I login with username "admin" and invalid password "qwerty"
+		Then I should be redirected to a page with the title "ownCloud"
+		When I login with username "admin" and password "admin" after a redirect from the "personal general settings" page
+		Then I should be redirected to a page with the title "Settings - ownCloud"


### PR DESCRIPTION
Backport of #28257 

This will be needed in stable10 ready for when issue #28129 is fixed by PR #28255 and that fix is backported to stable10. #28255 will unskip the skipped test, so that test had better be there to be unskipped.