### PR TITLE
Federated Cloud Sharing info icon format

### DIFF
--- a/apps/federatedfilesharing/templates/settings-admin.php
+++ b/apps/federatedfilesharing/templates/settings-admin.php
@@ -5,8 +5,8 @@ script('federatedfilesharing', 'settings-admin');
 ?>
 
 <div id="fileSharingSettings" class="section">
-	<h2><?php p($l->t('Federated Cloud Sharing'));?></h2>
-	<a target="_blank" rel="noreferrer" class="icon-info svg"
+	<h2 class="app-name has-documentation"><?php p($l->t('Federated Cloud Sharing'));?></h2>
+	<a target="_blank" rel="noreferrer" class="icon-info"
 		title="<?php p($l->t('Open documentation'));?>"
 		href="<?php p(link_to_docs('admin-sharing-federated')); ?>"></a>
 


### PR DESCRIPTION
## Description
Use the same classes etc. that other templates use to show the info icon on the same line after the heading text.

## Related Issue
https://github.com/owncloud/core/issues/28936

## Motivation and Context
Make the UI consistent.

## How Has This Been Tested?
View the result.

## Screenshots (if appropriate):
![federated-cloud-sharing-info-icon-2](https://user-images.githubusercontent.com/1535615/30250087-8d42bb28-9668-11e7-8005-6dfbaf19582f.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
