### PR TITLE
Retry file locks after delay in case of failure

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1330,6 +1330,16 @@ $CONFIG = array(
 'filelocking.ttl' => 3600,
 
 /**
+ * Number of times to retry acquiring a lock before failing.
+ */
+'filelocking.retries' => 5,
+
+/**
+ * How long to wait between each retries, in milliseconds.
+ */
+'filelocking.retrydelay' => 1000,
+
+/**
  * Memory caching backend for file locking
  *
  * Because most memcache backends can clean values without warning using redis

--- a/lib/private/Lock/RetryLockingProvider.php
+++ b/lib/private/Lock/RetryLockingProvider.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Lock;
+
+use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
+
+/**
+ * Decorator for locking provider that will retry acquire locks
+ * a given number of times.
+ *
+ * When acquireLock() is called, if a LockedException is thrown it will
+ * retry as many times as $retries after waiting a delay of $retryDelay (ms)
+ * between each tries. If the last try failed, it will forward the exception.
+ */
+class RetryLockingProvider implements ILockingProvider {
+	/**
+	 * Wrapped locking provider
+	 *
+	 * @var ILockingProvider
+	 */
+	private $provider;
+
+	/**
+	 * Retries count
+	 *
+	 * @var int
+	 */
+	private $retries;
+
+	/**
+	 * Time to wait for between retries in milliseconds
+	 *
+	 * @var int
+	 */
+	private $retryDelay;
+
+	/**
+	 * Wrap a given locking provider
+	 *
+	 * @param ILockingProvider $provider provider to wrap
+	 * @param int $retries number of retries before giving up
+	 * @param int $retryDelay delay to wait between retries, in milliseconds
+	 */
+	public function __construct($provider, $retries = 5, $retryDelay = 1000) {
+		$this->provider = $provider;
+		$this->retries = $retries;
+		$this->retryDelay = $retryDelay;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function isLocked($path, $type) {
+		return $this->provider->isLocked($path, $type);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function acquireLock($path, $type) {
+		return $this->callAndRetry('acquireLock', $path, $type);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function changeLock($path, $type) {
+		return $this->callAndRetry('changeLock', $path, $type);
+	}
+
+	/**
+	 * Calls the given locking method with given arguments with
+	 * the retry logic.
+	 *
+	 * @param string $methodName locking method to call
+	 * @param string $path path to lock
+	 * @param int $type lock type
+	 */
+	private function callAndRetry($methodName, $path, $type) {
+		$lastException = null;
+		$tries = $this->retries;
+		while ($tries > 0) {
+			try {
+				return $this->provider->$methodName($path, $type);
+			} catch (LockedException $e) {
+				$lastException = $e;
+				if ($tries > 0) {
+					$tries--;
+					usleep($this->retryDelay * 1000);
+				}
+			}
+		}
+		throw $lastException;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function releaseLock($path, $type) {
+		return $this->provider->releaseLock($path, $type);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function releaseAll() {
+		return $this->provider->releaseAll();
+	}
+}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -63,6 +63,7 @@ use OC\IntegrityCheck\Checker;
 use OC\IntegrityCheck\Helpers\AppLocator;
 use OC\IntegrityCheck\Helpers\EnvironmentHelper;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
+use OC\Lock\RetryLockingProvider;
 use OC\Lock\DBLockingProvider;
 use OC\Lock\MemcacheLockingProvider;
 use OC\Lock\NoopLockingProvider;
@@ -645,9 +646,15 @@ class Server extends ServerContainer implements IServerContainer {
 				$memcacheFactory = $c->getMemCacheFactory();
 				$memcache = $memcacheFactory->createLocking('lock');
 				if (!($memcache instanceof \OC\Memcache\NullCache)) {
-					return new MemcacheLockingProvider($memcache, $ttl);
+					$provider = new MemcacheLockingProvider($memcache, $ttl);
+				} else {
+					$provider = new DBLockingProvider($c->getDatabaseConnection(), $c->getLogger(), new TimeFactory(), $ttl);
 				}
-				return new DBLockingProvider($c->getDatabaseConnection(), $c->getLogger(), new TimeFactory(), $ttl);
+				return new RetryLockingProvider(
+					$provider,
+					(int)$config->getSystemValue('filelocking.retries', 5),
+					(int)$config->getSystemValue('filelocking.retrydelay', 5000)
+				);
 			}
 			return new NoopLockingProvider();
 		});

--- a/tests/lib/Lock/RetryLockingProviderTest.php
+++ b/tests/lib/Lock/RetryLockingProviderTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2015, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Lock;
+
+use OC\Lock\RetryLockingProvider;
+use OCP\Lock\ILockingProvider;
+use Test\TestCase;
+use OCP\Lock\LockedException;
+
+/**
+ * Class DBLockingProvider
+ *
+ * @group DB
+ *
+ * @package Test\Lock
+ */
+class RetryLockingProviderTest extends TestCase {
+
+	/**
+	 * Instance to be tested
+	 *
+	 * @var RetryLockingProviderTest
+	 */
+	private $instance;
+
+	/**
+	 * Wrapped provider
+	 *
+	 * @var ILockingProvider
+	 */
+	private $provider;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->provider = $this->createMock(ILockingProvider::class);
+		$this->instance = new RetryLockingProvider($this->provider, 4, 1);
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function testIsLocked() {
+		$this->provider->expects($this->once())
+			->method('isLocked')
+			->with('abc', ILockingProvider::LOCK_EXCLUSIVE)
+			->willReturn(true);
+		$this->assertTrue($this->instance->isLocked('abc', ILockingProvider::LOCK_EXCLUSIVE));
+	}
+
+	public function retriedNethodNameProvider() {
+		return [
+			['acquireLock'],
+			['changeLock'],
+		];
+	}
+
+	/**
+	 * @dataProvider retriedNethodNameProvider
+	 */
+	public function testLockSuccess($methodName) {
+		$this->provider->expects($this->once())
+			->method($methodName)
+			->with('abc', ILockingProvider::LOCK_EXCLUSIVE)
+			->willReturn(true);
+		$this->assertTrue($this->instance->$methodName('abc', ILockingProvider::LOCK_EXCLUSIVE));
+	}
+
+	/**
+	 * @dataProvider retriedNethodNameProvider
+	 */
+	public function testLockRetrySuccess($methodName) {
+		$this->provider->expects($this->at(0))
+			->method($methodName)
+			->with('abc', ILockingProvider::LOCK_EXCLUSIVE)
+			->will($this->throwException(new LockedException('one')));
+		$this->provider->expects($this->at(1))
+			->method($methodName)
+			->with('abc', ILockingProvider::LOCK_EXCLUSIVE)
+			->will($this->throwException(new LockedException('two')));
+		$this->provider->expects($this->at(2))
+			->method($methodName)
+			->with('abc', ILockingProvider::LOCK_EXCLUSIVE)
+			->will($this->throwException(new LockedException('three')));
+		$this->provider->expects($this->at(3))
+			->method($methodName)
+			->with('abc', ILockingProvider::LOCK_EXCLUSIVE)
+			->willReturn(true);
+		$this->assertTrue($this->instance->$methodName('abc', ILockingProvider::LOCK_EXCLUSIVE));
+	}
+
+	/**
+	 * @dataProvider retriedNethodNameProvider
+	 * @expectedException \OCP\Lock\LockedException
+	 */
+	public function testLockRetryFail($methodName) {
+		$this->provider->expects($this->at(0))
+			->method($methodName)
+			->with('abc', ILockingProvider::LOCK_EXCLUSIVE)
+			->will($this->throwException(new LockedException('one')));
+		$this->provider->expects($this->at(1))
+			->method($methodName)
+			->with('abc', ILockingProvider::LOCK_EXCLUSIVE)
+			->will($this->throwException(new LockedException('two')));
+		$this->provider->expects($this->at(2))
+			->method($methodName)
+			->with('abc', ILockingProvider::LOCK_EXCLUSIVE)
+			->will($this->throwException(new LockedException('three')));
+		$this->provider->expects($this->at(3))
+			->method($methodName)
+			->with('abc', ILockingProvider::LOCK_EXCLUSIVE)
+			->will($this->throwException(new LockedException('three')));
+		$this->instance->$methodName('abc', ILockingProvider::LOCK_EXCLUSIVE);
+	}
+
+	public function testReleaseLock() {
+		$this->provider->expects($this->once())
+			->method('releaseLock')
+			->with('abc', ILockingProvider::LOCK_EXCLUSIVE)
+			->willReturn(true);
+		$this->assertTrue($this->instance->releaseLock('abc', ILockingProvider::LOCK_EXCLUSIVE));
+	}
+
+	public function testReleaseAll() {
+		$this->provider->expects($this->once())
+			->method('releaseAll')
+			->willReturn(true);
+		$this->assertTrue($this->instance->releaseAll());
+	}
+}


### PR DESCRIPTION
## Description
Adds a decorator to retry acquiring file locks after a delay in case of failure.

## Related Issue
Fixes https://github.com/owncloud/core/issues/17016

## Motivation and Context
See issue.
Basically some cron tasks or concurrent tasks might prevent an expensive upload to finish due to a lock. Instead of abandoning directly, the code tries again shortly after to give a few more chances to finish the transaction and avoid having to redo it.

In my personal case, it often happens that I upload files with Android around at a round quarter of an hour which conflicts with cron run, and often times the upload fails with locking issues so I need to retry manually.

## How Has This Been Tested?
- [x] unit tests
- [ ] need manual concurrent testing / smashbox

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

