### PR TITLE
[stable10] UI tests default timeout constant and accurate timer calculations

### DIFF
--- a/tests/ui/features/bootstrap/bootstrap.php
+++ b/tests/ui/features/bootstrap/bootstrap.php
@@ -10,3 +10,6 @@ $classLoader->register();
 // Sleep for 10 milliseconds
 const STANDARDSLEEPTIMEMILLISEC = 10;
 const STANDARDSLEEPTIMEMICROSEC = STANDARDSLEEPTIMEMILLISEC * 1000;
+
+// Default timeout for use in code that needs to wait for the UI
+const STANDARDUIWAITTIMEOUTMILLISEC = 10000;

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -164,7 +164,7 @@ class FilesPage extends OwnCloudPage
 	 * @param Session $session
 	 * @param int $timeout_msec
 	 */
-	public function scrollDownAppContent ($numberOfFilesOld, Session $session, $timeout_msec=5000)
+	public function scrollDownAppContent ($numberOfFilesOld, Session $session, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
 		$session->evaluateScript(
 			'$("#' . $this->appContentId . '").scrollTop($("#' . $this->appContentId . '")[0].scrollHeight);'
@@ -172,7 +172,9 @@ class FilesPage extends OwnCloudPage
 
 		// there is no loading indicator here, so we are going to wait until we have
 		// more files than before
-		for ($counter = 0; $counter <= $timeout_msec; $counter += STANDARDSLEEPTIMEMILLISEC) {
+		$currentTime = microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
 			$this->waitForOutstandingAjaxCalls($session);
 			$fileNameSpans = $this->find("xpath", $this->fileListXpath)->findAll(
 				"xpath", $this->fileNamesXpath
@@ -181,6 +183,7 @@ class FilesPage extends OwnCloudPage
 				break;
 			}
 			usleep(STANDARDSLEEPTIMEMICROSEC);
+			$currentTime = microtime(true);
 		}
 	}
 
@@ -292,15 +295,18 @@ class FilesPage extends OwnCloudPage
 
 	//there is no reliable loading indicator on the files page, so wait for
 	//the table or the Empty Folder message to be shown
-	public function waitTillPageIsLoaded(Session $session, $timeout_msec=10000)
+	public function waitTillPageIsLoaded(Session $session, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
-		for ($counter = 0; $counter <= $timeout_msec; $counter += STANDARDSLEEPTIMEMILLISEC) {
+		$currentTime = microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
 			$fileList = $this->findById("fileList");
 			if ($fileList !== null && ($fileList->has("xpath", "//a") || ! $this->find("xpath",
 				$this->emptyContentXpath)->hasClass("hidden"))) {
 				break;
 			}
 			usleep(STANDARDSLEEPTIMEMICROSEC);
+			$currentTime = microtime(true);
 		}
 		$this->waitForOutstandingAjaxCalls($session);
 	}

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -32,9 +32,11 @@ use WebDriver\Key;
 class OwncloudPage extends Page
 {
 	protected $userNameDispayId = "expandDisplayName";
-	public function waitTillPageIsLoaded(Session $session, $timeout_msec=10000)
+	public function waitTillPageIsLoaded(Session $session, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
-		for ($counter = 0; $counter <= $timeout_msec; $counter += STANDARDSLEEPTIMEMILLISEC) {
+		$currentTime = microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
 			$loadingIndicator=$this->find("css", '.loading');
 			$visibility = $this->elementHasCSSValue(
 				$loadingIndicator, 'visibility', 'visible'
@@ -43,6 +45,7 @@ class OwncloudPage extends Page
 				break;
 			}
 			usleep(STANDARDSLEEPTIMEMICROSEC);
+			$currentTime = microtime(true);
 		}
 		$this->waitForOutstandingAjaxCalls($session);
 	}
@@ -52,9 +55,11 @@ class OwncloudPage extends Page
 	 * @param string $xpath
 	 * @param int $timeout_msec
 	 */
-	public function waitTillElementIsNull ($xpath, $timeout_msec=10000)
+	public function waitTillElementIsNull ($xpath, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
-		for ($counter = 0; $counter <= $timeout_msec; $counter += STANDARDSLEEPTIMEMILLISEC) {
+		$currentTime = microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
 			try {
 				$element = $this->find("xpath",$xpath);
 			} catch (WebDriverException $e) {
@@ -64,6 +69,7 @@ class OwncloudPage extends Page
 				break;
 			}
 			usleep(STANDARDSLEEPTIMEMICROSEC);
+			$currentTime = microtime(true);
 		}
 	}
 
@@ -72,9 +78,11 @@ class OwncloudPage extends Page
 	 * @param string $xpath
 	 * @param int $timeout_msec
 	 */
-	public function waitTillElementIsNotNull ($xpath, $timeout_msec=10000)
+	public function waitTillElementIsNotNull ($xpath, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
-		for ($counter = 0; $counter <= $timeout_msec; $counter += STANDARDSLEEPTIMEMILLISEC) {
+		$currentTime = microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
 			try {
 				$element = $this->find("xpath",$xpath);
 				if ($element === null || !$element->isValid()) {
@@ -84,6 +92,7 @@ class OwncloudPage extends Page
 				}
 			} catch (WebDriverException $e) {
 				usleep(STANDARDSLEEPTIMEMICROSEC);
+				$currentTime = microtime(true);
 			}
 		}
 	}
@@ -145,7 +154,7 @@ class OwncloudPage extends Page
 	 * @param number $timeout_msec
 	 * @throws \Exception
 	 */
-	public function waitForOutstandingAjaxCalls (Session $session, $timeout_msec=5000)
+	public function waitForOutstandingAjaxCalls (Session $session, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
 		$timeout_msec = (int) $timeout_msec;
 		if ($timeout_msec <= 0) {
@@ -204,7 +213,7 @@ class OwncloudPage extends Page
 	 * @param Session $session
 	 * @param int $timeout_msec
 	 */
-	public function waitForAjaxCallsToStartAndFinish (Session $session, $timeout_msec=5000)
+	public function waitForAjaxCallsToStartAndFinish (Session $session, $timeout_msec=STANDARDUIWAITTIMEOUTMILLISEC)
 	{
 		$start = microtime(true);
 		$this->waitForAjaxCallsToStart($session);

--- a/tests/ui/features/lib/SharingDialog.php
+++ b/tests/ui/features/lib/SharingDialog.php
@@ -61,7 +61,7 @@ class SharingDialog extends OwnCloudPage
 	 * @return \Behat\Mink\Element\NodeElement AutocompleteElement
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 */
-	public function fillShareWithField ($input, Session $session, $timeout_msec = 10000)
+	public function fillShareWithField ($input, Session $session, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC)
 	{
 		$shareWithField = $this->_findShareWithField();
 		$shareWithField->setValue($input);


### PR DESCRIPTION
Backport of #28142 
Needed so that underlying stuff like STANDARDUIWAITTIMEOUTMILLISEC can exist for later backporting of stuff that refers to it. (e.g. to help #28292 )