### PR TITLE
Revert "Ensure that FileInfo return values as required by its phpdoc."

### DIFF
--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -133,12 +133,10 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	}
 
 	/**
-	 * Get FileInfo ID or null in case of part file
-	 *
-	 * @return int/null
+	 * @return int
 	 */
 	public function getId() {
-		return isset($this->data['fileid']) ? intval($this->data['fileid']) : null;
+		return $this->data['fileid'];
 	}
 
 	/**
@@ -178,14 +176,14 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 * @return int
 	 */
 	public function getSize() {
-		return isset($this->data['size']) ? intval($this->data['size']) : 0;
+		return isset($this->data['size']) ? $this->data['size'] : 0;
 	}
 
 	/**
 	 * @return int
 	 */
 	public function getMTime() {
-		return intval($this->data['mtime']);
+		return $this->data['mtime'];
 	}
 
 	/**
@@ -201,7 +199,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 * @return int
 	 */
 	public function getEncryptedVersion() {
-		return isset($this->data['encryptedVersion']) ? intval($this->data['encryptedVersion']) : 1;
+		return isset($this->data['encryptedVersion']) ? (int) $this->data['encryptedVersion'] : 1;
 	}
 
 	/**
@@ -212,7 +210,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 		if (\OCP\Util::isSharingDisabledForUser() || ($this->isShared() && !\OC\Share\Share::isResharingAllowed())) {
 			$perms = $perms & ~\OCP\Constants::PERMISSION_SHARE;
 		}
-		return intval($perms);
+		return $perms;
 	}
 
 	/**


### PR DESCRIPTION
Reverts owncloud/core#27389

Fixes https://github.com/owncloud/core/issues/28275

However we still need to investigate why sometimes a size can be a string without being on 32-bit platform and without being bigger than max int. There could be bugs somewhere else in the code.