### PR TITLE
Fix directory mime type in trashbin list

### DIFF
--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -114,7 +114,9 @@ class Helper {
 			$entry['id'] = $id++;
 			$entry['etag'] = $entry['mtime']; // add fake etag, it is only needed to identify the preview image
 			$entry['permissions'] = \OCP\Constants::PERMISSION_READ;
-			$entry['mimetype'] = \OC::$server->getMimeTypeDetector()->detectPath($entry['name']);
+			if ($entry['mimetype'] !== 'httpd/unix-directory') {
+				$entry['mimetype'] = \OC::$server->getMimeTypeDetector()->detectPath($entry['name']);
+			}
 			$files[] = $entry;
 		}
 		return $files;


### PR DESCRIPTION
## Description
Fix directory mime type in trashbin list

## Related Issue
Fixes https://github.com/owncloud/core/issues/28686

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test in web UI with deleted folder.
Before: wrong icon
After: folder icon

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Note: the reason we call mime type detector here is because trashbin doesn't store the correct mimetype in the DB due to the special ".d1234567" extension, so we redetect it in this list.