### PR TITLE
Only set X-OC-Mtime when browser provided lastModified on upload

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -284,11 +284,17 @@ OC.FileUpload.prototype = {
 		}
 
 		var uid = OC.getCurrentUser().uid;
+		var mtime = this.getFile().lastModified;
+		var headers = {};
+		if (mtime) {
+			headers['X-OC-Mtime'] = mtime / 1000;
+		}
+
 		return this.uploader.davClient.move(
 			'uploads/' + encodeURIComponent(uid) + '/' + encodeURIComponent(this.getId()) + '/.file',
 			'files/' + encodeURIComponent(uid) + '/' + OC.joinPaths(this.getFullPath(), this.getFileName()),
 			true,
-			{'X-OC-Mtime': this.getFile().lastModified / 1000}
+			headers
 		);
 	},
 


### PR DESCRIPTION
@individual-it @DeepDiver1975 please review and retest with IE11.

The original bug was that with IE11 no mtime value was found so the header was set to `NaN` for new dav chunked uploads.