### PR TITLE
Use regularuser for quota UI tests

### DIFF
--- a/tests/ui/features/bootstrap/UsersContext.php
+++ b/tests/ui/features/bootstrap/UsersContext.php
@@ -21,6 +21,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Behat\Mink\Exception\ExpectationException;
 
@@ -35,6 +36,7 @@ class UsersContext extends RawMinkContext implements Context {
 
 
 	private $usersPage;
+	private $featureContext;
 
 	/**
 	 * UsersContext constructor.
@@ -43,6 +45,17 @@ class UsersContext extends RawMinkContext implements Context {
 	 */
 	public function __construct(UsersPage $usersPage) {
 		$this->usersPage = $usersPage;
+	}
+
+	/**
+	 * substitute codes like "%regularuser%" with the actual name of the user
+	 *
+	 * @param string $username
+	 * @return string
+	 * @Transform :username
+	 */
+	public function checkUsername($username) {
+		return $this->featureContext->substituteInLineCodes($username);
 	}
 
 	/**
@@ -93,5 +106,19 @@ class UsersContext extends RawMinkContext implements Context {
 				$quota . '"', $this->getSession()
 			);
 		}
+	}
+
+	/**
+	 * This will run before EVERY scenario.
+	 *
+	 * @param BeforeScenarioScope $scope
+	 * @return void
+	 * @BeforeScenario
+	 */
+	public function before(BeforeScenarioScope $scope) {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->featureContext = $environment->getContext('FeatureContext');
 	}
 }

--- a/tests/ui/features/other/users.feature
+++ b/tests/ui/features/other/users.feature
@@ -1,11 +1,14 @@
 Feature: users
 
+	Background:
+		Given a regular user exists
+		And I am logged in as admin
+
 	Scenario Outline: change quota to a valid value
-		Given I am logged in as admin
-		And quota of user "admin" is set to "<start_quota>"
-		When quota of user "admin" is changed to "<wished_quota>"
+		And quota of user "%regularuser%" is set to "<start_quota>"
+		When quota of user "%regularuser%" is changed to "<wished_quota>"
 		And the users page is reloaded
-		Then quota of user "admin" should be set to "<expected_quota>"
+		Then quota of user "%regularuser%" should be set to "<expected_quota>"
 
 		Examples:
 		|start_quota|wished_quota|expected_quota|
@@ -19,10 +22,9 @@ Feature: users
 		|Unlimited  |45Kb        |45 KB         |
 
 	Scenario Outline: change quota to an invalid value
-		Given I am logged in as admin
-		When quota of user "admin" is changed to "<wished_quota>"
+		When quota of user "%regularuser%" is changed to "<wished_quota>"
 		Then a notification should be displayed with the text 'Invalid quota value "<wished_quota>"'
-		Then quota of user "admin" should be set to "Default"
+		Then quota of user "%regularuser%" should be set to "Default"
 
 		Examples:
 		|wished_quota|


### PR DESCRIPTION
## Description
Change the quota of a regular user for the quota tests, rather than changing the admin account.

## Related Issue
#28904 

## Motivation and Context
Cleaner test environment.

## How Has This Been Tested?
Run quota UI tests in a dev environment, verify that the admin quota is still "Unlimited" after the test run.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

