### PR TITLE
Don't display warning about limited commands when running maintenance:install

### DIFF
--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -87,6 +87,7 @@ class Application {
 		if ($input->getOption('no-warnings')) {
 			$output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
 		}
+		$input = new ArgvInput();
 		try {
 			require_once __DIR__ . '/../../../core/register_command.php';
 			if ($this->config->getSystemValue('installed', false)) {
@@ -116,13 +117,14 @@ class Application {
 					}
 				}
 			} else {
-				$output->writeln("ownCloud is not installed - only a limited number of commands are available");
+				if ($input->getFirstArgument() !== 'maintenance:install') {
+					$output->writeln("ownCloud is not installed - only a limited number of commands are available");
+				}
 			}
 		} catch (NeedsUpdateException $ex) {
 			$output->writeln("ownCloud or one of the apps require upgrade - only a limited number of commands are available");
 			$output->writeln("You may use your browser or the occ upgrade command to do the upgrade");
 		};
-		$input = new ArgvInput();
 		if ($input->getFirstArgument() !== 'check') {
 			$errors = \OC_Util::checkServer(\OC::$server->getConfig());
 			if (!empty($errors)) {


### PR DESCRIPTION
I dedicate this PR to you @settermjd!

## Description
Don't show useless warning about OC not being installed when running the install command.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28176

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
With OC not installed:
- [x] TEST: run `occ` alone shows the warning
- [x] TEST: run `occ maintenance:install` does not show it

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

