### PR TITLE
Store new dav chunks directly, no hooks

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -461,4 +461,14 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node
 
 		return true;
 	}
+
+	/**
+	 * Create a file directly, bypassing the hooks
+	 *
+	 * @param string $name name
+	 * @param resource $data data
+	 */
+	public function createFileDirectly($name, $data) {
+		$this->fileView->file_put_contents($this->getPath() . '/' .  $name, $data);
+	}
 }

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -394,4 +394,8 @@ abstract class Node implements \Sabre\DAV\INode {
 		return $mtime;
 	}
 
+	public function getView() {
+		return $this->fileView;
+	}
+
 }

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -393,9 +393,4 @@ abstract class Node implements \Sabre\DAV\INode {
 		}
 		return $mtime;
 	}
-
-	public function getView() {
-		return $this->fileView;
-	}
-
 }

--- a/apps/dav/lib/Upload/UploadFolder.php
+++ b/apps/dav/lib/Upload/UploadFolder.php
@@ -34,8 +34,8 @@ class UploadFolder implements ICollection {
 	}
 
 	function createFile($name, $data = null) {
-		// TODO: verify name - should be a simple number
-		$this->node->createFile($name, $data);
+		$view = $this->node->getView();
+		$view->file_put_contents($this->node->getPath() . '/' .  $name, $data);
 	}
 
 	function createDirectory($name) {

--- a/apps/dav/lib/Upload/UploadFolder.php
+++ b/apps/dav/lib/Upload/UploadFolder.php
@@ -34,8 +34,8 @@ class UploadFolder implements ICollection {
 	}
 
 	function createFile($name, $data = null) {
-		$view = $this->node->getView();
-		$view->file_put_contents($this->node->getPath() . '/' .  $name, $data);
+		// need to bypass hooks for individual chunks
+		$this->node->createFileDirectly($name, $data);
 	}
 
 	function createDirectory($name) {

--- a/tests/integration/features/checksums.feature
+++ b/tests/integration/features/checksums.feature
@@ -124,12 +124,22 @@ Feature: checksums
     When user "user0" downloads the file "/local_storage/prueba_cksum.txt"
     Then The header checksum should match "SHA1:a35b7605c8f586d735435535c337adc066c2ccb6"
 
-  Scenario: Upload chunked file where checksum does not match
+  Scenario: Upload new dav chunked file where checksum matches
     Given using new dav path
     And user "user0" exists
     And user "user0" creates a new chunking upload with id "chunking-42"
     And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
-    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" with checksum "SHA1:f005ba11"
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
+    And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1"
+    Then the HTTP status code should be "201"
+
+  Scenario: Upload new dav chunked file where checksum does not match
+    Given using new dav path
+    And user "user0" exists
+    And user "user0" creates a new chunking upload with id "chunking-42"
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
+    And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:f005ba11"
     Then the HTTP status code should be "400"
 
   Scenario: Upload a file where checksum does not match


### PR DESCRIPTION
## Description
Store new dav chunks directly instead of going through File::put() which
would run all hooks. Hooks are now only triggered at the end of the
transfer when the future file is moved to the final file, in which case
the assemble data goes through File::put() and triggers the hooks.

**Note:** this likely doesn't solve the problem for storage wrappers. For storage wrappers, these need to verify whether the target path is outside of "files" and bypass operation in such cases. Not part of this PR, needs to be implemented in every storage wrapper.

## Related Issue
https://github.com/owncloud/enterprise/issues/2229

## Motivation and Context
Prevent hooks to be fired for every chunk.

## How Has This Been Tested?
Upload 100 MB file in web UI.

Before this fix: oc_activity polluted with extra entries for each chunk
After this fix: oc_activity only

Also works with encryption.

Can someone test this with object store ? @DeepDiver1975 @SergioBertolinSG 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

