### PR TITLE
these methods return string or null, document properly or fix

### DIFF
--- a/lib/private/User/Backend.php
+++ b/lib/private/User/Backend.php
@@ -123,10 +123,10 @@ abstract class Backend implements UserInterface {
 	/**
 	* get the user's home directory
 	* @param string $uid the username
-	* @return boolean
+	* @return string|null
 	*/
 	public function getHome($uid) {
-		return false;
+		return null;
 	}
 
 	/**

--- a/lib/public/User/IProvidesEMailBackend.php
+++ b/lib/public/User/IProvidesEMailBackend.php
@@ -36,7 +36,7 @@ interface IProvidesEMailBackend {
 	 * Get a users email address
 	 *
 	 * @param string $uid The username
-	 * @return string
+	 * @return string|null
 	 * @since 10.0
 	 */
 	public function getEMailAddress($uid);

--- a/lib/public/User/IProvidesQuotaBackend.php
+++ b/lib/public/User/IProvidesQuotaBackend.php
@@ -36,7 +36,7 @@ interface IProvidesQuotaBackend {
 	 * Get a users quota
 	 *
 	 * @param string $uid The username
-	 * @return string
+	 * @return string|null
 	 * @since 10.0
 	 */
 	public function getQuota($uid);


### PR DESCRIPTION
All user backend methods / IProvidesXYZ either return a string or they don't. null is what the UserManager tests for because that is what is stored inside the Account table. https://github.com/owncloud/core/blob/master/lib/private/User/Manager.php#L432-L438

The default User Backend returns false for home which is only treated correctly because the UserMapper uses is_string on it: https://github.com/owncloud/core/blob/master/lib/private/User/Manager.php#L452

This PR fixes the PHP doc and returns null for an unset home.