### PR TITLE
[stable9] Catch lock file if exception occurs during cron execution

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -184,5 +184,12 @@ try {
 	exit();
 
 } catch (Exception $ex) {
+	// Unlock cron if it was locked
+	if(isset($fp) && is_resource($fp)) {
+		// unlock the file
+		flock($fp, LOCK_UN);
+		fclose($fp);
+	}
+	// Log the cron exception
 	\OCP\Util::writeLog('cron', $ex->getMessage(), \OCP\Util::FATAL);
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
If a cron job causes an uncaught exception, the lock file can remain and block further usage of the cron. This patch catches the lock file in the catch block and cleans it up.

No forward port needed as jobs lock individually from 9.1 onwards.

## How Has This Been Tested?
Locally running cron and triggering an exception in the code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

