### PR TITLE
testMicrosecondsLogTimestamp is always a 6-digit string

### DIFF
--- a/tests/lib/Log/OwncloudTest.php
+++ b/tests/lib/Log/OwncloudTest.php
@@ -72,7 +72,7 @@ class OwncloudTest extends TestCase
 		# check timestamp has microseconds part
 		$values = (array) json_decode($line);
 		$microseconds = $values['time'];
-		$this->assertNotEquals(0, $microseconds);
+		$this->assertRegExp('/^\d{6}$/', $microseconds);
 		
 	}
 


### PR DESCRIPTION
## Description
Check that the microseconds in the log file entry is a 6-digit string.

## Related Issue
#28891 

## Motivation and Context
It is annoying to have a 1 in a million chance (actually I think 1 in a 1000 or 1 in 100 depending on the time resolution that the underlying OS actually bothers with) chance for testMicrosecondsLogTimestamp to fail.

## How Has This Been Tested?
Run the change in a dev environment, check that it passes a lot when checking for a 6-digit string.
Verify that it would fail if the check is changed to a 5 or 7-digit string.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

