### PR TITLE
Fix REPORT method when going through Backbone-Webdav adapter

### DIFF
--- a/core/js/oc-backbone-webdav.js
+++ b/core/js/oc-backbone-webdav.js
@@ -252,12 +252,20 @@
 	}
 
 	function callMethod(client, options, model, headers) {
-		headers['Content-Type'] = 'application/json';
+		var data = options.data;
+		if (_.isObject(data)) {
+			headers['Content-Type'] = 'application/json';
+			data = JSON.stringify(data);
+		} else if (_.isString(data) && data.substr(0, 6) === '<?xml ') {
+			headers['Content-Type'] = 'application/xml';
+		} else {
+			headers['Content-Type'] = 'text/plain';
+		}
 		return client.request(
 			options.type,
 			options.url,
 			headers,
-			JSON.stringify(options.data)
+			data
 		).then(function(result) {
 			if (!isSuccessStatus(result.status)) {
 				if (_.isFunction(options.error)) {


### PR DESCRIPTION
## Description
Don't assume that data is a JS object. If it's a string, let it pass as is.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28826

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Test with ticket steps.
Unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

