### PR TITLE
Fix getting drop target when dragging from file manager

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -251,6 +251,7 @@ OC.FileUpload.prototype = {
 			this.data.headers['Authorization'] =
 				'Basic ' + btoa(userName + ':' + (password || ''));
 		}
+		this.data.headers['requesttoken'] = OC.requestToken;
 
 		var chunkFolderPromise;
 		if ($.support.blobSlice

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1196,11 +1196,15 @@ OC.Uploader.prototype = _.extend({
 				fileupload.on('fileuploaddone', function(e, data) {
 					var upload = self.getUpload(data);
 					upload.done().then(function() {
-						// don't hide if there are more files to process
-						if (!self.isProcessing()) {
-							self._hideProgressBar();
-						}
 						self.trigger('done', e, upload);
+						// defer because sometimes the current upload is still in pending
+						// state but frees itself afterwards
+						_.defer(function() {
+							// don't hide if there are more files to process
+							if (!self.isProcessing()) {
+								self._hideProgressBar();
+							}
+						});
 					}).fail(function(status, response) {
 						var message = response.message;
 						self._hideProgressBar();

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2702,7 +2702,7 @@
 					return false;
 				}
 
-				var dropTarget = $(e.originalEvent.target);
+				var dropTarget = $(e.originalEvent.delegatedEvent.target);
 				// check if dropped inside this container and not another one
 				if (dropTarget.length
 					&& !self.$el.is(dropTarget) // dropped on list directly

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2649,7 +2649,9 @@ describe('OCA.Files.FileList tests', function() {
 			function dropOn($target, data) {
 				var eventData = {
 					originalEvent: {
-						target: $target
+						delegatedEvent: {
+							target: $target
+						}
 					}
 				};
 				uploader.trigger('drop', eventData, data || {});


### PR DESCRIPTION
## Description
Possibly related to jquery.fileupload upgrade, now
e.originalEvent.target might be null.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28689.

## Motivation and Context
See ticket

## How Has This Been Tested?
Manual testing like in the ticket.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

