### PR TITLE
Allowing chunking an empty file

### DIFF
--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -159,6 +159,10 @@ class UploadHelper {
 			$chunks[] = fread($fp, $chunkSize);
 		}
 		fclose($fp);
+		if (count($chunks) === 0) {
+			// chunk an empty file
+			$chunks[] = '';
+		}
 		return $chunks;
 	}
 


### PR DESCRIPTION
## Description
If we are trying to split an empty file into "chunks", then there won't be any because feof() is reached as soon as the file is opened.

Purposely make a single empty chunk.

## Related Issue
#28664 

## Motivation and Context
Make an edge case work in the test infrastructure, so that tests that loop around trying [no|v1|v2] chunking will work OK when trying to upload a 0 byte file.

## How Has This Been Tested?
Enable a firewall test with 0 byte file to try all chunking versions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

