### PR TITLE
UploadHelper for UI/Integration tests

### DIFF
--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann
+ * @copyright 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace TestHelpers;
+
+use GuzzleHttp\Stream\Stream;
+
+class UploadHelper
+{
+	/**
+	 * 
+	 * @param string $baseUrl
+	 * URL of owncloud e.g. http://localhost:8080
+	 * should include the subfolder if owncloud runs in a subfolder e.g. http://localhost:8080/owncloud-core
+	 * @param string $user
+	 * @param string $password
+	 * @param string $source
+	 * @param string $destination
+	 * @param array $headers
+	 * @param int $davPathVersionToUse (1|2)
+	 * @param int $chunkingVersion (1|2|null) if set to null chunking will not be used
+	 * @param int $noOfChunks how many chunks do we want to upload
+	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 */
+	static function upload(
+		$baseUrl,
+		$user,
+		$password,
+		$source,
+		$destination,
+		$headers = array(),
+		$davPathVersionToUse = 1,
+		$chunkingVersion = null,
+		$noOfChunks = 1)
+	{
+		//simple upload with no chunking
+		if ($chunkingVersion === null) {
+			$data = Stream::factory(fopen($source, 'r'));
+			return WebDavHelper::makeDavRequest(
+				$baseUrl,
+				$user,
+				$password,
+				"PUT",
+				$destination,
+				$headers,
+				$data,
+				null,
+				$davPathVersionToUse
+			);
+		} else {
+			//prepare chunking
+			$chunks = self::chunkFile($source, $noOfChunks);
+			$chunkingId = 'chunking-' . (string)rand(1000,9999);
+			$v2ChunksDestination = '/uploads/'.$user.'/'. $chunkingId;
+		}
+		
+		//prepare chunking version specific stuff
+		if ($chunkingVersion === 1) {
+			$headers['OC-Chunked'] = '1';
+		} elseif ($chunkingVersion === 2) {
+			WebDavHelper::makeDavRequest(
+				$baseUrl,
+				$user,
+				$password,
+				'MKCOL',
+				$v2ChunksDestination,
+				[], null, null,
+				$davPathVersionToUse,
+				"uploads"
+			);
+		}
+		
+		//upload chunks
+		foreach ($chunks as $index => $chunk) {
+			$data = Stream::factory($chunk);
+			if ($chunkingVersion === 1) {
+				$filename = $destination . "-" . $chunkingId . "-" .
+							count($chunks) . '-' . ( string ) $index;
+				$davRequestType = "files";
+			} elseif ($chunkingVersion === 2) {
+				$filename = $v2ChunksDestination .'/' . (string)($index);
+				$davRequestType = "uploads";
+			}
+			$result = WebDavHelper::makeDavRequest(
+				$baseUrl,
+				$user,
+				$password,
+				"PUT",
+				$filename,
+				$headers,
+				$data,
+				null,
+				$davPathVersionToUse,
+				$davRequestType
+			);
+		}
+		//finish upload for new chunking
+		if ($chunkingVersion === 2) {
+			$source = $v2ChunksDestination . '/.file';
+			$finalDestination = $baseUrl . "/" . 
+						WebDavHelper::getDavPath($user, $davPathVersionToUse) .
+						$destination;
+			$result = WebDavHelper::makeDavRequest(
+				$baseUrl,
+				$user,
+				$password,
+				'MOVE',
+				$source,
+				['Destination' => $finalDestination ],
+				null, null,
+				$davPathVersionToUse,
+				"uploads"
+			);
+		}
+		return $result;
+	}
+
+	/**
+	 * cut the file in multiple chunks
+	 * returns an array of chunks with the content of the file
+	 * @param string $file
+	 * @param number $noOfChunks
+	 * @return string[]
+	 */
+	static function chunkFile ($file, $noOfChunks = 1) {
+		$size = filesize($file);
+		$chunkSize = ceil($size / $noOfChunks);
+		$chunks = [];
+		$fp = fopen($file, 'r');
+		while (!feof($fp) && ftell($fp) < $size) {
+			$chunks[] = fread($fp, $chunkSize);
+		}
+		fclose($fp);
+		return $chunks;
+	}
+}

