### PR TITLE
Web UI goes back to old DAV endpoint

### DIFF
--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -867,7 +867,7 @@
 
 		var client = new OC.Files.Client({
 			host: OC.getHost(),
-			root: OC.linkToRemoteBase('dav') + '/files/' + encodeURIComponent(OC.getCurrentUser().uid) + '/',
+			root: OC.linkToRemoteBase('webdav'),
 			useHTTPS: OC.getProtocol() === 'https'
 		});
 		OC.Files._defaultClient = client;

--- a/core/js/tests/specs/files/clientSpec.js
+++ b/core/js/tests/specs/files/clientSpec.js
@@ -904,7 +904,7 @@ describe('OC.Files.Client tests', function() {
 
 			expect(propFindStub.calledOnce).toEqual(true);
 			expect(propFindStub.getCall(0).args[0])
-				.toEqual('https://somehost:8080/owncloud/remote.php/dav/files/test%40%23%3F%25test/path/to%20sp%40ce/a%40b%23%3F%25/x');
+				.toEqual('https://somehost:8080/owncloud/remote.php/webdav/path/to%20sp%40ce/a%40b%23%3F%25/x');
 		});
 	});
 });


### PR DESCRIPTION
## Description
Workaround for https://github.com/owncloud/core/issues/28779 as the new DAV endpoint still has issues.

## Related Issue
Ref https://github.com/owncloud/core/issues/28779

## Motivation and Context
This is to prevent the regression in the next release.
We need to continue working on a fix for new DAV: https://github.com/owncloud/core/pull/28853.

## How Has This Been Tested?
Test steps in  https://github.com/owncloud/core/issues/28779.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

