### PR TITLE
Handle no user session in isSharingDisabledForUser()

### DIFF
--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -87,21 +87,21 @@ class ViewControllerTest extends TestCase {
 		$this->rootFolder = $this->createMock('\OCP\Files\Folder');
 		$this->viewController = $this->getMockBuilder('\OCA\Files\Controller\ViewController')
 			->setConstructorArgs([
-			'files',
-			$this->request,
-			$this->urlGenerator,
-			$this->l10n,
-			$this->config,
-			$this->eventDispatcher,
-			$this->userSession,
-			$this->appManager,
-			$this->rootFolder
-		])
-		->setMethods([
-			'getStorageInfo',
-			'renderScript'
-		])
-		->getMock();
+				'files',
+				$this->request,
+				$this->urlGenerator,
+				$this->l10n,
+				$this->config,
+				$this->eventDispatcher,
+				$this->userSession,
+				$this->appManager,
+				$this->rootFolder
+			])
+			->setMethods([
+				'getStorageInfo',
+				'renderScript'
+			])
+			->getMock();
 	}
 
 	public function testIndexWithIE8RedirectAndDirDefined() {
@@ -200,7 +200,7 @@ class ViewControllerTest extends TestCase {
 				'icon' => '',
 			],
 			[
-			'id' => 'sharingin',
+				'id' => 'sharingin',
 				'appname' => 'files_sharing',
 				'script' => 'list.php',
 				'order' => 10,
@@ -209,7 +209,7 @@ class ViewControllerTest extends TestCase {
 				'icon' => '',
 			],
 			[
-			'id' => 'sharingout',
+				'id' => 'sharingout',
 				'appname' => 'files_sharing',
 				'script' => 'list.php',
 				'order' => 15,

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -188,6 +188,8 @@ class Util {
 			if ($user !== null) {
 				$user = $user->getUID();
 			}
+		} else {
+			$user = null;
 		}
 
 		return self::$shareManager->sharingDisabledForUser($user);


### PR DESCRIPTION
## Description
If isSharingDisabledForUser() is called when there is no user context, then set user to null.

## Related Issue

## Motivation and Context
In the log of Travis output, I noticed:
```
owncloud.log:
{"reqId":"pqAijCPvaiHvZolHHCdO","level":3,"time":"2017-09-05T08:06:49+00:00","remoteAddr":"","user":"--","app":"PHP","method":"--","url":"--","message":"Undefined variable: user at \/home\/travis\/build\/[secure]\/core\/lib\/public\/Util.php#193"}
```

It is nice to get rid of undefined variable messages.

## How Has This Been Tested?
Try logging in and creating files... as a user with this code in place. See that it does not explode.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

