### PR TITLE
removed deprecated tipps and tricks links

### DIFF
--- a/settings/templates/panels/admin/tips.php
+++ b/settings/templates/panels/admin/tips.php
@@ -9,7 +9,6 @@
 	<h2 class="app-name"><?php p($l->t('Tips & tricks'));?></h2>
 	<ul>
 		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs('admin-backup')); ?>"><?php p($l->t('How to do backups'));?> ↗</a></li>
-		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs('admin-monitoring')); ?>"><?php p($l->t('Advanced monitoring'));?> ↗</a></li>
 		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs('admin-performance')); ?>"><?php p($l->t('Performance tuning'));?> ↗</a></li>
 		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs('admin-config')); ?>"><?php p($l->t('Improving the config.php'));?> ↗</a></li>
 		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs('developer-theming')); ?>"><?php p($l->t('Theming'));?> ↗</a></li>


### PR DESCRIPTION

## Description
Removed the link "Advanced Monitoring" from the "Tips & Tricks" panel in the owncloud admin interface since this sections is no longer present in the current owncloud 10 documentation.

## Related Issue
#28296 
[#documentation/3192](https://github.com/owncloud/documentation/issues/3192)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@owncloud/qa please test and verify this is correct