### PR TITLE
[stable9] Stop processing in case of filecache loop inside propagator

### DIFF
--- a/lib/private/files/cache/propagator.php
+++ b/lib/private/files/cache/propagator.php
@@ -53,7 +53,11 @@ class Propagator implements IPropagator {
 		$propagatedEntries = [];
 		while ($parentId !== -1) {
 			$entry = $cache->get($parentId);
-			$propagatedEntries[] = $entry;
+			if (isset($propagatedEntries[$entry['fileid']])) {
+				// potential loop in file cache, aborting
+				break;
+			}
+			$propagatedEntries[$entry['fileid']] = $entry;
 			if (!$entry) {
 				return $propagatedEntries;
 			}
@@ -69,6 +73,6 @@ class Propagator implements IPropagator {
 			$parentId = $entry['parent'];
 		}
 
-		return $propagatedEntries;
+		return array_values($propagatedEntries);
 	}
 }


### PR DESCRIPTION
## Description
If there's a loop in the file cache structure, prevent infinite loop when propagating changes.

## Related Issue
https://github.com/owncloud/enterprise/issues/2131

## Motivation and Context
Duh

## How Has This Been Tested?
1. Checkout v9.0.10
1. Login as admin
1. Create folders "a/b/c/d"
1. Find file id of "a/b/c/d": `select fileid from oc_filecache where path='files/a/b/c/d'`
1. `update oc_filecache set parent=$fileId where path='files/a/b';
1. With Webdav, `cd a/b/c/d` then put a file.

Before the fix: infinite loop, the upload never finishes. Size column increases forever.
After the fix: file is uploaded correctly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@tomneedham @jvillafanez @SergioBertolinSG

cc @butonic @DeepDiver1975

To be forward ported
