### PR TITLE
[WIP] Add foreign keys to filecache, share

### DIFF
--- a/core/Migrations/Version20170728163700.php
+++ b/core/Migrations/Version20170728163700.php
@@ -1,0 +1,32 @@
+<?php
+namespace OC\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\ISqlMigration;
+use OCP\IDBConnection;
+
+/**
+ * Add dummy root entry for fileid -1.
+ *
+ * Required for foreign keys.
+ */
+class Version20170728163700 implements ISqlMigration {
+
+	public function sql(IDBConnection $connection) {
+		$qb = $connection->getQueryBuilder();
+
+		$qb->insert('storages')
+			->values([
+				'id' => $qb->expr()->literal('root::'),
+				'numeric_id' => $qb->expr()->literal(-1),
+			])->execute();
+
+		$qb->insert('filecache')
+			->values([
+				'fileid' => $qb->expr()->literal(-1),
+				// hacky
+				'parent' => $qb->expr()->literal(-1),
+				'storage' => $qb->expr()->literal(-1),
+			])->execute();
+	}
+}

--- a/core/Migrations/Version20170728163844.php
+++ b/core/Migrations/Version20170728163844.php
@@ -1,0 +1,34 @@
+<?php
+namespace OC\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Add freaking foreign keys, it's about time!
+ */
+class Version20170728163844 implements ISchemaMigration {
+
+	public function changeSchema(Schema $schema, array $options) {
+		// Get the table
+		$prefix = $options['tablePrefix'];
+		$fileCacheTable = $schema->getTable("{$prefix}filecache");
+
+		// filecache.parent -> filecache.fileid
+		$fileCacheTable->addForeignKeyConstraint(
+			"{$prefix}filecache",
+			["parent"],
+			["fileid"],
+			['onDelete' => 'CASCADE']
+		);
+
+		$shareTable = $schema->getTable("{$prefix}share");
+		// share.file_source -> filecache.fileid
+		$shareTable->addForeignKeyConstraint(
+			"{$prefix}filecache",
+			["file_source"],
+			["fileid"],
+			['onDelete' => 'CASCADE']
+		);
+	}
+}

--- a/core/Migrations/Version20170728163844.php
+++ b/core/Migrations/Version20170728163844.php
@@ -22,6 +22,14 @@ class Version20170728163844 implements ISchemaMigration {
 			['onDelete' => 'CASCADE']
 		);
 
+		// filecache.storage -> storages.numeric_id
+		$fileCacheTable->addForeignKeyConstraint(
+			"{$prefix}storages",
+			["storage"],
+			["numeric_id"],
+			['onDelete' => 'CASCADE']
+		);
+
 		$shareTable = $schema->getTable("{$prefix}share");
 		// share.file_source -> filecache.fileid
 		$shareTable->addForeignKeyConstraint(
@@ -30,5 +38,8 @@ class Version20170728163844 implements ISchemaMigration {
 			["fileid"],
 			['onDelete' => 'CASCADE']
 		);
+
+		// one root to rule them all: workaround for the "-1" file id
+
 	}
 }


### PR DESCRIPTION
Just for fun...

Fixes https://github.com/owncloud/core/issues/13143.

Setting up the DB works but as soon as you try accessing the filesystem 💥 

