### PR TITLE
Add occ command dav:cleanup-chunks to remove all upload folders which…

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -26,5 +26,6 @@
 		<command>OCA\DAV\Command\CreateCalendar</command>
 		<command>OCA\DAV\Command\SyncBirthdayCalendar</command>
 		<command>OCA\DAV\Command\SyncSystemAddressBook</command>
+		<command>OCA\DAV\Command\CleanupChunks</command>
 	</commands>
 </info>

--- a/apps/dav/lib/Command/CleanupChunks.php
+++ b/apps/dav/lib/Command/CleanupChunks.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\Command;
+
+use OCA\DAV\Upload\UploadFolder;
+use OCA\DAV\Upload\UploadHome;
+use OCP\IUser;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CleanupChunks extends Command {
+
+	/** @var IUserManager */
+	protected $userManager;
+
+	/**
+	 * @param IUserManager $userManager
+	 */
+	function __construct(IUserManager $userManager) {
+		parent::__construct();
+		$this->userManager = $userManager;
+	}
+
+	protected function configure() {
+		$this
+			->setName('dav:cleanup-chunks')
+			->setDescription('Cleanup outdated chunks')
+			->addArgument('age-in-days', InputArgument::OPTIONAL,
+				'age of uploads in days - minimum 2 days - maximum 100',
+				2);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$d = $input->getArgument('age-in-days');
+		$d = max(2, min($d, 100));
+		$cutOffTime = new \DateTime("$d days ago");
+		$output->writeln("Cleaning chunks older than $d days({$cutOffTime->format('c')})");
+		$this->userManager->callForSeenUsers(function (IUser $user) use ($output, $cutOffTime) {
+			$output->writeln("Cleaning chunks for {$user->getUID()}");
+			\OC_Util::tearDownFS();
+			\OC_Util::setupFS($user->getUID());
+
+			$home = new UploadHome(['user' => $user]);
+			$uploads = $home->getChildren();
+
+			$p = new ProgressBar($output);
+			$p->start(count($uploads));
+			foreach ($uploads as $upload) {
+				$p->advance();
+				/** @var UploadFolder $upload */
+				if ($upload->getLastModified() < $cutOffTime->getTimestamp()) {
+					$upload->delete();
+				}
+			}
+
+			$p->finish();
+			$output->writeln('');
+
+		});
+	}
+}

--- a/apps/dav/lib/Upload/UploadHome.php
+++ b/apps/dav/lib/Upload/UploadHome.php
@@ -29,6 +29,8 @@ use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\ICollection;
 
 class UploadHome implements ICollection {
+	private $principalInfo;
+
 	/**
 	 * UploadHome constructor.
 	 *
@@ -81,7 +83,11 @@ class UploadHome implements ICollection {
 	 */
 	private function impl() {
 		$rootView = new View();
-		$user = \OC::$server->getUserSession()->getUser();
+		if (isset($this->principalInfo['user'])) {
+			$user = $this->principalInfo['user'];
+		} else {
+			$user = \OC::$server->getUserSession()->getUser();
+		}
 		Filesystem::initMountPoints($user->getUID());
 		if (!$rootView->file_exists('/' . $user->getUID() . '/uploads')) {
 			$rootView->mkdir('/' . $user->getUID() . '/uploads');

--- a/apps/dav/tests/unit/Command/CleanupChunksTest.php
+++ b/apps/dav/tests/unit/Command/CleanupChunksTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\DAV\Tests\Unit\Command;
+
+
+use OC\Files\View;
+use OCA\DAV\Command\CleanupChunks;
+use OCP\IUser;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+use Test\Traits\UserTrait;
+
+/**
+ * Class CleanupChunksTest
+ *
+ * @package OCA\DAV\Tests\Unit\Command
+ * @group DB
+ */
+class CleanupChunksTest extends TestCase {
+	use UserTrait;
+
+	/** @var CommandTester */
+	private $commandTester;
+	/** @var IUser */
+	private $user;
+
+	public function setUp() {
+		parent::setUp();
+
+		$command = new CleanupChunks(\OC::$server->getUserManager());
+		$this->commandTester = new CommandTester($command);
+	}
+
+	/**
+	 * @dataProvider providesDays
+	 * @param $inputDays
+	 * @param $expectedDays
+	 */
+	public function testCommandInput($inputDays, $expectedDays) {
+		$this->commandTester->execute([
+			'age-in-days' => $inputDays
+		]);
+		$output = $this->commandTester->getDisplay();
+		$this->assertContains("Cleaning chunks older than $expectedDays days", $output);
+	}
+
+	public function testCommand() {
+		$userId = 'dav-clean-chunks-user';
+		$uploadId = $this->getUniqueID('upload');
+		// create one user for testing
+		$this->user = $this->createUser($userId);
+		$this->loginAsUser($this->user->getUID());
+
+		// generate old chunks
+		$view = new View("/$userId/uploads");
+		$view->mkdir($uploadId);
+		$this->assertTrue($view->file_exists($uploadId));
+		$view->touch($uploadId, 0);
+
+		$this->commandTester->execute([]);
+		$output = $this->commandTester->getDisplay();
+		$this->assertContains("Cleaning chunks older than 2 days", $output);
+		$this->assertContains("Cleaning chunks for $userId", $output);
+
+		$this->assertFalse($view->file_exists($uploadId));
+	}
+
+	public function providesDays() {
+		return [
+			[0, 2],
+			[55, 55],
+			[200, 100],
+		];
+	}
+}


### PR DESCRIPTION
… are older then 2 days 

## Description


## Related Issue
fixes #26981

## How Has This Been Tested?
- create an upload folder via dav
- set the mtime in database to an older value then 2 days ago
- run the command
- see the foller being killed

## Screenshots (if appropriate):
![bildschirmfoto von 2017-08-04 16-27-00](https://user-images.githubusercontent.com/1005065/28972915-c87da828-7931-11e7-811d-71c8ffdb2e33.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

