### PR TITLE
occ app:list filter

### DIFF
--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -53,7 +53,7 @@ class ListApps extends Base {
 			->addArgument(
 				'search-pattern',
 				InputArgument::OPTIONAL,
-				'Restrict the list to apps whose name matches the given regular expression'
+				'Restrict the list of apps to those whose name matches the given regular expression'
 			)
 			->addOption(
 				'shipped',

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -27,6 +27,7 @@ namespace OC\Core\Command\App;
 use OC\Core\Command\Base;
 use OCP\App\IAppManager;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -49,6 +50,11 @@ class ListApps extends Base {
 		$this
 			->setName('app:list')
 			->setDescription('List all available apps')
+			->addArgument(
+				'search-pattern',
+				InputArgument::OPTIONAL,
+				'Restrict the list to apps whose name matches the given regular expression'
+			)
 			->addOption(
 				'shipped',
 				null,
@@ -59,6 +65,8 @@ class ListApps extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		$appNameSubString = $input->getArgument('search-pattern');
+
 		if ($input->getOption('shipped') === 'true' || $input->getOption('shipped') === 'false'){
 			$shippedFilter = $input->getOption('shipped') === 'true';
 		} else {
@@ -74,6 +82,11 @@ class ListApps extends Base {
 			if ($shippedFilter !== null && \OC_App::isShipped($app) !== $shippedFilter){
 				continue;
 			}
+
+			if ($appNameSubString !== null && !preg_match('/' . $appNameSubString . '/', $app)) {
+				continue;
+			}
+			
 			if ($this->manager->isInstalled($app)) {
 				$enabledApps[] = $app;
 			} else {
@@ -104,11 +117,15 @@ class ListApps extends Base {
 	protected function writeAppList(InputInterface $input, OutputInterface $output, $items) {
 		switch ($input->getOption('output')) {
 			case self::OUTPUT_FORMAT_PLAIN:
-				$output->writeln('Enabled:');
-				parent::writeArrayInOutputFormat($input, $output, $items['enabled']);
+				if (count($items['enabled'])) {
+					$output->writeln('Enabled:');
+					parent::writeArrayInOutputFormat($input, $output, $items['enabled']);
+				}
 
-				$output->writeln('Disabled:');
-				parent::writeArrayInOutputFormat($input, $output, $items['disabled']);
+				if (count($items['disabled'])) {
+					$output->writeln('Disabled:');
+					parent::writeArrayInOutputFormat($input, $output, $items['disabled']);
+				}
 			break;
 
 			default:


### PR DESCRIPTION
## Description
- Allow a search-pattern to be entered as a parameter to ``oc app:list`` so the user can filter the list to just matching app names.
- only print the "Enabled:" and "Disabled:" sections of output if they have at least 1 app in them
- make use of this in the integration tests ``run.sh`` script to preserve the existing state of the testing app

## Related Issue
#28638

## Motivation and Context
- it is handy for a script to have some way to know if an app is currently enabled or disabled
- it could be handy for sysadmins to be able to filter the output of ``occ app:list``, that possibility comes for free here

## How Has This Been Tested?
- enable the testing app
- run some integration tests
- verify that the testing app is still enabled
- disable the testing app
- run some integration tests
- verify that the testing app is disabled

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

