### PR TITLE
[stable10] Add passwordEnabled field to postHookData

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -644,6 +644,7 @@ class Manager implements IManager {
 			'shareWith' => $share->getSharedWith(),
 			'itemTarget' => $share->getTarget(),
 			'fileTarget' => $share->getTarget(),
+			'passwordEnabled' => (!is_null($share->getPassword()) and ($share->getPassword() !== '')),
 		];
 
 		\OC_Hook::emit('OCP\Share', 'post_shared', $postHookData);

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1785,6 +1785,7 @@ class ManagerTest extends \Test\TestCase {
 			'itemTarget' => '/target',
 			'fileTarget' => '/target',
 			'shareWith' => null,
+			'passwordEnabled' => true,
 		];
 
 		$hookListner->expects($this->once())


### PR DESCRIPTION
Add passwordEnabled field to postHookData

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Adding additional parameter passwordDisabled to the postHookData. This data would help us to determine if password is enabled for the share or not while creating the share.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This would help us know if the share was created with password or not.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Create public folder share with password - the logs should help us understand that password was enabled.
- [x] Create public folder share without password - the logs should help us understand that password wasn't enabled.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

