### PR TITLE
separate the files PageObject into smaller Objects

### DIFF
--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -71,16 +71,16 @@ class FilesContext extends RawMinkContext implements Context
 		if ($itemsCount > 0) {
 			$lastItemCoordinates = $this->filesPage->getCoordinatesOfElement(
 				$this->getSession(),
-				$this->filesPage->findActionMenuByNo($itemsCount)
+				$this->filesPage->findFileActionsMenuBtnByNo($itemsCount)
 			);
 		}
-
+		
 		while ($windowHeight > $lastItemCoordinates['top']) {
 			$this->filesPage->createFolder();
 			$itemsCount = $this->filesPage->getSizeOfFileFolderList();
 			$lastItemCoordinates = $this->filesPage->getCoordinatesOfElement(
 				$this->getSession(),
-				$this->filesPage->findActionMenuByNo($itemsCount)
+				$this->filesPage->findFileActionsMenuBtnByNo($itemsCount)
 			);
 		}
 		$this->getSession()->reload();
@@ -169,21 +169,24 @@ class FilesContext extends RawMinkContext implements Context
 	 */
 	public function theFilesactionmenuShouldBeCompletelyVisibleAfterClickingOnIt()
 	{
-		for ($i = 1; $i < $this->filesPage->getSizeOfFileFolderList(); $i++) {
-			$actionMenu = $this->filesPage->findActionMenuByNo($i);
-			$actionMenu->click();
+		for ($i = 1; $i <= $this->filesPage->getSizeOfFileFolderList(); $i++) {
+			$actionMenu = $this->filesPage->openFileActionsMenuByNo($i);
 
 			$windowHeight = $this->filesPage->getWindowHeight(
 				$this->getSession()
 			);
 
+			$deleteBtn = $actionMenu->findButton(
+				$actionMenu->getDeleteActionLabel()
+			);
 			$deleteBtnCoordinates = $this->filesPage->getCoordinatesOfElement(
-				$this->getSession(), $this->filesPage->findDeleteByNo($i)
+				$this->getSession(), $deleteBtn
 			);
 			PHPUnit_Framework_Assert::assertLessThan(
 				$windowHeight, $deleteBtnCoordinates ["top"]
 			);
-			$actionMenu->click();
+			//this will close the menu again
+			$this->filesPage->clickFileActionsMenuBtnByNo($i);
 		}
 	}
 }

--- a/tests/ui/features/bootstrap/SharingContext.php
+++ b/tests/ui/features/bootstrap/SharingContext.php
@@ -24,7 +24,6 @@ use Behat\Behat\Context\Context;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Page\FilesPage;
-use Page\SharingDialog;
 
 require_once 'bootstrap.php';
 

--- a/tests/ui/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/ui/features/lib/FilesPageElement/FileActionsMenu.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Page\FilesPageElement;
+
+use Page\OwncloudPage;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use Behat\Mink\Element\NodeElement;
+
+/**
+ * Object for files action Menu on the FilesPage
+ * containing actions like Rename, Delete, etc
+ */
+class FileActionsMenu extends OwnCloudPage {
+	/**
+	 * @var NodeElement of this action menu
+	 */
+	protected $menuElement;
+	protected $fileActionXpath = "//a[@data-action='%s']";
+	protected $renameActionLabel = "Rename";
+	protected $deleteActionLabel = "Delete";
+	
+	/**
+	 * sets the NodeElement for the current action menu
+	 * a little bit like __construct() but as we access this "sub-page-object"
+	 * from an other Page Object by $this->getPage("FilesPageElement\\FileActionsMenu")
+	 * there is no real __construct() that can take arguments
+	 *
+	 * @param \Behat\Mink\Element\NodeElement $menuElement
+	 * @return void
+	 */
+	public function setElement(NodeElement $menuElement) {
+		$this->menuElement = $menuElement;
+	}
+	
+	/**
+	 * clicks the rename button
+	 * 
+	 * @param string $xpathToWaitFor wait for this element to appear before returning
+	 * @param int $timeout_msec
+	 * @return void
+	 */
+	public function rename(
+		$xpathToWaitFor = null, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+	) {
+		$renameBtn = $this->findButton($this->renameActionLabel);
+		$renameBtn->click();
+		if ($xpathToWaitFor !== null) {
+			$this->waitTillElementIsNotNull($xpathToWaitFor, $timeout_msec);
+		}
+	}
+
+	/**
+	 * clicks the delete button
+	 * 
+	 * @return void
+	 */
+	public function delete() {
+		;
+	}
+	
+	/**
+	 * finds the actual action link in the action menu
+	 * 
+	 * @param string $action
+	 * @return \Behat\Mink\Element\NodeElement
+	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
+	 */
+	public function findButton($action) {
+		$this->waitTillElementIsNotNull(sprintf($this->fileActionXpath, $action));
+		$button = $this->menuElement->find(
+			"xpath",
+			sprintf($this->fileActionXpath, $action)
+		);
+		if ($button === null) {
+			throw new ElementNotFoundException(
+				"could not find button '$action' in action Menu"
+			);
+		} else {
+			return $button;
+		}
+	}
+
+	/**
+	 * just so the label can be reused in other places
+	 * and does not need to be redefined
+	 * 
+	 * @return string
+	 */
+	public function getDeleteActionLabel() {
+		return $this->deleteActionLabel;
+	}
+
+	/**
+	 * just so the label can be reused in other places
+	 * and does not need to be redefined
+	 *
+	 * @return string
+	 */
+	public function getRenameActionLabel() {
+		return $this->renameActionLabel;
+	}
+}

