### PR TITLE
[stable10] Proper message shown when private links accessed

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -281,9 +281,12 @@ class ViewController extends Controller {
 		$params = [];
 
 		if (empty($files) && $this->appManager->isEnabledForUser('files_trashbin')) {
-			$baseFolder = $this->rootFolder->get($uid . '/files_trashbin/files/');
-			$files = $baseFolder->getById($fileId);
-			$params['view'] = 'trashbin';
+			// Access files_trashbin if it exists
+			if ( $this->rootFolder->nodeExists($uid . '/files_trashbin/files/')) {
+				$baseFolder = $this->rootFolder->get($uid . '/files_trashbin/files/');
+				$files = $baseFolder->getById($fileId);
+				$params['view'] = 'trashbin';
+			}
 		}
 
 		if (!empty($files)) {
@@ -298,6 +301,11 @@ class ViewController extends Controller {
 				$params['scrollto'] = $file->getName();
 			}
 			return new RedirectResponse($this->urlGenerator->linkToRoute('files.view.index', $params));
+		}
+
+		if ( $this->userSession->isLoggedIn() and empty($files)) {
+			$param["error"] = $this->l10n->t("You don't have permissions to access this file/folder - Please contact the owner to share it with you.");
+			return new TemplateResponse("core", 'error', ["errors" => [$param]], 'guest');
 		}
 		throw new \OCP\Files\NotFoundException();
 	}

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -428,6 +428,10 @@ class ViewControllerTest extends TestCase {
 			->with('files_trashbin')
 			->will($this->returnValue(true));
 
+		$this->rootFolder->expects($this->once())
+			->method('nodeExists')
+			->will($this->returnValue(true));
+
 		$parentNode = $this->createMock('\OCP\Files\Folder');
 		$parentNode->expects($this->once())
 			->method('getPath')
@@ -440,7 +444,8 @@ class ViewControllerTest extends TestCase {
 			->method('get')
 			->with('testuser1/files/')
 			->will($this->returnValue($baseFolderFiles));
-		$this->rootFolder->expects($this->at(1))
+		//The index is pointing to 2, because nodeExists internally calls get method.
+		$this->rootFolder->expects($this->at(2))
 			->method('get')
 			->with('testuser1/files_trashbin/files/')
 			->will($this->returnValue($baseFolderTrash));

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -165,6 +165,21 @@ class LoginController extends Controller {
 			$parameters['user_autofocus'] = true;
 		}
 
+		/**
+		 * If redirect_url is not empty and remember_login is null and
+		 * user not logged in and check if the string
+		 * webroot+"/index.php/f/" is in redirect_url then
+		 * user is trying to access files for which he needs to login.
+		 */
+
+		if ((!empty($redirect_url)) and ($remember_login === null) and
+			($this->userSession->isLoggedIn() === false) and
+			(strpos($this->urlGenerator->getAbsoluteURL(urldecode($redirect_url)),
+					$this->urlGenerator->getAbsoluteURL('/index.php/f/')) !== false)) {
+
+				$parameters['accessLink'] = true;
+		}
+
 		return new TemplateResponse(
 			$this->appName, 'login', $parameters, 'guest'
 		);

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -66,6 +66,11 @@ script('core', [
 				<?php p($l->t('Wrong password.')); ?>
 			</p>
 		<?php } ?>
+		<?php if (!empty($_['accessLink'])) { ?>
+			<p class="warning">
+				<?php p($l->t("You are trying to access a private link. Please log in first.")) ?>
+			</p>
+		<?php } ?>
 		<?php if ($_['rememberLoginAllowed'] === true) : ?>
 		<div class="remember-login-container">
 			<?php if ($_['rememberLoginState'] === 0) { ?>

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -136,6 +136,23 @@ class LoginControllerTest extends TestCase {
 		$this->assertEquals($expectedResponse, $this->loginController->showLoginForm('', '', ''));
 	}
 
+	public function testResponseForNotLoggedinUser() {
+		$params = [
+			'messages' => Array (),
+			'loginName' => '',
+			'user_autofocus' => true,
+			'redirect_url' => '%2Findex.php%2Ff%2F17',
+			'canResetPassword' => true,
+			'resetPasswordLink' => null,
+			'alt_login' => Array (),
+			'rememberLoginAllowed' => false,
+			'rememberLoginState' => 0
+		];
+
+		$expectedResponse = new TemplateResponse('core', 'login', $params, 'guest');
+		$this->assertEquals($expectedResponse, $this->loginController->showLoginForm('', '%2Findex.php%2Ff%2F17', ''));
+	}
+
 	public function testShowLoginFormWithErrorsInSession() {
 		$this->userSession
 			->expects($this->once())


### PR DESCRIPTION
When user tries to access private links which are
not accessible, then proper message is delivered
instead of Internal server error message. So is the
case when user is logged in and tries to access
private links not accessible.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
This change addresses 2 causes:

1. When user logged in and tries to access private link which is not accessible. Instead of internal server error, now it shows up a message.
2. When user is not logged in and tries to access link which is not accessible

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change tries to polish up the message to be shown when non accessible private links are accessed by user under: logged in and non logged in state respectively.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created folder private which is accessed by another user under logged in and non logged in states. The messages are displayed on the browser.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of thiThis change addresses 2 causes:

When user logged in and tries to access private link which is not accessible. Instead of internal server error, now it shows up a message.
When user is not logged in and tries to access link which is not accessibles project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

