### PR TITLE
[stable10] Use correct class namespace for ownCloud ext storage

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -575,7 +575,7 @@ class File extends Node implements IFile {
 		// TODO: in the future use ChunkHandler provided by storage
 		// and/or add method on Storage called "needsPartFile()"
 		return !$storage->instanceOfStorage('OCA\Files_Sharing\External\Storage') &&
-			!$storage->instanceOfStorage('OC\Files\Storage\OwnCloud') &&
+			!$storage->instanceOfStorage('OCA\Files_external\Lib\Storage\OwnCloud') &&
 			!$storage->instanceOfStorage('OC\Files\ObjectStore\ObjectStoreStorage');
 	}
 


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/28931 to stable10

Note: merge for 10.0.4