### PR TITLE
do not cache logger when running unit tests

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1142,7 +1142,9 @@ class Server extends ServerContainer implements IServerContainer {
 	 * @return \OCP\ILogger
 	 */
 	public function getLogger() {
-		if ($this->logger === null) {
+		//cache the logger for performance reasons
+		//except when running PHPUNIT tests to make it possible to use getLogger() easily in tests
+		if ($this->logger === null || (defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 			$this->logger = $this->query('Logger');
 		}
 		return $this->logger;


### PR DESCRIPTION
## Description
when running unit tests the logger should not be cached to make it possible to mock it

## Related Issue
file firewall unit tests were failing after #28215

## Screenshots (if appropriate):
travis run on firewall tests before fix
![bildschirmfoto von 2017-07-05 15-40-34](https://user-images.githubusercontent.com/2425577/27898345-4aafb5a6-6245-11e7-9506-9923235215cf.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

