### PR TITLE
skip to next user on OutOfBoundsException

### DIFF
--- a/lib/public/User/IProvidesEMailBackend.php
+++ b/lib/public/User/IProvidesEMailBackend.php
@@ -37,6 +37,7 @@ interface IProvidesEMailBackend {
 	 *
 	 * @param string $uid The username
 	 * @return string|null
+	 * @throws \OutOfBoundsException if the email could not be determined as expected
 	 * @since 10.0
 	 */
 	public function getEMailAddress($uid);

--- a/lib/public/User/IProvidesExtendedSearchBackend.php
+++ b/lib/public/User/IProvidesExtendedSearchBackend.php
@@ -38,6 +38,7 @@ interface IProvidesExtendedSearchBackend {
 	 *
 	 * @param string $uid The username
 	 * @return string[]
+	 * @throws \OutOfBoundsException if the search attributes could not be determined as expected
 	 * @since 10.0.1
 	 */
 	public function getSearchTerms($uid);

--- a/lib/public/User/IProvidesQuotaBackend.php
+++ b/lib/public/User/IProvidesQuotaBackend.php
@@ -37,6 +37,7 @@ interface IProvidesQuotaBackend {
 	 *
 	 * @param string $uid The username
 	 * @return string|null
+	 * @throws \OutOfBoundsException if the quota could not be determined as expected
 	 * @since 10.0
 	 */
 	public function getQuota($uid);


### PR DESCRIPTION
on large ldap instances a missing uuid or username currently aborts the whole sync. This PR allows backends to indicate these problems and fail with an OutOfBoundsException. For now core will log the exception and continue with the next user.

In the future we should expose this to the cli.

together with https://github.com/owncloud/user_ldap/pull/125 this skips problematic ldap users