### PR TITLE
[stable10] move SetupHelper

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -19,6 +19,7 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+namespace TestHelpers;
 
 class SetupHelper
 {
@@ -105,7 +106,7 @@ class SetupHelper
 	 * @param string $escaping
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
 	 */
-	private static function runOcc($args = [], $ocPath, $escaping = true) {
+	public static function runOcc($args = [], $ocPath, $escaping = true) {
 		if ($escaping === true){
 			$args = array_map(function($arg) {
 				return escapeshellarg($arg);

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -22,6 +22,7 @@
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use TestHelpers\SetupHelper;
 
 require_once 'bootstrap.php';
 

--- a/tests/ui/features/bootstrap/bootstrap.php
+++ b/tests/ui/features/bootstrap/bootstrap.php
@@ -1,9 +1,9 @@
 <?php
 require __DIR__ . '/../../../../lib/composer/autoload.php';
-require_once __DIR__ . '/../lib/setupHelper.php';
 
 $classLoader = new \Composer\Autoload\ClassLoader();
 $classLoader->addPsr4("Page\\", __DIR__. "/../lib", true);
+$classLoader->addPsr4("TestHelpers\\", __DIR__. "/../../../TestHelpers/", true);
 
 $classLoader->register();
 


### PR DESCRIPTION
Backport #28334 
As usual, this test infrastructure needs to port back into stable10 so that tests that use it can run against 10.0.*