### PR TITLE
[stable10] Make occ upgrade verbose by default

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -84,6 +84,11 @@ class Upgrade extends Command {
 	 * @param OutputInterface $output output interface
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		if ($output->getVerbosity() === OutputInterface::VERBOSITY_NORMAL
+			&& !$input->hasParameterOption('--verbose=0', true)) {
+			// set to more verbose on upgrade if no explicit verbosity was set
+			$output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
+		}
 
 		if(\OC::checkUpgrade(false)) {
 			if (OutputInterface::VERBOSITY_NORMAL < $output->getVerbosity()) {


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/28813 to stable10