### PR TITLE
Fix getByEmail attemp for non-emails

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -184,7 +184,7 @@ class LoginController extends Controller {
 		$originalUser = $user;
 		// TODO: Add all the insane error handling
 		$loginResult = $this->userSession->login($user, $password);
-		if ($loginResult !== true) {
+		if ($loginResult !== true && \OC::$server->getMailer()->validateMailAddress($user)) {
 			$users = $this->userManager->getByEmail($user);
 			// we only allow login by email if unique
 			if (count($users) === 1) {

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -287,7 +287,6 @@ class LoginControllerTest extends TestCase {
 	}
 
 	public function testLoginWithInvalidCredentials() {
-		$user = $this->createMock(IUser::class);
 		$password = 'secret';
 		$loginPageUrl = 'some url';
 
@@ -303,7 +302,7 @@ class LoginControllerTest extends TestCase {
 			->method('createSessionToken');
 
 		$expected = new RedirectResponse($loginPageUrl);
-		$this->assertEquals($expected, $this->loginController->tryLogin($user, $password, ''));
+		$this->assertEquals($expected, $this->loginController->tryLogin('Jane', $password, ''));
 	}
 
 	public function testLoginWithValidCredentials() {


### PR DESCRIPTION
When a failed login attempts, We are trying email login also even for non-emails and it is producing an unnecessary error log. This PR to fix getByEmail attempts for non-emails.

Related issue: #28234 