### PR TITLE
Tests for files with multiple spaces

### DIFF
--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -93,7 +93,7 @@ class FilesContext extends RawMinkContext implements Context
 	public function iRenameTheFileFolderTo($fromName, $toName)
 	{
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
-		$this->filesPage->renameFile($fromName, '', $toName, $this->getSession());
+		$this->filesPage->renameFile($fromName, $toName, $this->getSession());
 	}
 
 	/**
@@ -102,7 +102,7 @@ class FilesContext extends RawMinkContext implements Context
 	public function iRenameTheFileFolderFromPlusToPlus($fromNamePartA, $fromNamePartB, $toNamePartA, $toNamePartB)
 	{
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
-		$this->filesPage->renameFile($fromNamePartA, $fromNamePartB, $toNamePartA . $toNamePartB, $this->getSession());
+		$this->filesPage->renameFile([$fromNamePartA, $fromNamePartB], $toNamePartA . $toNamePartB, $this->getSession());
 	}
 
 	/**
@@ -112,7 +112,7 @@ class FilesContext extends RawMinkContext implements Context
 	{
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
 		foreach ($table->getRows() as $row) {
-			$this->filesPage->renameFile($fromName, '', $row[0], $this->getSession());
+			$this->filesPage->renameFile($fromName, $row[0], $this->getSession());
 		}
 		
 	}
@@ -123,7 +123,7 @@ class FilesContext extends RawMinkContext implements Context
 	public function theFileFolderShouldBeListed($name)
 	{
 		PHPUnit_Framework_Assert::assertNotNull(
-			$this->filesPage->findFileRowByName($this->getSession(), $name)
+			$this->filesPage->findFileRowByName($name, $this->getSession())
 		);
 	}
 
@@ -133,7 +133,7 @@ class FilesContext extends RawMinkContext implements Context
 	public function theFileFolderPlusShouldBeListed($namePartA, $namePartB)
 	{
 		PHPUnit_Framework_Assert::assertNotNull(
-			$this->filesPage->findFileRowByName($this->getSession(), $namePartA, $namePartB)
+			$this->filesPage->findFileRowByName([$namePartA, $namePartB], $this->getSession())
 		);
 	}
 

--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -97,12 +97,21 @@ class FilesContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @Given I rename the file/folder :fromNamePartA plus :fromNamePartB to :toNamePartA plus :toNamePartB
+	 * @Given I rename the following file/folder to
+	 * @param TableNode $namePartsTable table of parts of the from and to file names
+	 * table headings: must be: |from-name-parts |to-name-parts |
 	 */
-	public function iRenameTheFileFolderFromPlusToPlus($fromNamePartA, $fromNamePartB, $toNamePartA, $toNamePartB)
+	public function iRenameTheFollowingFileFolderTo(TableNode $namePartsTable)
 	{
+		$fromNameParts = [];
+		$toNameParts = [];
+
+		foreach ($namePartsTable as $namePartsRow) {
+			$fromNameParts[] = $namePartsRow['from-name-parts'];
+			$toNameParts[] = $namePartsRow['to-name-parts'];
+		}
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
-		$this->filesPage->renameFile([$fromNamePartA, $fromNamePartB], $toNamePartA . $toNamePartB, $this->getSession());
+		$this->filesPage->renameFile($fromNameParts, $toNameParts, $this->getSession());
 	}
 
 	/**
@@ -128,12 +137,20 @@ class FilesContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @Then the file/folder :namePartA plus :namePartB should be listed
+	 * @Then the following file/folder should be listed
+	 * @param TableNode $namePartsTable table of parts of the file name
+	 * table headings: must be: |name-parts |
 	 */
-	public function theFileFolderPlusShouldBeListed($namePartA, $namePartB)
+	public function theFollowingFileFolderShouldBeListed(TableNode $namePartsTable)
 	{
+		$fileNameParts = [];
+
+		foreach ($namePartsTable as $namePartsRow) {
+			$fileNameParts[] = $namePartsRow['name-parts'];
+		}
+
 		PHPUnit_Framework_Assert::assertNotNull(
-			$this->filesPage->findFileRowByName([$namePartA, $namePartB], $this->getSession())
+			$this->filesPage->findFileRowByName($fileNameParts, $this->getSession())
 		);
 	}
 

