### PR TITLE
Fix Behat tests with null SRV_HOST_URL

### DIFF
--- a/tests/travis/start_behat_tests.sh
+++ b/tests/travis/start_behat_tests.sh
@@ -79,9 +79,14 @@ fi
 
 if [ "$SRV_HOST_PORT" == "80" ] || [ -z "$SRV_HOST_PORT" ]
 then
-	BASE_URL="http://$SRV_HOST_NAME/$SRV_HOST_URL"
+	BASE_URL="http://$SRV_HOST_NAME"
 else
-	BASE_URL="http://$SRV_HOST_NAME:$SRV_HOST_PORT/$SRV_HOST_URL"
+	BASE_URL="http://$SRV_HOST_NAME:$SRV_HOST_PORT"
+fi
+
+if [ -n "$SRV_HOST_URL" ]
+then
+	BASE_URL="$BASE_URL/$SRV_HOST_URL"
 fi
 
 if [ "$BROWSER" == "firefox" ]


### PR DESCRIPTION
## Description
When running start_behat_tests.sh to run the UI tests, if SRV_HOST_URL is empty (i.e. ownCloud is accessed directly at some URL like http://localhost ) then do not put a "/" on the end (that was making http://localhost/ ) when making BASE_URL.

In the case where there is a SRV_HOST_URL (e.g. of owncloud or data or something) there is no "/" at the end. So we need to be consistent here. Some test code would build URLs like:
```
http://localhost//remote.php
```
when it should have just done:
```
http://localhost/remote.php
```

## Related Issue

## Motivation and Context
Make UI tests that depend on BASE_URL run OK in the case where SRV_HOST_URL is empty.

## How Has This Been Tested?
Run some failing app tests in a VM with this kind of setup before the change.
Make the change to start_behat_tests.sh
Run the tests again and confirm that they pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

