### PR TITLE
Validate user:inactive parameter even when it is a string

### DIFF
--- a/core/Command/User/Inactive.php
+++ b/core/Command/User/Inactive.php
@@ -55,7 +55,7 @@ class Inactive extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$days = $input->getArgument('days');
-		if(!is_int($days) || $days < 1) {
+		if((!is_int($days) && !ctype_digit($days)) || $days < 1) {
 			throw new InvalidArgumentException('Days must be integer and above zero');
 		}
 


### PR DESCRIPTION
## Description
Validate the parameter as being an int type or a string of digits.
occ command interactively passes the digit(s) as string type.

## Related Issue
#28377 

## Motivation and Context
user:inactive command needs to get past parameter validation.

## How Has This Been Tested?
Run occ user:inactive command on a test system and make sure it gets past the validation.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

