### PR TITLE
IRouter is deprecated, deprecate it in the server container?

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1191,6 +1191,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 	 * Returns a router for generating and matching urls
 	 *
 	 * @return \OCP\Route\IRouter
+	 * @since 7.0.0
+	 * @deprecated 9.0.0
 	 */
 	public function getRouter() {
 		return $this->query('Router');


### PR DESCRIPTION
The IRouter interface was deprecated two years ago with  https://github.com/owncloud/core/commit/34c8249799c2fc89af021a085f4b15c3156d1b11 in https://github.com/owncloud/core/pull/21032

But we use it happily in core to match the url and hand over execution to the responsible controller in base.php

Why? What should app developers use instead? What should we use in core instead?

- [ ] add the answer to PHPDoc