### PR TITLE
Use del() - both Redis and RedisCluster support this method 

### DIFF
--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -28,9 +28,7 @@ namespace OC\Memcache;
 use OCP\IMemcacheTTL;
 
 class Redis extends Cache implements IMemcacheTTL {
-	/**
-	 * @var \Redis $cache
-	 */
+	/** @var \Redis | \RedisCluster $cache */
 	private static $cache = null;
 
 	public function __construct($prefix = '') {
@@ -69,7 +67,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	}
 
 	public function remove($key) {
-		if (self::$cache->delete($this->getNameSpace() . $key)) {
+		if (self::$cache->del($this->getNameSpace() . $key)) {
 			return true;
 		} else {
 			return false;
@@ -81,7 +79,7 @@ class Redis extends Cache implements IMemcacheTTL {
 		$it = null;
 		self::$cache->setOption(\Redis::OPT_SCAN, \Redis::SCAN_RETRY);
 		while ($keys = self::$cache->scan($it, $prefix)) {
-			self::$cache->delete($keys);
+			self::$cache->del($keys);
 		}
 		return true;
 	}

--- a/lib/private/RedisFactory.php
+++ b/lib/private/RedisFactory.php
@@ -23,7 +23,7 @@
 namespace OC;
 
 class RedisFactory {
-	/** @var  \Redis */
+	/** @var \Redis | \RedisCluster */
 	private $instance;
 
 	/** @var  SystemConfig */
@@ -91,6 +91,10 @@ class RedisFactory {
 		}
 	}
 
+	/**
+	 * @return \Redis|\RedisCluster
+	 * @throws \Exception
+	 */
 	public function getInstance() {
 		if (!$this->isAvailable()) {
 			throw new \Exception('Redis support is not available');


### PR DESCRIPTION
## Description
RedisCluster does not support delete/() but del() - so dies class Redis

## Related Issue
fixes #28393

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

