### PR TITLE
ocPath and app enable disable refactoring

### DIFF
--- a/tests/TestHelpers/LoggingHelper.php
+++ b/tests/TestHelpers/LoggingHelper.php
@@ -31,12 +31,11 @@ class LoggingHelper {
 	/**
 	 * returns the log file path
 	 * 
-	 * @param string $ocPath
 	 * @throws \Exception
 	 * @return string
 	 */
-	public static function getLogFilePath($ocPath) {
-		$result = SetupHelper::runOcc(['log:owncloud'], $ocPath);
+	public static function getLogFilePath() {
+		$result = SetupHelper::runOcc(['log:owncloud']);
 		if ($result["code"] != 0) {
 			throw new \Exception(
 				"could not get owncloud log file information" .
@@ -55,16 +54,15 @@ class LoggingHelper {
 		}
 		return $matches[2];
 	}
-	
+
 	/**
 	 * returns the currently set log level [debug, info, warning, error, fatal]
-	 * 
-	 * @param string $ocPath
+	 *
 	 * @throws \Exception
 	 * @return string
 	 */
-	public static function getLogLevel($ocPath) {
-		$result = SetupHelper::runOcc(["log:manage"], $ocPath);
+	public static function getLogLevel() {
+		$result = SetupHelper::runOcc(["log:manage"]);
 		if ($result["code"] != 0) {
 			throw new \Exception(
 				"could not get log level " . $result ["stdOut"] . " " .
@@ -79,17 +77,16 @@ class LoggingHelper {
 
 	/**
 	 * 
-	 * @param string $ocPath
 	 * @param string $logLevel (debug|info|warning|error|fatal)
 	 * @return void
 	 * @throws \InvalidArgumentException
 	 * @throws \Exception
 	 */
-	public static function setLogLevel($ocPath, $logLevel) {
+	public static function setLogLevel($logLevel) {
 		if (!in_array($logLevel, ["debug", "info", "warning", "error", "fatal"])) {
 			throw new \InvalidArgumentException("invalid log level");
 		}
-		$result = SetupHelper::runOcc(["log:manage", "--level=$logLevel"], $ocPath);
+		$result = SetupHelper::runOcc(["log:manage", "--level=$logLevel"]);
 		if ($result["code"] != 0) {
 			throw new \Exception(
 				"could not set log level " . $result ["stdOut"] . " " .
@@ -100,13 +97,12 @@ class LoggingHelper {
 
 	/**
 	 * returns the currently set logging backend (owncloud|syslog|errorlog)
-	 * 
-	 * @param string $ocPath
+	 *
 	 * @throws \Exception
 	 * @return string
 	 */
-	public static function getLogBackend($ocPath) {
-		$result = SetupHelper::runOcc(["log:manage"], $ocPath);
+	public static function getLogBackend() {
+		$result = SetupHelper::runOcc(["log:manage"]);
 		if ($result["code"] != 0) {
 			throw new \Exception(
 				"could not get log backend " . $result ["stdOut"] . " " .
@@ -125,17 +121,16 @@ class LoggingHelper {
 
 	/**
 	 * 
-	 * @param string $ocPath
 	 * @param string $backend (owncloud|syslog|errorlog)
 	 * @return void
 	 * @throws \InvalidArgumentException
 	 * @throws \Exception
 	 */
-	public static function setLogBackend($ocPath, $backend) {
+	public static function setLogBackend($backend) {
 		if (!in_array($backend, ["owncloud", "syslog", "errorlog"])) {
 			throw new \InvalidArgumentException("invalid log backend");
 		}
-		$result = SetupHelper::runOcc(["log:manage", "--backend=$backend"], $ocPath);
+		$result = SetupHelper::runOcc(["log:manage", "--backend=$backend"]);
 		if ($result["code"] != 0) {
 			throw new \Exception(
 				"could not set log backend " . $result ["stdOut"] . " " .
@@ -146,13 +141,12 @@ class LoggingHelper {
 
 	/**
 	 * returns the currently set logging timezone
-	 * 
-	 * @param string $ocPath
+	 *
 	 * @throws \Exception
 	 * @return string
 	 */
-	public static function getLogTimezone($ocPath) {
-		$result = SetupHelper::runOcc(["log:manage"], $ocPath);
+	public static function getLogTimezone() {
+		$result = SetupHelper::runOcc(["log:manage"]);
 		if ($result["code"] != 0) {
 			throw new \Exception(
 				"could not get log timezone " . $result ["stdOut"] . " " .
@@ -169,16 +163,13 @@ class LoggingHelper {
 	}
 
 	/**
-	 * 
-	 * @param string $ocPath
+	 *
 	 * @param string $timezone
 	 * @return void
 	 * @throws \Exception
 	 */
-	public static function setLogTimezone($ocPath, $timezone) {
-		$result = SetupHelper::runOcc(
-			["log:manage", "--timezone=$timezone"], $ocPath
-		);
+	public static function setLogTimezone($timezone) {
+		$result = SetupHelper::runOcc(["log:manage", "--timezone=$timezone"]);
 		if ($result["code"] != 0) {
 			throw new \Exception(
 				"could not set log timezone " . $result ["stdOut"] . " " .
@@ -189,12 +180,11 @@ class LoggingHelper {
 
 	/**
 	 * 
-	 * @param string $ocPath
 	 * @return void
 	 * @throws \Exception
 	 */
-	public static function clearLogFile($ocPath) {
-		$fp = fopen(self::getLogFilePath($ocPath), 'w');
+	public static function clearLogFile() {
+		$fp = fopen(self::getLogFilePath(), 'w');
 		if ($fp === false) {
 			throw new \Exception("could not clear the log file");
 		}

--- a/tests/TestHelpers/LoggingHelper.php
+++ b/tests/TestHelpers/LoggingHelper.php
@@ -2,8 +2,8 @@
 /**
  * ownCloud
  *
- * @author Artur Neumann <info@jankaritech.com>
- * @copyright 2017 Artur Neumann info@jankaritech.com
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright 2017 Artur Neumann artur@jankaritech.com
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -2,8 +2,8 @@
 /**
  * ownCloud
  *
- * @author Artur Neumann <info@jankaritech.com>
- * @copyright 2017 Artur Neumann info@jankaritech.com
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright 2017 Artur Neumann artur@jankaritech.com
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -1,24 +1,24 @@
 <?php
 /**
  * ownCloud
-*
-* @author Artur Neumann
-* @copyright 2017 Artur Neumann info@individual-it.net
-*
-* This library is free software; you can redistribute it and/or
-* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
-* License as published by the Free Software Foundation; either
-* version 3 of the License, or any later version.
-*
-* This library is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
-*
-* You should have received a copy of the GNU Affero General Public
-* License along with this library.  If not, see <http://www.gnu.org/licenses/>.
-*
-*/
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright 2017 Artur Neumann artur@individual-it.net
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
@@ -28,10 +28,10 @@ use TestHelpers\SetupHelper;
 require_once 'bootstrap.php';
 
 /**
- * Features context.
+ * BasicStructure trait
  */
-trait BasicStructure
-{
+trait BasicStructure {
+
 	private $adminPassword;
 	private $regularUserPassword;
 	private $regularUserName;
@@ -39,6 +39,7 @@ trait BasicStructure
 	/**
 	 * list of users that were created during test runs
 	 * key is the username value is an array of user attributes
+	 *
 	 * @var array
 	 */
 	private $createdUsers = array();
@@ -48,9 +49,9 @@ trait BasicStructure
 
 	/**
 	 * @Given I am logged in as admin
+	 * @return void
 	 */
-	public function iAmLoggedInAsAdmin()
-	{
+	public function iAmLoggedInAsAdmin() {
 		$this->loginPage->open();
 		$this->filesPage = $this->loginPage->loginAs("admin", "admin");
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
@@ -58,16 +59,20 @@ trait BasicStructure
 
 	/**
 	 * @Given I am logged in as a regular user
+	 * @return void
 	 */
-	public function iAmLoggedInAsARegularUser()
-	{
+	public function iAmLoggedInAsARegularUser() {
 		$this->loginPage->open();
-		$this->filesPage = $this->loginPage->loginAs($this->regularUserName, $this->regularUserPassword);
+		$this->filesPage = $this->loginPage->loginAs(
+			$this->regularUserName,
+			$this->regularUserPassword
+		);
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
 	}
 
 	/**
 	 * @When I logout
+	 * @return void
 	 */
 	public function iLogout() {
 		$settingsMenu = $this->owncloudPage->openSettingsMenu();
@@ -76,17 +81,17 @@ trait BasicStructure
 	
 	/**
 	 * @Given a regular user exists
+	 * @return void
 	 */
-	public function aRegularUserExists()
-	{
+	public function aRegularUserExists() {
 		$this->createUser($this->regularUserName, $this->regularUserPassword);
 	}
 
 	/**
 	 * @Given regular users exist
+	 * @return void
 	 */
-	public function regularUsersExist()
-	{
+	public function regularUsersExist() {
 		foreach ($this->regularUserNames as $user) {
 			$this->createUser($user, $this->regularUserPassword);
 		}
@@ -96,9 +101,10 @@ trait BasicStructure
 	 * @Given these users exist:
 	 * expects a table of users with the heading "|username|password|displayname|email|"
 	 * displayname & email are optional
+	 * @param TableNode $table
+	 * @return void
 	 */
-	public function theseUsersExist(TableNode $table)
-	{
+	public function theseUsersExist(TableNode $table) {
 		foreach ($table as $row) {
 			if (isset($row['displayname'])) {
 				$displayName = $row['displayname'];
@@ -118,10 +124,12 @@ trait BasicStructure
 	
 	/**
 	 * creates a single user
+	 *
 	 * @param string $user
 	 * @param string $password
 	 * @param string $displayName
 	 * @param string $email
+	 * @return void
 	 * @throws Exception
 	 */
 	private function createUser($user, $password,
@@ -133,7 +141,9 @@ trait BasicStructure
 			$user, $password, $displayName, $email
 		);
 		if ($result["code"] != 0) {
-			throw new Exception("could not create user. " . $result["stdOut"] . " " . $result["stdErr"]);
+			throw new Exception(
+				"could not create user. " . $result["stdOut"] . " " . $result["stdErr"]
+			);
 		}
 		$this->createdUsers [$user] = [ 
 				"password" => $password,
@@ -141,12 +151,14 @@ trait BasicStructure
 				"email" => $email
 		];
 	}
+
 	/**
 	 * @Given these groups exist:
 	 * expects a table of groups with the heading "groupname"
+	 * @param TableNode $table
+	 * @return void
 	 */
-	public function theseGroupsExist(TableNode $table)
-	{
+	public function theseGroupsExist(TableNode $table) {
 		foreach ($table as $row) {
 			$this->createGroup($row['groupname']);
 		}
@@ -154,17 +166,17 @@ trait BasicStructure
 	
 	/**
 	 * @Given a regular group exists
+	 * @return void
 	 */
-	public function aRegularGroupExists()
-	{
+	public function aRegularGroupExists() {
 		$this->createGroup($this->regularGroupName);
 	}
 
 	/**
 	 * @Given regular groups exist
+	 * @return void
 	 */
-	public function regularGroupsExist()
-	{
+	public function regularGroupsExist() {
 		foreach ($this->regularGroupNames as $group) {
 			$this->createGroup($group);
 		}
@@ -172,23 +184,27 @@ trait BasicStructure
 
 	/**
 	 * creates a single group
+	 *
 	 * @param string $group
+	 * @return void
 	 * @throws Exception
 	 */
-	private function createGroup($group)
-	{
+	private function createGroup($group) {
 		$group = trim($group);
 		$result = SetupHelper::createGroup($group);
 		if ($result["code"] != 0) {
-			throw new Exception("could not create group. " . $result["stdOut"] . " " . $result["stdErr"]);
+			throw new Exception(
+				"could not create group. "
+				. $result["stdOut"] . " " . $result["stdErr"]
+			);
 		}
 		array_push($this->createdGroupNames, $group);
 	}
 	/**
 	 * @Given a regular user is in a regular group
+	 * @return void
 	 */
-	public function aRegularUserIsInARegularGroup()
-	{
+	public function aRegularUserIsInARegularGroup() {
 		$group = $this->regularGroupName;
 		$user = $this->regularUserName;
 		if (!in_array($user, $this->getCreatedUserNames())) {
@@ -196,81 +212,122 @@ trait BasicStructure
 		}
 		$this->theUserIsInTheGroup($user, $group);
 	}
-	
+
 	/**
 	 * @Given the user :user is in the group :group
+	 * @param string $user
+	 * @param string $group
+	 * @return void
+	 * @throws Exception
 	 */
-	public function theUserIsInTheGroup($user, $group)
-	{
+	public function theUserIsInTheGroup($user, $group) {
 		$result = SetupHelper::addUserToGroup($group, $user);
 		if ($result["code"] != 0) {
-			throw new Exception("could not add user to group. " . $result["stdOut"] . " " . $result["stdErr"]);
+			throw new Exception(
+				"could not add user to group. "
+				. $result["stdOut"] . " " . $result["stdErr"]
+			);
 		}
 	}
 
-	/** @BeforeScenario */
-	public function setUpScenarioGetRegularUsersAndGroups(BeforeScenarioScope $scope)
-	{
+	/**
+	 * @param BeforeScenarioScope $scope
+	 * @return void
+	 * @BeforeScenario
+	 */
+	public function setUpScenarioGetRegularUsersAndGroups(
+		BeforeScenarioScope $scope
+	) {
 		SetupHelper::setOcPath($scope);
 		$suiteParameters = SetupHelper::getSuiteParameters($scope);
 		$this->adminPassword = (string)$suiteParameters['adminPassword'];
-		$this->regularUserNames = explode(",", $suiteParameters['regularUserNames']);
+		$this->regularUserNames = explode(
+			",",
+			$suiteParameters['regularUserNames']
+		);
 		$this->regularUserName = (string)$suiteParameters['regularUserName'];
 		$this->regularUserPassword = (string)$suiteParameters['regularUserPassword'];
-		$this->regularGroupNames = explode(",", $suiteParameters['regularGroupNames']);
+		$this->regularGroupNames = explode(
+			",",
+			$suiteParameters['regularGroupNames']
+		);
 		$this->regularGroupName = (string)$suiteParameters['regularGroupName'];
 	}
 
-	/** @AfterScenario */
-	public function tearDownScenarioDeleteCreatedUsersAndGroups(AfterScenarioScope $scope)
-	{
+	/**
+	 * @param AfterScenarioScope $scope
+	 * @return void
+	 * @throws Exception
+	 * @AfterScenario
+	 */
+	public function tearDownScenarioDeleteCreatedUsersAndGroups(AfterScenarioScope $scope) {
 		foreach ($this->getCreatedUserNames() as $user) {
 			$result = SetupHelper::deleteUser($user);
 			if ($result["code"] != 0) {
-				throw new Exception("could not delete user. " . $result["stdOut"] . " " . $result["stdErr"]);
+				throw new Exception(
+					"could not delete user. "
+					. $result["stdOut"] . " " . $result["stdErr"]
+				);
 			}
 		}
 
 		foreach ($this->getCreatedGroupNames() as $group) {
 			$result = SetupHelper::deleteGroup($group);
 			if ($result["code"] != 0) {
-				throw new Exception("could not delete group. " . $result["stdOut"] . " " . $result["stdErr"]);
+				throw new Exception(
+					"could not delete group. "
+					. $result["stdOut"] . " " . $result["stdErr"]
+				);
 			}
 		}
 	}
 
-	public function getRegularUserPassword()
-	{
+	/**
+	 * @return string
+	 */
+	public function getRegularUserPassword() {
 		return $this->regularUserPassword;
 	}
 
-	public function getRegularUserName()
-	{
+	/**
+	 * @return string
+	 */
+	public function getRegularUserName() {
 		return $this->regularUserName;
 	}
 
-	public function getRegularUserNames()
-	{
+	/**
+	 * @return array
+	 */
+	public function getRegularUserNames() {
 		return $this->regularUserNames;
 	}
 
-	public function getCreatedUserNames()
-	{
+	/**
+	 * @return array
+	 */
+	public function getCreatedUserNames() {
 		return array_keys($this->createdUsers);
 	}
 
-	public function getRegularGroupName()
-	{
+	/**
+	 * @return string
+	 */
+	public function getRegularGroupName() {
 		return $this->regularGroupName;
 	}
 
-	public function getRegularGroupNames()
-	{
+	/**
+	 * @return array
+	 */
+	public function getRegularGroupNames() {
 		return $this->regularGroupNames;
 	}
 
-	public function getCreatedGroupNames()
-	{
+	/**
+	 * @return array
+	 */
+	public function getCreatedGroupNames() {
 		return $this->createdGroupNames;
 	}
 
@@ -279,13 +336,14 @@ trait BasicStructure
 	 * @param string $username
 	 * @return string password
 	 */
-	public function getUserPassword($username)
-	{
+	public function getUserPassword($username) {
 		if ($username === 'admin') {
 			$password = $this->adminPassword;
 		} else {
 			if (!array_key_exists($username, $this->createdUsers)) {
-				throw new Exception("user '$username' was not created by this test run");
+				throw new Exception(
+					"user '$username' was not created by this test run"
+				);
 			}
 			$password = $this->createdUsers[$username]['password'];
 		}
@@ -295,12 +353,13 @@ trait BasicStructure
 
 	/**
 	 * substitutes codes like %base_url% with the value
-	 * if the given values does not have anything to be substituted its returned unmodified
+	 * if the given value does not have anything to be substituted
+	 * then it is returned unmodified
+	 *
 	 * @param string $value
 	 * @return string
 	 */
-	public function substituteInLineCodes($value)
-	{
+	public function substituteInLineCodes($value) {
 		$substitutions = [ 
 			[ 
 				"code" => "%base_url%",
@@ -324,7 +383,10 @@ trait BasicStructure
 		foreach ($substitutions as $substitution) {
 			$value = str_replace(
 				$substitution["code"],
-				call_user_func_array($substitution["function"], $substitution["parameter"]),
+				call_user_func_array(
+					$substitution["function"],
+					$substitution["parameter"]
+				),
 				$value
 			);
 		}

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -45,7 +45,6 @@ trait BasicStructure
 	private $regularGroupName;
 	private $regularGroupNames = array();
 	private $createdGroupNames = array();
-	private $ocPath;
 
 	/**
 	 * @Given I am logged in as admin
@@ -131,7 +130,7 @@ trait BasicStructure
 	) {
 		$user = trim($user);
 		$result = SetupHelper::createUser(
-			$this->ocPath, $user, $password, $displayName, $email
+			$user, $password, $displayName, $email
 		);
 		if ($result["code"] != 0) {
 			throw new Exception("could not create user. " . $result["stdOut"] . " " . $result["stdErr"]);
@@ -179,7 +178,7 @@ trait BasicStructure
 	private function createGroup($group)
 	{
 		$group = trim($group);
-		$result = SetupHelper::createGroup($this->ocPath, $group);
+		$result = SetupHelper::createGroup($group);
 		if ($result["code"] != 0) {
 			throw new Exception("could not create group. " . $result["stdOut"] . " " . $result["stdErr"]);
 		}
@@ -203,7 +202,7 @@ trait BasicStructure
 	 */
 	public function theUserIsInTheGroup($user, $group)
 	{
-		$result = SetupHelper::addUserToGroup($this->ocPath, $group, $user);
+		$result = SetupHelper::addUserToGroup($group, $user);
 		if ($result["code"] != 0) {
 			throw new Exception("could not add user to group. " . $result["stdOut"] . " " . $result["stdErr"]);
 		}
@@ -212,28 +211,28 @@ trait BasicStructure
 	/** @BeforeScenario */
 	public function setUpScenarioGetRegularUsersAndGroups(BeforeScenarioScope $scope)
 	{
-		$suiteParameters = $scope->getEnvironment()->getSuite()->getSettings() ['context'] ['parameters'];
+		SetupHelper::setOcPath($scope);
+		$suiteParameters = SetupHelper::getSuiteParameters($scope);
 		$this->adminPassword = (string)$suiteParameters['adminPassword'];
 		$this->regularUserNames = explode(",", $suiteParameters['regularUserNames']);
 		$this->regularUserName = (string)$suiteParameters['regularUserName'];
 		$this->regularUserPassword = (string)$suiteParameters['regularUserPassword'];
 		$this->regularGroupNames = explode(",", $suiteParameters['regularGroupNames']);
 		$this->regularGroupName = (string)$suiteParameters['regularGroupName'];
-		$this->ocPath = rtrim($suiteParameters['ocPath'], '/') . '/';
 	}
 
 	/** @AfterScenario */
 	public function tearDownScenarioDeleteCreatedUsersAndGroups(AfterScenarioScope $scope)
 	{
 		foreach ($this->getCreatedUserNames() as $user) {
-			$result = SetupHelper::deleteUser($this->ocPath, $user);
+			$result = SetupHelper::deleteUser($user);
 			if ($result["code"] != 0) {
 				throw new Exception("could not delete user. " . $result["stdOut"] . " " . $result["stdErr"]);
 			}
 		}
 
 		foreach ($this->getCreatedGroupNames() as $group) {
-			$result = SetupHelper::deleteGroup($this->ocPath, $group);
+			$result = SetupHelper::deleteGroup($group);
 			if ($result["code"] != 0) {
 				throw new Exception("could not delete group. " . $result["stdOut"] . " " . $result["stdErr"]);
 			}

--- a/tests/ui/features/bootstrap/Logging.php
+++ b/tests/ui/features/bootstrap/Logging.php
@@ -48,7 +48,7 @@ trait Logging
 		//-1 because getRows gives also the header
 		$linesToRead = count($expectedLogEntries->getRows()) - 1;
 		$logLines = LoggingHelper::tailFile(
-			LoggingHelper::getLogFilePath($this->ocPath),
+			LoggingHelper::getLogFilePath(),
 			$linesToRead
 		);
 		$lineNo = 0;
@@ -89,7 +89,7 @@ trait Logging
 	 */
 	public function theLogFileShouldNotContainAnyLogEntriesWithTheseAttributes(TableNode $logEntriesExpectedNotToExist)
 	{
-		$logLines = file(LoggingHelper::getLogFilePath($this->ocPath));
+		$logLines = file(LoggingHelper::getLogFilePath());
 		foreach ($logLines as $logLine) {
 			$logEntries = json_decode($logLine, true);
 			foreach ($logEntriesExpectedNotToExist as $logEntryExpectedNotToExist) {
@@ -123,7 +123,7 @@ trait Logging
 	 */
 	public function owncloudLogLevelIsSetTo($logLevel)
 	{
-		LoggingHelper::setLogLevel($this->ocPath, $logLevel);
+		LoggingHelper::setLogLevel($logLevel);
 	}
 
 	/**
@@ -133,7 +133,7 @@ trait Logging
 	 */
 	public function owncloudLogBackendIsSetTo($backend)
 	{
-		LoggingHelper::setLogBackend($this->ocPath, $backend);
+		LoggingHelper::setLogBackend($backend);
 	}
 
 	/**
@@ -143,7 +143,7 @@ trait Logging
 	 */
 	public function owncloudLogTimezoneIsSetTo($timezone)
 	{
-		LoggingHelper::setLogTimezone($this->ocPath, $timezone);
+		LoggingHelper::setLogTimezone($timezone);
 	}
 
 	/**
@@ -152,7 +152,7 @@ trait Logging
 	 */
 	public function theOwncloudLogIsCleared()
 	{
-		LoggingHelper::clearLogFile($this->ocPath);
+		LoggingHelper::clearLogFile();
 	}
 
 	/**
@@ -164,9 +164,9 @@ trait Logging
 	 */
 	public function setUpScenarioLogging(BeforeScenarioScope $scope)
 	{
-		$this->oldLogLevel = LoggingHelper::getLogLevel($this->ocPath);
-		$this->oldLogBackend = LoggingHelper::getLogBackend($this->ocPath);
-		$this->oldLogTimezone = LoggingHelper::getLogTimezone($this->ocPath);
+		$this->oldLogLevel = LoggingHelper::getLogLevel();
+		$this->oldLogBackend = LoggingHelper::getLogBackend();
+		$this->oldLogTimezone = LoggingHelper::getLogTimezone();
 	}
 
 	/**
@@ -179,19 +179,19 @@ trait Logging
 	public function tearDownScenarioLogging(AfterScenarioScope $scope)
 	{
 		if ($this->oldLogLevel !== null
-			&& $this->oldLogLevel !== LoggingHelper::getLogLevel($this->ocPath)
+			&& $this->oldLogLevel !== LoggingHelper::getLogLevel()
 		) {
-			LoggingHelper::setLogLevel($this->ocPath, $this->oldLogLevel);
+			LoggingHelper::setLogLevel($this->oldLogLevel);
 		}
 		if ($this->oldLogBackend !== null
-			&& $this->oldLogBackend !== LoggingHelper::getLogBackend($this->ocPath)
+			&& $this->oldLogBackend !== LoggingHelper::getLogBackend()
 		) {
-			LoggingHelper::setLogBackend($this->ocPath, $this->oldLogBackend);
+			LoggingHelper::setLogBackend($this->oldLogBackend);
 		}
 		if ($this->oldLogTimezone !== null
-			&& $this->oldLogTimezone !== LoggingHelper::getLogTimezone($this->ocPath)
+			&& $this->oldLogTimezone !== LoggingHelper::getLogTimezone()
 		) {
-			LoggingHelper::setLogTimezone($this->ocPath, $this->oldLogTimezone);
+			LoggingHelper::setLogTimezone($this->oldLogTimezone);
 		}
 	}
 }

--- a/tests/ui/features/bootstrap/Logging.php
+++ b/tests/ui/features/bootstrap/Logging.php
@@ -2,8 +2,8 @@
 /**
  * ownCloud
  *
- * @author Artur Neumann <info@jankaritech.com>
- * @copyright 2017 Artur Neumann info@jankaritech.com
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright 2017 Artur Neumann artur@jankaritech.com
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -24,8 +24,11 @@ use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 
-trait Logging
-{
+/**
+ * Logging trait
+ */
+trait Logging {
+
 	private $oldLogLevel = null;
 	private $oldLogBackend = null;
 	private $oldLogTimezone = null;
@@ -34,11 +37,11 @@ trait Logging
 	 * checks for specific rows in the log file.
 	 * order of the table has to be the same as in the log file
 	 * empty cells in the table will not be checked!
-	 * 
+	 *
 	 * @param TableNode $expectedLogEntries table with headings that correspond
-	 * to the json keys in the log entry
-	 * e.g.
-	 * |user|app|method|message|
+	 *                                      to the json keys in the log entry
+	 *                                      e.g.
+	 *                                      |user|app|method|message|
 	 * @Then the last lines of the log file should contain log-entries with these attributes:
 	 * @return void
 	 */
@@ -55,12 +58,13 @@ trait Logging
 		foreach ($expectedLogEntries as $expectedLogEntry) {
 			$logEntry = json_decode($logLines[$lineNo], true);
 			foreach (array_keys($expectedLogEntry) as $attribute) {
-				$expectedLogEntry [$attribute] = $this->featureContext->substituteInLineCodes(
-					$expectedLogEntry [$attribute]
-				);
+				$expectedLogEntry [$attribute]
+					= $this->featureContext->substituteInLineCodes(
+						$expectedLogEntry [$attribute]
+					);
 				PHPUnit_Framework_Assert::assertArrayHasKey(
 					$attribute, $logEntry,
-					"could not find attribute: '". $attribute .
+					"could not find attribute: '" . $attribute .
 					"' in log entry: '" . $logLines [$lineNo] . "'"
 				);
 				if ($expectedLogEntry [$attribute] !== "") {
@@ -80,15 +84,15 @@ trait Logging
 	 * attributes in the table that are empty will match any value in the 
 	 * corresponding attribute in the log file
 	 * 
-	 * @param TableNode $logEntriesExpectedNotToExist table with headings that correspond
-	 * to the json keys in the log entry
-	 * e.g.
-	 * |user|app|method|message|
+	 * @param TableNode $logEntriesExpectedNotToExist table with headings that
+	 *                                                correspond to the json
+	 *                                                keys in the log entry
+	 *                                                e.g.
+	 *                                                |user|app|method|message|
 	 * @Then the log file should not contain any log-entries with these attributes:
 	 * @return void
 	 */
-	public function theLogFileShouldNotContainAnyLogEntriesWithTheseAttributes(TableNode $logEntriesExpectedNotToExist)
-	{
+	public function theLogFileShouldNotContainAnyLogEntriesWithTheseAttributes(TableNode $logEntriesExpectedNotToExist) {
 		$logLines = file(LoggingHelper::getLogFilePath());
 		foreach ($logLines as $logLine) {
 			$logEntries = json_decode($logLine, true);
@@ -121,8 +125,7 @@ trait Logging
 	 * @Given owncloud log level is set to :logLevel
 	 * @return void
 	 */
-	public function owncloudLogLevelIsSetTo($logLevel)
-	{
+	public function owncloudLogLevelIsSetTo($logLevel) {
 		LoggingHelper::setLogLevel($logLevel);
 	}
 
@@ -131,8 +134,7 @@ trait Logging
 	 * @Given owncloud log backend is set to :backend
 	 * @return void
 	 */
-	public function owncloudLogBackendIsSetTo($backend)
-	{
+	public function owncloudLogBackendIsSetTo($backend) {
 		LoggingHelper::setLogBackend($backend);
 	}
 
@@ -141,8 +143,7 @@ trait Logging
 	 * @Given owncloud log timezone is set to :timezone
 	 * @return void
 	 */
-	public function owncloudLogTimezoneIsSetTo($timezone)
-	{
+	public function owncloudLogTimezoneIsSetTo($timezone) {
 		LoggingHelper::setLogTimezone($timezone);
 	}
 
@@ -150,8 +151,7 @@ trait Logging
 	 * @Given the owncloud log is cleared
 	 * @return void
 	 */
-	public function theOwncloudLogIsCleared()
-	{
+	public function theOwncloudLogIsCleared() {
 		LoggingHelper::clearLogFile();
 	}
 
@@ -162,8 +162,7 @@ trait Logging
 	 * @BeforeScenario
 	 * @return void
 	 */
-	public function setUpScenarioLogging(BeforeScenarioScope $scope)
-	{
+	public function setUpScenarioLogging(BeforeScenarioScope $scope) {
 		$this->oldLogLevel = LoggingHelper::getLogLevel();
 		$this->oldLogBackend = LoggingHelper::getLogBackend();
 		$this->oldLogTimezone = LoggingHelper::getLogTimezone();
@@ -176,8 +175,7 @@ trait Logging
 	 * @AfterScenario
 	 * @return void
 	 */
-	public function tearDownScenarioLogging(AfterScenarioScope $scope)
-	{
+	public function tearDownScenarioLogging(AfterScenarioScope $scope) {
 		if ($this->oldLogLevel !== null
 			&& $this->oldLogLevel !== LoggingHelper::getLogLevel()
 		) {


### PR DESCRIPTION
## Description
1) Moved the "memory" of $ocPath (that is delivered in $scope) down into SetupHelper.
2) Make setOcPath() to be able to set it just once - that is effectively a "constructor" for the SetupHelper class (which does not have a real constructor because it is just a bunch of static utility functions and thus never gets instantiated)
3) Call setOcPath() in the BeforeScenario so that SetupHelper knows it "up front".
4) Remove the need to pass around $ocPath in loads of places.
5) Refactor until the IDE told me it was happy and the tests pass!

## Related Issue

## Motivation and Context
Started out making enableApp() and disableApp() be able to be more easily called so that there would not be so much boiler-plate code in the UI tests BeforeScenario in each set of app tests, reducing duplication. I first changed those to take $scope as parameter and work out $ocPath internally.

Then as the consequences rolled on, more refactoring because there were more places that then needed similar treatment.

This makes it simpler to use various SetupHelper functions from within app UI test suites (and also from core).

## How Has This Been Tested?
Full runs of core, files_texteditor and firewall tests using this as a base.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

