### PR TITLE
Introduce UserSession::verifyAuthHeaders which validates the session …

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -113,6 +113,7 @@ class Auth extends AbstractBasic {
 			return false;
 		}
 		if ($this->userSession->isLoggedIn() &&
+			$this->userSession->verifyAuthHeaders($this->request) &&
 			$this->isDavAuthenticated($this->userSession->getUser()->getUID())
 		) {
 			\OC_Util::setupFS($this->userSession->getUser()->getUID());

--- a/core/Application.php
+++ b/core/Application.php
@@ -40,6 +40,7 @@ use OC\Core\Controller\TwoFactorChallengeController;
 use OC\Core\Controller\UserController;
 use OC_Defaults;
 use OCP\AppFramework\App;
+use OCP\IServerContainer;
 use OCP\Util;
 
 /**
@@ -87,6 +88,8 @@ class Application extends App {
 			);
 		});
 		$container->registerService('AvatarController', function(SimpleContainer $c) {
+			/** @var IServerContainer $server */
+			$server = $c->query('ServerContainer');
 			return new AvatarController(
 				$c->query('AppName'),
 				$c->query('Request'),
@@ -95,7 +98,7 @@ class Application extends App {
 				$c->query('L10N'),
 				$c->query('UserManager'),
 				$c->query('UserSession'),
-				$c->query('UserFolder'),
+				$server->getRootFolder(),
 				$c->query('Logger')
 			);
 		});
