### PR TITLE
Test deleting file directly on storage, then download

### DIFF
--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -356,6 +356,14 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @Given file :filename is deleted in local storage
+	 * @param string $filename
+	 */
+	public function fileIsDeletedInLocalStorage($filename) {
+		unlink("work/local_storage/$filename");
+	}
+
+	/**
 	 * @param string $userName
 	 * @return string
 	 */

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -341,7 +341,7 @@ trait WebDav {
 	 */
 	public function asTheFileOrFolderDoesNotExist($user, $entry, $path) {
 		$client = $this->getSabreClient($user);
-		$response = $client->request('HEAD', $this->makeSabrePath($user, $path));
+		$response = $client->request('HEAD', $this->makeSabrePath($user, '/' . ltrim($path, '/')));
 		if ($response['statusCode'] !== 404) {
 			throw new \Exception($entry . ' "' . $path . '" expected to not exist (status code ' . $response['statusCode'] . ', expected 404)');
 		}

--- a/tests/integration/features/external-storage.feature
+++ b/tests/integration/features/external-storage.feature
@@ -49,3 +49,13 @@ Feature: external-storage
     And as "user0" the file "/local_storage/foo2/textfile0.txt" does not exist
     And as "user1" the file "/local.txt" exists
 
+  Scenario: Download a file that exists in filecache but not storage fails with 404
+    Given user "user0" exists
+    And As an "user0"
+    And user "user0" created a folder "/local_storage/foo3"
+    And User "user0" moved file "/textfile0.txt" to "/local_storage/foo3/textfile0.txt"
+    And file "foo3/textfile0.txt" is deleted in local storage
+    When Downloading file "local_storage/foo3/textfile0.txt"
+    Then the HTTP status code should be "404"
+    And as "user0" the file "local_storage/foo3/textfile0.txt" does not exist
+


### PR DESCRIPTION
Downloading a file that was deleted directly on storage and is still
present in oc_filecache must return 404.

This is the integration test that matches https://github.com/owncloud/core/pull/28598.

I tested without the fix and it fails with 503. With the fix the test passes.

@jvillafanez please review

