### PR TITLE
Make lost password errors distinguishable

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -159,18 +159,18 @@ class LostController extends Controller {
 		$splittedToken = explode(':', $this->config->getUserValue($userId, 'owncloud', 'lostpassword', null));
 		if(count($splittedToken) !== 2) {
 			$this->config->deleteUserValue($userId, 'owncloud', 'lostpassword');
-			throw new \Exception($this->l10n->t('Couldn\'t reset password because the token is invalid'));
+			throw new \Exception($this->l10n->t('Could not reset password because the token is invalid'));
 		}
 
 		if ($splittedToken[0] < ($this->timeFactory->getTime() - 60*60*12) ||
 			$user->getLastLogin() > $splittedToken[0]) {
 			$this->config->deleteUserValue($userId, 'owncloud', 'lostpassword');
-			throw new \Exception($this->l10n->t('Couldn\'t reset password because the token is expired'));
+			throw new \Exception($this->l10n->t('Could not reset password because the token expired'));
 		}
 
 		if (!hash_equals($splittedToken[1], $token)) {
 			$this->config->deleteUserValue($userId, 'owncloud', 'lostpassword');
-			throw new \Exception($this->l10n->t('Couldn\'t reset password because the token is invalid'));
+			throw new \Exception($this->l10n->t('Could not reset password because the token does not match'));
 		}
 	}
 

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -128,7 +128,7 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 			'error',
 			[
 				'errors' => [
-					['error' => 'Couldn\'t reset password because the token is invalid'],
+					['error' => 'Could not reset password because the token is invalid'],
 				]
 			],
 			'guest');
@@ -159,7 +159,7 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 			'error',
 			[
 				'errors' => [
-					['error' => 'Couldn\'t reset password because the token is invalid'],
+					['error' => 'Could not reset password because the token does not match'],
 				]
 			],
 			'guest');
@@ -193,7 +193,7 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 			'error',
 			[
 				'errors' => [
-					['error' => 'Couldn\'t reset password because the token is expired'],
+					['error' => 'Could not reset password because the token expired'],
 				]
 			],
 			'guest');
@@ -452,7 +452,7 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 		$response = $this->lostController->setPassword('wrongToken', $userName, 'NewPassword', true);
 		$expectedResponse = [
 			'status' => 'error',
-			'msg' => 'Couldn\'t reset password because the token is invalid'
+			'msg' => 'Could not reset password because the token is invalid'
 		];
 		$this->assertSame($expectedResponse, $response);
 
@@ -546,7 +546,7 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 		$response = $this->lostController->setPassword('TheOnlyAndOnlyOneTokenToResetThePassword', 'ValidTokenUser', 'NewPassword', true);
 		$expectedResponse = [
 			'status' => 'error',
-			'msg' => 'Couldn\'t reset password because the token is expired',
+			'msg' => 'Could not reset password because the token expired',
 		];
 		$this->assertSame($expectedResponse, $response);
 	}
@@ -568,7 +568,7 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 		$response = $this->lostController->setPassword('TheOnlyAndOnlyOneTokenToResetThePassword', 'ValidTokenUser', 'NewPassword', true);
 		$expectedResponse = [
 			'status' => 'error',
-			'msg' => 'Couldn\'t reset password because the token is invalid',
+			'msg' => 'Could not reset password because the token is invalid',
 		];
 		$this->assertSame($expectedResponse, $response);
 	}
@@ -598,7 +598,7 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 		$response = $this->lostController->setPassword('TheOnlyAndOnlyOneTokenToResetThePassword', 'ValidTokenUser', 'NewPassword', true);
 		$expectedResponse = [
 			'status' => 'error',
-			'msg' => 'Couldn\'t reset password because the token is expired',
+			'msg' => 'Could not reset password because the token expired',
 		];
 		$this->assertSame($expectedResponse, $response);
 	}
@@ -613,7 +613,7 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 		$response = $this->lostController->setPassword('', 'ValidTokenUser', 'NewPassword', true);
 		$expectedResponse = [
 			'status' => 'error',
-			'msg' => 'Couldn\'t reset password because the token is invalid'
+			'msg' => 'Could not reset password because the token is invalid'
 			];
 		$this->assertSame($expectedResponse, $response);
 	}


### PR DESCRIPTION
1. Make the error messages distinguishable. Allows actually debugging the problem. Using cryptic numbers would not increase security because an attacker can just look them up in the code.
2. In written form `Couldn't` becomes `Could not`