### PR TITLE
[WIP] scroll element into view in findFileRowByName

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,22 +126,19 @@ matrix:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - if: type = cron
-      php: 5.6
+    - php: 5.6
       env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="other" PLATFORM="Windows 7" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - if: type = cron
-      php: 5.6
+    - php: 5.6
       env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="files" PLATFORM="Windows 7" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - if: type = cron
-      php: 5.6
+    - php: 5.6
       env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="trashbin" PLATFORM="Windows 7" TEST_DAV=0
       addons:
         apt: *common_apt

--- a/tests/ui/features/files/renameFiles.feature
+++ b/tests/ui/features/files/renameFiles.feature
@@ -44,16 +44,16 @@ Feature: renameFiles
 		When I rename the file "lorem.txt" to " space at start"
 		And the files page is reloaded
 		Then the file " space at start" should be listed
-		When I rename the file " space at start" to "space at end "
+		When I rename the file " space at start" to "fspace at end "
 		And the files page is reloaded
-		Then the file "space at end " should be listed
-		When I rename the file "space at end " to "space at end .txt"
+		Then the file "fspace at end " should be listed
+		When I rename the file "fspace at end " to "zspace at end .txt"
 		And the files page is reloaded
-		Then the file "space at end .txt" should be listed
-		When I rename the file "space at end .txt" to "space at end. lis"
+		Then the file "zspace at end .txt" should be listed
+		When I rename the file "zspace at end .txt" to "aspace at end. lis"
 		And the files page is reloaded
-		Then the file "space at end. lis" should be listed
-		When I rename the file "space at end. lis" to "space at end.log "
+		Then the file "aspace at end. lis" should be listed
+		When I rename the file "aspace at end. lis" to "space at end.log "
 		And the files page is reloaded
 		Then the file "space at end.log " should be listed
 		When I rename the file "space at end.log " to "  multiple   space    all     over   .  dat  "

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -130,6 +130,25 @@ class FilesPage extends FilesPageBasic {
 	}
 
 	/**
+	 * Returns the same <0, 0, >0 as strcmp()
+	 * But the names can be in pieces in an array or as plain strings
+	 *
+	 * @param string|array $name1
+	 * @param string|array $name2
+	 * @return int
+	 */
+	public function strcmpNames($name1, $name2) {
+		if (is_array($name1)) {
+			$name1 = implode($name1);
+		}
+		if (is_array($name2)) {
+			$name2 = implode($name2);
+		}
+
+		return strcmp($name1, $name2);
+	}
+
+	/**
 	 * moves a file or folder into an other folder by drag and drop
 	 * 
 	 * @param string|array $name
@@ -138,8 +157,17 @@ class FilesPage extends FilesPageBasic {
 	 * @return void
 	 */
 	public function moveFileTo($name, $destination, Session $session) {
-		$toMoveFileRow = $this->findFileRowByName($name, $session);
-		$destinationFileRow = $this->findFileRowByName($destination, $session);
+		// The "top" item needs to be found last, so that it is at the top
+		// of the displayed scroll window and the other file will be somewhere
+		// below it. dragTo does not work when trying to drag somewhere that
+		// is up the list out of view.
+		if ($this->strcmpNames($destination, $name) < 0) {
+			$toMoveFileRow = $this->findFileRowByName($name, $session);
+			$destinationFileRow = $this->findFileRowByName($destination, $session);
+		} else {
+			$destinationFileRow = $this->findFileRowByName($destination, $session);
+			$toMoveFileRow = $this->findFileRowByName($name, $session);
+		}
 		$toMoveFileRow->findFileLink()->dragTo($destinationFileRow->findFileLink());
 		$this->waitForAjaxCallsToStartAndFinish($session);
 	}

