### PR TITLE
PHP 7.2 is not supported yet

### DIFF
--- a/console.php
+++ b/console.php
@@ -41,6 +41,13 @@ if (version_compare(PHP_VERSION, '5.6.0') === -1) {
 	return;
 }
 
+// Show warning if PHP 7.2 is used as ownCloud is not compatible with PHP 7.2
+if (version_compare(PHP_VERSION, '7.2.0alpha1') !== -1) {
+	echo 'This version of ownCloud is not compatible with PHP 7.2' . PHP_EOL;
+	echo 'You are currently running ' . PHP_VERSION . '.' . PHP_EOL;
+	return;
+}
+
 // running oC on Windows is unsupported since 8.1, this has to happen here because
 // is seems that the autoloader on Windows fails later and just throws an exception.
 if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {

--- a/index.php
+++ b/index.php
@@ -35,6 +35,13 @@ if (version_compare(PHP_VERSION, '5.6.0') === -1) {
 	return;
 }
 
+// Show warning if PHP 7.2 is used as ownCloud is not compatible with PHP 7.2
+if (version_compare(PHP_VERSION, '7.2.0alpha1') !== -1) {
+	echo 'This version of ownCloud is not compatible with PHP 7.2<br/>';
+	echo 'You are currently running ' . PHP_VERSION . '.';
+	return;
+}
+
 // running oC on Windows is unsupported since 8.1, this has to happen here because
 // is seems that the autoloader on Windows fails later and just throws an exception.
 if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {


### PR DESCRIPTION
## Description
owncloud is not yet ready to be used with php 7.2

## Motivation and Context
protect users from failing ....

## How Has This Been Tested?
- install 7.2.0 (alpha or beta)
- run occ -> message is displayed
- run in browser -> message is displayed

## Screenshots (if appropriate):
![bildschirmfoto von 2017-08-03 14-53-35](https://user-images.githubusercontent.com/1005065/28922716-8df3a3c8-785b-11e7-9899-8948dc7c4d8b.png)
![bildschirmfoto von 2017-08-03 14-53-28](https://user-images.githubusercontent.com/1005065/28922717-8df6d69c-785b-11e7-94ce-5e30ac9a78ef.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