--- a/tests/ui/features/lib/FilesPageElement/FileRow.php
+++ b/tests/ui/features/lib/FilesPageElement/FileRow.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Page\FilesPageElement;
+
+use Page\OwncloudPage;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use Behat\Mink\Element\NodeElement;
+
+/**
+ * Object of a row on the FilesPage
+ */
+class FileRow extends OwnCloudPage {
+	/**
+	 * @var NodeElement of this row
+	 */
+	protected $rowElement;
+	
+	/**
+	 * name of the file
+	 * 
+	 * @var string
+	 */
+	protected $name;
+	protected $fileActionMenuBtnXpath = "//a[@data-action='menu']";
+	protected $shareBtnXpath = "//a[@data-action='Share']";
+	protected $loadingIndicatorXpath = ".//*[@class='loading']";
+	protected $fileRenameInputXpath = "//input[contains(@class,'filename')]";
+	protected $fileBusyIndicatorXpath = ".//*[@class='thumbnail' and contains(@style,'loading')]";
+	protected $fileTooltipXpath = ".//*[@class='tooltip-inner']";
+	
+	/**
+	 * sets the NodeElement for the current file row
+	 * a little bit like __construct() but as we access this "sub-page-object"
+	 * from an other Page Object by $this->getPage("FilesPageElement\\FileRow")
+	 * there is no real __construct() that can take arguments
+	 *
+	 * @param \Behat\Mink\Element\NodeElement $rowElement
+	 * @return void
+	 */
+	public function setElement(NodeElement $rowElement) {
+		$this->rowElement = $rowElement;
+	}
+
+	/**
+	 * 
+	 * @param string $name
+	 * @return void
+	 */
+	public function setName($name) {
+		$this->name = $name;
+	}
+
+	/**
+	 * finds the Action Button
+	 * 
+	 * @return \Behat\Mink\Element\NodeElement
+	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
+	 */
+	public function findFileActionButton() {
+		$actionButton = $this->rowElement->find(
+			"xpath", $this->fileActionMenuBtnXpath
+		);
+		if ($actionButton === null) {
+			throw new ElementNotFoundException(
+				"could not find actionButton in fileRow"
+			);
+		}
+		return $actionButton;
+	}
+
+	/**
+	 * finds and clicks the file actions button
+	 * 
+	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
+	 * @return void
+	 */
+	public function clickFileActionButton() {
+		$this->findFileActionButton()->click();
+	}
+	
+	/**
+	 * opens the file action menu
+	 * 
+	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
+	 * @return FileActionsMenu
+	 */
+	public function openFileActionsMenu() {
+		$this->clickFileActionButton();
+		$filesPage = $this->getPage('FilesPage');
+		$actionMenuElement = $filesPage->findFileActionMenuElement();
+		$actionMenu = $this->getPage('FilesPageElement\\FileActionsMenu');
+		$actionMenu->setElement($actionMenuElement);
+		return $actionMenu;
+	}
+	
+	/**
+	 * opens the sharing dialog
+	 * 
+	 * @throws ElementNotFoundException
+	 * @return SharingDialog
+	 */
+	public function openSharingDialog() {
+		$shareBtn = $this->rowElement->find("xpath", $this->shareBtnXpath);
+		if (is_null($shareBtn)) {
+			throw new ElementNotFoundException(
+				"could not find sharing button in fileRow"
+			);
+		}
+		$shareBtn->click();
+		$this->waitTillElementIsNull($this->loadingIndicatorXpath);
+		return $this->getPage("FilesPageElement\\SharingDialog");
+	}
+
+	/**
+	 * finds the input field to rename the file/folder
+	 * 
+	 * @throws ElementNotFoundException
+	 * @return \Behat\Mink\Element\NodeElement
+	 */
+	public function findRenameInputField() {
+		$inputField = $this->rowElement->find(
+			"xpath", $this->fileRenameInputXpath
+		);
+		if ($inputField === null) {
+			throw new ElementNotFoundException("could not find input field");
+		}
+		return $inputField;
+	}
+
+	/**
+	 * renames the file
+	 * 
+	 * @param string $toName
+	 * @return void
+	 */
+	public function rename($toName) {
+		$actionMenu = $this->openFileActionsMenu();
+		$actionMenu->rename($this->fileRenameInputXpath);
+		$this->waitTillElementIsNotNull($this->fileRenameInputXpath);
+		$inputField = $this->findRenameInputField();
+		$this->cleanInputAndSetValue($inputField, $toName);
+		$inputField->blur();
+		$this->waitTillElementIsNull($this->fileBusyIndicatorXpath);
+	}
+
+	/**
+	 * finds and returns the tooltip element
+	 * 
+	 * @throws ElementNotFoundException
+	 * @return \Behat\Mink\Element\NodeElement
+	 */
+	public function findTooltipElement() {
+		$element = $this->rowElement->find("xpath", $this->fileTooltipXpath);
+		if ($element === null) {
+			throw new ElementNotFoundException(
+				"could not find tooltip element of file " . $this->name
+			);
+		}
+		return $element;
+	}
+
+	/**
+	 * returns the tooltip text
+	 * 
+	 * @return string
+	 */
+	public function getTooltip() {
+		return $this->findTooltipElement()->getText();
+	}
+}

