### PR TITLE
UI tests structure to open a subfolder

### DIFF
--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -187,6 +187,17 @@ class FilesContext extends RawMinkContext implements Context
 	}
 
 	/**
+	 * @When I open the file/folder :name
+	 * @param string $name
+	 * @return void
+	 */
+	public function iOpenTheFolder($name) {
+		$this->filesPage->waitTillPageIsLoaded($this->getSession());
+		$this->filesPage->openFile($name, $this->getSession());
+		$this->filesPage->waitTillPageIsLoaded($this->getSession());
+	}
+
+	/**
 	 * @Then the file/folder :name should be listed
 	 * @param string $name
 	 * @return void

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -247,6 +247,17 @@ class FilesPage extends OwnCloudPage
 	}
 
 	/**
+	 * opens a file or navigates into a folder
+	 * 
+	 * @param string $name
+	 * @param Session $session
+	 * @return void
+	 */
+	public function openFile($name, Session $session) {
+		$fileRow = $this->findFileRowByName($name, $session);
+		$fileRow->openFileFolder();
+	}
+	/**
 	 * renames a file
 	 * @param string|array $fromFileName
 	 * @param string|array $toFileName

--- a/tests/ui/features/lib/FilesPageElement/FileRow.php
+++ b/tests/ui/features/lib/FilesPageElement/FileRow.php
@@ -50,6 +50,7 @@ class FileRow extends OwnCloudPage {
 	protected $fileBusyIndicatorXpath = ".//*[@class='thumbnail' and contains(@style,'loading')]";
 	protected $fileTooltipXpath = ".//*[@class='tooltip-inner']";
 	protected $thumbnailXpath = "//*[@class='thumbnail']";
+	protected $fileLinkXpath = "//span[@class='nametext']";
 	
 	/**
 	 * sets the NodeElement for the current file row
@@ -234,5 +235,30 @@ class FileRow extends OwnCloudPage {
 	 */
 	public function selectForBatchAction() {
 		$this->findThumbnail()->click();
+	}
+
+	/**
+	 * find and return the link to the file/folder
+	 * 
+	 * @throws ElementNotFoundException
+	 * @return \Behat\Mink\Element\NodeElement
+	 */
+	public function findFileLink() {
+		$linkElement = $this->rowElement->find("xpath", $this->fileLinkXpath);
+		if (is_null($linkElement)) {
+			throw new ElementNotFoundException(
+				"could not find link to " . $this->name
+			);
+		}
+		return $linkElement;
+	}
+
+	/**
+	 * opens the current file or folder by clicking on the link
+	 * 
+	 * @return void
+	 */
+	public function openFileFolder() {
+		$this->findFileLink()->click();
 	}
 }

--- a/tests/ui/features/other/sharing.feature
+++ b/tests/ui/features/other/sharing.feature
@@ -25,6 +25,9 @@ Feature: Sharing
 		And the folder "simple-folder (2)" should be marked as shared by "User Two"
 		And the file "testimage (2).jpg" should be listed
 		And the file "testimage (2).jpg" should be marked as shared by "User Two"
+		And I open the folder "simple-folder (2)"
+		Then the file "lorem.txt" should be listed
+		But the folder "simple-folder (2)" should not be listed
 
 	Scenario: share a folder with an internal group
 		And I logout


### PR DESCRIPTION
## Description
This makes it possible for UI tests to navigate into a subfolder and run actions there

## Related Issue
owncloud/QA#437

## Motivation and Context
we need to be able to run tests inside other folders

## How Has This Been Tested?
used it in sharing UI test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

