### PR TITLE
Never show the servername in status.php

### DIFF
--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -711,7 +711,7 @@ class Util {
 	 * @return array
 	 * @since 10.0
 	 */
-	public static function getStatusInfo($includeVersion = false) {
+	public static function getStatusInfo($includeVersion = false, $serverHide = false) {
 		$systemConfig = \OC::$server->getSystemConfig();
 
 		$installed = (bool) $systemConfig->getValue('installed', false);
@@ -726,16 +726,20 @@ class Util {
 			'version' => '',
 			'versionstring' => '',
 			'edition' => '',
-			'productname' => '',
-			'hostname' => ''];
+			'productname' => ''];
 
+		# expose version and servername details 
 		if ($includeVersion || (bool) $systemConfig->getValue('version.hide', false) === false) {
 			$values['version'] = implode('.', self::getVersion());
 			$values['versionstring'] = \OC_Util::getVersionString();
 			$values['edition'] = \OC_Util::getEditionString();
 			$values['productname'] = $defaults->getName();
-			$values['hostname'] = gethostname();
+			# expose the servername only if allowed via version, but never when called via status.php
+			if ($serverHide === false) {
+				$values['hostname'] = gethostname();
+			}
 		}
+
 
 		return $values;
 	}

--- a/status.php
+++ b/status.php
@@ -34,7 +34,9 @@ try {
 
 	require_once __DIR__ . '/lib/base.php';
 
-	$values = \OCP\Util::getStatusInfo();
+	# show the version details based on config.php parameter, 
+	# but do not expose the servername in the public via url
+	$values = \OCP\Util::getStatusInfo(null,true);
 
 	if (OC::$CLI) {
 		print_r($values);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
This is an update to https://github.com/owncloud/core/pull/28472
and adds the coding that a servername will never be shown via status.php
The servername will only be shown in the browser via settings/general and only if the version.hide config.php parameter is set to false or is missing. 
@PVince81 , @DeepDiver1975 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

