### PR TITLE
Add emitting of hook post_unshareFromSelf to Share 2.0

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -764,6 +764,32 @@ class Manager implements IManager {
 		return $deletedShares;
 	}
 
+	protected static function formatUnshareHookParams(\OCP\Share\IShare $share) {
+		// Prepare hook
+		$shareType = $share->getShareType();
+		$sharedWith = '';
+		if ($shareType === \OCP\Share::SHARE_TYPE_USER) {
+			$sharedWith = $share->getSharedWith();
+		} else if ($shareType === \OCP\Share::SHARE_TYPE_GROUP) {
+			$sharedWith = $share->getSharedWith();
+		} else if ($shareType === \OCP\Share::SHARE_TYPE_REMOTE) {
+			$sharedWith = $share->getSharedWith();
+		}
+
+		$hookParams = [
+			'id'         => $share->getId(),
+			'itemType'   => $share->getNodeType(),
+			'itemSource' => $share->getNodeId(),
+			'shareType'  => $shareType,
+			'shareWith'  => $sharedWith,
+			'itemparent' => method_exists($share, 'getParent') ? $share->getParent() : '',
+			'uidOwner'   => $share->getSharedBy(),
+			'fileSource' => $share->getNodeId(),
+			'fileTarget' => $share->getTarget()
+		];
+		return $hookParams;
+	}
+
 	/**
 	 * Delete a share
 	 *
@@ -779,33 +805,7 @@ class Manager implements IManager {
 			throw new \InvalidArgumentException('Share does not have a full id');
 		}
 
-		$formatHookParams = function(\OCP\Share\IShare $share) {
-			// Prepare hook
-			$shareType = $share->getShareType();
-			$sharedWith = '';
-			if ($shareType === \OCP\Share::SHARE_TYPE_USER) {
-				$sharedWith = $share->getSharedWith();
-			} else if ($shareType === \OCP\Share::SHARE_TYPE_GROUP) {
-				$sharedWith = $share->getSharedWith();
-			} else if ($shareType === \OCP\Share::SHARE_TYPE_REMOTE) {
-				$sharedWith = $share->getSharedWith();
-			}
-
-			$hookParams = [
-				'id'         => $share->getId(),
-				'itemType'   => $share->getNodeType(),
-				'itemSource' => $share->getNodeId(),
-				'shareType'  => $shareType,
-				'shareWith'  => $sharedWith,
-				'itemparent' => method_exists($share, 'getParent') ? $share->getParent() : '',
-				'uidOwner'   => $share->getSharedBy(),
-				'fileSource' => $share->getNodeId(),
-				'fileTarget' => $share->getTarget()
-			];
-			return $hookParams;
-		};
-
-		$hookParams = $formatHookParams($share);
+		$hookParams = self::formatUnshareHookParams($share);
 
 		// Emit pre-hook
 		\OC_Hook::emit('OCP\Share', 'pre_unshare', $hookParams);
@@ -821,9 +821,7 @@ class Manager implements IManager {
 		$deletedShares[] = $share;
 
 		//Format hook info
-		$formattedDeletedShares = array_map(function($share) use ($formatHookParams) {
-			return $formatHookParams($share);
-		}, $deletedShares);
+		$formattedDeletedShares = array_map('self::formatUnshareHookParams', $deletedShares);
 
 		$hookParams['deletedShares'] = $formattedDeletedShares;
 
@@ -846,6 +844,15 @@ class Manager implements IManager {
 		$provider = $this->factory->getProvider($providerId);
 
 		$provider->deleteFromSelf($share, $recipientId);
+
+		// Emit post hook. The parameter data structure is slightly different
+		// from the post_unshare hook to maintain backward compatibility with
+		// Share 1.0: the array contains all the key-value pairs from the old
+		// library plus some new ones.
+		$hookParams = self::formatUnshareHookParams($share);
+		$hookParams['itemTarget'] = $hookParams['fileTarget'];
+		$hookParams['unsharedItems'] = [$hookParams];
+		\OC_Hook::emit('OCP\Share', 'post_unshareFromSelf', $hookParams);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Emit the hook signal `post_unshareFromSelf` when the recipient of a share unshares it. This signal used to be present in Share 1.0 but was missing from 2.0. Share 2.0 sent a signal (`post_unshare`) only in case the usharing was done by the file owner.

Some new key-value pairs are added to the hook parameter data as compared to 1.0. This is to make the hook more useful and to enable unified handling of the hooks `post_unshare` and `post_unshareFromSelf`.

## Related Issue
#28337

## Motivation and Context
There must be a way for applications to detect when a file or folder becomes unavailable. The missing signal emission is regression as compared to Share 1.0.

The parameter data of the `post_unshareFromSelf` signal was augmented as compared to Share 1.0. The motivation for this was to make the data more similar with the other signal `post_unshare` and to make the signal more useful: with the parameter content of Share 1.0, it was impossible to obtain the node ID of the unshared file/folder.

## How Has This Been Tested?
Tested on top of ownCloud 9.1.3. Connected the hooks `post_unshare` and `post_unshareFromSelf` in application code and added debug logging to the connected hook functions. Tested user shares and group shares, and unshared them both from the file owner and the share recipient, and checked in each case from the log that the hooks had fired and the parameter data was as expected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (In my test environment, 45 out of 8928 core php test failed both before and after my changes)

