### PR TITLE
Use new DAV endpoint in web UI

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1694,7 +1694,8 @@
 					encodedPath += '/' + encodeURIComponent(section);
 				}
 			});
-			return OC.linkToRemoteBase('webdav') + encodedPath;
+			var uid = encodeURIComponent(OC.getCurrentUser().uid);
+			return OC.linkToRemoteBase('dav') + '/files/' + uid + encodedPath;
 		},
 
 		/**

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -1630,6 +1630,29 @@ describe('OCA.Files.FileList tests', function() {
 				.toEqual(OC.webroot + '/index.php/apps/files/ajax/test.php?a=1&b=x%20y');
 		});
 	});
+	describe('Upload Url', function() {
+		var testPath;
+		beforeEach(function() {
+			currentUserStub = sinon.stub(OC, 'getCurrentUser').returns({uid: 'test@#?%test'});
+			testPath = 'path/to sp@ce/a@b#?%/x';
+		});
+		afterEach(function() {
+			currentUserStub.restore();
+		});
+		it('returns correct upload URL for single files with provided dir', function() {
+			expect(fileList.getUploadUrl('some file.txt', testPath))
+				.toEqual(OC.webroot + '/remote.php/dav/files/test%40%23%3F%25test/path/to%20sp%40ce/a%40b%23%3F%25/x/some%20file.txt');
+		});
+		it('returns correct upload URL with current list dir for single files when no dir argument was provided', function() {
+			expect(fileList.getUploadUrl('some file.txt'))
+				.toEqual(OC.webroot + '/remote.php/dav/files/test%40%23%3F%25test/subdir/some%20file.txt');
+		});
+		it('returns correct upload URL with current list dir when in root for single files when no dir argument was provided', function() {
+			$('#dir').val('/');
+			expect(fileList.getUploadUrl('some file.txt'))
+				.toEqual(OC.webroot + '/remote.php/dav/files/test%40%23%3F%25test/some%20file.txt');
+		});
+	});
 	describe('File selection', function() {
 		beforeEach(function() {
 			fileList.setFiles(testFiles);

--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -897,7 +897,7 @@
 
 		var client = new OC.Files.Client({
 			host: OC.getHost(),
-			root: OC.linkToRemoteBase('webdav'),
+			root: OC.linkToRemoteBase('dav') + '/files/' + encodeURIComponent(OC.getCurrentUser().uid) + '/',
 			useHTTPS: OC.getProtocol() === 'https'
 		});
 		OC.Files._defaultClient = client;

--- a/core/js/tests/specs/files/clientSpec.js
+++ b/core/js/tests/specs/files/clientSpec.js
@@ -904,7 +904,7 @@ describe('OC.Files.Client tests', function() {
 
 			expect(propFindStub.calledOnce).toEqual(true);
 			expect(propFindStub.getCall(0).args[0])
-				.toEqual('https://somehost:8080/owncloud/remote.php/webdav/path/to%20sp%40ce/a%40b%23%3F%25/x');
+				.toEqual('https://somehost:8080/owncloud/remote.php/dav/files/test%40%23%3F%25test/path/to%20sp%40ce/a%40b%23%3F%25/x');
 		});
 	});
 });


### PR DESCRIPTION
## Description
Use new DAV endpoint for everything, including single file uploads

- [x] ⚠️ requires https://github.com/owncloud/core/pull/28853 to avoid performance refressions and regressions related to locking and external storage ⚠️ 

## Related Issue
None.
Also see https://github.com/owncloud/core/pull/25494

## Motivation and Context
Same as https://github.com/owncloud/core/pull/25494

## How Has This Been Tested?
- [x] TEST: upload single file into current view
- [x] TEST: upload a file as a user "test@test" to confirm encoding works for the full DAV path
- [ ] TEST: make sure these https://github.com/owncloud/core/issues/28779 steps work correctly

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Not sure if we want this right now, I'm thinking of reverting new dav for 10.0.3 due to https://github.com/owncloud/core/issues/28779.

Setting to "planned" to have a look later.