### PR TITLE
Add @no_default_encryption tag to the feature

### DIFF
--- a/tests/integration/features/transfer-ownership.feature
+++ b/tests/integration/features/transfer-ownership.feature
@@ -1,6 +1,6 @@
 Feature: transfer-ownership
 
-	# TODO: change to @no_default_encryption once all this works with master key
+	@no_default_encryption
 	Scenario: transfering ownership of a file
 		Given user "user0" exists
 		And user "user1" exists
@@ -11,6 +11,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_default_encryption
 	Scenario: transfering ownership of a file after updating the file
 		Given user "user0" exists
 		And user "user1" exists
@@ -24,6 +25,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/PARENT/textfile0.txt" with range "bytes=0-5" should be "AABBCC"
 
+	@no_default_encryption
 	Scenario: transfering ownership of a folder
 		Given user "user0" exists
 		And user "user1" exists
@@ -35,6 +37,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_default_encryption
 	Scenario: transfering ownership of file shares
 		Given user "user0" exists
 		And user "user1" exists
@@ -46,6 +49,7 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_default_encryption
 	Scenario: transfering ownership of folder shared with third user
 		Given user "user0" exists
 		And user "user1" exists
@@ -58,6 +62,7 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_default_encryption
 	Scenario: transfering ownership of folder shared with transfer recipient
 		Given user "user0" exists
 		And user "user1" exists
@@ -71,6 +76,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		And Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_default_encryption
 	Scenario: transfering ownership of folder doubly shared with third user
 		Given group "group1" exists
 		And user "user0" exists
@@ -86,6 +92,7 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_default_encryption
 	Scenario: transfering ownership does not transfer received shares
 		Given user "user0" exists
 		And user "user1" exists
@@ -98,7 +105,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then as "user1" the folder "/test" does not exist
 
-	@local_storage
+	@local_storage @no_default_encryption
 	Scenario: transfering ownership does not transfer external storage
 		Given user "user0" exists
 		And user "user1" exists
@@ -108,6 +115,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then as "user1" the folder "/local_storage" does not exist
 
+	@no_default_encryption
 	Scenario: transfering ownership does not fail with shared trashed files
 		Given user "user0" exists
 		And user "user1" exists
@@ -131,6 +139,7 @@ Feature: transfer-ownership
 		Then the command error output contains the text "Unknown target user"
 		And the command failed with exit code 1
 
+	@no_default_encryption
 	Scenario: transfering ownership of a folder
 		Given user "user0" exists
 		And user "user1" exists
@@ -142,6 +151,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_default_encryption
 	Scenario: transfering ownership of file shares
 		Given user "user0" exists
 		And user "user1" exists
@@ -154,6 +164,7 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_default_encryption
 	Scenario: transfering ownership of folder shared with third user
 		Given user "user0" exists
 		And user "user1" exists
@@ -166,6 +177,7 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_default_encryption
 	Scenario: transfering ownership of folder shared with transfer recipient
 		Given user "user0" exists
 		And user "user1" exists
@@ -179,6 +191,7 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		And Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 
+	@no_default_encryption
 	Scenario: transfering ownership of folder doubly shared with third user
 		Given group "group1" exists
 		And user "user0" exists


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
This is to fix the transfer-ownership.feature failure for the stable10 branch.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This change tries to address the issue: https://github.com/owncloud/core/issues/28625

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
transfer-ownership.feature would fail if just encryption is enabled. We need to enable masterkey too to satisfy the test.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Had ran ```OC_TEST_ALT_HOME=1 OC_TEST_ENCRYPTION_ENABLED=1 OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED=1``` ./run.sh in my local machine and verified.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

