### PR TITLE
[stable10] Replacing password icons with shield for secuirity

### DIFF
--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -432,3 +432,12 @@ img.icon-loading-small-dark, object.icon-loading-small-dark, video.icon-loading-
 .icon-social-googleplus {
 	background-image: url('../img/social/social-googleplus.svg');
 }
+
+/* apps icons */
+.icon-shield {
+	background-image: url('../img/apps/shield.svg')
+}
+
+.icon-workflow {
+	background-image: url('../img/apps/workflow.svg')
+}

--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -198,7 +198,7 @@ class SettingsManager implements ISettingsManager {
 				new Section('apps', $this->l->t('Apps'), 105, 'list'),
 				new Section('general', $this->l->t('General'), 100),
 				new Section('storage', $this->l->t('Storage'), 95, 'folder'),
-				new Section('security', $this->l->t('Security'), 90, 'password'),
+				new Section('security', $this->l->t('Security'), 90, 'shield'),
 				new Section('authentication', $this->l->t('User Authentication'), 87, 'user'),
 				new Section('encryption', $this->l->t('Encryption'), 85, 'password'),
 				new Section('workflow', $this->l->t('Workflows & Tags'), 85, 'workflows'),
@@ -212,7 +212,7 @@ class SettingsManager implements ISettingsManager {
 			return [
 				new Section('general', $this->l->t('General'), 100, 'user'),
 				new Section('storage', $this->l->t('Storage'), 50, 'folder'),
-				new Section('security', $this->l->t('Security'), 30, 'password'),
+				new Section('security', $this->l->t('Security'), 30, 'shield'),
 				new Section('encryption', $this->l->t('Encryption'), 20),
 				new Section('additional', $this->l->t('Additional'), -10, 'more'),
 			];


### PR DESCRIPTION
Replacing password icons with shield for
security in the settings page.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Using new sheild icon for Security under the settings page.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/28641

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Using sheild icon for Security under the settings page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by verifying in the UI.

## Screenshots (if appropriate):
![security-icon-settingspage](https://user-images.githubusercontent.com/3600427/29202224-9bdf0684-7e83-11e7-892c-46ded8c4d18c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

