### PR TITLE
Do not show warnings when using scripted occ output

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -73,14 +73,14 @@ export TEST_SERVER_URL="http://localhost:$PORT/ocs/"
 export TEST_SERVER_FED_URL="http://localhost:$PORT_FED/ocs/"
 
 #Set up personalized skeleton
-PREVIOUS_SKELETON_DIR=$($OCC config:system:get skeletondirectory)
+PREVIOUS_SKELETON_DIR=$($OCC --no-warnings config:system:get skeletondirectory)
 $OCC config:system:set skeletondirectory --value="$(pwd)/skeleton"
 
 #Enable external storage app
 $OCC config:app:set core enable_external_storage --value=yes
 $OCC config:system:set files_external_allow_create_new_local --value=true
 
-PREVIOUS_TESTING_APP_STATUS=$($OCC app:list "^testing$")
+PREVIOUS_TESTING_APP_STATUS=$($OCC --no-warnings app:list "^testing$")
 if [[ "$PREVIOUS_TESTING_APP_STATUS" =~ ^Disabled: ]]
 then
 	$OCC app:enable testing

--- a/tests/travis/start_behat_tests.sh
+++ b/tests/travis/start_behat_tests.sh
@@ -134,7 +134,7 @@ EXTRA_CAPABILITIES=$EXTRA_CAPABILITIES'"maxDuration":"3600"'
 
 #Set up personalized skeleton
 OCC=./occ
-PREVIOUS_SKELETON_DIR=$($OCC config:system:get skeletondirectory)
+PREVIOUS_SKELETON_DIR=$($OCC --no-warnings config:system:get skeletondirectory)
 $OCC config:system:set skeletondirectory --value="$(pwd)/tests/ui/skeleton" >/dev/null
 
 echo "Running tests on '$BROWSER' ($BROWSER_VERSION) on $PLATFORM"


### PR DESCRIPTION
## Description
Add ``--no-warnings`` option so that these testing scripts can rely on getting just the information output that they expect.

## Related Issue
#28638 

## Motivation and Context
If testing, and switching branches etc., it is easy to accidentally get in a state where a message like this comes out from the ``occ`` command:
```
ownCloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
```
and that messes up automated parsing of the expected ``app:list`` or ``config:system:get`` output.

## How Has This Been Tested?
Switch branches/tags to ones with different oC versions to induce this.
Run some integration and UI tests.
Check that skeletondirectory and testing app status are preserved OK.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

