### PR TITLE
Improve show password checkbox id names

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -445,26 +445,26 @@ label.infield {
 }
 
 /* Show password toggle */
-#show, #dbpassword {
+#showadminpass, #showdbpass {
 	position: absolute;
 	right: 1em;
 	top: .8em;
 	float: right;
 }
-#show, #dbpassword, #personal-show {
+#showadminpass, #showdbpass, #personal-show {
 	display: none;
 }
-#show + label, #dbpassword + label {
+#showadminpass + label, #showdbpass + label {
 	right: 21px;
 	top: 15px !important;
 	margin: -14px !important;
 	padding: 14px !important;
 }
-#show:checked + label, #dbpassword:checked + label, #personal-show:checked + label {
+#showadminpass:checked + label, #showdbpass:checked + label, #personal-show:checked + label {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=80)";
 	opacity: .8;
 }
-#show + label, #dbpassword + label, #personal-show + label {
+#showadminpass + label, #showdbpass + label, #personal-show + label {
 	position: absolute !important;
 	height: 20px;
 	width: 24px;
@@ -474,7 +474,7 @@ label.infield {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=30)";
 	opacity: .3;
 }
-#show + label:before, #dbpassword + label:before, #personal-show + label:before {
+#showadminpass + label:before, #showdbpass + label:before, #personal-show + label:before {
 	display: none;
 }
 #pass2, input[name="personal-password-clone"] {

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -35,13 +35,13 @@ script('core', [
 			<label for="adminlogin" class="infield"><?php p($l->t( 'Username' )); ?></label>
 		</p>
 		<p class="groupbottom">
-			<input type="password" name="adminpass" data-typetoggle="#show" id="adminpass"
+			<input type="password" name="adminpass" data-typetoggle="#showadminpass" id="adminpass"
 				placeholder="<?php p($l->t( 'Password' )); ?>"
 				value="<?php p($_['adminpass']); ?>"
 				autocomplete="off" autocapitalize="off" autocorrect="off" required>
 			<label for="adminpass" class="infield"><?php p($l->t( 'Password' )); ?></label>
-			<input type="checkbox" id="show" name="show">
-			<label for="show"></label>
+			<input type="checkbox" id="showadminpass" name="showadminpass">
+			<label for="showadminpass"></label>
 		</p>
 	</fieldset>
 
@@ -98,13 +98,13 @@ script('core', [
 					autocomplete="off" autocapitalize="off" autocorrect="off">
 			</p>
 			<p class="groupmiddle">
-				<input type="password" name="dbpass" id="dbpass" data-typetoggle="#dbpassword"
+				<input type="password" name="dbpass" id="dbpass" data-typetoggle="#showdbpass"
 					placeholder="<?php p($l->t( 'Database password' )); ?>"
 					value="<?php p($_['dbpass']); ?>"
 					autocomplete="off" autocapitalize="off" autocorrect="off">
 				<label for="dbpass" class="infield"><?php p($l->t( 'Database password' )); ?></label>
-				<input type="checkbox" id="dbpassword" name="dbpassword">
-				<label for="dbpassword"></label>
+				<input type="checkbox" id="showdbpass" name="showdbpass">
+				<label for="showdbpass"></label>
 			</p>
 			<p class="groupmiddle">
 				<label for="dbname" class="infield"><?php p($l->t( 'Database name' )); ?></label>


### PR DESCRIPTION
## Description
Make the show password checkbox id names unique (and hopefully sensible) so they do not conflict with other keys used by back-end code.

## Related Issue
#26129 

## Motivation and Context
Using "dbpassword" as an id for a "show db password" checkbox is going to be a source of confusion, and a source of trouble (as detailed in the related issue).
Using just "show" as an id for a "show admin password" checkbox is also going to be a source of confusion (although not currently a source of trouble) when some other "show xxx password" checkbox is added.

## How Has This Been Tested?
Set installed to false in config.php
Try to login, get the installation page.
Select mySQL database tab.
Click to show password.
Enter database owner, database password etc and submit.

Before the change:
![oc-install-dbpass](https://user-images.githubusercontent.com/1535615/28807698-8e77b1ac-7696-11e7-9c27-69e63c6b8bf8.png)

config.php does not have the database owner/password

After the change:
config.php does have the database owner/password

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

