### PR TITLE
[stable9.1] Repair wrong directory mime types

### DIFF
--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -52,6 +52,7 @@ use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use OC\Repair\RepairDirectoryMimeType;
 
 class Repair implements IOutput{
 	/* @var IRepairStep[] */
@@ -125,6 +126,7 @@ class Repair implements IOutput{
 	public static function getRepairSteps() {
 		return [
 			new RepairMimeTypes(\OC::$server->getConfig()),
+			new RepairDirectoryMimeType(\OC::$server->getDatabaseConnection(), \OC::$server->getMimeTypeLoader()),
 			new AssetCache(),
 			new FillETags(\OC::$server->getDatabaseConnection()),
 			new CleanTags(\OC::$server->getDatabaseConnection(), \OC::$server->getUserManager()),

--- a/lib/private/Repair/RepairDirectoryMimeType.php
+++ b/lib/private/Repair/RepairDirectoryMimeType.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Repair;
+
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\IMimeTypeLoader;
+
+/**
+ * Repairs filecache entries that are supposed to be directories
+ * but have a non-directory mime type.
+ *
+ * See https://github.com/owncloud/core/pull/27668 for context.
+ */
+class RepairDirectoryMimeType implements IRepairStep {
+
+	const CHUNK_SIZE = 200;
+
+	/** @var \OCP\IDBConnection */
+	protected $connection;
+
+	/** @var IMimeTypeLoader */
+	protected $mimeTypeLoader;
+
+	/**
+	 * @param \OCP\IDBConnection $connection
+	 * @param IMimeTypeLoader $mimeTypeLoader
+	 */
+	public function __construct($connection, $mimeTypeLoader) {
+		$this->connection = $connection;
+		$this->mimeTypeLoader = $mimeTypeLoader;
+	}
+
+	public function getName() {
+		return 'Repair mime type of directories';
+	}
+
+	private function countResultsToProcess($directoryMimeTypeId, $directoryMimePartId) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select($qb->createFunction('COUNT(*)'));
+		$this->addQueryConditions($qb, $directoryMimeTypeId, $directoryMimePartId);
+		$results = $qb->execute();
+		$count = $results->fetchColumn(0);
+		$results->closeCursor();
+		return (int)$count;
+	}
+
+	private function addQueryConditions($qb, $directoryMimeTypeId, $directoryMimePartId) {
+		$qbe = $this->connection->getQueryBuilder();
+		$qbe->select($qbe->expr()->literal(1))
+			->from('filecache', 'fc')
+			->where($qbe->expr()->eq('fc.parent', 'f.fileid'));
+
+		// where f.mimetype=m.id
+		// from oc_filecache f
+		$qb->from('filecache', 'f')
+			->where(
+				$qb->expr()->orX(
+					$qb->expr()->neq('f.mimetype', $qb->createNamedParameter($directoryMimeTypeId)),
+					$qb->expr()->neq('f.mimepart', $qb->createNamedParameter($directoryMimePartId))
+				)
+			)
+			// and exists (select 1 from oc_filecache fc where fc.parent=f.fileid);
+			->andWhere($qb->createFunction('EXISTS (' . $qbe->getSQL() . ')'));
+	}
+
+	private function repair(IOutput $out, $directoryMimeTypeId, $directoryMimePartId) {
+		// selects all filecache entries that have a mime type which is not
+		// the one of directories but still have at least one child
+		$qb = $this->connection->getQueryBuilder();
+		// select fileid
+		$qb->select('fileid');
+		$this->addQueryConditions($qb, $directoryMimeTypeId, $directoryMimePartId);
+		$qb->setMaxResults(self::CHUNK_SIZE);
+
+		// update query to fix the mime type in bulk
+		$qbu = $this->connection->getQueryBuilder();
+		$qbu->update('filecache')
+			->set('mimetype', $qbu->createNamedParameter($directoryMimeTypeId))
+			->set('mimepart', $qbu->createNamedParameter($directoryMimePartId))
+			->where($qbu->expr()->in('fileid', $qbu->createParameter('fileids')));
+
+		do {
+			$results = $qb->execute();
+			$fileIds = [];
+			while ($row = $results->fetch()) {
+				$fileIds[] = $row['fileid'];
+			}
+			$results->closeCursor();
+
+			if (!empty($fileIds)) {
+				$qbu->setParameter('fileids', $fileIds, IQueryBuilder::PARAM_INT_ARRAY);
+				$qbu->execute();
+			}
+
+			$out->advance(count($fileIds));
+		} while (!empty($fileIds));
+	}
+
+	public function run(IOutput $out) {
+		$directoryMimeTypeId = (int)$this->mimeTypeLoader->getId('httpd/unix-directory');
+		$directoryMimePartId = (int)$this->mimeTypeLoader->getId('httpd');
+
+		$out->startProgress($this->countResultsToProcess($directoryMimeTypeId, $directoryMimePartId));
+
+		$this->repair($out, $directoryMimeTypeId, $directoryMimePartId);
+
+		$out->finishProgress();
+	}
+}

--- a/tests/lib/Repair/RepairDirectoryMimeTypeTest.php
+++ b/tests/lib/Repair/RepairDirectoryMimeTypeTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Copyright (c) 2017 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Repair;
+
+
+use OC\Repair\RepairDirectoryMimeType;
+use OCP\Migration\IRepairStep;
+use Test\TestCase;
+
+/**
+ * Tests for repairing mismatch file cache paths
+ *
+ * @group DB
+ *
+ * @see \OC\Repair\RepairDirectoryMimeType
+ */
+class RepairDirectoryMimeTypeTest extends TestCase {
+
+	const MIMEPART_DIR_ID = 1;
+	const MIMETYPE_DIR_ID = 2;
+	const MIMEPART_TEXT_ID = 3;
+	const MIMETYPE_TEXT_ID = 4;
+
+	/** @var IRepairStep */
+	private $repair;
+
+	/** @var \OCP\IDBConnection */
+	private $connection;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+
+		$mimeTypeLoader = $this->getMock('OCP\Files\IMimeTypeLoader');
+		$mimeTypeLoader->method('getId')
+			->will($this->returnValueMap([
+				['httpd', self::MIMEPART_DIR_ID],
+				['httpd/unix-directory', self::MIMETYPE_DIR_ID],
+				['text', self::MIMEPART_TEXT_ID],
+				['text/plain', self::MIMEPART_DIR_ID],
+			]));
+
+		$this->repair = new RepairDirectoryMimeType($this->connection, $mimeTypeLoader);
+
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('filecache')->execute();
+	}
+
+	protected function tearDown() {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('filecache')->execute();
+		parent::tearDown();
+	}
+
+	private function createFileCacheEntry($path, $parent, $mimeTypeId, $mimePartId) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert('filecache')
+			->values([
+				'storage' => $qb->createNamedParameter(1),
+				'path' => $qb->createNamedParameter($path),
+				'path_hash' => $qb->createNamedParameter(md5($path)),
+				'name' => $qb->createNamedParameter(basename($path)),
+				'parent' => $qb->createNamedParameter($parent),
+				'mimetype' => $qb->createNamedParameter($mimeTypeId),
+				'mimepart' => $qb->createNamedParameter($mimePartId),
+			]);
+		$qb->execute();
+		return $this->connection->lastInsertId('*PREFIX*filecache');
+	}
+
+	private function getFileCacheEntry($fileId) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('*')
+			->from('filecache')
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)));
+		$results = $qb->execute();
+		$result = $results->fetch();
+		$results->closeCursor();
+		return $result;
+	}
+
+	public function brokennessProvider() {
+		return [
+			[self::MIMETYPE_TEXT_ID, self::MIMEPART_TEXT_ID],
+			[self::MIMETYPE_TEXT_ID, self::MIMEPART_DIR_ID],
+			[self::MIMETYPE_DIR_ID, self::MIMEPART_TEXT_ID],
+		];
+	}
+
+	/**
+	 * Test repair
+	 *
+	 * @dataProvider brokennessProvider
+	 */
+	public function testRepairEntry($brokenEntryMimeType, $brokenEntryMimePart) {
+		$rootId = $this->createFileCacheEntry('', -1, self::MIMETYPE_DIR_ID, self::MIMEPART_DIR_ID);
+		$baseId = $this->createFileCacheEntry('files', $rootId, self::MIMETYPE_DIR_ID, self::MIMEPART_DIR_ID);
+
+		$brokenDirId = $this->createFileCacheEntry('files/brokendir', $baseId, $brokenEntryMimeType, $brokenEntryMimePart);
+		$brokenDirChildId = $this->createFileCacheEntry('files/brokendir/child.txt', $brokenDirId, self::MIMETYPE_TEXT_ID, self::MIMEPART_TEXT_ID);
+
+		$outputMock = $this->getMock('\OCP\Migration\IOutput');
+		$this->repair->run($outputMock);
+
+		// broken dir mime type repaired
+		$entry = $this->getFileCacheEntry($brokenDirId);
+		$this->assertEquals(self::MIMETYPE_DIR_ID, (int)$entry['mimetype']);
+		$this->assertEquals(self::MIMEPART_DIR_ID, (int)$entry['mimepart']);
+
+		// child left alone
+		$entry = $this->getFileCacheEntry($brokenDirChildId);
+		$this->assertEquals(self::MIMETYPE_TEXT_ID, (int)$entry['mimetype']);
+		$this->assertEquals(self::MIMEPART_TEXT_ID, (int)$entry['mimepart']);
+	}
+
+	public function testNonRepair() {
+		$rootId = $this->createFileCacheEntry('', -1, self::MIMETYPE_DIR_ID, self::MIMEPART_DIR_ID);
+		$baseId = $this->createFileCacheEntry('files', $rootId, self::MIMETYPE_DIR_ID, self::MIMEPART_DIR_ID);
+
+		$regularDirId = $this->createFileCacheEntry('files/regulardir', $baseId, self::MIMETYPE_DIR_ID, self::MIMEPART_DIR_ID);
+		$regularDirChildId = $this->createFileCacheEntry('files/regulardir/child.txt', $regularDirId, self::MIMETYPE_TEXT_ID, self::MIMEPART_TEXT_ID);
+		$nonDirId = $this->createFileCacheEntry('files/text.txt', $baseId, self::MIMETYPE_TEXT_ID, self::MIMEPART_TEXT_ID);
+
+		$outputMock = $this->getMock('\OCP\Migration\IOutput');
+		$this->repair->run($outputMock);
+
+		// all left alone
+		$entry = $this->getFileCacheEntry($regularDirId);
+		$this->assertEquals(self::MIMETYPE_DIR_ID, $entry['mimetype']);
+		$this->assertEquals(self::MIMEPART_DIR_ID, $entry['mimepart']);
+
+		$entry = $this->getFileCacheEntry($regularDirChildId);
+		$this->assertEquals(self::MIMETYPE_TEXT_ID, $entry['mimetype']);
+		$this->assertEquals(self::MIMEPART_TEXT_ID, $entry['mimepart']);
+
+		$entry = $this->getFileCacheEntry($nonDirId);
+		$this->assertEquals(self::MIMETYPE_TEXT_ID, $entry['mimetype']);
+		$this->assertEquals(self::MIMEPART_TEXT_ID, $entry['mimepart']);
+	}
+}
+


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/28329/ to stable9.1.

There was a conflict in Repair.php so I just reran `occ upgrade` to make sure it was resolved correctly.