### PR TITLE
Default share perms

### DIFF
--- a/apps/files_sharing/lib/API/OCSShareWrapper.php
+++ b/apps/files_sharing/lib/API/OCSShareWrapper.php
@@ -34,7 +34,8 @@ class OCSShareWrapper {
 			\OC::$server->getRootFolder(),
 			\OC::$server->getURLGenerator(),
 			\OC::$server->getUserSession()->getUser(),
-			\OC::$server->getL10N('files_sharing')
+			\OC::$server->getL10N('files_sharing'),
+			\OC::$server->getConfig()
 		);
 	}
 

--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -78,6 +78,8 @@ class Capabilities implements ICapability {
 			$res['resharing'] = $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes') === 'yes';
 
 			$res['group_sharing'] = $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes') === 'yes';
+
+			$res['default_permissions'] = (int)$this->config->getAppValue('core', 'shareapi_default_permissions', \OCP\Constants::PERMISSION_ALL);
 		}
 
 		//Federated sharing

--- a/apps/files_sharing/tests/API/Share20OCSTest.php
+++ b/apps/files_sharing/tests/API/Share20OCSTest.php
@@ -36,6 +36,7 @@ use OCP\Files\IRootFolder;
 use OCP\Lock\LockedException;
 use OCP\Share;
 use Test\TestCase;
+use OCP\IConfig;
 
 /**
  * Class Share20OCSTest
@@ -96,6 +97,12 @@ class Share20OCSTest extends TestCase {
 				return vsprintf($text, $parameters);
 			}));
 
+		$this->config = $this->createMock(IConfig::class);
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['core', 'shareapi_default_permissions', \OCP\Constants::PERMISSION_ALL, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE]
+			]));
+
 		$this->ocs = new Share20OCS(
 			$this->shareManager,
 			$this->groupManager,
@@ -104,7 +111,8 @@ class Share20OCSTest extends TestCase {
 			$this->rootFolder,
 			$this->urlGenerator,
 			$this->currentUser,
-			$this->l
+			$this->l,
+			$this->config
 		);
 	}
 
@@ -119,6 +127,7 @@ class Share20OCSTest extends TestCase {
 				$this->urlGenerator,
 				$this->currentUser,
 				$this->l,
+				$this->config,
 			])->setMethods(['formatShare'])
 			->getMock();
 	}
@@ -425,6 +434,7 @@ class Share20OCSTest extends TestCase {
 					$this->urlGenerator,
 					$this->currentUser,
 					$this->l,
+					$this->config,
 				])->setMethods(['canAccessShare'])
 				->getMock();
 
@@ -751,6 +761,7 @@ class Share20OCSTest extends TestCase {
 				$this->urlGenerator,
 				$this->currentUser,
 				$this->l,
+				$this->config,
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -867,6 +878,7 @@ class Share20OCSTest extends TestCase {
 				$this->urlGenerator,
 				$this->currentUser,
 				$this->l,
+				$this->config,
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -1403,6 +1415,7 @@ class Share20OCSTest extends TestCase {
 				$this->urlGenerator,
 				$this->currentUser,
 				$this->l,
+				$this->config,
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -2678,7 +2691,8 @@ class Share20OCSTest extends TestCase {
 			$this->rootFolder,
 			$this->urlGenerator,
 			$this->currentUser,
-			$this->l
+			$this->l,
+			$this->config
 		);
 	}
 

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -123,7 +123,8 @@ class ApiTest extends TestCase {
 			\OC::$server->getRootFolder(),
 			\OC::$server->getURLGenerator(),
 			$currentUser,
-			$l
+			$l,
+			\OC::$server->getConfig()
 		);
 	}
 

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -198,6 +198,10 @@ if (\OC::$server->getUserSession() !== null && \OC::$server->getUserSession()->i
 	$array['oc_config']['versionstring'] = OC_Util::getVersionString();
 	$array['oc_defaults']['docBaseUrl'] = $defaults->getDocBaseUrl();
 	$array['oc_defaults']['docPlaceholderUrl'] = $defaults->buildDocLinkToKey('PLACEHOLDER');
+	$caps = \OC::$server->getCapabilitiesManager()->getCapabilities();
+	// remove status.php info as we already have the version above
+	unset($caps['core']['status']);
+	$array['oc_capabilities'] = json_encode($caps);
 }
 
 // Allow hooks to modify the output values

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -68,6 +68,13 @@ var OC = {
 	 */
 	webroot: oc_webroot,
 
