### PR TITLE
Remove apostrophe from error text

### DIFF
--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -177,13 +177,13 @@ class OC_Files {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
 			$l = \OC::$server->getL10N('core');
-			\OC_Template::printErrorPage($l->t('Can\'t read file'), $ex->getMessage(), 403);
+			\OC_Template::printErrorPage($l->t('File cannot be read'), $ex->getMessage(), 403);
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
 			$l = \OC::$server->getL10N('core');
 			$hint = method_exists($ex, 'getHint') ? $ex->getHint() : '';
-			\OC_Template::printErrorPage($l->t('Can\'t read file'), $hint);
+			\OC_Template::printErrorPage($l->t('File cannot be read'), $hint);
 		}
 	}
 


### PR DESCRIPTION
## Description
Do not use special characters in the text saying that a file cannot be read.

## Related Issue
https://github.com/owncloud/core/issues/28684
https://github.com/owncloud/firewall/issues/309

## Motivation and Context
This is a pragmatic work-around for this particular case - just get rid of the apostrophe.

## How Has This Been Tested?
Block a folder with a firewall rule, share a public link to it, access the public link and try to download a file in that folder. Verify that the message is displayed OK.

## Screenshots (if appropriate):
![cannot](https://user-images.githubusercontent.com/1535615/29311669-9518a59c-81d2-11e7-8983-e32c0ba596e5.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

