### PR TITLE
Fix group issues in UI tests

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -72,7 +72,7 @@ class SetupHelper
 	 */
 	public static function addUserToGroup($ocPath, $groupName, $userName)
 	{
-		return self::runOcc(['group:add-member', '--member '.$userName, $groupName], $ocPath);
+		return self::runOcc(['group:add-member', '--member', $userName, $groupName], $ocPath);
 	}
 
 	/**
@@ -84,7 +84,7 @@ class SetupHelper
 	 */
 	public static function removeUserFromGroup($ocPath, $groupName, $userName)
 	{
-		return self::runOcc(['group:remove-member', '--member '.$userName, $groupName], $ocPath);
+		return self::runOcc(['group:remove-member', '--member', $userName, $groupName], $ocPath);
 	}
 
 	/**

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -127,7 +127,6 @@ trait BasicStructure
 			$this->aRegularUserExists();
 		}
 		$this->theUserIsInTheGroup($user, $group);
-		array_push($this->createdGroupNames, $group);
 	}
 	
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
1. when adding a user to a group the group name does not need to be added a second time to the list of created groups
2. `runOcc`needs to have the switch and the option in separate items of the array

## How Has This Been Tested?
created file firewall tests that uses this functions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

