### PR TITLE
[WIP] add missing getCsrfTokenManager() to new Request for CryptoWrapper

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -687,7 +687,7 @@ class Server extends ServerContainer implements IServerContainer {
 			return new EventDispatcher();
 		});
 		$this->registerService('CryptoWrapper', function (Server $c) {
-			// FIXME: Instantiiated here due to cyclic dependency
+			// FIXME: Instantiated here due to cyclic dependency
 			$request = new Request(
 				[
 					'get' => $_GET,
@@ -701,7 +701,8 @@ class Server extends ServerContainer implements IServerContainer {
 						: null,
 				],
 				$c->getSecureRandom(),
-				$c->getConfig()
+				$c->getConfig(),
+				$c->getCsrfTokenManager()
 			);
 
 			return new CryptoWrapper(


### PR DESCRIPTION
## Description
Add the (apparently missing) CsrfTokenManager when doing ``new Request`` inside registerService for CryptoWrapper.

## Related Issue
#28920 

## Motivation and Context
Try to track down what causes the "CSRF check failed" issue.

## How Has This Been Tested?
Let's see what passes/fails :)

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

