### PR TITLE
Save and restore skeleton dir for integration and UI tests

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -73,6 +73,7 @@ export TEST_SERVER_URL="http://localhost:$PORT/ocs/"
 export TEST_SERVER_FED_URL="http://localhost:$PORT_FED/ocs/"
 
 #Set up personalized skeleton
+PREVIOUS_SKELETON_DIR=$($OCC config:system:get skeletondirectory)
 $OCC config:system:set skeletondirectory --value="$(pwd)/skeleton"
 
 #Enable external storage app
@@ -133,6 +134,12 @@ $OCC config:app:set core enable_external_storage --value=no
 
 $OCC app:disable testing
 
+# Put back personalized skeleton
+if test "A$PREVIOUS_SKELETON_DIR" = "A"; then
+	$OCC config:system:delete skeletondirectory
+else
+	$OCC config:system:set skeletondirectory --value="$PREVIOUS_SKELETON_DIR"
+fi
 
 # Clear storage folder
 rm -Rf work/local_storage/*

--- a/tests/preseed-config.php
+++ b/tests/preseed-config.php
@@ -21,7 +21,3 @@ if (is_dir(OC::$SERVERROOT.'/apps2')) {
 if (substr(strtolower(PHP_OS), 0, 3) === 'win') {
 	$CONFIG['openssl'] = ['config' => OC::$SERVERROOT . '/tests/data/openssl.cnf'];
 }
-
-if (getenv("TC") === "selenium") {
-	$CONFIG['skeletondirectory'] = OC::$SERVERROOT . '/tests/ui/skeleton';
-}

--- a/tests/travis/start_behat_tests.sh
+++ b/tests/travis/start_behat_tests.sh
@@ -132,6 +132,11 @@ fi
 
 EXTRA_CAPABILITIES=$EXTRA_CAPABILITIES'"maxDuration":"3600"'
 
+#Set up personalized skeleton
+OCC=./occ
+PREVIOUS_SKELETON_DIR=$($OCC config:system:get skeletondirectory)
+$OCC config:system:set skeletondirectory --value="$(pwd)/tests/ui/skeleton" >/dev/null
+
 echo "Running tests on '$BROWSER' ($BROWSER_VERSION) on $PLATFORM"
 export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"browser_name": "'$BROWSER'", "base_url" : "'$BASE_URL'", "selenium2":{"capabilities": {"browser": "'$BROWSER'", "version": "'$BROWSER_VERSION'", "platform": "'$PLATFORM'", "name": "'$TRAVIS_REPO_SLUG' - '$TRAVIS_JOB_NUMBER'", "extra_capabilities": {'$EXTRA_CAPABILITIES'}}, "wd_host":"http://'$SAUCE_USERNAME:$SAUCE_ACCESS_KEY'@localhost:4445/wd/hub"}}}}' 
 export IPV4_URL
@@ -163,6 +168,13 @@ then
 		cat "$DRY_RUN_FILE"
 	fi
 	rm -f "$DRY_RUN_FILE"
+fi
+
+# Put back personalized skeleton
+if test "A$PREVIOUS_SKELETON_DIR" = "A"; then
+	$OCC config:system:delete skeletondirectory >/dev/null
+else
+	$OCC config:system:set skeletondirectory --value="$PREVIOUS_SKELETON_DIR" >/dev/null
 fi
 
 if [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && [ -e /tmp/saucelabs_sessionid ]


### PR DESCRIPTION
## Description
When starting integration or UI tests, remember the previous value of skeletondirectory
At the end, out it back
Remove the now-unneeded setting of skeletondirectory in preseed-config.php

## Related Issue
#28602 
## Motivation and Context
Make life easier for development manual runs of integration and UI tests

## How Has This Been Tested?
1. Set skeletondirectory to some "random" string
2. Run some UI tests - make sure they work
3. Check that skeletondirectory keeps its value
4. Run some integration tests - make sure they work
5. Check that skeletondirectory keeps its value

Repeat with skeletondirectory undefined, make sure it stays undefined after each test run.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

