### PR TITLE
[stable10] Server name in admin page, don't show in status.php

### DIFF
--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -730,13 +730,15 @@ class Util {
 			'version' => '',
 			'versionstring' => '',
 			'edition' => '',
-			'productname' => ''];
+			'productname' => '',
+			'hostname' => ''];
 
 		if ($includeVersion || (bool) $systemConfig->getValue('version.hide', false) === false) {
 			$values['version'] = implode('.', self::getVersion());
 			$values['versionstring'] = \OC_Util::getVersionString();
 			$values['edition'] = \OC_Util::getEditionString();
 			$values['productname'] = $defaults->getName();
+			$values['hostname'] = gethostname();
 		}
 
 		return $values;

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -715,7 +715,7 @@ class Util {
 	 * @return array
 	 * @since 10.0
 	 */
-	public static function getStatusInfo($includeVersion = false) {
+	public static function getStatusInfo($includeVersion = false, $serverHide = false) {
 		$systemConfig = \OC::$server->getSystemConfig();
 
 		$installed = (bool) $systemConfig->getValue('installed', false);
@@ -730,16 +730,20 @@ class Util {
 			'version' => '',
 			'versionstring' => '',
 			'edition' => '',
-			'productname' => '',
-			'hostname' => ''];
+			'productname' => ''];
 
+		# expose version and servername details 
 		if ($includeVersion || (bool) $systemConfig->getValue('version.hide', false) === false) {
 			$values['version'] = implode('.', self::getVersion());
 			$values['versionstring'] = \OC_Util::getVersionString();
 			$values['edition'] = \OC_Util::getEditionString();
 			$values['productname'] = $defaults->getName();
-			$values['hostname'] = gethostname();
+			# expose the servername only if allowed via version, but never when called via status.php
+			if ($serverHide === false) {
+				$values['hostname'] = gethostname();
+			}
 		}
+
 
 		return $values;
 	}

--- a/status.php
+++ b/status.php
@@ -34,7 +34,9 @@ try {
 
 	require_once __DIR__ . '/lib/base.php';
 
-	$values = \OCP\Util::getStatusInfo();
+	# show the version details based on config.php parameter, 
+	# but do not expose the servername in the public via url
+	$values = \OCP\Util::getStatusInfo(null,true);
 
 	if (OC::$CLI) {
 		print_r($values);


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/28472 and https://github.com/owncloud/core/pull/28513 to stable10