### PR TITLE
Do not allow slash in filename when renaming

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -101,6 +101,8 @@
 				throw t('files', '"{name}" is an invalid file name.', {name: name});
 			} else if (trimmedName.length === 0) {
 				throw t('files', 'File name cannot be empty.');
+			} else if (trimmedName.indexOf("/") >= 0) {
+				throw t('files', 'File name cannot contain "/".');
 			} else if (OC.fileIsBlacklisted(trimmedName)) {
 				throw t('files', '"{name}" has a forbidden file type/extension.', {name: name});
 			}

--- a/apps/files/tests/js/filesSpec.js
+++ b/apps/files/tests/js/filesSpec.js
@@ -59,6 +59,10 @@ describe('OCA.Files.Files tests', function() {
 				'.. ',
 				'. ',
 				' .',
+				'/',
+				'folder/',
+				'/file',
+				'folder/file',
 				'foo.part',
 				'bar.filepart'
 			];

--- a/tests/ui/features/renameFiles.feature
+++ b/tests/ui/features/renameFiles.feature
@@ -36,11 +36,9 @@ Feature: renameFiles
 
 	Scenario: Rename a file using forbidden characters
 		When I rename the file "data.zip" to one of these names
-		|lorem/txt  |
 		|lorem\txt  |
 		|\\.txt     |
 		Then notifications should be displayed with the text
-		|Could not rename "data.zip"|
 		|Could not rename "data.zip"|
 		|Could not rename "data.zip"|
 		And the file "data.zip" should be listed
@@ -56,3 +54,20 @@ Feature: renameFiles
 	Scenario: Rename a file putting a name of a file which already exists
 		When I rename the file "data.zip" to "lorem.txt"
 		Then near the file "data.zip" a tooltip with the text 'lorem.txt already exists' should be displayed
+
+	Scenario: Rename a file using forward slash
+		When I rename the file "data.zip" to "lorem/txt"
+		Then near the file "data.zip" a tooltip with the text 'File name cannot contain "/".' should be displayed
+
+	Scenario: Rename a file to ..
+		When I rename the file "data.zip" to ".."
+		Then near the file "data.zip" a tooltip with the text '".." is an invalid file name.' should be displayed
+
+	Scenario: Rename a file to .
+		When I rename the file "data.zip" to "."
+		Then near the file "data.zip" a tooltip with the text '"." is an invalid file name.' should be displayed
+
+	Scenario: Rename a file to .part
+		When I rename the file "data.zip" to "data.part"
+		Then near the file "data.zip" a tooltip with the text '"data.part" has a forbidden file type/extension.' should be displayed
+

--- a/tests/ui/features/renameFolders.feature
+++ b/tests/ui/features/renameFolders.feature
@@ -35,13 +35,9 @@ Feature: renameFolders
 
 	Scenario: Rename a folder using forbidden characters
 		When I rename the folder "simple-folder" to one of these names
-		|simple/folder   |
 		|simple\folder   |
-		|\\simple/folder |
-		|../simple-folder|
+		|\\simple-folder |
 		Then notifications should be displayed with the text
-		|Could not rename "simple-folder"|
-		|Could not rename "simple-folder"|
 		|Could not rename "simple-folder"|
 		|Could not rename "simple-folder"|
 		And the folder "simple-folder" should be listed
@@ -57,3 +53,20 @@ Feature: renameFolders
 	Scenario: Rename a folder putting a name of a file which already exists
 		When I rename the folder "simple-folder" to "lorem.txt"
 		Then near the folder "simple-folder" a tooltip with the text 'lorem.txt already exists' should be displayed
+
+	Scenario: Rename a folder using forward slash
+		When I rename the folder "simple-folder" to "simple/folder"
+		Then near the folder "simple-folder" a tooltip with the text 'File name cannot contain "/".' should be displayed
+
+	Scenario: Rename a folder to ..
+		When I rename the folder "simple-folder" to ".."
+		Then near the folder "simple-folder" a tooltip with the text '".." is an invalid file name.' should be displayed
+
+	Scenario: Rename a folder to .
+		When I rename the folder "simple-folder" to "."
+		Then near the folder "simple-folder" a tooltip with the text '"." is an invalid file name.' should be displayed
+
+	Scenario: Rename a folder to .part
+		When I rename the folder "simple-folder" to "simple.part"
+		Then near the folder "simple-folder" a tooltip with the text '"simple.part" has a forbidden file type/extension.' should be displayed
+


### PR DESCRIPTION
## Description
In the JS for the UI, do not allow the forward slash when renaming or creating a new file.

## Related Issue
#28475 

## Motivation and Context
Trying to use relative paths like "foldera/x.txt" when renaming a file, or creating a new text file with the UI is not supposed to be a "feature" and causes various issues in the UI after such a file action.

## How Has This Been Tested?
JS tests verify that "/" is disallowed by isFileNameValid.
Tried renaming and create text file in the UI to verify it really is banned now.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

