### PR TITLE
Add option to disable sharing in user-mounted external storages

### DIFF
--- a/apps/files_external/lib/Panels/Admin.php
+++ b/apps/files_external/lib/Panels/Admin.php
@@ -67,6 +67,8 @@ class Admin implements ISettings {
 		$tmpl->assign('authMechanisms', $this->backendService->getAuthMechanisms());
 		$tmpl->assign('dependencies', \OC_Mount_Config::dependencyMessage($this->backendService->getBackends()));
 		$tmpl->assign('allowUserMounting', $this->backendService->isUserMountingAllowed());
+		$tmpl->assign('allowUserMountSharing', $this->config->getAppValue('core', 'allow_user_mount_sharing', 'yes') === 'yes');
+
 		return $tmpl;
 	}
 

--- a/apps/files_external/lib/Panels/Personal.php
+++ b/apps/files_external/lib/Panels/Personal.php
@@ -68,6 +68,7 @@ class Personal implements ISettings {
 		$tmpl->assign('backends', $this->backendService->getAvailableBackends());
 		$tmpl->assign('authMechanisms', $this->backendService->getAuthMechanisms());
 		$tmpl->assign('allowUserMounting', $enabled);
+		$tmpl->assign('allowUserMountSharing', $this->config->getAppValue('core', 'allow_user_mount_sharing', 'yes') === 'yes');
 		return $tmpl;
     }
 

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -152,7 +152,14 @@
 				<?php endif; ?>
 				<?php $i++; ?>
 			<?php endforeach; ?>
+			<br/>
+			<input type="checkbox" name="allowUserMountSharing" id="allowUserMountSharing" class="checkbox"
+				value="1" <?php if ($_['allowUserMountSharing'] === 'yes') print_unescaped(' checked="checked"'); ?> />
+			<label for="allowUserMountSharing"><?php p($l->t('Allow sharing on user-mounted external storages')); ?></label> <span id="userMountSharingMsg" class="msg"></span>
 		</p>
+	<?php else: ?>
+		<input type="hidden" name="allowUserMountSharing" id="allowUserMountSharing"
+			value="<?php p($_['allowUserMountSharing']) ?>" />
 	<?php endif; ?>
 	</div>
 </form>

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -336,7 +336,7 @@ describe('OCA.External.Settings tests', function() {
 				expect($td.find('.dropdown').length).toEqual(0);
 			});
 
-			it('doesnt show the encryption option when encryption is disabled', function () {
+			it('does not show the encryption option when encryption is disabled', function () {
 				view._encryptionEnabled = false;
 				$td.find('img').click();
 
@@ -374,6 +374,41 @@ describe('OCA.External.Settings tests', function() {
 					filesystem_check_changes: 0,
 					encoding_compatibility: false
 				});
+			});
+
+			it('does not show the sharing option when sharing is disabled for user shares', function () {
+				var testCases = [
+					{
+						personal: false,
+						sharingAllowed: false,
+						expectedVisible: true
+					},
+					{
+						personal: true,
+						sharingAllowed: false,
+						expectedVisible: false
+					},
+					{
+						personal: true,
+						sharingAllowed: true,
+						expectedVisible: true
+					},
+				];
+
+				_.each(testCases, function(testCase) {
+					view._isPersonal = testCase.personal;
+					view._allowUserMountSharing = testCase.sharingAllowed;
+
+					$td.find('img').click();
+
+					expect($td.find('.dropdown [name=enable_sharing]:visible').length)
+						.toEqual(testCase.expectedVisible ? 1 : 0);
+
+					$('body').mouseup();
+
+					expect($td.find('.dropdown').length).toEqual(0);
+				});
+
 			});
 		});
 	});

