### PR TITLE
Properly set the status text in the ocs response for v2 calls 

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -120,7 +120,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 */
 	public function __construct(array $vars= [],
 								ISecureRandom $secureRandom = null,
-								IConfig $config,
+								IConfig $config = null,
 								CsrfTokenManager $csrfTokenManager = null,
 								$stream = 'php://input') {
 		$this->inputStream = $stream;

--- a/lib/public/AppFramework/Http/OCSResponse.php
+++ b/lib/public/AppFramework/Http/OCSResponse.php
@@ -29,8 +29,7 @@
  */
 
 namespace OCP\AppFramework\Http;
-
-use OCP\AppFramework\Http;
+use OC\OCS\Result;
 
 /**
  * A renderer for OCS responses
@@ -44,26 +43,30 @@ class OCSResponse extends Response {
 	private $message;
 	private $itemscount;
 	private $itemsperpage;
+	private $isV2;
 
 	/**
 	 * generates the xml or json response for the API call from an multidimenional data array.
+	 *
 	 * @param string $format
 	 * @param int $statuscode
 	 * @param string $message
 	 * @param array $data
 	 * @param int|string $itemscount
 	 * @param int|string $itemsperpage
+	 * @param bool $isV2
 	 * @since 8.1.0
 	 */
 	public function __construct($format, $statuscode, $message,
 								$data=[], $itemscount='',
-								$itemsperpage='') {
+								$itemsperpage='', $isV2 = false) {
 		$this->format = $format;
 		$this->statuscode = $statuscode;
 		$this->message = $message;
 		$this->data = $data;
 		$this->itemscount = $itemscount;
 		$this->itemsperpage = $itemsperpage;
+		$this->isV2 = $isV2;
 
 		// set the correct header based on the format parameter
 		if ($format === 'json') {
@@ -82,11 +85,15 @@ class OCSResponse extends Response {
 	 * @since 8.1.0
 	 */
 	public function render() {
-		$r = new \OC_OCS_Result($this->data, $this->statuscode, $this->message);
+		$r = new Result($this->data, $this->statuscode, $this->message);
 		$r->setTotalItems($this->itemscount);
 		$r->setItemsPerPage($this->itemsperpage);
+		$meta = $r->getMeta();
+		if ($this->isV2 && $this->statuscode === 200) {
+			$meta['status'] = 'ok';
+		}
 
-		return \OC_API::renderResult($this->format, $r->getMeta(), $r->getData());
+		return \OC_API::renderResult($this->format, $meta, $r->getData());
 	}
 
 	/**

--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -105,10 +105,12 @@ abstract class OCSController extends ApiController {
 			$params[$key] = $value;
 		}
 
+		$isV2 = substr($this->request->getScriptName(), -11) === '/ocs/v2.php';
+
 		$resp = new OCSResponse(
 			$format, $params['statuscode'],
 			$params['message'], $params['data'],
-			$params['itemscount'], $params['itemsperpage']
+			$params['itemscount'], $params['itemsperpage'], $isV2
 		);
 		if (isset($data['headers'])) {
 			foreach ($data['headers'] as $key => $value) {

--- a/tests/lib/AppFramework/Controller/OCSControllerTest.php
+++ b/tests/lib/AppFramework/Controller/OCSControllerTest.php
@@ -191,7 +191,7 @@ class OCSControllerTest extends TestCase {
 			$this->createMock(ISecureRandom::class),
 			$configMock
 		));
-		$expected = '{"ocs":{"meta":{"status":"failure","statuscode":200,"message":"OK",' .
+		$expected = '{"ocs":{"meta":{"status":"ok","statuscode":200,"message":"OK",' .
 		            '"totalitems":"","itemsperpage":""},"data":{"test":"hi"}}}';
 		$params = [
 			'data' => [


### PR DESCRIPTION
## Description
For OCS v2 calls the status text for status 200 has to be 'ok' not failure

## Related Issue
fixes https://github.com/owncloud/notifications/issues/103

## How Has This Been Tested?
Observe OCS responses in the notifications app

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

