### PR TITLE
[stable10] Changes to encryption wrapper

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -24,10 +24,12 @@
 
 namespace OCA\Files\Command;
 
+use OC\Encryption\Manager;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OCP\Files\FileInfo;
 use OCP\Files\Mount\IMountManager;
+use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
@@ -48,6 +50,12 @@ class TransferOwnership extends Command {
 
 	/** @var IMountManager */
 	private $mountManager;
+
+	/** @var Manager  */
+	private $encryptionManager;
+
+	/** @var ILogger  */
+	private  $logger;
 
 	/** @var FileInfo[] */
 	private $allFiles = [];
@@ -70,10 +78,12 @@ class TransferOwnership extends Command {
 	/** @var string */
 	private $finalTarget;
 
-	public function __construct(IUserManager $userManager, IManager $shareManager, IMountManager $mountManager) {
+	public function __construct(IUserManager $userManager, IManager $shareManager, IMountManager $mountManager, Manager $encryptionManager, ILogger $logger) {
 		$this->userManager = $userManager;
 		$this->shareManager = $shareManager;
 		$this->mountManager = $mountManager;
+		$this->encryptionManager = $encryptionManager;
+		$this->logger = $logger;
 		parent::__construct();
 	}
 
@@ -260,7 +270,9 @@ class TransferOwnership extends Command {
 				$this->finalTarget = $this->finalTarget . '/' . basename($sourcePath);
 			}
 		}
+
 		$view->rename($sourcePath, $this->finalTarget);
+
 		if (!is_dir("$this->sourceUser/files")) {
 			// because the files folder is moved away we need to recreate it
 			$view->mkdir("$this->sourceUser/files");

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -86,6 +86,11 @@ class Encryption extends Wrapper {
 	/** @var  ArrayCache */
 	private $arrayCache;
 
+	/** @var array which has information of sourcePath during rename operation */
+	private $sourcePath;
+
+	private static $disableWriteEncryption = false;
+
 	/**
 	 * @param array $parameters
 	 * @param IManager $encryptionManager
@@ -201,16 +206,18 @@ class Encryption extends Wrapper {
 	 */
 	public function file_get_contents($path) {
 
-		$encryptionModule = $this->getEncryptionModule($path);
+		if ($this->encryptionManager->isEnabled() !== false) {
+			$encryptionModule = $this->getEncryptionModule($path);
 
-		if ($encryptionModule) {
-			$handle = $this->fopen($path, "r");
-			if (!$handle) {
-				return false;
+			if ($encryptionModule) {
+				$handle = $this->fopen($path, "r");
+				if (!$handle) {
+					return false;
+				}
+				$data = stream_get_contents($handle);
+				fclose($handle);
+				return $data;
 			}
-			$data = stream_get_contents($handle);
-			fclose($handle);
-			return $data;
 		}
 		return $this->storage->file_get_contents($path);
 	}
@@ -358,12 +365,11 @@ class Encryption extends Wrapper {
 	 *
 	 * @param string $path
 	 * @param string $mode
-	 * @param string|null $sourceFileOfRename
 	 * @return resource|bool
 	 * @throws GenericEncryptionException
 	 * @throws ModuleDoesNotExistsException
 	 */
-	public function fopen($path, $mode, $sourceFileOfRename = null) {
+	public function fopen($path, $mode) {
 
 		// check if the file is stored in the array cache, this means that we
 		// copy a file over to the versions folder, in this case we don't want to
@@ -451,14 +457,33 @@ class Encryption extends Wrapper {
 			}
 
 			if ($shouldEncrypt === true && $encryptionModule !== null) {
+				/**
+				 * The check of $disableWriteEncryption, required to get the file in the decrypted state.
+				 * It will help us get the normal file handler. And hence we can re-encrypt
+				 * the file when necessary, later. The true/false of $getDecryptedFile decides whether
+				 * to keep the file decrypted or not. The intention is to get the data decrypt
+				 * for write mode.
+				 */
+				if (self::$disableWriteEncryption && ($mode !== 'r')) {
+					return $this->getWrapperStorage()->fopen($path, $mode);
+				}
+
 				$headerSize = $this->getHeaderSize($path);
 				$source = $this->storage->fopen($path, $mode);
 				if (!is_resource($source)) {
 					return false;
 				}
+
+				if (isset($this->sourcePath[$path])) {
+					$sourceFileOfRename = $this->sourcePath[$path];
+				} else {
+					$sourceFileOfRename = null;
+				}
 				$handle = \OC\Files\Stream\Encryption::wrap($source, $path, $fullPath, $header,
 					$this->uid, $encryptionModule, $this->storage, $this, $this->util, $this->fileHelper, $mode,
 					$size, $unencryptedSize, $headerSize, $signed, $sourceFileOfRename);
+				unset($this->sourcePath[$path]);
+
 				return $handle;
 			}
 
@@ -622,6 +647,15 @@ class Encryption extends Wrapper {
 		return $result;
 	}
 
+	/**
+	 * Set the flag to true, so that the file would be
+	 * in the decrypted state.
+	 *
+	 * @param $isDisabled bool
+	 */
+	public static function setDisableWriteEncryption($isDisabled) {
+		self::$disableWriteEncryption = $isDisabled;
+	}
 
 	/**
 	 * @param Storage $sourceStorage
@@ -748,10 +782,11 @@ class Encryption extends Wrapper {
 				$source = $sourceStorage->fopen($sourceInternalPath, 'r');
 				if ($isRename) {
 					$absSourcePath = Filesystem::normalizePath($sourceStorage->getOwner($sourceInternalPath). '/' . $sourceInternalPath);
-					$target = $this->fopen($targetInternalPath, 'w', $absSourcePath);
+					$this->sourcePath[$targetInternalPath] = $absSourcePath;
 				} else {
-					$target = $this->fopen($targetInternalPath, 'w');
+					unset($this->sourcePath[$targetInternalPath]);
 				}
+				$target = $this->fopen($targetInternalPath, 'w');
 				list(, $result) = \OC_Helper::streamCopy($source, $target);
 				fclose($source);
 				fclose($target);

--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -139,6 +139,7 @@ class Encryption extends Wrapper {
 	 * @param int $unencryptedSize
 	 * @param int $headerSize
 	 * @param bool $signed
+	 * @param null|string $sourceFileOfRename
 	 * @param string $wrapper stream wrapper class
 	 * @return resource
 	 *


### PR DESCRIPTION
Changes made to encryption wrapper so that we can
get the commands like transfer-ownership or recreate
masterkey work. This change doesn't alter the core
functionality of copy or fopen function. The arguments
passed to the function remains same as other wrappers.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Changes made to the ecnryption warpper and view to get the transfer-ownership command recreate master key work. Basically there was a problem which caused to change the arguments passed to the routines like fopen or copy. With this change we don't have to alter them. But we use flags to control the code flow for the commands.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change would prevent the modification to common routines which were made to arguments of functions like fopen or copy etc.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Scratch installation of oC and create 2 users
- [x] Verified transfer ownership command works with and without encryption between two users.
- [x] Verified Recreate command for master key works on the same setup.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

