### PR TITLE
Do not call the callback if the selected auth method can't be retreived

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -692,7 +692,11 @@ MountConfigListView.prototype = _.extend({
 		var self = this;
 		this.$el.find('tbody tr:not(#addMountPoint)').each(function(i, tr) {
 			var authMechanism = $(tr).find('.selectAuthMechanism').val();
-			callback($(tr), authMechanism, self._allAuthMechanisms[authMechanism]['scheme']);
+			if (authMechanism !== undefined) {
+				var onCompletion = jQuery.Deferred();
+				callback($(tr), authMechanism, self._allAuthMechanisms[authMechanism]['scheme'], onCompletion);
+				onCompletion.resolve();
+			}
 		});
 		this.on('selectAuthMechanism', callback);
 	},
@@ -1404,7 +1408,7 @@ OCA.External.Settings.UserStorageConfig = UserStorageConfig;
 OCA.External.Settings.MountConfigListView = MountConfigListView;
 
 /**
- * @namespace OAuth2 namespace which is used to verify a storage adapter 
+ * @namespace OAuth2 namespace which is used to verify a storage adapter
  *            using AuthMechanism as oauth2::oauth2
  */
 OCA.External.Settings.OAuth2 = OCA.External.Settings.OAuth2 || {};
@@ -1413,7 +1417,7 @@ OCA.External.Settings.OAuth2 = OCA.External.Settings.OAuth2 || {};
  * This function sends a request to the given backendUrl and gets the OAuth2 URL
  * for any given backend storage, executes the callback if any, set the data-* parameters
  * of the storage and REDIRECTS the client to Authentication page
- * 
+ *
  * @param  {String}   backendUrl The backend URL to which request will be sent
  * @param  {Object}   data       Keys -> (backend_id, client_id, client_secret, redirect, tr)
  */
@@ -1454,7 +1458,7 @@ OCA.External.Settings.OAuth2.getAuthUrl = function (backendUrl, data) {
  * This function verifies the OAuth2 code returned to the client after verification
  * by sending request to the backend with the given CODE and if the code is verified
  * it sets the data-* params to configured and disables the authorize buttons
- * 
+ *
  * @param  {String}   backendUrl The backend URL to which request will be sent
  * @param  {Object}   data       Keys -> (backend_id, client_id, client_secret, redirect, tr, code)
  * @return {Promise} jQuery Deferred Promise object
@@ -1487,7 +1491,7 @@ OCA.External.Settings.OAuth2.verifyCode = function (backendUrl, data) {
 					deferredObject.resolve(status);
 				});
 			} else {
-				deferredObject.reject(result.data.message); 
+				deferredObject.reject(result.data.message);
 			}
 		}
 	);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/owncloud/files_onedrive/issues/25

## Motivation and Context
javscript code crashed and prevented oauth2 storages to be granted access as the button was missing

## How Has This Been Tested?
Manually with google drive in master, adding an artificial delay to force the issue happen consistenly

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Backport to stable10 will be needed.