### PR TITLE
[stable10] Web UI goes back to old DAV endpoint

### DIFF
--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -867,7 +867,7 @@
 
 		var client = new OC.Files.Client({
 			host: OC.getHost(),
-			root: OC.linkToRemoteBase('dav') + '/files/' + encodeURIComponent(OC.getCurrentUser().uid) + '/',
+			root: OC.linkToRemoteBase('webdav'),
 			useHTTPS: OC.getProtocol() === 'https'
 		});
 		OC.Files._defaultClient = client;

--- a/core/js/tests/specs/files/clientSpec.js
+++ b/core/js/tests/specs/files/clientSpec.js
@@ -904,7 +904,7 @@ describe('OC.Files.Client tests', function() {
 
 			expect(propFindStub.calledOnce).toEqual(true);
 			expect(propFindStub.getCall(0).args[0])
-				.toEqual('https://somehost:8080/owncloud/remote.php/dav/files/test%40%23%3F%25test/path/to%20sp%40ce/a%40b%23%3F%25/x');
+				.toEqual('https://somehost:8080/owncloud/remote.php/webdav/path/to%20sp%40ce/a%40b%23%3F%25/x');
 		});
 	});
 });


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/28914 to stable10