### PR TITLE
Load the app in the migration service. This allows execution of app c…

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -56,7 +56,10 @@ class MigrationService {
 	 * @param IOutput|null $output
 	 * @throws \Exception
 	 */
-	function __construct($appName, IDBConnection $connection, IOutput $output = null, AppLocator $appLocator = null) {
+	function __construct($appName,
+						 IDBConnection $connection,
+						 IOutput $output = null,
+						 AppLocator $appLocator = null) {
 		$this->appName = $appName;
 		$this->connection = $connection;
 		$this->output = $output;
@@ -81,6 +84,9 @@ class MigrationService {
 				throw new \Exception("Could not create migration folder \"{$this->migrationsPath}\"");
 			};
 		}
+
+		// load the app so that app code can be used during migrations
+		\OC_App::loadApp($this->appName);
 	}
 
 	private static function requireOnce($file) {
@@ -196,6 +202,7 @@ class MigrationService {
 
 	/**
 	 * @param string $to
+	 * @return array
 	 */
 	private function getMigrationsToExecute($to) {
 		$knownMigrations = $this->getMigratedVersions();
@@ -215,7 +222,9 @@ class MigrationService {
 	}
 
 	/**
+	 * @param string $m
 	 * @param string[] $knownMigrations
+	 * @return bool
 	 */
 	private function shallBeExecuted($m, $knownMigrations) {
 		if (in_array($m, $knownMigrations)) {
@@ -315,6 +324,7 @@ class MigrationService {
 	}
 
 	/**
+	 * @param string $version
 	 * @return string
 	 */
 	private function getClass($version) {


### PR DESCRIPTION
…ode in migrations

## Description
Migration steps of an app can include code of the app itself - e.g. mapper classes for database access.
These classes cannot be loaded if the app is not loaded.

This change fixes this.

## How Has This Been Tested?
https://github.com/owncloud/oauth2/pull/55/commits/9f75e0ac65ccc94871a3456e8edb878bf5c4c3eb


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

