### PR TITLE
[stable10] Prevent cert manager to access FS before an upgrade

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -69,7 +69,7 @@ class Client implements IClient {
 			// If the instance is not yet setup we need to use the static path as
 			// $this->certificateManager->getAbsoluteBundlePath() tries to instantiiate
 			// a view
-			if ($this->config->getSystemValue('installed', false)) {
+			if ($this->config->getSystemValue('installed', false) && !\OCP\Util::needUpgrade()) {
 				$this->client->setDefaultOption('verify', $this->certificateManager->getAbsoluteBundlePath(null));
 			} else {
 				$this->client->setDefaultOption('verify', \OC::$SERVERROOT . '/resources/config/ca-bundle.crt');


### PR DESCRIPTION
## Description
Prevent cert manager to access FS functions before an upgrade as this would cause oc_filecache access and might bump into non-migrated table situations (ex: checksum column not existing with 8.2 DB when upgrading from 8.2 to 10)

## Related Issue
Fixes https://github.com/owncloud/core/issues/28667

## Motivation and Context
See ticket

## How Has This Been Tested?
Manual test with ticket steps

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODO:
- [ ] forward port to master!

@DeepDiver1975 @phisch I hope the cert manager doesn't require self signed certs anywhere during the update process...
