### PR TITLE
Individual "page is reloaded" steps for UI pages

### DIFF
--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -48,7 +48,16 @@ class FilesContext extends RawMinkContext implements Context
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
 	}
 
-	
+
+	/**
+	 * @When the files page is reloaded
+	 */
+	public function theFilesPageIsReloaded()
+	{
+		$this->getSession()->reload();
+		$this->filesPage->waitTillPageIsLoaded($this->getSession());
+	}
+
 	/**
 	 * @When I create a folder with the name :name
 	 * 
@@ -57,6 +66,7 @@ class FilesContext extends RawMinkContext implements Context
 	 */
 	public function createAFolder($name) {
 		$this->filesPage->createFolder($name);
+		$this->filesPage->waitTillPageIsLoaded($this->getSession());
 	}
 	/**
 	 * @Given the list of files\/folders does not fit in one browser page
@@ -83,8 +93,7 @@ class FilesContext extends RawMinkContext implements Context
 				$this->filesPage->findFileActionsMenuBtnByNo($itemsCount)
 			);
 		}
-		$this->getSession()->reload();
-		$this->filesPage->waitTillPageIsLoaded($this->getSession());
+		$this->theFilesPageIsReloaded();
 	}
 
 	/**

--- a/tests/ui/features/bootstrap/UsersContext.php
+++ b/tests/ui/features/bootstrap/UsersContext.php
@@ -62,9 +62,9 @@ class UsersContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When the page is reloaded
+	 * @When the users page is reloaded
 	 */