+	/**
+	 * Capabilities
+	 *
+	 * @type array
+	 */
+	_capabilities: window.oc_capabilities || null,
+
 	appswebroots: (typeof oc_appswebroots !== 'undefined') ? oc_appswebroots : false,
 	/**
 	 * Currently logged in user or null if none
@@ -296,6 +303,15 @@ var OC = {
 	 */
 	getRootPath: function () {
 		return OC.webroot;
+	},
+
+	/**
+	 * Returns the capabilities
+	 *
+	 * @return {array} capabilities
+	 */
+	getCapabilities: function() {
+		return OC._capabilities;
 	},
 
 	/**

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -126,23 +126,25 @@
 			options = options || {};
 			attributes = _.extend({}, attributes);
 
+			var defaultPermissions = OC.getCapabilities()['files_sharing']['default_permissions'] || OC.PERMISSION_ALL;
+
 			// Default permissions are Edit (CRUD) and Share
 			// Check if these permissions are possible
-			var permissions = OC.PERMISSION_READ;
+			var possiblePermissions = OC.PERMISSION_READ;
 			if (this.updatePermissionPossible()) {
-				permissions = permissions | OC.PERMISSION_UPDATE;
+				possiblePermissions = possiblePermissions | OC.PERMISSION_UPDATE;
 			}
 			if (this.createPermissionPossible()) {
-				permissions = permissions | OC.PERMISSION_CREATE;
+				possiblePermissions = possiblePermissions | OC.PERMISSION_CREATE;
 			}
 			if (this.deletePermissionPossible()) {
-				permissions = permissions | OC.PERMISSION_DELETE;
+				possiblePermissions = possiblePermissions | OC.PERMISSION_DELETE;
 			}
 			if (this.configModel.get('isResharingAllowed') && (this.sharePermissionPossible())) {
-				permissions = permissions | OC.PERMISSION_SHARE;
+				possiblePermissions = possiblePermissions | OC.PERMISSION_SHARE;
 			}
 
-			attributes.permissions = permissions;
+			attributes.permissions = defaultPermissions & possiblePermissions;
 			if (_.isUndefined(attributes.path)) {
 				attributes.path = this.fileInfoModel.getFullPath();
 			}

--- a/core/js/tests/specs/shareitemmodelSpec.js
+++ b/core/js/tests/specs/shareitemmodelSpec.js
@@ -25,6 +25,7 @@ describe('OC.Share.ShareItemModel', function() {
 	var fetchSharesDeferred, fetchReshareDeferred;
 	var fileInfoModel, configModel, model;
 	var oldCurrentUser;
+	var capsSpec;
 
 	beforeEach(function() {
 		oldCurrentUser = OC.currentUser;
@@ -56,8 +57,15 @@ describe('OC.Share.ShareItemModel', function() {
 			configModel: configModel,
 			fileInfoModel: fileInfoModel
 		});
+		capsSpec = sinon.stub(OC, 'getCapabilities');
+		capsSpec.returns({
+			'files_sharing': {
+				'default_permissions': OC.PERMISSION_ALL
+			}
+		});
 	});
 	afterEach(function() {
+		capsSpec.restore(); 
 		if (fetchSharesStub) {
 			fetchSharesStub.restore();
 		}
@@ -559,7 +567,22 @@ describe('OC.Share.ShareItemModel', function() {
 				});
 				expect(
 					testWithPermissions(OC.PERMISSION_UPDATE | OC.PERMISSION_SHARE)
-				).toEqual(OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_UPDATE);
+				).toEqual(OC.PERMISSION_READ | OC.PERMISSION_UPDATE);
+			});
+			it('uses default permissions from capabilities', function() {
+				capsSpec.returns({
+					'files_sharing': {
+						'default_permissions': OC.PERMISSION_READ | OC.PERMISSION_CREATE | OC.PERMISSION_SHARE
+					}
+				});
+				configModel.set('isResharingAllowed', true);
+				model.set({
+					reshare: {},
+					shares: []
+				});
+				expect(
+					testWithPermissions(OC.PERMISSION_ALL)
+				).toEqual(OC.PERMISSION_READ | OC.PERMISSION_CREATE | OC.PERMISSION_SHARE);
 			});
 		});
 	});

--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -282,7 +282,7 @@ class SettingsManager implements ISettingsManager {
 				$this->urlGenerator,
 				$this->certificateManager),
 			Encryption::class => new Encryption(),
-			FileSharing::class => new FileSharing($this->config, $this->helper),
+			FileSharing::class => new FileSharing($this->config, $this->helper, $this->l),
 			Logging::class => new Logging($this->config, $this->urlGenerator, $this->helper),
 			Mail::class => new Mail($this->config, $this->helper),
 			SecurityWarning::class => new SecurityWarning(

--- a/settings/Panels/Admin/FileSharing.php
+++ b/settings/Panels/Admin/FileSharing.php
@@ -77,7 +77,7 @@ class FileSharing implements ISettings {
 			],
 			[
 				'id' => 'canupdate',
-				'label' => $this->l->t('Update'),
+				'label' => $this->l->t('Change'),
 				'value' => \OCP\Constants::PERMISSION_UPDATE
 			],
 			[

--- a/settings/Panels/Admin/FileSharing.php
+++ b/settings/Panels/Admin/FileSharing.php
@@ -25,6 +25,7 @@ use OC\Settings\Panels\Helper;
 use OCP\IConfig;
 use OCP\Settings\ISettings;
 use OCP\Template;
+use OCP\IL10N;
 
 class FileSharing implements ISettings {
 
@@ -32,10 +33,13 @@ class FileSharing implements ISettings {
 	protected $config;
 	/** @var Helper */
 	protected $helper;