--- a/tests/ui/features/lib/FilesPageBasic.php
+++ b/tests/ui/features/lib/FilesPageBasic.php
@@ -96,7 +96,7 @@ class FilesPageBasic extends OwnCloudPage {
 	}
 
 	/**
-	 * finds the complete row of the file
+	 * finds the complete row of the file and scrolls the row into view
 	 *
 	 * @param string|array $name
 	 * @param Session $session
@@ -159,6 +159,19 @@ class FilesPageBasic extends OwnCloudPage {
 				. $this->fileRowFromNameXpath . "'"
 			);
 		}
+
+		// We might have scrolled past the element, so bring it into view
+		$fileRowElementCoordinates = $this->getCoordinatesOfElement(
+			$session, $fileRowElement
+		);
+
+		$currentOffest = $this->getOffsetBySelector(
+			'#filestable',
+			$session
+		);
+
+		$this->scrollToPosition('#' . $this->appContentId, $fileRowElementCoordinates['top'] - $currentOffest, $session);
+
 		$fileRow = $this->getPage('FilesPageElement\\FileRow');
 		$fileRow->setElement($fileRowElement);
 		$fileRow->setName($name);

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -227,9 +227,10 @@ class OwncloudPage extends Page {
 	 * @return Array
 	 */
 	public function getCoordinatesOfElement($session, $element) {
+		$elementXpath = str_replace('"', '\"', $element->getXpath());
 		return $session->evaluateScript(
 			'return document.evaluate( "' .
-			$element->getXpath() .
+			$elementXpath .
 			'",document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)' .
 			'.singleNodeValue.getBoundingClientRect();'
 		);
@@ -248,8 +249,36 @@ class OwncloudPage extends Page {
 	}
 
 	/**
+	 * get the current offset of a specified element
+	 *
+	 * @param string $jQuerySelector e.g. "#app-content"
+	 * @param Session $session
+	 * @return float current scroll position in pixels
+	 */
+	public function getOffsetBySelector($jQuerySelector, Session $session) {
+		return $session->evaluateScript(
+			'return $("' . $jQuerySelector . '").offset().top;'
+		);
+	}
+
+	/**
+	 * get the current scroll position of a specified element
+	 * seems to return 0 all the time ???
+	 * when I thought it would tell where the scroll bar is.
+	 *
+	 * @param string $jQuerySelector e.g. "#app-content"
+	 * @param Session $session
+	 * @return float current scroll position in pixels
+	 */
+	public function getScrollPosition($jQuerySelector, Session $session) {
+		return $session->evaluateScript(
+			'return $("' . $jQuerySelector . '").scrollTop();'
+		);
+	}
+
+	/**
 	 * scrolls to a position in a specified element
-	 * 
+	 *
 	 * @param string $jQuerySelector e.g. "#app-content"
 	 * @param int|string $position number or JS function that returns a number
 	 * @param Session $session
@@ -258,6 +287,19 @@ class OwncloudPage extends Page {
 	public function scrollToPosition($jQuerySelector, $position, Session $session) {
 		$session->evaluateScript(
 			'$("' . $jQuerySelector . '").scrollTop(' . $position . ');'
+		);
+	}
+
+	/**
+	 * scrolls the specified element into view
+	 *
+	 * @param string $jQuerySelector e.g. "#app-content"
+	 * @param Session $session
+	 * @return void
+	 */
+	public function scrollIntoView($jQuerySelector, Session $session) {
+		$session->evaluateScript(
+			'$("' . $jQuerySelector . '")[0].scrollIntoView();'
 		);
 	}
 


### PR DESCRIPTION
## Description
When the file row element has been found, scroll it into view. Then later steps can rely on the fact that, if the file row element was found then it has also been scrolled into view.

Note: while investigating this problem, I also discovered an issue with ``getCoordinatesOfElement()`` - if ``getXpath()`` of the element ends up having double-quotes in it, then the code will fail (e.g. an xpath for an element that is a file name containing double quotes). Double quotes in the xpath need to be escaped to send into ``document.evaluate`` . I discovered this while trying to use ``getCoordinatesOfElement()`` to scroll the files list to a particular position. In the end the solution here does not do that, because ``scrollIntoView`` turned out to be easy and work.

## Related Issue
#28916 

## Motivation and Context
Make the UI tests more reliable

## How Has This Been Tested?
Local runs of relevant UI tests.
Travis will tell us if it at least works.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

