### PR TITLE
[stable9] Block corrupted filecache updates

### DIFF
--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -302,6 +302,12 @@ class Cache implements ICache {
 			$data['name'] = $this->normalize($data['name']);
 		}
 
+		if (isset($data['mimetype']) && $data['mimetype'] !== 'httpd/unix-directory') {
+			$trace = json_encode(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 50));
+			$mime = $data['mimetype'];
+			\OC::$server->getLogger()->warning("Setting mime type of file $id to \"$mime\" Trace: $trace");
+		}
+
 		list($queryParts, $params) = $this->buildParts($data);
 		// duplicate $params because we need the parts twice in the SQL statement
 		// once for the SET part, once in the WHERE clause

--- a/lib/private/files/cache/cache.php
+++ b/lib/private/files/cache/cache.php
@@ -231,6 +231,7 @@ class Cache implements ICache {
 	 * @throws \RuntimeException
 	 */
 	public function insert($file, array $data) {
+
 		// normalize file
 		$file = $this->normalize($file);
 
@@ -283,6 +284,13 @@ class Cache implements ICache {
 	 * @param array $data [$key => $value] the metadata to update, only the fields provided in the array will be updated, non-provided values will remain unchanged
 	 */
 	public function update($id, array $data) {
+
+		if(isset($data['parent']) && $data['parent'] === $id) {
+			// Catch the case when we are trying to update the parent to be itself
+			$trace = json_encode(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 50));
+			\OC::$server->getLogger()->error("Trying to set parent of file: $id to itself! Trace: $trace");
+			throw new \InvalidArgumentException('Parent cannot be same as self during filecache update');
+		}
 
 		if (isset($data['path'])) {
 			// normalize path

--- a/lib/private/files/cache/updater.php
+++ b/lib/private/files/cache/updater.php
@@ -188,10 +188,15 @@ class Updater implements IUpdater {
 		}
 
 		if (pathinfo($source, PATHINFO_EXTENSION) !== pathinfo($target, PATHINFO_EXTENSION)) {
-			// handle mime type change
-			$mimeType = $this->storage->getMimeType($target);
-			$fileId = $this->cache->getId($target);
-			$this->cache->update($fileId, ['mimetype' => $mimeType]);
+			$isTrash = (($sourceStorage->instanceOfStorage('\OCP\Files\IHomeStorage') && explode('/', $source)[0] === 'files_trashbin')
+				|| ($this->storage->instanceOfStorage('\OCP\Files\IHomeStorage') && explode('/', $target)[0] === 'files_trashbin'));
+
+			if (!$isTrash) {
+				// handle mime type change
+				$mimeType = $this->storage->getMimeType($target);
+				$fileId = $this->cache->getId($target);
+				$this->cache->update($fileId, ['mimetype' => $mimeType]);
+			}
 		}
 
 		if ($sourceCache instanceof Cache) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
At some point, the filecache can become corrupted when entries having `fileid=parent`. This PR throws and exception at this point to stop the update and logs a stacktrace to get some logging information as to when this occurs.


## How Has This Been Tested?
 - Creating a folder structure in UI
 - Sharing some files with another user
 - Manually tweaking the parent column of several files to match their id
 - Usage of the UI

Haven't managed to trigger the exception through normal usage.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

