### PR TITLE
Support starting IPv6 PHP dev server

### DIFF
--- a/tests/travis/start_php_dev_server.sh
+++ b/tests/travis/start_php_dev_server.sh
@@ -36,7 +36,6 @@ ps -p $serverPID  > /dev/null 2>&1
 if [ $? -eq 1 ] ; then
 	echo "could not start PHP development webserver"
 	ERROR_STARTING_SERVER=true
-	# exit 1
 else
 	echo "started PHP dev. webserver with PID $serverPID"
 fi

--- a/tests/travis/start_php_dev_server.sh
+++ b/tests/travis/start_php_dev_server.sh
@@ -6,6 +6,27 @@
 # @copyright 2017 Artur Neumann info@individual-it.net
 #
 
+ENV_PARAM_MISSING=false
+ERROR_STARTING_SERVER=false
+
+if [ -z "$SRV_HOST_NAME" ]
+then
+	echo "environment variable SRV_HOST_NAME is not defined"
+	ENV_PARAM_MISSING=true
+fi
+
+if [ -z "$SRV_HOST_PORT" ]
+then
+	echo "environment variable SRV_HOST_PORT is not defined"
+	ENV_PARAM_MISSING=true
+fi
+
+if [ "$ENV_PARAM_MISSING" = true ]
+then
+	echo "PHP development webserver not started"
+	exit 1
+fi
+
 php -S $SRV_HOST_NAME:$SRV_HOST_PORT > /dev/null 2>&1 &
 serverPID=$!
 sleep 1
@@ -14,10 +35,38 @@ ps -p $serverPID  > /dev/null 2>&1
 
 if [ $? -eq 1 ] ; then
 	echo "could not start PHP development webserver"
+	ERROR_STARTING_SERVER=true
+	# exit 1
+else
+	echo "started PHP dev. webserver with PID $serverPID"
+fi
+
+if [ ! -z "$IPV4_HOST_NAME" ] && [ "$SRV_HOST_NAME" != "$IPV4_HOST_NAME" ]
+then
+	php -S $IPV4_HOST_NAME:$SRV_HOST_PORT > /dev/null 2>&1 &
+	if [ $? -eq 1 ] ; then
+		echo "could not start IPV4 PHP development webserver"
+		ERROR_STARTING_SERVER=true
+	else
+		echo "started IPv4 PHP dev. webserver with PID $serverPID"
+	fi
+fi
+
+if [ ! -z "$IPV6_HOST_NAME" ] && [ "$SRV_HOST_NAME" != "$IPV6_HOST_NAME" ]
+then
+	php -S $IPV6_HOST_NAME:$SRV_HOST_PORT > /dev/null 2>&1 &
+	if [ $? -eq 1 ] ; then
+		echo "could not start IPV6 PHP development webserver"
+		ERROR_STARTING_SERVER=true
+	else
+		echo "started IPv6 PHP dev. webserver with PID $serverPID"
+	fi
+fi
+
+if [ "$ERROR_STARTING_SERVER" = true ]
+then
 	echo -e "\nnetstat output:\n"
 	netstat -l -n -p
 	exit 1
-else
-	echo "started PHP dev. webserver with PID $serverPID"
 fi
 


### PR DESCRIPTION
## Description
Allow the developer to specify separate IPv4 and IPv6 host names or addresses for the dev PHP server.
Start a separate dev PHP server listening on each of those.

The following environment variables are used:

SRV_HOST_NAME - the default host that the server will run on (tests will typical run against that host)
IPV4_HOST_NAME - a different IPv4 host, typically used if SRV_HOST_NAME is a specifically IPv6 name
IPV6_HOST_NAME - a different IPv6 host, typically used if SRV_HOST_NAME is a specifically IPv4 name

## Related Issue

## Motivation and Context
Tests may need to test functionality specifically using IPv4 or IPv6 (e.g. firewall is starting to do this). In the dev environment there needs to be a way to easily startup and use dev PHP servers listening on both IPv4 and IPv6.

## How Has This Been Tested?
Running ordinary core tests in a dev environment with SRV_HOST_NAME ip6-localhost - the tests drive the UI accessing it through IPv6.

Running IPv6-specific tests, with IPV6_HOST_NAME ip6-localhost and SRV_HOST_NAME localhost - the tests drive the UI accessing it through IPv4, and IPv6-specific tests access the IPv6 server listening at ::1

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) (to the dev environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

