### PR TITLE
occ show integer user ids in output

### DIFF
--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -31,6 +31,7 @@ class Base extends Command {
 	const OUTPUT_FORMAT_PLAIN = 'plain';
 	const OUTPUT_FORMAT_JSON = 'json';
 	const OUTPUT_FORMAT_JSON_PRETTY = 'json_pretty';
+	const DEFAULT_OUTPUT_PREFIX = '  - ';
 
 	protected $defaultOutputFormat = self::OUTPUT_FORMAT_PLAIN;
 
@@ -58,7 +59,7 @@ class Base extends Command {
 	 * @param array $items
 	 * @param string $prefix
 	 */
-	protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, $items, $prefix = '  - ') {
+	protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, $items, $prefix = self::DEFAULT_OUTPUT_PREFIX, $showIntKeys = false) {
 		switch ($input->getOption('output')) {
 			case self::OUTPUT_FORMAT_JSON:
 				$output->writeln(json_encode($items));
@@ -73,7 +74,7 @@ class Base extends Command {
 						$this->writeArrayInOutputFormat($input, $output, $item, '  ' . $prefix);
 						continue;
 					}
-					if (!is_int($key)) {
+					if ($showIntKeys || !is_int($key)) {
 						$value = $this->valueToString($item);
 						if (!is_null($value)) {
 							$output->writeln($prefix . $key . ': ' . $value);
@@ -158,3 +159,4 @@ class Base extends Command {
 		return parent::run($input, $output);
 	}
 }
+

--- a/core/Command/Group/ListGroupMembers.php
+++ b/core/Command/Group/ListGroupMembers.php
@@ -62,6 +62,6 @@ class ListGroupMembers extends Base {
 		}
 
 		$displayNames = $this->groupManager->displayNamesInGroup($group->getGID());
-		parent::writeArrayInOutputFormat($input, $output, $displayNames);
+		parent::writeArrayInOutputFormat($input, $output, $displayNames, self::DEFAULT_OUTPUT_PREFIX, true);
 	}
 }

--- a/core/Command/User/ListUsers.php
+++ b/core/Command/User/ListUsers.php
@@ -60,6 +60,6 @@ class ListUsers extends Base {
 			/** @var IUser $user */
 			return $user->getDisplayName();
 		}, $users);
-		parent::writeArrayInOutputFormat($input, $output, $users);
+		parent::writeArrayInOutputFormat($input, $output, $users, self::DEFAULT_OUTPUT_PREFIX, true);
 	}
 }


### PR DESCRIPTION
## Description
Provide an option to display all keys when outputting an array with writeArrayInOutputFormat
Take the option when we know that we care about seeing (possibly integer) keys.

## Related Issue
#28410 

## Motivation and Context
It fixes the missing data in the output

## How Has This Been Tested?
Manually add a user with integer UID, add to a group, try the list commands as in the issue steps.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

