### PR TITLE
substitute inline codes in behat features of UI tests

### DIFF
--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -284,4 +284,14 @@ trait BasicStructure
 		//make sure the function always returns a string
 		return (string) $password;
 	}
+
+	/**
+	 * substitutes codes like %base_url% with the value
+	 * @param string $value
+	 * @return string
+	 */
+	public function substituteInLineCodes ($value) {
+		//the only code so far, maybe we will need more one day
+		return str_replace("%base_url%",  $this->getMinkParameter("base_url"), $value);
+	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
make it possible to have `%base_url%` mentioned in behat features and that will transform into the relating value in the tests

## Motivation and Context
While writing behat feature files it's sometimes handy to be able to mention some "variable" and not need to hardcode the value in the feature

## How Has This Been Tested?
run firewall tests using this function

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