--- a/lib/private/Files/Storage/Temporary.php
+++ b/lib/private/Files/Storage/Temporary.php
@@ -44,4 +44,8 @@ class Temporary extends Local{
 	public function getDataDir() {
 		return $this->datadir;
 	}
+
+	public function getAvailability() {
+		return ['available' => true, 'last_checked' => 0];
+	}
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -556,6 +556,7 @@ class Server extends ServerContainer implements IServerContainer {
 			// external storage
 			if ($config->getAppValue('core', 'enable_external_storage', 'no') === 'yes') {
 				$manager->registerProvider(new \OC\Files\External\ConfigAdapter(
+					$c->query('AllConfig'),
 					$c->query('UserStoragesService'),
 					$c->query('UserGlobalStoragesService')
 				));

--- a/tests/lib/Files/External/ConfigAdapterTest.php
+++ b/tests/lib/Files/External/ConfigAdapterTest.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace Test\Files\External;
+
+use OCP\Files\External\Service\IUserStoragesService;
+use OCP\Files\External\Service\IUserGlobalStoragesService;
+use OCP\IUser;
+use OC\Files\External\ConfigAdapter;
+use OCP\IConfig;
+use OC\Files\External\Service\UserStoragesService;
+use OC\Files\External\Service\UserGlobalStoragesService;
+use OCP\Files\External\IStorageConfig;
+use OCP\Files\External\Auth\AuthMechanism;
+use OCP\Files\External\Backend\Backend;
+use OC\Files\External\PersonalMount;
+use OC\Files\Mount\MountPoint;
+use OC\Files\Storage\StorageFactory;
+
+class ConfigAdapterTest extends \Test\TestCase {
+
+	/** @var \OCP\IConfig */
+	private $config;
+
+	/** @var IUserStoragesService */
+	private $userStoragesService;
+
+	/** @var IUserGlobalStoragesService */
+	private $userGlobalStoragesService;
+
+	/** @var IUser **/
+	private $user;
+
+	protected function setUp() {
+		$this->config = $this->createMock(IConfig::class);
+		$this->userStoragesService = $this->createMock(UserStoragesService::class);
+		$this->userGlobalStoragesService = $this->createMock(UserGlobalStoragesService::class);
+		$this->user = $this->createMock(IUser::class);
+		$this->user->expects($this->any())
+			->method('getUID')
+			->willReturn('user1');
+	}
+
+	private function createStorageConfig($mountPoint, $mountOptions) {
+		$auth = $this->createMock(AuthMechanism::class);
+		$backend = $this->createMock(Backend::class);
+		$config = $this->createMock(IStorageConfig::class);
+
+		$config->expects($this->any())
+			->method('getBackendOptions')
+			->willReturn([]);
+		$config->expects($this->any())
+			->method('getBackendOption')
+			->willReturn(null);
+		$config->expects($this->any())
+			->method('getAuthMechanism')
+			->willReturn($auth);
+		$config->expects($this->any())
+			->method('getBackend')
+			->willReturn($backend);
+		$config->expects($this->any())
+			->method('getMountPoint')
+			->willReturn($mountPoint);
+		$config->expects($this->any())
+			->method('getMountOptions')
+			->willReturn($mountOptions);
+
+		$auth->expects($this->once())
+			->method('manipulateStorageConfig')
+			->with($config, $this->user);
+		$backend->expects($this->once())
+			->method('manipulateStorageConfig')
+			->with($config, $this->user);
+
+		$backend->expects($this->once())
+			->method('getStorageClass')
+			->willReturn('\OC\Files\Storage\Temporary');
+
+		$backend->expects($this->once())
+			->method('wrapStorage')
+			->will($this->returnArgument(0));
+		$auth->expects($this->once())
+			->method('wrapStorage')
+			->will($this->returnArgument(0));
+
+		return $config;
+	}
+
+	private function getMountsForUser($globalStorages, $personalStorages) {
+		$storageFactory = $this->createMock(StorageFactory::class);
+		$storageFactory->expects($this->any())
+			->method('wrap')
+			->will($this->returnArgument(1));
+
+		$this->userStoragesService->expects($this->at(0))
+			->method('setUser')
+			->with($this->user);
+		$this->userGlobalStoragesService->expects($this->at(0))
+			->method('setUser')
+			->with($this->user);
+
+		$this->userGlobalStoragesService->expects($this->at(1))
+			->method('getUniqueStorages')
+			->willReturn($globalStorages);
+		$this->userStoragesService->expects($this->at(1))
+			->method('getStorages')
+			->willReturn($personalStorages);
+
+		$this->userStoragesService->expects($this->at(2))
+			->method('resetUser');
+		$this->userGlobalStoragesService->expects($this->at(2))
+			->method('resetUser');
+
+		$configAdapter = new ConfigAdapter(
+			$this->config,
+			$this->userStoragesService,
+			$this->userGlobalStoragesService
+		);
+
+		return $configAdapter->getMountsForUser($this->user, $storageFactory);
+	}
+
+	public function testGetPersonalMounts() {
+		$storage1 = $this->createStorageConfig('/mount1', ['test_value' => true]);
+		$storage2 = $this->createStorageConfig('/globalmount1', ['test_value2' => 'abc']);
+
+		$result = $this->getMountsForUser([$storage2], [$storage1]);
+
+		$this->assertCount(2, $result);
+
+		$mount = $result['/mount1'];
+		$this->assertInstanceOf(PersonalMount::class, $mount);
+		$this->assertEquals('/user1/files/mount1/', $mount->getMountPoint());
+		$options = $mount->getOptions();
+		$this->assertTrue($options['test_value']);
+
+		$mount = $result['/globalmount1'];
+		$this->assertEquals('/user1/files/globalmount1/', $mount->getMountPoint());
+		$options = $mount->getOptions();
+		$this->assertEquals('abc', $options['test_value2']);
+	}
+
+	public function sharingOptionProvider() {
+		return [
+			[true, true],
+			[false, false],
+		];
+	}
+
+	/**
+	 * @dataProvider sharingOptionProvider
+	 */
+	public function testGetPersonalMountSharingOption($isSharingAllowed, $expectedValue) {
+		$this->config->expects($this->any())
+			->method('getAppValue')
+			->will($this->returnValueMap([
+				['core', 'allow_user_mount_sharing', 'yes', $isSharingAllowed ? 'yes' : 'no']
+			]));
+
+		$storage1 = $this->createStorageConfig('/mount1', ['enable_sharing' => true]);
+		$storage2 = $this->createStorageConfig('/globalmount1', ['enable_sharing' => true]);
+
+		$result = $this->getMountsForUser([$storage2], [$storage1]);
+
+		$this->assertCount(2, $result);
+
+		$mount = $result['/mount1'];
+		$options = $mount->getOptions();
+		$this->assertEquals($expectedValue, $options['enable_sharing']);
+
+		$mount = $result['/globalmount1'];
+		$options = $mount->getOptions();
+		$this->assertTrue($options['enable_sharing']);
+	}
+}
+


### PR DESCRIPTION
## Description
Adds a new checkbox to disable sharing in user-mount external storages.

Since ConfigAdapterTest was missing I had to write all of it from scratch.
It turned out that some interfaces had missing methods for mocking (IStorageFactory::wrap), so I added it.
And also added `Temporary::getAvailability()` for the temporary test storage to avoid a DB round trip which would fail in this test.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28636

## Motivation and Context
See ticket

## How Has This Been Tested?
- [x] TEST: manual testing in web UI
    - [x] TEST: when allowed, user mount has "Enable sharing" option visible. Share action visible in files UI.
    - [x] TEST: when disallowed, user mount has no "Enable sharing" option visible. Share action not visible in files UI
    - [x] TEST: when disallowed, system mounts can still have sharing enabled
- [x] TEST: unit tests

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

