### PR TITLE
add SetupHelper methods to enable and disable apps

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -135,10 +135,60 @@ class SetupHelper {
 	}
 
 	/**
+	 * enables an app
+	 *
+	 * @param string $ocPath
+	 * @param string $appName
+	 * @return string[] associated array with "code", "stdOut", "stdErr"
+	 */
+	public static function enableApp($ocPath, $appName) {
+		return self::runOcc(['app:enable', $appName], $ocPath);
+	}
+
+	/**
+	 * disables an app
+	 *
+	 * @param string $ocPath
+	 * @param string $appName
+	 * @return string[] associated array with "code", "stdOut", "stdErr"
+	 */
+	public static function disableApp($ocPath, $appName) {
+		return self::runOcc(['app:disable', $appName], $ocPath);
+	}
+
+	/**
+	 * checks if an app is currently enabled
+	 *
+	 * @param string $ocPath
+	 * @param string $appName
+	 * @return boolean true if enabled, false if disabled or not existing
+	 */
+	public static function isAppEnabled($ocPath, $appName) {
+		$result =  self::runOcc(['app:list', '^' . $appName . '$'], $ocPath);
+		return strtolower(substr($result['stdOut'], 0, 7)) === 'enabled';
+	}
+
+	/**
+	 * lists app status (enabled or disabled)
+	 *
+	 * @param string $ocPath
+	 * @param string $appName
+	 * @return boolean true if the app needed to be enabled, false otherwise
+	 */
+	public static function enableAppIfNotEnabled($ocPath, $appName) {
+		if (!self::isAppEnabled($ocPath, $appName)) {
+			self::enableApp($ocPath, $appName);
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * invokes an OCC command
 	 *
 	 * @param array $args anything behind "occ".
-	 * For example: "files:transfer-ownership"
+	 *                    For example: "files:transfer-ownership"
 	 * @param string $ocPath
 	 * @param string $escaping
 	 * @return string[] associated array with "code", "stdOut", "stdErr"


### PR DESCRIPTION
## Description

## Related Issue

## Motivation and Context
Test code within Behat can enable and disable apps if it needs to.
Useful when testing a particular app - so you don;t have to remember to manually enable it before running the test suite.

## How Has This Been Tested?
Start with files_texteditor disabled.
Run files_texteditor UI tests, with code to enable/disable the app
Check that the tests work

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