+	/** @var IL10N */
+	protected $l;
 
-	public function __construct(IConfig $config, Helper $helper) {
+	public function __construct(IConfig $config, Helper $helper, IL10N $l) {
 		$this->config = $config;
 		$this->helper = $helper;
+		$this->l = $l;
 	}
 
 	public function getPriority() {
@@ -64,6 +68,31 @@ class FileSharing implements ISettings {
 		$template->assign('shareExcludedGroupsList', !is_null($excludedGroupsList) ? implode('|', $excludedGroupsList) : '');
 		$template->assign('shareExpireAfterNDays', $this->config->getAppValue('core', 'shareapi_expire_after_n_days', '7'));
 		$template->assign('shareEnforceExpireDate', $this->config->getAppValue('core', 'shareapi_enforce_expire_date', 'no'));
+
+		$permList = [
+			[
+				'id' => 'cancreate',
+				'label' => $this->l->t('Create'),
+				'value' => \OCP\Constants::PERMISSION_CREATE
+			],
+			[
+				'id' => 'canupdate',
+				'label' => $this->l->t('Update'),
+				'value' => \OCP\Constants::PERMISSION_UPDATE
+			],
+			[
+				'id' => 'candelete',
+				'label' => $this->l->t('Delete'),
+				'value' => \OCP\Constants::PERMISSION_DELETE
+			],
+			[
+				'id' => 'canshare',
+				'label' => $this->l->t('Share'),
+				'value' => \OCP\Constants::PERMISSION_SHARE
+			],
+		];
+		$template->assign('shareApiDefaultPermissions', $this->config->getAppValue('core', 'shareapi_default_permissions', \OCP\Constants::PERMISSION_ALL));
+		$template->assign('shareApiDefaultPermissionsCheckboxes', $permList);
 		return $template;
 	}
 

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -483,14 +483,22 @@ table.grid td.date{
 
 #shareAPI p { padding-bottom: 0.8em; }
 #shareAPI input#shareapiExpireAfterNDays {width: 25px;}
+#shareAPI .nocheckbox {
+	padding-left: 20px;
+}
 #shareAPI .indent {
 	padding-left: 28px;
 }
 #shareAPI .double-indent {
 	padding-left: 56px;
 }
