### PR TITLE
Typo settings_ajax_changegroupname

### DIFF
--- a/settings/routes.php
+++ b/settings/routes.php
@@ -84,7 +84,7 @@ $this->create('settings_ajax_togglesubadmins', '/settings/ajax/togglesubadmins.p
 $this->create('settings_users_changepassword', '/settings/users/changepassword')
 	->post()
 	->action('OC\Settings\ChangePassword\Controller', 'changeUserPassword');
-$this->create('settings_ajax_changegorupname', '/settings/ajax/changegroupname.php')
+$this->create('settings_ajax_changegroupname', '/settings/ajax/changegroupname.php')
 	->actionInclude('settings/ajax/changegroupname.php');
 // personal
 $this->create('settings_personal_changepassword', '/settings/personal/changepassword')


### PR DESCRIPTION
## Description
Fix typo of settings_ajax_changegroupname

## Related Issue
Is there anything actually broken?

## Motivation and Context
This looks wrong.

## How Has This Been Tested?
Not tested - if it is used then that could be tested.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

This looks wrong, but I do not see where it is used, so what is broken?
