### PR TITLE
Add "fileids" virtual collection with file ids

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -54,6 +54,13 @@ use OCA\DAV\Connector\Sabre\TagsPlugin;
 use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCA\DAV\Connector\Sabre\ValidateRequestPlugin;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\HTTP\RequestInterface;
+use OCP\Files\Folder;
+use OCP\IUserSession;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\Exception\MethodNotAllowed;
+use OCP\Files\NotFoundException;
 
 class Server {
 
@@ -163,12 +170,19 @@ class Server {
 		}
 
 		// wait with registering these until auth is handled and the filesystem is setup
-		$this->server->on('beforeMethod', function () use ($root) {
+		$this->server->on('beforeMethod', function (RequestInterface $request, ResponseInterface $response) use ($root) {
 			// custom properties plugin must be the last one
 			$userSession = \OC::$server->getUserSession();
 			$user = $userSession->getUser();
 			if (!is_null($user)) {
 				$view = \OC\Files\Filesystem::getView();
+
+				// TODO: switch to LazyUserFolder
+				$userFolder = \OC::$server->getUserFolder();
+				if ($this->handleRedirectFileId($request, $response, $userSession, $userFolder) === false) {
+					return false;
+				}
+
 				$this->server->addPlugin(
 					new FilesPlugin(
 						$this->server->tree,
@@ -213,8 +227,6 @@ class Server {
 						$this->server->tree, \OC::$server->getTagManager()
 					)
 				);
-				// TODO: switch to LazyUserFolder
-				$userFolder = \OC::$server->getUserFolder();
 				$this->server->addPlugin(new SharesPlugin(
 					$this->server->tree,
 					$userSession,
@@ -250,6 +262,45 @@ class Server {
 				$root->addChild($appCollection);
 			}
 		});
+	}
+
+	private function handleRedirectFileId(RequestInterface $request, ResponseInterface $response, IUserSession $userSession, Folder $userFolder) {
+		$sections = explode('/', $request->getPath());
+		if (count($sections) < 3 || $sections[0] !== 'meta' || $sections[2] !== 'link') {
+			return;
+		}
+
+		if (count($sections) > 3) {
+			// trying to access sub-entry of link...
+			throw new NotFound();
+		}
+
+		$fileId = $sections[1];
+
+		$results = $userFolder->getById($fileId);
+		if (empty($results)) {
+			throw new NotFound('File with id ' . $fileId . ' not found');
+		}
+
+		$node = $results[0];
+		$nodePath = trim($userFolder->getRelativePath($node->getPath()), '/');
+
+		$nodePath = implode(
+			'/', array_map(
+				rawurlencode,
+				explode('/', $nodePath)
+			)
+		);
+
+		// redirect
+		$davPath = rtrim($request->getBaseUrl(), '/') . '/files/' . rawurlencode($userSession->getUser()->getUid()) . '/' . $nodePath;
+		$response->setStatus(302);
+		$response->setHeader('Location', $davPath);
+		$response->setHeader('Redirect-ref', 'URI');
+
+		$this->server->sapi->sendResponse($response);
+
+		return false;
 	}
 
 	public function exec() {


### PR DESCRIPTION
## Description
Redirects any queries on "fileids/$fileId" to the matching DAV path
inside of "files/$userId" if applicable. If the file id is not reachable
or in trashbin, returns 404.

Note, I'm not too happy that I couldn't put this into a plugin. The reason I couldn't is because I need to listen to the generic "beforeMethod" event. However in this weird way we implemented the DAV server plugins, we are already inside an existing generic "beforeMethod" event handler, so adding an additional generic handler does not work. The solution was to put the handler directly here.

Also, the "fileids" collection doesn't really exist. I could add it to make it visible in the root tree but it wouldn't have any children as it's not listable.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28615

## Motivation and Context
See ticket.

## How Has This Been Tested?
`curl -D - -X PROPFIND -u admin:admin http://localhost/owncloud/remote.php/dav/fileids/4` and check the "Location" header. Do this for a file and a folder.
Then do this again for "fileids/4/sub/dir" where 4 is a subdir, the redirect points at the subdir.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODOs:
- [ ] add "fileids" virtual unlistable collection in root FS, mostly for the eyes
- [ ] add unit tests
