### PR TITLE
[stable10] Fix check new dav rename target path name

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -126,11 +126,22 @@ abstract class Node implements \Sabre\DAV\INode {
 			throw new \Sabre\DAV\Exception\Forbidden();
 		}
 
+		// verify path of the source
+		$this->verifyPath();
+
 		list($parentPath,) = \Sabre\HTTP\URLUtil::splitPath($this->path);
 		list(, $newName) = \Sabre\HTTP\URLUtil::splitPath($name);
 
-		// verify path of the target
-		$this->verifyPath();
+		// verify path of target
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($parentPath . '/' . $newName)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+
+		try {
+			$this->fileView->verifyPath($parentPath, $newName);
+		} catch (\OCP\Files\InvalidPathException $ex) {
+			throw new InvalidPath($ex->getMessage());
+		}
 
 		$newPath = $parentPath . '/' . $newName;
 

--- a/tests/integration/features/webdav-related-new-endpoint.feature
+++ b/tests/integration/features/webdav-related-new-endpoint.feature
@@ -78,7 +78,6 @@ Feature: webdav-related-new-endpoint
 		When User "user0" moves file "/welcome.txt" to "/a\\a"
 		Then the HTTP status code should be "400"
 
-	@skip @issue-28441
 	Scenario: rename a file into a banned filename
 		Given using new dav path
 		And user "user0" exists
@@ -388,7 +387,6 @@ Feature: webdav-related-new-endpoint
 		When User "user0" moves folder "/testshare" to "/hola%5Chola"
 		Then the HTTP status code should be "400"
 
-	@skip @issue-28441
 	Scenario: Renaming a folder into a banned name
 		Given using new dav path
 		And user "user0" exists

--- a/tests/ui/features/files/renameFiles.feature
+++ b/tests/ui/features/files/renameFiles.feature
@@ -36,11 +36,9 @@ Feature: renameFiles
 
 	Scenario: Rename a file using forbidden characters
 		When I rename the file "data.zip" to one of these names
-		|.htaccess  |
 		|lorem\txt  |
 		|\\.txt     |
 		Then notifications should be displayed with the text
-		|Could not rename "data.zip"|
 		|Could not rename "data.zip"|
 		|Could not rename "data.zip"|
 		And the file "data.zip" should be listed

--- a/tests/ui/features/files/renameFiles.feature
+++ b/tests/ui/features/files/renameFiles.feature
@@ -45,6 +45,13 @@ Feature: renameFiles
 		|Could not rename "data.zip"|
 		And the file "data.zip" should be listed
 
+	Scenario: Rename a file to a forbidden name
+		When I rename the file "data.zip" to one of these names
+		|.htaccess  |
+		Then notifications should be displayed with the text
+		|Could not rename "data.zip"|
+		And the file "data.zip" should be listed
+
 	Scenario: Rename a file putting a name of a file which already exists
 		When I rename the file "data.zip" to "lorem.txt"
 		Then near the file "data.zip" a tooltip with the text 'lorem.txt already exists' should be displayed

--- a/tests/ui/features/files/renameFolders.feature
+++ b/tests/ui/features/files/renameFolders.feature
@@ -35,11 +35,9 @@ Feature: renameFolders
 
 	Scenario: Rename a folder using forbidden characters
 		When I rename the folder "simple-folder" to one of these names
-		|.htaccess       |
 		|simple\folder   |
 		|\\simple-folder |
 		Then notifications should be displayed with the text
-		|Could not rename "simple-folder"|
 		|Could not rename "simple-folder"|
 		|Could not rename "simple-folder"|
 		And the folder "simple-folder" should be listed

--- a/tests/ui/features/files/renameFolders.feature
+++ b/tests/ui/features/files/renameFolders.feature
@@ -44,6 +44,13 @@ Feature: renameFolders
 		|Could not rename "simple-folder"|
 		And the folder "simple-folder" should be listed
 
+	Scenario: Rename a folder to a forbidden name
+		When I rename the folder "simple-folder" to one of these names
+		|.htaccess       |
+		Then notifications should be displayed with the text
+		|Could not rename "simple-folder"|
+		And the folder "simple-folder" should be listed
+
 	Scenario: Rename a folder putting a name of a file which already exists
 		When I rename the folder "simple-folder" to "lorem.txt"
 		Then near the folder "simple-folder" a tooltip with the text 'lorem.txt already exists' should be displayed


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/28735/ to stable10

UI tests don't need adjusting as they are correct since stable10 UI uses old DAV endpoint.