### PR TITLE
Fix user_ldap login on master by using userSession to retrieve the user object

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -201,7 +201,7 @@ class LoginController extends Controller {
 			return new RedirectResponse($this->urlGenerator->linkToRoute('core.login.showLoginForm', $args));
 		}
 		/* @var $loginResult IUser */
-		$loginResult = $this->userManager->get($user);
+		$loginResult = $this->userSession->getUser();
 		// TODO: remove password checks from above and let the user session handle failures
 		// requires https://github.com/owncloud/core/pull/24616
 		$this->userSession->createSessionToken($this->request, $loginResult->getUID(), $user, $password);

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -200,17 +200,17 @@ class LoginController extends Controller {
 			$args = !is_null($user) ? ['user' => $originalUser] : [];
 			return new RedirectResponse($this->urlGenerator->linkToRoute('core.login.showLoginForm', $args));
 		}
-		/* @var $loginResult IUser */
-		$loginResult = $this->userSession->getUser();
+		/* @var $userObject IUser */
+		$userObject = $this->userSession->getUser();
 		// TODO: remove password checks from above and let the user session handle failures
 		// requires https://github.com/owncloud/core/pull/24616
-		$this->userSession->createSessionToken($this->request, $loginResult->getUID(), $user, $password);
+		$this->userSession->createSessionToken($this->request, $userObject->getUID(), $user, $password);
 
 		// User has successfully logged in, now remove the password reset link, when it is available
-		$this->config->deleteUserValue($loginResult->getUID(), 'owncloud', 'lostpassword');
+		$this->config->deleteUserValue($userObject->getUID(), 'owncloud', 'lostpassword');
 
-		if ($this->twoFactorManager->isTwoFactorAuthenticated($loginResult)) {
-			$this->twoFactorManager->prepareTwoFactorLogin($loginResult);
+		if ($this->twoFactorManager->isTwoFactorAuthenticated($userObject)) {
+			$this->twoFactorManager->prepareTwoFactorLogin($userObject);
 			if (!is_null($redirect_url)) {
 				return new RedirectResponse($this->urlGenerator->linkToRoute('core.TwoFactorChallenge.selectChallenge', [
 					'redirect_url' => $redirect_url

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -316,9 +316,8 @@ class LoginControllerTest extends TestCase {
 			->method('login')
 			->with($user, $password)
 			->will($this->returnValue(true));
-		$this->userManager->expects($this->once())
-			->method('get')
-			->with($user)
+		$this->userSession->expects($this->once())
+			->method('getUser')
 			->will($this->returnValue($user));
 		$this->userSession->expects($this->once())
 			->method('createSessionToken')
@@ -364,9 +363,8 @@ class LoginControllerTest extends TestCase {
 			->method('login')
 			->with('Jane', $password)
 			->will($this->returnValue(true));
-		$this->userManager->expects($this->once())
-			->method('get')
-			->with('Jane')
+		$this->userSession->expects($this->once())
+			->method('getUser')
 			->will($this->returnValue($user));
 		$this->userSession->expects($this->once())
 			->method('createSessionToken')
@@ -396,8 +394,8 @@ class LoginControllerTest extends TestCase {
 		$this->userSession->expects($this->once())
 			->method('login')
 			->will($this->returnValue(true));
-		$this->userManager->expects($this->once())
-			->method('get')
+		$this->userSession->expects($this->once())
+			->method('getUser')
 			->will($this->returnValue($user));
 		$this->userSession->expects($this->once())
 			->method('login')


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description

After having successfully validated the user credentials, the ``tryLogin`` function calls
```php
$loginResult = $this->userManager->get($user)
```
 to get hold of the user object. Here, ``$user`` is the login name provided by the user on login.

This causes a problem if the ``user_ldap`` app is used because the UID does not correspond to the login name given by the user in that case. Rather, the UID is the UUID of the LDAP entry (e.g. ``7c1247da-d30e-1036-8350-cd5127ce8b3b``). Consequently, ``userManager->get($user)`` does not find the user and returns ``null``, which causes an exception when ``$loginResult->getUID()`` is called in the next line.

This PR works around this problem by retrieving the user object via ``userSession->getUser`` instead. However, I don't know much about the ownCloud codebase, so please let me know if there is anything wrong with this approach :-)

## Related Issue
#28449

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It fixes user login when using the user_ldap app.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the login manually.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

