### PR TITLE
allow to ignore specific chunks during size calculation for a chunked file

### DIFF
--- a/apps/dav/lib/Upload/FutureFile.php
+++ b/apps/dav/lib/Upload/FutureFile.php
@@ -96,14 +96,28 @@ class FutureFile implements \Sabre\DAV\IFile {
 	}
 
 	/**
-	 * @inheritdoc
+	 * Returns the size of the node, in bytes
+	 *
+	 * @param array $ignoreChildren array of names of children that should be
+	 * ignored for the calculation
+	 * @return int
 	 */
-	function getSize() {
+	function getSize($ignoreChildren = []) {
 		$children = $this->root->getChildren();
-		$sizes = array_map(function($node) {
-			/** @var IFile $node */
-			return $node->getSize();
-		}, $children);
+		for ($i = count($children) - 1; $i >= 0; $i--) {
+			if (in_array($children[$i]->getName(), $ignoreChildren)) {
+				unset($children[$i]);
+			}
+		}
+		$sizes = array_map(
+			function ($node) {
+				/**
+				 * @var IFile $node
+				 */
+				return $node->getSize();
+			},
+			$children
+		);
 
 		return array_sum($sizes);
 	}

--- a/lib/private/legacy/filechunking.php
+++ b/lib/private/legacy/filechunking.php
@@ -131,14 +131,19 @@ class OC_FileChunking {
 
 	/**
 	 * Returns the size of the chunks already present
+	 * 
+	 * @param array $ignoreChunks array of chunk ids that should be
+	 * ignored for the calculation
 	 * @return integer size in bytes
 	 */
-	public function getCurrentSize() {
+	public function getCurrentSize($ignoreChunks = []) {
 		$cache = $this->getCache();
 		$prefix = $this->getPrefix();
 		$total = 0;
 		for ($i = 0; $i < $this->info['chunkcount']; $i++) {
-			$total += $cache->size($prefix.$i);
+			if (!in_array($i, $ignoreChunks)) {
+				$total += $cache->size($prefix . $i);
+			}
 		}
 		return $total;
 	}

--- a/tests/lib/FileChunkingTest.php
+++ b/tests/lib/FileChunkingTest.php
@@ -67,4 +67,64 @@ class FileChunkingTest extends \Test\TestCase {
 
 		$this->assertEquals($expected, $fileChunking->isComplete());
 	}
+
+	/**
+	 * data provider for testGetCurrentSize
+	 * [[array of chunksizes], [chunk ids to ignore], expected size]
+	 * 
+	 * @return array[][]|number[][]|number[][][]
+	 */
+	public function dataGetCurrentSize() {
+		return [
+			[[1, 2, 3], [ ], 6],
+			[[100, 200, 300], [ ], 600],
+			[[1, 2, 0, 4], [ ], 7],
+			[[10, 20, 30, 40], [2], 70],
+			[[10, 20, 30, 40], [0, 2], 60],
+			[[10, 20, 30, 40], [0, 2, 3], 20],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetCurrentSize
+	 * 
+	 * @param array $chunkSizes
+	 * @param array $ignoreChunks
+	 * @param int $expected
+	 * @return void
+	 */
+	public function testGetCurrentSize(
+		array $chunkSizes, array $ignoreChunks, $expected
+	) {
+		$fileName = "file";
+		$transferId = "42";
+		$fileChunking = $this->getMockBuilder('\OC_FileChunking')
+			->setMethods(['getCache'])
+			->setConstructorArgs(
+				[[
+					'name' => $fileName,
+					'transferid' => $transferId,
+					'chunkcount' => count($chunkSizes),
+				]]
+			)
+			->getMock();
+
+		$cache = $this->createMock('\OC\Cache\File');
+		$chunkNo = 0;
+		foreach ($chunkSizes as $size) {
+			$chunkSizeMap [] = [ 
+				$fileName . "-chunking-" . $transferId . "-" . $chunkNo,
+				$size 
+			];
+			$chunkNo++;
+		}
+
+		$cache->expects($this->atLeastOnce())
+			->method('size')
+			->will($this->returnValueMap($chunkSizeMap));
+
+		$fileChunking->method('getCache')->willReturn($cache);
+
+		$this->assertEquals($expected, $fileChunking->getCurrentSize($ignoreChunks));
+	}
 }


### PR DESCRIPTION
## Description
This change makes it possible to ignore some chunks when calculation the sum of all already uploaded chunks.

## Related Issue
https://github.com/owncloud/firewall/issues/356

## Motivation and Context
In the firewall app we need to be able to calculate the sum of all already uploaded chunks plus the one is currently uploaded. In the case that a chunk is uploaded a second time we need to ignore the size of the chunk that is already stored on the server.
e.g.:
client uploads chunk 1 5MB => sum 5MB
client uploads chunk 2 5MB => sum 10MB
client uploads chunk 3 5MB => sum 15MB
client reuploads chunk 1 5MB  => sum has to be 15MB and not 20MB

Here the PR in firewall that depend on this code https://github.com/owncloud/firewall/pull/397

## How Has This Been Tested?
Unit Tests + Firewall acceptance tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

