### PR TITLE
UI tests - make it possible to create users&groups using a table

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -28,12 +28,23 @@ class SetupHelper
 	 * @param string $ocPath
 	 * @param string $userName
 	 * @param string $password
+	 * @param string $displayName
+	 * @param string $email
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
 	 */
-	public static function createUser($ocPath, $userName, $password)
+	public static function createUser(
+		$ocPath, $userName, $password,
+		$displayName = null, $email = null)
 	{
+		$occCommand = ['user:add', '--password-from-env'];
+		if ($displayName !== null) {
+			$occCommand = array_merge($occCommand, ["--display-name", $displayName]);
+		}
+		if ($email !== null) {
+			$occCommand = array_merge($occCommand, ["--email", $email]);
+		}
 		putenv("OC_PASS=".$password);
-		return self::runOcc(['user:add', '--password-from-env', $userName], $ocPath);
+		return self::runOcc(array_merge($occCommand, [$userName]), $ocPath);
 	}
 
 	/**

--- a/tests/ui/config/behat.yml
+++ b/tests/ui/config/behat.yml
@@ -11,6 +11,7 @@ default:
       context:
         parameters:
           ocPath: ./
+          adminPassword: admin
           regularUserPassword: 123456
           regularUserName: regularuser
           regularUserNames: user1,user2,user3,usergrp,grpuser

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -22,6 +22,7 @@
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Gherkin\Node\TableNode;
 use TestHelpers\SetupHelper;
 
 require_once 'bootstrap.php';
@@ -65,12 +66,7 @@ trait BasicStructure
 	 */
 	public function aRegularUserExists()
 	{
-		$user = $this->regularUserName;
-		$result=SetupHelper::createUser($this->ocPath, $user, $this->regularUserPassword);
-		if ($result["code"] != 0) {
-			throw new Exception("could not create user. " . $result["stdOut"] . " " . $result["stdErr"]);
-		}
-		array_push($this->createdUserNames, $user);
+		$this->createUser($this->regularUserName, $this->regularUserPassword);
 	}
 
 	/**
@@ -79,13 +75,24 @@ trait BasicStructure
 	public function regularUsersExist()
 	{
 		foreach ($this->regularUserNames as $user) {
-			$user = trim($user);
-			$result=SetupHelper::createUser($this->ocPath, $user, $this->regularUserPassword);
-			if ($result["code"] != 0) {
-				throw new Exception("could not create user. " . $result["stdOut"] . " " . $result["stdErr"]);
-			}
-			array_push($this->createdUserNames, $user);
+			$this->createUser($user, $this->regularUserPassword);
 		}
+	}
+
+	/**
+	 * creates a single user
+	 * @param string $user
+	 * @param string $password
+	 * @throws Exception
+	 */
+	private function createUser($user, $password)
+	{
+		$user = trim($user);
+		$result = SetupHelper::createUser($this->ocPath, $user, $password);
+		if ($result["code"] != 0) {
+			throw new Exception("could not create user. " . $result["stdOut"] . " " . $result["stdErr"]);
+		}
+		array_push($this->createdUserNames, $user);
 	}
 
 	/**
@@ -93,12 +100,7 @@ trait BasicStructure
 	 */
 	public function aRegularGroupExists()
 	{
-		$group = $this->regularGroupName;
-		$result=SetupHelper::createGroup($this->ocPath, $group);
-		if ($result["code"] != 0) {
-			throw new Exception("could not create group. " . $result["stdOut"] . " " . $result["stdErr"]);
-		}
-		array_push($this->createdGroupNames, $group);
+		$this->createGroup($this->regularGroupName);
 	}
 
 	/**
@@ -107,15 +109,24 @@ trait BasicStructure
 	public function regularGroupsExist()
 	{
 		foreach ($this->regularGroupNames as $group) {
-			$group = trim($group);
-			$result=SetupHelper::createGroup($this->ocPath, $group);
-			if ($result["code"] != 0) {
-				throw new Exception("could not create group. " . $result["stdOut"] . " " . $result["stdErr"]);
-			}
-			array_push($this->createdGroupNames, $group);
+			$this->createGroup($group);
 		}
 	}
 
+	/**
+	 * creates a single group
+	 * @param string $group
+	 * @throws Exception
+	 */
+	private function createGroup($group)
+	{
+		$group = trim($group);
+		$result=SetupHelper::createGroup($this->ocPath, $group);
+		if ($result["code"] != 0) {
+			throw new Exception("could not create group. " . $result["stdOut"] . " " . $result["stdErr"]);
+		}
+		array_push($this->createdGroupNames, $group);
+	}
 	/**
 	 * @Given a regular user is in a regular group
 	 */

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -87,12 +87,25 @@ trait BasicStructure
 
 	/**
 	 * @Given these users exist:
-	 * expects a table of users with the heading "|username|password|"
+	 * expects a table of users with the heading "|username|password|displayname|email|"
+	 * displayname & email are optional
 	 */
 	public function theseUsersExist(TableNode $table)
 	{
 		foreach ($table as $row) {
-			$this->createUser($row['username'], $row['password']);
+			if (isset($row['displayname'])) {
+				$displayName = $row['displayname'];
+			} else {
+				$displayName = null;
+			}
+			if (isset($row['email'])) {
+				$email = $row['email'];
+			} else {
+				$email = null;
+			}
+			$this->createUser(
+				$row ['username'], $row ['password'], $displayName, $email
+			);
 		}
 	}
 	
@@ -100,16 +113,25 @@ trait BasicStructure
 	 * creates a single user
 	 * @param string $user
 	 * @param string $password
+	 * @param string $displayName
+	 * @param string $email
 	 * @throws Exception
 	 */
-	private function createUser($user, $password)
+	private function createUser($user, $password,
+		$displayName = null, $email = null)
 	{
 		$user = trim($user);
-		$result = SetupHelper::createUser($this->ocPath, $user, $password);
+		$result = SetupHelper::createUser(
+			$this->ocPath, $user, $password, $displayName, $email
+		);
 		if ($result["code"] != 0) {
 			throw new Exception("could not create user. " . $result["stdOut"] . " " . $result["stdErr"]);
 		}
-		$this->createdUsers[$user] = ["password" => $password];
+		$this->createdUsers [$user] = [ 
+				"password" => $password,
+				"displayname" => $displayName,
+				"email" => $email
+		];
 	}
 	/**
 	 * @Given these groups exist:


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
This makes it possible for UI tests to create a bunch of users and groups using a behat table in the feature

## Motivation and Context
a handy way to quickly create users and groups for the tests

## How Has This Been Tested?
- travis run all current UI tests
- new UI tests in the file firewall are using this functionality

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

