### PR TITLE
Make occ upgrade verbose by default

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -84,6 +84,11 @@ class Upgrade extends Command {
 	 * @param OutputInterface $output output interface
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		if ($output->getVerbosity() === OutputInterface::VERBOSITY_NORMAL
+			&& !$input->hasParameterOption('--verbose=0', true)) {
+			// set to more verbose on upgrade if no explicit verbosity was set
+			$output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
+		}
 
 		if(\OC::checkUpgrade(false)) {
 			if (OutputInterface::VERBOSITY_NORMAL < $output->getVerbosity()) {


### PR DESCRIPTION
## Description
This will always output timestamps and also mention each market app that
is being checked through the marketplace.

The previous behavior can be set using `--verbose=0`. But I think the verbose mode will be useful in any case.

## Related Issue
None

## Motivation and Context
Often times admin just run `occ upgrade` thinking there will be no error and then it is too late to set a more verbose mode. Setting verbose mode by default also provides more useful info like where each app is being checked against the marketplace, so it looks more like progress than having no output for many seconds.

## How Has This Been Tested?
Run `occ upgrade` with a few apps to be updated. You'll see entries about checking app updates against the marketplace, for each app individually.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

