### PR TITLE
Only reload file list when switching navigation sections

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -217,7 +217,8 @@
 			if (e && e.itemId) {
 				params = {
 					view: e.itemId,
-					dir: '/'
+					dir: '/',
+					force: true
 				};
 				this._changeUrl(params.view, params.dir);
 				OC.Apps.hideAppSidebar($('.detailsView'));

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -330,7 +330,6 @@
 			this.$fileList.on('click','td.filename>a.name, td.filesize, td.date', _.bind(this._onClickFile, this));
 
 			this.$fileList.on('change', 'td.filename>.selectCheckBox', _.bind(this._onClickFileCheckbox, this));
-			this.$el.on('show', _.bind(this._onShow, this));
 			this.$el.on('urlChanged', _.bind(this._onUrlChanged, this));
 			this.$el.find('.select-all').click(_.bind(this._onClickSelectAll, this));
 			this.$el.find('.download').click(_.bind(this._onClickDownloadSelected, this));
@@ -546,13 +545,6 @@
 			this.breadcrumb.setMaxWidth(containerWidth - actionsWidth - 10);
 
 			this.$table.find('>thead').width($('#app-content').width() - OC.Util.getScrollBarWidth());
-		},
-
-		/**
-		 * Event handler when leaving previously hidden state
-		 */
-		_onShow: function(e) {
-			this.reload();
 		},
 
 		/**

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -554,8 +554,10 @@
 			if (e && _.isString(e.dir)) {
 				var currentDir = this.getCurrentDirectory();
 				// this._currentDirectory is NULL when fileList is first initialised
-				if( (this._currentDirectory || this.$el.find('#dir').val()) && currentDir === e.dir) {
-					return;
+				if (!e.force) {
+					if( (this._currentDirectory || this.$el.find('#dir').val()) && currentDir === e.dir) {
+						return;
+					}
 				}
 				this.changeDirectory(e.dir, false, true);
 			}

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1501,12 +1501,6 @@ describe('OCA.Files.FileList tests', function() {
 			$('#app-content-files').trigger(new $.Event('urlChanged', {view: 'files', dir: '/somedir'}));
 			expect(fileList.getCurrentDirectory()).toEqual('/somedir');
 		});
-		it('reloads the list when leaving hidden state', function() {
-			var reloadStub = sinon.stub(fileList, 'reload');
-			$('#app-content-files').trigger(new $.Event('show'));
-			expect(reloadStub.calledOnce).toEqual(true);
-			reloadStub.restore();
-		});
 		it('refreshes breadcrumb after update', function() {
 			var setDirSpy = sinon.spy(fileList.breadcrumb, 'setDirectory');
 			fileList.changeDirectory('/anothersubdir');


### PR DESCRIPTION
## Description
Reverts a previous bad fix from https://github.com/owncloud/core/pull/27703 which causes a double reload and even breaks sometimes when opening a private link by reloading the wrong list.

Adds a better fix that only reloads a file list whenever the active navigation section has changed, because that's when we need to refresh, for example after restoring a file from trash, the "All files" list needs to refresh to display the restored folder.

Also prevents initial double reload of the file list.

## Related Issue
Fixes https://github.com/owncloud/core/issues/27890

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- create folder "test" in "All files", delete it. go to trash: folder appears
- create folder "test/sub" in "All files". Refresh page several times: folder contents is still correct, no blinking. (before this fix it was either blinking or showing the wrong contents)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