--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -2,7 +2,7 @@
 /**
  * ownCloud
  *
- * @author Artur Neumann
+ * @author Artur Neumann <artur@jankaritech.com>
  * @copyright 2017 Artur Neumann artur@jankaritech.com
  *
  * This library is free software; you can redistribute it and/or
@@ -23,21 +23,29 @@ namespace TestHelpers;
 
 use GuzzleHttp\Stream\Stream;
 
+/**
+ * Helper for Uploads
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ *
+ */
 class UploadHelper
 {
 	/**
 	 * 
-	 * @param string $baseUrl
-	 * URL of owncloud e.g. http://localhost:8080
-	 * should include the subfolder if owncloud runs in a subfolder e.g. http://localhost:8080/owncloud-core
+	 * @param string $baseUrl             URL of owncloud
+	 * e.g. http://localhost:8080
+	 * should include the subfolder if owncloud runs in a subfolder
+	 * e.g. http://localhost:8080/owncloud-core
 	 * @param string $user
 	 * @param string $password
-	 * @param string $source
+	 * @param string $source 
 	 * @param string $destination
-	 * @param array $headers
-	 * @param int $davPathVersionToUse (1|2)
-	 * @param int $chunkingVersion (1|2|null) if set to null chunking will not be used
-	 * @param int $noOfChunks how many chunks do we want to upload
+	 * @param array  $headers
+	 * @param int    $davPathVersionToUse (1|2)
+	 * @param int    $chunkingVersion     (1|2|null)
+	 * if set to null chunking will not be used
+	 * @param int    $noOfChunks          how many chunks do we want to upload
 	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
 	 */
 	static function upload(
@@ -49,8 +57,9 @@ class UploadHelper
 		$headers = array(),
 		$davPathVersionToUse = 1,
 		$chunkingVersion = null,
-		$noOfChunks = 1)
-	{
+		$noOfChunks = 1
+	) {
+	
 		//simple upload with no chunking
 		if ($chunkingVersion === null) {
 			$data = Stream::factory(fopen($source, 'r'));
@@ -68,7 +77,7 @@ class UploadHelper
 		} else {
 			//prepare chunking
 			$chunks = self::chunkFile($source, $noOfChunks);
-			$chunkingId = 'chunking-' . (string)rand(1000,9999);
+			$chunkingId = 'chunking-' . (string)rand(1000, 9999);
 			$v2ChunksDestination = '/uploads/'.$user.'/'. $chunkingId;
 		}
 		
@@ -136,11 +145,13 @@ class UploadHelper
 	/**
 	 * cut the file in multiple chunks
 	 * returns an array of chunks with the content of the file
+	 *
 	 * @param string $file
 	 * @param number $noOfChunks
-	 * @return string[]
+	 * @return array $string
 	 */
-	static function chunkFile ($file, $noOfChunks = 1) {
+	static function chunkFile($file, $noOfChunks = 1) 
+	{
 		$size = filesize($file);
 		$chunkSize = ceil($size / $noOfChunks);
 		$chunks = [];

--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -78,7 +78,7 @@ class UploadHelper
 			//prepare chunking
 			$chunks = self::chunkFile($source, $noOfChunks);
 			$chunkingId = 'chunking-' . (string)rand(1000, 9999);
-			$v2ChunksDestination = '/uploads/'.$user.'/'. $chunkingId;
+			$v2ChunksDestination = '/uploads/' . $user . '/' . $chunkingId;
 		}
 		
 		//prepare chunking version specific stuff
@@ -105,7 +105,7 @@ class UploadHelper
 							count($chunks) . '-' . ( string ) $index;
 				$davRequestType = "files";
 			} elseif ($chunkingVersion === 2) {
-				$filename = $v2ChunksDestination .'/' . (string)($index);
+				$filename = $v2ChunksDestination . '/' . (string)($index);
 				$davRequestType = "uploads";
 			}
 			$result = WebDavHelper::makeDavRequest(


### PR DESCRIPTION
## Description
This is a TeseHelper that can be used in UI/Integration tests to upload files through both DAV path and it supports chunking

## Motivation and Context
The test Helpers didn't support chunking upload so far

## How Has This Been Tested?
created firewall tests that are using the new Helper

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

