### PR TITLE
Add conditional delay to avoid same stime in int test

### DIFF
--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -21,6 +21,9 @@ trait Sharing {
 	/** @var int */
 	private $savedShareId = null;
 
+	/** @var int */
+	private $lastShareTime = null;
+
 	/**
 	 * @Given /^as "([^"]*)" creating a share with$/
 	 * @param string $user
@@ -425,6 +428,14 @@ trait Sharing {
 		if ($this->isUserOrGroupInSharedData($user2, $permissions)){
 			return;
 		} else {
+			$time = time();
+			if ($this->lastShareTime !== null && $time - $this->lastShareTime < 1) {
+				// prevent creating two shares with the same "stime" which is based on
+				// seconds, this affects share merging order and could affect expected test
+				// result order
+				sleep(1);
+			}
+			$this->lastShareTime = $time;
 			$this->createShare($user1, $filepath, 0, $user2, null, null, $permissions);
 		}
 		$this->response = $client->get($fullUrl, $options);


### PR DESCRIPTION
## Description
Should prevent the "Merging shares" test suites to fail randomly as the
results order is dependent on the share time.

## Related Issue
None

## Motivation and Context
Because we hate randomly failing tests and we already have enough trouble needing to constantly rebase for Jenkins, so we could do without this additional annoyance.

## How Has This Been Tested?
Run the sharing-v1.feature tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@SergioBertolinSG 
