### PR TITLE
Handle fatal log level in occ log:manage

### DIFF
--- a/core/Command/Log/Manage.php
+++ b/core/Command/Log/Manage.php
@@ -59,7 +59,7 @@ class Manage extends Command {
 				'level',
 				null,
 				InputOption::VALUE_REQUIRED,
-				'set the log level [debug, info, warning, error]'
+				'set the log level [debug, info, warning, error, fatal]'
 			)
 			->addOption(
 				'timezone',
@@ -149,6 +149,8 @@ class Manage extends Command {
 		case 'error':
 		case 'err':
 			return 3;
+		case 'fatal':
+			return 4;
 		}
 		throw new \InvalidArgumentException('Invalid log level string');
 	}
@@ -168,7 +170,10 @@ class Manage extends Command {
 			return 'Warning';
 		case 3:
 			return 'Error';
+		case 4:
+			return 'Fatal';
 		}
 		throw new \InvalidArgumentException('Invalid log level number');
 	}
 }
+

--- a/tests/TestHelpers/LoggingHelper.php
+++ b/tests/TestHelpers/LoggingHelper.php
@@ -57,7 +57,7 @@ class LoggingHelper {
 	}
 	
 	/**
-	 * returns the currently set log level [debug, info, warning, error]
+	 * returns the currently set log level [debug, info, warning, error, fatal]
 	 * 
 	 * @param string $ocPath
 	 * @throws \Exception
@@ -80,13 +80,13 @@ class LoggingHelper {
 	/**
 	 * 
 	 * @param string $ocPath
-	 * @param string $logLevel (debug|info|warning|error)
+	 * @param string $logLevel (debug|info|warning|error|fatal)
 	 * @return void
 	 * @throws \InvalidArgumentException
 	 * @throws \Exception
 	 */
 	public static function setLogLevel($ocPath, $logLevel) {
-		if (!in_array($logLevel, ["debug", "info", "warning", "error"])) {
+		if (!in_array($logLevel, ["debug", "info", "warning", "error", "fatal"])) {
 			throw new \InvalidArgumentException("invalid log level");
 		}
 		$result = SetupHelper::runOcc(["log:manage", "--level=$logLevel"], $ocPath);


### PR DESCRIPTION
## Description
Add the "fatal" log level to the list of log levels that the ``occ log:manage`` command knows about.
And similar for LoggingHelper.

## Related Issue
#28679 

## Motivation and Context
Make ``occ log:manage`` work with the same log levels as available in the UI.

## How Has This Been Tested?
1. Set log level to Fatal in the UI.
2. ``occ log:manage`` and confirm it produces good output
3. Use ``occ log:manage`` to change to another log level - make sure the UI shows the new level.
4. Use ``occ log:manage`` to change to fatal log level - make sure the UI shows the fatal level.

Make some UI tests that set the logging level to "fatal" and confirm that they run.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

