### PR TITLE
Add a script to automate environment setup

### DIFF
--- a/bin/setup-environment.sh
+++ b/bin/setup-environment.sh
@@ -47,11 +47,27 @@ function check_permissions()
 
 function install_required_packages()
 {
-  # Ensure that Apt’s cache is up to date
-  sudo apt-get -y -q update
+  case "$( grep -Eoi 'Debian|SUSE|Ubuntu' /etc/issue )" in 
+    "SUSE") echo "Installing required packages on SUSE"
+      install_required_suse_packages
+      ;;
+    "Ubuntu"|"Debian") echo "Installing required packages on Ubuntu/Debian"
+      install_required_ubuntu_debian_packages
+      ;;
+  esac
+}
 
-  # Auto-install the required dependencies with a minimum of output
-  sudo apt-get install -y -q wget make npm nodejs nodejs-legacy unzip git
+function install_required_suse_packages()
+{
+  sudo zypper --quiet --non-interactive install wget make nodejs6 \
+    nodejs-common unzip git npm6 phantomjs
+}
+
+function install_required_ubuntu_debian_packages()
+{
+  sudo apt-get -y -q update && \
+    apt-get install -y -q wget make npm \
+      nodejs nodejs-legacy unzip git
 }
 
 function main()
@@ -94,10 +110,10 @@ then
      exit $#
    fi
 
-   if [ $( grep -E 'Debian|Ubuntu' /etc/issue ) ]; then 
+   if grep -Eq 'Debian|Ubuntu|SUSE' /etc/issue; then 
      main "$1" "$2"
    else
-     echo 'Currently, only Debian-based distributions are supported'
+     echo 'Currently, only Debian, Ubuntu, and SUSE distributions are supported'
      echo 'Others are planned to be supported in the future.'
      exit -1
    fi

--- a/bin/setup-environment.sh
+++ b/bin/setup-environment.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+#
+## 
+## Usage: setup-environment.sh 
+##
+## This script will setup an ownCloud development environment on a Debian-Linux
+## distribution. 
+##
+set -euo pipefail
+IFS=$'\n\t'
+REQUIRED_ARGS=2
+
+if [ "$( whoami )" == 'root' ]
+then
+  echo 'Do not run this script as root.'
+  echo 'Please run it as your webserver user.'
+  exit -1
+fi;
+
+## ---------------------------------------------------- ##
+## Variables
+## ---------------------------------------------------- ##
+
+lockfile=.setup-environment.lock
+
+function check_user()
+{
+  if [ "$( whoami )" == "root" ]; then
+    echo 'This script should not be executed as root.'
+    echo 'Please run it as your web user'
+    exit -1
+  fi
+}
+
+function check_permissions()
+{
+  echo 'Checking user, group, and permissions'
+
+  if [ "$directory_owner" != "$www_user" ] && [ -z "$directory_permissions" ]; then
+    echo "Unable to write to $owncloud_directory."
+    echo "Please ensure that $www_user has read/write access to $owncloud_directory"
+    exit -1
+  fi
+
+  echo 'User & group permissions pass.'
+}
+
+function install_required_packages()
+{
+  # Ensure that Apt’s cache is up to date
+  sudo apt-get -y -q update
+
+  # Auto-install the required dependencies with a minimum of output
+  sudo apt-get install -y -q wget make npm nodejs unzip git
+}
+
+function fix_nodejs_binary()
+{
+  nodejs=$( which nodejs )
+
+  if [ -z "$( which node )" ]; then
+    echo 'Node is installed, but not correctly set in the system path.'
+    echo 'Linking ' "$nodejs" ' to /usr/bin/node'
+    sudo ln -s "$nodejs" /usr/bin/node
+  fi
+}
+
+function main()
+{
+
+  # Users
+  local www_user="$1"
+
+  # Directories
+  local owncloud_directory="$2"
+
+  echo "Running script with webserver user: $www_user and directory: $owncloud_directory"
+  echo 
+
+  # Directory owners
+  directory_owner=$( stat -c "%A %U %G" "$owncloud_directory" )
+
+  # Directory permissions
+  directory_permissions=$( stat -c %a "$owncloud_directory" | grep '[67]..' )
+
+  check_user
+  check_permissions
+
+  echo 'Preparing ownCloud development environment'
+
+  install_required_packages
+  fix_nodejs_binary
+
+  # Install the required third-party packages
+  make
+
+  echo 'Finished preparing ownCloud development environment'
+}
+
+if ( set -o noclobber; echo "$$" > "$lockfile") 2> /dev/null; 
+then
+   trap 'rm -f "$lockfile"; exit $?' INT TERM EXIT
+
+   if [ $# -ne $REQUIRED_ARGS ]; then
+     echo "Usage: $( basename $0 ) <webserver user> <owncloud install dir>"
+     exit $#
+   fi
+
+   if [ $( grep -E 'Debian|Ubuntu' /etc/issue ) ]; then 
+     main "$1" "$2"
+   else
+     echo 'Currently, only Debian-based distributions are supported'
+     echo 'Others are planned to be supported in the future.'
+     exit -1
+   fi
+
+   rm -f "$lockfile"
+   trap - INT TERM EXIT
+else
+   echo "Failed to acquire lockfile: $lockfile." 
+   echo "Held by $(cat $lockfile)"
+fi

--- a/bin/setup-environment.sh
+++ b/bin/setup-environment.sh
@@ -10,13 +10,6 @@ set -euo pipefail
 IFS=$'\n\t'
 REQUIRED_ARGS=2
 
-if [ "$( whoami )" == 'root' ]
-then
-  echo 'Do not run this script as root.'
-  echo 'Please run it as your webserver user.'
-  exit -1
-fi;
-
 ## ---------------------------------------------------- ##
 ## Variables
 ## ---------------------------------------------------- ##

--- a/bin/setup-environment.sh
+++ b/bin/setup-environment.sh
@@ -51,18 +51,7 @@ function install_required_packages()
   sudo apt-get -y -q update
 
   # Auto-install the required dependencies with a minimum of output
-  sudo apt-get install -y -q wget make npm nodejs unzip git
-}
-
-function fix_nodejs_binary()
-{
-  nodejs=$( which nodejs )
-
-  if [ -z "$( which node )" ]; then
-    echo 'Node is installed, but not correctly set in the system path.'
-    echo 'Linking ' "$nodejs" ' to /usr/bin/node'
-    sudo ln -s "$nodejs" /usr/bin/node
-  fi
+  sudo apt-get install -y -q wget make npm nodejs nodejs-legacy unzip git
 }
 
 function main()
