### PR TITLE
[stable10] send 403 code when printing error page after ForbiddenException

### DIFF
--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -177,7 +177,7 @@ class OC_Files {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
 			$l = \OC::$server->getL10N('core');
-			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage());
+			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage(), 403);
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -318,8 +318,9 @@ class OC_Template extends \OC\Template\Base {
 		* Print a fatal error page and terminates the script
 		* @param string $error_msg The error message to show
 		* @param string $hint An optional hint message - needs to be properly escaped
+		* @param int HTTP Status Code
 		*/
-	public static function printErrorPage( $error_msg, $hint = '' ) {
+	public static function printErrorPage( $error_msg, $hint = '', $httpStatusCode = null ) {
 		if ($error_msg === $hint) {
 			// If the hint is the same as the message there is no need to display it twice.
 			$hint = '';
@@ -329,6 +330,9 @@ class OC_Template extends \OC\Template\Base {
 			$content = new \OC_Template( '', 'error', 'error', false );
 			$errors = [['error' => \OCP\Util::sanitizeHTML($error_msg), 'hint' => \OCP\Util::sanitizeHTML($hint)]];
 			$content->assign( 'errors', $errors );
+			if ($httpStatusCode !== null) {
+				http_response_code((int)$httpStatusCode);
+			}
 			$content->printPage();
 		} catch (\Exception $e) {
 			$logger = \OC::$server->getLogger();


### PR DESCRIPTION
simple backport of #28378 

1. allow the printErrorPage function in the template to set the status code header
2. when the access to a (public) file is forbidden send a 403 status code
