### PR TITLE
[stable9] Fix default quota

### DIFF
--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -597,6 +597,10 @@ class Trashbin {
 			return 0;
 		}
 		$quota = $userObject->getQuota();
+		if ($quota === null || $quota === 'default') {
+			$quota = \OC::$server->getConfig()->getAppValue('files', 'default_quota', null);
+		}
+
 		if ($quota === null || $quota === 'none') {
 			$quota = Filesystem::free_space('/');
 			$softQuota = false;

--- a/apps/files_trashbin/lib/trashbin.php
+++ b/apps/files_trashbin/lib/trashbin.php
@@ -596,12 +596,8 @@ class Trashbin {
 		if(is_null($userObject)) {
 			return 0;
 		}
-		$quota = $userObject->getQuota();
-		if ($quota === null || $quota === 'default') {
-			$quota = \OC::$server->getConfig()->getAppValue('files', 'default_quota', null);
-		}
-
-		if ($quota === null || $quota === 'none') {
+		$quota = \OC_Util::getUserQuota($userObject);
+		if ($quota === \OCP\Files\FileInfo::SPACE_UNLIMITED) {
 			$quota = Filesystem::free_space('/');
 			$softQuota = false;
 			// inf or unknown free space

--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -715,11 +715,8 @@ class Storage {
 			$versionsFileview = new View('/'.$uid.'/files_versions');
 
 			$softQuota = true;
-			$quota = $user->getQuota();
-			if ($quota === null || $quota === 'default') {
-				$quota = $config->getAppValue('files', 'default_quota', null);
-			}
-			if ($quota === null || $quota === 'none') {
+			$quota = \OC_Util::getUserQuota($user);
+			if ($quota === \OCP\Files\FileInfo::SPACE_UNLIMITED) {
 				$quota = Filesystem::free_space('/');
 				$softQuota = false;
 			} else {

--- a/apps/files_versions/lib/storage.php
+++ b/apps/files_versions/lib/storage.php
@@ -716,7 +716,10 @@ class Storage {
 
 			$softQuota = true;
 			$quota = $user->getQuota();
-			if ( $quota === null || $quota === 'none' ) {
+			if ($quota === null || $quota === 'default') {
+				$quota = $config->getAppValue('files', 'default_quota', null);
+			}
+			if ($quota === null || $quota === 'none') {
 				$quota = Filesystem::free_space('/');
 				$softQuota = false;
 			} else {

--- a/lib/private/user/user.php
+++ b/lib/private/user/user.php
@@ -341,11 +341,7 @@ class User implements IUser {
 	 * @since 9.0.0
 	 */
 	public function getQuota() {
-		$quota = $this->config->getUserValue($this->uid, 'files', 'quota', 'default');
-		if($quota === 'default') {
-			$quota = $this->config->getAppValue('files', 'default_quota', 'none');
-		}
-		return $quota;
+		return $this->config->getUserValue($this->uid, 'files', 'quota', 'default');
 	}
 
 	/**

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -296,7 +296,10 @@ class OC_Util {
 			return \OCP\Files\FileInfo::SPACE_UNLIMITED;
 		}
 		$userQuota = $user->getQuota();
-		if($userQuota === 'none') {
+		if ($userQuota === null || $userQuota === 'default') {
+			$userQuota = \OC::$server->getConfig()->getAppValue('files', 'default_quota', 'none');
+		}
+		if ($userQuota === null || $userQuota === 'none') {
 			return \OCP\Files\FileInfo::SPACE_UNLIMITED;
 		}
 		return OC_Helper::computerFileSize($userQuota);

--- a/lib/private/util.php
+++ b/lib/private/util.php
@@ -287,11 +287,15 @@ class OC_Util {
 	/**
 	 * Get the quota of a user
 	 *
-	 * @param string $userId
+	 * @param string|IUser $userId
 	 * @return int Quota bytes
 	 */
 	public static function getUserQuota($userId) {
-		$user = \OC::$server->getUserManager()->get($userId);
+		if ($userId instanceof IUser) {
+			$user = $userId;
+		} else {
+			$user = \OC::$server->getUserManager()->get($userId);
+		}
 		if (is_null($user)) {
 			return \OCP\Files\FileInfo::SPACE_UNLIMITED;
 		}


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/27896/ to stable9

Supersedes https://github.com/owncloud/core/pull/27957

Please review @DeepDiver1975 @jvillafanez @Gomez 

TODO: manual retest:
- [x] TEST: newly created user gets "default" quota, properly applies in personal page, 5 GB
- [x] TEST: set existing user quota to "default", properly applies in personal page, 5 GB
- [x] TEST: set existing user quota to "unlimited", properly applies in personal page (unlimited)
- [x] TEST: set existing user quota to "1 GB", properly applies in personal page, 1 GB