### PR TITLE
Check for null when traversing app passwords table rows

### DIFF
--- a/tests/ui/features/lib/PersonalSecuritySettingsPage.php
+++ b/tests/ui/features/lib/PersonalSecuritySettingsPage.php
@@ -72,7 +72,7 @@ class PersonalSecuritySettingsPage extends OwncloudPage
 		$appTrs = $this->findAll("xpath", $this->linkedAppsTrXpath);
 		foreach ($appTrs as $appTr) {
 			$app = $appTr->find("xpath", $this->linkedAppNameXpath);
-			if ($app->getText() === $appName) {
+			if (!is_null($app) && ($app->getText() === $appName)) {
 				return $appTr;
 			}
 		}


### PR DESCRIPTION
## Description
When traversing each UI row of the table of app passwords, ignore rows that do not have the ``class="token-name"`` 
We just care about checking rows that do have that class in them somewhere, and finding one that has the matching ``appName``.

## Related Issue
#28889 

## Motivation and Context
"random" test fails are not good

## How Has This Been Tested?
Run the UI test over and over a dozen or more times in a dev VM.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