@@ -89,7 +78,6 @@ function main()
   echo 'Preparing ownCloud development environment'
 
   install_required_packages
-  fix_nodejs_binary
 
   # Install the required third-party packages
   make

--- a/bin/setup-environment.sh
+++ b/bin/setup-environment.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 ## 
-## Usage: setup-environment.sh 
+## Usage: setup-environment.sh <webserver user> <owncloud install dir>
 ##
 ## This script will setup an ownCloud development environment on a Debian-Linux
 ## distribution. 

--- a/bin/setup-environment.sh
+++ b/bin/setup-environment.sh
@@ -40,38 +40,52 @@ function check_permissions()
 
 function which_distro()
 {
-  case "$( grep -Eoi 'Debian|SUSE|Ubuntu' /etc/issue )" in 
-    "SUSE") 
-      echo "SUSE"
-      ;;
-    "Ubuntu") 
-      echo "Ubuntu"
-      ;;
-  esac
+  echo $( grep '^ID=' /etc/os-release ) | awk '{split($0,array,"=")} END { print array[2] }'
+}
 
-  redhat_release_file=/etc/redhat-release
-
-  # Need to do a bit more work to detect RedHat-based distributions
-  if [ -e "$redhat_release_file" ]; then
-    case "$( grep -Eoi 'CentOS' $redhat_release_file )" in 
-      "CentOS") 
-        echo "CentOS"
-        ;;
-    esac
-  fi
+function distro_version()
+{
+  echo $( grep '^VERSION_ID=' /etc/os-release ) | awk '{split($0,array,"=")} END { print array[2] }' | tr -d '""'
 }
 
 function install_required_packages()
 {
+  version=$( distro_version )
+
   case "$( which_distro )" in 
-    "SUSE") echo "Installing required packages on SUSE"
-      install_required_suse_packages
+    "sles") 
+      if [ "$version" == "12" ] || [ "$version" == "12 SP1" ]; then
+        echo "Installing required packages on SUSE Linux Enterprise Server $version"
+        install_required_suse_packages
+      else
+        echo "Only version 12 & 12 SP1 of SUSE Linux Enterprise Server are supported."
+      fi;
       ;;
-    "Ubuntu"|"Debian") echo "Installing required packages on Ubuntu/Debian"
-      install_required_ubuntu_debian_packages
+    "debian") 
+      if [ "$version" == 7 ] || [ "$version" == 8 ]; then
+        echo "Installing required packages on Debian $version"
+        install_required_ubuntu_debian_packages
+      else
+        echo "Sorry, but Debian $version is not supported."
+        echo "Only versions 7 & 8 of Debian are supported."
+      fi;
       ;;
-    "CentOS") echo "Installing required packages on Centos"
-      install_required_centos_packages
+    "ubuntu") 
+      if [ "$version" == "14.04" ] || [ "$version" == "16.04" ]; then
+        echo "Installing required packages on Ubuntu $version"
+        install_required_ubuntu_debian_packages
+      else
+        echo "Sorry, but Ubuntu $version is not supported."
+        echo "Only versions 14.04 & 16.04 of Ubuntu are supported."
+      fi;
+      ;;
+    "centos") 
+      if [ "$version" == "6.5" ] || [ "$version" == "7" ]; then
+        echo "Installing required packages on CentOS $version"
+        install_required_centos_packages
+      else
+        echo "Only versions 6.5 and 7 of CentOS are supported."
+      fi;
       ;;
   esac
 }


### PR DESCRIPTION
This PR creates a script for automating the setup of ownCloud, right up to the point of either using the installation wizard or command line installer. It:

- Installs `wget`, `make`, `npm`, `nodejs`, `unzip`, & `git`
- Ensures nodejs is available in the user path, fixing it if necessary
- Runs `make` to install the PHP and JS dependencies

It's not, currently, special. But it's a good start. It was written after going through [the development environment setup documentation](https://doc.owncloud.com/server/latest/developer_manual/general/devenv.html) and seeing that there was both incorrect and missing information — and that a script might just save users a lot of time.

### Supports

- **Debian/Ubuntu:** 16.04
- **openSUSE Leap:** 42.3
- **CentOS:** 7

All constructive feedback welcome.

### Assumptions

- Apache (or another web server) are already installed