+#shareAPI
 #fileSharingSettings h2 {
 	display: inline-block;
+}
+
+#shareApiDefaultPermissionsSection label {
+	margin-right: 20px;
 }
 
 /* correctly display help icons next to headings */

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -57,7 +57,7 @@ $(document).ready(function(){
 		}
 	});
 
-	$('#shareAPI input:not(#excludedGroups)').change(function() {
+	$('#shareAPI input:not(.noautosave)').change(function() {
 		var value = $(this).val();
 		if ($(this).attr('type') === 'checkbox') {
 			if (this.checked) {
@@ -85,6 +85,28 @@ $(document).ready(function(){
 
 	$('#shareapiExcludeGroups').change(function() {
 		$("#selectExcludedGroups").toggleClass('hidden', !this.checked);
+	});
+
+	$('#shareApiDefaultPermissionsSection input').change(function(ev) {
+		var $el = $('#shareApiDefaultPermissions');
+		var $target = $(ev.target);
+
+		var value = $el.val();
+		if ($target.is(':checked')) {
+			value = value | $target.val();
+		} else {
+			value = value & ~$target.val();
+		}
+
+		// always set read permission
+		value |= OC.PERMISSION_READ;
+
+		// this will trigger the field's change event and will save it
+		$el.val(value).change();
+
+		ev.preventDefault();
+
+		return false;
 	});
 
 

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -60,6 +60,11 @@
 		<label for="allowGroupSharing"><?php p($l->t('Allow sharing with groups'));?></label><br />
 	</p>
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
+		<input type="checkbox" name="shareapi_default_permissions" id="shareApiDefaultPermissions" class="checkbox"
+			   value="31" <?php if ($_['shareapiDefaultPermissions'] === 31) print_unescaped('checked="checked"'); ?> />
+		<label for="shareApiDefaultPermissions"><?php p($l->t('Newly created local shares are read-write by default'));?></label><br/>
+	</p>
+	<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
 		<input type="checkbox" name="shareapi_only_share_with_group_members" id="onlyShareWithGroupMembers" class="checkbox"
 			   value="1" <?php if ($_['onlyShareWithGroupMembers']) print_unescaped('checked="checked"'); ?> />
 		<label for="onlyShareWithGroupMembers"><?php p($l->t('Restrict users to only share with users in their groups'));?></label><br/>

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -59,7 +59,7 @@
 			   value="1" <?php if ($_['allowGroupSharing'] === 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="allowGroupSharing"><?php p($l->t('Allow sharing with groups'));?></label><br />
 	</p>
-	<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
+	<p class="nocheckbox <?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
 		<input type="hidden" name="shareapi_default_permissions" id="shareApiDefaultPermissions" class="checkbox"
 		value="<?php p($_['shareApiDefaultPermissions']) ?>" />
 		<?php p($l->t('Default local share permissions'));?>
@@ -68,7 +68,7 @@
 		<?php foreach ($_['shareApiDefaultPermissionsCheckboxes'] as $perm): ?>
 		<input type="checkbox" name="shareapi_default_permission_<?php p($perm['id']) ?>" id="shareapi_default_permission_<?php p($perm['id']) ?>"
 			class="noautosave checkbox" value="<?php p($perm['value']) ?>" <?php if (($_['shareApiDefaultPermissions'] & $perm['value']) !== 0) print_unescaped('checked="checked"'); ?> />
-		<label for="shareapi_default_permission_<?php p($perm['id']) ?>"><?php p($perm['label']);?></label><br/>
+		<label for="shareapi_default_permission_<?php p($perm['id']) ?>"><?php p($perm['label']);?></label>
 		<?php endforeach ?>
 	</p>
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -60,9 +60,16 @@
 		<label for="allowGroupSharing"><?php p($l->t('Allow sharing with groups'));?></label><br />
 	</p>
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
-		<input type="checkbox" name="shareapi_default_permissions" id="shareApiDefaultPermissions" class="checkbox"
-			   value="31" <?php if ($_['shareapiDefaultPermissions'] === 31) print_unescaped('checked="checked"'); ?> />
-		<label for="shareApiDefaultPermissions"><?php p($l->t('Newly created local shares are read-write by default'));?></label><br/>
+		<input type="hidden" name="shareapi_default_permissions" id="shareApiDefaultPermissions" class="checkbox"
+		value="<?php p($_['shareApiDefaultPermissions']) ?>" />
+		<?php p($l->t('Default local share permissions'));?>
+	</p>
+	<p id="shareApiDefaultPermissionsSection" class="indent <?php if ($_['shareAPIEnabled'] === 'no') p('hidden'); ?>">
+		<?php foreach ($_['shareApiDefaultPermissionsCheckboxes'] as $perm): ?>
+		<input type="checkbox" name="shareapi_default_permission_<?php p($perm['id']) ?>" id="shareapi_default_permission_<?php p($perm['id']) ?>"
+			class="noautosave checkbox" value="<?php p($perm['value']) ?>" <?php if (($_['shareApiDefaultPermissions'] & $perm['value']) !== 0) print_unescaped('checked="checked"'); ?> />
+		<label for="shareapi_default_permission_<?php p($perm['id']) ?>"><?php p($perm['label']);?></label><br/>
+		<?php endforeach ?>
 	</p>
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
 		<input type="checkbox" name="shareapi_only_share_with_group_members" id="onlyShareWithGroupMembers" class="checkbox"
@@ -80,7 +87,7 @@
 		<label for="shareapiExcludeGroups"><?php p($l->t('Exclude groups from sharing'));?></label><br/>
 	</p>
 	<p id="selectExcludedGroups" class="indent <?php if (!$_['shareExcludeGroups'] || $_['shareAPIEnabled'] === 'no') p('hidden'); ?>">
-		<input name="shareapi_exclude_groups_list" type="hidden" id="excludedGroups" value="<?php p($_['shareExcludedGroupsList']) ?>" style="width: 400px"/>
+		<input name="shareapi_exclude_groups_list" class="noautosave" type="hidden" id="excludedGroups" value="<?php p($_['shareExcludedGroupsList']) ?>" style="width: 400px"/>
 		<br />
 		<em><?php p($l->t('These groups will still be able to receive shares, but not to initiate them.')); ?></em>
 	</p>

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -59,18 +59,6 @@
 			   value="1" <?php if ($_['allowGroupSharing'] === 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="allowGroupSharing"><?php p($l->t('Allow sharing with groups'));?></label><br />
 	</p>
-	<p class="nocheckbox <?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
-		<input type="hidden" name="shareapi_default_permissions" id="shareApiDefaultPermissions" class="checkbox"
-		value="<?php p($_['shareApiDefaultPermissions']) ?>" />
-		<?php p($l->t('Default local share permissions'));?>
-	</p>
-	<p id="shareApiDefaultPermissionsSection" class="indent <?php if ($_['shareAPIEnabled'] === 'no') p('hidden'); ?>">
-		<?php foreach ($_['shareApiDefaultPermissionsCheckboxes'] as $perm): ?>
-		<input type="checkbox" name="shareapi_default_permission_<?php p($perm['id']) ?>" id="shareapi_default_permission_<?php p($perm['id']) ?>"
-			class="noautosave checkbox" value="<?php p($perm['value']) ?>" <?php if (($_['shareApiDefaultPermissions'] & $perm['value']) !== 0) print_unescaped('checked="checked"'); ?> />
-		<label for="shareapi_default_permission_<?php p($perm['id']) ?>"><?php p($perm['label']);?></label>
-		<?php endforeach ?>
-	</p>
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
 		<input type="checkbox" name="shareapi_only_share_with_group_members" id="onlyShareWithGroupMembers" class="checkbox"
 			   value="1" <?php if ($_['onlyShareWithGroupMembers']) print_unescaped('checked="checked"'); ?> />
@@ -100,5 +88,17 @@
 		<input type="checkbox" name="shareapi_share_dialog_user_enumeration_group_members" value="1" id="shareapi_share_dialog_user_enumeration_group_members" class="checkbox"
 			<?php if ($_['shareDialogUserEnumerationGroupMembers'] === 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="shareapi_share_dialog_user_enumeration_group_members"><?php p($l->t('Restrict enumeration to group members'));?></label><br />
+	</p>
+	<p class="nocheckbox <?php if ($_['shareAPIEnabled'] === 'no') p('hidden');?>">
+		<input type="hidden" name="shareapi_default_permissions" id="shareApiDefaultPermissions" class="checkbox"
+		value="<?php p($_['shareApiDefaultPermissions']) ?>" />
+		<?php p($l->t('Default user and group share permissions'));?>
+	</p>
+	<p id="shareApiDefaultPermissionsSection" class="indent <?php if ($_['shareAPIEnabled'] === 'no') p('hidden'); ?>">
+		<?php foreach ($_['shareApiDefaultPermissionsCheckboxes'] as $perm): ?>
+		<input type="checkbox" name="shareapi_default_permission_<?php p($perm['id']) ?>" id="shareapi_default_permission_<?php p($perm['id']) ?>"
+			class="noautosave checkbox" value="<?php p($perm['value']) ?>" <?php if (($_['shareApiDefaultPermissions'] & $perm['value']) !== 0) print_unescaped('checked="checked"'); ?> />
+		<label for="shareapi_default_permission_<?php p($perm['id']) ?>"><?php p($perm['label']);?></label>
+		<?php endforeach ?>
 	</p>
 </div>

--- a/tests/Settings/Panels/Admin/FileSharingTest.php
+++ b/tests/Settings/Panels/Admin/FileSharingTest.php
@@ -13,6 +13,7 @@ namespace Tests\Settings\Panels\Admin;
 use OC\Settings\Panels\Admin\FileSharing;
 use OC\Settings\Panels\Helper;
 use OCP\IConfig;
+use OCP\IL10N;
 
 /**
  * @package Tests\Settings\Panels\Admin
@@ -30,7 +31,8 @@ class FileSharingTest extends \Test\TestCase {
 		parent::setUp();
 		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->helper = $this->getMockBuilder(Helper::class)->getMock();
-		$this->panel = new FileSharing($this->config, $this->helper);
+		$l10n = $this->getMockBuilder(IL10N::class)->getMock();
+		$this->panel = new FileSharing($this->config, $this->helper, $l10n);
 	}
 
 	public function testGetSection() {


### PR DESCRIPTION
## Description
Default share permissions setting for local shares.

The default permissions are exposed via capabilities.
To make it visible to the JS frontend code, the capabilities are now added in "js/config.php" and accessible through `OC.getCapabilities()`. This will make passing such config values more convenient in the future especially for values that other clients need.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28384.

## Motivation and Context
See ticket

## How Has This Been Tested?
- [x] TEST: manual testing
- [x] TEST: add unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
