### PR TITLE
make UI tests delete feature more readable

### DIFF
--- a/tests/ui/features/files/delete.feature
+++ b/tests/ui/features/files/delete.feature
@@ -6,66 +6,54 @@ Feature: delete
 		And I am on the files page
 
 	Scenario: Delete files & folders one by one and check its existence after page reload
-		When I delete the folder "simple-folder"
-		Then the folder "simple-folder" should not be listed
-		When I delete the file "lorem.txt"
-		Then the file "lorem.txt" should not be listed
-		When I delete the folder "strängé नेपाली folder"
-		Then the folder "strängé नेपाली folder" should not be listed
-		When I delete the file "strängé filename (duplicate #2).txt"
-		Then the file "strängé filename (duplicate #2).txt" should not be listed
-		When the files page is reloaded
-		Then the folder "simple-folder" should not be listed
-		And the folder "strängé नेपाली folder" should not be listed
-		And the file "lorem.txt" should not be listed
-		And the file "strängé filename (duplicate #2).txt" should not be listed
+		When I delete the elements
+		| name                                |
+		| simple-folder                       |
+		| lorem.txt                           |
+		| strängé नेपाली folder                  |
+		| strängé filename (duplicate #2).txt |
+		Then the deleted elements should not be listed
+		And the deleted elements should not be listed after a page reload
 
 	Scenario: Delete a file with problematic characters
 		When I rename the following file to
-			|from-name-parts |to-name-parts  |
-			|lorem.txt       |'single'       |
-			|                |"double" quotes|
-			|                |question?      |
-			|                |&and#hash      |
+			| from-name-parts | to-name-parts   |
+			| lorem.txt       | 'single'        |
+			|                 | "double" quotes |
+			|                 | question?       |
+			|                 | &and#hash       |
 		And the files page is reloaded
 		Then the following file should be listed
-			|name-parts     |
-			|'single'       |
-			|"double" quotes|
-			|question?      |
-			|&and#hash      |
+			| name-parts      |
+			| 'single'        |
+			| "double" quotes |
+			| question?       |
+			| &and#hash       |
 		And I delete the following file
-			|name-parts     |
-			|'single'       |
-			|"double" quotes|
-			|question?      |
-			|&and#hash      |
+			| name-parts      |
+			| 'single'        |
+			| "double" quotes |
+			| question?       |
+			| &and#hash       |
 		Then the following file should not be listed
-			|name-parts     |
-			|'single'       |
-			|"double" quotes|
-			|question?      |
-			|&and#hash      |
+			| name-parts      |
+			| 'single'        |
+			| "double" quotes |
+			| question?       |
+			| &and#hash       |
 		And the files page is reloaded
 		Then the following file should not be listed
-			|name-parts     |
-			|'single'       |
-			|"double" quotes|
-			|question?      |
-			|&and#hash      |
+			| name-parts      |
+			| 'single'        |
+			| "double" quotes |
+			| question?       |
+			| &and#hash       |
 	
 	Scenario: Delete multiple files at once
-		When I mark these files for batch action
-		|name     |
-		|data.zip|
-		|lorem.txt|
-		|simple-folder|
-		And I batch delete the marked files
-		Then the folder "simple-folder" should not be listed
-		And the file "data.zip" should not be listed
-		And the file "lorem.txt" should not be listed
-		When the files page is reloaded
-		Then the folder "simple-folder" should not be listed
-		And the file "data.zip" should not be listed
-		And the file "lorem.txt" should not be listed
-		
+		When I batch delete these files
+		| name          |
+		| data.zip      |
+		| lorem.txt     |
+		| simple-folder |
+		Then the deleted elements should not be listed
+		And the deleted elements should not be listed after a page reload


### PR DESCRIPTION
## Description
as discussed here https://github.com/owncloud/core/pull/28811#pullrequestreview-58874968 this PR makes the delete tests more readable and moves the single steps into PHP

`When I delete the elements` does check itself if the elements are disappearing from the WebUI. 
Plus there is an extra step to make sure the elemens do not come back after a page reload.

I suggest to leave the `Delete a file with problematic characters` Scenario as it is because of the complicated way we need to combine the single parts of that file name

## Motivation and Context
make better readable test

## How Has This Been Tested?
run UI tests locally, travis will test more

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

