### PR TITLE
make ping() available, reconnect after assemble

### DIFF
--- a/lib/private/AppFramework/Db/Db.php
+++ b/lib/private/AppFramework/Db/Db.php
@@ -254,4 +254,11 @@ class Db implements IDb {
 	public function allows4ByteCharacters() {
 		return $this->connection->allows4ByteCharacters();
 	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function ping() {
+		return $this->connection->ping();
+	}
 }

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -284,4 +284,28 @@ interface IDBConnection {
 	 * @since 10.0
 	 */
 	public function allows4ByteCharacters();
+
+	/**
+	 * Ping the server
+	 *
+	 * When the server is not available the method returns FALSE.
+	 * It is responsibility of the developer to handle this case
+	 * and abort the request or reconnect manually:
+	 *
+	 * @example
+	 *
+	 *   if ($conn->ping() === false) {
+	 *      $conn->close();
+	 *      $conn->connect();
+	 *   }
+	 *
+	 * It is undefined if the underlying driver attempts to reconnect
+	 * or disconnect when the connection is not available anymore
+	 * as long it returns TRUE when a reconnect succeeded and
+	 * FALSE when the connection was dropped.
+	 *
+	 * @return bool
+	 * @since 10.0.3
+	 */
+	public function ping();
 }


### PR DESCRIPTION
fixes mysql server gone away on huge chunked file upload assemblys by using doctrines ping(). also see https://github.com/owncloud/core/issues/15407#issuecomment-135458449

alternative might be to use
```
'dbdriveroptions' => array(PDO::MYSQL_ATTR_INIT_COMMAND => 'SET wait_timeout = 28800'),
```