### PR TITLE
[stable10] Missing oc_authtoken (session) for native clients

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -133,24 +133,24 @@ class OC_App {
 		// once all authentication apps are loaded we can validate the session
 		if (is_null($types) || in_array('authentication', $types)) {
 			if (\OC::$server->getUserSession()) {
+				$request = \OC::$server->getRequest();
+				$session = \OC::$server->getUserSession();
 				$davUser = \OC::$server->getUserSession()->getSession()->get(\OCA\DAV\Connector\Sabre\Auth::DAV_AUTHENTICATED);
 				if (is_null($davUser)) {
-					\OC::$server->getUserSession()->validateSession();
+					$session->validateSession();
 				} else {
-					$request = \OC::$server->getRequest();
-					$userSession = \OC::$server->getUserSession();
 					/** @var \OC\Authentication\Token\DefaultTokenProvider $tokenProvider */
 					$tokenProvider = \OC::$server->query('\OC\Authentication\Token\DefaultTokenProvider');
 					$token = null;
 					try {
-						$token = $tokenProvider->getToken($userSession->getSession()->getId());
+						$token = $tokenProvider->getToken($session->getSession()->getId());
 					} catch (\Exception $ex) {
 						$password = null;
 						if (isset($_SERVER['PHP_AUTH_PW'])) {
 							$password = $_SERVER['PHP_AUTH_PW'];
 						}
 
-						$userSession->createSessionToken($request, $userSession->getUser()->getUID(), $userSession->getLoginName(), $password);
+						$session->createSessionToken($request, $session->getUser()->getUID(), $session->getLoginName(), $password);
 					}
 
 					if ($token) {

--- a/settings/Controller/AuthSettingsController.php
+++ b/settings/Controller/AuthSettingsController.php
@@ -168,7 +168,15 @@ class AuthSettingsController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function destroy($id) {
+
 		$user = $this->userManager->get($this->uid);
+		$currentToken = $this->tokenProvider->getToken($this->session->getId());
+
+		if ($currentToken && ($currentToken->getId() === intval($id))) {
+			return (new JSONResponse())->setStatus(Http::STATUS_CONFLICT);
+		}
+
+
 		if (is_null($user)) {
 			return [];
 		}


### PR DESCRIPTION
## Description
oc_authtoken was not created for clients which use basic auth. (Probably everything, except browser and some dav-clients)

## Related Issue
fixes #27845
fixes #28553 
fixes #28881 

## Motivation and Context
This  bug was introduced with commit f1dc2d9 - "Validate session only if we are not in a basic auth request". 

Looking at the commit message the intent is not quite clear to me because the dektop client and all the mobile clients use basic auth at the moment. As the issue is relatively old I assume that some technical circumstances changed or that the validateSesion method is badly named because basic auth is technically not a persistent session trough requests. With this assumption the intent of the commit makes sense.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

