### PR TITLE
[stable10] Add tooltip to public shares

### DIFF
--- a/core/js/sharedialoglinklistview.js
+++ b/core/js/sharedialoglinklistview.js
@@ -21,21 +21,21 @@
 			'<span class="link-entry--icon icon-public-white"></span>' +
 			'<span class="link-entry--title">{{linkTitle}}</span>' +
 			'<div class="minify"><input id="linkText-{{../cid}}-{{id}}" class="linkText" type="text" readonly="readonly" value="{{link}}" /></div>' +
-			'<div class="link-entry--icon-button clipboardButton" data-clipboard-target="#linkText-{{../cid}}-{{id}}">' +
+			'<div class="link-entry--icon-button clipboardButton" data-clipboard-target="#linkText-{{../cid}}-{{id}}" title="{{../copyToClipboardText}}">' +
 			'	<span class="icon icon-clippy-dark"></span>' +
 			'	<span class="hidden">{{../copyToClipboardText}}</span>' +
 			'</div>' +
-			'<div class="link-entry--icon-button editLink">' +
+			'<div class="link-entry--icon-button editLink" title="{{../editLinkText}}">' +
 			'	<span class="icon icon-settings-dark"></span>' +
 			'	<span class="hidden">{{../editLinkText}}</span>' +
 			'</div>' +
 			'{{#if ../socialShareEnabled}}' +
-			'<div class="link-entry--icon-button shareLink">' +
+			'<div class="link-entry--icon-button shareLink" title="{{../shareText}}">' +
 			'	<span class="icon icon-share"></span>' +
 			'	<span class="hidden">{{../shareText}}</span>' +
 			'</div>' +
 			'{{/if}}' +
-			'<div class="link-entry--icon-button removeLink">' +
+			'<div class="link-entry--icon-button removeLink"  title="{{../removeLinkText}}">' +
 			'	<span class="icon icon-delete"></span>' +
 			'	<span class="hidden">{{../removeLinkText}}</span>' +
 			'</div>' +
@@ -241,7 +241,7 @@
 				addLinkText: t('core', 'Create public link'),
 				editLinkText: t('core', 'Edit'),
 				removeLinkText: t('core', 'Remove'),
-				copyToClipboardText: t('core', 'Click to copy to clipboard'),
+				copyToClipboardText: t('core', 'Copy to clipboard'),
 				shareText: t('core', 'Social share'),
 				socialShareEnabled: this.configModel.isSocialShareEnabled(),
 				noShares: !this.collection.length,
@@ -250,7 +250,7 @@
 				shares: this.collection.map(_.bind(this._formatItem, this))
 			}));
 
-			this.$el.find('.has-tooltip').tooltip();
+			this.$el.find('[title]').tooltip();
 
 			var clipboard = new Clipboard('#' + this.id + ' .clipboardButton');
 			clipboard.on('success', function (e) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Add tooltips to the function buttons displayed for public link shares.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes https://github.com/owncloud/core/issues/28721
Core PR: https://github.com/owncloud/core/pull/28776

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visual check in FF, Chrome, IE11 and Edge

## Screenshots (if appropriate):
![copy_to_clipboard](https://user-images.githubusercontent.com/12717530/29606814-ab0291f6-87ef-11e7-8571-1634a0d434af.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.