--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -93,7 +93,16 @@ class FilesContext extends RawMinkContext implements Context
 	public function iRenameTheFileFolderTo($fromName, $toName)
 	{
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
-		$this->filesPage->renameFile($fromName, $toName, $this->getSession());
+		$this->filesPage->renameFile($fromName, '', $toName, $this->getSession());
+	}
+
+	/**
+	 * @Given I rename the file/folder :fromNamePartA plus :fromNamePartB to :toNamePartA plus :toNamePartB
+	 */
+	public function iRenameTheFileFolderFromPlusToPlus($fromNamePartA, $fromNamePartB, $toNamePartA, $toNamePartB)
+	{
+		$this->filesPage->waitTillPageIsLoaded($this->getSession());
+		$this->filesPage->renameFile($fromNamePartA, $fromNamePartB, $toNamePartA . $toNamePartB, $this->getSession());
 	}
 
 	/**
@@ -103,7 +112,7 @@ class FilesContext extends RawMinkContext implements Context
 	{
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
 		foreach ($table->getRows() as $row) {
-			$this->filesPage->renameFile($fromName, $row[0], $this->getSession());
+			$this->filesPage->renameFile($fromName, '', $row[0], $this->getSession());
 		}
 		
 	}
@@ -114,7 +123,17 @@ class FilesContext extends RawMinkContext implements Context
 	public function theFileFolderShouldBeListed($name)
 	{
 		PHPUnit_Framework_Assert::assertNotNull(
-			$this->filesPage->findFileRowByName($name, $this->getSession())
+			$this->filesPage->findFileRowByName($this->getSession(), $name)
+		);
+	}
+
+	/**
+	 * @Then the file/folder :namePartA plus :namePartB should be listed
+	 */
+	public function theFileFolderPlusShouldBeListed($namePartA, $namePartB)
+	{
+		PHPUnit_Framework_Assert::assertNotNull(
+			$this->filesPage->findFileRowByName($this->getSession(), $namePartA, $namePartB)
 		);
 	}
 

--- a/tests/ui/features/files/renameFiles.feature
+++ b/tests/ui/features/files/renameFiles.feature
@@ -14,7 +14,6 @@ Feature: renameFiles
 		|'"quotes1"'     |
 		|"'quotes2'"     |
 
-		
 	Scenario Outline: Rename a file that has special characters in its name
 		When I rename the file <from_name> to <to_name>
 		Then the file <to_name> should be listed
@@ -36,6 +35,26 @@ Feature: renameFiles
 		When I rename the file 'no-double-quotes.txt' to "hash#And&QuestionMark?At@Filename.txt"
 		And the page is reloaded
 		Then the file "hash#And&QuestionMark?At@Filename.txt" should be listed
+
+	Scenario: Rename a file using spaces at front and/or back of file name and type
+		When I rename the file "lorem.txt" to " space at start"
+		And the page is reloaded
+		Then the file " space at start" should be listed
+		When I rename the file " space at start" to "space at end "
+		And the page is reloaded
+		Then the file "space at end " should be listed
+		When I rename the file "space at end " to "space at end .txt"
+		And the page is reloaded
+		Then the file "space at end .txt" should be listed
+		When I rename the file "space at end .txt" to "space at end. lis"
+		And the page is reloaded
+		Then the file "space at end. lis" should be listed
+		When I rename the file "space at end. lis" to "space at end.log "
+		And the page is reloaded
+		Then the file "space at end.log " should be listed
+		When I rename the file "space at end.log " to "  multiple   space    all     over   .  dat  "
+		And the page is reloaded
+		Then the file "  multiple   space    all     over   .  dat  " should be listed
 
 	Scenario: Rename a file using forbidden characters
 		When I rename the file "data.zip" to one of these names

--- a/tests/ui/features/files/renameFiles.feature
+++ b/tests/ui/features/files/renameFiles.feature
@@ -56,6 +56,14 @@ Feature: renameFiles
 		And the page is reloaded
 		Then the file "  multiple   space    all     over   .  dat  " should be listed
 
+	Scenario: Rename a file using both double and single quotes
+		When I rename the file "lorem" plus ".txt" to "First 'single' " plus 'then "double".txt'
+		And the page is reloaded
+		Then the file "First 'single' " plus 'then "double".txt' should be listed
+		When I rename the file "First 'single' " plus 'then "double".txt' to "loremz" plus ".dat"
+		And the page is reloaded
+		Then the file "loremz" plus ".dat" should be listed
+
 	Scenario: Rename a file using forbidden characters
 		When I rename the file "data.zip" to one of these names
 		|lorem\txt  |

--- a/tests/ui/features/files/renameFiles.feature
+++ b/tests/ui/features/files/renameFiles.feature
@@ -57,12 +57,21 @@ Feature: renameFiles
 		Then the file "  multiple   space    all     over   .  dat  " should be listed
 
 	Scenario: Rename a file using both double and single quotes
-		When I rename the file "lorem" plus ".txt" to "First 'single' " plus 'then "double".txt'
+		When I rename the following file to
+			|from-name-parts |to-name-parts         |
+			|lorem.txt       |First 'single' quotes |
+			|                |-then "double".txt    |
 		And the page is reloaded
-		Then the file "First 'single' " plus 'then "double".txt' should be listed
-		When I rename the file "First 'single' " plus 'then "double".txt' to "loremz" plus ".dat"
+		Then the following file should be listed
+			|name-parts            |
+			|First 'single' quotes |
+			|-then "double".txt    |
+		When I rename the following file to
+			|from-name-parts       |to-name-parts |
+			|First 'single' quotes |loremz.dat    |
+			|-then "double".txt    |              |
 		And the page is reloaded
