### PR TITLE
Add hyphens to add-member and remove-member occ group commands

### DIFF
--- a/core/Command/Group/AddMember.php
+++ b/core/Command/Group/AddMember.php
@@ -44,7 +44,7 @@ class AddMember extends Command {
 
 	protected function configure() {
 		$this
-			->setName('group:addmember')
+			->setName('group:add-member')
 			->setDescription('add members to a group')
 			->addArgument(
 				'group',

--- a/core/Command/Group/RemoveMember.php
+++ b/core/Command/Group/RemoveMember.php
@@ -44,7 +44,7 @@ class RemoveMember extends Command {
 
 	protected function configure() {
 		$this
-			->setName('group:removemember')
+			->setName('group:remove-member')
 			->setDescription('remove member(s) from a group')
 			->addArgument(
 				'group',

--- a/tests/ui/features/lib/setupHelper.php
+++ b/tests/ui/features/lib/setupHelper.php
@@ -71,7 +71,7 @@ class SetupHelper
 	 */
 	public static function addUserToGroup($ocPath, $groupName, $userName)
 	{
-		return self::runOcc(['group:addmember', '--member '.$userName, $groupName], $ocPath);
+		return self::runOcc(['group:add-member', '--member '.$userName, $groupName], $ocPath);
 	}
 
 	/**
@@ -83,7 +83,7 @@ class SetupHelper
 	 */
 	public static function removeUserFromGroup($ocPath, $groupName, $userName)
 	{
-		return self::runOcc(['group:removemember', '--member '.$userName, $groupName], $ocPath);
+		return self::runOcc(['group:remove-member', '--member '.$userName, $groupName], $ocPath);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Put hyphens in the group:add-member and group:remove-member occ commands.

## Related Issue
#20629

## Motivation and Context
Other occ commands use hyphens between words. It is better to be consistent, and to change this now, before it gets released into userland.

## How Has This Been Tested?
To group:add-member and group:remove-member occ commands in a test system.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) (non-breaking because the first implementation has not been released yet)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Doc PR https://github.com/owncloud/documentation/pull/3201 updated.