### PR TITLE
Handle read only apps folders properly

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -58,25 +58,18 @@ class AppManager implements IAppManager {
 
 	/** @var \OCP\IUserSession */
 	private $userSession;
-
 	/** @var \OCP\IAppConfig */
 	private $appConfig;
-
 	/** @var \OCP\IGroupManager */
 	private $groupManager;
-
 	/** @var \OCP\ICacheFactory */
 	private $memCacheFactory;
-
 	/** @var string[] $appId => $enabled */
 	private $installedAppsCache;
-
 	/** @var string[] */
 	private $shippedApps;
-
 	/** @var string[] */
 	private $alwaysEnabled;
-
 	/** @var EventDispatcherInterface */
 	private $dispatcher;
 
@@ -212,6 +205,7 @@ class AppManager implements IAppManager {
 	 * Enable an app for every user
 	 *
 	 * @param string $appId
+	 * @throws \Exception
 	 */
 	public function enableApp($appId) {
 		if(OC_App::getAppPath($appId) === false) {
@@ -429,5 +423,19 @@ class AppManager implements IAppManager {
 		$appInfo = Installer::checkAppsIntegrity($data, $appCodeDir, $path);
 		Files::rmdirr($appCodeDir);
 		return $appInfo;
+	}
+
+	/**
+	 * Indicates if app installation is supported. Usually it is but in certain
+	 * environments it is disallowed because of hardening. In a clustered setup
+	 * apps need to be installed on each cluster node which is out of scope of
+	 * ownCloud itself.
+	 *
+	 * @return bool
+	 * @since 10.0.3
+	 */
+	public function canInstall() {
+		$appsFolder = OC_App::getInstallPath();
+		return $appsFolder !== null && is_writable($appsFolder) && is_readable($appsFolder);
 	}
 }

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -91,7 +91,12 @@ class Installer {
 
 		$info = self::checkAppsIntegrity($data, $extractDir, $path);
 		$appId = OC_App::cleanAppId($info['id']);
-		$basedir = OC_App::getInstallPath().'/'.$appId;
+		$appsFolder = OC_App::getInstallPath();
+
+		if ($appsFolder === null || !is_writable($appsFolder)) {
+			throw new \Exception('Apps folder is not writable');
+		}
+		$basedir = "$appsFolder/$appId";
 		//check if the destination directory already exists
 		if(is_dir($basedir)) {
 			OC_Helper::rmdirr($extractDir);

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -1001,7 +1001,7 @@ class OC_App {
 	 * This means that it's possible to specify "requiremin" => 6
 	 * and "requiremax" => 6 and it will still match ownCloud 6.0.3.
 	 *
-	 * @param string $ocVersion ownCloud version to check against
+	 * @param string|array $ocVersion ownCloud version to check against
 	 * @param array $appInfo app info (from xml)
 	 *
 	 * @return boolean true if compatible, otherwise false

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -156,4 +156,14 @@ interface IAppManager {
 	 */
 	public function readAppPackage($path);
 
+	/**
+	 * Indicates if app installation is supported. Usually it is but in certain
+	 * environments it is disallowed because of hardening. In a clustered setup
+	 * apps need to be installed on each cluster node which is out of scope of
+	 * ownCloud itself.
+	 *
+	 * @return bool
+	 * @since 10.0.3
+	 */
+	public function canInstall();
 }


### PR DESCRIPTION
## Description
This is planned to support clustered setup much better ....

## Related Issue
refs  https://github.com/owncloud/platform/issues/133

## How Has This Been Tested?
1. add the config parameter 'cluster.mode' -> true
2. try to install
3. try to operate as usual
4. expectation: nothing will break apart ....

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

