### PR TITLE
[stable10] move sharing functions of integration tests into helper

### DIFF
--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann
+ * @copyright 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace TestHelpers;
+
+use GuzzleHttp\Client as GClient;
+
+class SharingHelper
+{
+	/**
+	 * 
+	 * @param string $baseUrl baseURL of the ownCloud installation without /ocs.
+	 * @param string $user user that creates the share.
+	 * @param string $password password of the user that creates the share.
+	 * @param string $path The path to the file or folder which should be shared.
+	 * @param int $shareType The type of the share. This can be one of: 0 = user, 1 = group, 3 = public link, 6 = federated cloud share.
+	 * @param string $shareWith The user or group id with which the file should be shared.
+	 * @param boolean $publicUpload Whether to allow public upload to a public shared folder.
+	 * @param string $sharePassword The password to protect the public link share with.
+	 * @param int $permissions The permissions to set on the share. 1 = read; 2 = update; 4 = create; 8 = delete; 16 = share; 31 = all (default: 31, for public shares: 1)
+	 * @param string $linkName A (human-readable) name for the share, which can be up to 64 characters in length.
+	 * @param string $expireDate **NOT IMPLEMENTED** An expire date for public link shares. This argument expects a date string in the following format 'YYYY-MM-DD'.
+	 * @param number $apiVersion
+	 * @param number $sharingApiVersion
+	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 */
+	public static function createShare(
+		$baseUrl,
+		$user,
+		$password,
+		$path,
+		$shareType,
+		$shareWith = null,
+		$publicUpload = false,
+		$sharePassword = null,
+		$permissions = null,
+		$linkName = null,
+		$expireDate = null,
+		$apiVersion = 1,
+		$sharingApiVersion = 1) {
+			$fd = [];
+			$options = [];
+			foreach ([$path, $baseUrl, $user, $password] as $variableToCheck) {
+				if (!is_string($variableToCheck)){
+					throw new \InvalidArgumentException("mandatory argument missing or wrong type ($variableToCheck => " . gettype($variableToCheck) .")");
+				}
+			}
+			if (!in_array($shareType,[0, 1, 3, 6], true)) {
+				throw new \InvalidArgumentException("invalid share type");
+			}
+			if (!is_null($permissions)){
+				$permissions = (int) $permissions;
+				if ($permissions < 1 || $permissions > 31) {
+					throw new \InvalidArgumentException("invalid permissions ($permissions)");
+				}
+				$fd['permissions'] = $permissions;
+			}
+			if (!in_array($apiVersion,[1, 2], true) || !in_array($sharingApiVersion,[1,2],true)) {
+				throw new \InvalidArgumentException("invalid apiVersion/sharingApiVersion");
+			}
+			
+			$fullUrl = $baseUrl . "/ocs/v{$apiVersion}.php/apps/files_sharing/api/v{$sharingApiVersion}/shares";
+			$client = new GClient();
+			$options['auth'] = [$user, $password];
+			$fd['path'] = $path;
+			$fd['shareType'] = $shareType;
+	
+			if (!is_null($shareWith)){
+				$fd['shareWith'] = $shareWith;
+			}
+			if (!is_null($publicUpload)){
+				$fd['publicUpload'] = (bool) $publicUpload;
+			}
+			if (!is_null($sharePassword)){
+				$fd['password'] = $sharePassword;
+			}
+			if (!is_null($linkName)){
+				$fd['name'] = $linkName;
+			}
+			
+			$options['body'] = $fd;
+			
+			return $client->send($client->createRequest("POST", $fullUrl, $options));
+	}
+}

--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -23,12 +23,6 @@ trait BasicStructure {
 	/** @var string */
 	private $baseUrl = '';
 
-	/**
-	 * base URL without the /ocs part
-	 * @var string
-	 */
-	private $baseUrlWithoutOCSAppendix = '';
-
 	/** @var int */
 	private $apiVersion = 1;
 
@@ -65,9 +59,11 @@ trait BasicStructure {
 		if ($testRemoteServerUrl !== false) {
 			$this->remoteBaseUrl = $testRemoteServerUrl;
 		}
-		$this->baseUrlWithoutOCSAppendix = substr($this->baseUrl, 0, -4);
 	}
 
+	/**
+	 * returns the base URL without the /ocs part
+	 */
 	private function baseUrlWithoutOCSAppendix() {
 		return substr($this->baseUrl, 0, -4);
 	}
@@ -365,9 +361,9 @@ trait BasicStructure {
 	 */
 	private function getPasswordForUser($userName) {
 		if ($userName === 'admin') {
-			return $this->adminUser[1];
+			return (string) $this->adminUser[1];
 		} else {
-			return $this->regularUser;
+			return (string) $this->regularUser;
 		}
 	}
 

--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -3,6 +3,7 @@
 use GuzzleHttp\Client;
 use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Exception\ClientException;
+use TestHelpers\SharingHelper;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
@@ -256,42 +257,21 @@ trait Sharing {
 								$password = null,
 								$permissions = null,
 								$linkName = null) {
-		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
-		$client = new Client();
-		$options = [];
-
-		if ($user === 'admin') {
-			$options['auth'] = $this->adminUser;
-		} else {
-			$options['auth'] = [$user, $this->regularUser];
-		}
-		$fd = [];
-		if (!is_null($path)){
-			$fd['path'] = $path;
-		}
-		if (!is_null($shareType)){
-			$fd['shareType'] = $shareType;
-		}
-		if (!is_null($shareWith)){
-			$fd['shareWith'] = $shareWith;
-		}
-		if (!is_null($publicUpload)){
-			$fd['publicUpload'] = $publicUpload;
-		}
-		if (!is_null($password)){
-			$fd['password'] = $password;
-		}
-		if (!is_null($permissions)){
-			$fd['permissions'] = $permissions;
-		}
-		if (!is_null($linkName)){
-			$fd['name'] = $linkName;
-		}
-
-		$options['body'] = $fd;
 
 		try {
-			$this->response = $client->send($client->createRequest("POST", $fullUrl, $options));
+			$this->response = SharingHelper::createShare(
+				$this->baseUrlWithoutOCSAppendix(),
+				$user,
+				$this->getPasswordForUser($user),
+				$path,
+				$shareType,
+				$shareWith,
+				$publicUpload,
+				$password,
+				$permissions,
+				$linkName,
+				$this->apiVersion,
+				$this->sharingApiVersion);
 			$this->lastShareData = $this->response->xml();
 		} catch (\GuzzleHttp\Exception\ClientException $ex) {
 			$this->response = $ex->getResponse();


### PR DESCRIPTION
Backport of #28347 
to keep testing infrastructure up-to-date in stable10