### PR TITLE
Better timeout detection in web UI uploads + chunked uploads

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -253,6 +253,9 @@ OC.FileUpload.prototype = {
 		}
 		this.data.headers['requesttoken'] = OC.requestToken;
 
+		// prevent global error handler to kick in on timeout
+		this.data.allowAuthErrors = true;
+
 		var chunkFolderPromise;
 		if ($.support.blobSlice
 			&& this.uploader.fileUploadParam.maxChunkSize
@@ -340,6 +343,13 @@ OC.FileUpload.prototype = {
 	getResponse: function() {
 		var response = this.data.response();
 		if (response.errorThrown) {
+			if (response.errorThrown === 'timeout') {
+				return {
+					status: 0,
+					message: t('core', 'Upload timeout')
+				};
+			}
+
 			// attempt parsing Sabre exception is available
 			var xml = response.jqXHR.responseXML;
 			if (xml.documentElement.localName === 'error' && xml.documentElement.namespaceURI === 'DAV:') {
@@ -362,8 +372,20 @@ OC.FileUpload.prototype = {
 				// likely due to internal server error
 				response = {status: 500};
 			}
-		} else {
+		} else if (response.result) {
 			response = response.result;
+		} else {
+			if (response.jqXHR.status === 0 && response.jqXHR.statusText === 'error') {
+				// timeout (IE11)
+				return {
+					status: 0,
+					message: t('core', 'Upload timeout')
+				};
+			}
+			return {
+				status: response.jqXHR.status,
+				message: t('core', 'Unknown error: ') + response.jqXHR.statusText
+			};
 		}
 		return response;
 	},

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -346,7 +346,7 @@ OC.FileUpload.prototype = {
 			if (response.errorThrown === 'timeout') {
 				return {
 					status: 0,
-					message: t('core', 'Upload timeout')
+					message: t('core', 'Upload timeout for file "{file}"', {file: this.getFileName()})
 				};
 			}
 
@@ -379,12 +379,12 @@ OC.FileUpload.prototype = {
 				// timeout (IE11)
 				return {
 					status: 0,
-					message: t('core', 'Upload timeout')
+					message: t('core', 'Upload timeout for file "{file}"', {file: this.getFileName()})
 				};
 			}
 			return {
 				status: response.jqXHR.status,
-				message: t('core', 'Unknown error: ') + response.jqXHR.statusText
+				message: t('core', 'Unknown error "{error}" uploading file "{file}"', {error: response.jqXHR.statusText, file: this.getFileName()})
 			};
 		}
 		return response;


### PR DESCRIPTION
## Description
Detects timeouts during web UI uploads and displays a notification when it happens.
Also prevents the global ajax error detection to prevent the full page reload.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] TEST: Set client-side "timeout: 5000" in file-upload.js's `fileUploadParam`. Add `sleep(500)` in `OCA\DAV\Connector\Sabre\File::put()`. Upload < 10 mb file. Notification about timeout appears.
- [x] TEST: Set client-side "timeout: 5000" in file-upload.js's `fileUploadParam`. Upload 100 mb file. Notification about timeout appears.
- [x] TEST: IE11: Add `sleep(500)` in `apps/dav/lib/Upload/UploadFolder::createFile()`, upload 100 mb file. Notification appears after 2 minutes
- [ ] TEST: IE11: Add `sleep(500)` in `apps/dav/lib/Upload/AssemblyStream::stream_open()`. Upload 100 mb file, wait. Notification appears after 2 minutes of stalling at the end of the progress bar.
=> cannot test, it seems IE11 doesn't have a timeout on MOVE, only on PUT

Note: remove extra modifications between each test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

