### PR TITLE
Reduce JS test warnings

### DIFF
--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -133,7 +133,7 @@ describe('OC.Upload tests', function() {
 				'<input type="checkbox" id="select_all_files" class="select-all">' +
 				'<a class="name columntitle" data-sort="name"><span>Name</span><span class="sort-indicator"></span></a>' +
 				'<span id="selectedActionsList" class="selectedActions hidden">' +
-				'<a href class="download"><img src="actions/download.svg">Download</a>' +
+				'<a href class="download"><img/>Download</a>' +
 				'<a href class="delete-selected">Delete</a></span>' +
 				'</th>' +
 				'<th class="hidden column-size"><a class="columntitle" data-sort="size"><span class="sort-indicator"></span></a></th>' +

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -94,7 +94,7 @@ describe('OCA.Files.FileList tests', function() {
 			'<input type="checkbox" id="select_all_files" class="select-all checkbox">' +
 			'<a class="name columntitle" data-sort="name"><span>Name</span><span class="sort-indicator"></span></a>' +
 			'<span id="selectedActionsList" class="selectedActions hidden">' +
-			'<a href class="download"><img src="actions/download.svg">Download</a>' +
+			'<a href class="download"><img/>Download</a>' +
 			'<a href class="delete-selected">Delete</a></span>' +
 			'</th>' +
 			'<th class="hidden column-size"><a class="columntitle" data-sort="size"><span class="sort-indicator"></span></a></th>' +

--- a/core/js/tests/specHelper.js
+++ b/core/js/tests/specHelper.js
@@ -182,6 +182,7 @@ window.isPhantom = /phantom/i.test(navigator.userAgent);
 		// reset pop state handlers
 		OC.Util.History._handlers = [];
 
+		$(window).off('beforeunload');
 	});
 })();
 

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -994,7 +994,12 @@ describe('Core base tests', function() {
 			var $rows = $el.find('.row');
 			expect($rows.length).toEqual(2);
 
+			// when called without arguments, a warning to be logged
+			// to ask devs to adjust their usage of the API.
+			// we stub it to avoid polluting the actual console
+			var warnStub = sinon.stub(console, 'warn');
 			OC.Notification.hide();
+			warnStub.restore();
 
 			$rows = $el.find('.row');
 			expect($rows.length).toEqual(1);

--- a/core/js/tests/specs/l10nSpec.js
+++ b/core/js/tests/specs/l10nSpec.js
@@ -7,7 +7,6 @@
  * See the COPYING-README file.
  *
  */
-
 describe('OC.L10N tests', function() {
 	var TEST_APP = 'jsunittestapp';
 
@@ -25,7 +24,7 @@ describe('OC.L10N tests', function() {
 				'Hello world!': 'Hallo Welt!',
 				'Hello {name}, the weather is {weather}': 'Hallo {name}, das Wetter ist {weather}',
 				'sunny': 'sonnig'
-			});
+			}, 'nplurals=2; plural=(n != 1);');
 		});
 		it('returns untranslated text when no bundle exists', function() {
 			delete OC.L10N._bundles[TEST_APP];
@@ -56,12 +55,21 @@ describe('OC.L10N tests', function() {
 			OC.L10N.register(TEST_APP, {
 				'sunny': 'sonnig',
 				'new': 'neu'
-			});
+			}, 'nplurals=2; plural=(n != 1);');
 			expect(t(TEST_APP, 'sunny')).toEqual('sonnig');
 			expect(t(TEST_APP, 'new')).toEqual('neu');
 		});
 	});
 	describe('plurals', function() {
+		var warnStub;
+
+		beforeEach(function() {
+			warnStub = sinon.stub(console, 'warn');
+		});
+		afterEach(function() { 
+			warnStub.restore(); 
+		});
+	
 		function checkPlurals() {
 			expect(
 				n(TEST_APP, 'download %n file', 'download %n files', 0)
@@ -80,6 +88,7 @@ describe('OC.L10N tests', function() {
 		it('generates plural for default text when translation does not exist', function() {
 			OC.L10N.register(TEST_APP, {
 			});
+			expect(warnStub.called).toEqual(true);
 			expect(
 				n(TEST_APP, 'download %n file', 'download %n files', 0)
 			).toEqual('download 0 files');
@@ -98,6 +107,7 @@ describe('OC.L10N tests', function() {
 				'_download %n file_::_download %n files_':
 					['%n Datei herunterladen', '%n Dateien herunterladen']
 			});
+			expect(warnStub.called).toEqual(true);
 			checkPlurals();
 		});
 		it('generates plural with generated function when forms is specified', function() {
@@ -105,6 +115,7 @@ describe('OC.L10N tests', function() {
 				'_download %n file_::_download %n files_':
 					['%n Datei herunterladen', '%n Dateien herunterladen']
 			}, 'nplurals=2; plural=(n != 1);');
+			expect(warnStub.notCalled).toEqual(true);
 			checkPlurals();
 		});
 		it('generates plural with function when forms is specified as function', function() {
@@ -117,6 +128,7 @@ describe('OC.L10N tests', function() {
 					plural: (n !== 1) ? 1 : 0
 				};
 			});
+			expect(warnStub.notCalled).toEqual(true);
 			checkPlurals();
 		});
 	});
@@ -152,7 +164,7 @@ describe('OC.L10N tests', function() {
 			var callbackStub = sinon.stub();
 			OC.L10N.register(TEST_APP, {
 				'Hello world!': 'Hallo Welt!'
-			});
+			}, 'nplurals=2; plural=(n != 1);');
 			OC.L10N.load(TEST_APP, callbackStub).then(promiseStub);
 			expect(callbackStub.calledOnce).toEqual(true);
 			expect(promiseStub.calledOnce).toEqual(true);


### PR DESCRIPTION
## Description
Remove "ERROR: undefined" at the end of the tests which were due to the
"onbeforeunload" event.
Removed "download.svg" errors.
Removed warnings about missing plurals.

For the rest, need to spend some time to replace the last tipsy usages and port some of the notification calls.

## Related Issue
None raised

## Motivation and Context
Warnings are annoying.

## How Has This Been Tested?
`make test-js`
See that there are less warnings.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

