### PR TITLE
Fix check new dav rename target path name

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -126,11 +126,22 @@ abstract class Node implements \Sabre\DAV\INode {
 			throw new \Sabre\DAV\Exception\Forbidden();
 		}
 
+		// verify path of the source
+		$this->verifyPath();
+
 		list($parentPath,) = \Sabre\HTTP\URLUtil::splitPath($this->path);
 		list(, $newName) = \Sabre\HTTP\URLUtil::splitPath($name);
 
-		// verify path of the target
-		$this->verifyPath();
+		// verify path of target
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($parentPath . '/' . $newName)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+
+		try {
+			$this->fileView->verifyPath($parentPath, $newName);
+		} catch (\OCP\Files\InvalidPathException $ex) {
+			throw new InvalidPath($ex->getMessage());
+		}
 
 		$newPath = $parentPath . '/' . $newName;
 

--- a/tests/integration/features/webdav-related-new-endpoint.feature
+++ b/tests/integration/features/webdav-related-new-endpoint.feature
@@ -78,7 +78,6 @@ Feature: webdav-related-new-endpoint
 		When User "user0" moves file "/welcome.txt" to "/a\\a"
 		Then the HTTP status code should be "400"
 
-	@skip @issue-28441
 	Scenario: rename a file into a banned filename
 		Given using new dav path
 		And user "user0" exists
@@ -388,7 +387,6 @@ Feature: webdav-related-new-endpoint
 		When User "user0" moves folder "/testshare" to "/hola%5Chola"
 		Then the HTTP status code should be "400"
 
-	@skip @issue-28441
 	Scenario: Renaming a folder into a banned name
 		Given using new dav path
 		And user "user0" exists

--- a/tests/ui/features/files/renameFiles.feature
+++ b/tests/ui/features/files/renameFiles.feature
@@ -50,6 +50,13 @@ Feature: renameFiles
 		|Could not rename "data.zip"|
 		And the file "data.zip" should be listed
 
+	Scenario: Rename a file to a forbidden name
+		When I rename the file "data.zip" to one of these names
+		|.htaccess  |
+		Then notifications should be displayed with the text
+		|Could not rename "data.zip"|
+		And the file "data.zip" should be listed
+
 	Scenario: Rename a file putting a name of a file which already exists
 		When I rename the file "data.zip" to "lorem.txt"
 		Then near the file "data.zip" a tooltip with the text 'lorem.txt already exists' should be displayed

--- a/tests/ui/features/files/renameFiles.feature
+++ b/tests/ui/features/files/renameFiles.feature
@@ -43,7 +43,6 @@ Feature: renameFiles
 		|Could not rename "data.zip"|
 		And the file "data.zip" should be listed
 
-	@skip @issue-28441
 	Scenario: Rename a file to a forbidden name
 		When I rename the file "data.zip" to one of these names
 		|.htaccess  |

--- a/tests/ui/features/files/renameFolders.feature
+++ b/tests/ui/features/files/renameFolders.feature
@@ -42,7 +42,6 @@ Feature: renameFolders
 		|Could not rename "simple-folder"|
 		And the folder "simple-folder" should be listed
 
-	@skip @issue-28441
 	Scenario: Rename a folder to a forbidden name
 		When I rename the folder "simple-folder" to one of these names
 		|.htaccess       |

--- a/tests/ui/features/files/renameFolders.feature
+++ b/tests/ui/features/files/renameFolders.feature
@@ -49,6 +49,13 @@ Feature: renameFolders
 		|Could not rename "simple-folder"|
 		And the folder "simple-folder" should be listed
 
+	Scenario: Rename a folder to a forbidden name
+		When I rename the folder "simple-folder" to one of these names
+		|.htaccess       |
+		Then notifications should be displayed with the text
+		|Could not rename "simple-folder"|
+		And the folder "simple-folder" should be listed
+
 	Scenario: Rename a folder putting a name of a file which already exists
 		When I rename the folder "simple-folder" to "lorem.txt"
 		Then near the folder "simple-folder" a tooltip with the text 'lorem.txt already exists' should be displayed


### PR DESCRIPTION
## Description
Verify target path earlier to make sure 403 is returned in case of wrong
target (ex: ".htaccess") instead of 404.

The reason this happens is because the rename code path between old and new DAV endpoints are different. Old DAV fails earlier when Sabre's CorePlugin does a `getNodeForPath()` on the target even for a local rename. New DAV doesn't go through this code path and reached `Node:setName()` more directly, possibly due to the necessary changes that were done lately regarding moves.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28441.
Should also fix the renameFile/renameFolder failures on master.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual testing with cadaver on new dav endpoint: rename "welcome.txt" to ".htaccess".
Before the fix: 404
After the fix: 403

Automated tests have been reenabled.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

