### PR TITLE
UI tests - close sharing dialog panel

### DIFF
--- a/tests/ui/features/bootstrap/SharingContext.php
+++ b/tests/ui/features/bootstrap/SharingContext.php
@@ -55,6 +55,7 @@ class SharingContext extends RawMinkContext implements Context
 			$folder, $this->getSession()
 		);
 		$this->sharingDialog->shareWithUser($user, $this->getSession());
+		$this->iCloseTheShareDialog();
 	}
 
 	/**
@@ -67,6 +68,7 @@ class SharingContext extends RawMinkContext implements Context
 			$folder, $this->getSession()
 		);
 		$this->sharingDialog->shareWithGroup($group, $this->getSession());
+		$this->iCloseTheShareDialog();
 	}
 
 	/**
@@ -78,6 +80,14 @@ class SharingContext extends RawMinkContext implements Context
 		$this->sharingDialog = $this->filesPage->openSharingDialog(
 			$name, $this->getSession()
 		);
+	}
+
+	/**
+	 * @Given I close the share dialog
+	 */
+	public function iCloseTheShareDialog()
+	{
+		$this->sharingDialog->closeSharingDialog();
 	}
 
 	/**

--- a/tests/ui/features/lib/SharingDialog.php
+++ b/tests/ui/features/lib/SharingDialog.php
@@ -38,6 +38,7 @@ class SharingDialog extends OwnCloudPage
 	protected $shareWithTooltipXpath = "/..//*[@class='tooltip-inner']";
 	protected $shareWithAutocompleteListXpath = ".//ul[contains(@class,'ui-autocomplete')]";
 	protected $autocompleteItemsTextXpath = "//*[@class='autocomplete-item-text']";
+	protected $shareWithCloseXpath = "/..//*[@class='close icon-close']";
 	protected $suffixToIdentifyGroups = " (group)";
 
 	/**
@@ -155,7 +156,7 @@ class SharingDialog extends OwnCloudPage
 				break;
 			}
 		}
-		
+
 		if ($userFound !== true) {
 			throw new ElementNotFoundException("could not share with '$name'");
 		}
@@ -214,5 +215,13 @@ class SharingDialog extends OwnCloudPage
 			throw new ElementNotFoundException("could not find share-with-tooltip");
 		}
 		return $shareWithTooltip->getText();
+	}
+
+	/**
+	 * closes the sharing dialog panel
+	 */
+	public function closeSharingDialog()
+	{
+		$this->find("xpath", $this->shareWithCloseXpath)->click();
 	}
 }

--- a/tests/ui/features/lib/SharingDialog.php
+++ b/tests/ui/features/lib/SharingDialog.php
@@ -219,9 +219,14 @@ class SharingDialog extends OwnCloudPage
 
 	/**
 	 * closes the sharing dialog panel
+	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 */
 	public function closeSharingDialog()
 	{
-		$this->find("xpath", $this->shareWithCloseXpath)->click();
+		$shareDialogCloseButton = $this->find("xpath", $this->shareWithCloseXpath);
+		if ($shareDialogCloseButton === null) {
+			throw new ElementNotFoundException("could not find share-dialog-close-button");
+		}
+		$shareDialogCloseButton->click();
 	}
 }


### PR DESCRIPTION
## Description
After doing a step that is a "whole functional transaction" in the sharing dialog, close the dialog at the end. e.g. ``theFileFolderIsSharedWithTheUser`` already opens the sharing dialog and does the sharing. Make it "clean up after itself" by closing the dialog on its way out.

Provide a step definition "Given I close the share dialog" that can be used in future by any test that wants to step through individual actions to open the share dialog, fill in a field, click a button, do this, do that, close the share dialog.

## Related Issue
#28715 

## Motivation and Context
Make the UI tests more robust.

## How Has This Been Tested?
Run UI feature:
```
bash tests/travis/start_behat_tests.sh --feature tests/ui/features/other/shareeAutocompletion.feature
```
with a narrow browser window and confirm it all passes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

