### PR TITLE
Let Logging.php be outside FeatureContext

### DIFF
--- a/tests/ui/features/bootstrap/Logging.php
+++ b/tests/ui/features/bootstrap/Logging.php
@@ -55,7 +55,7 @@ trait Logging
 		foreach ($expectedLogEntries as $expectedLogEntry) {
 			$logEntry = json_decode($logLines[$lineNo], true);
 			foreach (array_keys($expectedLogEntry) as $attribute) {
-				$expectedLogEntry [$attribute] = $this->substituteInLineCodes(
+				$expectedLogEntry [$attribute] = $this->featureContext->substituteInLineCodes(
 					$expectedLogEntry [$attribute]
 				);
 				PHPUnit_Framework_Assert::assertArrayHasKey(
@@ -95,7 +95,7 @@ trait Logging
 			foreach ($logEntriesExpectedNotToExist as $logEntryExpectedNotToExist) {
 				foreach (array_keys($logEntryExpectedNotToExist) as $attribute) {
 					$logEntryExpectedNotToExist [$attribute]
-						= $this->substituteInLineCodes(
+						= $this->featureContext->substituteInLineCodes(
 							$logEntryExpectedNotToExist [$attribute]
 						);
 					if (isset($logEntries [$attribute]) 


### PR DESCRIPTION
## Description
From Logging.php traits, when calling substituteInLineCodes, make the call into FeatureContext.
(At the moment Logging.php assumes it will be already in FeatureContext, whch is not true.


## Related Issue
Duplication of code in Firewall UI testing

## Motivation and Context
Firewall has an "almost copy" of FeatureContext.php from core. It would be good to get rid of that and directly make use of the one from core.
To do that, we need Logging traits to not assume they are embedded in FeatureContext.

## How Has This Been Tested?
1) Make needed changes to firewall also
2) Run a full set of automated Firewall tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

