### PR TITLE
[WIP] Add IpHelper and support sourceIpAddress on API operations

### DIFF
--- a/tests/TestHelpers/IpHelper.php
+++ b/tests/TestHelpers/IpHelper.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Phillip Davis
+ * @copyright 2017 Phillip Davis phil@jankaritech.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace TestHelpers;
+
+use Exception;
+use InvalidArgumentException;
+
+class IpHelper
+{
+	const IPV6_LOOPBACK_ADDRESS = '::1';
+	const IPV6_LOOPBACK_ADDRESS_SUBNET = '::0';
+	const IPV4_LOOPBACK_ADDRESS_TOP = '127.';
+	const IPV6_LINK_LOCAL_ADDRESS_TOP = 'fe80';
+	
+	/**
+	 * parse the output of ifconfig to find matching items such as IP addresses
+	 * @param string $regex that will match the desired text in the ifconfig output
+	 * @throws Exception
+	 * @return array of elements that match the inner part of the regex
+	 */
+	private static function parseIfconfigOutput($regex)
+	{
+		$output = [];
+		$return_var = null;
+		exec('ifconfig', $output, $return_var);
+		if ($return_var) {
+			throw new \Exception("parseIfconfigOutput: Error $return_var calling exec ifconfig");
+		}
+		preg_match_all($regex, implode($output, ' '), $matches);
+		return $matches[1];
+	}
+
+	/**
+	 * @return array of IPv4 addresses found on the local system
+	 */
+	private static function systemIpv4Addresses()
+	{
+		// IPv4 addresses are like 192.168.12.34
+		return self::parseIfconfigOutput('/inet addr:([\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3})/');
+	}
+
+	/**
+	 * @return array of IPv6 addresses found on the local system
+	 */
+	private static function systemIpv6Addresses()
+	{
+		// IPv6 addresses are like fe80::6e26:388d:7bf:15d1
+		return self::parseIfconfigOutput('/inet6 addr: ([0123456789abcdef:]+)/');
+	}
+
+	/**
+	 * calculate the base address of the subnet with the given CIDR that contains the given IPv4 address
+	 * @param string $ipv4Address with format like "192.168.1.1"
+	 * @param int $cidr the CIDR "mask" size for the subnet (0 to 32)
+	 * @throws InvalidArgumentException
+	 * @return string IPv4 subnet base address
+	 */
+	private static function ipv4AddressSubnet($ipv4Address, $cidr)
+	{
+		$cidr = (int) $cidr;
+		if (($cidr < 0) || ($cidr > 32)) {
+			throw new \InvalidArgumentException("ipv4AddressSubnet: CIDR $cidr is invalid. CIDR must be from 0 to 32.");
+		}
+
+		$addressMask = ip2long($ipv4Address);
+		if ($addressMask === false) {
+			throw new \InvalidArgumentException("ipv4AddressSubnet: IPv4 address $ipv4Address is invalid.");
+		}
+
+		$cidrMask = -1 << (32 - $cidr);
+		$netMask = $addressMask & $cidrMask;
+		return long2ip($netMask);
+	}
+
+	/**
+	 * calculate the base address of the subnet with the given CIDR that contains the given IPv6 address
+	 * @param string $ipv6Address with format like "a:b:c::1"
+	 * @param int $cidr the CIDR "mask" size for the subnet (0 to 128)
+	 * @throws InvalidArgumentException
+	 * @return string IPv6 subnet base address
+	 */
+	private static function ipv6AddressSubnet($ipv6Address, $cidr)
+	{
+		$cidr = (int) $cidr;
+		if (($cidr < 0) || ($cidr > 128)) {
+			throw new \InvalidArgumentException("ipv6AddressSubnet: CIDR $cidr is invalid. CIDR must be from 0 to 128.");
+		}
+
+		$ipBin = inet_pton($ipv6Address);
+		if ($ipBin === false) {
+			throw new \InvalidArgumentException("ipv6AddressSubnet: IPv6 address $ipv6Address is invalid.");
+		}
+
+		$hexString = bin2hex($ipBin);
+
+		// Turn the hex string into a string of 128 "binary" characters "0" and "1"
+		$binNumber = '';
+		for ($i = 0; $length = strlen($hexString), $i < $length; $i++) {
+			$binNumber .= sprintf('%04d', decbin(hexdec($hexString[$i])));
+		}
+		
+		// Set all the values past the end of the CIDR to "0" ("masking" the binary string value)
+		$binNumber = substr($binNumber, 0, $cidr) . str_repeat("0", 128 - $cidr);
+		
+		// Convert it back to a hex string
+		$hexSubnetBase = "";
+		foreach (str_split($binNumber, 4) as $binString) {
+		  $hexSubnetBase .= base_convert( $binString, 2, 16);
+		}
+
+		// Put the hex into the hex2bin() internal format,
+		// use inet_ntop to make a human-readable IPv6 address string
+		// and return the answer.
+		return inet_ntop(hex2bin($hexSubnetBase));
+	}
+
+	/**
+	 * find the first IPv4 address on the local system that is a loopback address
+	 * @throws Exception
+	 * @return string IPv4 loopback address
+	 */
+	private static function loopbackIpv4Address()
+	{
+		foreach (self::systemIpv4Addresses() as $ipv4Address) {
+			if (strpos($ipv4Address, self::IPV4_LOOPBACK_ADDRESS_TOP) === 0) {
+				return $ipv4Address;
+			}
+		}
+
+		throw new \Exception("loopbackIpv4Address: No IP address found");
+	}
+
+	/**
+	 * get the IPv6 loopback address
+	 * Note: for IPv6 the loopback address is a well-defined constant value
+	 * @return string IPv6 loopback address
+	 */
+	private static function loopbackIpv6Address()
+	{
+		return self::IPV6_LOOPBACK_ADDRESS;
+	}
+
+	/**
+	 * get a loopback address for the given IP address family
+	 * @param string IP address family IPv4 or IPv6 (not case sensitive)
+	 * @throws InvalidArgumentException
+	 * @return string IP loopback address
+	 */
+	private static function loopbackIpAddress($ipAddressFamily)
+	{
+		switch (strtolower($ipAddressFamily)) {
+			case 'ipv4':
+				return self::loopbackIpv4Address();
+			case 'ipv6':
+				return self::loopbackIpv6Address();
+		}
+		
+		throw new \InvalidArgumentException("loopbackIpAddress: Invalid IP address family");
+	}
+
+	/**
+	 * calculate the base address of the subnet with the given CIDR that contains the loopback IPv4 address
+	 * @param int $cidr the CIDR "mask" size for the subnet
+	 * @return string IPv4 loopback subnet base address
+	 */
+	private static function loopbackIpv4AddressSubnet($cidr)
+	{
+		return self::ipv4AddressSubnet(self::loopbackIpv4Address(), $cidr);
+	}
+
+	/**
+	 * calculate the base address of the subnet with the given CIDR that contains the loopback IPv6 address
+	 * @param int $cidr the CIDR "mask" size for the subnet
+	 * @return string IPv6 loopback subnet base address
+	 */
+	private static function loopbackIpv6AddressSubnet($cidr)
+	{
+		return self::IPV6_LOOPBACK_ADDRESS_SUBNET;
+	}
+
+	/**
+	 * calculate the base address of the subnet with the given CIDR
+	 * that contains the loopback address of the given IP address family
+	 * @param string IP address family IPv4 or IPv6 (not case sensitive)
+	 * @param int $cidr the CIDR "mask" size for the subnet
+	 * @throws InvalidArgumentException
+	 * @return string IP of loopback subnet base address
+	 */
+	private static function loopbackIpAddressSubnet($ipAddressFamily, $cidr)
+	{
+		switch (strtolower($ipAddressFamily)) {
+			case 'ipv4':
+				return self::loopbackIpv4Address($cidr);
+			case 'ipv6':
+				return self::loopbackIpv6Address($cidr);
+		}
+		
+		throw new \InvalidArgumentException("loopbackIpAddressSubnet: Invalid IP address family");
+	}
+
+	/**
+	 * find the first IPv4 address on the local system that is not a loopback address
+	 * i.e. a "real" routable IPv4 address on some network interface
+	 * @throws InvalidArgumentException
+	 * @return string IPv4 address
+	 */
+	private static function routableIpv4Address()
+	{
+		foreach (self::systemIpv4Addresses() as $ipv4Address) {
+			if (strpos($ipv4Address, self::IPV4_LOOPBACK_ADDRESS_TOP) !== 0) {
+				return $ipv4Address;
+			}
+		}
+
+		throw new \InvalidArgumentException("routableIpv4Address: No IP address found");
+	}
+
+	/**
+	 * find the first IPv6 address on the local system that is not a loopback or link-local address
+	 * i.e. a "real" routable IPv6 address on some network interface
+	 * @throws InvalidArgumentException
+	 * @return string IPv6 address
+	 */
+	private static function routeableIpv6Address()
+	{
+		foreach (self::systemIpv6Addresses() as $ipv6Address) {
+			if (($ipv6Address !== self::IPV6_LOOPBACK_ADDRESS)
+				&& (strpos($ipv6Address, self::IPV6_LINK_LOCAL_ADDRESS_TOP) !== 0)) {
+				return $ipv6Address;
+			}
+		}
+
+		throw new \InvalidArgumentException("routeableIpv6Address: No IP address found");
+	}
+
+	/**
+	 * get a non-loopback address on the local system for the given IP address family
+	 * i.e. a "real" routable IP address on some network interface
+	 * @param string IP address family IPv4 or IPv6 (not case sensitive)
+	 * @throws InvalidArgumentException
+	 * @return string IP address
+	 */
+	private static function routableIpAddress($ipAddressFamily)
+	{
+		switch (strtolower($ipAddressFamily)) {
+			case 'ipv4':
+				return self::routableIpv4Address();
+			case 'ipv6':
+				return self::routeableIpv6Address();
+		}
+		
+		throw new \InvalidArgumentException("routableIpAddress: Invalid IP address family");
+	}
+
+	/**
+	 * calculate the base address of the subnet with the given CIDR
+	 * that contains the IPv4 address of the first routable IPv4 subnet
+	 * @param int $cidr the CIDR "mask" size for the subnet
+	 * @return string IPv4 local subnet base address
+	 */
+	private static function routableIpv4AddressSubnet($cidr)
+	{
+		return self::ipv4AddressSubnet(self::routableIpv4Address(), $cidr);
+	}
+
+	/**
+	 * calculate the base address of the subnet with the given CIDR
+	 * that contains the IPv6 address of the first routable IPv6 subnet
+	 * @param int $cidr the CIDR "mask" size for the subnet
+	 * @return string IPv6 local subnet base address
+	 */
+	private static function routeableIpv6AddressSubnet($cidr)
+	{
+		return self::ipv6AddressSubnet(self::routeableIpv6Address(), $cidr);
+	}
+
+	/**
+	 * calculate the base address of the subnet with the given CIDR
+	 * that contains the first routable IP address of the given IP address family
+	 * @param string IP address family IPv4 or IPv6 (not case sensitive)
+	 * @param int $cidr the CIDR "mask" size for the subnet
+	 * @throws InvalidArgumentException
+	 * @return string IP of local subnet base address
+	 */
+	private static function routableIpAddressSubnet($ipAddressFamily, $cidr)
+	{
+		switch (strtolower($ipAddressFamily)) {
+			case 'ipv4':
+				return self::routableIpv4AddressSubnet($cidr);
+			case 'ipv6':
+				return self::routeableIpv6AddressSubnet($cidr);
+		}
+		
+		throw new \InvalidArgumentException("routableIpAddressSubnet: Invalid IP address family");
+	}
+
+	/**
+	 * find an IP address on the local system that is either a loopback address
+	 * or a routable IP address of the given IP address family.
+	 * @param $networkScope which type of address to return - "routable" or "loopback"
+	 * @param string IP address family IPv4 or IPv6 (not case sensitive)
+	 * @throws InvalidArgumentException
+	 * @return string IP address
+	 */
+	public static function ipAddress($networkScope, $ipAddressFamily)
+	{
+		switch (strtolower($networkScope)) {
+			case 'routable':
+				return self::routableIpAddress($ipAddressFamily);
+				break;
+			case 'loopback':
+				return self::loopbackIpAddress($ipAddressFamily);
+				break;
+			default:
+				throw new \InvalidArgumentException("ipAddress: Invalid networkScope passed. (Must be routable or loopback)");
+				break;
+		}
+	}
+
+	/**
+	 * calculate the base address of the subnet with the given CIDR
+	 * that contains a routable or loopback IP address of the given IP address family
+	 * @param $networkScope which type of address to return - "routable" or "loopback"
+	 * @param string IP address family IPv4 or IPv6 (not case sensitive)
+	 * @param int $cidr the CIDR "mask" size for the subnet
+	 * @throws InvalidArgumentException
+	 * @return string IP of base address
+	 */
+	public static function ipAddressSubnet($networkScope, $ipAddressFamily, $cidr)
+	{
+		switch (strtolower($networkScope)) {
+			case 'routable':
+				return self::routableIpAddressSubnet($ipAddressFamily, $cidr);
+				break;
+			case 'loopback':
+				return self::loopbackIpAddressSubnet($ipAddressFamily, $cidr);
+				break;
+			default:
+				throw new \InvalidArgumentException("ipAddressSubnet: Invalid networkScope passed. (Must be routable or loopback)");
+				break;
+		}
+	}
+}

