### PR TITLE
[stable10] testMicrosecondsLogTimestamp is always a 6-digit string

### DIFF
--- a/tests/lib/Log/OwncloudTest.php
+++ b/tests/lib/Log/OwncloudTest.php
@@ -72,7 +72,7 @@ class OwncloudTest extends TestCase
 		# check timestamp has microseconds part
 		$values = (array) json_decode($line);
 		$microseconds = $values['time'];
-		$this->assertNotEquals(0, $microseconds);
+		$this->assertRegExp('/^\d{6}$/', $microseconds);
 		
 	}
 


### PR DESCRIPTION
Backport #28892 