### PR TITLE
[stable10] Handle BSD case for 32 bit filemtime and install warning

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -180,7 +180,12 @@ class Local extends \OC\Files\Storage\Common {
 			return false;
 		}
 		if (PHP_INT_SIZE === 4) {
-			return (int) exec ('stat -c %Y '. escapeshellarg ($fullPath));
+			if (\OC_Util::runningOn('linux')) {
+				return (int) exec ('stat -c %Y '. escapeshellarg ($fullPath));
+			} else if (\OC_Util::runningOn('bsd') || \OC_Util::runningOn('mac')) {
+				return (int) exec ('stat -f %m '. escapeshellarg ($fullPath));
+			}
+			return false;
 		}
 		return filemtime($fullPath);
 	}

--- a/lib/private/LargeFileHelper.php
+++ b/lib/private/LargeFileHelper.php
@@ -142,19 +142,12 @@ class LargeFileHelper {
 	*/
 	public function getFileSizeViaExec($filename) {
 		if (\OC_Helper::is_function_enabled('exec')) {
-			$os = strtolower(php_uname('s'));
 			$arg = escapeshellarg($filename);
 			$result = null;
-			if (strpos($os, 'linux') !== false) {
+			if (\OC_Util::runningOn('linux')) {
 				$result = $this->exec("stat -c %s $arg");
-			} else if (strpos($os, 'bsd') !== false || strpos($os, 'darwin') !== false) {
+			} else if (\OC_Util::runningOn('bsd') || \OC_Util::runningOn('mac')) {
 				$result = $this->exec("stat -f %z $arg");
-			} else if (strpos($os, 'win') !== false) {
-				$result = $this->exec("for %F in ($arg) do @echo %~zF");
-				if (is_null($result)) {
-					// PowerShell
-					$result = $this->exec("(Get-Item $arg).length");
-				}
 			}
 			return $result;
 		}

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -203,12 +203,18 @@ class Setup {
 			\OC\Setup::protectDataDirectory();
 		}
 
-		if (\OC_Util::runningOnMac()) {
+		if (!\OC_Util::runningOn('linux')) {
+			if (\OC_Util::runningOn('mac')) {
+				$os = 'Mac OS X';
+			} else {
+				$os = PHP_OS;
+			}
+
 			$errors[] = [
 				'error' => $this->l10n->t(
-					'Mac OS X is not supported and %s will not work properly on this platform. ' .
+					'%s is not supported and %s will not work properly on this platform. ' .
 					'Use it at your own risk! ',
-					$this->defaults->getName()
+					[$os, $this->defaults->getName()]
 				),
 				'hint' => $this->l10n->t('For the best results, please consider using a GNU/Linux server instead.')
 			];

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1250,12 +1250,30 @@ class OC_Util {
 	}
 
 	/**
-	 * Checks whether the server is running on Mac OS X
+	 * Checks whether the server is running on the given OS type
 	 *
-	 * @return bool true if running on Mac OS X, false otherwise
+	 * @param string $osType linux|mac|bsd
+	 * @return bool true if running on that OS type, false otherwise
 	 */
-	public static function runningOnMac() {
-		return (strtoupper(substr(PHP_OS, 0, 6)) === 'DARWIN');
+	public static function runningOn($osType) {
+		$osType = strtolower($osType);
+
+		switch($osType) {
+			case 'linux':
+				return (strtolower(substr(PHP_OS, 0, 5)) === 'linux');
+				break;
+
+			case 'mac':
+				return (strtolower(substr(PHP_OS, 0, 6)) === 'darwin');
+				break;
+
+			case 'bsd':
+				return (strpos(strtolower(PHP_OS), 'bsd') !== false);
+				break;
+
+			default;
+				return false;
+		}
 	}
 
 	/**

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1252,27 +1252,16 @@ class OC_Util {
 	/**
 	 * Checks whether the server is running on the given OS type
 	 *
-	 * @param string $osType linux|mac|bsd
+	 * @param string $osType linux|mac|bsd etc
 	 * @return bool true if running on that OS type, false otherwise
 	 */
 	public static function runningOn($osType) {
-		$osType = strtolower($osType);
+		$osType = strtolower($osType) === 'mac' ? 'darwin' : strtolower($osType);
 
-		switch($osType) {
-			case 'linux':
-				return (strtolower(substr(PHP_OS, 0, 5)) === 'linux');
-				break;
-
-			case 'mac':
-				return (strtolower(substr(PHP_OS, 0, 6)) === 'darwin');
-				break;
-
-			case 'bsd':
-				return (strpos(strtolower(PHP_OS), 'bsd') !== false);
-				break;
-
-			default;
-				return false;
+		if ($osType === 'bsd') {
+			return (strpos(strtolower(PHP_OS), $osType) !== false);
+		} else {
+			return (strtolower(substr(PHP_OS, 0, strlen($osType))) === $osType);
 		}
 	}
 


### PR DESCRIPTION
Backport #28759 
because it makes the setup warning more generic so it applies when on any non-linux-style platform.