### PR TITLE
Don't enable market app on upgrade from 9.1.x or lower when app store…

### DIFF
--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -179,7 +179,7 @@ class Repair implements IOutput{
 			new Collation(\OC::$server->getConfig(), $connection),
 			new SqliteAutoincrement($connection),
 			new SearchLuceneTables(),
-			new Apps(\OC::$server->getAppManager(), \OC::$server->getEventDispatcher(), \OC::$server->getConfig()),
+			new Apps(\OC::$server->getAppManager(), \OC::$server->getEventDispatcher(), \OC::$server->getConfig(), new \OC_Defaults()),
 		];
 
 		//There is no need to delete all previews on every single update

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -51,15 +51,22 @@ class Apps implements IRepairStep {
 	/** @var IConfig */
 	private $config;
 
+	/** @var \OC_Defaults */
+	private $defaults;
+
 	/**
 	 * Apps constructor.
 	 *
 	 * @param IAppManager $appManager
+	 * @param EventDispatcher $eventDispatcher
+	 * @param IConfig $config
+	 * @param \OC_Defaults $defaults
 	 */
-	public function __construct(IAppManager $appManager, EventDispatcher $eventDispatcher, IConfig $config) {
+	public function __construct(IAppManager $appManager, EventDispatcher $eventDispatcher, IConfig $config, \OC_Defaults $defaults) {
 		$this->appManager = $appManager;
 		$this->eventDispatcher = $eventDispatcher;
 		$this->config = $config;
+		$this->defaults = $defaults;
 	}
 
 	/**
@@ -75,7 +82,7 @@ class Apps implements IRepairStep {
 	 */
 	private function isCoreUpdate() {
 		$installedVersion = $this->config->getSystemValue('version', '0.0.0');
-		$currentVersion = implode('.', \OCP\Util::getVersion());
+		$currentVersion = implode('.', Util::getVersion());
 		$versionDiff = version_compare($currentVersion, $installedVersion);
 		if ($versionDiff > 0) {
 			return true;
@@ -90,10 +97,11 @@ class Apps implements IRepairStep {
 	private function requiresMarketEnable() {
 		$installedVersion = $this->config->getSystemValue('version', '0.0.0');
 		$versionDiff = version_compare('10.0.0', $installedVersion);
-		if ($versionDiff >= 0) {
-			return true;
+		if ($versionDiff < 0) {
+			return false;
 		}
-		return false;
+		return true;
+
 	}
 
 	/**
@@ -101,67 +109,66 @@ class Apps implements IRepairStep {
 	 * @throws RepairException
 	 */
 	public function run(IOutput $output) {
-		$isCoreUpdate = $this->isCoreUpdate();
+
+		if ($this->config->getSystemValue('has_internet_connection', true) !== true) {
+			$link = $this->defaults->buildDocLinkToKey('admin-marketplace-apps');
+			$output->info('No internet connection available - no app updates will be taken from the marketplace.');
+			$output->info("How to update apps in such situation please see $link");
+			return;
+		}
 		$appsToUpgrade = $this->getAppsToUpgrade();
 		$failedCompatibleApps = [];
 		$failedMissingApps = $appsToUpgrade[self::KEY_MISSING];
 		$failedIncompatibleApps = $appsToUpgrade[self::KEY_INCOMPATIBLE];
 		$hasNotUpdatedCompatibleApps = 0;
-		$requiresMarketEnable = $this->requiresMarketEnable();
 
-		if($isCoreUpdate && $requiresMarketEnable) {
-			// Then we need to enable the market app to support app updates / downloads during upgrade
-			$output->info('Enabling market app to assist with update');
-			// delete old value that might influence old APIs
-			if ($this->config->getSystemValue('appstoreenabled', null) !== null) {
-				$this->config->deleteSystemValue('appstoreenabled');
+		// fix market app state
+		$shallContactMarketplace = $this->fixMarketAppState($output);
+		if ($shallContactMarketplace) {
+			// Check if we can use the marketplace to update apps as needed?
+			if ($this->appManager->isEnabledForUser('market')) {
+				// Use market to fix missing / old apps
+				$this->loadApp('market');
+				$output->info('Using market to update existing apps');
+				try {
+					// Try to update incompatible apps
+					if (!empty($appsToUpgrade[self::KEY_INCOMPATIBLE])) {
+						$output->info('Attempting to update the following existing but incompatible app from market: ' . implode(', ', $appsToUpgrade[self::KEY_INCOMPATIBLE]));
+						$failedIncompatibleApps = $this->getAppsFromMarket(
+							$output,
+							$appsToUpgrade[self::KEY_INCOMPATIBLE],
+							'upgradeAppStoreApp'
+						);
+					}
+
+					// Try to download missing apps
+					if (!empty($appsToUpgrade[self::KEY_MISSING])) {
+						$output->info('Attempting to update the following missing apps from market: ' . implode(', ', $appsToUpgrade[self::KEY_MISSING]));
+						$failedMissingApps = $this->getAppsFromMarket(
+							$output,
+							$appsToUpgrade[self::KEY_MISSING],
+							'reinstallAppStoreApp'
+						);
+					}
+
+					// Try to update compatible apps
+					if (!empty($appsToUpgrade[self::KEY_COMPATIBLE])) {
+						$output->info('Attempting to update the following existing compatible apps from market: ' . implode(', ', $appsToUpgrade[self::KEY_MISSING]));
+						$failedCompatibleApps = $this->getAppsFromMarket(
+							$output,
+							$appsToUpgrade[self::KEY_COMPATIBLE],
+							'upgradeAppStoreApp'
+						);
+					}
+
+					$hasNotUpdatedCompatibleApps = count($failedCompatibleApps);
+				} catch (AppManagerException $e) {
+					$output->warning('No connection to marketplace: ' . $e->getPrevious());
+				}
+			} else {
+				// No market available, output error and continue attempt
+				$output->warning('Market app is unavailable for updating of apps. Enable with: occ app:enable market');
 			}
-			$this->appManager->enableApp('market');
-		}
-
-		// Check if we can use the marketplace to update apps as needed?
-		if($this->appManager->isEnabledForUser('market')) {
-			// Use market to fix missing / old apps
-			$this->loadApp('market');
-			$output->info('Using market to update existing apps');
-			try {
-				// Try to update incompatible apps
-				if(!empty($appsToUpgrade[self::KEY_INCOMPATIBLE])) {
-					$output->info('Attempting to update the following existing but incompatible app from market: '.implode(', ', $appsToUpgrade[self::KEY_INCOMPATIBLE]));
-					$failedIncompatibleApps = $this->getAppsFromMarket(
-						$output,
-						$appsToUpgrade[self::KEY_INCOMPATIBLE],
-						'upgradeAppStoreApp'
-					);
-				}
-
-				// Try to download missing apps
-				if(!empty($appsToUpgrade[self::KEY_MISSING])) {
-					$output->info('Attempting to update the following missing apps from market: '.implode(', ', $appsToUpgrade[self::KEY_MISSING]));
-					$failedMissingApps = $this->getAppsFromMarket(
-						$output,
-						$appsToUpgrade[self::KEY_MISSING],
-						'reinstallAppStoreApp'
-					);
-				}
-
-				// Try to update compatible apps
-				if(!empty($appsToUpgrade[self::KEY_COMPATIBLE])) {
-					$output->info('Attempting to update the following existing compatible apps from market: '.implode(', ', $appsToUpgrade[self::KEY_MISSING]));
-					$failedCompatibleApps = $this->getAppsFromMarket(
-						$output,
-						$appsToUpgrade[self::KEY_COMPATIBLE],
-						'upgradeAppStoreApp'
-					);
-				}
-
-				$hasNotUpdatedCompatibleApps = count($failedCompatibleApps);
-			} catch (AppManagerException $e) {
-				$output->warning('No connection to marketplace: ' . $e->getPrevious());
-			}
-		} else {
-			// No market available, output error and continue attempt
-			$output->warning('Market app is unavailable for updating of apps. Enable with: occ app:enable market');
 		}
 
 		$hasBlockingMissingApps = count($failedMissingApps);
@@ -190,6 +197,7 @@ class Apps implements IRepairStep {
 	 *
 	 * @param IOutput $output
 	 * @param string[] $appList
+	 * @param string $event
 	 * @return array
 	 * @throws AppManagerException
 	 */
@@ -273,5 +281,42 @@ class Apps implements IRepairStep {
 	 */
 	protected function loadApp($app) {
 		OC_App::loadApp($app, false);
+	}
+
+	/**
+	 * @return bool
+	 */
+	private function isAppStoreEnabled() {
+		// if appstoreenabled was explicitly disabled we shall not use the market app for upgrade
+		$appStoreEnabled = $this->config->getSystemValue('appstoreenabled', null);
+		if ($appStoreEnabled === false) {
+			return false;
+		}
+		return true;
+	}
+
+	private function fixMarketAppState(IOutput $output) {
+		// no core update -> nothing to do
+		if (!$this->isCoreUpdate()) {
+			return false;
+		}
+
+		// no update from a version before 10.0 -> nothing to do, but allow apps to be updated
+		if (!$this->requiresMarketEnable()) {
+			return true;
+		}
+		// if the appstore was explicitly disabled -> disable market app as well
+		if (!$this->isAppStoreEnabled()) {
+			$this->appManager->disableApp('market');
+			$link = $this->defaults->buildDocLinkToKey('admin-marketplace-apps');
+			$output->info('Appstore was disabled in past versions and marketplace interactions are disabled for now as well.');
+			$output->info('If you would like to get automated app updates on upgrade please enable the market app and remove "appstoreenabled" from your config.');
+			$output->info("Please note that the market app is not recommended for clustered setups - see $link");
+			return false;
+		}
+		// Then we need to enable the market app to support app updates / downloads during upgrade
+		$output->info('Enabling market app to assist with update');
+		$this->appManager->enableApp('market');
+		return true;
 	}
 }

--- a/tests/lib/Repair/AppsTest.php
+++ b/tests/lib/Repair/AppsTest.php
@@ -19,53 +19,57 @@
  *
  */
 namespace Test\Repair;
+use OC\Repair\Apps;
 use OCP\App\IAppManager;
 use OCP\IConfig;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Test\TestCase;
 
 /**
  * Tests to check version comparison
  *
  * @see \OC\Repair\AppsTest
  */
-class AppsTest extends \Test\TestCase {
+class AppsTest extends TestCase {
 
-	/** @var \OC\Repair\AvatarPermissions */
+	/** @var Apps */
 	protected $repair;
-
-	/** @var IAppManager */
+	/** @var IAppManager | \PHPUnit_Framework_MockObject_MockObject */
 	protected $appManager;
-	/** @var  EventDispatcher */
+	/** @var  EventDispatcher | \PHPUnit_Framework_MockObject_MockObject */
 	protected $eventDispatcher;
-	/** @var  IConfig */
+	/** @var  IConfig | \PHPUnit_Framework_MockObject_MockObject*/
 	protected $config;
+	/** @var \OC_Defaults | \PHPUnit_Framework_MockObject_MockObject */
+	private $defaults;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->appManager = $this->getMockBuilder(IAppManager::class)->getMock();
-		$this->eventDispatcher = $this->getMockBuilder(EventDispatcher::class)->getMock();
-		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
-		$this->repair = new \OC\Repair\Apps($this->appManager, $this->eventDispatcher, $this->config);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->defaults = $this->createMock(\OC_Defaults::class);
+		$this->eventDispatcher = $this->createMock(EventDispatcher::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->repair = new Apps($this->appManager, $this->eventDispatcher, $this->config, $this->defaults);
 	}
 
 	public function testMarketEnableVersionCompare10() {
-		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->will($this->returnValue('10.0.0'));
+		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->willReturn('10.0.0');
 		$this->assertTrue($this->invokePrivate($this->repair, 'requiresMarketEnable'));
 	}
 
 	public function testMarketEnableVersionCompare9() {
-		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->will($this->returnValue('9.1.5'));
+		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->willReturn('9.1.5');
 		$this->assertTrue($this->invokePrivate($this->repair, 'requiresMarketEnable'));
 	}
 
 	public function testMarketEnableVersionCompareFuture() {
-		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->will($this->returnValue('10.0.2'));
+		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->willReturn('10.0.2');
 		$this->assertFalse($this->invokePrivate($this->repair, 'requiresMarketEnable'));
 	}
 
 	public function testMarketEnableVersionCompareCurrent() {
-		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->will($this->returnValue('10.0.1'));
+		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->willReturn('10.0.1');
 		$this->assertFalse($this->invokePrivate($this->repair, 'requiresMarketEnable'));
 	}
 }


### PR DESCRIPTION
… was disabled in the past 


## Description
Prio to 10.0 appstoreenable was used as config option to disable installation from apps.owncloud.com

In migration scenarios we respect this value now and do not enable the market app-

## Related Issue
fixes https://github.com/owncloud/market/issues/118

## How Has This Been Tested?
- set version in config.php to 9.1.0.0
- set appstoreenabled to false in config.php
- run occ up

## Screenshots (if appropriate):
![bildschirmfoto von 2017-08-16 15-25-38](https://user-images.githubusercontent.com/1005065/29365447-542036a2-8297-11e7-8b44-892f81bda1db.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

