### PR TITLE
Highlight files after setFiles

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -146,6 +146,12 @@
 		_filter: '',
 
 		/**
+		 * File to be highlighted in view
+		 * @type String
+		 */
+		_scrollTo: null,
+
+		/**
 		 * @type Backbone.Model
 		 */
 		_filesConfig: undefined,
@@ -209,7 +215,9 @@
 			if (this.initialized) {
 				return;
 			}
-
+			if (options.scrollTo) {
+				this._scrollTo = options.scrollTo;
+			}
 			if (options.config) {
 				this._filesConfig = options.config;
 			} else if (!_.isUndefined(OCA.Files) && !_.isUndefined(OCA.Files.App)) {
@@ -331,12 +339,6 @@
 			this.$el.find('.selectedActions a').tooltip({placement:'top'});
 
 			this.$container.on('scroll', _.bind(this._onScroll, this));
-
-			if (options.scrollTo) {
-				this.$fileList.one('updated', function() {
-					self.scrollTo(options.scrollTo);
-				});
-			}
 
 			if (options.enableUpload) {
 				// TODO: auto-create this element
@@ -1033,6 +1035,13 @@
 			_.defer(function() {
 				self.$el.closest('#app-content').trigger(jQuery.Event('apprendered'));
 			});
+
+			if (this._scrollTo) {
+				this.$fileList.on('updated', function() {
+					self.scrollTo(self._scrollTo);
+					self._scrollTo = null;
+				});
+			}
 		},
 
 		/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Call file highlighting *after* files are redered to view

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes https://github.com/owncloud/core/issues/28106

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Visual test in FF; Chrome, IE11 and MS Edge

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.