-		Then the file "loremz" plus ".dat" should be listed
+		Then the file "loremz.dat" should be listed
 
 	Scenario: Rename a file using forbidden characters
 		When I rename the file "data.zip" to one of these names

--- a/tests/ui/features/files/renameFolders.feature
+++ b/tests/ui/features/files/renameFolders.feature
@@ -36,6 +36,17 @@ Feature: renameFolders
 		And the page is reloaded
 		Then the folder "hash#And&QuestionMark?At@FolderName" should be listed
 
+	Scenario: Rename a folder using spaces at front and/or back of the name
+		When I rename the folder "simple-folder" to " space at start"
+		And the page is reloaded
+		Then the folder " space at start" should be listed
+		When I rename the folder " space at start" to "space at end "
+		And the page is reloaded
+		Then the folder "space at end " should be listed
+		When I rename the folder "space at end " to "  multiple   spaces    all     over   "
+		And the page is reloaded
+		Then the folder "  multiple   spaces    all     over   " should be listed
+
 	Scenario: Rename a folder using forbidden characters
 		When I rename the folder "simple-folder" to one of these names
 		|simple\folder   |

--- a/tests/ui/features/files/renameFolders.feature
+++ b/tests/ui/features/files/renameFolders.feature
@@ -47,6 +47,14 @@ Feature: renameFolders
 		And the page is reloaded
 		Then the folder "  multiple   spaces    all     over   " should be listed
 
+	Scenario: Rename a folder using both double and single quotes
+		When I rename the folder "simple" plus "-folder" to "First 'single' " plus 'then "double"'
+		And the page is reloaded
+		Then the folder "First 'single' " plus 'then "double"' should be listed
+		When I rename the folder "First 'single' " plus 'then "double"' to "a normal " plus "folder"
+		And the page is reloaded
+		Then the folder "a normal " plus "folder" should be listed
+
 	Scenario: Rename a folder using forbidden characters
 		When I rename the folder "simple-folder" to one of these names
 		|simple\folder   |

--- a/tests/ui/features/files/renameFolders.feature
+++ b/tests/ui/features/files/renameFolders.feature
@@ -48,12 +48,21 @@ Feature: renameFolders
 		Then the folder "  multiple   spaces    all     over   " should be listed
 
 	Scenario: Rename a folder using both double and single quotes
-		When I rename the folder "simple" plus "-folder" to "First 'single' " plus 'then "double"'
+		When I rename the following folder to
+			|from-name-parts |to-name-parts        |
+			|simple-folder  |First 'single' quotes |
+			|               |-then "double"        |
 		And the page is reloaded
-		Then the folder "First 'single' " plus 'then "double"' should be listed
-		When I rename the folder "First 'single' " plus 'then "double"' to "a normal " plus "folder"
+		Then the following folder should be listed
+			|name-parts            |
+			|First 'single' quotes |
+			|-then "double"        |
+		When I rename the following folder to
+			|from-name-parts       |to-name-parts   |
+			|First 'single' quotes |a normal folder |
+			|-then "double"        |                |
 		And the page is reloaded
-		Then the folder "a normal " plus "folder" should be listed
+		Then the folder "a normal folder" should be listed
 
 	Scenario: Rename a folder using forbidden characters
 		When I rename the folder "simple-folder" to one of these names

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -274,12 +274,16 @@ class FilesPage extends OwnCloudPage
 	/**
 	 * renames a file
 	 * @param string|array $fromFileName
-	 * @param string $toFileName
+	 * @param string|array $toFileName
 	 * @param Session $session
 	 * @param int $maxRetries
 	 */
 	public function renameFile($fromFileName, $toFileName, Session $session, $maxRetries = 5)
 	{
+		if (is_array($toFileName)) {
+			$toFileName = implode($toFileName);
+		}
+
 		for ($counter = 0; $counter < $maxRetries; $counter++) {
 			try {
 				$this->_renameFile($fromFileName, $toFileName, $session);


### PR DESCRIPTION
## Description
scrollDownAppContent() - refactor so it does not need to be passed the number of files that were on the screen when it was called. It can keep track of that itself.

findFileRowByName() - use a more specific xpath that looks directly for an element that has the desired text. That xpath element matching works without stripping/compressing white space, retain exact matching to things like a filename with multiple contiguous spaces.

(The previous problem was that the Mink getText() method returned a stripped-compressed "normalized" version of the string in the HTML, which prevented exact comparisons with the expected file name)

Add various tests to confirm that users can put (multiple) spaces in front, in the middle and at the end of file names.

## Related Issue
#28754 

## Motivation and Context
Make tests be able to use files with multiple contiguous spaces in the file name.

## How Has This Been Tested?
Local UI test run.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
