### PR TITLE
dispatch event for 404 errors

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -937,6 +937,11 @@ class OC {
 				throw $e;
 			} catch (Symfony\Component\Routing\Exception\ResourceNotFoundException $e) {
 				//header('HTTP/1.0 404 Not Found');
+				$dispatcher = \OC::$server->getEventDispatcher();
+				$dispatcher->dispatch(\OCP\Http\HttpEvents::EVENT_404, new OCP\Http\HttpEvents(
+					\OCP\Http\HttpEvents::EVENT_404,
+					OC::$server->getRequest()
+				));
 			} catch (Symfony\Component\Routing\Exception\MethodNotAllowedException $e) {
 				OC_Response::setStatus(405);
 				return;

--- a/lib/public/Http/HttpEvents.php
+++ b/lib/public/Http/HttpEvents.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Http;
+
+use OCP\IRequest;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * @since 10.0.3
+ */
+class HttpEvents extends Event {
+	/** @var string */
+	const EVENT_404 = 'resource.not_found';
+
+	/** @var string */
+	protected $event;
+	/** @var IRequest */
+	protected $request;
+
+	/**
+	 * @param string $event
+	 * @param IRequest $request
+	 * @since 10.0.3
+	 */
+	public function __construct($event, $request) {
+		$this->event = $event;
+		$this->request = $request;
+	}
+
+	/**
+	 * @return string
+	 * @since 10.0.3
+	 */
+	public function getEvent() {
+		return $this->event;
+	}
+
+
+	/**
+	 * @return IRequest
+	 * @since 10.0.3
+	 */
+	public function getRequest() {
+		return $this->request;
+	}
+}

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -11,6 +11,7 @@
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Tom Needham <tom@owncloud.com>
  * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
  *
  * @copyright Copyright (c) 2017, ownCloud GmbH
  * @license AGPL-3.0
@@ -34,6 +35,7 @@ use OC\OCS\Result;
 use OC\User\LoginException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use OCP\Http\HttpEvents;
 
 require_once __DIR__ . '/../lib/base.php';
 
@@ -63,6 +65,11 @@ try {
 	OC::$server->getRouter()->match('/ocs'.\OC::$server->getRequest()->getRawPathInfo());
 	return;
 } catch (ResourceNotFoundException $e) {
+	$dispatcher = \OC::$server->getEventDispatcher();
+	$dispatcher->dispatch(\OCP\Http\HttpEvents::EVENT_404, new OCP\Http\HttpEvents(
+		\OCP\Http\HttpEvents::EVENT_404,
+		OC::$server->getRequest()
+	));
 	// Fall through the not found
 } catch (MethodNotAllowedException $e) {
 	OC_API::setContentType();
@@ -85,6 +92,11 @@ try {
 } catch (LoginException $e) {
 	OC_API::respond(new Result(null, \OCP\API::RESPOND_UNAUTHORISED, 'Unauthorised'), OC_API::requestedFormat());
 } catch (ResourceNotFoundException $e) {
+	$dispatcher = \OC::$server->getEventDispatcher();
+	$dispatcher->dispatch(\OCP\Http\HttpEvents::EVENT_404, new OCP\Http\HttpEvents(
+		\OCP\Http\HttpEvents::EVENT_404,
+		OC::$server->getRequest()
+	));
 	OC_API::setContentType();
 	OC_API::notFound();
 } catch (MethodNotAllowedException $e) {

--- a/public.php
+++ b/public.php
@@ -44,6 +44,11 @@ try {
 
 	if (!$pathInfo && $request->getParam('service', '') === '') {
 		header('HTTP/1.0 404 Not Found');
+		$dispatcher = \OC::$server->getEventDispatcher();
+		$dispatcher->dispatch(\OCP\Http\HttpEvents::EVENT_404, new OCP\Http\HttpEvents(
+			\OCP\Http\HttpEvents::EVENT_404,
+			OC::$server->getRequest()
+		));
 		exit;
 	} elseif ($request->getParam('service', '')) {
 		$service = $request->getParam('service', '');
@@ -54,6 +59,11 @@ try {
 	$file = OCP\Config::getAppValue('core', 'public_' . strip_tags($service));
 	if (is_null($file)) {
 		header('HTTP/1.0 404 Not Found');
+		$dispatcher = \OC::$server->getEventDispatcher();
+		$dispatcher->dispatch(\OCP\Http\HttpEvents::EVENT_404, new OCP\Http\HttpEvents(
+			\OCP\Http\HttpEvents::EVENT_404,
+			OC::$server->getRequest()
+		));
 		exit;
 	}
 

--- a/remote.php
+++ b/remote.php
@@ -123,6 +123,11 @@ try {
 	$request = \OC::$server->getRequest();
 	$pathInfo = $request->getPathInfo();
 	if ($pathInfo === false || $pathInfo === '') {
+		$dispatcher = \OC::$server->getEventDispatcher();
+		$dispatcher->dispatch(\OCP\Http\HttpEvents::EVENT_404, new OCP\Http\HttpEvents(
+			\OCP\Http\HttpEvents::EVENT_404,
+			OC::$server->getRequest()
+		));
 		throw new RemoteException('Path not found', OC_Response::STATUS_NOT_FOUND);
 	}
 	if (!$pos = strpos($pathInfo, '/', 1)) {
@@ -133,6 +138,11 @@ try {
 	$file = resolveService($service);
 
 	if(is_null($file)) {
+		$dispatcher = \OC::$server->getEventDispatcher();
+		$dispatcher->dispatch(\OCP\Http\HttpEvents::EVENT_404, new OCP\Http\HttpEvents(
+			\OCP\Http\HttpEvents::EVENT_404,
+			OC::$server->getRequest()
+		));
 		throw new RemoteException('Path not found', OC_Response::STATUS_NOT_FOUND);
 	}
 


### PR DESCRIPTION
## Description
Dispatch event from possible 404 error locations.

## Related Issue
https://github.com/owncloud/security/issues/3

## Motivation and Context
The goal is to be able to detect 404 errors
## How Has This Been Tested?
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@DeepDiver1975 @Peter-Prochaska  please review.