### PR TITLE
Improve market upgrade messages + new switch

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1343,6 +1343,11 @@ $CONFIG = array(
 'upgrade.disable-web' => false,
 
 /**
+ * Automatic update of market apps, set to "false" to disable.
+ */
+'upgrade.automatic-app-update' => true,
+
+/**
  * Set this ownCloud instance to debugging mode
  *
  * Only enable this for local development and not in production environments

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -114,6 +114,7 @@ class Apps implements IRepairStep {
 			$link = $this->defaults->buildDocLinkToKey('admin-marketplace-apps');
 			$output->info('No internet connection available - no app updates will be taken from the marketplace.');
 			$output->info("How to update apps in such situation please see $link");
+			$this->appManager->disableApp('market');
 			return;
 		}
 		$appsToUpgrade = $this->getAppsToUpgrade();
@@ -124,6 +125,14 @@ class Apps implements IRepairStep {
 
 		// fix market app state
 		$shallContactMarketplace = $this->fixMarketAppState($output);
+
+		// market might be enabled but admin does not want to automatically update apps through it
+		// (they might want to manually click through the updates in the web UI so keeping the
+		// market enabled here is a legitimate use case)
+		if ($this->config->getSystemValue('upgrade.automatic-app-update', true) !== true) {
+			$shallContactMarketplace = false;
+		}
+
 		if ($shallContactMarketplace) {
 			// Check if we can use the marketplace to update apps as needed?
 			if ($this->appManager->isEnabledForUser('market')) {
@@ -167,7 +176,8 @@ class Apps implements IRepairStep {
 				}
 			} else {
 				// No market available, output error and continue attempt
-				$output->warning('Market app is unavailable for updating of apps. Enable with: occ app:enable market');
+				$link = $this->defaults->buildDocLinkToKey('admin-marketplace-apps');
+				$output->warning("Market app is unavailable for updating of apps. Please update manually, see $link");
 			}
 		}
 
@@ -178,9 +188,11 @@ class Apps implements IRepairStep {
 			// fail
 			$output->warning('You have incompatible or missing apps enabled that could not be found or updated via the marketplace.');
 			$output->warning(
-				'please install app manually with tarball or disable them with:'
+				'Please install or update the following apps manually or disable them with:'
 				. $this->getOccDisableMessage(array_merge($failedIncompatibleApps, $failedMissingApps))
 			);
+			$link = $this->defaults->buildDocLinkToKey('admin-marketplace-apps');
+			$output->warning("For manually updating, see $link");
 
 			throw new RepairException('Upgrade is not possible');
 		} elseif ($hasNotUpdatedCompatibleApps) {
@@ -314,6 +326,7 @@ class Apps implements IRepairStep {
 			$output->info("Please note that the market app is not recommended for clustered setups - see $link");
 			return false;
 		}
+
 		// Then we need to enable the market app to support app updates / downloads during upgrade
 		$output->info('Enabling market app to assist with update');
 		$this->appManager->enableApp('market');

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -115,7 +115,6 @@ class Apps implements IRepairStep {
 			$output->info('No internet connection available - no app updates will be taken from the marketplace.');
 			$output->info("How to update apps in such situation please see $link");
 			$this->appManager->disableApp('market');
-			return;
 		}
 		$appsToUpgrade = $this->getAppsToUpgrade();
 		$failedCompatibleApps = [];


### PR DESCRIPTION
## Description
Improve market upgrade messages.
Added switch to disable automatic app updates during occ upgrade.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28734

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] TEST: does not attempt to update apps if `upgrade.automatic-app-update` is set to false
- [x] TEST: attempts to update apps if `upgrade.automatic-app-update` is set to false
- [x] TEST: check message when occ upgrade with market app disabled: link to docs is there
- [x] TEST: check message when upgrading incompatible apps not present on marketplace: link to docs is there
- [x] TEST: market app auto-disables if "has_internet_connection" is false during occ ugprade.
- [x] TEST: if "has_internet_connection" is false and incompatible apps detected, stop update and mention those

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

