### PR TITLE
Adding detailed mode to occ security:routes

### DIFF
--- a/core/Command/Security/ListRoutes.php
+++ b/core/Command/Security/ListRoutes.php
@@ -21,12 +21,14 @@
 
 namespace OC\Core\Command\Security;
 
+use OC\AppFramework\App;
 use OC\Core\Command\Base;
+use OC\Route\Route;
 use OC\Route\Router;
-use OCP\ICertificate;
 use OCP\Route\IRouter;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListRoutes extends Base {
@@ -44,7 +46,8 @@ class ListRoutes extends Base {
 	protected function configure() {
 		$this
 			->setName('security:routes')
-			->setDescription('list used routes');
+			->setDescription('list used routes')
+			->addOption('with-details', 'd', InputOption::VALUE_NONE);
 		parent::configure();
 	}
 
@@ -56,24 +59,54 @@ class ListRoutes extends Base {
 
 		$rows = [];
 
-		foreach ($this->router->getCollections() as $routeCollection) {
-			foreach ($routeCollection as $route) {
-				$path = $route->getPath();
-				if (isset($rows[$path])) {
-					$rows[$path]['methods'] = array_unique(array_merge($rows[$path]['methods'], $route->getMethods()));
-				} else {
-					$rows[$path] = [
-						'path' => $path,
-						'methods' => $route->getMethods()
-					];
+		if ($input->getOption('with-details')) {
+			$headers = [
+				'Path',
+				'Methods',
+				'Controller',
+				'Annotations',
+			];
+			/** @var Route[] $collections */
+			$collections = [];
+			foreach ($this->router->getCollections() as $c) {
+				$new = $c->all();
+				$collections = $collections + $new;
+			}
+
+			foreach ($collections as $name => $route) {
+				$c = $this->buildController($name);
+				$rows[] = array_merge([
+					'path' => $route->getPath(),
+					'methods' => $route->getMethods()
+				], $c);
+			}
+		} else {
+			$headers = [
+				'Path',
+				'Methods'
+			];
+			foreach ($this->router->getCollections() as $routeCollection) {
+				foreach ($routeCollection as $route) {
+					$path = $route->getPath();
+					if (isset($rows[$path])) {
+						$rows[$path]['methods'] = array_unique(array_merge($rows[$path]['methods'], $route->getMethods()));
+					} else {
+						$rows[$path] = [
+							'path' => $path,
+							'methods' => $route->getMethods()
+						];
+					}
+					sort ($rows[$path]['methods']);
 				}
-				sort ($rows[$path]['methods']);
 			}
 		}
-
 		usort($rows, function ($a, $b) {
 			return strcmp($a['path'], $b['path']);
 		});
+		$rows = array_map(function($row) {
+			$row['methods'] = implode(',', $row['methods']);
+			return $row;
+		}, $rows);
 
 		if ($outputType === self::OUTPUT_FORMAT_JSON ) {
 			$output->write(json_encode($rows));
@@ -81,15 +114,99 @@ class ListRoutes extends Base {
 			$output->writeln(json_encode($rows, JSON_PRETTY_PRINT));
 		} else {
 			$table = new Table($output);
-			$table->setHeaders([
-				'Path',
-				'Methods',
-			]);
+			$table->setHeaders($headers);
 
-			foreach ($rows as $row) {
-				$table->addRow([$row['path'], join(',', $row['methods'])]);
-			}
+			$table->addRows($rows);
 			$table->render();
 		}
 	}
+
+	private function buildController($name) {
+		$parts = explode('.', $name);
+		if (count($parts) === 4 && $parts[0] === 'ocs') {
+			array_shift($parts);
+		}
+		if (count($parts) !== 3) {
+			return [
+				'controllerClass' => '*** not controller based ***'
+			];
+		}
+		$appName = $parts[0];
+		$controllerName = $parts[1];
+		$method = $parts[2];
+		$reflection = $this->buildReflection($appName, $controllerName, $method);
+		if ($reflection === null) {
+			return [
+				'controllerClass' => '*** controller not resolvable ***'
+			];
+		}
+		$docs = $reflection->getDocComment();
+
+		// extract everything prefixed by @ and first letter uppercase
+		preg_match_all('/@([A-Z]\w+)/', $docs, $matches);
+		$annotations = $matches[1];
+
+		return [
+			'controllerClass' => $reflection->getDeclaringClass()->getName() . '::' . $reflection->getName(),
+			'annotations' => implode(',', $annotations),
+		];
+	}
+
+	/**
+	 * @param string $appName
+	 * @param string $controllerName
+	 * @param string $method
+	 * @return null|\ReflectionMethod
+	 */
+	private function buildReflection($appName, $controllerName, $method) {
+		foreach ($this->listControllerNames($appName, $controllerName) as $controllerName) {
+			foreach ($this->listMethodNames($method) as $m) {
+				try {
+					$reflection = new \ReflectionMethod($controllerName, $m);
+					return $reflection;
+				} catch (\ReflectionException $ex) {
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * @param string $appName
+	 * @param string $controllerName
+	 * @return \Generator | string[]
+	 */
+	private function listControllerNames($appName, $controllerName) {
+		foreach ([App::buildAppNamespace($appName), App::buildAppNamespace($appName, 'OC\\')] as $appNameSpace) {
+			foreach (['\\Controller\\', '\\Controllers\\'] as $namespace) {
+				yield $appNameSpace . $namespace . $controllerName;
+				yield $appNameSpace . $namespace . ucfirst(strtolower($controllerName));
+				yield $appNameSpace . $namespace . $controllerName . 'Controller';
+				yield $appNameSpace . $namespace . ucfirst(strtolower($controllerName)) . 'Controller';
+				$controllerName = implode('', array_map(function ($word) {
+					return ucfirst($word);
+				}, explode('_', $controllerName)));
+				yield $appNameSpace . $namespace . $controllerName;
+				yield $appNameSpace . $namespace . ucfirst(strtolower($controllerName));
+				yield $appNameSpace . $namespace . $controllerName . 'Controller';
+				yield $appNameSpace . $namespace . ucfirst(strtolower($controllerName)) . 'Controller';
+			}
+		}
+	}
+
+	/**
+	 * @param string $method
+	 * @return \Generator | string[]
+	 */
+	private function listMethodNames($method) {
+		yield $method;
+		yield implode('', explode('_', $method));
+		foreach (['post', 'put'] as $verb) {
+			if (substr( $method, -strlen($verb)) == $verb) {
+				yield substr($method, 0, -strlen($verb));
+				yield implode('', explode('_', substr($method, 0, -strlen($verb))));
+			}
+		}
+	}
+
 }

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -38,13 +38,12 @@ $application->registerRoutes($this, [
 	'resources' => [
 		'groups' => ['url' => '/settings/users/groups'],
 		'users' => ['url' => '/settings/users/users'],
-		'AuthSettings' => ['url' => '/settings/personal/authtokens'],
+		'auth_settings' => ['url' => '/settings/personal/authtokens'],
 	],
 	'routes' => [
 		['name' => 'MailSettings#setMailSettings', 'url' => '/settings/admin/mailsettings', 'verb' => 'POST'],
 		['name' => 'MailSettings#storeCredentials', 'url' => '/settings/admin/mailsettings/credentials', 'verb' => 'POST'],
 		['name' => 'MailSettings#sendTestMail', 'url' => '/settings/admin/mailtest', 'verb' => 'POST'],
-		['name' => 'Encryption#startMigration', 'url' => '/settings/admin/startmigration', 'verb' => 'POST'],
 		['name' => 'AppSettings#listApps', 'url' => '/settings/apps/list', 'verb' => 'GET'],
 		['name' => 'Users#setDisplayName', 'url' => '/settings/users/{username}/displayName', 'verb' => 'POST'],
 		['name' => 'Users#setMailAddress', 'url' => '/settings/users/{id}/mailAddress', 'verb' => 'PUT'],


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Related Issue
 refs https://github.com/owncloud/enterprise/issues/2207

## Whats missing?
- [x] no annotations for controllers which are not resolved via their class name https://github.com/owncloud/diagnostics/blob/master/lib/AppInfo/Application.php#L62
- [x] all controllers in core - because they are named \OC\Core and not \OCA\...
-  [ ] ocs routes need a second look

## How Has This Been Tested?
Manual local testing ...

## Screenshots (if appropriate):
![bildschirmfoto von 2017-09-11 10-57-26](https://user-images.githubusercontent.com/1005065/30266556-0e2d3a34-96e0-11e7-870d-a4d6d1471efd.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

