### PR TITLE
Implement race-condition-safe DB upsert and use in filecache

### DIFF
--- a/lib/private/AppFramework/Db/Db.php
+++ b/lib/private/AppFramework/Db/Db.php
@@ -254,4 +254,11 @@ class Db implements IDb {
 	public function allows4ByteCharacters() {
 		return $this->connection->allows4ByteCharacters();
 	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function upsert($table, $input, array $compare = null) {
+		return $this->connection->upsert($table, $input, $compare);
+	}
 }

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -28,6 +28,7 @@
 namespace OC\DB;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\Platforms\OraclePlatform;
 
 /**
  * This handles the way we use to write queries, into something that can be
@@ -137,7 +138,11 @@ class Adapter {
 		$updateQuery .= '`' . implode('`  = ?, `', array_keys($input)) . '` = ?  WHERE ';
 		$updateParams = array_values($input);
 		foreach ($compare as $key) {
-			$updateQuery .= '`' . $key . '`';
+			if($this->conn->getDatabasePlatform() instanceof OraclePlatform) {
+				$updateQuery .= 'to_char(`' . $key . '`)';
+			} else {
+				$updateQuery .= '`' . $key . '`';
+			}
 			if (is_null($input[$key])) {
 				$updateQuery .= ' IS NULL AND ';
 			} else {

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -191,7 +191,8 @@ class Adapter {
 
 		// Pass through failures correctly
 		if($count === $maxTry) {
-			throw new \RuntimeException("DB upsert failed after $maxTry attempts. Query: $updateQuery");
+			$params = implode(',', $input);
+			throw new \RuntimeException("DB upsert failed after $maxTry attempts. Query: $updateQuery. Params: $params");
 		}
 
 		$this->conn->commit();

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -6,6 +6,7 @@
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Robin Appelman <icewind@owncloud.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Tom Needham <tom@owncloud.com>
  *
  * @copyright Copyright (c) 2017, ownCloud GmbH
  * @license AGPL-3.0
@@ -120,6 +121,7 @@ class Adapter {
 	 * @param $input array the key=>value pairs to insert into the db row
 	 * @param $compare array columns that should be compared
 	 * @return int the number of rows affected by the operation
+	 * @throws \Exception
 	 */
 	public function upsert($table, $input, $compare = null) {
 		$this->conn->beginTransaction();
@@ -132,7 +134,7 @@ class Adapter {
 
 		// Construct the update query
 		$updateQuery = 'UPDATE `' . $table . '` SET ';
-		$updateQuery .= '`' . implode('`  = ?, `', array_keys($input)) . '` = ?  WHERE';
+		$updateQuery .= '`' . implode('`  = ?, `', array_keys($input)) . '` = ?  WHERE ';
 		$updateParams = array_values($input);
 		foreach ($compare as $key) {
 			$updateQuery .= '`' . $key . '`';
@@ -146,8 +148,10 @@ class Adapter {
 		// Remove the last ' AND ' from the query
 		$updateQuery = substr($updateQuery, 0, strlen($updateQuery) - 5);
 
+		$rows = 0;
 		$count = 0;
 		$maxTry = 10;
+
 		while(!$done && $count < $maxTry) {
 			// Try to update
 			try {
@@ -157,6 +161,9 @@ class Adapter {
 				if($e->getErrorCode() == 1213) {
 					$count++;
 					continue;
+				} else {
+					// We should catch other exceptions up the stack
+					throw $e;
 				}
 			}
 			if($rows > 0) {
@@ -172,12 +179,14 @@ class Adapter {
 					// Catch the unique violation and try the loop again
 					$count++;
 				}
+				// Other exceptions are not caught, they should be caught up the stack
 				$this->conn->commit();
 			}
 		}
 
+		// Pass through failures correctly
 		if($count === $maxTry) {
-			throw new \RuntimeException("DB upsert failed after $maxTry attempts. Query $updateQuery");
+			throw new \RuntimeException("DB upsert failed after $maxTry attempts. Query: $updateQuery");
 		}
 
 		$this->conn->commit();

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -141,7 +141,7 @@ class Adapter {
 			->setParameter($col, $val);
 		}
 		foreach($compare as $key) {
-			if (is_null($input[$key])) {
+			if (is_null($input[$key]) || ($input[$key] === '' && $this->conn->getDatabasePlatform() instanceof OraclePlatform)) {
 				$qbu->andWhere($qbu->expr()->isNull($key));
 			} else {
 				if($this->conn->getDatabasePlatform() instanceof OraclePlatform) {

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -120,11 +120,11 @@ class Adapter {
 	 * Inserts, or updates a row into the database. Returns the inserted or updated rows
 	 * @param $table string table name including **PREFIX**
 	 * @param $input array the key=>value pairs to insert into the db row
-	 * @param $compare array columns that should be compared
+	 * @param $compare array columns that should be compared to look for existing arrays
 	 * @return int the number of rows affected by the operation
 	 * @throws DriverException|\RuntimeException
 	 */
-	public function upsert($table, $input, $compare = null) {
+	public function upsert($table, $input, $compare) {
 
 		$this->conn->beginTransaction();
 		$done = false;
@@ -142,16 +142,16 @@ class Adapter {
 		}
 		foreach($compare as $key) {
 			if (is_null($input[$key])) {
-				$qbu->where($qbu->expr()->isNull($key));
+				$qbu->andWhere($qbu->expr()->isNull($key));
 			} else {
 				if($this->conn->getDatabasePlatform() instanceof OraclePlatform) {
-					$qbu->where(
+					$qbu->andWhere(
 						$qbu->expr()->eq(
 							// needs to cast to char in order to compare with char
-							$qbu->createFunction('to_char(`'.$key.'`)'),
+							$qbu->createFunction('to_char(`'.$key.'`)'), // TODO does this handle empty strings on oracle correclty
 							$qbu->expr()->literal($input[$key])));
 				} else {
-					$qbu->where(
+					$qbu->andWhere(
 						$qbu->expr()->eq(
 							$key,
 							$qbu->expr()->literal($input[$key])));
@@ -184,6 +184,7 @@ class Adapter {
 					continue;
 				} else {
 					// We should catch other exceptions up the stack
+					$this->conn->rollBack();
 					throw $e;
 				}
 			}
@@ -210,7 +211,7 @@ class Adapter {
 		if($count === $maxTry) {
 			$params = implode(',', $input);
 			$updateQuery = $qbu->getSQL();
-			$insertQuery = isset($qbi) ? $qbi->getSQL() : "N/A";
+			$insertQuery = $qbi->getSQL();
 			throw new \RuntimeException("DB upsert failed after $count attempts. UpdateQuery: $updateQuery InsertQuery: $insertQuery");
 		}
 

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -125,6 +125,7 @@ class Adapter {
 	 * @throws DriverException|\RuntimeException
 	 */
 	public function upsert($table, $input, $compare = null) {
+
 		$this->conn->beginTransaction();
 		$done = false;
 

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -249,6 +249,21 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 		return $this->adapter->insertIfNotExist($table, $input, $compare);
 	}
 
+	/**
+	 * Attempt to update a row, else insert a new one
+	 *
+	 * @param string $table The table name (will replace *PREFIX* with the actual prefix)
+	 * @param array $input data that should be inserted into the table  (column name => value)
+	 * @param array|null $compare List of values that should be checked for "if not exists"
+	 *				If this is null or an empty array, all keys of $input will be compared
+	 *				Please note: text fields (clob) must not be used in the compare array
+	 * @return int number of affected rows
+	 * @throws \Doctrine\DBAL\DBALException
+	 */
+	public function upsert($table, $input, array $compare = null) {
+		return $this->adapter->upsert($table, $input, $compare);
+	}
+
 	private function getType($value) {
 		if (is_bool($value)) {
 			return IQueryBuilder::PARAM_BOOL;

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -261,21 +261,19 @@ class Cache implements ICache {
 			return trim($item, "`");
 		}, $queryParts);
 		$values = array_combine($queryParts, $params);
-		if (\OC::$server->getDatabaseConnection()->insertIfNotExist('*PREFIX*filecache', $values, [
-			'storage',
-			'path_hash',
-		])
-		) {
-			return (int)$this->connection->lastInsertId('*PREFIX*filecache');
-		}
+		// Update or insert this to the filecache
+		\OC::$server->getDatabaseConnection()->upsert(
+			'*PREFIX*filecache',
+			$values,
+			[
+				'storage',
+				'path_hash',
+			]
+		);
+		// Now return the id for this row - crappy that we have to select here
+		// GetID should already return a value if upsert returned a positive value
+		return (int)$this->getId($file);
 
-		// The file was created in the mean time
-		if (($id = $this->getId($file)) > -1) {
-			$this->update($id, $data);
-			return $id;
-		} else {
-			throw new \RuntimeException('File entry could not be inserted with insertIfNotExist() but could also not be selected with getId() in order to perform an update. Please try again.');
-		}
 	}
 
 	/**

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -116,6 +116,20 @@ interface IDBConnection {
 	public function insertIfNotExist($table, $input, array $compare = null);
 
 	/**
+	 * Attempt to update a row, else insert a new one
+	 *
+	 * @param string $table The table name (will replace *PREFIX* with the actual prefix)
+	 * @param array $input data that should be inserted into the table  (column name => value)
+	 * @param array|null $compare List of values that should be checked for "if not exists"
+	 *				If this is null or an empty array, all keys of $input will be compared
+	 *				Please note: text fields (clob) must not be used in the compare array
+	 * @return int number of affected rows
+	 * @throws \Doctrine\DBAL\DBALException
+	 * @since 10.0.3
+	 */
+	public function upsert($table, $input, array $compare = null);
+
+	/**
 	 * Insert or update a row value
 	 *
 	 * @param string $table

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -301,4 +301,5 @@ interface IDBConnection {
 	 * @since 10.0
 	 */
 	public function allows4ByteCharacters();
+
 }

--- a/tests/lib/DB/AdapterTest.php
+++ b/tests/lib/DB/AdapterTest.php
@@ -21,7 +21,8 @@
  */
 
 namespace Test\DB;
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\DriverException;
 use OC\DB\Adapter;
 use OCP\IDBConnection;
 
@@ -39,72 +40,140 @@ class AdapterTest extends \Test\TestCase {
 	/** @var IDBConnection  */
 	protected $conn;
 
-	protected $testTable = 'testdbadapter';
-
 	public function __construct() {
 		$this->conn = \OC::$server->getDatabaseConnection();
 		$this->adapter = new Adapter($this->conn);
 		parent::__construct();
 	}
 
-	public function setUp() {
-		// Create a dummy table
-		$toSchema = $this->conn->createSchema();
-
-		if(!$toSchema->hasTable($this->conn->getPrefix() . $this->testTable)) {
-			$table = $toSchema->createTable($this->conn->getPrefix() . $this->testTable);
-			$table->addColumn('id', Type::BIGINT, [
-				'autoincrement' => true,
-				'unsigned' => true,
-				'notnull' => true,
-			]);
-			$table->addColumn('val1', Type::TEXT, [
-				'notnull' => true,
-			]);
-			$table->setPrimaryKey(['id']);
-			$this->conn->migrateToSchema($toSchema);
-		}
-	}
-
 	public function tearDown() {
-		// Drop the test table
-		$toSchema = $this->conn->createSchema();
+		// remove columns from the appconfig table
+		$this->conn->prepare('DELETE FROM *PREFIX*appconfig WHERE `appid` LIKE ?')->execute(['testadapter-%']);
+	}
 
-		if($toSchema->hasTable($this->conn->getPrefix() . $this->testTable)) {
-			$table = $toSchema->dropTable($this->conn->getPrefix() . $this->testTable);
-			$this->conn->migrateToSchema($toSchema);
+	/**
+	 * Helper to insert a row
+	 * Checks one was inserted
+	 * @param array associative array of columns and values to insert
+	 */
+	public function insertRow($data) {
+		$table = $this->conn->getPrefix() . 'appconfig';
+		$data['appid'] = uniqid('testadapter-');
+		$query = "INSERT INTO $table";
+		$query .= "(" . implode(',', array_keys($data)) .')';
+		$query .= ' VALUES (' . str_repeat('?, ', count($data)-1) . '?)';
+		$rows = $this->conn->executeUpdate($query, array_values($data));
+		$this->assertEquals(1, $rows);
+	}
+
+	/**
+	 * Helper to delete a row
+	 */
+	public function deleteRow($where) {
+		$table = $this->conn->getPrefix() . 'appconfig';
+		$params = [];
+		$query = "DELETE FROM $table WHERE ";
+		foreach($where as $col => $val) {
+			$query .= "`?` = `?`, ";
+			$params[] = $col;
+			$params[] = $val;
 		}
+		$rows = $this->conn->executeUpdate($query, $params);
+		$this->assertEquals(1, $rows);
+		return $rows;
 	}
 
 	/**
-	 * Use upsert to insert a row into the database
+	 * Use upsert to insert a row into the database when nothing exists
+	 * Should fail to update, and insert a new row
 	 */
-	public function testUpsertWithNoValuePresent() {
-		$rows = $this->adapter->upsert($this->conn->getPrefix() . $this->testTable, ['val1' => 'test']);
+	public function testUpsertWithNoRowPresent() {
+		// Insert or update a new row
+		$rows = $this->adapter->upsert('*PREFIX*appconfig', ['configvalue' => 'test1', 'configkey' => 'test1']);
 		$this->assertEquals(1, $rows);
+		$this->assertRowExists('test1', 'test1');
 	}
 
 	/**
-	 * Use upsert to update an existing row in the database
+	 * Use upsert to insert a row into the database when row exists
+	 * Should update row
 	 */
-	public function testUpsertToUpdateRow() {
-		$row1 = [];
-		$row2 = [];
-		$rows = $this->conn->insert($this->conn->getPrefix() . $this->testTable, ['val1' => 'test']);
+	public function testUpsertWithRowPresent() {
+		// Insert row
+		$this->insertRow(['configvalue' => 'test2', 'configkey' => 'test2']);
+		// Update it
+		$rows = $this->adapter->upsert('*PREFIX*appconfig', ['configvalue' => 'test2-updated', 'configkey' => 'test2-updated']);
 		$this->assertEquals(1, $rows);
-		$rows = $this->adapter->upsert($this->conn->getPrefix() . $this->testTable, ['val1' => 'test-updated']);
-		$this->assertEquals(1, $rows);
-		// Now cehck the value of this column for this row
+		$this->assertRowExists('test2-updated', 'test2-updated');
+
 	}
 
-	public function testUpsertToUpdateWithCompare() {
-		$row1 = [];
-		$row2 = [];
+	/**
+	 * Use upsert to insert a row into the database when row exists, using compare col
+	 * Should update row
+	 */
+	public function testUpsertWithRowPresentUsingCompare() {
+		// Insert row
+		$this->insertRow(['configvalue' => 'test3', 'configkey' => 'test3']);
+		// Update it
+		$rows = $this->adapter->upsert('*PREFIX*appconfig', ['configvalue' => 'test3-updated', 'configkey' => 'test3-updated'], ['configvalue']);
+		$this->assertEquals(1, $rows);
+		$this->assertRowExists('test3-updated', 'test3-updated');
+
 	}
 
-	public function testUpsertToUpdateWithCompareNoMatches() {
-		$row1 = [];
-		$row2 = [];
+	public function testUpsertCatchDeadlockAndThrowsException() {
+		$mockConn = $this->createMock(IDBConnection::class);
+
+		$ex = $this->createMock(DriverException::class);
+		$ex->expects($this->exactly(10))->method('getErrorCode')->willReturn(1213);
+		$e = new \Doctrine\DBAL\Exception\DriverException('1213', $ex);
+		$mockConn->expects($this->exactly(10))->method('executeUpdate')->willThrowException($e);
+
+		$this->expectException(\RuntimeException::class);
+
+		// Run
+		$adapter = new Adapter($mockConn);
+		$rows = $adapter->upsert('*PREFIX*appconfig', ['configvalue' => 'test4-updated', 'configkey' => 'test4-updated']);
+	}
+
+	public function testUpsertCatchExceptionAndThrowImmediately() {
+		$mockConn = $this->createMock(IDBConnection::class);
+
+		$e = new DBALException();
+		$mockConn->expects($this->exactly(1))->method('executeUpdate')->willThrowException($e);
+
+		$this->expectException(DBALException::class);
+
+		// Run
+		$adapter = new Adapter($mockConn);
+		$rows = $adapter->upsert('*PREFIX*appconfig', ['configvalue' => 'test4-updated', 'configkey' => 'test4-updated']);
+
+	}
+
+	public function testUpsertAndThrowOtherDriverExceptions() {
+		$mockConn = $this->createMock(IDBConnection::class);
+
+		$ex = $this->createMock(DriverException::class);
+		$ex->expects($this->exactly(1))->method('getErrorCode')->willReturn(1214);
+		$e = new \Doctrine\DBAL\Exception\DriverException('1214', $ex);
+		$mockConn->expects($this->exactly(1))->method('executeUpdate')->willThrowException($e);
+
+		$this->expectException(\Doctrine\DBAL\Exception\DriverException::class);
+
+		// Run
+		$adapter = new Adapter($mockConn);
+		$rows = $adapter->upsert('*PREFIX*appconfig', ['configvalue' => 'test4-updated', 'configkey' => 'test4-updated']);
+	}
+
+	private function assertRowExists($key, $value) {
+		$query = $this->conn->getQueryBuilder();
+		$result = $query->select('*')
+			->from('*PREFIX*appconfig')
+			->where($query->expr()->eq('configvalue', $query->createNamedParameter($value)))
+			->where($query->expr()->eq('configkey', $query->createNamedParameter($key)))
+			->execute();
+		$this->assertCount(1, $result->fetchAll());
 	}
 
 }

--- a/tests/lib/DB/AdapterTest.php
+++ b/tests/lib/DB/AdapterTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\DB;
+use Doctrine\DBAL\Types\Type;
+use OC\DB\Adapter;
+use OCP\IDBConnection;
+
+/**
+ * Class Adapter
+ *
+ * @group DB
+ *
+ * @package Test\DB
+ */
+class AdapterTest extends \Test\TestCase {
+
+	/** @var Adapter  */
+	protected $adapter;
+	/** @var IDBConnection  */
+	protected $conn;
+
+	protected $testTable = 'testdbadapter';
+
+	public function __construct() {
+		$this->conn = \OC::$server->getDatabaseConnection();
+		$this->adapter = new Adapter($this->conn);
+		parent::__construct();
+	}
+
+	public function setUp() {
+		// Create a dummy table
+		$toSchema = $this->conn->createSchema();
+
+		if(!$toSchema->hasTable($this->conn->getPrefix() . $this->testTable)) {
+			$table = $toSchema->createTable($this->conn->getPrefix() . $this->testTable);
+			$table->addColumn('id', Type::BIGINT, [
+				'autoincrement' => true,
+				'unsigned' => true,
+				'notnull' => true,
+			]);
+			$table->addColumn('val1', Type::TEXT, [
+				'notnull' => true,
+			]);
+			$table->setPrimaryKey(['id']);
+			$this->conn->migrateToSchema($toSchema);
+		}
+	}
+
+	public function tearDown() {
+		// Drop the test table
+		$toSchema = $this->conn->createSchema();
+
+		if($toSchema->hasTable($this->conn->getPrefix() . $this->testTable)) {
+			$table = $toSchema->dropTable($this->conn->getPrefix() . $this->testTable);
+			$this->conn->migrateToSchema($toSchema);
+		}
+	}
+
+	/**
+	 * Use upsert to insert a row into the database
+	 */
+	public function testUpsertWithNoValuePresent() {
+		$rows = $this->adapter->upsert($this->conn->getPrefix() . $this->testTable, ['val1' => 'test']);
+		$this->assertEquals(1, $rows);
+	}
+
+	/**
+	 * Use upsert to update an existing row in the database
+	 */
+	public function testUpsertToUpdateRow() {
+		$row1 = [];
+		$row2 = [];
+		$rows = $this->conn->insert($this->conn->getPrefix() . $this->testTable, ['val1' => 'test']);
+		$this->assertEquals(1, $rows);
+		$rows = $this->adapter->upsert($this->conn->getPrefix() . $this->testTable, ['val1' => 'test-updated']);
+		$this->assertEquals(1, $rows);
+		// Now cehck the value of this column for this row
+	}
+
+	public function testUpsertToUpdateWithCompare() {
+		$row1 = [];
+		$row2 = [];
+	}
+
+	public function testUpsertToUpdateWithCompareNoMatches() {
+		$row1 = [];
+		$row2 = [];
+	}
+
+}

--- a/tests/lib/DB/AdapterTest.php
+++ b/tests/lib/DB/AdapterTest.php
@@ -59,7 +59,7 @@ class AdapterTest extends \Test\TestCase {
 	public function insertRow($data) {
 		$table = $this->conn->getPrefix() . 'appconfig';
 		$data['appid'] = uniqid('testadapter-');
-		$query = "INSERT INTO $table";
+		$query = "INSERT INTO $table ";
 		$query .= "(" . implode(',', array_keys($data)) .')';
 		$query .= ' VALUES (' . str_repeat('?, ', count($data)-1) . '?)';
 		$rows = $this->conn->executeUpdate($query, array_values($data));


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Implements a proper upsert method.

Wrapped in a transaction:
1. Attempts to update row
2. If not found inserts
3. Catch insert exception, go to 1.

Tries 10 times (added this in case something else goes crazy and we get stuck) else throws RunTimeException.

Still WIP and open for discussion / thoughts.

One point is that currently I try update, then try insert. This is the opposite when compared to the current implementation - could leave to performance improvements / degradation, depending on common usages of this?

So, checking the usages:
<img width="954" alt="screen shot 2017-08-15 at 17 54 42" src="https://user-images.githubusercontent.com/660805/29326291-e0b39664-81e2-11e7-8010-ae87c719087a.png">

I would say most of these are insert-biased - opinions?

## Related Issue
https://github.com/owncloud/core/issues/22563

## Motivation and Context
Our current insertOrUpdate method is vulnerable to race conditions.

## How Has This Been Tested?
UI / files:scan usage so far. And `db:stress -f` from owncloud/diagnostics:stress branch
 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
