### PR TITLE
PHP 5.5 is EOL as well by now

### DIFF
--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -37,7 +37,6 @@ use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
-use OC_Util;
 use OCP\IURLGenerator;
 
 /**
@@ -253,7 +252,7 @@ class CheckSetupController extends Controller {
 
 	/**
 	 * @NoCSRFRequired
-	 * @return DataResponse
+	 * @return DataResponse | DataDisplayResponse
 	 */
 	public function getFailedIntegrityCheckFiles() {
 		if(!$this->checker->isCodeCheckEnforced()) {
@@ -339,8 +338,9 @@ Raw output
 	protected function isEndOfLive() {
 		$eol = false;
 
-		//PHP 5.4 is EOL on 14 Sep 2015
-		if (version_compare(PHP_VERSION, '5.5.0') === -1) {
+		// PHP 5.4 is EOL on 14 Sep 2015
+		// PHP 5.5 is EOL on 21 Jul 2016
+		if (version_compare(PHP_VERSION, '5.6.0') === -1) {
 			$eol = true;
 			return $eol;
 		}

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -21,6 +21,7 @@
 
 namespace Tests\Settings\Controller;
 
+use GuzzleHttp\Exception\ClientException;
 use OC\Settings\Controller\CheckSetupController;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataDisplayResponse;
@@ -452,6 +453,7 @@ class CheckSetupControllerTest extends TestCase {
 			->will($this->returnValue(['ssl_version' => 'NSS/1.0.2b']));
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
+		/** @var ClientException | \PHPUnit_Framework_MockObject_MockObject $exception */
 		$exception = $this->getMockBuilder('\GuzzleHttp\Exception\ClientException')
 			->disableOriginalConstructor()->getMock();
 		$response = $this->getMockBuilder('\GuzzleHttp\Message\ResponseInterface')
@@ -486,6 +488,7 @@ class CheckSetupControllerTest extends TestCase {
 			->will($this->returnValue(['ssl_version' => 'NSS/1.0.2b']));
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
+		/** @var ClientException | \PHPUnit_Framework_MockObject_MockObject $exception */
 		$exception = $this->getMockBuilder('\GuzzleHttp\Exception\ClientException')
 			->disableOriginalConstructor()->getMock();
 		$response = $this->getMockBuilder('\GuzzleHttp\Message\ResponseInterface')


### PR DESCRIPTION
## Motivation and Context
Notify users/admins that PHP 5.5 is EOL as well by now

## How Has This Been Tested?
Not tested on master - master requires PHP 5.6 anyway ....

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

