### PR TITLE
php checkstyle config file to check code style

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<ruleset name="ownCloud Standard">
+	<description>ownCloud coding standard</description>
+	<arg name="colors" />
+	<arg value="sp" />
+
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/3rdparty/*</exclude-pattern>
+
+	<!-- make sure we use tabs for indent and not spaces -->
+	<arg name="tab-width" value="4" />
+	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent" />
+	<rule ref="Generic.WhiteSpace.ScopeIndent">
+		<properties>
+			<property name="indent" value="4" />
+			<property name="tabIndent" value="true" />
+		</properties>
+		<exclude name="Generic.WhiteSpace.DisallowTabIndent.TabsUsed" />
+		<exclude name="Generic.WhiteSpace.DisallowTabIndent.NonIndentTabsUsed" />
+	</rule>
+
+	<rule ref="PEAR">
+		<exclude name="Generic.Commenting.DocComment.ShortNotCapital" />
+		<exclude name="Generic.Commenting.DocComment.SpacingAfter" />
+		<exclude name="Generic.Commenting.DocComment.MissingShort" />
+		<exclude name="Generic.Commenting.DocComment.TagValueIndent" />
+		<exclude name="Generic.Commenting.DocComment.NonParamGroup" />
+		<exclude name="PEAR.Commenting.FileComment.MissingVersion" />
+		<exclude name="PEAR.Commenting.FileComment.MissingCategoryTag" />
+		<exclude name="PEAR.Commenting.FileComment.MissingPackageTag" />
+		<exclude name="PEAR.Commenting.FileComment.MissingLicenseTag" />
+		<exclude name="PEAR.Commenting.FileComment.MissingLinkTag" />
+		<exclude name="PEAR.Commenting.ClassComment.MissingCategoryTag" />
+		<exclude name="PEAR.Commenting.ClassComment.MissingPackageTag" />
+		<exclude name="PEAR.Commenting.ClassComment.MissingAuthorTag" />
+		<exclude name="PEAR.Commenting.ClassComment.MissingLicenseTag" />
+		<exclude name="PEAR.Commenting.ClassComment.MissingLinkTag" />
+		<exclude name="PEAR.Commenting.FunctionComment.MissingParamComment" />
+		<exclude name="PEAR.Commenting.FunctionComment.SpacingAfterParamType" />
+		<exclude name="PEAR.Commenting.FunctionComment.SpacingAfterParamName" />
+		<exclude
+			name="PEAR.NamingConventions.ValidVariableName.PrivateNoUnderscore" />
+		<exclude
+			name="PEAR.NamingConventions.ValidFunctionName.PrivateNoUnderscore" />
+		<exclude name="PEAR.WhiteSpace.ScopeIndent.IncorrectExact" />
+		<exclude name="PEAR.Functions.FunctionDeclaration.BraceOnSameLine" />
+		<exclude name="PEAR.Classes.ClassDeclaration.OpenBraceNewLine" />
+	</rule>
+
+	<rule ref="Squiz.WhiteSpace.OperatorSpacing.NoSpaceBefore" />
+	<rule ref="Squiz.WhiteSpace.OperatorSpacing.NoSpaceAfter" />
+	<rule ref="Squiz.Commenting.DocCommentAlignment" />
+	<rule ref="Generic.WhiteSpace.ScopeIndent" />
+	<rule ref="Squiz.Strings.ConcatenationSpacing">
+		<properties>
+			<property name="spacing" value="1" />
+			<property name="ignoreNewlines" value="true" />
+		</properties>
+	</rule>
+	<rule ref="PSR2.ControlStructures.SwitchDeclaration.BreakIndent">
+		<exclude
+			name="PSR2.ControlStructures.SwitchDeclaration.SpaceBeforeColonDEFAULT" />
+		<exclude
+			name="PSR2.ControlStructures.SwitchDeclaration.SpaceBeforeColonCASE" />
+	</rule>
+	<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
+	<rule ref="Generic.Classes.OpeningBraceSameLine" />
+
+	<!-- storage wrapper uses php function names to wrap them -->
+	<rule ref="PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps">
+		<exclude-pattern>*/lib/storagewrapper.php</exclude-pattern>
+	</rule>
+
+</ruleset>


### PR DESCRIPTION
## Description
this is a configuration file for [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer) to check if code is written according to [ownCloud code style guidlines](https://doc.owncloud.org/server/10.0/developer_manual/general/codingguidelines.html)

Documentation change PR https://github.com/owncloud/documentation/pull/3247
## Related Issue
https://github.com/owncloud/core/issues/28518

## Motivation and Context
Currently there is no way to check the code style automatically. This should help developers to stick to the code style rules.

## How Has This Been Tested?
Fixed formatting in UI test code in core https://github.com/owncloud/core/pull/28497
Fixed formatting in UI tests code in firewall https://github.com/owncloud/firewall/pull/360

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.