### PR TITLE
[stable10] directly output error messages from market app

### DIFF
--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -171,7 +171,7 @@ class Apps implements IRepairStep {
 
 					$hasNotUpdatedCompatibleApps = count($failedCompatibleApps);
 				} catch (AppManagerException $e) {
-					$output->warning('No connection to marketplace: ' . $e->getPrevious());
+					$output->warning($e->getMessage());
 				}
 			} else {
 				// No market available, output error and continue attempt


### PR DESCRIPTION
Backport of #28941 
