### PR TITLE
Parallel decrypt command

### DIFF
--- a/apps/encryption/lib/Crypto/DecryptAll.php
+++ b/apps/encryption/lib/Crypto/DecryptAll.php
@@ -96,7 +96,7 @@ class DecryptAll {
 					'Do you want to use the users login password to decrypt all files? (y/n) ',
 					false
 				);
-				$useLoginPassword = $this->questionHelper->ask($input, $output, $questionUseLoginPassword);
+				$useLoginPassword = false;//$this->questionHelper->ask($input, $output, $questionUseLoginPassword);
 				if ($useLoginPassword) {
 					$question = new Question('Please enter the user\'s login password: ');
 				} else if ($this->util->isRecoveryEnabledForUser($user) === false) {
@@ -114,10 +114,11 @@ class DecryptAll {
 
 			$question->setHidden(true);
 			$question->setHiddenFallback(false);
-			$password = $this->questionHelper->ask($input, $output, $question);
+		//	$password = $this->questionHelper->ask($input, $output, $question);
 		}
 
-		$privateKey = $this->getPrivateKey($user, $password);
+		$output->writeLn('Got recovery key: '.getenv('OC_RECOVERY'));
+		$privateKey = $this->getPrivateKey($user, getenv('OC_RECOVERY'));
 		if ($privateKey !== false) {
 			$this->updateSession($user, $privateKey);
 			return true;

--- a/core/Command/Encryption/ParallelDecryptAll.php
+++ b/core/Command/Encryption/ParallelDecryptAll.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @author Björn Schießle <bjoern@schiessle.org>
+ * @author davitol <dtoledo@solidgear.es>
+ * @author Joas Schilling <coding@schilljs.com>
+ * @author Sergio Bertolín <sbertolin@solidgear.es>
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Encryption;
+
+use OCP\App\IAppManager;
+use OCP\Encryption\IManager;
+use OCP\IConfig;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class ParallelDecryptAll extends Command {
+
+	/** @var IManager */
+	protected $encryptionManager;
+
+	/** @var  IAppManager */
+	protected $appManager;
+
+	/** @var IConfig */
+	protected $config;
+
+	/** @var  bool */
+	protected $wasSingleUserModeEnabled;
+
+	/** @var \OC\Encryption\DecryptAll */
+	protected $decryptAll;
+
+	/** @var  OutputInterface */
+	protected $output;
+
+	/** @var  InputInterface  */
+	protected $input;
+
+	/**
+	 * @param IManager $encryptionManager
+	 * @param IAppManager $appManager
+	 * @param IConfig $config
+	 * @param \OC\Encryption\DecryptAll $decryptAll
+	 */
+	public function __construct(
+		IManager $encryptionManager,
+		IAppManager $appManager,
+		IConfig $config,
+		\OC\Encryption\DecryptAll $decryptAll
+	) {
+		parent::__construct();
+		$this->appManager = $appManager;
+		$this->encryptionManager = $encryptionManager;
+		$this->config = $config;
+		$this->decryptAll = $decryptAll;
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this->setName('encryption:parallel-decrypt-all');
+		$this->setDescription('Decrypts all files for a user - can be used in parallel');
+		$this->addArgument(
+			'user',
+			InputArgument::REQUIRED,
+			'user for which you want to decrypt all files'
+		);
+	}
+
+	protected function checkSetup() {
+		$this->output->writeln('Enable single user, disable trashbin, disable encryption...');
+		$this->config->setSystemValue('singleuser', true);
+		$this->appManager->disableApp('files_trashbin');
+		$this->config->setAppValue('core', 'encryption_enabled', 'no');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$this->output = $output;
+		$this->input = $input;
+
+		$this->checkSetup();
+		$user = $input->getArgument('user');
+		$output->writeln("Decrypting $user...");
+
+		// Run the decryption
+		$result = $this->decryptAll->decryptAll($input, $output, $user);
+		if ($result === false) {
+			$output->writeln(' aborted.');
+		}
+
+	}
+}

--- a/core/Command/Encryption/ParallelDecryptAll.php
+++ b/core/Command/Encryption/ParallelDecryptAll.php
@@ -59,19 +59,19 @@ class ParallelDecryptAll extends Command {
 	 * @param IManager $encryptionManager
 	 * @param IAppManager $appManager
 	 * @param IConfig $config
-	 * @param \OC\Encryption\DecryptAll $decryptAll
+	 * @param \OC\Encryption\DecryptAll $parallelDecryptAll
 	 */
 	public function __construct(
 		IManager $encryptionManager,
 		IAppManager $appManager,
 		IConfig $config,
-		\OC\Encryption\DecryptAll $decryptAll
+		\OC\Encryption\ParallelDecryptAll $parallelDecryptAll
 	) {
 		parent::__construct();
 		$this->appManager = $appManager;
 		$this->encryptionManager = $encryptionManager;
 		$this->config = $config;
-		$this->decryptAll = $decryptAll;
+		$this->parallelDecryptAll = $parallelDecryptAll;
 	}
 
 	protected function configure() {
@@ -97,6 +97,8 @@ class ParallelDecryptAll extends Command {
 		$this->output = $output;
 		$this->input = $input;
 
+		$this->parallelDecryptAll->setInOut($input, $output);
+
 		$user = $input->getArgument('user');
 
 		$this->output->writeln('Preparing module for decryption...');
@@ -113,7 +115,7 @@ class ParallelDecryptAll extends Command {
 		$progress->setFormat(" %message% \n [%bar%]");
 		$this->parallelDecryptAll->decryptUsersFiles($user, $progress, 1);
 
-		return $this->parallelDecryptAll->checkForFailure();
+		return $this->parallelDecryptAll->checkForFailure($output);
 
 	}
 }

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -102,6 +102,12 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 		new \OC\Encryption\DecryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getUserManager(), new \OC\Files\View()),
 		new \Symfony\Component\Console\Helper\QuestionHelper())
 	);
+	$application->add(new OC\Core\Command\Encryption\ParallelDecryptAll(
+			\OC::$server->getEncryptionManager(),
+			\OC::$server->getAppManager(),
+			\OC::$server->getConfig(),
+			new \OC\Encryption\DecryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getUserManager(), new \OC\Files\View()))
+	);
 
 	$application->add(new OC\Core\Command\Log\Manage(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Log\OwnCloud(\OC::$server->getConfig()));

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -106,7 +106,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 			\OC::$server->getEncryptionManager(),
 			\OC::$server->getAppManager(),
 			\OC::$server->getConfig(),
-			new \OC\Encryption\DecryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getUserManager(), new \OC\Files\View()))
+			new \OC\Encryption\ParallelDecryptAll(\OC::$server->getEncryptionManager(), \OC::$server->getUserManager(), new \OC\Files\View()))
 	);
 
 	$application->add(new OC\Core\Command\Log\Manage(\OC::$server->getConfig()));

