### PR TITLE
send 403 code when printing error page after ForbiddenException

### DIFF
--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -177,7 +177,8 @@ class OC_Files {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
 			$l = \OC::$server->getL10N('core');
-			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage(), '403 Forbidden');
+			header(\OC::$server->getRequest()->getHttpProtocol() . ' 403 Forbidden');
+			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage());
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -177,7 +177,7 @@ class OC_Files {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
 			$l = \OC::$server->getL10N('core');
-			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage());
+			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage(), '403 Forbidden');
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -177,7 +177,7 @@ class OC_Files {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
 			$l = \OC::$server->getL10N('core');
-			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage(), '403 Forbidden');
+			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage(), 403);
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -177,8 +177,7 @@ class OC_Files {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
 			$l = \OC::$server->getL10N('core');
-			header(\OC::$server->getRequest()->getHttpProtocol() . ' 403 Forbidden');
-			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage());
+			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage(), '403 Forbidden');
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -319,7 +319,7 @@ class OC_Template extends \OC\Template\Base {
 		* @param string $error_msg The error message to show
 		* @param string $hint An optional hint message - needs to be properly escaped
 		*/
-	public static function printErrorPage( $error_msg, $hint = '') {
+	public static function printErrorPage( $error_msg, $hint = '', $status = null ) {
 		if ($error_msg === $hint) {
 			// If the hint is the same as the message there is no need to display it twice.
 			$hint = '';
@@ -329,6 +329,9 @@ class OC_Template extends \OC\Template\Base {
 			$content = new \OC_Template( '', 'error', 'error', false );
 			$errors = [['error' => \OCP\Util::sanitizeHTML($error_msg), 'hint' => \OCP\Util::sanitizeHTML($hint)]];
 			$content->assign( 'errors', $errors );
+			if ($status !== null) {
+				header(self::getHttpProtocol() . ' ' . $status);
+			}
 			$content->printPage();
 		} catch (\Exception $e) {
 			$logger = \OC::$server->getLogger();

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -319,7 +319,7 @@ class OC_Template extends \OC\Template\Base {
 		* @param string $error_msg The error message to show
 		* @param string $hint An optional hint message - needs to be properly escaped
 		*/
-	public static function printErrorPage( $error_msg, $hint = '' ) {
+	public static function printErrorPage( $error_msg, $hint = '', $status = null ) {
 		if ($error_msg === $hint) {
 			// If the hint is the same as the message there is no need to display it twice.
 			$hint = '';
@@ -329,6 +329,9 @@ class OC_Template extends \OC\Template\Base {
 			$content = new \OC_Template( '', 'error', 'error', false );
 			$errors = [['error' => \OCP\Util::sanitizeHTML($error_msg), 'hint' => \OCP\Util::sanitizeHTML($hint)]];
 			$content->assign( 'errors', $errors );
+			if ($status !== null) {
+				header(self::getHttpProtocol() . ' ' . $status);
+			}
 			$content->printPage();
 		} catch (\Exception $e) {
 			$logger = \OC::$server->getLogger();

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -318,8 +318,9 @@ class OC_Template extends \OC\Template\Base {
 		* Print a fatal error page and terminates the script
 		* @param string $error_msg The error message to show
 		* @param string $hint An optional hint message - needs to be properly escaped
+		* @param int HTTP Status Code
 		*/
-	public static function printErrorPage( $error_msg, $hint = '', $status = null ) {
+	public static function printErrorPage( $error_msg, $hint = '', $httpStatusCode = null ) {
 		if ($error_msg === $hint) {
 			// If the hint is the same as the message there is no need to display it twice.
 			$hint = '';
@@ -329,8 +330,8 @@ class OC_Template extends \OC\Template\Base {
 			$content = new \OC_Template( '', 'error', 'error', false );
 			$errors = [['error' => \OCP\Util::sanitizeHTML($error_msg), 'hint' => \OCP\Util::sanitizeHTML($hint)]];
 			$content->assign( 'errors', $errors );
-			if ($status !== null) {
-				header(self::getHttpProtocol() . ' ' . $status);
+			if ($httpStatusCode !== null) {
+				http_response_code((int)$httpStatusCode);
 			}
 			$content->printPage();
 		} catch (\Exception $e) {

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -319,7 +319,7 @@ class OC_Template extends \OC\Template\Base {
 		* @param string $error_msg The error message to show
 		* @param string $hint An optional hint message - needs to be properly escaped
 		*/
-	public static function printErrorPage( $error_msg, $hint = '', $status = null ) {
+	public static function printErrorPage( $error_msg, $hint = '') {
 		if ($error_msg === $hint) {
 			// If the hint is the same as the message there is no need to display it twice.
 			$hint = '';
@@ -329,9 +329,6 @@ class OC_Template extends \OC\Template\Base {
 			$content = new \OC_Template( '', 'error', 'error', false );
 			$errors = [['error' => \OCP\Util::sanitizeHTML($error_msg), 'hint' => \OCP\Util::sanitizeHTML($hint)]];
 			$content->assign( 'errors', $errors );
-			if ($status !== null) {
-				header(self::getHttpProtocol() . ' ' . $status);
-			}
 			$content->printPage();
 		} catch (\Exception $e) {
 			$logger = \OC::$server->getLogger();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
1. allow the `printErrorPage` function in the template to set the status code header
2. when the access to a (public) file is forbidden send a 403 status code

## Related Issue
https://github.com/owncloud/firewall/issues/322

## Motivation and Context
if the access to a file is forbidden the HTTP status code should be 403 not 200

## How Has This Been Tested?
- made public share of a file
-  blocked the access by file firewall
- accessed the public link

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/2425577/28112321-58465b66-6718-11e7-8dd7-82b580825a8a.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.