### PR TITLE
[stable9.1] PHP 5.5 is EOL as well by now

### DIFF
--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -36,7 +36,6 @@ use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
-use OC_Util;
 use OCP\IURLGenerator;
 
 /**
@@ -263,7 +262,7 @@ class CheckSetupController extends Controller {
 
 	/**
 	 * @NoCSRFRequired
-	 * @return DataResponse
+	 * @return DataResponse | DataDisplayResponse
 	 */
 	public function getFailedIntegrityCheckFiles() {
 		if(!$this->checker->isCodeCheckEnforced()) {
@@ -349,8 +348,9 @@ Raw output
 	protected function isEndOfLive() {
 		$eol = false;
 
-		//PHP 5.4 is EOL on 14 Sep 2015
-		if (version_compare(PHP_VERSION, '5.5.0') === -1) {
+		// PHP 5.4 is EOL on 14 Sep 2015
+		// PHP 5.5 is EOL on 21 Jul 2016
+		if (version_compare(PHP_VERSION, '5.6.0') === -1) {
 			$eol = true;
 			return $eol;
 		}

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -21,6 +21,7 @@
 
 namespace Tests\Settings\Controller;
 
+use GuzzleHttp\Exception\ClientException;
 use OC\Settings\Controller\CheckSetupController;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataDisplayResponse;
@@ -465,6 +466,7 @@ class CheckSetupControllerTest extends TestCase {
 			->will($this->returnValue(['ssl_version' => 'NSS/1.0.2b']));
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
+		/** @var ClientException | \PHPUnit_Framework_MockObject_MockObject $exception */
 		$exception = $this->getMockBuilder('\GuzzleHttp\Exception\ClientException')
 			->disableOriginalConstructor()->getMock();
 		$response = $this->getMockBuilder('\GuzzleHttp\Message\ResponseInterface')
@@ -499,6 +501,7 @@ class CheckSetupControllerTest extends TestCase {
 			->will($this->returnValue(['ssl_version' => 'NSS/1.0.2b']));
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
+		/** @var ClientException | \PHPUnit_Framework_MockObject_MockObject $exception */
 		$exception = $this->getMockBuilder('\GuzzleHttp\Exception\ClientException')
 			->disableOriginalConstructor()->getMock();
 		$response = $this->getMockBuilder('\GuzzleHttp\Message\ResponseInterface')


### PR DESCRIPTION
backport of #28764 to stable9.1