### PR TITLE
Add file owner info to sharing if reshare != owner

### DIFF
--- a/core/css/share.css
+++ b/core/css/share.css
@@ -155,7 +155,7 @@ a.unshare {
 	width:12px;
 }
 
-.reshare,#link label,
+.fileowner,.reshare,#link label,
 #expiration label {
 	display: inline-block;
 	padding: 6px 4px;

--- a/core/js/sharedialogresharerinfoview.js
+++ b/core/js/sharedialogresharerinfoview.js
@@ -21,6 +21,7 @@
 		'    {{sharedByText}}' +
 		'</span>' +
 		'{{#if reshareNotOwner}}' +
+	    	'<br>' +
 		'<span class="fileowner">' +
 		'    {{#if avatarEnabled}}' +
 		'    <div class="avatar" data-userName="{{fileOwner}}"></div>' +

--- a/core/js/sharedialogresharerinfoview.js
+++ b/core/js/sharedialogresharerinfoview.js
@@ -19,8 +19,16 @@
 		'    <div class="avatar" data-userName="{{reshareOwner}}"></div>' +
 		'    {{/if}}' +
 		'    {{sharedByText}}' +
-		'</span><br/>'
-		;
+		'</span>' +
+		'{{#if reshareNotOwner}}' +
+		'<span class="fileowner">' +
+		'    {{#if avatarEnabled}}' +
+		'    <div class="avatar" data-userName="{{fileOwner}}"></div>' +
+		'    {{/if}}' +
+		'    {{fileOwnerText}}' +
+		'</span>' +
+		'{{/if}}' +
+		'<br/>';
 
 	/**
 	 * @class OCA.Share.ShareDialogView
@@ -72,6 +80,7 @@
 
 			var reshareTemplate = this.template();
 			var ownerDisplayName = this.model.getReshareOwnerDisplayname();
+			var fileOwnerText = t('core', 'Owner: {owner}', { owner: this.model.getFileOwnerDisplayname() });
 			var sharedByText = '';
 			if (this.model.getReshareType() === OC.Share.SHARE_TYPE_GROUP) {
 				sharedByText = t(
@@ -90,10 +99,17 @@
 				);
 			}
 
+			// console.log(this.model);
+			console.log(this.model.getFileOwner());
+
+
 			this.$el.html(reshareTemplate({
 				avatarEnabled: this.configModel.areAvatarsEnabled(),
 				reshareOwner: this.model.getReshareOwner(),
-				sharedByText: sharedByText
+				sharedByText: sharedByText,
+				fileOwner: this.model.getFileOwner(),
+				fileOwnerText: fileOwnerText,
+				reshareNotOwner: this.model.getReshareOwner() != this.model.getFileOwner()
 			}));
 
 			if(this.configModel.areAvatarsEnabled()) {

--- a/core/js/sharedialogresharerinfoview.js
+++ b/core/js/sharedialogresharerinfoview.js
@@ -99,10 +99,6 @@
 				);
 			}
 
-			// console.log(this.model);
-			console.log(this.model.getFileOwner());
-
-
 			this.$el.html(reshareTemplate({
 				avatarEnabled: this.configModel.areAvatarsEnabled(),
 				reshareOwner: this.model.getReshareOwner(),

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -285,6 +285,20 @@
 		/**
 		 * @returns {string}
 		 */
+		getFileOwner: function() {
+			return this.get('reshare').uid_file_owner;
+		},
+
+		/**
+		 * @returns {string}
+		 */
+		getFileOwnerDisplayname: function() {
+			return this.get('reshare').displayname_file_owner;
+		},
+
+		/**
+		 * @returns {string}
+		 */
 		getReshareOwner: function() {
 			return this.get('reshare').uid_owner;
 		},

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -169,10 +169,10 @@ describe('OC.Share.ShareDialogView', function() {
 			});
 
 			it('test correct function calls', function() {
-				expect(avatarStub.calledTwice).toEqual(true);
+				expect(avatarStub.calledThrice).toEqual(true);
 				expect(placeholderStub.calledTwice).toEqual(true);
 				expect(dialog.$('.shareWithList').children().length).toEqual(3);
-				expect(dialog.$('.avatar').length).toEqual(4);
+				expect(dialog.$('.avatar').length).toEqual(5);
 			});
 
 			it('test avatar owner', function() {
@@ -182,7 +182,7 @@ describe('OC.Share.ShareDialogView', function() {
 			});
 
 			it('test avatar user', function() {
-				var args = avatarStub.getCall(1).args;
+				var args = avatarStub.getCall(2).args;
 				expect(args.length).toEqual(2);
 				expect(args[0]).toEqual('user1');
 			});


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Additionally add info about original file-owner, if file is reshared and reshare is not the original owner

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes: https://github.com/owncloud/enterprise/issues/1935

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visual only (so far)

## Screenshots (if appropriate):
![bildschirmfoto 2017-09-06 um 17 27 12](https://user-images.githubusercontent.com/12717530/30120280-ad1d5cca-9328-11e7-8afb-07c2c43256f2.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

