### PR TITLE
Dispatch event for accept/reject federated share

### DIFF
--- a/apps/files_sharing/lib/API/Remote.php
+++ b/apps/files_sharing/lib/API/Remote.php
@@ -26,6 +26,7 @@ namespace OCA\Files_Sharing\API;
 use OC\Files\Filesystem;
 use OCA\FederatedFileSharing\DiscoveryManager;
 use OCA\Files_Sharing\External\Manager;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Remote {
 
@@ -74,7 +75,18 @@ class Remote {
 			\OC_User::getUser()
 		);
 
+		$shareInfo = $externalManager->getShare($params['id']);
+
 		if ($externalManager->acceptShare((int) $params['id'])) {
+			$dispatcher = \OC::$server->getEventDispatcher();
+			$event = new GenericEvent(null,
+				['shareAcceptedFrom' => $shareInfo['owner'],
+					'sharedAcceptedBy' => $shareInfo['user'],
+					'sharedItem' => $shareInfo['name'],
+					'remoteUrl' => $shareInfo['remote']
+				]
+			);
+			$dispatcher->dispatch('remoteshare.accepted', $event);
 			return new \OC_OCS_Result();
 		}
 
@@ -105,7 +117,18 @@ class Remote {
 			\OC_User::getUser()
 		);
 
+		$shareInfo = $externalManager->getShare($params['id']);
+
 		if ($externalManager->declineShare((int) $params['id'])) {
+			$dispatcher = \OC::$server->getEventDispatcher();
+			$event = new GenericEvent(null,
+				['shareAcceptedFrom' => $shareInfo['owner'],
+					'sharedAcceptedBy' => $shareInfo['user'],
+					'sharedItem' => $shareInfo['name'],
+					'remoteUrl' => $shareInfo['remote']
+				]
+			);
+			$dispatcher->dispatch('remoteshare.declined', $event);
 			return new \OC_OCS_Result();
 		}
 


### PR DESCRIPTION
Dispatch events for accept/reject federated share.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Sending dispatch events so that logger can capture the logs for federated share accept/reject.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The generated event when captured will help users to know if federated share is accepted/rejected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Create folder and try to share the folder using federated share.
- [x] When the recipient accepts the share, event is generated.
- [x] When the recipient rejects the share, event is generated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