-	public function pageIsReloaded()
+	public function theUsersPageIsReloaded()
 	{
 		$this->getSession()->reload();
 		$this->usersPage->waitTillPageIsLoaded($this->getSession());

--- a/tests/ui/features/files/files.feature
+++ b/tests/ui/features/files/files.feature
@@ -13,7 +13,7 @@ Feature: files
 	Scenario Outline: Create a folder using special characters
 		When I create a folder with the name <folder_name>
 		Then the folder <folder_name> should be listed
-		And the page is reloaded
+		And the files page is reloaded
 		Then the folder <folder_name> should be listed
 		Examples:
 		|folder_name    |

--- a/tests/ui/features/files/renameFiles.feature
+++ b/tests/ui/features/files/renameFiles.feature
@@ -24,36 +24,36 @@ Feature: renameFiles
 
 	Scenario: Rename a file using special characters and check its existence after page reload
 		When I rename the file "lorem.txt" to "लोरेम।तयक्स्त $%&"
-		And the page is reloaded
+		And the files page is reloaded
 		Then the file "लोरेम।तयक्स्त $%&" should be listed
 		When I rename the file "लोरेम।तयक्स्त $%&" to '"double"quotes.txt'
-		And the page is reloaded
+		And the files page is reloaded
 		Then the file '"double"quotes.txt' should be listed
 		When I rename the file '"double"quotes.txt' to "no-double-quotes.txt"
-		And the page is reloaded
+		And the files page is reloaded
 		Then the file "no-double-quotes.txt" should be listed
 		When I rename the file 'no-double-quotes.txt' to "hash#And&QuestionMark?At@Filename.txt"
-		And the page is reloaded
+		And the files page is reloaded
 		Then the file "hash#And&QuestionMark?At@Filename.txt" should be listed
 
 	Scenario: Rename a file using spaces at front and/or back of file name and type
 		When I rename the file "lorem.txt" to " space at start"
-		And the page is reloaded
+		And the files page is reloaded
 		Then the file " space at start" should be listed
 		When I rename the file " space at start" to "space at end "
-		And the page is reloaded
+		And the files page is reloaded
 		Then the file "space at end " should be listed
 		When I rename the file "space at end " to "space at end .txt"
-		And the page is reloaded
+		And the files page is reloaded
 		Then the file "space at end .txt" should be listed
 		When I rename the file "space at end .txt" to "space at end. lis"
-		And the page is reloaded
+		And the files page is reloaded
 		Then the file "space at end. lis" should be listed
 		When I rename the file "space at end. lis" to "space at end.log "
-		And the page is reloaded
+		And the files page is reloaded
 		Then the file "space at end.log " should be listed
 		When I rename the file "space at end.log " to "  multiple   space    all     over   .  dat  "
-		And the page is reloaded
+		And the files page is reloaded
 		Then the file "  multiple   space    all     over   .  dat  " should be listed
 
 	Scenario: Rename a file using both double and single quotes
@@ -61,7 +61,7 @@ Feature: renameFiles
 			|from-name-parts |to-name-parts         |
 			|lorem.txt       |First 'single' quotes |
 			|                |-then "double".txt    |
-		And the page is reloaded
+		And the files page is reloaded
 		Then the following file should be listed
 			|name-parts            |
 			|First 'single' quotes |
@@ -70,7 +70,7 @@ Feature: renameFiles
 			|from-name-parts       |to-name-parts |
 			|First 'single' quotes |loremz.dat    |
 			|-then "double".txt    |              |
-		And the page is reloaded
+		And the files page is reloaded
 		Then the file "loremz.dat" should be listed
 
 	Scenario: Rename a file using forbidden characters

--- a/tests/ui/features/files/renameFolders.feature
+++ b/tests/ui/features/files/renameFolders.feature
@@ -24,27 +24,27 @@ Feature: renameFolders
 
 	Scenario: Rename a folder using special characters and check its existence after page reload
 		When I rename the folder "simple-folder" to "लोरेम।तयक्स्त $%&"
-		And the page is reloaded
+		And the files page is reloaded
 		Then the folder "लोरेम।तयक्स्त $%&" should be listed
 		When I rename the folder "लोरेम।तयक्स्त $%&" to '"double"quotes'
-		And the page is reloaded
+		And the files page is reloaded
 		Then the folder '"double"quotes' should be listed
 		When I rename the folder '"double"quotes' to "no-double-quotes"
-		And the page is reloaded
+		And the files page is reloaded
 		Then the folder "no-double-quotes" should be listed
 		When I rename the folder 'no-double-quotes' to "hash#And&QuestionMark?At@FolderName"
-		And the page is reloaded
+		And the files page is reloaded
 		Then the folder "hash#And&QuestionMark?At@FolderName" should be listed
 
 	Scenario: Rename a folder using spaces at front and/or back of the name
 		When I rename the folder "simple-folder" to " space at start"
-		And the page is reloaded
+		And the files page is reloaded
 		Then the folder " space at start" should be listed
 		When I rename the folder " space at start" to "space at end "
-		And the page is reloaded
+		And the files page is reloaded
 		Then the folder "space at end " should be listed
 		When I rename the folder "space at end " to "  multiple   spaces    all     over   "
-		And the page is reloaded
+		And the files page is reloaded
 		Then the folder "  multiple   spaces    all     over   " should be listed
 
 	Scenario: Rename a folder using both double and single quotes
@@ -52,7 +52,7 @@ Feature: renameFolders
 			|from-name-parts |to-name-parts        |
 			|simple-folder  |First 'single' quotes |
 			|               |-then "double"        |
-		And the page is reloaded
+		And the files page is reloaded
 		Then the following folder should be listed
 			|name-parts            |
 			|First 'single' quotes |
@@ -61,7 +61,7 @@ Feature: renameFolders
 			|from-name-parts       |to-name-parts   |
 			|First 'single' quotes |a normal folder |
 			|-then "double"        |                |
-		And the page is reloaded
+		And the files page is reloaded
 		Then the folder "a normal folder" should be listed
 
 	Scenario: Rename a folder using forbidden characters

--- a/tests/ui/features/other/users.feature
+++ b/tests/ui/features/other/users.feature
@@ -4,7 +4,7 @@ Feature: users
 		Given I am logged in as admin
 		And quota of user "admin" is set to "<start_quota>"
 		When quota of user "admin" is changed to "<wished_quota>"
-		And the page is reloaded
+		And the users page is reloaded
 		Then quota of user "admin" should be set to "<expected_quota>"
 
 		Examples:


### PR DESCRIPTION
## Description
Make separate steps for theFilesPageIsReloaded and theUsersPageIsReloaded and invoke them in the appropriate places.

When doing createAFolder, waitTillPageIsLoaded at the end. Without this, it would quite often look for the new folder too quickly, and not find it.

## Related Issue
#28798 

## Motivation and Context
Make the UI tests more reliable

## How Has This Been Tested?
Run the "files.feature" UI tests about 10 times. Before this change there would be a step failure somewhere about 1 in 3 times. After the change I could not break it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
