### PR TITLE
Fix encoding mismatch in JS

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -259,7 +259,7 @@ OC.FileUpload.prototype = {
 		) {
 			data.isChunked = true;
 			chunkFolderPromise = this.uploader.davClient.createDirectory(
-				'uploads/' + encodeURIComponent(OC.getCurrentUser().uid) + '/' + encodeURIComponent(this.getId())
+				'uploads/' + OC.getCurrentUser().uid + '/' + this.getId()
 			);
 			// TODO: if fails, it means same id already existed, need to retry
 		} else {
@@ -296,8 +296,8 @@ OC.FileUpload.prototype = {
 		}
 
 		return this.uploader.davClient.move(
-			'uploads/' + encodeURIComponent(uid) + '/' + encodeURIComponent(this.getId()) + '/.file',
-			'files/' + encodeURIComponent(uid) + '/' + OC.joinPaths(this.getFullPath(), this.getFileName()),
+			'uploads/' + uid + '/' + this.getId() + '/.file',
+			'files/' + uid + '/' + OC.joinPaths(this.getFullPath(), this.getFileName()),
 			true,
 			headers
 		);
@@ -306,7 +306,7 @@ OC.FileUpload.prototype = {
 	_deleteChunkFolder: function() {
 		// delete transfer directory for this upload
 		this.uploader.davClient.remove(
-			'uploads/' + encodeURIComponent(OC.getCurrentUser().uid) + '/' + encodeURIComponent(this.getId())
+			'uploads/' + OC.getCurrentUser().uid + '/' + this.getId()
 		);
 	},
 

--- a/core/js/tests/specs/files/clientSpec.js
+++ b/core/js/tests/specs/files/clientSpec.js
@@ -171,7 +171,8 @@ describe('OC.Files.Client tests', function() {
 			'<?xml version="1.0" encoding="utf-8"?>' +
 			'<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">' +
 			makeResponseBlock(
-			'/owncloud/remote.php/webdav/path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9/',
+			// NOTE: Sabre DAV doesn't encode "@" sign in href response, but JS does, we still need to properly match
+			'/owncloud/remote.php/webdav/path/to%20sp@ce/%E6%96%87%E4%BB%B6%E5%A4%B9/',
 			{
 				'd:getlastmodified': 'Fri, 10 Jul 2015 10:00:05 GMT',
 				'd:getetag': '"56cfcabd79abb"',
@@ -187,7 +188,7 @@ describe('OC.Files.Client tests', function() {
 			]
 			) +
 			makeResponseBlock(
-			'/owncloud/remote.php/webdav/path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9/One.txt',
+			'/owncloud/remote.php/webdav/path/to%20sp@ce/%E6%96%87%E4%BB%B6%E5%A4%B9/One.txt',
 			{
 				'd:getlastmodified': 'Fri, 10 Jul 2015 13:38:05 GMT',
 				'd:getetag': '"559fcabd79a38"',
@@ -203,7 +204,7 @@ describe('OC.Files.Client tests', function() {
 			]
 			) +
 			makeResponseBlock(
-			'/owncloud/remote.php/webdav/path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9/sub',
+			'/owncloud/remote.php/webdav/path/to%20sp@ce/%E6%96%87%E4%BB%B6%E5%A4%B9/sub',
 			{
 				'd:getlastmodified': 'Fri, 10 Jul 2015 14:00:00 GMT',
 				'd:getetag': '"66cfcabd79abb"',
@@ -222,11 +223,11 @@ describe('OC.Files.Client tests', function() {
 		);
 
 		it('sends PROPFIND with explicit properties to get file list', function() {
-			client.getFolderContents('path/to space/文件夹');
+			client.getFolderContents('path/to sp@ce/文件夹');
 
 			expect(requestStub.calledOnce).toEqual(true);
 			expect(requestStub.lastCall.args[0]).toEqual('PROPFIND');
-			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9');
+			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20sp%40ce/%E6%96%87%E4%BB%B6%E5%A4%B9');
 			expect(requestStub.lastCall.args[2].Depth).toEqual(1);
 
 			var props = getRequestedProperties(requestStub.lastCall.args[3]);
@@ -250,7 +251,7 @@ describe('OC.Files.Client tests', function() {
 			expect(requestStub.lastCall.args[1]).toEqual(baseUrl);
 		});
 		it('parses the result list into a FileInfo array', function() {
-			var promise = client.getFolderContents('path/to space/文件夹');
+			var promise = client.getFolderContents('path/to sp@ce/文件夹');
 
 			expect(requestStub.calledOnce).toEqual(true);
 
@@ -269,7 +270,7 @@ describe('OC.Files.Client tests', function() {
 				var info = response[0];
 				expect(info instanceof OC.Files.FileInfo).toEqual(true);
 				expect(info.id).toEqual(51);
-				expect(info.path).toEqual('/path/to space/文件夹');
+				expect(info.path).toEqual('/path/to sp@ce/文件夹');
 				expect(info.name).toEqual('One.txt');
 				expect(info.permissions).toEqual(27);
 				expect(info.size).toEqual(250);
@@ -281,7 +282,7 @@ describe('OC.Files.Client tests', function() {
 				info = response[1];
 				expect(info instanceof OC.Files.FileInfo).toEqual(true);
 				expect(info.id).toEqual(15);
-				expect(info.path).toEqual('/path/to space/文件夹');
+				expect(info.path).toEqual('/path/to sp@ce/文件夹');
 				expect(info.name).toEqual('sub');
 				expect(info.permissions).toEqual(31);
 				expect(info.size).toEqual(100);
@@ -291,7 +292,7 @@ describe('OC.Files.Client tests', function() {
 			});
 		});
 		it('returns parent node in result if specified', function() {
-			var promise = client.getFolderContents('path/to space/文件夹', {includeParent: true});
+			var promise = client.getFolderContents('path/to sp@ce/文件夹', {includeParent: true});
 
 			expect(requestStub.calledOnce).toEqual(true);
 
@@ -310,7 +311,7 @@ describe('OC.Files.Client tests', function() {
 				var info = response[0];
 				expect(info instanceof OC.Files.FileInfo).toEqual(true);
 				expect(info.id).toEqual(11);
-				expect(info.path).toEqual('/path/to space');
+				expect(info.path).toEqual('/path/to sp@ce');
 				expect(info.name).toEqual('文件夹');
 				expect(info.permissions).toEqual(31);
 				expect(info.size).toEqual(120);
@@ -324,7 +325,7 @@ describe('OC.Files.Client tests', function() {
 			});
 		});
 		it('rejects promise when an error occurred', function() {
-			var promise = client.getFolderContents('path/to space/文件夹', {includeParent: true});
+			var promise = client.getFolderContents('path/to sp@ce/文件夹', {includeParent: true});
 			respondAndCheckError(promise, 404);
 		});
 		it('throws exception if arguments are missing', function() {
@@ -339,7 +340,7 @@ describe('OC.Files.Client tests', function() {
 			'<?xml version="1.0" encoding="utf-8"?>' +
 			'<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">' +
 			makeResponseBlock(
-			'/owncloud/remote.php/webdav/path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9/',
+			'/owncloud/remote.php/webdav/path/to%20sp@ce/%E6%96%87%E4%BB%B6%E5%A4%B9/',
 			{
 				'd:getlastmodified': 'Fri, 10 Jul 2015 10:00:05 GMT',
 				'd:getetag': '"56cfcabd79abb"',
@@ -355,7 +356,7 @@ describe('OC.Files.Client tests', function() {
 			]
 			) +
 			makeResponseBlock(
-			'/owncloud/remote.php/webdav/path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9/One.txt',
+			'/owncloud/remote.php/webdav/path/to%20sp@ce/%E6%96%87%E4%BB%B6%E5%A4%B9/One.txt',
 			{
 				'd:getlastmodified': 'Fri, 10 Jul 2015 13:38:05 GMT',
 				'd:getetag': '"559fcabd79a38"',
@@ -371,7 +372,7 @@ describe('OC.Files.Client tests', function() {
 			]
 			) +
 			makeResponseBlock(
-			'/owncloud/remote.php/webdav/path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9/sub',
+			'/owncloud/remote.php/webdav/path/to%20sp@ce/%E6%96%87%E4%BB%B6%E5%A4%B9/sub',
 			{
 				'd:getlastmodified': 'Fri, 10 Jul 2015 14:00:00 GMT',
 				'd:getetag': '"66cfcabd79abb"',
@@ -489,7 +490,7 @@ describe('OC.Files.Client tests', function() {
 			'<?xml version="1.0" encoding="utf-8"?>' +
 			'<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">' +
 			makeResponseBlock(
-			'/owncloud/remote.php/webdav/path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9/',
+			'/owncloud/remote.php/webdav/path/to%20sp@ce/%E6%96%87%E4%BB%B6%E5%A4%B9/',
 			{
 				'd:getlastmodified': 'Fri, 10 Jul 2015 10:00:05 GMT',
 				'd:getetag': '"56cfcabd79abb"',
@@ -508,11 +509,11 @@ describe('OC.Files.Client tests', function() {
 		);
 
 		it('sends PROPFIND with zero depth to get single file info', function() {
-			client.getFileInfo('path/to space/文件夹');
+			client.getFileInfo('path/to sp@ce/文件夹');
 
 			expect(requestStub.calledOnce).toEqual(true);
 			expect(requestStub.lastCall.args[0]).toEqual('PROPFIND');
-			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9');
+			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20sp%40ce/%E6%96%87%E4%BB%B6%E5%A4%B9');
 			expect(requestStub.lastCall.args[2].Depth).toEqual(0);
 
 			var props = getRequestedProperties(requestStub.lastCall.args[3]);
@@ -526,7 +527,7 @@ describe('OC.Files.Client tests', function() {
 			expect(props).toContain('{http://owncloud.org/ns}permissions');
 		});
 		it('parses the result into a FileInfo', function() {
-			var promise = client.getFileInfo('path/to space/文件夹');
+			var promise = client.getFileInfo('path/to sp@ce/文件夹');
 
 			expect(requestStub.calledOnce).toEqual(true);
 
@@ -542,7 +543,7 @@ describe('OC.Files.Client tests', function() {
 				var info = response;
 				expect(info instanceof OC.Files.FileInfo).toEqual(true);
 				expect(info.id).toEqual(11);
-				expect(info.path).toEqual('/path/to space');
+				expect(info.path).toEqual('/path/to sp@ce');
 				expect(info.name).toEqual('文件夹');
 				expect(info.permissions).toEqual(31);
 				expect(info.size).toEqual(120);
@@ -600,7 +601,7 @@ describe('OC.Files.Client tests', function() {
 			});
 		});
 		it('rejects promise when an error occurred', function() {
-			var promise = client.getFileInfo('path/to space/文件夹');
+			var promise = client.getFileInfo('path/to sp@ce/文件夹');
 			respondAndCheckError(promise, 404);
 		});
 		it('throws exception if arguments are missing', function() {
@@ -712,11 +713,11 @@ describe('OC.Files.Client tests', function() {
 
 	describe('get file contents', function() {
 		it('returns file contents', function() {
-			var promise = client.getFileContents('path/to space/文件夹/One.txt');
+			var promise = client.getFileContents('path/to sp@ce/文件夹/One.txt');
 
 			expect(requestStub.calledOnce).toEqual(true);
 			expect(requestStub.lastCall.args[0]).toEqual('GET');
-			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9/One.txt');
+			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20sp%40ce/%E6%96%87%E4%BB%B6%E5%A4%B9/One.txt');
 
 			requestDeferred.resolve({
 				status: 200,
@@ -729,7 +730,7 @@ describe('OC.Files.Client tests', function() {
 			});
 		});
 		it('rejects promise when an error occurred', function() {
-			var promise = client.getFileContents('path/to space/文件夹/One.txt');
+			var promise = client.getFileContents('path/to sp@ce/文件夹/One.txt');
 			respondAndCheckError(promise, 409);
 		});
 		it('throws exception if arguments are missing', function() {
@@ -740,13 +741,13 @@ describe('OC.Files.Client tests', function() {
 	describe('put file contents', function() {
 		it('sends PUT with file contents', function() {
 			var promise = client.putFileContents(
-					'path/to space/文件夹/One.txt',
+					'path/to sp@ce/文件夹/One.txt',
 					'some contents'
 			);
 
 			expect(requestStub.calledOnce).toEqual(true);
 			expect(requestStub.lastCall.args[0]).toEqual('PUT');
-			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9/One.txt');
+			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20sp%40ce/%E6%96%87%E4%BB%B6%E5%A4%B9/One.txt');
 			expect(requestStub.lastCall.args[2]['If-None-Match']).toEqual('*');
 			expect(requestStub.lastCall.args[2]['Content-Type']).toEqual('text/plain;charset=utf-8');
 			expect(requestStub.lastCall.args[3]).toEqual('some contents');
@@ -755,7 +756,7 @@ describe('OC.Files.Client tests', function() {
 		});
 		it('sends PUT with file contents with headers matching options', function() {
 			var promise = client.putFileContents(
-					'path/to space/文件夹/One.txt',
+					'path/to sp@ce/文件夹/One.txt',
 					'some contents',
 					{
 						overwrite: false,
@@ -765,7 +766,7 @@ describe('OC.Files.Client tests', function() {
 
 			expect(requestStub.calledOnce).toEqual(true);
 			expect(requestStub.lastCall.args[0]).toEqual('PUT');
-			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9/One.txt');
+			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20sp%40ce/%E6%96%87%E4%BB%B6%E5%A4%B9/One.txt');
 			expect(requestStub.lastCall.args[2]['If-None-Match']).not.toBeDefined();
 			expect(requestStub.lastCall.args[2]['Content-Type']).toEqual('text/markdown');
 			expect(requestStub.lastCall.args[3]).toEqual('some contents');
@@ -774,7 +775,7 @@ describe('OC.Files.Client tests', function() {
 		});
 		it('rejects promise when an error occurred', function() {
 			var promise = client.putFileContents(
-					'path/to space/文件夹/One.txt',
+					'path/to sp@ce/文件夹/One.txt',
 					'some contents'
 			);
 			respondAndCheckError(promise, 409);
@@ -786,16 +787,16 @@ describe('OC.Files.Client tests', function() {
 
 	describe('create directory', function() {
 		it('sends MKCOL with specified path', function() {
-			var promise = client.createDirectory('path/to space/文件夹/new dir');
+			var promise = client.createDirectory('path/to sp@ce/文件夹/new dir');
 
 			expect(requestStub.calledOnce).toEqual(true);
 			expect(requestStub.lastCall.args[0]).toEqual('MKCOL');
-			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9/new%20dir');
+			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20sp%40ce/%E6%96%87%E4%BB%B6%E5%A4%B9/new%20dir');
 
 			respondAndCheckStatus(promise, 201);
 		});
 		it('rejects promise when an error occurred', function() {
-			var promise = client.createDirectory('path/to space/文件夹/new dir');
+			var promise = client.createDirectory('path/to sp@ce/文件夹/new dir');
 			respondAndCheckError(promise, 404);
 		});
 		it('throws exception if arguments are missing', function() {
@@ -805,16 +806,16 @@ describe('OC.Files.Client tests', function() {
 
 	describe('deletion', function() {
 		it('sends DELETE with specified path', function() {
-			var promise = client.remove('path/to space/文件夹');
+			var promise = client.remove('path/to sp@ce/文件夹');
 
 			expect(requestStub.calledOnce).toEqual(true);
 			expect(requestStub.lastCall.args[0]).toEqual('DELETE');
-			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9');
+			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20sp%40ce/%E6%96%87%E4%BB%B6%E5%A4%B9');
 
 			respondAndCheckStatus(promise, 201);
 		});
 		it('rejects promise when an error occurred', function() {
-			var promise = client.remove('path/to space/文件夹');
+			var promise = client.remove('path/to sp@ce/文件夹');
 			respondAndCheckError(promise, 404);
 		});
 		it('throws exception if arguments are missing', function() {
@@ -825,15 +826,15 @@ describe('OC.Files.Client tests', function() {
 	describe('move', function() {
 		it('sends MOVE with specified paths with fail on overwrite by default', function() {
 			var promise = client.move(
-					'path/to space/文件夹',
-					'path/to space/anotherdir/文件夹'
+					'path/to sp@ce/文件夹',
+					'path/to sp@ce/anotherdir/文件夹'
 			);
 
 			expect(requestStub.calledOnce).toEqual(true);
 			expect(requestStub.lastCall.args[0]).toEqual('MOVE');
-			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9');
+			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20sp%40ce/%E6%96%87%E4%BB%B6%E5%A4%B9');
 			expect(requestStub.lastCall.args[2].Destination)
-				.toEqual(baseUrl + 'path/to%20space/anotherdir/%E6%96%87%E4%BB%B6%E5%A4%B9');
+				.toEqual(baseUrl + 'path/to%20sp%40ce/anotherdir/%E6%96%87%E4%BB%B6%E5%A4%B9');
 			expect(requestStub.lastCall.args[2].Overwrite)
 				.toEqual('F');
 
@@ -841,16 +842,16 @@ describe('OC.Files.Client tests', function() {
 		});
 		it('sends MOVE with silent overwrite mode when specified', function() {
 			var promise = client.move(
-					'path/to space/文件夹',
-					'path/to space/anotherdir/文件夹',
+					'path/to sp@ce/文件夹',
+					'path/to sp@ce/anotherdir/文件夹',
 					{allowOverwrite: true}
 			);
 
 			expect(requestStub.calledOnce).toEqual(true);
 			expect(requestStub.lastCall.args[0]).toEqual('MOVE');
-			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20space/%E6%96%87%E4%BB%B6%E5%A4%B9');
+			expect(requestStub.lastCall.args[1]).toEqual(baseUrl + 'path/to%20sp%40ce/%E6%96%87%E4%BB%B6%E5%A4%B9');
 			expect(requestStub.lastCall.args[2].Destination)
-				.toEqual(baseUrl + 'path/to%20space/anotherdir/%E6%96%87%E4%BB%B6%E5%A4%B9');
+				.toEqual(baseUrl + 'path/to%20sp%40ce/anotherdir/%E6%96%87%E4%BB%B6%E5%A4%B9');
 			expect(requestStub.lastCall.args[2].Overwrite)
 				.not.toBeDefined();
 
@@ -858,8 +859,8 @@ describe('OC.Files.Client tests', function() {
 		});
 		it('rejects promise when an error occurred', function() {
 			var promise = client.move(
-					'path/to space/文件夹',
-					'path/to space/anotherdir/文件夹',
+					'path/to sp@ce/文件夹',
+					'path/to sp@ce/anotherdir/文件夹',
 					{allowOverwrite: true}
 			);
 			respondAndCheckError(promise, 404);
@@ -882,7 +883,7 @@ describe('OC.Files.Client tests', function() {
 			getRootPathStub = sinon.stub(OC, 'getRootPath').returns('/owncloud');
 			getCurrentUserStub = sinon.stub(OC, 'getCurrentUser');
 			getCurrentUserStub.returns({
-				uid: 'test@test'
+				uid: 'test@#?%test'
 			});
 			propFindStub = sinon.stub(dav.Client.prototype, 'propFind');
 			propFindStub.returns($.Deferred().promise());
@@ -899,11 +900,11 @@ describe('OC.Files.Client tests', function() {
 		it('returns default client based on current user', function() {
 			var client = OC.Files.getClient();
 
-			client.getFolderContents('path/to space/a@b');
+			client.getFolderContents('path/to sp@ce/a@b#?%/x');
 
 			expect(propFindStub.calledOnce).toEqual(true);
 			expect(propFindStub.getCall(0).args[0])
-				.toEqual('https://somehost:8080/owncloud/remote.php/dav/files/test@test/path/to%20space/a@b');
+				.toEqual('https://somehost:8080/owncloud/remote.php/dav/files/test%40%23%3F%25test/path/to%20sp%40ce/a%40b%23%3F%25/x');
 		});
 	});
 });

--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -45,8 +45,19 @@ class FilesContext extends RawMinkContext implements Context
 	public function iAmOnTheFilesPage()
 	{
 		$this->filesPage->open();
+		$this->filesPage->waitTillPageIsLoaded($this->getSession());
 	}
 
+	
+	/**
+	 * @When I create a folder with the name :name
+	 * 
+	 * @param string $name
+	 * @return void
+	 */
+	public function createAFolder($name) {
+		$this->filesPage->createFolder($name);
+	}
 	/**
 	 * @Given the list of files\/folders does not fit in one browser page
 	 */

--- a/tests/ui/features/files/files.feature
+++ b/tests/ui/features/files/files.feature
@@ -1,9 +1,22 @@
 Feature: files
 
-	@skipOnIE
-	Scenario: scroll fileactionsmenu into view
+	Background:
 		Given a regular user exists
 		And I am logged in as a regular user
 		And I am on the files page
+
+	@skipOnIE
+	Scenario: scroll fileactionsmenu into view
 		And the list of files/folders does not fit in one browser page
 		Then the filesactionmenu should be completely visible after clicking on it
+
+	Scenario Outline: Create a folder using special characters
+		When I create a folder with the name <folder_name>
+		Then the folder <folder_name> should be listed
+		And the page is reloaded
+		Then the folder <folder_name> should be listed
+		Examples:
+		|folder_name    |
+		|'सिमप्ले फोल्देर $%#?&@'|
+		|'"somequotes1"'|
+		|"'somequotes2'"|

--- a/tests/ui/features/files/renameFiles.feature
+++ b/tests/ui/features/files/renameFiles.feature
@@ -9,10 +9,10 @@ Feature: renameFiles
 		When I rename the file "lorem.txt" to <to_file_name>
 		Then the file <to_file_name> should be listed
 		Examples:
-		|to_file_name  |
-		|'लोरेम।तयक्स्त $%&'    |
-		|'"quotes1"'   |
-		|"'quotes2'"   |
+		|to_file_name    |
+		|'लोरेम।तयक्स्त? $%#&@' |
+		|'"quotes1"'     |
+		|"'quotes2'"     |
 
 		
 	Scenario Outline: Rename a file that has special characters in its name
@@ -33,6 +33,9 @@ Feature: renameFiles
 		When I rename the file '"double"quotes.txt' to "no-double-quotes.txt"
 		And the page is reloaded
 		Then the file "no-double-quotes.txt" should be listed
+		When I rename the file 'no-double-quotes.txt' to "hash#And&QuestionMark?At@Filename.txt"
+		And the page is reloaded
+		Then the file "hash#And&QuestionMark?At@Filename.txt" should be listed
 
 	Scenario: Rename a file using forbidden characters
 		When I rename the file "data.zip" to one of these names

--- a/tests/ui/features/files/renameFolders.feature
+++ b/tests/ui/features/files/renameFolders.feature
@@ -10,17 +10,17 @@ Feature: renameFolders
 		Then the folder <to_folder_name> should be listed
 		Examples:
 		|to_folder_name|
-		|'सिमप्ले फोल्देर'    |
-		|'"quotes1"'   |
-		|"'quotes2'"   |
+		|'सिमप्ले फोल्देर$%#?&@' |
+		|'"quotes1"'    |
+		|"'quotes2'"    |
 
 	Scenario Outline: Rename a folder that has special characters in its name
 		When I rename the folder <from_name> to <to_name>
 		Then the folder <to_name> should be listed
 		Examples:
-		|from_name           |to_name               |
-		|"strängé नेपाली folder"|"strängé नेपाली folder-2"|
-		|"'single'quotes"    |"single-quotes"       |
+		|from_name           |to_name                 |
+		|"strängé नेपाली folder"|"strängé नेपाली folder-#?2"|
+		|"'single'quotes"    |"single-quotes"         |
 
 	Scenario: Rename a folder using special characters and check its existence after page reload
 		When I rename the folder "simple-folder" to "लोरेम।तयक्स्त $%&"
@@ -32,6 +32,9 @@ Feature: renameFolders
 		When I rename the folder '"double"quotes' to "no-double-quotes"
 		And the page is reloaded
 		Then the folder "no-double-quotes" should be listed
+		When I rename the folder 'no-double-quotes' to "hash#And&QuestionMark?At@FolderName"
+		And the page is reloaded
+		Then the folder "hash#And&QuestionMark?At@FolderName" should be listed
 
 	Scenario: Rename a folder using forbidden characters
 		When I rename the folder "simple-folder" to one of these names


### PR DESCRIPTION
## Description
Encode with encodeURIComponent again.
Note that "@" gets encoded to "%40" but when Sabre DAV returns a
PROPFIND response, the "@" in the URL is not encoded. To make sure that
the href root is properly match, we now compare each section
individually in their decoded form.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28748

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
JS unit tests.
Create a folder "test@?#" in the web UI and navigate into it.
Create a user "test@test" with a subfolder, navigate into it.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

