### PR TITLE
occ commands to list users and groups

### DIFF
--- a/core/Command/Group/ListGroupMembers.php
+++ b/core/Command/Group/ListGroupMembers.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Group;
+
+use OC\Core\Command\Base;
+use OCP\IGroupManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class ListGroupMembers extends Base {
+	/** @var \OCP\IGroupManager */
+	protected $groupManager;
+
+	/**
+	 * @param IGroupManager $groupManager
+	 */
+	public function __construct(IGroupManager $groupManager) {
+		parent::__construct();
+		$this->groupManager = $groupManager;
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('group:listmembers')
+			->setDescription('list group members')
+			->addArgument(
+				'group',
+				InputArgument::REQUIRED,
+				'Name of the group'
+			)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$groupName = $input->getArgument('group');
+		$group = $this->groupManager->get($groupName);
+		if (!$group) {
+			$output->writeln('<error>Group "' . $groupName . '" does not exist</error>');
+			return 1;
+		}
+
+		$displayNames = $this->groupManager->displayNamesInGroup($group->getGID());
+		parent::writeArrayInOutputFormat($input, $output, $displayNames);
+	}
+}

--- a/core/Command/Group/ListGroupMembers.php
+++ b/core/Command/Group/ListGroupMembers.php
@@ -23,9 +23,7 @@ namespace OC\Core\Command\Group;
 
 use OC\Core\Command\Base;
 use OCP\IGroupManager;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -45,7 +43,7 @@ class ListGroupMembers extends Base {
 		parent::configure();
 
 		$this
-			->setName('group:listmembers')
+			->setName('group:list-members')
 			->setDescription('list group members')
 			->addArgument(
 				'group',
@@ -59,7 +57,7 @@ class ListGroupMembers extends Base {
 		$groupName = $input->getArgument('group');
 		$group = $this->groupManager->get($groupName);
 		if (!$group) {
-			$output->writeln('<error>Group "' . $groupName . '" does not exist</error>');
+			$output->writeln("<error>Group $groupName does not exist</error>");
 			return 1;
 		}
 

--- a/core/Command/Group/ListGroups.php
+++ b/core/Command/Group/ListGroups.php
@@ -46,7 +46,7 @@ class ListGroups extends Base {
 			->setName('group:list')
 			->setDescription('list groups')
 			->addArgument(
-				'group',
+				'search-pattern',
 				InputArgument::OPTIONAL,
 				'Restrict the list to groups whose name contains the string'
 			)
@@ -54,7 +54,7 @@ class ListGroups extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$groupNameSubString = $input->getArgument('group');
+		$groupNameSubString = $input->getArgument('search-pattern');
 		$groups = $this->groupManager->search($groupNameSubString, null, null, 'management');
 		$groups = array_map(function($group) {
 			/** @var IGroup $group */

--- a/core/Command/Group/ListGroups.php
+++ b/core/Command/Group/ListGroups.php
@@ -23,9 +23,7 @@ namespace OC\Core\Command\Group;
 
 use OC\Core\Command\Base;
 use OCP\IGroupManager;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 

--- a/core/Command/Group/ListGroups.php
+++ b/core/Command/Group/ListGroups.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Group;
+
+use OC\Core\Command\Base;
+use OCP\IGroupManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class ListGroups extends Base {
+	/** @var \OCP\IGroupManager */
+	protected $groupManager;
+
+	/**
+	 * @param IGroupManager $groupManager
+	 */
+	public function __construct(IGroupManager $groupManager) {
+		parent::__construct();
+		$this->groupManager = $groupManager;
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('group:list')
+			->setDescription('list groups')
+			->addArgument(
+				'group',
+				InputArgument::OPTIONAL,
+				'Restrict the list to groups whose name contains the string'
+			)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$groupNameSubString = $input->getArgument('group');
+		$groups = $this->groupManager->search($groupNameSubString, null, null, 'management');
+		$groups = array_map(function($group) {
+			/** @var IGroup $group */
+			return $group->getGID();
+		}, $groups);
+		parent::writeArrayInOutputFormat($input, $output, $groups);
+	}
+}

--- a/core/Command/User/ListUserGroups.php
+++ b/core/Command/User/ListUserGroups.php
@@ -24,9 +24,7 @@ namespace OC\Core\Command\User;
 use OC\Core\Command\Base;
 use OCP\IUserManager;
 use OCP\IGroupManager;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 
@@ -51,7 +49,7 @@ class ListUserGroups extends Base {
 		parent::configure();
 
 		$this
-			->setName('user:listgroups')
+			->setName('user:list-groups')
 			->setDescription('list groups for a user')
 			->addArgument(
 				'uid',
@@ -64,7 +62,7 @@ class ListUserGroups extends Base {
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$uid = $input->getArgument('uid');
 		if (!$this->userManager->userExists($uid)) {
-			$output->writeln('<error>User "' . $uid . '" does not exist.</error>');
+			$output->writeln("<error>User $uid does not exist.</error>");
 			return 1;
 		}
 

--- a/core/Command/User/ListUserGroups.php
+++ b/core/Command/User/ListUserGroups.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\User;
+
+use OC\Core\Command\Base;
+use OCP\IUserManager;
+use OCP\IGroupManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class ListUserGroups extends Base {
+	/** @var \OCP\IUserManager */
+	protected $userManager;
+
+	/** @var \OCP\IGroupManager */
+	protected $groupManager;
+
+	/**
+	 * @param IUserManager $userManager
+	 * @param IGroupManager $groupManager
+	 */
+	public function __construct(IUserManager $userManager, IGroupManager $groupManager) {
+		parent::__construct();
+		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('user:listgroups')
+			->setDescription('list groups for a user')
+			->addArgument(
+				'uid',
+				InputArgument::REQUIRED,
+				'User ID'
+			)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$uid = $input->getArgument('uid');
+		if (!$this->userManager->userExists($uid)) {
+			$output->writeln('<error>User "' . $uid . '" does not exist.</error>');
+			return 1;
+		}
+
+		$user = $this->userManager->get($uid);
+		$groupNames = $this->groupManager->getUserGroupIds($user);
+		parent::writeArrayInOutputFormat($input, $output, $groupNames);
+	}
+}

--- a/core/Command/User/ListUsers.php
+++ b/core/Command/User/ListUsers.php
@@ -23,9 +23,7 @@ namespace OC\Core\Command\User;
 
 use OC\Core\Command\Base;
 use OCP\IUserManager;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 

--- a/core/Command/User/ListUsers.php
+++ b/core/Command/User/ListUsers.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\User;
+
+use OC\Core\Command\Base;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+
+class ListUsers extends Base {
+	/** @var \OCP\IUserManager */
+	protected $userManager;
+
+	/**
+	 * @param IUserManager $userManager
+	 */
+	public function __construct(IUserManager $userManager) {
+		parent::__construct();
+		$this->userManager = $userManager;
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('user:list')
+			->setDescription('list users')
+			->addArgument(
+				'uid',
+				InputArgument::OPTIONAL,
+				'Restrict the list to users whose User ID contains the string'
+			)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$userNameSubString = $input->getArgument('uid');
+		$users = $this->userManager->search($userNameSubString);
+		$users = array_map(function($user) {
+			/** @var IUser $user */
+			return $user->getDisplayName();
+		}, $users);
+		parent::writeArrayInOutputFormat($input, $output, $users);
+	}
+}

--- a/core/Command/User/ListUsers.php
+++ b/core/Command/User/ListUsers.php
@@ -46,7 +46,7 @@ class ListUsers extends Base {
 			->setName('user:list')
 			->setDescription('list users')
 			->addArgument(
-				'uid',
+				'search-pattern',
 				InputArgument::OPTIONAL,
 				'Restrict the list to users whose User ID contains the string'
 			)
@@ -54,7 +54,7 @@ class ListUsers extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$userNameSubString = $input->getArgument('uid');
+		$userNameSubString = $input->getArgument('search-pattern');
 		$users = $this->userManager->search($userNameSubString);
 		$users = array_map(function($user) {
 			/** @var IUser $user */

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -140,6 +140,8 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\Disable(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Enable(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\LastSeen(\OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\User\ListUsers(\OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\User\ListUserGroups(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Report(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig(), \OC::$server->getDatabaseConnection()));
@@ -150,6 +152,8 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Group\Delete(\OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\Group\AddMember(\OC::$server->getGroupManager(), \OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\Group\RemoveMember(\OC::$server->getGroupManager(), \OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\Group\ListGroups(\OC::$server->getGroupManager()));
+	$application->add(new OC\Core\Command\Group\ListGroupMembers(\OC::$server->getGroupManager()));
 
 	$application->add(new OC\Core\Command\Security\ListCertificates(\OC::$server->getCertificateManager(null), \OC::$server->getL10N('core')));
 	$application->add(new OC\Core\Command\Security\ImportCertificate(\OC::$server->getCertificateManager(null)));


### PR DESCRIPTION
## Description
Provide the following new items for the occ command:
1) ListGroupMembers.php - given a group name, list the members in that group
2) ListGroups.php - list all groups on the system, with the ability to provide a string and filter the list to show only groups containing that string
3) ListUserGroups.php - given a User ID, lists the groups which that user is i
4) ListUsers.php - list all users on the system, with the ability to provide a string and filter the list to show only User IDs containing that string

## Related Issue
#28311 

## Motivation and Context
Help with managing users and groups from the occ command line.

## How Has This Been Tested?
Running the occ commands on a test system with various filters, no filtering, with non-existent user and group names.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

