### PR TITLE
send 403 HTTP code when access to public preview is forbidden

### DIFF
--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -113,6 +113,9 @@ try{
 } catch (\OCP\Files\NotFoundException $e) {
 	\OC_Response::setStatus(\OC_Response::STATUS_NOT_FOUND);
 	\OCP\Util::writeLog('core-preview', 'Requested file not found', \OCP\Util::WARN);
+} catch (\OCP\Files\ForbiddenException $e) {
+	\OC_Response::setStatus(\OC_Response::STATUS_FORBIDDEN);
+	\OCP\Util::writeLog('core', $e->getmessage(), \OCP\Util::DEBUG);
 } catch (\Exception $e) {
 	\OC_Response::setStatus(\OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 	\OCP\Util::writeLog('core', $e->getmessage(), \OCP\Util::DEBUG);


### PR DESCRIPTION
## Description
setting correct error code when file preview of public links is blocked

## Related Issue
https://github.com/owncloud/firewall/issues/364

## Motivation and Context
server does return the wrong error code when previews of public files are blocked

## How Has This Been Tested?
https://github.com/owncloud/firewall/pull/365

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/2425577/28823073-94f4facc-76db-11e7-8042-a37330cb2f79.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

