### PR TITLE
Don't query Sabre parent nodes

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -83,7 +83,7 @@ class Directory extends Node implements ICollection, IQuota, IMoveTarget {
 	 * @param ObjectTree|null $tree
 	 * @param \OCP\Share\IManager $shareManager
 	 */
-	public function __construct($view, $info, $tree = null, $shareManager = null) {
+	public function __construct($view, $info, ObjectTree $tree = null, $shareManager = null) {
 		parent::__construct($view, $info, $shareManager);
 		$this->tree = $tree;
 	}

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -130,28 +130,23 @@ class ObjectTree extends \Sabre\DAV\Tree {
 			throw new \Sabre\DAV\Exception\ServiceUnavailable('filesystem not setup');
 		}
 
-		// check the path, also called when the path has been entered manually eg via a file explorer
-		if (\OC\Files\Filesystem::isForbiddenFileOrDir($path)) {
-			throw new \Sabre\DAV\Exception\Forbidden();
-		}
-
 		$path = trim($path, '/');
 
 		if (isset($this->cache[$path]) && $this->cache[$path] !== false) {
 			return $this->cache[$path];
 		}
 
-		if ($path) {
+		// check the path, also called when the path has been entered manually eg via a file explorer
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($path)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+
+		if ($path !== '') {
 			try {
 				$this->fileView->verifyPath($path, basename($path));
 			} catch (\OCP\Files\InvalidPathException $ex) {
 				throw new InvalidPath($ex->getMessage());
 			}
-		}
-
-		// check the path, also called when the path has been entered manually eg via a file explorer
-		if (\OC\Files\Filesystem::isForbiddenFileOrDir($path)) {
-			throw new \Sabre\DAV\Exception\Forbidden();
 		}
 
 		// Is it the root node?

--- a/apps/dav/lib/Files/FilesHome.php
+++ b/apps/dav/lib/Files/FilesHome.php
@@ -21,11 +21,13 @@
  */
 namespace OCA\DAV\Files;
 
-use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Connector\Sabre\ObjectTree;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\HTTP\URLUtil;
+use Sabre\DAV\ICollection;
+use OCA\DAV\Connector\Sabre\Directory;
 
-class FilesHome extends Directory {
+class FilesHome extends ObjectTree implements ICollection {
 
 	/**
 	 * @var array
@@ -38,10 +40,37 @@ class FilesHome extends Directory {
 	 * @param array $principalInfo
 	 */
 	public function __construct($principalInfo) {
+		parent::__construct();
 		$this->principalInfo = $principalInfo;
 		$view = \OC\Files\Filesystem::getView();
 		$rootInfo = $view->getFileInfo('');
-		parent::__construct($view, $rootInfo);
+		$rootNode = new Directory($view, $rootInfo, $this);
+		$this->init($rootNode, $view, \OC::$server->getMountManager());
+
+	}
+
+	function createFile($name, $data = null) {
+		return $this->rootNode->createFile($name, $data);
+	}
+
+	function createDirectory($name) {
+		return $this->rootNode->createDirectory($name);
+	}
+
+	function getChild($name) {
+		return $this->rootNode->getChild($name);
+	}
+
+	function getChildren() {
+		return $this->rootNode->getChildren();
+	}
+
+	function childExists($name) {
+		return $this->rootNode->childExists($name);
+	}
+
+	function getLastModified() {
+		return $this->rootNode->getLastModified();
 	}
 
 	function delete() {

--- a/apps/dav/lib/Files/FilesHome.php
+++ b/apps/dav/lib/Files/FilesHome.php
@@ -25,13 +25,10 @@ use OCA\DAV\Connector\Sabre\ObjectTree;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\HTTP\URLUtil;
 use Sabre\DAV\ICollection;
-use OCA\DAV\Connector\Sabre\Directory;
 
 class FilesHome extends ObjectTree implements ICollection {
 
-	/**
-	 * @var array
-	 */
+	/** @var array */
 	private $principalInfo;
 
 	/**
@@ -42,11 +39,6 @@ class FilesHome extends ObjectTree implements ICollection {
 	public function __construct($principalInfo) {
 		parent::__construct();
 		$this->principalInfo = $principalInfo;
-		$view = \OC\Files\Filesystem::getView();
-		$rootInfo = $view->getFileInfo('');
-		$rootNode = new Directory($view, $rootInfo, $this);
-		$this->init($rootNode, $view, \OC::$server->getMountManager());
-
 	}
 
 	function createFile($name, $data = null) {
@@ -54,15 +46,18 @@ class FilesHome extends ObjectTree implements ICollection {
 	}
 
 	function createDirectory($name) {
-		return $this->rootNode->createDirectory($name);
+		$this->rootNode->createDirectory($name);
 	}
 
 	function getChild($name) {
 		return $this->rootNode->getChild($name);
 	}
 
-	function getChildren() {
-		return $this->rootNode->getChildren();
+	function getChildren($path = null) {
+		if ($path === null) {
+			return $this->rootNode->getChildren();
+		}
+		return parent::getChildren($path);
 	}
 
 	function childExists($name) {
@@ -73,8 +68,15 @@ class FilesHome extends ObjectTree implements ICollection {
 		return $this->rootNode->getLastModified();
 	}
 
-	function delete() {
-		throw new Forbidden('Permission denied to delete home folder');
+	/**
+	 * @param string $path
+	 * @throws Forbidden
+	 */
+	function delete($path = null) {
+		if ($path === null) {
+			throw new Forbidden('Permission denied to delete home folder');
+		}
+		parent::delete($path);
 	}
 
 	function getName() {
@@ -82,6 +84,10 @@ class FilesHome extends ObjectTree implements ICollection {
 		return $name;
 	}
 
+	/**
+	 * @param string $name
+	 * @throws Forbidden
+	 */
 	function setName($name) {
 		throw new Forbidden('Permission denied to rename this folder');
 	}

--- a/apps/dav/lib/Files/RootCollection.php
+++ b/apps/dav/lib/Files/RootCollection.php
@@ -21,6 +21,7 @@
  */
 namespace OCA\DAV\Files;
 
+use OCA\DAV\Connector\Sabre\Directory;
 use Sabre\DAV\INode;
 use Sabre\DAV\SimpleCollection;
 use Sabre\DAVACL\AbstractPrincipalCollection;
@@ -47,7 +48,13 @@ class RootCollection extends AbstractPrincipalCollection {
 			// in the future this could be considered to be used for accessing shared files
 			return new SimpleCollection($name);
 		}
-		return new FilesHome($principalInfo);
+		$view = \OC\Files\Filesystem::getView();
+		$home = new FilesHome($principalInfo);
+		$rootInfo = $view->getFileInfo('');
+		$rootNode = new Directory($view, $rootInfo, $home);
+		$home->init($rootNode, $view, \OC::$server->getMountManager());
+
+		return $home;
 	}
 
 	function getName() {

--- a/apps/dav/lib/Tree.php
+++ b/apps/dav/lib/Tree.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV;
+
+use OCA\DAV\Connector\Sabre\Exception\Forbidden;
+use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
+use OCA\DAV\Connector\Sabre\Exception\FileLocked;
+use OCP\Files\ForbiddenException;
+use OCP\Files\StorageInvalidException;
+use OCP\Files\StorageNotAvailableException;
+use OCP\Lock\LockedException;
+use OC\Files\View;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\ICollection;
+use OCA\DAV\Connector\Sabre\Node;
+
+/**
+ * Sabre tree of nodes.
+ *
+ * Provides a shortcut when accessing the "files/" subtree to avoid
+ * having to walk through every node and trigger unnecessary extra queries.
+ */
+class Tree extends \Sabre\DAV\Tree {
+
+	/**
+	 * Cache specific for file nodes to avoid conflicting with
+	 * the regular tree nodes cache which have the full DAV path.
+	 *
+	 * This file node cache uses the DAV subpath after "/files/$userId/"
+	 * as key
+	 *
+	 * @var array
+	 */
+	private $fileNodeCache;
+
+	/**
+	 * Creates the tree
+	 *
+	 * @param \Sabre\DAV\INode $rootNode
+	 */
+	public function __construct(ICollection $rootNode) {
+		parent::__construct($rootNode);
+		$this->fileNodeCache = [];
+	}
+
+	/**
+	 * Cache a files specific node
+	 */
+	public function cacheNode(Node $node) {
+		// FIXME this is used by Directory::getChildren() to cache every
+		// found children directly. We should find a better way in the future.
+		// This is only to keep compatible with ObjectTree and the Directory class'
+		// expectations.
+		$this->fileNodeCache[trim($node->getPath(), '/')] = $node;
+	}
+
+	/**
+	 * Returns the INode object for the requested path
+	 *
+	 * @param string $path
+	 * @return \Sabre\DAV\INode
+	 * @throws InvalidPath
+	 * @throws \Sabre\DAV\Exception\Locked
+	 * @throws \Sabre\DAV\Exception\NotFound
+	 * @throws \Sabre\DAV\Exception\Forbidden
+	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
+	 */
+	public function getNodeForPath($path) {
+		// querying "files" directly or anything outside of it
+		// will fallback to the regular implementation
+		if (strpos(rtrim($path, '/'), 'files/') !== 0) {
+			return parent::getNodeForPath($path);
+		}
+
+		// anything else will go through this shortcut to file nodes to avoid
+		// traversing every parent because it would trigger
+		// additional filecache queries and also
+		// additional locking of parent nodes and
+		// potential rescan in the case of external storages with update detection
+		$sections = explode('/', $path);
+		array_shift($sections);
+		$userId = array_shift($sections);
+
+		// this will ensure that the user exists and is accessible and also
+		// use the cached version when needed
+		$filesRoot = parent::getNodeForPath('files/' . $userId);
+
+		$path = implode('/', $sections);
+
+		$path = trim($path, '/');
+
+		// is it the root node?
+		if ($path === '') {
+			return $filesRoot;
+		}
+
+		if (isset($this->fileNodeCache[$path])) {
+			if ($this->fileNodeCache[$path] === false) {
+				throw new \Sabre\DAV\Exception\NotFound('File with name ' . $path . ' could not be located');
+			}
+			return $this->fileNodeCache[$path];
+		}
+
+		// check the path, also called when the path has been entered manually eg via a file explorer
+		if (\OC\Files\Filesystem::isForbiddenFileOrDir($path)) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+
+		$fileView = new View('/' . $userId . '/files/');
+
+		try {
+			$fileView->verifyPath($path, basename($path));
+		} catch (\OCP\Files\InvalidPathException $ex) {
+			throw new InvalidPath($ex->getMessage());
+		}
+
+		// read from file cache
+		try {
+			$info = $fileView->getFileInfo($path);
+		} catch (StorageNotAvailableException $e) {
+			throw new \Sabre\DAV\Exception\ServiceUnavailable('Storage is temporarily not available', 0, $e);
+		} catch (StorageInvalidException $e) {
+			throw new \Sabre\DAV\Exception\NotFound('Storage ' . $path . ' is invalid');
+		} catch (LockedException $e) {
+			throw new \Sabre\DAV\Exception\Locked();
+		} catch (ForbiddenException $e) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+
+		if (!$info) {
+			$this->fileNodeCache[$path] = false;
+			throw new \Sabre\DAV\Exception\NotFound('File with name ' . $path . ' could not be located');
+		}
+
+		if ($info->getType() === 'dir') {
+			$node = new \OCA\DAV\Connector\Sabre\Directory($fileView, $info, $this);
+		} else {
+			$node = new \OCA\DAV\Connector\Sabre\File($fileView, $info);
+		}
+
+		$this->fileNodeCache[$path] = $node;
+		return $node;
+
+	}
+}

--- a/apps/dav/lib/Tree.php
+++ b/apps/dav/lib/Tree.php
@@ -21,17 +21,9 @@
 
 namespace OCA\DAV;
 
-use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
-use OCA\DAV\Connector\Sabre\Exception\FileLocked;
-use OCP\Files\ForbiddenException;
-use OCP\Files\StorageInvalidException;
-use OCP\Files\StorageNotAvailableException;
-use OCP\Lock\LockedException;
-use OC\Files\View;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\ICollection;
-use OCA\DAV\Connector\Sabre\Node;
 
 /**
  * Sabre tree of nodes.
@@ -45,11 +37,7 @@ class Tree extends \Sabre\DAV\Tree {
 	 *
 	 * @param string $path
 	 * @return \Sabre\DAV\INode
-	 * @throws InvalidPath
-	 * @throws \Sabre\DAV\Exception\Locked
-	 * @throws \Sabre\DAV\Exception\NotFound
-	 * @throws \Sabre\DAV\Exception\Forbidden
-	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
+	 * @throws NotFound
 	 */
 	public function getNodeForPath($path) {
 		// FIXME: remove this check when we are sure that other

--- a/apps/dav/tests/unit/Files/FilesHomeTest.php
+++ b/apps/dav/tests/unit/Files/FilesHomeTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\Files;
+
+use OC\Files\FileInfo;
+use OC\Files\View;
+use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Files\FilesHome;
+use OCP\Files\Mount\IMountManager;
+use Test\TestCase;
+
+class FilesHomeTest extends TestCase {
+
+	/** @var FilesHome */
+	private $filesHome;
+	/** @var Directory | \PHPUnit_Framework_MockObject_MockObject */
+	private $rootNode;
+	/** @var View | \PHPUnit_Framework_MockObject_MockObject */
+	private $view;
+
+	protected function setUp() {
+		$this->view = $this->createMock(View::class);
+		$this->filesHome = new FilesHome([
+			'uri' => 'principals/users/user01'
+		]);
+
+		$this->rootNode = $this->createMock(Directory::class);
+		/** @var IMountManager | \PHPUnit_Framework_MockObject_MockObject $mountManager */
+		$mountManager = $this->createMock(IMountManager::class);
+
+		$this->filesHome->init($this->rootNode, $this->view, $mountManager);
+	}
+
+	public function testGetName() {
+		$this->assertEquals('user01', $this->filesHome->getName());
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 * @expectedExceptionMessage Permission denied to rename this folder
+	 * @throws \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testSetName() {
+		$this->filesHome->setName('alice');
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\Forbidden
+	 * @expectedExceptionMessage Permission denied to delete home folder
+	 * @throws \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testDelete() {
+		$this->filesHome->delete();
+	}
+
+	public function testGetLastModified() {
+		$this->rootNode->expects($this->once())->method('getLastModified')->willReturn('12345678');
+		$this->assertEquals('12345678', $this->filesHome->getLastModified());
+	}
+
+	public function testChildExists() {
+		$this->rootNode->expects($this->once())->method('childExists')->willReturn(true);
+		$this->assertTrue($this->filesHome->childExists('welcome.txt'));
+	}
+
+	public function testGetChildren() {
+		$this->rootNode->expects($this->once())->method('getChildren')->willReturn([]);
+		$this->assertEquals([], $this->filesHome->getChildren());
+	}
+
+	public function testGetChild() {
+		$this->rootNode->expects($this->once())->method('getChild')->willReturn([]);
+		$this->assertEquals([], $this->filesHome->getChild('xxx'));
+	}
+
+	public function testCreateDirectory() {
+		$this->rootNode->expects($this->once())->method('createDirectory')->willReturn([]);
+		$this->filesHome->createDirectory('abc');
+	}
+
+	public function testCreateFile() {
+		$this->rootNode->expects($this->once())->method('createFile')->willReturn([]);
+		$this->filesHome->createFile('abc');
+	}
+
+	/**
+	 * @throws \Sabre\DAV\Exception\Forbidden
+	 */
+	public function testDeleteWithPath() {
+		$fileInfo = $this->createMock(FileInfo::class);
+		$fileInfo->expects($this->once())->method('isDeletable')->willReturn(true);
+		$this->view->expects($this->once())->method('getFileInfo')->willReturnMap([
+			['foo/bar.txt', true, $fileInfo],
+		]);
+		$this->view->expects($this->once())->method('unlink')->willReturn(true);
+
+		$this->filesHome->delete('foo/bar.txt');
+	}
+
+	public function testGetChildrenWithPath() {
+		$fileInfo = $this->createMock(FileInfo::class);
+		$fileInfo->expects($this->once())->method('getType')->willReturn('dir');
+		$fileInfo->expects($this->once())->method('isReadable')->willReturn(true);
+
+		$this->view->expects($this->once())->method('getFileInfo')->willReturnMap([
+			['foo', true, $fileInfo],
+		]);
+		$this->view->expects($this->once())->method('getDirectoryContent')->willReturn([]);
+		$this->assertEquals([], $this->filesHome->getChildren('foo'));
+	}
+
+}

--- a/apps/dav/tests/unit/TreeTest.php
+++ b/apps/dav/tests/unit/TreeTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * @author Joas Schilling <coding@schilljs.com>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Robin Appelman <icewind@owncloud.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\unit;
+
+
+use OC\Files\FileInfo;
+use OC\Files\Filesystem;
+use OC\Files\Storage\Temporary;
+use OC\Files\View;
+use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Connector\Sabre\ObjectTree;
+use Test\TestCase;
+
+/**
+ * Class TreeTest
+ *
+ * @group DB
+ *
+ * @package OCA\DAV\Tests\Unit
+ */
+class TreeTest extends TestCase {
+
+	/**
+	 * @dataProvider nodeForPathProvider
+	 */
+	public function testGetNodeForPath(
+		$inputFileName,
+		$fileInfoQueryPath,
+		$outputFileName,
+		$type
+	) {
+		$rootNode = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
+			->disableOriginalConstructor()
+			->getMock();
+		$mountManager = $this->createMock('\OC\Files\Mount\Manager');
+		$view = $this->createMock('\OC\Files\View');
+		$fileInfo = $this->createMock('\OCP\Files\FileInfo');
+		$fileInfo->expects($this->once())
+			->method('getType')
+			->will($this->returnValue($type));
+		$fileInfo->expects($this->once())
+			->method('getName')
+			->will($this->returnValue($outputFileName));
+
+		$view->expects($this->once())
+			->method('getFileInfo')
+			->with($fileInfoQueryPath)
+			->will($this->returnValue($fileInfo));
+
+		$tree = new \OCA\DAV\Connector\Sabre\ObjectTree();
+		$tree->init($rootNode, $view, $mountManager);
+
+		$node = $tree->getNodeForPath($inputFileName);
+
+		$this->assertNotNull($node);
+		$this->assertEquals($outputFileName, $node->getName());
+
+		if ($type === 'file') {
+			$this->assertTrue($node instanceof \OCA\DAV\Connector\Sabre\File);
+		} else {
+			$this->assertTrue($node instanceof Directory);
+		}
+	}
+
+	function nodeForPathProvider() {
+		return [
+			// regular file
+			[
+				'regularfile.txt',
+				'regularfile.txt',
+				'regularfile.txt',
+				'file',
+			],
+			// regular directory
+			[
+				'regulardir',
+				'regulardir',
+				'regulardir',
+				'dir',
+			],
+			// regular file in subdir
+			[
+				'subdir/regularfile.txt',
+				'subdir/regularfile.txt',
+				'regularfile.txt',
+				'file',
+			],
+			// regular directory in subdir
+			[
+				'subdir/regulardir',
+				'subdir/regulardir',
+				'regulardir',
+				'dir',
+			],
+		];
+	}
+
+	/**
+	 * @expectedException \OCA\DAV\Connector\Sabre\Exception\InvalidPath
+	 */
+	public function testGetNodeForPathInvalidPath() {
+		$path = '/foo\bar';
+
+
+		$storage = new Temporary([]);
+
+		$view = $this->getMockBuilder(View::class)
+			->setMethods(['resolvePath'])
+			->getMock();
+		$view->expects($this->once())
+			->method('resolvePath')
+			->will($this->returnCallback(function($path) use ($storage){
+			return [$storage, ltrim($path, '/')];
+		}));
+
+		$rootNode = $this->getMockBuilder(Directory::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$mountManager = $this->createMock('\OC\Files\Mount\Manager');
+
+		$tree = new ObjectTree();
+		$tree->init($rootNode, $view, $mountManager);
+
+		$tree->getNodeForPath($path);
+	}
+
+	public function testGetNodeForPathRoot() {
+		$path = '/';
+
+
+		$storage = new Temporary([]);
+
+		$view = $this->createMock('\OC\Files\View', ['resolvePath']);
+		$view->expects($this->any())
+			->method('resolvePath')
+			->will($this->returnCallback(function ($path) use ($storage) {
+				return [$storage, ltrim($path, '/')];
+			}));
+
+		$rootNode = $this->getMockBuilder('\OCA\DAV\Connector\Sabre\Directory')
+			->disableOriginalConstructor()
+			->getMock();
+		$mountManager = $this->createMock('\OC\Files\Mount\Manager');
+
+		$tree = new \OCA\DAV\Connector\Sabre\ObjectTree();
+		$tree->init($rootNode, $view, $mountManager);
+
+		$this->assertInstanceOf('\Sabre\DAV\INode', $tree->getNodeForPath($path));
+	}
+
+}


### PR DESCRIPTION
## Description
When dealing with file access, the old DAV had a shortcut way to
directly access a file node without having to traverse all parents.
The new DAV endpoint needs this as well:

- added \OCA\DAV\Tree implementation with shortcut for "files"
- disable DAVACL plugin as it would also query all parents

There are several reasons for avoiding to query the parents:
- it causes file cache access for each node, not removable as it needs
to check for existence
- with external storages and update detection, querying a folder node
causes update detection to kick in and the scanner to do its work, the
scanner will set additional locks that might needlessly prevent
concurrent access.

The sad part is that any future Sabre plugin without caring for the above has a risk of retriggering these issues. So any Sabre plugin dealing with files must be aware of this and avoid needlessly querying every parent node.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28779

## Motivation and Context
Read from https://github.com/owncloud/core/issues/28779#issuecomment-325927979.
But also this will improve performance or at least bring it closer to the one from the old DAV endpoint by avoiding additional file cache queries.

## How Has This Been Tested?
Test steps from above ticket: deletion of three folders simultaneously on an external storage with update detection kept enabled.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

