### PR TITLE
Allow user 0 as role

### DIFF
--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -181,11 +181,10 @@ class Manager implements ICommentsManager {
 	 * @throws \InvalidArgumentException
 	 */
 	protected function checkRoleParameters($role, $type, $id) {
-		if(
-			   !is_string($type) || empty($type)
-			|| !is_string($id) || empty($id)
+		if (!is_string($type) || empty($type) ||
+		    !is_string($id) || ($id === '')
 		) {
-			throw new \InvalidArgumentException($role . ' parameters must be string and not empty');
+			throw new \InvalidArgumentException($role . ' parameters must be a non-blank string');
 		}
 	}
 


### PR DESCRIPTION
## Description
If the user id is "0" then the string here is considered "empty" and was causing an exception.
Allow the string "0" because a user id "0" can be created in the GUI or with the occ command.

## Related Issue
#28406 

## Motivation and Context
I noticed that:
```
php occ user:delete 0
```
throws a big red exception message.
(Although the user does seem to be deleted)

## How Has This Been Tested?
Try:
```
php occ user:add 0
php occ user:list
php occ user:delete 0
```
The user is added (can be seen in the list). The delete throws a red exception.
After the change it works without the big red exception message.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Note: it would be nice to have a suite of automated acceptance tests for the occ command some day.