### PR TITLE
Add user-configurable defaultapp_path (fixes broken external defaultapp)

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -164,6 +164,14 @@ $CONFIG = array(
 'defaultapp' => 'files',
 
 /**
+ * Set the default app path to open on login. For example if the default app is
+ * "external", set this to /1/ to default to the first External Site.  You can
+ * use a comma-separated list of paths to match up with the apps in defaultapp.
+ * e.g. if defaultapp='external,files' defaultapp_path='/1/,/?dir=accounting'
+ */
+'defaultapp_path' => '',
+
+/**
  * ``true`` enables the Help menu item in the user menu (top right of the
  * ownCloud Web interface). ``false`` removes the Help item.
  */

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -299,7 +299,7 @@ class UtilTest extends \Test\TestCase {
 	 *
 	 * @dataProvider defaultAppsProvider
 	 */
-	function testDefaultApps($defaultAppConfig, $expectedPath, $enabledApps) {
+	function testDefaultApps($defaultAppConfig, $defaultAppPathConfig, $expectedPath, $enabledApps) {
 		$oldDefaultApps = \OCP\Config::getSystemValue('defaultapp', '');
 		// CLI is doing messy stuff with the webroot, so need to work it around
 		$oldWebRoot = \OC::$WEBROOT;
@@ -316,6 +316,7 @@ class UtilTest extends \Test\TestCase {
 		// need to set a user id to make sure enabled apps are read from cache
 		\OC_User::setUserId($this->getUniqueID());
 		\OCP\Config::setSystemValue('defaultapp', $defaultAppConfig);
+		\OCP\Config::setSystemValue('defaultapp_path', $defaultAppPathConfig);
 		$this->assertEquals('http://localhost/' . $expectedPath, Dummy_OC_Util::getDefaultPageUrl());
 
 		// restore old state
@@ -326,28 +327,60 @@ class UtilTest extends \Test\TestCase {
 
 	function defaultAppsProvider() {
 		return [
-			// none specified, default to files
+			// neither app nor path specified, default to /files/
 			[
+				'',
 				'',
 				'index.php/apps/files/',
 				['files'],
 			],
-			// unexisting or inaccessible app specified, default to files
+			// non-existant or inaccessible app specified, default to /files/
 			[
 				'unexist',
+				'',
 				'index.php/apps/files/',
 				['files'],
 			],
-			// non-standard app
+			// non-standard app with no path specified
 			[
 				'calendar',
+				'',
 				'index.php/apps/calendar/',
 				['files', 'calendar'],
 			],
-			// non-standard app with fallback
+			// non-standard app with fallback and no paths specified
 			[
 				'contacts,calendar',
+				'',
 				'index.php/apps/calendar/',
+				['files', 'calendar'],
+			],
+			// files app with manual app path specified
+			[
+				'files',
+				'/?dir=/testfolder',
+				'index.php/apps/files/?dir=/testfolder',
+				['files'],
+			],
+			// external app with manual app path specified
+			[
+				'external',
+				'/3/',
+				'index.php/apps/external/3/',
+				['external'],
+			],
+			// external app with path / corrected to /1/ automatically
+			[
+				'external',
+				'/',
+				'index.php/apps/external/1/',
+				['external'],
+			],
+			// non-standard app with fallback and custom paths specified
+			[
+				'contacts,calendar',
+				'/?view=1,/?view=2',
+				'index.php/apps/calendar/?view=2',
 				['files', 'calendar'],
 			],
 		];


### PR DESCRIPTION
## Description
This adds a new user-configurable parameter called `defaultapp_path`, which corresponds with the existing `defaultapp` and allows users to specify a custom path.

This is useful if you want people to land on a certain folder or view in ownCloud upon logging in.
It's also especially useful for people who set `external` as their default app, because `external` doesn't work unless a site number is specified, e.g. `/1/` or `/3/`.
Defaulting to a specific file or view is surprisingly useful, I'm thinking about defaulting people to our folder where we keep today's TODO list:
```php
'defaultapp' => 'files',
'defaultapp_path' => '/?dir=/todos',
```
or
```php
'defaultapp' => 'doesntexist,external',
'defaultapp_path' => '/,/4/',
```

As an additional helper, if `external` is specified as the `defaultapp`, but no path is given, it automatically corrects it to `/1/`, which is necessary to fix https://github.com/owncloud/apps/issues/2125.

## Related Issue
Fixes: https://github.com/owncloud/apps/issues/2125
Documentation for this change: https://github.com/owncloud/documentation/pull/3383

## Motivation and Context
This fixes the issue reported by https://github.com/benlochard that `/external/` on its own is not a valid ownCloud URL.

## How Has This Been Tested?
Tested partially by: https://github.com/johncab & https://github.com/MichaelBarth https://github.com/owncloud/apps/issues/2125#issuecomment-178848897
Unit tests confirm the custom path behavior is correct.
I have not confirmed the UI behavior as I don't have a dev environment set up, (which is why this PR has so many commits, I had to keep waiting for the travis builds to finish before I knew my tests passed).

## Types of changes
- [X] Bug fix (broken redirect to /external/)
- [X] New feature (optional custom redirect paths for default apps)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly. (https://github.com/owncloud/documentation/pull/3383)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Comments:
I'm really impressed by the ownCloud code-quality so far, it seems like despite using PHP you guys managed to build a fairly clean, well-tested app that's easy to understand for a first-time contributor.
~~I plan to continue contributing as I find things to fix, I'm tackling https://github.com/owncloud/apps/pull/2216 + https://github.com/owncloud/apps/pull/2221 next.~~ Sorry guys, just discovered NextCloud and ended up switching :/