### PR TITLE
Make Backbone PROPPATCH work with options.wait mode

### DIFF
--- a/core/js/oc-backbone-webdav.js
+++ b/core/js/oc-backbone-webdav.js
@@ -180,9 +180,25 @@
 	}
 
 	function callPropPatch(client, options, model, headers) {
+		var changes = model.changed;
+		if (options.wait && _.isEmpty(changes)) {
+			// usually with "wait" mode, the changes aren't set yet,
+			changes = options.data;
+
+			// if options.patch is not set, then data contains all the data
+			// instead of just the properties to patch
+			if (!options.patch) {
+				// remove reserved properties
+				delete changes.href;
+				delete changes[_.result(model, 'idAttribute')];
+
+				// note: there is no way to diff with previous values here so
+				// we just send everything
+			}
+		}
 		return client.propPatch(
 			options.url,
-			convertModelAttributesToDavProperties(model.changed, options.davProperties),
+			convertModelAttributesToDavProperties(changes, options.davProperties),
 			headers
 		).then(function(result) {
 			if (result.status === 207 && result.body && result.body.length > 0) {
@@ -196,6 +212,11 @@
 			}
 
 			if (isSuccessStatus(result.status)) {
+				// with wait, we set the changes only after success
+				if (options.wait) {
+					model.set(changes, options);
+				}
+
 				if (_.isFunction(options.success)) {
 					// pass the object's own values because the server
 					// does not return the updated model
@@ -236,7 +257,7 @@
 			options.type,
 			options.url,
 			headers,
-			options.data
+			JSON.stringify(options.data)
 		).then(function(result) {
 			if (!isSuccessStatus(result.status)) {
 				if (_.isFunction(options.error)) {
@@ -353,7 +374,7 @@
 
 		// Ensure that we have the appropriate request data.
 		if (options.data == null && model && (method === 'create' || method === 'update' || method === 'patch')) {
-			params.data = JSON.stringify(options.attrs || model.toJSON(options));
+			params.data = options.attrs || model.toJSON(options);
 		}
 
 		// Don't process data on a non-GET request.


### PR DESCRIPTION
## Description
In options.wait mode, no model.changes are available as they haven't
been set yet. So in this mode we simply get all properties and send
these with PROPPATCH.

## Related Issue
Fixes https://github.com/owncloud/customgroups/issues/87

## Motivation and Context
Better compatibility with backbone options.

## How Has This Been Tested?
Manual testing with customgroups ticket and JS unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

