### PR TITLE
[stable10] Refactoring tags

### DIFF
--- a/tests/integration/config/behat.yml
+++ b/tests/integration/config/behat.yml
@@ -13,8 +13,6 @@ default:
               - admin
             regular_user_password: 123456
             mailhog_url: http://127.0.0.1:8025/api/v2/messages
-        - TagsContext:
-            baseUrl: http://localhost:8080
         - CardDavContext:
             baseUrl: http://localhost:8080
         - CalDavContext:

--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -12,6 +12,7 @@ trait BasicStructure {
 	use Checksums;
 	use Comments;
 	use MailTool;
+	use Tags;
 
 	/** @var string */
 	private $currentUser = '';

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -299,7 +299,7 @@ trait WebDav {
 		$response = $client->propfind($this->makeSabrePath($user, $path), $properties);
 		$this->response = $response;
 	 }
-	
+
 	/**
 	 * @Given /^"([^"]*)" sets property "([^"]*)" of (file|folder|entry) "([^"]*)" to "([^"]*)"$/
 	 * @param string $user
@@ -452,8 +452,11 @@ trait WebDav {
 			];
 		}
 
-		$response = $client->propfind($this->makeSabrePath($user, $path), $properties, $folderDepth);
-
+		try{
+			$response = $client->propfind($this->makeSabrePath($user, $path), $properties, $folderDepth);
+		} catch (Sabre\HTTP\ClientHttpException $e) {
+			$response = $e->getResponse();
+		}
 		return $response;
 	}
 
@@ -1074,7 +1077,11 @@ trait WebDav {
 	private function getFileIdForPath($user, $path) {
 		$propertiesTable = new \Behat\Gherkin\Node\TableNode([["{http://owncloud.org/ns}fileid"]]);
 		$this->asGetsPropertiesOfFolderWith($user, 'file', $path, $propertiesTable);
-		return (int) $this->response['{http://owncloud.org/ns}fileid'];
+		if (is_array($this->response)) {
+			return (int) $this->response['{http://owncloud.org/ns}fileid'];
+		} else {
+			return null;
+		}
 	}
 
 	/**

--- a/tests/integration/features/tags.feature
+++ b/tests/integration/features/tags.feature
@@ -1,4 +1,6 @@
 Feature: tags
+  Background:
+    Given using new dav path
 
   Scenario: Creating a normal tag as regular user should work
     Given user "user0" exists

--- a/tests/integration/features/tags.feature
+++ b/tests/integration/features/tags.feature
@@ -40,61 +40,54 @@ Feature: tags
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for "user0"
 
-  Scenario: Renaming a normal tag as regular user should work
+  Scenario Outline: Renaming a normal tag as regular user should work
     Given user "user0" exists
-    Given "admin" creates a "normal" tag with name "JustARegularTagName"
-    When "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName"
-    Then the HTTP status code should be "207"
+    And "admin" creates a "normal" tag with name "<tag_name>"
+    When "user0" edits the tag with name "<tag_name>" and sets its name to "AnotherTagName"
     And The following tags should exist for "admin"
       |AnotherTagName|true|true|
 
-  Scenario: Renaming a normal tag to an emoji as regular user should work
-    Given user "user0" exists
-    Given "admin" creates a "normal" tag with name "JustARegularTagName"
-    When "user0" edits the tag with name "JustARegularTagName" and sets its name to "😀"
-    Then the HTTP status code should be "207"
-    And The following tags should exist for "admin"
-      |😀|true|true|
+  Examples:
+    |tag_name|
+    |JustARegularTagName|
+    |😀|
 
   Scenario: Renaming a not user-assignable tag as regular user should fail
     Given user "user0" exists
-    Given "admin" creates a "not user-assignable" tag with name "JustARegularTagName"
+    And "admin" creates a "not user-assignable" tag with name "JustARegularTagName"
     When "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName"
-    Then the HTTP status code should be "403"
     And The following tags should exist for "admin"
       |JustARegularTagName|true|false|
 
   Scenario: Renaming a not user-visible tag as regular user should fail
     Given user "user0" exists
-    Given "admin" creates a "not user-visible" tag with name "JustARegularTagName"
+    And "admin" creates a "not user-visible" tag with name "JustARegularTagName"
     When "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName"
-    Then the HTTP status code should be "404"
     And The following tags should exist for "admin"
       |JustARegularTagName|false|true|
 
   Scenario: Editing tag groups as admin should work
     Given user "user0" exists
-    Given "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
+    And "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
     When "admin" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3"
-    Then the HTTP status code should be "207"
     And The "not user-assignable" tag with name "TagWithGroups" has the groups "group1|group3"
 
   Scenario: Editing tag groups as regular user should fail
     Given user "user0" exists
-    Given "admin" creates a "not user-assignable" tag with name "TagWithGroups"
+    And "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
     When "user0" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3"
-    Then the HTTP status code should be "403"
+    And The "not user-assignable" tag with name "TagWithGroups" has the groups "group1|group2"
 
   Scenario: Deleting a normal tag as regular user should work
     Given user "user0" exists
-    Given "admin" creates a "normal" tag with name "JustARegularTagName"
+    And "admin" creates a "normal" tag with name "JustARegularTagName"
     When "user0" deletes the tag with name "JustARegularTagName"
     Then the HTTP status code should be "204"
-    And "0" tags should exist for "admin"
+    And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Deleting a not user-assignable tag as regular user should fail
     Given user "user0" exists
-    Given "admin" creates a "not user-assignable" tag with name "JustARegularTagName"
+    And "admin" creates a "not user-assignable" tag with name "JustARegularTagName"
     When "user0" deletes the tag with name "JustARegularTagName"
     Then the HTTP status code should be "403"
     And The following tags should exist for "admin"
@@ -102,7 +95,7 @@ Feature: tags
 
   Scenario: Deleting a not user-visible tag as regular user should fail
     Given user "user0" exists
-    Given "admin" creates a "not user-visible" tag with name "JustARegularTagName"
+    And "admin" creates a "not user-visible" tag with name "JustARegularTagName"
     When "user0" deletes the tag with name "JustARegularTagName"
     Then the HTTP status code should be "404"
     And The following tags should exist for "admin"
@@ -112,13 +105,13 @@ Feature: tags
     Given "admin" creates a "not user-assignable" tag with name "JustARegularTagName"
     When "admin" deletes the tag with name "JustARegularTagName"
     Then the HTTP status code should be "204"
-    And "0" tags should exist for "admin"
+    And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Deleting a not user-visible tag as admin should work
     Given "admin" creates a "not user-visible" tag with name "JustARegularTagName"
     When "admin" deletes the tag with name "JustARegularTagName"
     Then the HTTP status code should be "204"
-    And "0" tags should exist for "admin"
+    And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Assigning a normal tag to a file shared by someone else as regular user should work
     Given user "user0" exists

--- a/tests/integration/features/tags.feature
+++ b/tests/integration/features/tags.feature
@@ -260,112 +260,92 @@ Feature: tags
 
   Scenario: Unassigning a not user-visible tag from a file shared by someone else as admin should work
     Given user "user0" exists
-    Given user "user1" exists
-    Given "admin" creates a "not user-visible" tag with name "MyFirstTag"
-    Given "admin" creates a "normal" tag with name "MySecondTag"
-    Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | user1 |
-      | shareType | 0 |
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | admin |
-      | shareType | 0 |
-    Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    When "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
+    And user "user1" exists
+    And user "another_admin" exists
+    And user "another_admin" belongs to group "admin"
+    And "another_admin" creates a "not user-visible" tag with name "MyFirstTag"
+    And "another_admin" creates a "normal" tag with name "MySecondTag"
+    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
+    And "another_admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    When "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
     Then the HTTP status code should be "204"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
-      |MySecondTag|
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "admin"
-      |MySecondTag|
+      |MySecondTag|normal|
+    And "/myFileToTag.txt" shared by "user0" has the following tags for "another_admin"
+      |MySecondTag|normal|
 
   Scenario: Unassigning a not user-visible tag from a file unshared by someone else should fail
     Given user "user0" exists
-    Given user "user1" exists
-    Given "admin" creates a "not user-visible" tag with name "MyFirstTag"
-    Given "admin" creates a "normal" tag with name "MySecondTag"
-    Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | user1 |
-      | shareType | 0 |
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | admin |
-      | shareType | 0 |
-    Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    Given As "user0" remove all shares from the file named "/myFileToTag.txt"
-    When "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
+    And user "user1" exists
+    And user "another_admin" exists
+    And user "another_admin" belongs to group "admin"
+    And "another_admin" creates a "not user-visible" tag with name "MyFirstTag"
+    And "another_admin" creates a "normal" tag with name "MySecondTag"
+    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
+    And "another_admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And As "user0" remove all shares from the file named "/myFileToTag.txt"
+    When "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
     Then the HTTP status code should be "404"
 
   Scenario: Unassigning a not user-assignable tag from a file shared by someone else as regular user should fail
     Given user "user0" exists
-    Given user "user1" exists
-    Given "admin" creates a "not user-assignable" tag with name "MyFirstTag"
-    Given "admin" creates a "normal" tag with name "MySecondTag"
-    Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | user1 |
-      | shareType | 0 |
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | admin |
-      | shareType | 0 |
-    Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user1" exists
+    And user "another_admin" exists
+    And user "another_admin" belongs to group "admin"
+    And "another_admin" creates a "not user-assignable" tag with name "MyFirstTag"
+    And "another_admin" creates a "normal" tag with name "MySecondTag"
+    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
+    And "another_admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
     Then the HTTP status code should be "403"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
-      |MyFirstTag|
-      |MySecondTag|
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "admin"
-      |MyFirstTag|
-      |MySecondTag|
+      |MyFirstTag|not user-assignable|
+      |MySecondTag|normal|
+    And "/myFileToTag.txt" shared by "user0" has the following tags for "another_admin"
+      |MyFirstTag|not user-assignable|
+      |MySecondTag|normal|
 
   Scenario: Unassigning a not user-assignable tag from a file shared by someone else as admin should work
     Given user "user0" exists
-    Given user "user1" exists
-    Given "admin" creates a "not user-assignable" tag with name "MyFirstTag"
-    Given "admin" creates a "normal" tag with name "MySecondTag"
-    Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | user1 |
-      | shareType | 0 |
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | admin |
-      | shareType | 0 |
-    Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    When "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
+    And user "user1" exists
+    And user "another_admin" exists
+    And user "another_admin" belongs to group "admin"
+    And "another_admin" creates a "not user-assignable" tag with name "MyFirstTag"
+    And "another_admin" creates a "normal" tag with name "MySecondTag"
+    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
+    And "another_admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    When "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
     Then the HTTP status code should be "204"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
-      |MySecondTag|
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "admin"
-      |MySecondTag|
+      |MySecondTag|normal|
+    And "/myFileToTag.txt" shared by "user0" has the following tags for "another_admin"
+      |MySecondTag|normal|
 
   Scenario: Unassigning a not user-assignable tag from a file unshared by someone else should fail
     Given user "user0" exists
-    Given user "user1" exists
-    Given "admin" creates a "not user-assignable" tag with name "MyFirstTag"
-    Given "admin" creates a "normal" tag with name "MySecondTag"
-    Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | user1 |
-      | shareType | 0 |
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | admin |
-      | shareType | 0 |
-    Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    Given As "user0" remove all shares from the file named "/myFileToTag.txt"
+    And user "user1" exists
+    And user "another_admin" exists
+    And user "another_admin" belongs to group "admin"
+    And "another_admin" creates a "not user-assignable" tag with name "MyFirstTag"
+    And "another_admin" creates a "normal" tag with name "MySecondTag"
+    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
+    And "another_admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And As "user0" remove all shares from the file named "/myFileToTag.txt"
     When "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
     Then the HTTP status code should be "404"
 
@@ -387,12 +367,12 @@ Feature: tags
 
   Scenario: Getting tags only works with access to the file
     Given user "user0" exists
-    Given user "user1" exists
-    Given "admin" creates a "normal" tag with name "MyFirstTag"
-    Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user1" exists
+    And "admin" creates a "normal" tag with name "MyFirstTag"
+    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
     When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
-      |MyFirstTag|
+    Then "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
+      |MyFirstTag|normal|
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user1"
       ||
     And the HTTP status code should be "404"

--- a/tests/integration/features/tags.feature
+++ b/tests/integration/features/tags.feature
@@ -2,141 +2,137 @@ Feature: tags
   Background:
     Given using new dav path
 
-  Scenario: Creating a normal tag as regular user should work
+  Scenario Outline: Creating a normal tag as regular user should work
     Given user "user0" exists
-    When "user0" creates a "normal" tag with name "MySuperAwesomeTagName"
-    Then The response should have a status code "201"
+    When "user0" creates a "normal" tag with name "<tag_name>"
+    Then the HTTP status code should be "201"
     And The following tags should exist for "admin"
-      |MySuperAwesomeTagName|true|true|
+      |<tag_name>|true|true|
     And The following tags should exist for "user0"
-      |MySuperAwesomeTagName|true|true|
+      |<tag_name>|true|true|
 
-  Scenario: Creating a normal tag with an emoji as regular user should work
-    Given user "user0" exists
-    When "user0" creates a "normal" tag with name "😀"
-    Then The response should have a status code "201"
-    And The following tags should exist for "admin"
-      |😀|true|true|
-    And The following tags should exist for "user0"
-      |😀|true|true|
+  Examples:
+    |tag_name|
+    |JustARegularTagName|
+    |😀|
 
   Scenario: Creating a not user-assignable tag as regular user should fail
     Given user "user0" exists
-    When "user0" creates a "not user-assignable" tag with name "MySuperAwesomeTagName"
-    Then The response should have a status code "400"
-    And "0" tags should exist for "admin"
+    When "user0" creates a "not user-assignable" tag with name "JustARegularTagName"
+    Then the HTTP status code should be "400"
+    And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Creating a not user-visible tag as regular user should fail
     Given user "user0" exists
-    When "user0" creates a "not user-visible" tag with name "MySuperAwesomeTagName"
-    Then The response should have a status code "400"
-    And "0" tags should exist for "admin"
+    When "user0" creates a "not user-visible" tag with name "JustARegularTagName"
+    Then the HTTP status code should be "400"
+    And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Creating a not user-assignable tag with groups as admin should work
     Given user "user0" exists
     When "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
-    Then The response should have a status code "201"
+    Then the HTTP status code should be "201"
     And The "not user-assignable" tag with name "TagWithGroups" has the groups "group1|group2"
 
   Scenario: Creating a normal tag with groups as regular user should fail
     Given user "user0" exists
-    When "user0" creates a "normal" tag with name "MySuperAwesomeTagName" and groups "group1|group2"
-    Then The response should have a status code "400"
-    And "0" tags should exist for "user0"
+    When "user0" creates a "normal" tag with name "JustARegularTagName" and groups "group1|group2"
+    Then the HTTP status code should be "400"
+    And tag "JustARegularTagName" should not exist for "user0"
 
   Scenario: Renaming a normal tag as regular user should work
     Given user "user0" exists
-    Given "admin" creates a "normal" tag with name "MySuperAwesomeTagName"
-    When "user0" edits the tag with name "MySuperAwesomeTagName" and sets its name to "AnotherTagName"
-    Then The response should have a status code "207"
+    Given "admin" creates a "normal" tag with name "JustARegularTagName"
+    When "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName"
+    Then the HTTP status code should be "207"
     And The following tags should exist for "admin"
       |AnotherTagName|true|true|
 
   Scenario: Renaming a normal tag to an emoji as regular user should work
     Given user "user0" exists
-    Given "admin" creates a "normal" tag with name "MySuperAwesomeTagName"
-    When "user0" edits the tag with name "MySuperAwesomeTagName" and sets its name to "😀"
-    Then The response should have a status code "207"
+    Given "admin" creates a "normal" tag with name "JustARegularTagName"
+    When "user0" edits the tag with name "JustARegularTagName" and sets its name to "😀"
+    Then the HTTP status code should be "207"
     And The following tags should exist for "admin"
       |😀|true|true|
 
   Scenario: Renaming a not user-assignable tag as regular user should fail
     Given user "user0" exists
-    Given "admin" creates a "not user-assignable" tag with name "MySuperAwesomeTagName"
-    When "user0" edits the tag with name "MySuperAwesomeTagName" and sets its name to "AnotherTagName"
-    Then The response should have a status code "403"
+    Given "admin" creates a "not user-assignable" tag with name "JustARegularTagName"
+    When "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName"
+    Then the HTTP status code should be "403"
     And The following tags should exist for "admin"
-      |MySuperAwesomeTagName|true|false|
+      |JustARegularTagName|true|false|
 
   Scenario: Renaming a not user-visible tag as regular user should fail
     Given user "user0" exists
-    Given "admin" creates a "not user-visible" tag with name "MySuperAwesomeTagName"
-    When "user0" edits the tag with name "MySuperAwesomeTagName" and sets its name to "AnotherTagName"
-    Then The response should have a status code "404"
+    Given "admin" creates a "not user-visible" tag with name "JustARegularTagName"
+    When "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName"
+    Then the HTTP status code should be "404"
     And The following tags should exist for "admin"
-      |MySuperAwesomeTagName|false|true|
+      |JustARegularTagName|false|true|
 
   Scenario: Editing tag groups as admin should work
     Given user "user0" exists
     Given "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
     When "admin" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3"
-    Then The response should have a status code "207"
+    Then the HTTP status code should be "207"
     And The "not user-assignable" tag with name "TagWithGroups" has the groups "group1|group3"
 
   Scenario: Editing tag groups as regular user should fail
     Given user "user0" exists
     Given "admin" creates a "not user-assignable" tag with name "TagWithGroups"
     When "user0" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3"
-    Then The response should have a status code "403"
+    Then the HTTP status code should be "403"
 
   Scenario: Deleting a normal tag as regular user should work
     Given user "user0" exists
-    Given "admin" creates a "normal" tag with name "MySuperAwesomeTagName"
-    When "user0" deletes the tag with name "MySuperAwesomeTagName"
-    Then The response should have a status code "204"
+    Given "admin" creates a "normal" tag with name "JustARegularTagName"
+    When "user0" deletes the tag with name "JustARegularTagName"
+    Then the HTTP status code should be "204"
     And "0" tags should exist for "admin"
 
   Scenario: Deleting a not user-assignable tag as regular user should fail
     Given user "user0" exists
-    Given "admin" creates a "not user-assignable" tag with name "MySuperAwesomeTagName"
-    When "user0" deletes the tag with name "MySuperAwesomeTagName"
-    Then The response should have a status code "403"
+    Given "admin" creates a "not user-assignable" tag with name "JustARegularTagName"
+    When "user0" deletes the tag with name "JustARegularTagName"
+    Then the HTTP status code should be "403"
     And The following tags should exist for "admin"
-      |MySuperAwesomeTagName|true|false|
+      |JustARegularTagName|true|false|
 
   Scenario: Deleting a not user-visible tag as regular user should fail
     Given user "user0" exists
-    Given "admin" creates a "not user-visible" tag with name "MySuperAwesomeTagName"
-    When "user0" deletes the tag with name "MySuperAwesomeTagName"
-    Then The response should have a status code "404"
+    Given "admin" creates a "not user-visible" tag with name "JustARegularTagName"
+    When "user0" deletes the tag with name "JustARegularTagName"
+    Then the HTTP status code should be "404"
     And The following tags should exist for "admin"
-      |MySuperAwesomeTagName|false|true|
+      |JustARegularTagName|false|true|
 
   Scenario: Deleting a not user-assignable tag as admin should work
-    Given "admin" creates a "not user-assignable" tag with name "MySuperAwesomeTagName"
-    When "admin" deletes the tag with name "MySuperAwesomeTagName"
-    Then The response should have a status code "204"
+    Given "admin" creates a "not user-assignable" tag with name "JustARegularTagName"
+    When "admin" deletes the tag with name "JustARegularTagName"
+    Then the HTTP status code should be "204"
     And "0" tags should exist for "admin"
 
   Scenario: Deleting a not user-visible tag as admin should work
-    Given "admin" creates a "not user-visible" tag with name "MySuperAwesomeTagName"
-    When "admin" deletes the tag with name "MySuperAwesomeTagName"
-    Then The response should have a status code "204"
+    Given "admin" creates a "not user-visible" tag with name "JustARegularTagName"
+    When "admin" deletes the tag with name "JustARegularTagName"
+    Then the HTTP status code should be "204"
     And "0" tags should exist for "admin"
 
   Scenario: Assigning a normal tag to a file shared by someone else as regular user should work
     Given user "user0" exists
     Given user "user1" exists
-    Given "admin" creates a "normal" tag with name "MySuperAwesomeTagName"
+    Given "admin" creates a "normal" tag with name "JustARegularTagName"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
     Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
-    When "user1" adds the tag "MySuperAwesomeTagName" to "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "201"
+    When "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0"
+    Then the HTTP status code should be "201"
     And "/myFileToTag.txt" shared by "user0" has the following tags
-      |MySuperAwesomeTagName|
+      |JustARegularTagName|
 
   Scenario: Assigning a normal tag to a file belonging to someone else as regular user should fail
     Given user "user0" exists
@@ -146,7 +142,7 @@ Feature: tags
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
     When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "404"
+    Then the HTTP status code should be "404"
     And "/myFileToTag.txt" shared by "user0" has the following tags
       |MyFirstTag|
 
@@ -162,7 +158,7 @@ Feature: tags
       | shareType | 0 |
     When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "403"
+    Then the HTTP status code should be "403"
     And "/myFileToTag.txt" shared by "user0" has the following tags
       |MyFirstTag|
 
@@ -171,16 +167,16 @@ Feature: tags
     Given user "user1" exists
     Given group "group1" exists
     Given user "user1" belongs to group "group1"
-    Given "admin" creates a "not user-assignable" tag with name "MySuperAwesomeTagName" and groups "group1"
+    Given "admin" creates a "not user-assignable" tag with name "JustARegularTagName" and groups "group1"
     Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
     Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
       | path | myFileToTag.txt |
       | shareWith | user1 |
       | shareType | 0 |
-    When "user1" adds the tag "MySuperAwesomeTagName" to "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "201"
+    When "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0"
+    Then the HTTP status code should be "201"
     And "/myFileToTag.txt" shared by "user0" has the following tags
-      |MySuperAwesomeTagName|
+      |JustARegularTagName|
 
 
   Scenario: Assigning a not user-visible tag to a file shared by someone else as regular user should fail
@@ -195,7 +191,7 @@ Feature: tags
       | shareType | 0 |
     When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "412"
+    Then the HTTP status code should be "412"
     And "/myFileToTag.txt" shared by "user0" has the following tags
       |MyFirstTag|
 
@@ -210,7 +206,7 @@ Feature: tags
       | shareType | 0 |
     When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     When "admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "201"
+    Then the HTTP status code should be "201"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "admin"
       |MyFirstTag|
       |MySecondTag|
@@ -228,7 +224,7 @@ Feature: tags
       | shareType | 0 |
     When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     When "admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "201"
+    Then the HTTP status code should be "201"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "admin"
       |MyFirstTag|
       |MySecondTag|
@@ -249,7 +245,7 @@ Feature: tags
     Given "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "204"
+    Then the HTTP status code should be "204"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
       |MySecondTag|
 
@@ -262,7 +258,7 @@ Feature: tags
     Given "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "404"
+    Then the HTTP status code should be "404"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
       |MyFirstTag|
       |MySecondTag|
@@ -284,7 +280,7 @@ Feature: tags
     Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "404"
+    Then the HTTP status code should be "404"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
       |MySecondTag|
     And "/myFileToTag.txt" shared by "user0" has the following tags for "admin"
@@ -308,7 +304,7 @@ Feature: tags
     Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "204"
+    Then the HTTP status code should be "204"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
       |MySecondTag|
     And "/myFileToTag.txt" shared by "user0" has the following tags for "admin"
@@ -332,7 +328,7 @@ Feature: tags
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     Given As "user0" remove all shares from the file named "/myFileToTag.txt"
     When "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "404"
+    Then the HTTP status code should be "404"
 
   Scenario: Unassigning a not user-assignable tag from a file shared by someone else as regular user should fail
     Given user "user0" exists
@@ -351,7 +347,7 @@ Feature: tags
     Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "403"
+    Then the HTTP status code should be "403"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
       |MyFirstTag|
       |MySecondTag|
@@ -376,7 +372,7 @@ Feature: tags
     Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "204"
+    Then the HTTP status code should be "204"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
       |MySecondTag|
     And "/myFileToTag.txt" shared by "user0" has the following tags for "admin"
@@ -400,23 +396,23 @@ Feature: tags
     Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     Given As "user0" remove all shares from the file named "/myFileToTag.txt"
     When "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
-    Then The response should have a status code "404"
+    Then the HTTP status code should be "404"
 
   Scenario: Overwriting existing normal tags should fail
     Given user "user0" exists
     Given "user0" creates a "normal" tag with name "MyFirstTag"
     When "user0" creates a "normal" tag with name "MyFirstTag"
-    Then The response should have a status code "409"
+    Then the HTTP status code should be "409"
 
   Scenario: Overwriting existing not user-assignable tags should fail
     Given "admin" creates a "not user-assignable" tag with name "MyFirstTag"
     When "admin" creates a "not user-assignable" tag with name "MyFirstTag"
-    Then The response should have a status code "409"
+    Then the HTTP status code should be "409"
 
   Scenario: Overwriting existing not user-visible tags should fail
     Given "admin" creates a "not user-visible" tag with name "MyFirstTag"
     When "admin" creates a "not user-visible" tag with name "MyFirstTag"
-    Then The response should have a status code "409"
+    Then the HTTP status code should be "409"
 
   Scenario: Getting tags only works with access to the file
     Given user "user0" exists
@@ -428,18 +424,18 @@ Feature: tags
       |MyFirstTag|
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user1"
       ||
-    And The response should have a status code "404"
+    And the HTTP status code should be "404"
 
   Scenario: User can assign tags when in the tag's groups
     Given user "user0" exists
     Given group "group1" exists
     Given user "user0" belongs to group "group1"
     When "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
-    Then The response should have a status code "201"
+    Then the HTTP status code should be "201"
     And the user "user0" can assign the "not user-assignable" tag with name "TagWithGroups"
 
   Scenario: User cannot assign tags when not in the tag's groups
     Given user "user0" exists
     When "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
-    Then The response should have a status code "201"
+    Then the HTTP status code should be "201"
     And the user "user0" cannot assign the "not user-assignable" tag with name "TagWithGroups"

--- a/tests/integration/features/tags.feature
+++ b/tests/integration/features/tags.feature
@@ -375,7 +375,6 @@ Feature: tags
       |MyFirstTag|normal|
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user1"
       ||
-    And the HTTP status code should be "404"
 
   Scenario: User can assign tags when in the tag's groups
     Given user "user0" exists

--- a/tests/integration/features/tags.feature
+++ b/tests/integration/features/tags.feature
@@ -177,95 +177,86 @@ Feature: tags
 
   Scenario: Assigning a not user-visible tag to a file shared by someone else as admin user should work
     Given user "user0" exists
-    Given "admin" creates a "normal" tag with name "MyFirstTag"
-    Given "admin" creates a "not user-visible" tag with name "MySecondTag"
-    Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | admin |
-      | shareType | 0 |
-    When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    When "admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "another_admin" exists
+    And user "another_admin" belongs to group "admin"
+    And "another_admin" creates a "normal" tag with name "MyFirstTag"
+    And "another_admin" creates a "not user-visible" tag with name "MySecondTag"
+    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
+    And "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
+    When "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     Then the HTTP status code should be "201"
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "admin"
-      |MyFirstTag|
-      |MySecondTag|
+    And "/myFileToTag.txt" shared by "user0" has the following tags for "another_admin"
+      |MyFirstTag|normal|
+      |MySecondTag|not user-visible|
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
-      |MyFirstTag|
+      |MyFirstTag|normal|
 
-  Scenario: Assigning a not user-assignable tag to a file shared by someone else as admin user should worj
+  Scenario: Assigning a not user-assignable tag to a file shared by someone else as admin user should work
     Given user "user0" exists
-    Given "admin" creates a "normal" tag with name "MyFirstTag"
-    Given "admin" creates a "not user-assignable" tag with name "MySecondTag"
-    Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | admin |
-      | shareType | 0 |
-    When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    When "admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "another_admin" exists
+    And user "another_admin" belongs to group "admin"
+    And "another_admin" creates a "normal" tag with name "MyFirstTag"
+    And "another_admin" creates a "not user-assignable" tag with name "MySecondTag"
+    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
+    And "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    When "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     Then the HTTP status code should be "201"
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "admin"
-      |MyFirstTag|
-      |MySecondTag|
+    And "/myFileToTag.txt" shared by "user0" has the following tags for "another_admin"
+      |MyFirstTag|normal|
+      |MySecondTag|not user-assignable|
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
-      |MyFirstTag|
-      |MySecondTag|
+      |MyFirstTag|normal|
+      |MySecondTag|not user-assignable|
 
   Scenario: Unassigning a normal tag from a file shared by someone else as regular user should work
     Given user "user0" exists
-    Given user "user1" exists
-    Given "admin" creates a "normal" tag with name "MyFirstTag"
-    Given "admin" creates a "normal" tag with name "MySecondTag"
-    Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | user1 |
-      | shareType | 0 |
-    Given "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user1" exists
+    And "admin" creates a "normal" tag with name "MyFirstTag"
+    And "admin" creates a "normal" tag with name "MySecondTag"
+    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
+    And "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
+    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" owned by "user0"
     When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
     Then the HTTP status code should be "204"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
-      |MySecondTag|
+      |MySecondTag|normal|
 
   Scenario: Unassigning a normal tag from a file unshared by someone else as regular user should fail
     Given user "user0" exists
-    Given user "user1" exists
-    Given "admin" creates a "normal" tag with name "MyFirstTag"
-    Given "admin" creates a "normal" tag with name "MySecondTag"
-    Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user1" exists
+    And "admin" creates a "normal" tag with name "MyFirstTag"
+    And "admin" creates a "normal" tag with name "MySecondTag"
+    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
+    And "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
     Then the HTTP status code should be "404"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
-      |MyFirstTag|
-      |MySecondTag|
+      |MyFirstTag|normal|
+      |MySecondTag|normal|
 
   Scenario: Unassigning a not user-visible tag from a file shared by someone else as regular user should fail
     Given user "user0" exists
-    Given user "user1" exists
-    Given "admin" creates a "not user-visible" tag with name "MyFirstTag"
-    Given "admin" creates a "normal" tag with name "MySecondTag"
-    Given user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | user1 |
-      | shareType | 0 |
-    Given As "user0" sending "POST" to "/apps/files_sharing/api/v1/shares" with
-      | path | myFileToTag.txt |
-      | shareWith | admin |
-      | shareType | 0 |
-    Given "admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    Given "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user1" exists
+    And user "another_admin" exists
+    And user "another_admin" belongs to group "admin"
+    And "another_admin" creates a "not user-visible" tag with name "MyFirstTag"
+    And "another_admin" creates a "normal" tag with name "MySecondTag"
+    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
+    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
+    And "another_admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
     Then the HTTP status code should be "404"
     And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
-      |MySecondTag|
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "admin"
-      |MyFirstTag|
-      |MySecondTag|
+      |MySecondTag|normal|
+    And "/myFileToTag.txt" shared by "user0" has the following tags for "another_admin"
+      |MyFirstTag|not user-visible|
+      |MySecondTag|normal|
 
   Scenario: Unassigning a not user-visible tag from a file shared by someone else as admin should work
     Given user "user0" exists


### PR DESCRIPTION
Backport #28141 
This is needed in stable10 so that later changes on top of it can also be backported.
(e.g. Tags.php needs to exist in stable10)