### PR TITLE
fix endless loop in waitTillElementIsNotNull

### DIFF
--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -79,9 +79,11 @@ class OwncloudPage extends Page
 	 *
 	 * @param string $xpath
 	 * @param int $timeout_msec
+	 * @return void
 	 */
-	public function waitTillElementIsNotNull ($xpath, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC)
-	{
+	public function waitTillElementIsNotNull(
+		$xpath, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+	) {
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
@@ -94,8 +96,8 @@ class OwncloudPage extends Page
 				}
 			} catch (WebDriverException $e) {
 				usleep(STANDARDSLEEPTIMEMICROSEC);
-				$currentTime = microtime(true);
 			}
+			$currentTime = microtime(true);
 		}
 	}
 	


### PR DESCRIPTION
## Description
`waitTillElementIsNotNull()` would loop forever if the element does never appear

## Related Issue
travis runs with strange timeouts

## Motivation and Context
we don't like endless loops

## How Has This Been Tested?
run UI tests locally, travis will tests the rest

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

