### PR TITLE
Get rid of l10n create function

### DIFF
--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -25,6 +25,7 @@
 
 namespace OCA\Files\Tests\Controller;
 
+use OC\L10N\L10NString;
 use OCA\Files\Controller\ViewController;
 use OCP\AppFramework\Http;
 use OCP\IUser;
@@ -185,7 +186,7 @@ class ViewControllerTest extends TestCase {
 				'appname' => 'files',
 				'script' => 'list.php',
 				'order' => 0,
-				'name' => new \OC_L10N_String(\OC::$server->getL10NFactory()->get('files'), 'All files', []),
+				'name' => new L10NString(\OC::$server->getL10NFactory()->get('files'), 'All files', []),
 				'active' => false,
 				'icon' => '',
 			],
@@ -203,7 +204,7 @@ class ViewControllerTest extends TestCase {
 				'appname' => 'files_sharing',
 				'script' => 'list.php',
 				'order' => 10,
-				'name' => new \OC_L10N_String(\OC::$server->getL10NFactory()->get('files_sharing'), 'Shared with you', []),
+				'name' => new L10NString(\OC::$server->getL10NFactory()->get('files_sharing'), 'Shared with you', []),
 				'active' => false,
 				'icon' => '',
 			],
@@ -212,7 +213,7 @@ class ViewControllerTest extends TestCase {
 				'appname' => 'files_sharing',
 				'script' => 'list.php',
 				'order' => 15,
-				'name' => new \OC_L10N_String(\OC::$server->getL10NFactory()->get('files_sharing'), 'Shared with others', []),
+				'name' => new L10NString(\OC::$server->getL10NFactory()->get('files_sharing'), 'Shared with others', []),
 				'active' => false,
 				'icon' => '',
 			],
@@ -221,7 +222,7 @@ class ViewControllerTest extends TestCase {
 				'appname' => 'files_sharing',
 				'script' => 'list.php',
 				'order' => 20,
-				'name' => new \OC_L10N_String(\OC::$server->getL10NFactory()->get('files_sharing'), 'Shared by link', []),
+				'name' => new L10NString(\OC::$server->getL10NFactory()->get('files_sharing'), 'Shared by link', []),
 				'active' => false,
 				'icon' => '',
 			],
@@ -230,7 +231,7 @@ class ViewControllerTest extends TestCase {
 				'appname' => 'systemtags',
 				'script' => 'list.php',
 				'order' => 25,
-				'name' => new \OC_L10N_String(\OC::$server->getL10NFactory()->get('systemtags'), 'Tags', []),
+				'name' => new L10NString(\OC::$server->getL10NFactory()->get('systemtags'), 'Tags', []),
 				'active' => false,
 				'icon' => '',
 			],
@@ -239,7 +240,7 @@ class ViewControllerTest extends TestCase {
 				'appname' => 'files_trashbin',
 				'script' => 'list.php',
 				'order' => 50,
-				'name' => new \OC_L10N_String(\OC::$server->getL10NFactory()->get('files_trashbin'), 'Deleted files', []),
+				'name' => new L10NString(\OC::$server->getL10NFactory()->get('files_trashbin'), 'Deleted files', []),
 				'active' => false,
 				'icon' => '',
 			],

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -325,67 +325,14 @@ class Factory implements IFactory {
 		return $this->serverRoot . '/core/l10n/';
 	}
 
-
 	/**
 	 * Creates a function from the plural string
 	 *
-	 * Parts of the code is copied from Habari:
-	 * https://github.com/habari/system/blob/master/classes/locale.php
 	 * @param string $string
-	 * @return string
+	 * @return string Unique function name
+	 * @since 9.0.0
 	 */
 	public function createPluralFunction($string) {
-		if (isset($this->pluralFunctions[$string])) {
-			return $this->pluralFunctions[$string];
-		}
-
-		if (preg_match( '/^\s*nplurals\s*=\s*(\d+)\s*;\s*plural=(.*)$/u', $string, $matches)) {
-			// sanitize
-			$nplurals = preg_replace( '/[^0-9]/', '', $matches[1] );
-			$plural = preg_replace( '#[^n0-9:\(\)\?\|\&=!<>+*/\%-]#', '', $matches[2] );
-
-			$body = str_replace(
-				['plural', 'n', '$n$plurals',],
-				['$plural', '$n', '$nplurals',],
-				'nplurals='. $nplurals . '; plural=' . $plural
-			);
-
-			// add parents
-			// important since PHP's ternary evaluates from left to right
-			$body .= ';';
-			$res = '';
-			$p = 0;
-			for($i = 0; $i < strlen($body); $i++) {
-				$ch = $body[$i];
-				switch ( $ch ) {
-					case '?':
-						$res .= ' ? (';
-						$p++;
-						break;
-					case ':':
-						$res .= ') : (';
-						break;
-					case ';':
-						$res .= str_repeat( ')', $p ) . ';';
-						$p = 0;
-						break;
-					default:
-						$res .= $ch;
-				}
-			}
-
-			$body = $res . 'return ($plural>=$nplurals?$nplurals-1:$plural);';
-			$function = create_function('$n', $body);
-			$this->pluralFunctions[$string] = $function;
-			return $function;
-		} else {
-			// default: one plural form for all cases but n==1 (english)
-			$function = create_function(
-				'$n',
-				'$nplurals=2;$plural=($n==1?0:1);return ($plural>=$nplurals?$nplurals-1:$plural);'
-			);
-			$this->pluralFunctions[$string] = $function;
-			return $function;
-		}
+		return '';
 	}
 }

