### PR TITLE
[stable10] Fix error logs due to deletion of keys

### DIFF
--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -200,6 +200,28 @@ class Storage extends Wrapper {
 	}
 
 	/**
+	 * Retain the encryption keys
+	 *
+	 * @param $filename
+	 * @param $owner
+	 * @param $ownerPath
+	 * @param $timestamp
+	 * @param $sourceStorage
+	 * @return bool
+	 */
+
+	public function retainKeys($filename, $owner, $ownerPath, $timestamp, $sourceStorage) {
+		if (\OC::$server->getEncryptionManager()->isEnabled()) {
+			if ($sourceStorage !== null) {
+				$sourcePath = '/' . $owner . '/files_trashbin/files/'. $filename . '.d' . $timestamp;
+				$targetPath = '/' . $owner . '/files/' . $ownerPath;
+				return $sourceStorage->copyKeys($sourcePath, $targetPath);
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Setup the storate wrapper callback
 	 */
 	public static function setupStorage() {

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -208,7 +208,7 @@ class Trashbin {
 		$view = new View('/');
 		self::copy_recursive($source, $target, $view);
 
-		self::retainVersions($targetFilename, $owner, $ownerPath, $timestamp, true);
+		self::retainVersions($targetFilename, $owner, $ownerPath, $timestamp, null, true);
 
 		if ($view->file_exists($target)) {
 			self::insertTrashEntry($owner, $targetFilename, $targetLocation, $timestamp);
@@ -304,7 +304,7 @@ class Trashbin {
 			\OCP\Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', ['filePath' => Filesystem::normalizePath($file_path),
 				'trashPath' => Filesystem::normalizePath($filename . '.d' . $timestamp)]);
 
-			self::retainVersions($filename, $owner, $ownerPath, $timestamp);
+			self::retainVersions($filename, $owner, $ownerPath, $timestamp, $sourceStorage);
 
 			// if owner !== user we need to also add a copy to the owners trash
 			if ($user !== $owner) {
@@ -331,8 +331,18 @@ class Trashbin {
 	 * @param integer $timestamp when the file was deleted
 	 * @param bool $forceCopy true to only make a copy of the versions into the trashbin
 	 */
-	private static function retainVersions($filename, $owner, $ownerPath, $timestamp, $forceCopy = false) {
+	private static function retainVersions($filename, $owner, $ownerPath, $timestamp, $sourceStorage = null, $forceCopy = false) {
 		if (\OCP\App::isEnabled('files_versions') && !empty($ownerPath)) {
+
+			$copyKeysResult = false;
+
+			/**
+			 * In case if encryption is enabled then we need to retain the keys which were
+			 * deleted due to move operation to trashbin.
+			 */
+			if ($sourceStorage !== null) {
+				$copyKeysResult = $sourceStorage->retainKeys($filename, $owner, $ownerPath, $timestamp, $sourceStorage);
+			}
 
 			$user = User::getUser();
 			$rootView = new View('/');
@@ -354,6 +364,10 @@ class Trashbin {
 						self::move($rootView, $owner . '/files_versions' . $v['path'] . '.v' . $v['version'], $user . '/files_trashbin/versions/' . $filename . '.v' . $v['version'] . '.d' . $timestamp);
 					}
 				}
+			}
+
+			if ($copyKeysResult === true) {
+				$sourceStorage->deleteAllFileKeys($filename);
 			}
 		}
 	}

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -1029,6 +1029,18 @@ class Encryption extends Wrapper {
 	}
 
 	/**
+	 *
+	 * delete file keys of the file
+	 *
+	 * @param $path path of the file key to delete
+	 * @return bool
+	 */
+	protected function deleteAllFileKeys($path) {
+		$fullPath = $this->getFullPath($path);
+		return $this->keyStorage->deleteAllFileKeys($fullPath);
+	}
+
+	/**
 	 * check if path points to a files version
 	 *
 	 * @param $path


### PR DESCRIPTION
When files are deleted and moved to trashbin,
the keys are deleted. This results in exception
due to file not exist. And hence this change
helps to fix the issue. The issue is caused
when the version of the files are tried to
retain in the trashbin.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
When the files are moved to trashbin, the retain version causes problem. Which means the retainVersion in the trashbin tries to access the file keys which are already deleted. So this causes exception.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/28883

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change tries to solve the issue caused by accessing file keys which are already deleted during the transfer of files to trashbin.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Enable encryption with master key
- [x] Enable external sotrage with SFTP
- [x] Upload a file to SFTP folder
- [x] Update the file.
- [x] Delete the file . The log file is clean and no exceptions.
- [x] Restore the file. The log file is clean and no exceptions.
- [x] Download the versions of the file.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

