### PR TITLE
Increment required only when encryption is enabled

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -385,7 +385,7 @@ class Encryption extends Wrapper {
 		$header = $this->getHeader($path);
 		$signed = (isset($header['signed']) && $header['signed'] === 'true') ? true : false;
 		$fullPath = $this->getFullPath($path);
-		$encryptionModuleId = ($encryptionEnabled) ? $this->util->getEncryptionModuleId($header): "";
+		$encryptionModuleId = $this->util->getEncryptionModuleId($header);
 
 		if ($this->util->isExcluded($fullPath) === false) {
 
@@ -712,7 +712,9 @@ class Encryption extends Wrapper {
 			 * incremented version of source file, for the destination file.
 			 */
 			$encryptedVersion = $sourceStorage->getCache()->get($sourceInternalPath)['encryptedVersion'];
-			$cacheInformation['encryptedVersion'] = $encryptedVersion + 1;
+			if ($this->encryptionManager->isEnabled()) {
+				$cacheInformation['encryptedVersion'] = $encryptedVersion + 1;
+			}
 			$sourceStorage->getCache()->put($sourceInternalPath, $cacheInformation);
 		} else {
 			$this->getCache()->put($targetInternalPath, $cacheInformation);
@@ -781,8 +783,7 @@ class Encryption extends Wrapper {
 			try {
 				$source = $sourceStorage->fopen($sourceInternalPath, 'r');
 				if ($isRename) {
-					$absSourcePath = Filesystem::normalizePath($sourceStorage->getOwner($sourceInternalPath). '/' . $sourceInternalPath);
-					$this->sourcePath[$targetInternalPath] = $absSourcePath;
+					$this->sourcePath[$targetInternalPath] = $sourceStorage->getFullPath($sourceInternalPath);
 				} else {
 					unset($this->sourcePath[$targetInternalPath]);
 				}

--- a/tests/integration/features/trashbin-new-endpoint.feature
+++ b/tests/integration/features/trashbin-new-endpoint.feature
@@ -121,7 +121,7 @@ Feature: trashbin-new-endpoint
 		And as "user0" the folder with original path "/textfile0.txt" exists in trash
 
 	@local_storage
-	@no_encryption
+	@no_default_encryption
 	Scenario: Deleting a folder into external storage moves it to the trashbin
 		Given As an "admin"
 		And invoking occ with "files:scan --all"
@@ -132,7 +132,7 @@ Feature: trashbin-new-endpoint
 		Then as "user0" the folder with original path "/local_storage/tmp" exists in trash
 
 	@local_storage
-	@no_encryption
+	@no_default_encryption
 	Scenario: Deleting a file into external storage moves it to the trashbin and can be restored
 		Given As an "admin"
 		And invoking occ with "files:scan --all"

--- a/tests/integration/features/trashbin-old-endpoint.feature
+++ b/tests/integration/features/trashbin-old-endpoint.feature
@@ -121,7 +121,7 @@ Feature: trashbin-new-endpoint
 		And as "user0" the folder with original path "/textfile0.txt" exists in trash
 
 	@local_storage
-	@no_encryption
+	@no_default_encryption
 	Scenario: Deleting a folder into external storage moves it to the trashbin
 		Given As an "admin"
 		And invoking occ with "files:scan --all"
@@ -132,7 +132,7 @@ Feature: trashbin-new-endpoint
 		Then as "user0" the folder with original path "/local_storage/tmp" exists in trash
 
 	@local_storage
-	@no_encryption
+	@no_default_encryption
 	Scenario: Deleting a file into external storage moves it to the trashbin and can be restored
 		Given As an "admin"
 		And invoking occ with "files:scan --all"
@@ -148,3 +148,19 @@ Feature: trashbin-new-endpoint
 			| /local_storage/ |
 			| /local_storage/tmp/ |
 			| /local_storage/tmp/textfile0.txt |
+
+	@local_storage
+	@no_default_encryption
+	Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored
+		Given As an "admin"
+		And invoking occ with "files:scan --all"
+		And user "user0" exists
+		And user "user0" created a folder "/local_storage/tmp"
+		And User "user0" moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
+		And user "user0" uploads chunk file "1" of "1" with "AA" to "/local_storage/tmp/textfile0.txt"
+		And User "user0" deletes file "/local_storage/tmp/textfile0.txt"
+		And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" exists in trash
+		And Logging in using web as "user0"
+		When as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" is restored
+		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" does not exist in trash
+		And Downloaded content when downloading file "/local_storage/tmp/textfile0.txt" with range "bytes=0-1" should be "AA"


### PR DESCRIPTION
Increment to files in filecache is required only when
encryption is enabled. Else use the version as it is.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
When encryption is not enabled then no need to go through each and every step in encryption wrapper's fopen. Instead we can get another storage wrapper's fopen handler.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/28780

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This would help resolve the exceptions thrown in the logs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Create external storage with SFTP
- [x] Create a folder `test` under shared folder.
- [x] upload a file under `test`
- [x] Delete the test folder
- [x] Try to access the `test` folder from the trash
- [x] No exception logs found

Also I have noted that during verification on my local machine the storage passes to local storage from the encryption wrapper ( when no encryption is enabled ).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

