### PR TITLE
Fix opendir php warning in case a file is passed in - e.g. opendir(/d…

### DIFF
--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -281,7 +281,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 			'.' => true,
 		];
 
-		if ($dh = opendir($dataDir)) {
+		if ($dh = @opendir($dataDir)) {
 			while (($file = readdir($dh)) !== false) {
 				if (!isset($knownEntries[$file])) {
 					self::tearDownAfterClassCleanStrayDataUnlinkDir($dataDir . '/' . $file);
@@ -297,21 +297,23 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	 * @param string $dir
 	 */
 	static protected function tearDownAfterClassCleanStrayDataUnlinkDir($dir) {
-		if ($dh = @opendir($dir)) {
-			while (($file = readdir($dh)) !== false) {
-				if (\OC\Files\Filesystem::isIgnoredDir($file)) {
-					continue;
+		if (is_dir($dir)) {
+			if ($dh = @opendir($dir)) {
+				while (($file = readdir($dh)) !== false) {
+					if (\OC\Files\Filesystem::isIgnoredDir($file)) {
+						continue;
+					}
+					$path = $dir . '/' . $file;
+					if (is_dir($path)) {
+						self::tearDownAfterClassCleanStrayDataUnlinkDir($path);
+					} else {
+						@unlink($path);
+					}
 				}
-				$path = $dir . '/' . $file;
-				if (is_dir($path)) {
-					self::tearDownAfterClassCleanStrayDataUnlinkDir($path);
-				} else {
-					@unlink($path);
-				}
+				closedir($dh);
 			}
-			closedir($dh);
+			@rmdir($dir);
 		}
-		@rmdir($dir);
 	}
 
 	/**


### PR DESCRIPTION
…ev/shm/data-autotest/logtest): failed to open dir: Not a directory

## Description
Under certain conditions phpunit execution just terminates and all you see it

![bildschirmfoto von 2017-08-14 15-04-26](https://user-images.githubusercontent.com/1005065/29272804-e4f1e92e-8101-11e7-8076-2a922f4f0f40.png)


## Motivation and Context
A bit more defensive coding ....

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

