### PR TITLE
[stable9] Add repair step to repair mismatch filecache paths

### DIFF
--- a/lib/private/repair.php
+++ b/lib/private/repair.php
@@ -49,6 +49,7 @@ use OC\Repair\SearchLuceneTables;
 use OC\Repair\UpdateOutdatedOcsIds;
 use OC\Repair\RepairInvalidShares;
 use OC\Repair\RepairUnmergedShares;
+use OC\Repair\RepairMismatchFileCachePath;
 
 class Repair extends BasicEmitter {
 	/**
@@ -108,6 +109,7 @@ class Repair extends BasicEmitter {
 	 */
 	public static function getRepairSteps() {
 		return [
+			new RepairMismatchFileCachePath(\OC::$server->getDatabaseConnection()),
 			new RepairMimeTypes(\OC::$server->getConfig()),
 			new AssetCache(),
 			new FillETags(\OC::$server->getDatabaseConnection()),

--- a/lib/private/repair/repairmismatchfilecachepath.php
+++ b/lib/private/repair/repairmismatchfilecachepath.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Repair;
+
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use OC\Hooks\BasicEmitter;
+
+/**
+ * Repairs file cache entry which path do not match the parent-child relationship
+ */
+class RepairMismatchFileCachePath extends BasicEmitter implements \OC\RepairStep {
+
+	const CHUNK_SIZE = 200;
+
+	/** @var \OCP\IDBConnection */
+	protected $connection;
+
+	/**
+	 * @param \OCP\IDBConnection $connection
+	 */
+	public function __construct($connection) {
+		$this->connection = $connection;
+	}
+
+	public function getName() {
+		return 'Repair file cache entries with path that does not match parent-child relationships';
+	}
+
+	/**
+	 * Fixes the broken entry's path.
+	 *
+	 * @param int $fileId file id of the entry to fix
+	 * @param string $wrongPath wrong path of the entry to fix
+	 * @param int $correctStorageNumericId numeric idea of the correct storage
+	 * @param string $correctPath value to which to set the path of the entry 
+	 * @return bool true for success
+	 */
+	private function fixEntryPath($fileId, $wrongPath, $correctStorageNumericId, $correctPath) {
+		$this->connection->beginTransaction();
+		// delete target if exists
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('filecache')
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($correctStorageNumericId)))
+			->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($correctPath)));
+		$entryExisted = $qb->execute() > 0;
+
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('filecache')
+			->set('path', $qb->createNamedParameter($correctPath))
+			->set('path_hash', $qb->createNamedParameter(md5($correctPath)))
+			->set('storage', $qb->createNamedParameter($correctStorageNumericId))
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)));
+		$qb->execute();
+
+		$this->connection->commit();
+	}
+
+	private function addQueryConditions($qb) {
+		// thanks, VicDeo!
+		if ($this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
+			$concatFunction = $qb->createFunction("CONCAT(fcp.path, '/', fc.name)");
+		} else {
+			$concatFunction = $qb->createFunction("(fcp.`path` || '/' || fc.`name`)");
+		}
+
+		if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+			$emptyPathExpr = $qb->expr()->isNotNull('fcp.path');
+		} else {
+			$emptyPathExpr = $qb->expr()->neq('fcp.path', $qb->expr()->literal(''));
+		}
+
+		$qb
+			->from('filecache', 'fc')
+			->from('filecache', 'fcp')
+			->where($qb->expr()->eq('fc.parent', 'fcp.fileid'))
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->neq(
+						$qb->createFunction($concatFunction),
+						'fc.path'
+					),
+					$qb->expr()->neq('fc.storage', 'fcp.storage')
+				)
+			)
+			->andWhere($emptyPathExpr)
+			// yes, this was observed in the wild...
+			->andWhere($qb->expr()->neq('fc.fileid', 'fcp.fileid'));
+	}
+
+	private function countResultsToProcess() {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select($qb->createFunction('COUNT(*)'));
+		$this->addQueryConditions($qb);
+		$results = $qb->execute();
+		$count = $results->fetchColumn(0);
+		$results->closeCursor();
+		return $count;
+	}
+
+	/**
+	 * Repair all entries for which the parent entry exists but the path
+	 * value doesn't match the parent's path.
+	 *
+	 * @return int number of results that were fixed
+	 */
+	private function fixEntriesWithCorrectParentIdButWrongPath() {
+		$totalResultsCount = 0;
+
+		// find all entries where the path entry doesn't match the path value that would
+		// be expected when following the parent-child relationship, basically
+		// concatenating the parent's "path" value with the name of the child
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('fc.storage', 'fc.fileid', 'fc.name')
+			->selectAlias('fc.path', 'path')
+			->selectAlias('fc.storage', 'storage')
+			->selectAlias('fc.parent', 'wrongparentid')
+			->selectAlias('fcp.storage', 'parentstorage')
+			->selectAlias('fcp.path', 'parentpath');
+		$this->addQueryConditions($qb);
+		$qb->setMaxResults(self::CHUNK_SIZE);
+
+		do {
+			$results = $qb->execute();
+			// since we're going to operate on fetched entry, better cache them
+			// to avoid DB lock ups
+			$rows = $results->fetchAll();
+			$results->closeCursor();
+
+			$lastResultsCount = 0;
+			foreach ($rows as $row) {
+				$wrongPath = $row['path'];
+				$correctPath = $row['parentpath'] . '/' . $row['name'];
+				// make sure the target is on a different subtree
+				if (substr($correctPath, 0, strlen($wrongPath)) === $wrongPath) {
+					// the path based parent entry is referencing one of its own children, skipping
+					// fix the entry's parent id instead
+					// note: fixEntryParent cannot fail to find the parent entry by path
+					// here because the reason we reached this code is because we already
+					// found it
+					$this->fixEntryParent(
+						$row['storage'],
+						$row['fileid'],
+						$row['path'],
+						$row['wrongparentid']
+					);
+				} else {
+					$this->fixEntryPath(
+						$row['fileid'],
+						$wrongPath,
+						$row['parentstorage'],
+						$correctPath
+					);
+				}
+				$lastResultsCount++;
+			}
+
+			$totalResultsCount += $lastResultsCount;
+
+			// note: this is not pagination but repeating the query over and over again
+			// until all possible entries were fixed
+		} while ($lastResultsCount > 0);
+
+		if ($totalResultsCount > 0) {
+			$this->emit('\OC\Repair', 'info', array("Fixed $totalResultsCount file cache entries with wrong path"));
+		}
+
+		return $totalResultsCount;
+	}
+
+	/**
+	 * Fixes the broken entry's path.
+	 *
+	 * @param int $storageId storage id of the entry to fix
+	 * @param int $fileId file id of the entry to fix
+	 * @param string $path path from the entry to fix
+	 * @param int $wrongParentId wrong parent id
+	 * @return bool true if the entry was fixed, false otherwise
+	 */
+	private function fixEntryParent($storageId, $fileId, $path, $wrongParentId) {
+		$this->connection->beginTransaction();
+
+		$parentPath = dirname($path);
+		if ($parentPath === '.') {
+			$parentPath = '';
+		}
+
+		// find the correct parent
+		$qb = $this->connection->getQueryBuilder();
+		// select fileid as "correctparentid"
+		$qb->select('fileid')
+			// from oc_filecache
+			->from('filecache')
+			// where storage=$storage and path='$parentPath'
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($storageId)))
+			->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($parentPath)));
+		$results = $qb->execute();
+		$rows = $results->fetchAll();
+		$results->closeCursor();
+
+		if (empty($rows)) {
+			// not the case we want to fix!
+			$this->connection->commit();
+			return false;
+		}
+
+		$correctParentId = $rows[0]['fileid'];
+
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('filecache')
+			->set('parent', $qb->createNamedParameter($correctParentId))
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)));
+		$qb->execute();
+
+		$this->connection->commit();
+
+		return true;
+	}
+
+	/**
+	 * Repair entries where the parent id doesn't point to any existing entry
+	 * by finding the actual parent entry matching the entry's path dirname.
+	 * 
+	 * @return int number of results that were fixed
+	 */
+	private function fixEntriesWithNonExistingParentIdEntry() {
+		// Subquery for parent existence
+		$qbe = $this->connection->getQueryBuilder();
+		$qbe->select($qbe->expr()->literal('1'))
+			->from('filecache', 'fce')
+			->where($qbe->expr()->eq('fce.fileid', 'fc.parent'));
+
+		$qb = $this->connection->getQueryBuilder();
+
+		// Find entries to repair
+		// select fc.storage,fc.fileid,fc.parent as "wrongparent",fc.path,fc.etag
+		// and not exists (select 1 from oc_filecache fc2 where fc2.fileid = fc.parent)
+		$qb->select('storage', 'fileid', 'path', 'parent')
+			// from oc_filecache fc
+			->from('filecache', 'fc')
+			// where fc.parent <> -1
+			->where($qb->expr()->neq('fc.parent', $qb->createNamedParameter(-1)))
+			// and not exists (select 1 from oc_filecache fc2 where fc2.fileid = fc.parent)
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->eq('fc.fileid', 'fc.parent'),
+					$qb->createFunction('NOT EXISTS (' . $qbe->getSQL() . ')'))
+				)
+			->andWhere($qb->expr()->notIn('fileid', $qb->createParameter('excludedids')));
+		$qb->setMaxResults(self::CHUNK_SIZE);
+
+		$totalResultsCount = 0;
+		$blacklist = [-1];
+		do {
+			$qb->setParameter('excludedids', $blacklist, IQueryBuilder::PARAM_INT_ARRAY);
+			$results = $qb->execute();
+			// since we're going to operate on fetched entry, better cache them
+			// to avoid DB lock ups
+			$rows = $results->fetchAll();
+			$results->closeCursor();
+
+			$lastResultsCount = 0;
+			foreach ($rows as $row) {
+				if ($this->fixEntryParent(
+					$row['storage'],
+					$row['fileid'],
+					$row['path'],
+					$row['parent']
+				)) {
+					$lastResultsCount++;
+				} else {
+					$blacklist[] = $row['fileid'];
+				};
+			}
+
+			$totalResultsCount += $lastResultsCount;
+
+			// note: this is not pagination but repeating the query over and over again
+			// until all possible entries were fixed
+		} while ($lastResultsCount > 0);
+
+		if ($totalResultsCount > 0) {
+			$this->emit('\OC\Repair', 'info', array("Fixed $totalResultsCount file cache entries with wrong parent"));
+		}
+
+		// remove first entry which is -1
+		array_shift($blacklist);
+		if (!empty($blacklist)) {
+			$chunks = array_chunk($blacklist, 100);
+			foreach ($chunks as $chunk) {
+				$this->emit(
+					'\OC\Repair',
+					'warning',
+					array('The entries with the following file ids could not be repaired because the matching parent was not found: ' . implode(', ', $chunk))
+				);
+			}
+		}
+
+		return $totalResultsCount;
+	}
+
+	/**
+	 * Run the repair step
+	 */
+	public function run() {
+		$totalFixed = 0;
+
+		/*
+		 * This repair itself might overwrite existing target parent entries and create
+		 * orphans where the parent entry of the parent id doesn't exist but the path matches.
+		 * This needs to be repaired by fixEntriesWithNonExistingParentIdEntry(), this is why
+		 * we need to keep this specific order of repair.
+		 */
+		$totalFixed += $this->fixEntriesWithCorrectParentIdButWrongPath();
+
+		$totalFixed += $this->fixEntriesWithNonExistingParentIdEntry();
+
+		if ($totalFixed > 0) {
+			$this->emit('\OC\Repair', 'warning', array('Please run `occ files:scan --all` once to complete the repair'));
+		}
+	}
+}