```
{"reqId":"21UH6QkWsTlqzd3QlFD9","level":4,"time":"2017-07-28T14:45:44+00:00","remoteAddr":"127.0.0.1","user":"admin","app":"webdav","method":"PROPFIND","url":"/owncloud/remote.php/webdav/","message":"Exception: {"Message":"An exception occurred while executing 'INSERT INTO `oc_filecache` (`mimepart`,`mimetype`,`mtime`,`size`,`etag`,`storage_mtime`,`permissions`,`checksum`,`path_hash`,`path`,`parent`,`name`,`storage`) SELECT ?,?,?,?,?,?,?,?,?,?,?,?,? FROM `oc_filecache` WHERE `storage` = ? AND `path_hash` = ? HAVING COUNT(*) = 0' with params ["1", "2", 1501253047, -1, "597b4e18a28aa", 1501253047, 23, "", "d41d8cd98f00b204e9800998ecf8427e", "", -1, "", 1, 1, "d41d8cd98f00b204e9800998ecf8427e"]:\n\nSQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`owncloud`.`oc_filecache`, CONSTRAINT `FK_D3AD7FD63D8E604F` FOREIGN KEY (`parent`) REFERENCES `oc_filecache` (`fileid`) ON DELETE CASCADE)","Exception":"Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException","Code":0,"Trace":"
#0 /srv/www/htdocs/owncloud/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php(128): Doctrine\DBAL\Driver\AbstractMySQLDriver->convertException('An exception oc...', Object(Doctrine\DBAL\Driver\PDOException))
#1 /srv/www/htdocs/owncloud/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(1015): Doctrine\DBAL\DBALException::driverExceptionDuringQuery(Object(Doctrine\DBAL\Driver\PDOMySql\Driver), Object(Doctrine\DBAL\Driver\PDOException), 'INSERT INTO `oc...', Array)
#2 /srv/www/htdocs/owncloud/lib/private/DB/Connection.php(211): Doctrine\DBAL\Connection->executeUpdate('INSERT INTO `oc...', Array, Array)
#3 /srv/www/htdocs/owncloud/lib/private/DB/Adapter.php(113): OC\DB\Connection->executeUpdate('INSERT INTO `*P...', Array)
#4 /srv/www/htdocs/owncloud/lib/private/DB/Connection.php(249): OC\DB\Adapter->insertIfNotExist('*PREFIX*filecac...', Array, Array)
#5 /srv/www/htdocs/owncloud/lib/private/Files/Cache/Cache.php(267): OC\DB\Connection->insertIfNotExist('*PREFIX*filecac...', Array, Array)
#6 /srv/www/htdocs/owncloud/lib/private/Files/Cache/Cache.php(222): OC\Files\Cache\Cache->insert('', Array)
#7 /srv/www/htdocs/owncloud/lib/private/Files/Cache/Scanner.php(269): OC\Files\Cache\Cache->put('', Array)
#8 /srv/www/htdocs/owncloud/lib/private/Files/Cache/Scanner.php(209): OC\Files\Cache\Scanner->addToCache('', Array, -1)
#9 /srv/www/htdocs/owncloud/lib/private/Files/Cache/Scanner.php(312): OC\Files\Cache\Scanner->scanFile('', 3, -1, NULL, true)
#10 /srv/www/htdocs/owncloud/lib/private/Files/View.php(1302): OC\Files\Cache\Scanner->scan('', false)
#11 /srv/www/htdocs/owncloud/lib/private/Files/View.php(1343): OC\Files\View->getCacheEntry(Object(OC\Files\Storage\Wrapper\Checksum), '', '/admin')
#12 /srv/www/htdocs/owncloud/lib/private/Files/Node/Root.php(182): OC\Files\View->getFileInfo('/admin')
#13 /srv/www/htdocs/owncloud/lib/private/Files/Node/Root.php(353): OC\Files\Node\Root->get('/admin')
#14 /srv/www/htdocs/owncloud/lib/private/Server.php(940): OC\Files\Node\Root->getUserFolder('admin')
#15 /srv/www/htdocs/owncloud/apps/dav/lib/Connector/Sabre/ServerFactory.php(128): OC\Server->getUserFolder()
#16 [internal function]: OCA\DAV\Connector\Sabre\ServerFactory->OCA\DAV\Connector\Sabre\{closure}(Object(Sabre\HTTP\Request), Object(Sabre\HTTP\Response))
#17 /srv/www/htdocs/owncloud/lib/composer/sabre/event/lib/EventEmitterTrait.php(105): call_user_func_array(Object(Closure), Array)
#18 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(466): Sabre\Event\EventEmitter->emit('beforeMethod', Array)
#19 /srv/www/htdocs/owncloud/lib/composer/sabre/dav/lib/DAV/Server.php(254): Sabre\DAV\Server->invokeMethod(Object(Sabre\HTTP\Request), Object(Sabre\HTTP\Response))
#20 /srv/www/htdocs/owncloud/apps/dav/appinfo/v1/webdav.php(63): Sabre\DAV\Server->exec()
#21 /srv/www/htdocs/owncloud/remote.php(165): require_once('/srv/www/htdocs...')
#22 {main}","File":"/srv/www/htdocs/owncloud/lib/composer/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php","Line":60,"User":"admin"}"}
```

@DeepDiver1975 @butonic @tomneedham 