### PR TITLE
Fix dav base path encoding

### DIFF
--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -191,7 +191,7 @@
 			var sections = path.split('/');
 			var i;
 			for (i = 0; i < sections.length; i++) {
-				sections[i] = encodeURIComponent(sections[i]);
+				sections[i] = encodeURI(sections[i]);
 			}
 			path = sections.join('/');
 			return path;
@@ -837,7 +837,7 @@
 
 		var client = new OC.Files.Client({
 			host: OC.getHost(),
-			root: OC.linkToRemoteBase('dav') + '/files/' + encodeURIComponent(OC.getCurrentUser().uid) + '/',
+			root: OC.linkToRemoteBase('dav') + '/files/' + encodeURI(OC.getCurrentUser().uid) + '/',
 			useHTTPS: OC.getProtocol() === 'https'
 		});
 		OC.Files._defaultClient = client;

--- a/core/js/tests/specs/files/clientSpec.js
+++ b/core/js/tests/specs/files/clientSpec.js
@@ -868,4 +868,42 @@ describe('OC.Files.Client tests', function() {
 			// TODO
 		});
 	});
+
+	describe('default client', function() {
+		var getCurrentUserStub;
+		var propFindStub;
+		var getHostStub;
+		var getProtocolStub;
+		var getRootPathStub;
+
+		beforeEach(function() {
+			getProtocolStub = sinon.stub(OC, 'getProtocol').returns('https');
+			getHostStub = sinon.stub(OC, 'getHost').returns('somehost:8080');
+			getRootPathStub = sinon.stub(OC, 'getRootPath').returns('/owncloud');
+			getCurrentUserStub = sinon.stub(OC, 'getCurrentUser');
+			getCurrentUserStub.returns({
+				uid: 'test@test'
+			});
+			propFindStub = sinon.stub(dav.Client.prototype, 'propFind');
+			propFindStub.returns($.Deferred().promise());
+			delete OC.Files._defaultClient;
+		});
+		afterEach(function() { 
+			getProtocolStub.restore();
+			getHostStub.restore();
+			getRootPathStub.restore();
+			propFindStub.restore();
+			getCurrentUserStub.restore();
+		});
+
+		it('returns default client based on current user', function() {
+			var client = OC.Files.getClient();
+
+			client.getFolderContents('path/to space/a@b');
+
+			expect(propFindStub.calledOnce).toEqual(true);
+			expect(propFindStub.getCall(0).args[0])
+				.toEqual('https://somehost:8080/owncloud/remote.php/dav/files/test@test/path/to%20space/a@b');
+		});
+	});
 });


### PR DESCRIPTION
## Description
Base path must be encoded with encodeURI, not encodeURIComponent, to be
able to keep "@" characters and other supported ones.

Failing to do so will mess up with parsing DAV response href URI which
would not match any more.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28730

## Motivation and Context


## How Has This Been Tested?
Manual testing, see ticket steps.
JS unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