--- a/tests/ui/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/ui/features/lib/FilesPageElement/SharingDialog.php
@@ -1,33 +1,38 @@
 <?php
 
 /**
-* ownCloud
-*
-* @author Artur Neumann
-* @copyright 2017 Artur Neumann artur@jankaritech.com
-*
-* This library is free software; you can redistribute it and/or
-* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
-* License as published by the Free Software Foundation; either
-* version 3 of the License, or any later version.
-*
-* This library is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
-*
-* You should have received a copy of the GNU Affero General Public
-* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
-*
-*/
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
-namespace Page;
+namespace Page\FilesPageElement;
 
+use Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 
-class SharingDialog extends OwnCloudPage
-{
+/**
+ * The Sharing Dialog
+ *
+ */
+class SharingDialog extends OwncloudPage {
+
 	/**
 	 *
 	 * @var string $path
@@ -46,24 +51,25 @@ class SharingDialog extends OwnCloudPage
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 * @return \Behat\Mink\Element\NodeElement|NULL
 	 */
-	private function _findShareWithField ()
-	{
+	private function _findShareWithField() {
 		$shareWithField = $this->find("xpath", $this->shareWithFieldXpath);
 		if ($shareWithField === null) {
 			throw new ElementNotFoundException("could not find share-with-field");
 		}
 		return $shareWithField;
 	}
-	 /**
+	/**
 	 * fills the "share-with" input field
+	 * 
 	 * @param string $input
 	 * @param Session $session
-	 * @param number $timeout how long to wait till the autocomplete comes back
+	 * @param number $timeout_msec how long to wait till the autocomplete comes back
 	 * @return \Behat\Mink\Element\NodeElement AutocompleteElement
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 */
-	public function fillShareWithField ($input, Session $session, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC)
-	{
+	public function fillShareWithField(
+		$input, Session $session, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+	) {
 		$shareWithField = $this->_findShareWithField();
 		$shareWithField->setValue($input);
 		$this->waitForAjaxCallsToStartAndFinish($session, $timeout_msec);
@@ -72,11 +78,11 @@ class SharingDialog extends OwnCloudPage
 
 	/**
 	 * gets the NodeElement of the autocomplete list
+	 * 
 	 * @return \Behat\Mink\Element\NodeElement
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 */
-	public function getAutocompleteNodeElement()
-	{
+	public function getAutocompleteNodeElement() {
 		$autocompleteNodeElement = $this->find("xpath", $this->shareWithAutocompleteListXpath);
 		if ($autocompleteNodeElement === null) {
 			throw new ElementNotFoundException("could not find autocompleteNodeElement");
@@ -86,11 +92,11 @@ class SharingDialog extends OwnCloudPage
 
 	/**
 	 * returns the group names as they could appear in an autocomplete list
+	 * 
 	 * @param string|array $groupNames
 	 * @return array
 	 */
-	public function groupStringsToMatchAutoComplete($groupNames)
-	{
+	public function groupStringsToMatchAutoComplete($groupNames) {
 		if (is_array($groupNames)) {
 			$autocompleteStrings = array();
 			foreach ($groupNames as $groupName) {
@@ -104,18 +110,18 @@ class SharingDialog extends OwnCloudPage
 
 	/**
 	 * gets the items (users, groups) listed in the autocomplete list as an array
+	 * 
 	 * @return array
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 */
-	public function getAutocompleteItemsList()
-	{
+	public function getAutocompleteItemsList() {
 		$itemsArray = array();
 		$itemElements = $this->getAutocompleteNodeElement()->findAll(
 			"xpath", 
 			$this->autocompleteItemsTextXpath
 		);
 		foreach ($itemElements as $item) {
-			array_push($itemsArray,$item->getText());
+			array_push($itemsArray, $item->getText());
 		}
 		return $itemsArray;
 	}
@@ -131,17 +137,26 @@ class SharingDialog extends OwnCloudPage
 	 * @param bool $changePermission not implemented yet
 	 * @param bool $deletePermission not implemented yet
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
+	 * @return void
 	 */
-	private function shareWithUserOrGroup($nameToType, $nameToMatch, Session $session, $canShare = true, $canEdit = true, 
+	private function shareWithUserOrGroup(
+		$nameToType,
+		$nameToMatch,
+		Session $session,
+		$canShare = true,
+		$canEdit = true,
 		$createPermission = true,
 		$changePermission = true,
 		$deletePermission = true
 	) {
-		if ($canShare !== true || $canEdit !== true ||
-			$createPermission !== true || $changePermission !== true ||
-			$deletePermission !== true) {
+		if ($canShare !== true
+			|| $canEdit !== true
+			|| $createPermission !== true
+			|| $changePermission !== true
+			|| $deletePermission !== true
+		) {
 				throw new \Exception("this function is not implemented");
-			}
+		}
 		$autocompleteNodeElement = $this->fillShareWithField($nameToType, $session);
 		$userElements = $autocompleteNodeElement->findAll(
 			"xpath", $this->autocompleteItemsTextXpath
@@ -172,14 +187,21 @@ class SharingDialog extends OwnCloudPage
 	 * @param bool $changePermission not implemented yet
 	 * @param bool $deletePermission not implemented yet
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
+	 * @return void
 	 */
-	public function shareWithUser($name, Session $session, $canShare = true, $canEdit = true, 
+	public function shareWithUser(
+		$name,
+		Session $session,
+		$canShare = true,
+		$canEdit = true,
 		$createPermission = true,
 		$changePermission = true,
 		$deletePermission = true
 	) {
-		return $this->shareWithUserOrGroup($name, $name, $session,
-			$canShare, $canEdit, $createPermission, $changePermission, $deletePermission);
+		return $this->shareWithUserOrGroup(
+			$name, $name, $session, $canShare, $canEdit, $createPermission,
+			$changePermission, $deletePermission
+		);
 	}
 
 	/**
@@ -192,23 +214,31 @@ class SharingDialog extends OwnCloudPage
 	 * @param bool $changePermission not implemented yet
 	 * @param bool $deletePermission not implemented yet
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
+	 * @return void
 	 */
-	public function shareWithGroup($name, Session $session, $canShare = true, $canEdit = true,
+	public function shareWithGroup(
+		$name,
+		Session $session,
+		$canShare = true,
+		$canEdit = true,
 		$createPermission = true,
 		$changePermission = true,
 		$deletePermission = true
 	) {
-		return $this->shareWithUserOrGroup($name, $name . $this->suffixToIdentifyGroups, $session,
-			$canShare, $canEdit, $createPermission, $changePermission, $deletePermission);
+		return $this->shareWithUserOrGroup(
+			$name, $name . $this->suffixToIdentifyGroups, $session,
+			$canShare, $canEdit, $createPermission, $changePermission,
+			$deletePermission
+		);
 	}
 
 	/**
 	 * gets the text of the tooltip associated with the "share-with" input
+	 * 
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 * @return string
 	 */
-	public function getShareWithTooltip()
-	{
+	public function getShareWithTooltip() {
 		$shareWithField = $this->_findShareWithField();
 		$shareWithTooltip = $shareWithField->find("xpath", $this->shareWithTooltipXpath);
 		if ($shareWithTooltip === null) {
@@ -219,10 +249,11 @@ class SharingDialog extends OwnCloudPage
 
 	/**
 	 * closes the sharing dialog panel
+	 * 
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
+	 * @return void
 	 */
-	public function closeSharingDialog()
-	{
+	public function closeSharingDialog() {
 		$shareDialogCloseButton = $this->find("xpath", $this->shareWithCloseXpath);
 		if ($shareDialogCloseButton === null) {
 			throw new ElementNotFoundException("could not find share-dialog-close-button");


### PR DESCRIPTION
## Description
cut the FilesPage for UI tests into smaller and better usable classes

## Related Issue
https://github.com/owncloud/QA/issues/437

## Motivation and Context
smaller classes are easier to handle and as the class is about to grow this is a good preparation to automate most smoke tests

## How Has This Been Tested?
run UI tests locally and travis

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

