### PR TITLE
In integration tests do files:scan when the user exists

### DIFF
--- a/tests/integration/features/trashbin-old-endpoint.feature
+++ b/tests/integration/features/trashbin-old-endpoint.feature
@@ -113,8 +113,8 @@ Feature: trashbin-new-endpoint
 	@local_storage
 	@no_default_encryption
 	Scenario: Deleting a folder into external storage moves it to the trashbin
-		Given invoking occ with "files:scan --all"
-		And user "user0" exists
+		Given user "user0" exists
+		And invoking occ with "files:scan --all"
 		And user "user0" created a folder "/local_storage/tmp"
 		And user "user0" moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
 		When user "user0" deletes folder "/local_storage/tmp"
@@ -123,8 +123,8 @@ Feature: trashbin-new-endpoint
 	@local_storage
 	@no_default_encryption
 	Scenario: Deleting a file into external storage moves it to the trashbin and can be restored
-		Given invoking occ with "files:scan --all"
-		And user "user0" exists
+		Given user "user0" exists
+		And invoking occ with "files:scan --all"
 		And user "user0" created a folder "/local_storage/tmp"
 		And user "user0" moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
 		And user "user0" deletes file "/local_storage/tmp/textfile0.txt"
@@ -140,8 +140,8 @@ Feature: trashbin-new-endpoint
 	@local_storage
 	@no_default_encryption
 	Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored
-		Given invoking occ with "files:scan --all"
-		And user "user0" exists
+		Given user "user0" exists
+		And invoking occ with "files:scan --all"
 		And user "user0" created a folder "/local_storage/tmp"
 		And user "user0" moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
 		And user "user0" uploads chunk file "1" of "1" with "AA" to "/local_storage/tmp/textfile0.txt"


### PR DESCRIPTION
## Description
``files:scan`` was being run while ``user0`` did not exist.
If there were files in external storage deleted "underneath" by the AfterScenario of the previous scenario, then ``files:scan`` is needed to make ownCloud "forget" about them. But AfterScenario has also deleted ``user0``. In that case ``files:scan`` does not see the files, because it does not see the user. But when the user is created again, ownCloud's "memory" of the files comes back.

Perhaps there is an issue here about being able to cleanup stale data about files of a user that no longer exists. I will raise that separately if I can easily make a case about it.

But here, the simple thing to do is to create the user first, then do ``files:scan``

## Related Issue
#28956

## Motivation and Context
Make integration tests more reliable in a range of environments.

## How Has This Been Tested?
Run the tests for the feature in a local dev VM.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