--- a/tests/TestHelpers/IpHelper.php
+++ b/tests/TestHelpers/IpHelper.php
@@ -2,7 +2,7 @@
 /**
  * ownCloud
  *
- * @author Phillip Davis
+ * @author Phillip Davis <info@jankaritech.com>
  * @copyright 2017 Phillip Davis phil@jankaritech.com
  *
  * This library is free software; you can redistribute it and/or
@@ -24,8 +24,14 @@ namespace TestHelpers;
 use Exception;
 use InvalidArgumentException;
 
-class IpHelper
-{
+/**
+ * Helper to to get run-time IP addresses and make IP calculations
+ * 
+ * @author Phillip Davis <info@jankaritech.com>
+ *
+ */
+class IpHelper {
+
 	const IPV6_LOOPBACK_ADDRESS = '::1';
 	const IPV6_LOOPBACK_ADDRESS_SUBNET = '::0';
 	const IPV4_LOOPBACK_ADDRESS_TOP = '127.';
@@ -33,17 +39,19 @@ class IpHelper
 	
 	/**
 	 * parse the output of ifconfig to find matching items such as IP addresses
+	 *
 	 * @param string $regex that will match the desired text in the ifconfig output
 	 * @throws Exception
 	 * @return array of elements that match the inner part of the regex
 	 */
-	private static function parseIfconfigOutput($regex)
-	{
+	private static function parseIfconfigOutput($regex) {
 		$output = [];
 		$return_var = null;
 		exec('ifconfig', $output, $return_var);
 		if ($return_var) {
-			throw new \Exception("parseIfconfigOutput: Error $return_var calling exec ifconfig");
+			throw new \Exception(
+				"parseIfconfigOutput: Error $return_var calling exec ifconfig"
+			);
 		}
 		preg_match_all($regex, implode($output, ' '), $matches);
 		return $matches[1];
@@ -52,38 +60,43 @@ class IpHelper
 	/**
 	 * @return array of IPv4 addresses found on the local system
 	 */
-	private static function systemIpv4Addresses()
-	{
+	private static function systemIpv4Addresses() {
 		// IPv4 addresses are like 192.168.12.34
-		return self::parseIfconfigOutput('/inet addr:([\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3})/');
+		return self::parseIfconfigOutput(
+			'/inet addr:([\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3})/'
+		);
 	}
 
 	/**
 	 * @return array of IPv6 addresses found on the local system
 	 */
-	private static function systemIpv6Addresses()
-	{
+	private static function systemIpv6Addresses() {
 		// IPv6 addresses are like fe80::6e26:388d:7bf:15d1
 		return self::parseIfconfigOutput('/inet6 addr: ([0123456789abcdef:]+)/');
 	}
 
 	/**
-	 * calculate the base address of the subnet with the given CIDR that contains the given IPv4 address
+	 * calculate the base address of the subnet with the given CIDR
+	 * that contains the given IPv4 address
+	 *
 	 * @param string $ipv4Address with format like "192.168.1.1"
 	 * @param int $cidr the CIDR "mask" size for the subnet (0 to 32)
 	 * @throws InvalidArgumentException
 	 * @return string IPv4 subnet base address
 	 */
-	private static function ipv4AddressSubnet($ipv4Address, $cidr)
-	{
+	private static function ipv4AddressSubnet($ipv4Address, $cidr) {
 		$cidr = (int) $cidr;
 		if (($cidr < 0) || ($cidr > 32)) {
-			throw new \InvalidArgumentException("ipv4AddressSubnet: CIDR $cidr is invalid. CIDR must be from 0 to 32.");
+			throw new \InvalidArgumentException(
+				"ipv4AddressSubnet: CIDR $cidr is invalid. CIDR must be 0 to 32."
+			);
 		}
 
 		$addressMask = ip2long($ipv4Address);
 		if ($addressMask === false) {
-			throw new \InvalidArgumentException("ipv4AddressSubnet: IPv4 address $ipv4Address is invalid.");
+			throw new \InvalidArgumentException(
+				"ipv4AddressSubnet: IPv4 address $ipv4Address is invalid."
+			);
 		}
 
 		$cidrMask = -1 << (32 - $cidr);
@@ -92,22 +105,27 @@ class IpHelper
 	}
 
 	/**
-	 * calculate the base address of the subnet with the given CIDR that contains the given IPv6 address
+	 * calculate the base address of the subnet with the given CIDR
+	 * that contains the given IPv6 address
+	 *
 	 * @param string $ipv6Address with format like "a:b:c::1"
 	 * @param int $cidr the CIDR "mask" size for the subnet (0 to 128)
 	 * @throws InvalidArgumentException
 	 * @return string IPv6 subnet base address
 	 */
-	private static function ipv6AddressSubnet($ipv6Address, $cidr)
-	{
+	private static function ipv6AddressSubnet($ipv6Address, $cidr) {
 		$cidr = (int) $cidr;
 		if (($cidr < 0) || ($cidr > 128)) {
-			throw new \InvalidArgumentException("ipv6AddressSubnet: CIDR $cidr is invalid. CIDR must be from 0 to 128.");
+			throw new \InvalidArgumentException(
+				"ipv6AddressSubnet: CIDR $cidr is invalid. CIDR must be 0 to 128."
+			);
 		}
 
 		$ipBin = inet_pton($ipv6Address);
 		if ($ipBin === false) {
-			throw new \InvalidArgumentException("ipv6AddressSubnet: IPv6 address $ipv6Address is invalid.");
+			throw new \InvalidArgumentException(
+				"ipv6AddressSubnet: IPv6 address $ipv6Address is invalid."
+			);
 		}
 
 		$hexString = bin2hex($ipBin);
@@ -118,13 +136,14 @@ class IpHelper
 			$binNumber .= sprintf('%04d', decbin(hexdec($hexString[$i])));
 		}
 		
-		// Set all the values past the end of the CIDR to "0" ("masking" the binary string value)
+		// Set all the values past the end of the CIDR to "0"
+		// ("masking" the binary string value)
 		$binNumber = substr($binNumber, 0, $cidr) . str_repeat("0", 128 - $cidr);
 		
 		// Convert it back to a hex string
 		$hexSubnetBase = "";
 		foreach (str_split($binNumber, 4) as $binString) {
-		  $hexSubnetBase .= base_convert( $binString, 2, 16);
+			$hexSubnetBase .= base_convert($binString, 2, 16);
 		}
 
 		// Put the hex into the hex2bin() internal format,
@@ -135,11 +154,11 @@ class IpHelper
 
 	/**
 	 * find the first IPv4 address on the local system that is a loopback address
+	 *
 	 * @throws Exception
 	 * @return string IPv4 loopback address
 	 */
-	private static function loopbackIpv4Address()
-	{
+	private static function loopbackIpv4Address() {
 		foreach (self::systemIpv4Addresses() as $ipv4Address) {
 			if (strpos($ipv4Address, self::IPV4_LOOPBACK_ADDRESS_TOP) === 0) {
 				return $ipv4Address;
@@ -152,21 +171,21 @@ class IpHelper
 	/**
 	 * get the IPv6 loopback address
 	 * Note: for IPv6 the loopback address is a well-defined constant value
+	 *
 	 * @return string IPv6 loopback address
 	 */
-	private static function loopbackIpv6Address()
-	{
+	private static function loopbackIpv6Address() {
 		return self::IPV6_LOOPBACK_ADDRESS;
 	}
 
 	/**
 	 * get a loopback address for the given IP address family
-	 * @param string IP address family IPv4 or IPv6 (not case sensitive)
+	 *
+	 * @param string $ipAddressFamily IPv4 or IPv6 (not case sensitive)
 	 * @throws InvalidArgumentException
 	 * @return string IP loopback address
 	 */
-	private static function loopbackIpAddress($ipAddressFamily)
-	{
+	private static function loopbackIpAddress($ipAddressFamily) {
 		switch (strtolower($ipAddressFamily)) {
 			case 'ipv4':
 				return self::loopbackIpv4Address();
@@ -174,39 +193,43 @@ class IpHelper
 				return self::loopbackIpv6Address();
 		}
 		
-		throw new \InvalidArgumentException("loopbackIpAddress: Invalid IP address family");
+		throw new \InvalidArgumentException(
+			"loopbackIpAddress: Invalid IP address family"
+		);
 	}
 
 	/**
-	 * calculate the base address of the subnet with the given CIDR that contains the loopback IPv4 address
+	 * calculate the base address of the subnet with the given CIDR
+	 * that contains the loopback IPv4 address
+	 *
 	 * @param int $cidr the CIDR "mask" size for the subnet
 	 * @return string IPv4 loopback subnet base address
 	 */
-	private static function loopbackIpv4AddressSubnet($cidr)
-	{
+	private static function loopbackIpv4AddressSubnet($cidr) {
 		return self::ipv4AddressSubnet(self::loopbackIpv4Address(), $cidr);
 	}
 
 	/**
-	 * calculate the base address of the subnet with the given CIDR that contains the loopback IPv6 address
+	 * calculate the base address of the subnet with the given CIDR
+	 * that contains the loopback IPv6 address
+	 *
 	 * @param int $cidr the CIDR "mask" size for the subnet
 	 * @return string IPv6 loopback subnet base address
 	 */
-	private static function loopbackIpv6AddressSubnet($cidr)
-	{
+	private static function loopbackIpv6AddressSubnet($cidr) {
 		return self::IPV6_LOOPBACK_ADDRESS_SUBNET;
 	}
 
 	/**
 	 * calculate the base address of the subnet with the given CIDR
 	 * that contains the loopback address of the given IP address family
-	 * @param string IP address family IPv4 or IPv6 (not case sensitive)
+	 *
+	 * @param string $ipAddressFamily IPv4 or IPv6 (not case sensitive)
 	 * @param int $cidr the CIDR "mask" size for the subnet
 	 * @throws InvalidArgumentException
 	 * @return string IP of loopback subnet base address
 	 */
-	private static function loopbackIpAddressSubnet($ipAddressFamily, $cidr)
-	{
+	private static function loopbackIpAddressSubnet($ipAddressFamily, $cidr) {
 		switch (strtolower($ipAddressFamily)) {
 			case 'ipv4':
 				return self::loopbackIpv4Address($cidr);
@@ -214,53 +237,61 @@ class IpHelper
 				return self::loopbackIpv6Address($cidr);
 		}
 		
-		throw new \InvalidArgumentException("loopbackIpAddressSubnet: Invalid IP address family");
+		throw new \InvalidArgumentException(
+			"loopbackIpAddressSubnet: Invalid IP address family"
+		);
 	}
 
 	/**
 	 * find the first IPv4 address on the local system that is not a loopback address
 	 * i.e. a "real" routable IPv4 address on some network interface
+	 *
 	 * @throws InvalidArgumentException
 	 * @return string IPv4 address
 	 */
-	private static function routableIpv4Address()
-	{
+	private static function routableIpv4Address() {
 		foreach (self::systemIpv4Addresses() as $ipv4Address) {
 			if (strpos($ipv4Address, self::IPV4_LOOPBACK_ADDRESS_TOP) !== 0) {
 				return $ipv4Address;
 			}
 		}
 
-		throw new \InvalidArgumentException("routableIpv4Address: No IP address found");
+		throw new \InvalidArgumentException(
+			"routableIpv4Address: No IP address found"
+		);
 	}
 
 	/**
-	 * find the first IPv6 address on the local system that is not a loopback or link-local address
+	 * find the first IPv6 address on the local system
+	 * that is not a loopback or link-local address,
 	 * i.e. a "real" routable IPv6 address on some network interface
+	 *
 	 * @throws InvalidArgumentException
 	 * @return string IPv6 address
 	 */
-	private static function routeableIpv6Address()
-	{
+	private static function routeableIpv6Address() {
 		foreach (self::systemIpv6Addresses() as $ipv6Address) {
 			if (($ipv6Address !== self::IPV6_LOOPBACK_ADDRESS)
-				&& (strpos($ipv6Address, self::IPV6_LINK_LOCAL_ADDRESS_TOP) !== 0)) {
+				&& (strpos($ipv6Address, self::IPV6_LINK_LOCAL_ADDRESS_TOP) !== 0)
+			) {
 				return $ipv6Address;
 			}
 		}
 
-		throw new \InvalidArgumentException("routeableIpv6Address: No IP address found");
+		throw new \InvalidArgumentException(
+			"routeableIpv6Address: No IP address found"
+		);
 	}
 
 	/**
 	 * get a non-loopback address on the local system for the given IP address family
 	 * i.e. a "real" routable IP address on some network interface
-	 * @param string IP address family IPv4 or IPv6 (not case sensitive)
+	 *
+	 * @param string $ipAddressFamily IPv4 or IPv6 (not case sensitive)
 	 * @throws InvalidArgumentException
 	 * @return string IP address
 	 */
-	private static function routableIpAddress($ipAddressFamily)
-	{
+	private static function routableIpAddress($ipAddressFamily) {
 		switch (strtolower($ipAddressFamily)) {
 			case 'ipv4':
 				return self::routableIpv4Address();
@@ -268,41 +299,43 @@ class IpHelper
 				return self::routeableIpv6Address();
 		}
 		
-		throw new \InvalidArgumentException("routableIpAddress: Invalid IP address family");
+		throw new \InvalidArgumentException(
+			"routableIpAddress: Invalid IP address family"
+		);
 	}
 
 	/**
 	 * calculate the base address of the subnet with the given CIDR
 	 * that contains the IPv4 address of the first routable IPv4 subnet
+	 *
 	 * @param int $cidr the CIDR "mask" size for the subnet
 	 * @return string IPv4 local subnet base address
 	 */
-	private static function routableIpv4AddressSubnet($cidr)
-	{
+	private static function routableIpv4AddressSubnet($cidr) {
 		return self::ipv4AddressSubnet(self::routableIpv4Address(), $cidr);
 	}
 
 	/**
 	 * calculate the base address of the subnet with the given CIDR
 	 * that contains the IPv6 address of the first routable IPv6 subnet
+	 *
 	 * @param int $cidr the CIDR "mask" size for the subnet
 	 * @return string IPv6 local subnet base address
 	 */
-	private static function routeableIpv6AddressSubnet($cidr)
-	{
+	private static function routeableIpv6AddressSubnet($cidr) {
 		return self::ipv6AddressSubnet(self::routeableIpv6Address(), $cidr);
 	}
 
 	/**
 	 * calculate the base address of the subnet with the given CIDR
 	 * that contains the first routable IP address of the given IP address family
-	 * @param string IP address family IPv4 or IPv6 (not case sensitive)
+	 *
+	 * @param string $ipAddressFamily IPv4 or IPv6 (not case sensitive)
 	 * @param int $cidr the CIDR "mask" size for the subnet
 	 * @throws InvalidArgumentException
 	 * @return string IP of local subnet base address
 	 */
-	private static function routableIpAddressSubnet($ipAddressFamily, $cidr)
-	{
+	private static function routableIpAddressSubnet($ipAddressFamily, $cidr) {
 		switch (strtolower($ipAddressFamily)) {
 			case 'ipv4':
 				return self::routableIpv4AddressSubnet($cidr);
@@ -310,19 +343,22 @@ class IpHelper
 				return self::routeableIpv6AddressSubnet($cidr);
 		}
 		
-		throw new \InvalidArgumentException("routableIpAddressSubnet: Invalid IP address family");
+		throw new \InvalidArgumentException(
+			"routableIpAddressSubnet: Invalid IP address family"
+		);
 	}
 
 	/**
 	 * find an IP address on the local system that is either a loopback address
 	 * or a routable IP address of the given IP address family.
-	 * @param $networkScope which type of address to return - "routable" or "loopback"
-	 * @param string IP address family IPv4 or IPv6 (not case sensitive)
+	 *
+	 * @param string $networkScope which type of address to return,
+	 *                             "routable" or "loopback"
+	 * @param string $ipAddressFamily IPv4 or IPv6 (not case sensitive)
 	 * @throws InvalidArgumentException
 	 * @return string IP address
 	 */
-	public static function ipAddress($networkScope, $ipAddressFamily)
-	{
+	public static function ipAddress($networkScope, $ipAddressFamily) {
 		switch (strtolower($networkScope)) {
 			case 'routable':
 				return self::routableIpAddress($ipAddressFamily);
@@ -331,7 +367,10 @@ class IpHelper
 				return self::loopbackIpAddress($ipAddressFamily);
 				break;
 			default:
-				throw new \InvalidArgumentException("ipAddress: Invalid networkScope passed. (Must be routable or loopback)");
+				throw new \InvalidArgumentException(
+					"ipAddress: Invalid networkScope passed. " .
+					"(Must be routable or loopback)"
+				);
 				break;
 		}
 	}
@@ -339,14 +378,15 @@ class IpHelper
 	/**
 	 * calculate the base address of the subnet with the given CIDR
 	 * that contains a routable or loopback IP address of the given IP address family
-	 * @param $networkScope which type of address to return - "routable" or "loopback"
-	 * @param string IP address family IPv4 or IPv6 (not case sensitive)
+	 *
+	 * @param string $networkScope which type of address to return,
+	 *                             "routable" or "loopback"
+	 * @param string $ipAddressFamily IPv4 or IPv6 (not case sensitive)
 	 * @param int $cidr the CIDR "mask" size for the subnet
 	 * @throws InvalidArgumentException
 	 * @return string IP of base address
 	 */
-	public static function ipAddressSubnet($networkScope, $ipAddressFamily, $cidr)
-	{
+	public static function ipAddressSubnet($networkScope, $ipAddressFamily, $cidr) {
 		switch (strtolower($networkScope)) {
 			case 'routable':
 				return self::routableIpAddressSubnet($ipAddressFamily, $cidr);
@@ -355,7 +395,10 @@ class IpHelper
 				return self::loopbackIpAddressSubnet($ipAddressFamily, $cidr);
 				break;
 			default:
-				throw new \InvalidArgumentException("ipAddressSubnet: Invalid networkScope passed. (Must be routable or loopback)");
+				throw new \InvalidArgumentException(
+					"ipAddressSubnet: Invalid networkScope passed. " .
+					"(Must be routable or loopback)"
+				);
 				break;
 		}
 	}

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -84,6 +84,7 @@ class WebDavHelper {
 	 * @param string $requestBody
 	 * @param int $davPathVersionToUse (1|2)
 	 * @param string $type of request
+	 * @param string $sourceIpAddress to initiate the request from
 	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
 	 * @throws \GuzzleHttp\Exception\BadResponseException
 	 */
@@ -97,7 +98,8 @@ class WebDavHelper {
 		$body = null,
 		$requestBody = null,
 		$davPathVersionToUse = 1,
-		$type = "files"
+		$type = "files",
+		$sourceIpAddress = null
 	) {
 		$baseUrl = self::sanitizeUrl($baseUrl, true);
 		$davPath = self::getDavPath($user, $davPathVersionToUse, $type);
@@ -109,6 +111,11 @@ class WebDavHelper {
 			$options['body'] = $requestBody;
 		}
 		$options['auth'] = [$user, $password];
+		
+		if (!is_null($sourceIpAddress)) {
+			$options['config'] =
+				[ 'curl' => [ CURLOPT_INTERFACE => $sourceIpAddress ]];
+		}
 		
 		$request = $client->createRequest($method, $fullUrl, $options);
 		if (!is_null($headers)) {

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -113,8 +113,8 @@ class WebDavHelper {
 		$options['auth'] = [$user, $password];
 		
 		if (!is_null($sourceIpAddress)) {
-			$options['config'] =
-				[ 'curl' => [ CURLOPT_INTERFACE => $sourceIpAddress ]];
+			$options['config']
+				= [ 'curl' => [ CURLOPT_INTERFACE => $sourceIpAddress ]];
 		}
 		
 		$request = $client->createRequest($method, $fullUrl, $options);


### PR DESCRIPTION
## Description
Provides helper functions so that test code can automagically:
- discover the loopback address and/or routable IP address of the system it is running on, for both IPv4 and IPv6.
- calculate the bottom address of a subnet, for a given CIDR, that encloses the discovered address
- specify a particular IP address on the running system from which Guzzle/cURL requests should be originated

## Related Issue

## Motivation and Context
Some tests need to check system functionality when the "end user" is coming from some different IP address to what the server is running on. For a simple case, we can use combinations of the loopback IPv4/IPv6 address/subnet and a "real" IPv4/IPv6 address/subnet on the same system. By having helper functions to gather the run-time addresses, the tests can talk generically about "loopback" and "routable" address - hiding the underlying run-time stuff needed to make it happen.

## How Has This Been Tested?
Using on a dev VM with some firewall rules.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

