### PR TITLE
Initialize lastCheck when creating session token

### DIFF
--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -85,6 +85,7 @@ class DefaultTokenProvider implements IProvider {
 		$dbToken->setToken($this->hashToken($token));
 		$dbToken->setType($type);
 		$dbToken->setLastActivity($this->time->getTime());
+		$dbToken->setLastCheck($this->time->getTime());
 
 		$this->mapper->insert($dbToken);
 

--- a/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/DefaultTokenProviderTest.php
@@ -77,6 +77,7 @@ class DefaultTokenProviderTest extends TestCase {
 		$toInsert->setToken(hash('sha512', $token . '1f4h9s'));
 		$toInsert->setType($type);
 		$toInsert->setLastActivity($this->time);
+		$toInsert->setLastCheck($this->time);
 
 		$this->config->expects($this->any())
 			->method('getSystemValue')


### PR DESCRIPTION
Hello there!

## Description
With this change applied, ``DefaultTokenProvider`` initially sets the ``lastCheck`` timestamp to the current time when generating new tokens.

## Related Issue
#28467

## Motivation and Context
On ownCloud master, each user login via the ``user_ldap`` app sends two bind requests to the LDAP backend. This breaks 2FA (because one-time passwords are reused). See #28467 and #26065 for more details.

The second LDAP bind request is triggered by an initial user session validation right after a successful login. This checks the user password (i.e. sends a bind request). If we set ``lastCheck`` of new tokens to the current time, this initial check is skipped. As a result, a user login only sends one LDAP Bind Request, which (1) improves performance and (2) makes it possible to implement 2FA in the LDAP backend.

This change fixes #28467, but I don't know enough about the ownCloud internals to evaluate whether this change is sensible. Does setting the ``lastCheck`` time like this have any security implications?

## How Has This Been Tested?
Manually checked that a user login only sends one LDAP bind request.

Please note that in order to test this on the current master, #28450 needs to be applied first! Otherwise, login via ``user_ldap`` fails generally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Thanks!