### PR TITLE
If exception message exists do not bother with cannot be read text

### DIFF
--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -176,8 +176,12 @@ class OC_Files {
 		} catch (\OCP\Files\ForbiddenException $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
-			$l = \OC::$server->getL10N('core');
-			\OC_Template::printErrorPage($l->t('File cannot be read'), $ex->getMessage(), 403);
+			$displayedMessage = $ex->getMessage();
+			if (strlen($displayedMessage) === 0) {
+				$l = \OC::$server->getL10N('core');
+				$displayedMessage = $l->t('File cannot be read');
+			}
+			\OC_Template::printErrorPage($displayedMessage, '', 403);
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);


### PR DESCRIPTION
For the ForbiddenException, if the exception has a message, then display that only rather than bothering to also display 'File cannot be read'.

another way to go???