### PR TITLE
Added IThemeService to public API (DIContainer)

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -337,6 +337,10 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			);
 		});
 
+		$this->registerService('OCP\Theme\IThemeService', function($c) {
+		    return $this->getServer()->getThemeService();
+        });
+
 
 		/**
 		 * Middleware

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -338,8 +338,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		});
 
 		$this->registerService('OCP\Theme\IThemeService', function($c) {
-		    return $this->getServer()->getThemeService();
-        });
+			return $this->getServer()->getThemeService();
+		});
 
 
 		/**

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -92,6 +92,7 @@ use OCP\ILogger;
 use OCP\IServerContainer;
 use OCP\ISession;
 use OCP\Security\IContentSecurityPolicyManager;
+use OCP\Theme\IThemeService;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use OC\Files\External\StoragesBackendService;
@@ -1508,4 +1509,11 @@ class Server extends ServerContainer implements IServerContainer {
 		return $this->query('ShareManager');
 	}
 
+    /**
+     * @return IThemeService
+     */
+    public function getThemeService()
+    {
+        return $this->query('\OCP\Theme\IThemeService');
+    }
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1509,11 +1509,10 @@ class Server extends ServerContainer implements IServerContainer {
 		return $this->query('ShareManager');
 	}
 
-    /**
-     * @return IThemeService
-     */
-    public function getThemeService()
-    {
-        return $this->query('\OCP\Theme\IThemeService');
-    }
+	/**
+	 * @return IThemeService
+	 */
+	public function getThemeService() {
+		return $this->query('\OCP\Theme\IThemeService');
+	}
 }

--- a/lib/public/IServerContainer.php
+++ b/lib/public/IServerContainer.php
@@ -531,4 +531,10 @@ interface IServerContainer {
 	 * @since 8.0.0
 	 */
 	public function getDateTimeFormatter();
+
+    /**
+     * @return \OCP\Theme\IThemeService
+     * @since 10.0.3
+     */
+	public function getThemeService();
 }

--- a/lib/public/IServerContainer.php
+++ b/lib/public/IServerContainer.php
@@ -532,9 +532,9 @@ interface IServerContainer {
 	 */
 	public function getDateTimeFormatter();
 
-    /**
-     * @return \OCP\Theme\IThemeService
-     * @since 10.0.3
-     */
+	/**
+	 * @return \OCP\Theme\IThemeService
+	 * @since 10.0.3
+	 */
 	public function getThemeService();
 }


### PR DESCRIPTION
## Description
Recently the templateeditor (https://github.com/owncloud/templateeditor) stopped working because its dependencies could not be resolved correctly. Apparently it had access to services defined in `Server` before, and now it only has access to its application container `DIContainer` which should be the correct behavior.

Added IThemeService to the public API to solve this issue.

## Related Issue
https://github.com/owncloud/templateeditor/pull/52

## How Has This Been Tested?
Debugged the DI-container to see how it autowires it's dependencies and tested with https://github.com/owncloud/templateeditor/pull/52

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

