### PR TITLE
Do not set the default quota if no suitable quota can be found

### DIFF
--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -513,7 +513,6 @@ class User {
 				$targetUser->setQuota($quota);
 			} else {
 				$this->log->log('not suitable default quota found for user ' . $this->uid . ': [' . $defaultQuota . ']', \OCP\Util::WARN);
-				$targetUser->setQuota('default');
 			}
 		} else {
 			$this->log->log('trying to set a quota for user ' . $this->uid . ' but the user is missing', \OCP\Util::ERROR);

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -430,9 +430,8 @@ class UserTest extends \Test\TestCase {
 			->will($this->returnValue(false));
 
 		$user = $this->getMock('\OCP\IUser');
-		$user->expects($this->once())
-			->method('setQuota')
-			->with('default');
+		$user->expects($this->never())
+			->method('setQuota');
 
 		$userMgr->expects($this->once())
 			->method('get')
@@ -472,9 +471,8 @@ class UserTest extends \Test\TestCase {
 			->method('__get');
 
 		$user = $this->getMock('\OCP\IUser');
-		$user->expects($this->once())
-			->method('setQuota')
-			->with('default');
+		$user->expects($this->never())
+			->method('setQuota');
 
 		$userMgr->expects($this->once())
 			->method('get')
@@ -610,9 +608,8 @@ class UserTest extends \Test\TestCase {
 			->will($this->returnValue(false));
 
 		$user = $this->getMock('\OCP\IUser');
-		$user->expects($this->once())
-			->method('setQuota')
-			->with('default');
+		$user->expects($this->never())
+			->method('setQuota');
 
 		$userMgr->expects($this->once())
 			->method('get')
@@ -658,9 +655,8 @@ class UserTest extends \Test\TestCase {
 			->will($this->returnValue(array('23 flush')));
 
 		$user = $this->getMock('\OCP\IUser');
-		$user->expects($this->once())
-			->method('setQuota')
-			->with('default');
+		$user->expects($this->never())
+			->method('setQuota');
 
 		$userMgr->expects($this->once())
 			->method('get')
@@ -703,9 +699,8 @@ class UserTest extends \Test\TestCase {
 			->method('readAttribute');
 
 		$user = $this->getMock('\OCP\IUser');
-		$user->expects($this->once())
-			->method('setQuota')
-			->with('default');
+		$user->expects($this->never())
+			->method('setQuota');
 
 		$userMgr->expects($this->once())
 			->method('get')


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Do not set the default quota if no suitable quota can be found. Setting the default quota seems a wrong choice.

## Related Issue
https://github.com/owncloud/core/issues/28309

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
manually tested

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Port to 10.0 will be needed.

@PVince81 