### PR TITLE
Better support of read only config file

### DIFF
--- a/apps/files_trashbin/tests/ExpirationTest.php
+++ b/apps/files_trashbin/tests/ExpirationTest.php
@@ -223,7 +223,8 @@ class ExpirationTest extends \Test\TestCase {
 						'deleteUserValue',
 						'deleteAllUserValues',
 						'deleteAppFromAllUsers',
-						'getUsersForUserValue'
+						'getUsersForUserValue',
+						'isSystemConfigReadOnly'
 					]
 				)
 				->getMock()

--- a/apps/files_versions/tests/ExpirationTest.php
+++ b/apps/files_versions/tests/ExpirationTest.php
@@ -192,7 +192,8 @@ class ExpirationTest extends \Test\TestCase {
 						'deleteUserValue',
 						'deleteAllUserValues',
 						'deleteAppFromAllUsers',
-						'getUsersForUserValue'
+						'getUsersForUserValue',
+						'isSystemConfigReadOnly'
 					]
 				)
 				->getMock()

--- a/lib/base.php
+++ b/lib/base.php
@@ -237,7 +237,7 @@ class OC {
 
 		// Check if config is writable
 		$configFileWritable = is_writable($configFilePath);
-		if (!$configFileWritable && !OC_Helper::isReadOnlyConfigEnabled()
+		if (!$configFileWritable && !\OC::$server->getConfig()->isSystemConfigReadOnly()
 			|| !$configFileWritable && self::checkUpgrade(false)) {
 
 			$urlGenerator = \OC::$server->getURLGenerator();

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -31,7 +31,6 @@ namespace OC;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use OC\Cache\CappedMemoryCache;
 use OCP\IDBConnection;
-use OCP\PreConditionNotMetException;
 
 /**
  * Class to combine all the configuration options ownCloud offers
@@ -444,5 +443,16 @@ class AllConfig implements \OCP\IConfig {
 		$query->closeCursor();
 
 		return $userIDs;
+	}
+
+	/**
+	 * In some environments the system config file is readonly. Find out if this
+	 * is the case.
+	 *
+	 * @return boolean
+	 * @since 10.0.3
+	 */
+	public function isSystemConfigReadOnly() {
+		return $this->systemConfig->isReadOnly();
 	}
 }

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -105,6 +105,9 @@ class Config {
 	 *                       If value is null, the config key will be deleted
 	 */
 	public function setValues(array $configs) {
+		if ($this->isReadOnly()) {
+			throw new \Exception('Config file is read only.');
+		}
 		$needsUpdate = false;
 		foreach ($configs as $key => $value) {
 			if ($value !== null) {
@@ -127,6 +130,9 @@ class Config {
 	 * @param mixed $value value
 	 */
 	public function setValue($key, $value) {
+		if ($this->isReadOnly()) {
+			throw new \Exception('Config file is read only.');
+		}
 		if ($this->set($key, $value)) {
 			// Write changes
 			$this->writeData();
@@ -155,6 +161,9 @@ class Config {
 	 * @param string $key
 	 */
 	public function deleteKey($key) {
+		if ($this->isReadOnly()) {
+			throw new \Exception('Config file is read only.');
+		}
 		if ($this->delete($key)) {
 			// Write changes
 			$this->writeData();
@@ -271,6 +280,13 @@ class Config {
 			// But if that doesn't work, clear the whole cache.
 			\OC_Util::clearOpcodeCache();
 		}
+	}
+
+	public function isReadOnly() {
+		if (!$this->getValue('installed', false)) {
+			return false;
+		}
+		return $this->getValue('config_is_read_only', false);
 	}
 }
 

--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -157,4 +157,8 @@ class SystemConfig {
 
 		return $value;
 	}
+
+	public function isReadOnly() {
+		return $this->config->isReadOnly();
+	}
 }

--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -657,12 +657,4 @@ class OC_Helper {
 		return ['free' => $free, 'used' => $used, 'total' => $total, 'relative' => $relative];
 
 	}
-
-	/**
-	 * Returns whether the config file is set manually to read-only
-	 * @return bool
-	 */
-	public static function isReadOnlyConfigEnabled() {
-		return \OC::$server->getConfig()->getSystemValue('config_is_read_only', false);
-	}
 }

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -715,7 +715,7 @@ class OC_Util {
 		}
 
 		// Check if config folder is writable.
-		if(!OC_Helper::isReadOnlyConfigEnabled()) {
+		if(!\OC::$server->getConfig()->isSystemConfigReadOnly()) {
 			if (!is_writable(OC::$configDir) or !is_readable(OC::$configDir)) {
 				$errors[] = [
 					'error' => $l->t('Cannot write into "config" directory'),
@@ -726,19 +726,6 @@ class OC_Util {
 			}
 		}
 
-		// Check if there is a writable install folder.
-		if (OC_App::getInstallPath() === null
-			|| !is_writable(OC_App::getInstallPath())
-			|| !is_readable(OC_App::getInstallPath())
-		) {
-			$errors[] = [
-				'error' => $l->t('Cannot write into "apps" directory'),
-				'hint' => $l->t('This can usually be fixed by '
-					. '%sgiving the webserver write access to the apps directory%s'
-					. ' or disabling the appstore in the config file.',
-					['<a href="' . $urlGenerator->linkToDocs('admin-dir_permissions') . '" target="_blank" rel="noreferrer">', '</a>'])
-			];
-		}
 		// Create root dir.
 		if ($config->getSystemValue('installed', false)) {
 			if (!is_dir($CONFIG_DATADIRECTORY)) {

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -223,4 +223,13 @@ interface IConfig {
 	 * @since 8.0.0
 	 */
 	public function getUsersForUserValue($appName, $key, $value);
+
+	/**
+	 * In some environments the system config file is readonly. Find out if this
+	 * is the case.
+	 *
+	 * @return boolean
+	 * @since 10.0.3
+	 */
+	public function isSystemConfigReadOnly();
 }

--- a/settings/Panels/Admin/Mail.php
+++ b/settings/Panels/Admin/Mail.php
@@ -46,6 +46,7 @@ class Mail implements ISettings {
 	public function getPanel() {
 		$template = new Template('settings', 'panels/admin/mail');
 		// Should we display sendmail as an option?
+		$template->assign('read-only', $this->config->isSystemConfigReadOnly());
 		$template->assign('sendmail_is_available', $this->helper->findBinaryPath('sendmail'));
 		$template->assign('loglevel', $this->config->getSystemValue("loglevel", 2));
 		$template->assign('mail_domain', $this->config->getSystemValue("mail_domain", ''));

--- a/settings/Panels/Admin/SecurityWarning.php
+++ b/settings/Panels/Admin/SecurityWarning.php
@@ -68,7 +68,7 @@ class SecurityWarning implements ISettings {
 		// warn if php is not setup properly to get system variables with getenv
 		$path = getenv('PATH');
 		$template->assign('getenvServerNotWorking', empty($path));
-		$template->assign('readOnlyConfigEnabled', $this->helper->isReadOnlyConfigEnabled());
+		$template->assign('readOnlyConfigEnabled', $this->config->isSystemConfigReadOnly());
 		$template->assign('isAnnotationsWorking', $this->helper->isAnnotationsWorking());
 		try {
 			if ($this->dbconnection->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\SqlitePlatform) {

--- a/settings/Panels/Helper.php
+++ b/settings/Panels/Helper.php
@@ -47,10 +47,6 @@ class Helper  {
 		return (bool) \OC_Helper::findBinaryPath($path);
 	}
 
-	public function isReadOnlyConfigEnabled() {
-		return \OC_Helper::isReadOnlyConfigEnabled();
-	}
-
 	public function isAnnotationsWorking() {
 		return \OC_Util::isAnnotationsWorking();
 	}

--- a/settings/templates/panels/admin/mail.php
+++ b/settings/templates/panels/admin/mail.php
@@ -22,87 +22,94 @@ if ($_['mail_smtpmode'] == 'qmail') {
 	$mail_smtpmode[] = 'qmail';
 }
 ?><div class="section">
-	<form id="mail_general_settings_form" class="mail_settings">
-		<h2 class="app-name has-documentation"><?php p($l->t('Email server'));?></h2>
-		<a target="_blank" rel="noreferrer" class="icon-info"
-			title="<?php p($l->t('Open documentation'));?>"
-			href="<?php p(link_to_docs('admin-email')); ?>"></a>
-
-		<p><?php p($l->t('This is used for sending out notifications.')); ?> <span id="mail_settings_msg" class="msg"></span></p>
-
+	<h2 class="app-name has-documentation"><?php p($l->t('Email server'));?></h2>
+	<a target="_blank" rel="noreferrer" class="icon-info"
+	   title="<?php p($l->t('Open documentation'));?>"
+	   href="<?php p(link_to_docs('admin-email')); ?>"></a>
+	<?php if ($_['read-only']) : ?>
 		<p>
-			<label for="mail_smtpmode"><?php p($l->t( 'Send mode' )); ?></label>
-			<select name='mail_smtpmode' id='mail_smtpmode'>
-				<?php foreach ($mail_smtpmode as $smtpmode):
-					$selected = '';
-					if ($smtpmode == $_['mail_smtpmode']):
-						$selected = 'selected="selected"';
-					endif; ?>
-					<option value='<?php p($smtpmode)?>' <?php p($selected) ?>><?php p($smtpmode) ?></option>
-				<?php endforeach;?>
-			</select>
-
-			<label id="mail_smtpsecure_label" for="mail_smtpsecure"
-				   <?php if ($_['mail_smtpmode'] != 'smtp') print_unescaped(' class="hidden"'); ?>>
-				<?php p($l->t( 'Encryption' )); ?>
-			</label>
-			<select name="mail_smtpsecure" id="mail_smtpsecure"
-					<?php if ($_['mail_smtpmode'] != 'smtp') print_unescaped(' class="hidden"'); ?>>
-				<?php foreach ($mail_smtpsecure as $secure => $name):
-					$selected = '';
-					if ($secure == $_['mail_smtpsecure']):
-						$selected = 'selected="selected"';
-					endif; ?>
-					<option value='<?php p($secure)?>' <?php p($selected) ?>><?php p($name) ?></option>
-				<?php endforeach;?>
-			</select>
+			<?php p($l->t('The config file is read only. Please adjust your setup by editing the config file manually.')); ?>
+			<br>
+			<?php p($l->t('In a clustered setup please make sure to sync the config.php file across all nodes.')); ?>
 		</p>
+	<?php else :?>
+		<form id="mail_general_settings_form" class="mail_settings">
 
-		<p>
-			<label for="mail_from_address"><?php p($l->t( 'From address' )); ?></label>
-			<input type="text" name='mail_from_address' id="mail_from_address" placeholder="<?php p($l->t('mail'))?>"
-				   value='<?php p($_['mail_from_address']) ?>' />@
-			<input type="text" name='mail_domain' id="mail_domain" placeholder="example.com"
-				   value='<?php p($_['mail_domain']) ?>' />
-		</p>
+			<p><?php p($l->t('This is used for sending out notifications.')); ?> <span id="mail_settings_msg" class="msg"></span></p>
 
-		<p id="setting_smtpauth" <?php if ($_['mail_smtpmode'] != 'smtp') print_unescaped(' class="hidden"'); ?>>
-			<label for="mail_smtpauthtype"><?php p($l->t( 'Authentication method' )); ?></label>
-			<select name='mail_smtpauthtype' id='mail_smtpauthtype'>
-				<?php foreach ($mail_smtpauthtype as $authtype => $name):
-					$selected = '';
-					if ($authtype == $_['mail_smtpauthtype']):
-						$selected = 'selected="selected"';
-					endif; ?>
-					<option value='<?php p($authtype)?>' <?php p($selected) ?>><?php p($name) ?></option>
-				<?php endforeach;?>
-			</select>
+			<p>
+				<label for="mail_smtpmode"><?php p($l->t( 'Send mode' )); ?></label>
+				<select name='mail_smtpmode' id='mail_smtpmode'>
+					<?php foreach ($mail_smtpmode as $smtpmode):
+						$selected = '';
+						if ($smtpmode == $_['mail_smtpmode']):
+							$selected = 'selected="selected"';
+						endif; ?>
+						<option value='<?php p($smtpmode)?>' <?php p($selected) ?>><?php p($smtpmode) ?></option>
+					<?php endforeach;?>
+				</select>
 
-			<input type="checkbox" name="mail_smtpauth" id="mail_smtpauth" class="checkbox" value="1"
-				   <?php if ($_['mail_smtpauth']) print_unescaped('checked="checked"'); ?> />
-			<label for="mail_smtpauth"><?php p($l->t( 'Authentication required' )); ?></label>
-		</p>
+				<label id="mail_smtpsecure_label" for="mail_smtpsecure"
+					   <?php if ($_['mail_smtpmode'] != 'smtp') print_unescaped(' class="hidden"'); ?>>
+					<?php p($l->t( 'Encryption' )); ?>
+				</label>
+				<select name="mail_smtpsecure" id="mail_smtpsecure"
+						<?php if ($_['mail_smtpmode'] != 'smtp') print_unescaped(' class="hidden"'); ?>>
+					<?php foreach ($mail_smtpsecure as $secure => $name):
+						$selected = '';
+						if ($secure == $_['mail_smtpsecure']):
+							$selected = 'selected="selected"';
+						endif; ?>
+						<option value='<?php p($secure)?>' <?php p($selected) ?>><?php p($name) ?></option>
+					<?php endforeach;?>
+				</select>
+			</p>
 
-		<p id="setting_smtphost" <?php if ($_['mail_smtpmode'] != 'smtp') print_unescaped(' class="hidden"'); ?>>
-			<label for="mail_smtphost"><?php p($l->t( 'Server address' )); ?></label>
-			<input type="text" name='mail_smtphost' id="mail_smtphost" placeholder="smtp.example.com"
-				   value='<?php p($_['mail_smtphost']) ?>' />
-			:
-			<input type="text" name='mail_smtpport' id="mail_smtpport" placeholder="<?php p($l->t('Port'))?>"
-				   value='<?php p($_['mail_smtpport']) ?>' />
-		</p>
-	</form>
-	<form class="mail_settings" id="mail_credentials_settings">
-		<p id="mail_credentials" <?php if (!$_['mail_smtpauth'] || $_['mail_smtpmode'] != 'smtp') print_unescaped(' class="hidden"'); ?>>
-			<label for="mail_smtpname"><?php p($l->t( 'Credentials' )); ?></label>
-			<input type="text" name='mail_smtpname' id="mail_smtpname" placeholder="<?php p($l->t('SMTP Username'))?>"
-				   value='<?php p($_['mail_smtpname']) ?>' />
-			<input type="password" name='mail_smtppassword' id="mail_smtppassword" autocomplete="off"
-				   placeholder="<?php p($l->t('SMTP Password'))?>" value='<?php p($_['mail_smtppassword']) ?>' />
-			<input id="mail_credentials_settings_submit" type="button" value="<?php p($l->t('Store credentials')) ?>">
-		</p>
-	</form>
+			<p>
+				<label for="mail_from_address"><?php p($l->t( 'From address' )); ?></label>
+				<input type="text" name='mail_from_address' id="mail_from_address" placeholder="<?php p($l->t('mail'))?>"
+					   value='<?php p($_['mail_from_address']) ?>' />@
+				<input type="text" name='mail_domain' id="mail_domain" placeholder="example.com"
+					   value='<?php p($_['mail_domain']) ?>' />
+			</p>
 
+			<p id="setting_smtpauth" <?php if ($_['mail_smtpmode'] != 'smtp') print_unescaped(' class="hidden"'); ?>>
+				<label for="mail_smtpauthtype"><?php p($l->t( 'Authentication method' )); ?></label>
+				<select name='mail_smtpauthtype' id='mail_smtpauthtype'>
+					<?php foreach ($mail_smtpauthtype as $authtype => $name):
+						$selected = '';
+						if ($authtype == $_['mail_smtpauthtype']):
+							$selected = 'selected="selected"';
+						endif; ?>
+						<option value='<?php p($authtype)?>' <?php p($selected) ?>><?php p($name) ?></option>
+					<?php endforeach;?>
+				</select>
+
+				<input type="checkbox" name="mail_smtpauth" id="mail_smtpauth" class="checkbox" value="1"
+					   <?php if ($_['mail_smtpauth']) print_unescaped('checked="checked"'); ?> />
+				<label for="mail_smtpauth"><?php p($l->t( 'Authentication required' )); ?></label>
+			</p>
+
+			<p id="setting_smtphost" <?php if ($_['mail_smtpmode'] != 'smtp') print_unescaped(' class="hidden"'); ?>>
+				<label for="mail_smtphost"><?php p($l->t( 'Server address' )); ?></label>
+				<input type="text" name='mail_smtphost' id="mail_smtphost" placeholder="smtp.example.com"
+					   value='<?php p($_['mail_smtphost']) ?>' />
+				:
+				<input type="text" name='mail_smtpport' id="mail_smtpport" placeholder="<?php p($l->t('Port'))?>"
+					   value='<?php p($_['mail_smtpport']) ?>' />
+			</p>
+		</form>
+		<form class="mail_settings" id="mail_credentials_settings">
+			<p id="mail_credentials" <?php if (!$_['mail_smtpauth'] || $_['mail_smtpmode'] != 'smtp') print_unescaped(' class="hidden"'); ?>>
+				<label for="mail_smtpname"><?php p($l->t( 'Credentials' )); ?></label>
+				<input type="text" name='mail_smtpname' id="mail_smtpname" placeholder="<?php p($l->t('SMTP Username'))?>"
+					   value='<?php p($_['mail_smtpname']) ?>' />
+				<input type="password" name='mail_smtppassword' id="mail_smtppassword" autocomplete="off"
+					   placeholder="<?php p($l->t('SMTP Password'))?>" value='<?php p($_['mail_smtppassword']) ?>' />
+				<input id="mail_credentials_settings_submit" type="button" value="<?php p($l->t('Store credentials')) ?>">
+			</p>
+		</form>
+	<?php endif; ?>
 	<br />
 	<em><?php p($l->t( 'Test email settings' )); ?></em>
 	<input type="submit" name="sendtestemail" id="sendtestemail" value="<?php p($l->t( 'Send email' )); ?>"/>


### PR DESCRIPTION
## Description
This change adds a better support and handling of a read only config file

## Motivation and Context
We need to support clustered setups better - in these setups the config file is not writable

## How Has This Been Tested?
- add 'config_is_read_only' => true to config.php
- see the changed mail settings section

## Screenshots (if appropriate):
![bildschirmfoto von 2017-08-03 17-23-32](https://user-images.githubusercontent.com/1005065/28929564-8ffc7e00-7870-11e7-81e1-9b512fb41575.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