@@ -169,9 +172,6 @@ class Application extends App {
 		});
 		$container->registerService('Cache', function(SimpleContainer $c) {
 			return $c->query('ServerContainer')->getCache();
-		});
-		$container->registerService('UserFolder', function(SimpleContainer $c) {
-			return $c->query('ServerContainer')->getUserFolder();
 		});
 		$container->registerService('Defaults', function() {
 			return new OC_Defaults;

--- a/lib/base.php
+++ b/lib/base.php
@@ -910,7 +910,8 @@ class OC {
 		if (!self::checkUpgrade(false)
 			&& !$systemConfig->getValue('maintenance', false)) {
 			// For logged-in users: Load everything
-			if(OC_User::isLoggedIn()) {
+			$userSession = \OC::$server->getUserSession();
+			if($userSession->isLoggedIn() && $userSession->verifyAuthHeaders($request)) {
 				OC_App::loadApps();
 			} else {
 				// For guests: Load only filesystem and logging
@@ -959,7 +960,7 @@ class OC {
 		}
 
 		// Someone is logged in
-		if (OC_User::isLoggedIn()) {
+		if($userSession->isLoggedIn() && $userSession->verifyAuthHeaders($request)) {
 			OC_App::loadApps();
 			OC_User::setupBackends();
 			OC_Util::setupFS();

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -130,10 +130,10 @@ class AppManager implements IAppManager {
 	/**
 	 * List all apps enabled for a user
 	 *
-	 * @param \OCP\IUser $user
+	 * @param \OCP\IUser|null $user
 	 * @return string[]
 	 */
-	public function getEnabledAppsForUser(IUser $user) {
+	public function getEnabledAppsForUser(IUser $user = null) {
 		$apps = $this->getInstalledAppsValues();
 		$appsForUser = array_filter($apps, function ($enabled) use ($user) {
 			return $this->checkAppForUser($enabled, $user);

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -443,7 +443,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 	 * @return boolean
 	 */
 	function isLoggedIn() {
-		return \OC_User::isLoggedIn();
+		return $this->getServer()->getUserSession()->isLoggedIn();
 	}
 
 	/**

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -296,7 +296,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$defaultTokenProvider = null;
 			}
 
-			$userSession = new \OC\User\Session($manager, $session, $timeFactory, $defaultTokenProvider, $c->getConfig());
+			$userSession = new \OC\User\Session($manager, $session, $timeFactory,
+				$defaultTokenProvider, $c->getConfig(), $this);
 			$userSession->listen('\OC\User', 'preCreateUser', function ($uid, $password) {
 				\OC_Hook::emit('OC_User', 'pre_createUser', ['run' => true, 'uid' => $uid, 'password' => $password]);
 			});

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -87,10 +87,14 @@ use OC\Tagging\TagMapper;
 use OC\Theme\ThemeService;
 use OC\User\AccountMapper;
 use OC\User\AccountTermMapper;
+use OCP\App\IServiceLoader;
+use OCP\AppFramework\QueryException;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\IServerContainer;
 use OCP\ISession;
+use OCP\IUser;
 use OCP\Security\IContentSecurityPolicyManager;
 use OCP\Theme\IThemeService;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -110,7 +114,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  *
  * TODO: hookup all manager classes
  */
-class Server extends ServerContainer implements IServerContainer {
+class Server extends ServerContainer implements IServerContainer, IServiceLoader {
 	/** @var string */
 	private $webRoot;
 
@@ -1551,5 +1555,47 @@ class Server extends ServerContainer implements IServerContainer {
 	 */
 	public function getTimeFactory() {
 		return $this->query('\OCP\AppFramework\Utility\ITimeFactory');
+	}
+
+	/**
+	 * @return IServiceLoader
+	 */
+	public function getServiceLoader() {
+		return $this;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function load(array $xmlPath, IUser $user = null) {
+		$appManager = $this->getAppManager();
+		$allApps = $appManager->getEnabledAppsForUser($user);
+
+		foreach ($allApps as $appId) {
+			$info = $appManager->getAppInfo($appId);
+			if ($info === null) {
+				$info = [];
+			}
+
+			foreach($xmlPath as $xml) {
+				$info = isset($info[$xml]) ? $info[$xml] : [];
+			}
+			if (!is_array($info)) {
+				$info = [$info];
+			}
+
+			foreach ($info as $class) {
+				try {
+					if (!\OC_App::isAppLoaded($appId)) {
+						\OC_App::loadApp($appId);
+					}
+
+					yield $this->query($class);
+
+				} catch (QueryException $exc) {
+					throw new \Exception("Could not load service $class");
+				}
+			}
+		}
 	}
 }

--- a/lib/private/User/BasicAuthModule.php
+++ b/lib/private/User/BasicAuthModule.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OC\User;
+
+
+use OCP\Authentication\IAuthModule;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserManager;
+
+class BasicAuthModule implements IAuthModule {
+
+	/** @var IUserManager */
+	private $manager;
+
+	public function __construct(IUserManager $manager) {
+		$this->manager = $manager;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function auth(IRequest $request) {
+		if (empty($request->server['PHP_AUTH_USER']) || empty($request->server['PHP_AUTH_PW'])) {
+			return null;
+		}
+
+		// check uid and password
+		$user = $this->manager->checkPassword($request->server['PHP_AUTH_USER'], $request->server['PHP_AUTH_PW']);
+		if ($user instanceof IUser) {
+			return $user;
+		}
+		// check email and password
+		$users = $this->manager->getByEmail($request->server['PHP_AUTH_USER']);
+		if (count($users) !== 1) {
+			return null;
+		}
+		return $this->manager->checkPassword($users[0]->getUID(), $request->server['PHP_AUTH_PW']);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getUserPassword(IRequest $request) {
+		if (empty($request->server['PHP_AUTH_USER']) || empty($request->server['PHP_AUTH_PW'])) {
+			return '';
+		}
+
+		return $request->server['PHP_AUTH_PW'];
+	}
+}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -40,12 +40,11 @@ use OC\Authentication\Exceptions\PasswordLoginForbiddenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
 use OC\Hooks\Emitter;
-use OC_App;
+use OC\Hooks\PublicEmitter;
 use OC_User;
 use OC_Util;
 use OCA\DAV\Connector\Sabre\Auth;
-use OCP\App\IAppManager;
-use OCP\AppFramework\QueryException;
+use OCP\App\IServiceLoader;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\IAuthModule;
 use OCP\Files\NotPermittedException;
@@ -57,7 +56,6 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use OCP\Util;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -82,7 +80,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class Session implements IUserSession, Emitter {
 
-	/** @var IUserManager $manager */
+	/** @var IUserManager | PublicEmitter $manager */
 	private $manager;
 
 	/** @var ISession $session */
@@ -100,19 +98,26 @@ class Session implements IUserSession, Emitter {
 	/** @var User $activeUser */
 	protected $activeUser;
 
+	/** @var IServiceLoader */
+	private $serviceLoader;
+
 	/**
 	 * @param IUserManager $manager
 	 * @param ISession $session
 	 * @param ITimeFactory $timeFactory
 	 * @param IProvider $tokenProvider
 	 * @param IConfig $config
+	 * @param IServiceLoader $serviceLoader
 	 */
-	public function __construct(IUserManager $manager, ISession $session, ITimeFactory $timeFactory, $tokenProvider, IConfig $config) {
+	public function __construct(IUserManager $manager, ISession $session,
+								ITimeFactory $timeFactory, $tokenProvider,
+								IConfig $config, IServiceLoader $serviceLoader) {
 		$this->manager = $manager;
 		$this->session = $session;
 		$this->timeFactory = $timeFactory;
 		$this->tokenProvider = $tokenProvider;
 		$this->config = $config;
+		$this->serviceLoader = $serviceLoader;
 	}
 
 	/**
@@ -138,15 +143,6 @@ class Session implements IUserSession, Emitter {
 	 */
 	public function removeListener($scope = null, $method = null, callable $callback = null) {
 		$this->manager->removeListener($scope, $method, $callback);
-	}
-
-	/**
-	 * get the manager object
-	 *
-	 * @return Manager
-	 */
-	public function getManager() {
-		return $this->manager;
 	}
 
 	/**
@@ -691,7 +687,7 @@ class Session implements IUserSession, Emitter {
 	 */
 	public function tryTokenLogin(IRequest $request) {
 		$authHeader = $request->getHeader('Authorization');
-		if (strpos($authHeader, 'token ') === false) {
+		if ($authHeader === null || strpos($authHeader, 'token ') === false) {
 			// No auth header, let's try session id
 			try {
 				$token = $this->session->getId();
@@ -719,34 +715,10 @@ class Session implements IUserSession, Emitter {
 	 * @throws Exception If the auth module could not be loaded
 	 */
 	public function tryAuthModuleLogin(IRequest $request) {
-		/** @var IAppManager $appManager */
-		$appManager = OC::$server->query('AppManager');
-		$allApps = $appManager->getInstalledApps();
-
-		foreach ($allApps as $appId) {
-			$info = $appManager->getAppInfo($appId);
-
-			if (isset($info['auth-modules'])) {
-				$authModules = $info['auth-modules'];
-
-				foreach ($authModules as $class) {
-					try {
-						if (!OC_App::isAppLoaded($appId)) {
-							OC_App::loadApp($appId);
-						}
-
-						/** @var IAuthModule $authModule */
-						$authModule = OC::$server->query($class);
-
-						if ($authModule instanceof IAuthModule) {
-							return $this->loginUser($authModule->auth($request), $authModule->getUserPassword($request));
-						} else {
-							throw new Exception("Could not load the auth module $class");
-						}
-					} catch (QueryException $exc) {
-						throw new Exception("Could not load the auth module $class");
-					}
-				}
+		foreach ($this->getAuthModules(false) as $authModule) {
+			$user = $authModule->auth($request);
+			if ($user !== null) {
+				return $this->loginUser($authModule->auth($request), $authModule->getUserPassword($request));
 			}
 		}
 
@@ -907,4 +879,42 @@ class Session implements IUserSession, Emitter {
 		}
 	}
 
+	public function verifyAuthHeaders($request) {
+		foreach ($this->getAuthModules(true) as $module) {
+			$user = $module->auth($request);
+			if ($user !== null) {
+				if ($this->isLoggedIn() && $this->getUser()->getUID() !== $user->getUID()) {
+					// the session is bad -> kill it
+					$this->logout();
+					return false;
+				}
+				return true;
+			}
+		}
+
+		// the session is bad -> kill it
+		$this->logout();
+		return false;
+	}
+
+	/**
+	 * @param $includeBuiltIn
+	 * @return \Generator | IAuthModule[]
+	 * @throws Exception
+	 */
+	private function getAuthModules($includeBuiltIn) {
+		if ($includeBuiltIn) {
+			yield new BasicAuthModule($this->manager);
+			yield new TokenAuthModule($this->session, $this->tokenProvider, $this->manager);
+		}
+
+		$modules = $this->serviceLoader->load(['auth-modules']);
+		foreach ($modules as $module) {
+			if ($module instanceof IAuthModule) {
+				yield $module;
+			} else {
+				continue;
+			}
+		}
+	}
 }

--- a/lib/private/User/TokenAuthModule.php
+++ b/lib/private/User/TokenAuthModule.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OC\User;
+
+
+use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Exceptions\PasswordlessTokenException;
+use OC\Authentication\Token\IProvider;
+use OCP\Authentication\IAuthModule;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Session\Exceptions\SessionNotAvailableException;
+
+class TokenAuthModule implements IAuthModule {
+
+	/** @var ISession */
+	private $session;
+
+	/** @var IProvider */
+	private $tokenProvider;
+
+	/** @var IUserManager */
+	private $manager;
+
+	/** @var string */
+	private $password = '';
+
+	public function __construct(ISession $session, IProvider $tokenProvider, IUserManager $manager) {
+		$this->session = $session;
+		$this->tokenProvider = $tokenProvider;
+		$this->manager = $manager;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function auth(IRequest $request) {
+		$authHeader = $request->getHeader('Authorization');
+		if ($authHeader === null || strpos($authHeader, 'token ') === false) {
+			// No auth header, let's try session id
+			try {
+				$token = $this->session->getId();
+			} catch (SessionNotAvailableException $ex) {
+				return null;
+			}
+		} else {
+			$token = substr($authHeader, 6);
+		}
+
+		try {
+			$dbToken = $this->tokenProvider->getToken($token);
+		} catch (InvalidTokenException $ex) {
+			return null;
+		}
+		$uid = $dbToken->getUID();
+
+		// When logging in with token, the password must be decrypted first before passing to login hook
+		try {
+			$this->password = $this->tokenProvider->getPassword($dbToken, $token);
+		} catch (PasswordlessTokenException $ex) {
+			// Ignore and use empty string instead
+		}
+
+		return $this->manager->get($uid);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getUserPassword(IRequest $request) {
+		return $this->password;
+	}
+}

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -81,11 +81,11 @@ interface IAppManager {
 	/**
 	 * List all apps enabled for a user
 	 *
-	 * @param \OCP\IUser $user
+	 * @param \OCP\IUser|null $user
 	 * @return string[]
 	 * @since 8.1.0
 	 */
-	public function getEnabledAppsForUser(IUser $user);
+	public function getEnabledAppsForUser(IUser $user = null);
 
 	/**
 	 * List all installed apps

--- a/lib/public/App/IServiceLoader.php
+++ b/lib/public/App/IServiceLoader.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCP\App;
+
+use OCP\IUser;
+
+/**
+ * Interface IServiceLoader - will load services based on a given xml tag from
+ * the info.xml file of any enabled app.
+ * In this context a service is a php class which is defined in info.xml and
+ * the server container is used to create an instance of this class.
+ *
+ * @package OCP\App
+ * @since 10.0.4
+ */
+interface IServiceLoader {
+
+	/**
+	 * Looks in info.xml of all enabled apps for the given xml path and returns
+	 * a generator which can be used to enumerate all occurrences.
+	 *
+	 * The xml path is defined as an array like ['sabre', 'plugins'].
+	 * The optional argument user can be used to look into apps which are only
+	 * enabled for a given user.
+	 *
+	 * @param array $xmlPath
+	 * @param IUser|null $user
+	 * @return \Generator
+	 * @since 10.0.4
+	 */
+	public function load(array $xmlPath, IUser $user = null);
+}

--- a/lib/public/ISession.php
+++ b/lib/public/ISession.php
@@ -29,9 +29,12 @@
  *
  */
 
+
 // use OCP namespace for all classes that are considered public.
 // This means that they should be used by apps instead of the internal ownCloud classes
 namespace OCP;
+
+use OCP\Session\Exceptions\SessionNotAvailableException;
 
 /**
  * Interface ISession

--- a/lib/public/User.php
+++ b/lib/public/User.php
@@ -111,7 +111,7 @@ class User {
 	 * @since 5.0.0
 	 */
 	public static function userExists( $uid, $excludingBackend = null ) {
-		return \OC_User::userExists( $uid, $excludingBackend );
+		return \OC_User::userExists( $uid);
 	}
 	/**
 	 * Logs the user out including all the session data

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -84,7 +84,7 @@ try {
  * Then we try the old OCS routes
  */
 try {
-	if(!\OC::$server->getUserSession()->isLoggedIn()) {
+	if(!\OC::$server->getUserSession()->isLoggedIn() || !\OC::$server->getUserSession()->verifyAuthHeaders(\OC::$server->getRequest())) {
 		OC::handleLogin(\OC::$server->getRequest());
 	}
 

--- a/tests/lib/ServerTest.php
+++ b/tests/lib/ServerTest.php
@@ -24,6 +24,10 @@
 
 namespace Test;
 
+use OC\Config;
+use OC\Server;
+use OCA\Comments\Dav\CommentsPlugin;
+
 /**
  * Class Server
  *
@@ -32,14 +36,14 @@ namespace Test;
  * @package Test
  */
 class ServerTest extends \Test\TestCase {
-	/** @var \OC\Server */
+	/** @var Server */
 	protected $server;
 
 
 	public function setUp() {
 		parent::setUp();
-		$config = new \OC\Config(\OC::$configDir);
-		$this->server = new \OC\Server('', $config);
+		$config = new Config(\OC::$configDir);
+		$this->server = new Server('', $config);
 	}
 
 	public function dataTestQuery() {
@@ -193,5 +197,25 @@ class ServerTest extends \Test\TestCase {
 		$this->assertInstanceOf('\OCP\Comments\ICommentsManager', $manager);
 
 		$config->setSystemValue('comments.managerFactory', $defaultManagerFactory);
+	}
+
+	/**
+	 * @dataProvider providesServiceLoader
+	 */
+	public function testServiceLoader($xmlPath, $expects) {
+		if ($expects === false) {
+			$this->expectException(\Exception::class);
+			iterator_to_array($this->server->load($xmlPath));
+		} else {
+			$iter = iterator_to_array($this->server->load($xmlPath));
+			$this->assertInstanceOf($expects, $iter[0]);
+		}
+	}
+
+	public function providesServiceLoader() {
+		return [
+			[['name'], false],
+			[['sabre', 'plugins'], CommentsPlugin::class]
+		];
 	}
 }

--- a/tests/lib/User/BasicAuthModuleTest.php
+++ b/tests/lib/User/BasicAuthModuleTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace Test\User;
+
+
+use OC\User\BasicAuthModule;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserManager;
+use Test\TestCase;
+
+class BasicAuthModuleTest extends TestCase {
+
+	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $manager;
+	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	private $request;
+	/** @var IUser | \PHPUnit_Framework_MockObject_MockObject */
+	private $user;
+
+	public function setUp() {
+		parent::setUp();
+		$this->manager = $this->createMock(IUserManager::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->user = $this->createMock(IUser::class);
+
+		$this->user->expects($this->any())->method('getUID')->willReturn('user1');
+
+		$this->manager->expects($this->any())->method('checkPassword')
+			->willReturnMap([
+				['user1', '123456', $this->user],
+				['user@example.com', '123456', $this->user],
+				['user2', '123456', null],
+				['not-unique@example.com', '123456', null],
+				['unique@example.com', '123456', null],
+			]);
+
+		$this->manager->expects($this->any())->method('getByEmail')
+			->willReturnMap([
+				['not-unique@example.com', [$this->user, $this->user]],
+				['unique@example.com', [$this->user]]
+			]);
+	}
+
+	/**
+	 * @dataProvider providesCredentials
+	 * @param bool $expectsUser
+	 * @param string $userId
+	 */
+	public function testAuth($expectsUser, $userId) {
+		$module = new BasicAuthModule($this->manager);
+		$this->request->server = [
+			'PHP_AUTH_USER' => $userId,
+			'PHP_AUTH_PW' => '123456',
+		];
+		$this->assertEquals($expectsUser ? $this->user : null, $module->auth($this->request));
+	}
+
+	public function testGetUserPassword() {
+		$module = new BasicAuthModule($this->manager);
+		$this->request->server = [
+			'PHP_AUTH_USER' => 'user1',
+			'PHP_AUTH_PW' => '123456',
+		];
+		$this->assertEquals('123456', $module->getUserPassword($this->request));
+
+		$this->request->server = [];
+		$this->assertEquals('', $module->getUserPassword($this->request));
+	}
+
+	public function providesCredentials() {
+		return [
+			'user1 can login' => [true, 'user1'],
+			'user1 can login with email' => [true, 'user@example.com'],
+			'unique email can login' => [true, 'unique@example.com'],
+			'not unique email can not login' => [false, 'not-unique@example.com'],
+			'user2 is not known' => [false, 'user2'],
+		];
+	}
+}

--- a/tests/lib/User/TokenAuthModuleTest.php
+++ b/tests/lib/User/TokenAuthModuleTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace Test\User;
+
+
+use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Token\IProvider;
+use OC\Authentication\Token\IToken;
+use OC\User\TokenAuthModule;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IUser;
+use OCP\IUserManager;
+use Test\TestCase;
+
+class TokenAuthModuleTest extends TestCase {
+
+	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $manager;
+	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	private $request;
+	/** @var IUser | \PHPUnit_Framework_MockObject_MockObject */
+	private $user;
+	/** @var ISession | \PHPUnit_Framework_MockObject_MockObject */
+	private $session;
+	/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject */
+	private $tokenProvider;
+
+	public function setUp() {
+		parent::setUp();
+		$this->manager = $this->createMock(IUserManager::class);
+		$this->session = $this->createMock(ISession::class);
+		$this->tokenProvider = $this->createMock(IProvider::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->user = $this->createMock(IUser::class);
+
+		$this->user->expects($this->any())->method('getUID')->willReturn('user1');
+
+		$this->tokenProvider->expects($this->any())->method('getToken')
+			->willReturnCallback(function ($token) {
+				if ($token === 'valid-token' || $token === 'valid-token-with-password') {
+					$token = $this->createMock(IToken::class);
+					$token->expects($this->any())->method('getUID')->willReturn('user1');
+					return $token;
+				}
+				throw new InvalidTokenException();
+			});
+
+		$this->tokenProvider->expects($this->any())->method('getPassword')
+			->willReturnCallback(function ($ignore, $token) {
+				if ($token === 'valid-token-with-password') {
+					return 'supersecret';
+				}
+				return '';
+			});
+
+		$this->manager->expects($this->any())->method('get')
+			->willReturnMap([
+				['user1', $this->user],
+			]);
+	}
+
+	/**
+	 * @dataProvider providesCredentials
+	 * @param bool $expectsUser
+	 * @param string $authHeader
+	 * @param string $password
+	 */
+	public function testModule($expectsUser, $authHeader, $password = '') {
+		$module = new TokenAuthModule($this->session, $this->tokenProvider, $this->manager);
+		$this->request->expects($this->any())->method('getHeader')->willReturn($authHeader);
+
+		$this->assertEquals($expectsUser ? $this->user : null, $module->auth($this->request));
+		$this->assertEquals($password, $module->getUserPassword($this->request));
+	}
+
+	public function providesCredentials() {
+		return [
+			'no auth header' => [false, ''],
+			'not valid token' => [false, 'token whateverbutnothingvalid'],
+			'valid token' => [true, 'token valid-token'],
+			'valid token with password' => [true, 'token valid-token-with-password', 'supersecret']
+		];
+	}
+}


### PR DESCRIPTION
…against given auth headers like basic auth or oauth

## Description

## Related Issue
https://github.com/owncloud/core/issues/28707

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

