### PR TITLE
Detect PROPPATCH failure by parsing multistatus

### DIFF
--- a/core/js/oc-backbone-webdav.js
+++ b/core/js/oc-backbone-webdav.js
@@ -185,6 +185,16 @@
 			convertModelAttributesToDavProperties(model.changed, options.davProperties),
 			headers
 		).then(function(result) {
+			if (result.status === 207 && result.body && result.body.length > 0) {
+				if (_.find(result.body[0].propStat, function(propStat) {
+					var statusCode = parseInt(propStat.status.split(' ')[1], 10);
+					return statusCode >= 400;
+				})) {
+					// in REST, validation errors are usually represented with 422 Unprocessable Entity,
+					result.status = 422;
+				}
+			}
+
 			if (isSuccessStatus(result.status)) {
 				if (_.isFunction(options.success)) {
 					// pass the object's own values because the server


### PR DESCRIPTION
## Description
PROPPATCH might fail but the HTTP status is still 207.
Need to check the propstat of the response to find the actual error
codes.
If an error is found, it now called the error callback instead with 422 Unprocessable Entity to match the way how REST is done for server side validation errors.

## Related Issue
None raised. This will be required.

## Motivation and Context
We need to be able to properly catch PROPPATCH issues.
So far I thought PROPPATCH would have a 4xx status code but it turns out it still returns 207 and the 4xx statuses are embedded in the propstat block. (at least that's what Sabre does)

## How Has This Been Tested?
- [x] Manual testing.
- [x] Unit tests
- [x] with https://github.com/owncloud/customgroups/pull/82 which depends on this

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

