### PR TITLE
Give install warning on all OS other than Linux

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -180,7 +180,12 @@ class Local extends \OC\Files\Storage\Common {
 			return false;
 		}
 		if (PHP_INT_SIZE === 4) {
-			return (int) exec ('stat -c %Y '. escapeshellarg ($fullPath));
+			if (\OC_Util::runningOnLinux()) {
+				return (int) exec ('stat -c %Y '. escapeshellarg ($fullPath));
+			} else if (\OC_Util::runningOnBSD() || \OC_Util::runningOnMac()) {
+				return (int) exec ('stat -f %m '. escapeshellarg ($fullPath));
+			}
+			return false;
 		}
 		return filemtime($fullPath);
 	}

--- a/lib/private/LargeFileHelper.php
+++ b/lib/private/LargeFileHelper.php
@@ -142,19 +142,12 @@ class LargeFileHelper {
 	*/
 	public function getFileSizeViaExec($filename) {
 		if (\OC_Helper::is_function_enabled('exec')) {
-			$os = strtolower(php_uname('s'));
 			$arg = escapeshellarg($filename);
 			$result = null;
-			if (strpos($os, 'linux') !== false) {
+			if (\OC_Util::runningOnLinux()) {
 				$result = $this->exec("stat -c %s $arg");
-			} else if (strpos($os, 'bsd') !== false || strpos($os, 'darwin') !== false) {
+			} else if (\OC_Util::runningOnBSD() || \OC_Util::runningOnMac()) {
 				$result = $this->exec("stat -f %z $arg");
-			} else if (strpos($os, 'win') !== false) {
-				$result = $this->exec("for %F in ($arg) do @echo %~zF");
-				if (is_null($result)) {
-					// PowerShell
-					$result = $this->exec("(Get-Item $arg).length");
-				}
 			}
 			return $result;
 		}

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -203,12 +203,18 @@ class Setup {
 			\OC\Setup::protectDataDirectory();
 		}
 
-		if (\OC_Util::runningOnMac()) {
+		if (!\OC_Util::runningOnLinux()) {
+			if (\OC_Util::runningOnMac()) {
+				$os = "Mac OS X";
+			} else {
+				$os = PHP_OS;
+			}
+
 			$errors[] = [
 				'error' => $this->l10n->t(
-					'Mac OS X is not supported and %s will not work properly on this platform. ' .
+					'%s is not supported and %s will not work properly on this platform. ' .
 					'Use it at your own risk! ',
-					$this->defaults->getName()
+					array($os, $this->defaults->getName())
 				),
 				'hint' => $this->l10n->t('For the best results, please consider using a GNU/Linux server instead.')
 			];

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1253,12 +1253,30 @@ class OC_Util {
 	}
 
 	/**
+	 * Checks whether the server is running on Linux
+	 *
+	 * @return bool true if running on Linux, false otherwise
+	 */
+	public static function runningOnLinux() {
+		return (strtolower(substr(PHP_OS, 0, 5)) === 'linux');
+	}
+
+	/**
 	 * Checks whether the server is running on Mac OS X
 	 *
 	 * @return bool true if running on Mac OS X, false otherwise
 	 */
 	public static function runningOnMac() {
-		return (strtoupper(substr(PHP_OS, 0, 6)) === 'DARWIN');
+		return (strtolower(substr(PHP_OS, 0, 6)) === 'darwin');
+	}
+
+	/**
+	 * Checks whether the server is running on BSD
+	 *
+	 * @return bool true if running on BSD, false otherwise
+	 */
+	public static function runningOnBSD() {
+		return (strpos(strtolower(PHP_OS), 'bsd') !== false);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Make the install warning for Mac OS X more generic, so the warning is given for any OS that is not Linux.

## Related Issue
#28760 

## Motivation and Context
People can install on officially-unsupported *BSD at the moment, without being given a warning.

## How Has This Been Tested?
Remove the "!" in front of \OC_Util::runningOnLinux() and set installed to false in a dev system.
(to trick it into thinking it is an unsupported system)
Go to the web UI. Confirm that the setup page gives a warning with reasonable text.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

This was noticed when looking at code that used runningOnMac(), PHP_OS and/or php_uname to do stuff based on the operating system.