### PR TITLE
[stable9.1] Use del() - both Redis and RedisCluster support this method - fixes #…

### DIFF
--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -28,9 +28,7 @@ namespace OC\Memcache;
 use OCP\IMemcacheTTL;
 
 class Redis extends Cache implements IMemcacheTTL {
-	/**
-	 * @var \Redis $cache
-	 */
+	/** @var \Redis | \RedisCluster $cache */
 	private static $cache = null;
 
 	public function __construct($prefix = '') {
@@ -69,7 +67,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	}
 
 	public function remove($key) {
-		if (self::$cache->delete($this->getNamespace() . $key)) {
+		if (self::$cache->del($this->getNameSpace() . $key)) {
 			return true;
 		} else {
 			return false;
@@ -81,7 +79,7 @@ class Redis extends Cache implements IMemcacheTTL {
 		$it = null;
 		self::$cache->setOption(\Redis::OPT_SCAN, \Redis::SCAN_RETRY);
 		while ($keys = self::$cache->scan($it, $prefix)) {
-			self::$cache->delete($keys);
+			self::$cache->del($keys);
 		}
 		return true;
 	}

--- a/lib/private/RedisFactory.php
+++ b/lib/private/RedisFactory.php
@@ -22,7 +22,7 @@
 namespace OC;
 
 class RedisFactory {
-	/** @var  \Redis */
+	/** @var \Redis | \RedisCluster */
 	private $instance;
 
 	/** @var  SystemConfig */
@@ -67,6 +67,10 @@ class RedisFactory {
 		}
 	}
 
+	/**
+	 * @return \Redis|\RedisCluster
+	 * @throws \Exception
+	 */
 	public function getInstance() {
 		if (!$this->isAvailable()) {
 			throw new \Exception('Redis support is not available');


### PR DESCRIPTION
…28393
backport of #28407 to stable9.1