### PR TITLE
Cleanup sample config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -527,13 +527,6 @@ $CONFIG = array(
  */
 
 /**
- * Checks an app before install whether it uses private APIs instead of the
- * proper public APIs. If this is set to true it will only allow to install or
- * enable apps that pass this check.
- */
-'appcodechecker' => true,
-
-/**
  * Check if ownCloud is up-to-date and shows a notification if a new version is
  * available.
  */
@@ -731,11 +724,6 @@ $CONFIG = array(
        'writable' => true,
      )
    ),
-
-/**
- * @see appcodechecker
- */
-
 
 /**
  * Previews

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -700,15 +700,6 @@ $CONFIG = array(
 'appstoreurl' => 'https://api.owncloud.com/v1',
 
 /**
- * Whether to show experimental apps in the appstore interface
- *
- * Experimental apps are not checked for security issues and are new or known
- * to be unstable and under heavy development. Installing these can cause data
- * loss or security breaches.
- */
-'appstore.experimental.enabled' => false,
-
-/**
  * Use the ``apps_paths`` parameter to set the location of the Apps directory,
  * which should be scanned for available apps, and where user-specific apps
  * should be installed from the Apps store. The ``path`` defines the absolute

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -659,12 +659,6 @@ $CONFIG = array(
 'logtimezone' => 'Europe/Berlin',
 
 /**
- * Append all database queries and parameters to the log file. Use this only for
- * debugging, as your logfile will become huge.
- */
-'log_query' => false,
-
-/**
  * Log successful cron runs.
  */
 'cron_log' => true,

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -362,12 +362,6 @@ class Installer {
 			}
 		}
 
-		// check the code for not allowed calls
-		if(!$isShipped && !Installer::checkCode($extractDir)) {
-			OC_Helper::rmdirr($extractDir);
-			throw new \Exception($l->t("App can't be installed because of not allowed code in the App"));
-		}
-
 		// check if the app is compatible with this version of ownCloud
 		if(!OC_App::isAppCompatible(\OCP\Util::getVersion(), $info)) {
 			OC_Helper::rmdirr($extractDir);
@@ -541,24 +535,7 @@ class Installer {
 	}
 
 	/**
-	 * check the code of an app with some static code checks
-	 * @param string $folder the folder of the app to check
-	 * @return boolean true for app is o.k. and false for app is not o.k.
-	 */
-	public static function checkCode($folder) {
-		// is the code checker enabled?
-		if(!\OC::$server->getConfig()->getSystemValue('appcodechecker', false)) {
-			return true;
-		}
-
-		$codeChecker = new CodeChecker(new PrivateCheck(new EmptyCheck()));
-		$errors = $codeChecker->analyseFolder($folder);
-
-		return empty($errors);
-	}
-
-	/**
-	 * @param $basedir
+	 * @param $script
 	 */
 	private static function includeAppScript($script) {
 		if ( file_exists($script) ){


### PR DESCRIPTION
## Description
log_query and appstore.experimental are not longer used in the code base
appcodechecker is defacto always false and never used - but if enabled it kills app installation

## Motivation and Context
- clean docs
- reduce admin config overhead
- clean installation of apps

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

