### PR TITLE
Remove unused win code (#28609)

### DIFF
--- a/tests/preseed-config.php
+++ b/tests/preseed-config.php
@@ -18,7 +18,3 @@ if (is_dir(OC::$SERVERROOT.'/apps2')) {
 		'writable' => false,
 	];
 }
-
-if (substr(strtolower(PHP_OS), 0, 3) === 'win') {
-	$CONFIG['openssl'] = ['config' => OC::$SERVERROOT . '/tests/data/openssl.cnf'];
-}


### PR DESCRIPTION
Backport #28609

might as well, the more stable10 is the same as master, the less conflicts for future backports.