### PR TITLE
Add request method getServerAddress()

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -538,6 +538,26 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	}
 
 	/**
+	 * Returns the server address.
+	 * Some servers do not set $_SERVER['SERVER_ADDR'] so also allow it to be
+	 * provided as an environment variable if needed.
+	 * Always use this instead of $_SERVER['SERVER_ADDR']
+	 * @return string|false server IP address or false if not found or not a valid IP
+	 * @since 10.0.3
+	 */
+	public function getServerAddress() {
+		if (isset($this->server['SERVER_ADDR'])) {
+			$serverAddress = $this->server['SERVER_ADDR'];
+		} else if (isset($this->env['SERVER_ADDR'])) {
+			$serverAddress = $this->env['SERVER_ADDR'];
+		} else {
+			$serverAddress = getenv('SERVER_ADDR');
+		}
+
+		return filter_var($serverAddress, FILTER_VALIDATE_IP);
+	}
+
+	/**
 	 * Check overwrite condition
 	 * @param string $type
 	 * @return bool

--- a/lib/public/IRequest.php
+++ b/lib/public/IRequest.php
@@ -164,6 +164,14 @@ interface IRequest {
 	public function getRemoteAddress();
 
 	/**
+	 * Returns the server address.
+	 *
+	 * @return string|false server IP address or false if not found or not a valid IP
+	 * @since 10.0.3
+	 */
+	public function getServerAddress();
+
+	/**
 	 * Returns the server protocol. It respects reverse proxy servers and load
 	 * balancers.
 	 *


### PR DESCRIPTION
## Description
provide getServerAddress() method that:
1) looks for it from $_SERVER
2) if not found, looks for it from $_ENV
3) if still not found, looks for it as a real external environment variable

## Related Issue

## Motivation and Context
Many servers provide the IP address of the server in $_SERVER['SERVER_ADDR'] but this is not guaranteed. In particular, as a developer, the built-in PHP dev server does not provide this! It also does not automatically load environment variables in $_ENV. So provide a function that gathers SERVER_ADDR from wherever it can find it.

This will allow devs to pre-define SERVER_ADDR as an environment variable before starting the PHP dev server. Or for other servers that may not provide it, the sysadmin can do similar.

This can be useful for things like "firewall" that may want to know which server address a request is coming in on (e.g. systems running dual stack IPv4 and IPv6, and/or multiple network interfaces). Then code can make different decisions depending on that.

## How Has This Been Tested?
Firewall app tests based on server address.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

