### PR TITLE
[stable10] Typo settings_ajax_changegroupname

### DIFF
--- a/settings/routes.php
+++ b/settings/routes.php
@@ -84,7 +84,7 @@ $this->create('settings_ajax_togglesubadmins', '/settings/ajax/togglesubadmins.p
 $this->create('settings_users_changepassword', '/settings/users/changepassword')
 	->post()
 	->action('OC\Settings\ChangePassword\Controller', 'changeUserPassword');
-$this->create('settings_ajax_changegorupname', '/settings/ajax/changegroupname.php')
+$this->create('settings_ajax_changegroupname', '/settings/ajax/changegroupname.php')
 	->actionInclude('settings/ajax/changegroupname.php');
 // personal
 $this->create('settings_personal_changepassword', '/settings/personal/changepassword')


### PR DESCRIPTION
Backport #28740 
Just because the less diffs between master and stable10, the easier it is to spot forgotten backports.