--- a/lib/private/Encryption/ParallelDecryptAll.php
+++ b/lib/private/Encryption/ParallelDecryptAll.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @author Tom Needham <tom@owncloud.com
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OC\Encryption;
+
+use Symfony\Component\Console\Helper\ProgressBar;
+
+class ParallelDecryptAll extends DecryptAll {
+
+	public function decryptUsersFiles($uid, ProgressBar $progress, $userCount) {
+		parent::decryptUsersFiles($uid, $progress, $userCount);
+	}
+
+	public function prepareEncryptionModules($user) {
+		return parent::prepareEncryptionModules($user);
+	}
+
+	public function checkForFailure() {
+		if (empty($this->failed)) {
+			$this->output->writeln('all files could be decrypted successfully!');
+			return 0;
+		} else {
+			$this->output->writeln('The following files failed to decrypt:');
+			foreach ($this->failed as $uid => $paths) {
+				$this->output->writeln('    ' . $uid);
+			}
+			$this->output->writeln('');
+			return 1;
+		}
+	}
+
+
+}

--- a/lib/private/Encryption/ParallelDecryptAll.php
+++ b/lib/private/Encryption/ParallelDecryptAll.php
@@ -23,8 +23,14 @@
 namespace OC\Encryption;
 
 use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class ParallelDecryptAll extends DecryptAll {
+
+	public function setInOut($in, $out) {
+		$this->input = $in;
+		$this->output = $out;
+	}
 
 	public function decryptUsersFiles($uid, ProgressBar $progress, $userCount) {
 		parent::decryptUsersFiles($uid, $progress, $userCount);
@@ -34,16 +40,16 @@ class ParallelDecryptAll extends DecryptAll {
 		return parent::prepareEncryptionModules($user);
 	}
 
-	public function checkForFailure() {
+	public function checkForFailure(OutputInterface $output) {
 		if (empty($this->failed)) {
-			$this->output->writeln('all files could be decrypted successfully!');
+			$output->writeln('all files could be decrypted successfully!');
 			return 0;
 		} else {
-			$this->output->writeln('The following files failed to decrypt:');
+			$output->writeln('The following files failed to decrypt:');
 			foreach ($this->failed as $uid => $paths) {
-				$this->output->writeln('    ' . $uid);
+				$output->writeln('    ' . $uid);
 			}
-			$this->output->writeln('');
+			$output->writeln('');
 			return 1;
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Allows parallel decryption of user data whilst the instance is in downtime.

Usage: 

`export OC_RECOVERY=recoverykey && ./occ encryption:parallel-decrypt-all $user`.
after all users are decrypted:
`./occ maintenance:singleuser --off`

## Motivation and Context
Utilise more CPU for large decryption cases

## How Has This Been Tested?
Multiple decryptions in parallel. It appears trashbin is deleted, but this is the case with normal decryption (?). Data is decrypted successfully, shares are preserved correctly. Versions are decrypted and still function correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