--- a/lib/private/L10N/L10N.php
+++ b/lib/private/L10N/L10N.php
@@ -77,7 +77,7 @@ class L10N implements IL10N {
 	 * returned.
 	 */
 	public function t($text, $parameters = []) {
-		return (string) new \OC_L10N_String($this, $text, $parameters);
+		return (string) new L10NString($this, $text, $parameters);
 	}
 
 	/**
@@ -98,12 +98,12 @@ class L10N implements IL10N {
 	public function n($text_singular, $text_plural, $count, $parameters = []) {
 		$identifier = "_${text_singular}_::_${text_plural}_";
 		if (isset($this->translations[$identifier])) {
-			return (string) new \OC_L10N_String($this, $identifier, $parameters, $count);
+			return (string) new L10NString($this, $identifier, $parameters, $count);
 		} else {
 			if ($count === 1) {
-				return (string) new \OC_L10N_String($this, $text_singular, $parameters, $count);
+				return (string) new L10NString($this, $text_singular, $parameters, $count);
 			} else {
-				return (string) new \OC_L10N_String($this, $text_plural, $parameters, $count);
+				return (string) new L10NString($this, $text_plural, $parameters, $count);
 			}
 		}
 	}
@@ -171,7 +171,7 @@ class L10N implements IL10N {
 	/**
 	 * Returns an associative array with all translations
 	 *
-	 * Called by \OC_L10N_String
+	 * Called by String
 	 * @return array
 	 */
 	public function getTranslations() {

--- a/lib/private/L10N/L10N.php
+++ b/lib/private/L10N/L10N.php
@@ -25,6 +25,7 @@ namespace OC\L10N;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use Punic\Calendar;
+use Symfony\Component\Translation\PluralizationRules;
 
 class L10N implements IL10N {
 
@@ -36,12 +37,6 @@ class L10N implements IL10N {
 
 	/** @var string Language of this object */
 	protected $lang;
-
-	/** @var string Plural forms (string) */
-	private $pluralFormString = 'nplurals=2; plural=(n != 1);';
-
-	/** @var string Plural forms (function) */
-	private $pluralFormFunction = null;
 
 	/** @var string[] */
 	private $translations = [];
@@ -184,19 +179,6 @@ class L10N implements IL10N {
 	}
 
 	/**
-	 * Returnsed function accepts the argument $n
-	 *
-	 * Called by \OC_L10N_String
-	 * @return string the plural form function
-	 */
-	public function getPluralFormFunction() {
-		if (is_null($this->pluralFormFunction)) {
-			$this->pluralFormFunction = $this->factory->createPluralFunction($this->pluralFormString);
-		}
-		return $this->pluralFormFunction;
-	}
-
-	/**
 	 * @param $translationFile
 	 * @return bool
 	 */
@@ -208,10 +190,17 @@ class L10N implements IL10N {
 			return false;
 		}
 
-		if (!empty($json['pluralForm'])) {
-			$this->pluralFormString = $json['pluralForm'];
-		}
 		$this->translations = array_merge($this->translations, $json['translations']);
 		return true;
+	}
+
+	/**
+	 * Computes the plural form
+	 *
+	 * @param int $number
+	 * @return int
+	 */
+	public function computePlural($number) {
+		return PluralizationRules::get($number, $this->lang);
 	}
 }

--- a/lib/private/L10N/L10NString.php
+++ b/lib/private/L10N/L10NString.php
@@ -25,8 +25,11 @@
  *
  */
 
-class OC_L10N_String implements JsonSerializable {
-	/** @var \OC\L10N\L10N */
+namespace OC\L10N;
+use JsonSerializable;
+
+class L10NString implements JsonSerializable {
+	/** @var L10N */
 	protected $l10n;
 
 	/** @var string */
@@ -39,7 +42,7 @@ class OC_L10N_String implements JsonSerializable {
 	protected $count;
 
 	/**
-	 * @param \OC\L10N\L10N $l10n
+	 * @param L10N $l10n
 	 * @param string|string[] $text
 	 * @param array $parameters
 	 * @param int $count
@@ -55,12 +58,11 @@ class OC_L10N_String implements JsonSerializable {
 		$translations = $this->l10n->getTranslations();
 
 		$text = $this->text;
-		if(array_key_exists($this->text, $translations)) {
-			if(is_array($translations[$this->text])) {
+		if (array_key_exists($this->text, $translations)) {
+			if (is_array($translations[$this->text])) {
 				$id = $this->l10n->computePlural($this->count);
 				$text = $translations[$this->text][$id];
-			}
-			else{
+			} else {
 				$text = $translations[$this->text];
 			}
 		}

--- a/lib/private/legacy/json.php
+++ b/lib/private/legacy/json.php
@@ -29,6 +29,8 @@
  *
  */
 
+use OC\L10N\L10NString;
+
 /**
  * Class OC_JSON
  * @deprecated Use a AppFramework JSONResponse instead
@@ -150,10 +152,10 @@ class OC_JSON{
 	}
 
 	/**
-	 * Convert OC_L10N_String to string, for use in json encodings
+	 * Convert \OC\L10N\String to string, for use in json encodings
 	 */
 	protected static function to_string(&$value) {
-		if ($value instanceof OC_L10N_String) {
+		if ($value instanceof L10NString) {
 			$value = (string)$value;
 		}
 	}

--- a/lib/private/legacy/l10n/string.php
+++ b/lib/private/legacy/l10n/string.php
@@ -57,8 +57,7 @@ class OC_L10N_String implements JsonSerializable {
 		$text = $this->text;
 		if(array_key_exists($this->text, $translations)) {
 			if(is_array($translations[$this->text])) {
-				$fn = $this->l10n->getPluralFormFunction();
-				$id = $fn($this->count);
+				$id = $this->l10n->computePlural($this->count);
 				$text = $translations[$this->text][$id];
 			}
 			else{

--- a/lib/public/IL10N.php
+++ b/lib/public/IL10N.php
@@ -44,9 +44,10 @@ namespace OCP;
 interface IL10N {
 	/**
 	 * Translating
+	 *
 	 * @param string $text The text we need a translation for
 	 * @param array $parameters default:array() Parameters for sprintf
-	 * @return \OC_L10N_String Translation or the same text
+	 * @return \OC\L10N\L10NString Translation or the same text
 	 *
 	 * Returns the translation. If no translation is found, $text will be
 	 * returned.
@@ -56,11 +57,12 @@ interface IL10N {
 
 	/**
 	 * Translating
+	 *
 	 * @param string $text_singular the string to translate for exactly one object
 	 * @param string $text_plural the string to translate for n objects
 	 * @param integer $count Number of objects
 	 * @param array $parameters default:array() Parameters for sprintf
-	 * @return \OC_L10N_String Translation or the same text
+	 * @return \OC\L10N\L10NString Translation or the same text
 	 *
 	 * Returns the translation. If no translation is found, $text will be
 	 * returned. %n will be replaced with the number of objects.

--- a/lib/public/L10N/IFactory.php
+++ b/lib/public/L10N/IFactory.php
@@ -74,6 +74,7 @@ interface IFactory {
 	 * @param string $string
 	 * @return string Unique function name
 	 * @since 9.0.0
+	 * @deprecated in 10.0.3
 	 */
 	public function createPluralFunction($string);
 }

--- a/lib/public/Template.php
+++ b/lib/public/Template.php
@@ -101,7 +101,7 @@ function human_file_size( $bytes ) {
  * Return the relative date in relation to today. Returns something like "last hour" or "two month ago"
  * @param int $timestamp unix timestamp
  * @param boolean $dateOnly
- * @return \OC_L10N_String human readable interpretation of the timestamp
+ * @return \OC\L10N\L10NString human readable interpretation of the timestamp
  *
  * @deprecated 8.0.0 Use \OCP\Template::relative_modified_date() instead
  */

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -428,31 +428,4 @@ class FactoryTest extends TestCase {
 		$factory = $this->getFactory();
 		$this->assertSame($expected, $this->invokePrivate($factory, 'findL10nDir', [$app]));
 	}
-
-	public function dataCreatePluralFunction() {
-		return [
-			['nplurals=2; plural=(n != 1);', 0, 1],
-			['nplurals=2; plural=(n != 1);', 1, 0],
-			['nplurals=2; plural=(n != 1);', 2, 1],
-			['nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;', 0, 2],
-			['nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;', 1, 0],
-			['nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;', 2, 1],
-			['nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;', 3, 1],
-			['nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;', 4, 1],
-			['nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;', 5, 2],
-		];
-	}
-
-	/**
-	 * @dataProvider dataCreatePluralFunction
-	 *
-	 * @param string $function
-	 * @param int $count
-	 * @param int $expected
-	 */
-	public function testCreatePluralFunction($function, $count, $expected) {
-		$factory = $this->getFactory();
-		$fn = $factory->createPluralFunction($function);
-		$this->assertEquals($expected, $fn($count));
-	}
 }


### PR DESCRIPTION
## Description
- php 7.2 is deprecating the php function 'create_function'
- also move the legacy class OC_L10N_String to its proper namespace \OC\L10N\String

## Motivation and Context
Get ready for future php version and cleaning up the mess ...

## How Has This Been Tested?
- manual local testing
- executing unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

