### PR TITLE
[stable10] Ignore broken/dead symlinks on filescan

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -372,6 +372,12 @@ class Local extends \OC\Files\Storage\Common {
 		if ($realPath) {
 			$realPath = $realPath . '/';
 		}
+
+		// Is broken symlink?
+		if (is_link($fullPath) && !file_exists($fullPath)) {
+			throw new ForbiddenException("$fullPath is a broken/dead symlink", false);
+		}
+
 		if (substr($realPath, 0, $this->dataDirLength) === $this->realDataDir) {
 			return $fullPath;
 		} else {

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -22,6 +22,8 @@
 
 namespace Test\Files\Storage;
 
+use OC\Files\Storage\Local;
+
 /**
  * Class LocalTest
  *
@@ -34,6 +36,9 @@ class LocalTest extends Storage {
 	 * @var string tmpDir
 	 */
 	private $tmpDir;
+
+	/** @var Local */
+	protected $instance;
 
 	protected function setUp() {
 		parent::setUp();
@@ -106,6 +111,21 @@ class LocalTest extends Storage {
 		$storage = new \OC\Files\Storage\Local(['datadir' => $subDir1]);
 
 		$storage->file_put_contents('sym/foo', 'bar');
+	}
+
+	/**
+	 * @expectedException \OCP\Files\ForbiddenException
+	 */
+	public function testBrokenSymlink() {
+
+		$linkTarget = $this->tmpDir . 'link_target';
+		$linkName = $this->tmpDir . 'broken_symlink';
+
+		mkdir($linkTarget);
+		symlink($linkTarget, $linkName);
+		rmdir($linkTarget);
+
+		$this->instance->getSourcePath('broken_symlink');
 	}
 }
 


### PR DESCRIPTION
```
Exception during scan: Invalid argument supplied for foreach()
#0 /home/ilja/code/core2/lib/private/Files/Cache/Scanner.php(384): OCA\Files\Command\Scan->exceptionErrorHandler(2, 'Invalid argumen...', '/home/ilja/code...', 384, Array)
#1 /home/ilja/code/core2/lib/private/Files/Cache/Scanner.php(385): OC\Files\Cache\Scanner->scanChildren('files', true, 3, '3', true)
#2 /home/ilja/code/core2/lib/private/Files/Cache/Scanner.php(316): OC\Files\Cache\Scanner->scanChildren('', true, 3, '1', true)
#3 /home/ilja/code/core2/lib/private/Files/Utils/Scanner.php(235): OC\Files\Cache\Scanner->scan('', true, 3)
#4 /home/ilja/code/core2/apps/files/lib/Command/Scan.php(159): OC\Files\Utils\Scanner->scan('/admin')
#5 /home/ilja/code/core2/apps/files/lib/Command/Scan.php(228): OCA\Files\Command\Scan->scanFiles('admin', '/admin', true, Object(Symfony\Component\Console\Output\ConsoleOutput), false)
#6 /home/ilja/code/core2/lib/composer/symfony/console/Command/Command.php(262): OCA\Files\Command\Scan->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /home/ilja/code/core2/core/Command/Base.php(159): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /home/ilja/code/core2/lib/composer/symfony/console/Application.php(826): OC\Core\Command\Base->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /home/ilja/code/core2/lib/composer/symfony/console/Application.php(189): Symfony\Component\Console\Application->doRunCommand(Object(OCA\Files\Command\Scan), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /home/ilja/code/core2/lib/composer/symfony/console/Application.php(120): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /home/ilja/code/core2/lib/private/Console/Application.php(160): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /home/ilja/code/core2/console.php(106): OC\Console\Application->run()
#13 /home/ilja/code/core2/occ(11): require_once('/home/ilja/code...')
```
https://github.com/owncloud/enterprise/issues/2235