### PR TITLE
send 403 error when preview is blocked by firewall rule

### DIFF
--- a/index.php
+++ b/index.php
@@ -63,6 +63,10 @@ try {
 	\OC::loadDefaultEnabledAppTheme();
 	OC_Response::setStatus(OC_Response::STATUS_FORBIDDEN);
 	OC_Template::printErrorPage($ex->getMessage());
+} catch (\OCP\Files\ForbiddenException $ex) {
+	\OC::loadDefaultEnabledAppTheme();
+	OC_Response::setStatus(OC_Response::STATUS_FORBIDDEN);
+	OC_Template::printErrorPage($ex->getMessage());
 } catch (Exception $ex) {
 	\OC::loadDefaultEnabledAppTheme();
 	try {


### PR DESCRIPTION
## Description
setting correct error code when file preview of public links is blocked

## Related Issue
https://github.com/owncloud/firewall/issues/366

## Motivation and Context
server does return the wrong error code when previews of files are blocked

## How Has This Been Tested?
manually & by writing tests for the firewall app

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