--- a/lib/private/repair/repairmismatchfilecachepath.php
+++ b/lib/private/repair/repairmismatchfilecachepath.php
@@ -133,7 +133,6 @@ class RepairMismatchFileCachePath extends BasicEmitter implements \OC\RepairStep
 		$qb = $this->connection->getQueryBuilder();
 		$qb->select('fc.storage', 'fc.fileid', 'fc.name')
 			->selectAlias('fc.path', 'path')
-			->selectAlias('fc.storage', 'storage')
 			->selectAlias('fc.parent', 'wrongparentid')
 			->selectAlias('fcp.storage', 'parentstorage')
 			->selectAlias('fcp.path', 'parentpath');

--- a/tests/lib/repair/repairmismatchfilecachepathtest.php
+++ b/tests/lib/repair/repairmismatchfilecachepathtest.php
@@ -35,6 +35,10 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->connection = \OC::$server->getDatabaseConnection();
 
 		$this->repair = new RepairMismatchFileCachePath($this->connection);
+
+		// some other tests aren't cleaning up...
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('filecache')->execute();
 	}
 
 	protected function tearDown() {

--- a/tests/lib/repair/repairmismatchfilecachepathtest.php
+++ b/tests/lib/repair/repairmismatchfilecachepathtest.php
@@ -1,0 +1,379 @@
+<?php
+/**
+ * Copyright (c) 2017 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Repair;
+
+
+use OC\Repair\RepairMismatchFileCachePath;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Test\TestCase;
+
+/**
+ * Tests for repairing mismatch file cache paths
+ *
+ * @group DB
+ *
+ * @see \OC\Repair\RepairMismatchFileCachePath
+ */
+class RepairMismatchFileCachePathTest extends TestCase {
+
+	/** @var IRepairStep */
+	private $repair;
+
+	/** @var \OCP\IDBConnection */
+	private $connection;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+
+		$this->repair = new RepairMismatchFileCachePath($this->connection);
+	}
+
+	protected function tearDown() {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('filecache')->execute();
+		parent::tearDown();
+	}
+
+	private function createFileCacheEntry($storage, $path, $parent = -1) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert('filecache')
+			->values([
+				'storage' => $qb->createNamedParameter($storage),
+				'path' => $qb->createNamedParameter($path),
+				'path_hash' => $qb->createNamedParameter(md5($path)),
+				'name' => $qb->createNamedParameter(basename($path)),
+				'parent' => $qb->createNamedParameter($parent),
+			]);
+		$qb->execute();
+		return $this->connection->lastInsertId('*PREFIX*filecache');
+	}
+
+	private function getFileCacheEntry($fileId) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('*')
+			->from('filecache')
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)));
+		$results = $qb->execute();
+		$result = $results->fetch();
+		$results->closeCursor();
+		return $result;
+	}
+
+	/**
+	 * Sets the parent of the given file id to the given parent id
+	 *
+	 * @param int $fileId file id of the entry to adjust
+	 * @param int $parentId parent id to set to
+	 */
+	private function setFileCacheEntryParent($fileId, $parentId) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('filecache')
+			->set('parent', $qb->createNamedParameter($parentId))
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)));
+		$qb->execute();
+	}
+
+	public function repairCasesProvider() {
+		return [
+			// same storage, different target dir
+			[1, 1, 'target'],
+			// different storage, same target dir name
+			[1, 2, 'source'],
+			// different storage, different target dir
+			[1, 2, 'target'],
+
+			// same storage, different target dir, target exists
+			[1, 1, 'target', true],
+			// different storage, same target dir name, target exists
+			[1, 2, 'source', true],
+			// different storage, different target dir, target exists
+			[1, 2, 'target', true],
+		];
+	}
+
+	/**
+	 * Test repair
+	 *
+	 * @dataProvider repairCasesProvider
+	 */
+	public function testRepairEntry($sourceStorageId, $targetStorageId, $targetDir, $targetExists = false) {
+		/*
+		 * Tree:
+		 *
+		 * source storage:
+		 *     - files/
+		 *     - files/source/
+		 *     - files/source/to_move (not created as we simulate that it was already moved)
+		 *     - files/source/to_move/content_to_update (bogus entry to fix)
+		 *     - files/source/to_move/content_to_update/sub (bogus subentry to fix)
+		 *     - files/source/do_not_touch (regular entry outside of the repair scope)
+		 *
+		 * target storage:
+		 *     - files/
+		 *     - files/target/
+		 *     - files/target/moved_renamed (already moved target)
+		 *     - files/target/moved_renamed/content_to_update (missing until repair)
+		 *
+		 * if $targetExists: pre-create these additional entries:
+		 *     - files/target/moved_renamed/content_to_update (will be overwritten)
+		 *     - files/target/moved_renamed/content_to_update/sub (will be overwritten)
+		 *     - files/target/moved_renamed/content_to_update/unrelated (will be reparented)
+		 *
+		 */
+
+		// source storage entries
+		$rootId1 = $this->createFileCacheEntry($sourceStorageId, '');
+		$baseId1 = $this->createFileCacheEntry($sourceStorageId, 'files', $rootId1);
+		if ($sourceStorageId !== $targetStorageId) {
+			$rootId2 = $this->createFileCacheEntry($targetStorageId, '');
+			$baseId2 = $this->createFileCacheEntry($targetStorageId, 'files', $rootId2);
+		} else {
+			$rootId2 = $rootId1;
+			$baseId2 = $baseId1;
+		}
+		$sourceId = $this->createFileCacheEntry($sourceStorageId, 'files/source', $baseId1);
+
+		// target storage entries
+		$targetParentId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir, $baseId2);
+
+		// the move does create the parent in the target
+		$targetId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir . '/moved_renamed', $targetParentId);
+
+		// bogus entry: any children of the source are not properly updated
+		$movedId = $this->createFileCacheEntry($sourceStorageId, 'files/source/to_move/content_to_update', $targetId);
+		$movedSubId = $this->createFileCacheEntry($sourceStorageId, 'files/source/to_move/content_to_update/sub', $movedId);
+
+		if ($targetExists) {
+			// after the bogus move happened, some code path recreated the parent under a
+			// different file id
+			$existingTargetId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir . '/moved_renamed/content_to_update', $targetId);
+			$existingTargetSubId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir . '/moved_renamed/content_to_update/sub', $existingTargetId);
+			$existingTargetUnrelatedId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir . '/moved_renamed/content_to_update/unrelated', $existingTargetId);
+		}
+
+		$doNotTouchId = $this->createFileCacheEntry($sourceStorageId, 'files/source/do_not_touch', $sourceId);
+
+		$this->repair->run();
+
+		$entry = $this->getFileCacheEntry($movedId);
+		$this->assertEquals($targetId, $entry['parent']);
+		$this->assertEquals((string)$targetStorageId, $entry['storage']);
+		$this->assertEquals('files/' . $targetDir . '/moved_renamed/content_to_update', $entry['path']);
+		$this->assertEquals(md5('files/' . $targetDir . '/moved_renamed/content_to_update'), $entry['path_hash']);
+
+		$entry = $this->getFileCacheEntry($movedSubId);
+		$this->assertEquals($movedId, $entry['parent']);
+		$this->assertEquals((string)$targetStorageId, $entry['storage']);
+		$this->assertEquals('files/' . $targetDir . '/moved_renamed/content_to_update/sub', $entry['path']);
+		$this->assertEquals(md5('files/' . $targetDir . '/moved_renamed/content_to_update/sub'), $entry['path_hash']);
+
+		if ($targetExists) {
+			$this->assertFalse($this->getFileCacheEntry($existingTargetId));
+			$this->assertFalse($this->getFileCacheEntry($existingTargetSubId));
+
+			// unrelated folder has been reparented
+			$entry = $this->getFileCacheEntry($existingTargetUnrelatedId);
+			$this->assertEquals($movedId, $entry['parent']);
+			$this->assertEquals((string)$targetStorageId, $entry['storage']);
+			$this->assertEquals('files/' . $targetDir . '/moved_renamed/content_to_update/unrelated', $entry['path']);
+			$this->assertEquals(md5('files/' . $targetDir . '/moved_renamed/content_to_update/unrelated'), $entry['path_hash']);
+		}
+
+		// root entries left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$sourceStorageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+
+		$entry = $this->getFileCacheEntry($rootId2);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$targetStorageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+
+		// "do not touch" entry left untouched
+		$entry = $this->getFileCacheEntry($doNotTouchId);
+		$this->assertEquals($sourceId, $entry['parent']);
+		$this->assertEquals((string)$sourceStorageId, $entry['storage']);
+		$this->assertEquals('files/source/do_not_touch', $entry['path']);
+		$this->assertEquals(md5('files/source/do_not_touch'), $entry['path_hash']);
+
+		// root entry left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$sourceStorageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+	}
+
+	/**
+	 * Test repair self referencing entries
+	 */
+	public function testRepairSelfReferencing() {
+		/**
+		 * Self-referencing:
+		 *     - files/all_your_zombies (parent=fileid must be reparented)
+		 *
+		 * Referencing child one level:
+		 *     - files/ref_child1 (parent=fileid of the child)
+		 *     - files/ref_child1/child (parent=fileid of the child)
+		 *
+		 * Referencing child two levels:
+		 *     - files/ref_child2/ (parent=fileid of the child's child)
+		 *     - files/ref_child2/child
+		 *     - files/ref_child2/child2
+		 */
+		$storageId = 1;
+		$rootId1 = $this->createFileCacheEntry($storageId, '');
+		$baseId1 = $this->createFileCacheEntry($storageId, 'files', $rootId1);
+
+		$selfRefId = $this->createFileCacheEntry($storageId, 'files/all_your_zombies', $baseId1);
+		$this->setFileCacheEntryParent($selfRefId, $selfRefId);
+
+		$refChild1Id = $this->createFileCacheEntry($storageId, 'files/ref_child1', $baseId1);
+		$refChild1ChildId = $this->createFileCacheEntry($storageId, 'files/ref_child1/child', $refChild1Id);
+		// make it reference its own child
+		$this->setFileCacheEntryParent($refChild1Id, $refChild1ChildId);
+
+		$refChild2Id = $this->createFileCacheEntry($storageId, 'files/ref_child2', $baseId1);
+		$refChild2ChildId = $this->createFileCacheEntry($storageId, 'files/ref_child2/child', $refChild2Id);
+		$refChild2ChildChildId = $this->createFileCacheEntry($storageId, 'files/ref_child2/child/child', $refChild2ChildId);
+		// make it reference its own sub child
+		$this->setFileCacheEntryParent($refChild2Id, $refChild2ChildChildId);
+
+		$this->repair->run();
+
+		// self-referencing updated
+		$entry = $this->getFileCacheEntry($selfRefId);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/all_your_zombies', $entry['path']);
+		$this->assertEquals(md5('files/all_your_zombies'), $entry['path_hash']);
+
+		// ref child 1 case was reparented to "files"
+		$entry = $this->getFileCacheEntry($refChild1Id);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child1', $entry['path']);
+		$this->assertEquals(md5('files/ref_child1'), $entry['path_hash']);
+
+		// ref child 1 child left alone
+		$entry = $this->getFileCacheEntry($refChild1ChildId);
+		$this->assertEquals($refChild1Id, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child1/child', $entry['path']);
+		$this->assertEquals(md5('files/ref_child1/child'), $entry['path_hash']);
+
+		// ref child 2 case was reparented to "files"
+		$entry = $this->getFileCacheEntry($refChild2Id);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child2', $entry['path']);
+		$this->assertEquals(md5('files/ref_child2'), $entry['path_hash']);
+
+		// ref child 2 child left alone
+		$entry = $this->getFileCacheEntry($refChild2ChildId);
+		$this->assertEquals($refChild2Id, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child2/child', $entry['path']);
+		$this->assertEquals(md5('files/ref_child2/child'), $entry['path_hash']);
+
+		// ref child 2 child child left alone
+		$entry = $this->getFileCacheEntry($refChild2ChildChildId);
+		$this->assertEquals($refChild2ChildId, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child2/child/child', $entry['path']);
+		$this->assertEquals(md5('files/ref_child2/child/child'), $entry['path_hash']);
+
+		// root entry left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+	}
+
+	/**
+	 * Test repair wrong parent id
+	 */
+	public function testRepairParentIdPointingNowhere() {
+		/**
+		 * Wrong parent id
+		 *     - wrongparentroot
+		 *     - files/wrongparent
+		 */
+		$storageId = 1;
+		$rootId1 = $this->createFileCacheEntry($storageId, '');
+		$baseId1 = $this->createFileCacheEntry($storageId, 'files', $rootId1);
+
+		$nonExistingParentId = $baseId1 + 100;
+		$wrongParentRootId = $this->createFileCacheEntry($storageId, 'wrongparentroot', $nonExistingParentId);
+		$wrongParentId = $this->createFileCacheEntry($storageId, 'files/wrongparent', $nonExistingParentId);
+
+		$this->repair->run();
+
+		// wrong parent root reparented to actual root
+		$entry = $this->getFileCacheEntry($wrongParentRootId);
+		$this->assertEquals($rootId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('wrongparentroot', $entry['path']);
+		$this->assertEquals(md5('wrongparentroot'), $entry['path_hash']);
+
+		// wrong parent subdir reparented to "files"
+		$entry = $this->getFileCacheEntry($wrongParentId);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/wrongparent', $entry['path']);
+		$this->assertEquals(md5('files/wrongparent'), $entry['path_hash']);
+
+		// root entry left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+	}
+
+	/**
+	 * Test repair does not repair some entries
+	 */
+	public function testRepairUntouched() {
+		/**
+		 * other:
+		 *     - files/orphaned/leave_me_alone (unrepairable unrelated orphaned entry)
+		 */
+		$storageId = 1;
+		$rootId1 = $this->createFileCacheEntry($storageId, '');
+		$baseId1 = $this->createFileCacheEntry($storageId, 'files', $rootId1);
+
+		$nonExistingParentId = $baseId1 + 100;
+		$orphanedId = $this->createFileCacheEntry($storageId, 'files/orphaned/leave_me_alone', $nonExistingParentId);
+
+		$this->repair->run();
+
+		// orphaned entry left untouched
+		$entry = $this->getFileCacheEntry($orphanedId);
+		$this->assertEquals($nonExistingParentId, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/orphaned/leave_me_alone', $entry['path']);
+		$this->assertEquals(md5('files/orphaned/leave_me_alone'), $entry['path_hash']);
+
+		// root entry left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+	}
+}
+

--- a/tests/lib/testcase.php
+++ b/tests/lib/testcase.php
@@ -207,7 +207,11 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		}
 		$dataDir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data-autotest');
 		if (self::$wasDatabaseAllowed && \OC::$server->getDatabaseConnection()) {
-			$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+			$connection = \OC::$server->getDatabaseConnection();
+			if ($connection->inTransaction()) {
+				throw new \Exception('Stray transaction in test class ' . get_called_class());
+			}
+			$queryBuilder = $connection->getQueryBuilder();
 
 			self::tearDownAfterClassCleanShares($queryBuilder);
 			self::tearDownAfterClassCleanStorages($queryBuilder);

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = array(9, 0, 10, 2);
+$OC_Version = array(9, 0, 10, 4);
 
 // The human readable string
 $OC_VersionString = '9.0.10';


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/28253 to stable9.

- [x] add missing extra commits, starting with https://github.com/owncloud/core/pull/28253#issuecomment-313335806

- [x] unit test doesn't work