### PR TITLE
UI test infrastructure to set share permissions

### DIFF
--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -317,6 +317,22 @@ class FilesContext extends RawMinkContext implements Context
 	}
 
 	/**
+	 * @Then it should not be possible to delete the file/folder :name
+	 * @param string $name
+	 * @return void
+	 */
+	public function itShouldNotBePossibleToDelete($name) {
+		try {
+			$this->iDeleteTheFile($name);
+		} catch (ElementNotFoundException $e) {
+			PHPUnit_Framework_Assert::assertSame(
+				"could not find button 'Delete' in action Menu",
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
 	 * @Then the filesactionmenu should be completely visible after clicking on it
 	 */
 	public function theFilesactionmenuShouldBeCompletelyVisibleAfterClickingOnIt()

--- a/tests/ui/features/bootstrap/SharingContext.php
+++ b/tests/ui/features/bootstrap/SharingContext.php
@@ -23,7 +23,9 @@
 use Behat\Behat\Context\Context;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\TableNode;
 use Page\FilesPage;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 require_once 'bootstrap.php';
 
@@ -95,6 +97,24 @@ class SharingContext extends RawMinkContext implements Context
 	public function iTypeInTheShareWithField($input)
 	{
 		$this->sharingDialog->fillShareWithField($input, $this->getSession());
+	}
+
+	/**
+	 * @Given the sharing permissions of :userName for :fileName are set to
+	 * @param string $userName
+	 * @param string $fileName
+	 * @param TableNode $permissionsTable table with two columns and no heading
+	 * first column one of the permissions (share|edit|create|change|delete)
+	 * second column yes|no
+	 * not mentioned permissions will not be touched
+	 */
+	public function theSharingPermissionsOfAreSetTo(
+		$userName, $fileName, TableNode $permissionsTable
+	) {
+		$this->theShareDialogForTheFileFolderIsOpen($fileName);
+		$this->sharingDialog->setSharingPermissions(
+			$userName, $permissionsTable->getRowsHash()
+		);
 	}
 
 	/**
@@ -206,6 +226,21 @@ class SharingContext extends RawMinkContext implements Context
 			PHPUnit_Framework_Assert::assertSame(
 				$sharedWithGroup,
 				$sharingDialog->getSharedWithGroupName()
+			);
+		}
+	}
+
+	/**
+	 * @Then it should not be possible to share the file/folder :name
+	 * @return void
+	 */
+	public function itShouldNotBePossibleToShare($name) {
+		try {
+			$this->theFileFolderIsSharedWithTheUser($name, null);
+		} catch (ElementNotFoundException $e) {
+			PHPUnit_Framework_Assert::assertSame(
+				'could not find share-with-field',
+				$e->getMessage()
 			);
 		}
 	}

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -79,9 +79,11 @@ class OwncloudPage extends Page
 	 *
 	 * @param string $xpath
 	 * @param int $timeout_msec
+	 * @return void
 	 */
-	public function waitTillElementIsNotNull ($xpath, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC)
-	{
+	public function waitTillElementIsNotNull(
+		$xpath, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+	) {
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
@@ -94,8 +96,8 @@ class OwncloudPage extends Page
 				}
 			} catch (WebDriverException $e) {
 				usleep(STANDARDSLEEPTIMEMICROSEC);
-				$currentTime = microtime(true);
 			}
+			$currentTime = microtime(true);
 		}
 	}
 	

--- a/tests/ui/features/other/sharing.feature
+++ b/tests/ui/features/other/sharing.feature
@@ -46,3 +46,21 @@ Feature: Sharing
 		And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three"
 		And the file "testimage (2).jpg" should be listed
 		And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three"
+
+	Scenario: share a folder with another internal user and prohibit resharing
+		When the folder "simple-folder" is shared with the user "User One"
+		And the sharing permissions of "User One" for "simple-folder" are set to
+		| share | no |
+		And I logout
+		And I login with username "user1" and password "1234"
+		Then it should not be possible to share the folder "simple-folder (2)"
+
+	Scenario: share a folder with another internal user and prohibit deleting
+		When the folder "simple-folder" is shared with the user "User One"
+		And the sharing permissions of "User One" for "simple-folder" are set to
+		| delete | no |
+		And I logout
+		And I login with username "user1" and password "1234"
+		And I open the folder "simple-folder (2)"
+		Then it should not be possible to delete the file "lorem.txt"
+		


### PR DESCRIPTION
## Description
make it possible to set share permissions in UI tests and adds some small tests that are using this function

this PR depends on https://github.com/owncloud/core/pull/28846

## Related Issue
owncloud/QA#437

## Motivation and Context
write tests that are changing the sharing permissions

## How Has This Been Tested?
wrote UI tests and run them locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

