### PR TITLE
Preserve sharing settings across integration test runs

### DIFF
--- a/tests/integration/capabilities_features/capabilities.feature
+++ b/tests/integration/capabilities_features/capabilities.feature
@@ -1,12 +1,27 @@
 Feature: capabilities
 	Background:
 		Given using api version "1"
+		And as an "admin"
+
+	Scenario: Check that the sharing API can be enabled
+		When parameter "shareapi_enabled" of app "core" is set to "yes"
+		Then the capabilities setting of "files_sharing" path "api_enabled" is "1"
+
+	Scenario: Check that the sharing API can be disabled
+		When parameter "shareapi_enabled" of app "core" is set to "no"
+		Then the capabilities setting of "files_sharing" path "api_enabled" is ""
+
+	Scenario: Check that group sharing can be enabled
+		When parameter "shareapi_allow_group_sharing" of app "core" is set to "yes"
+		Then the capabilities setting of "files_sharing" path "group_sharing" is "1"
+
+	Scenario: Check that group sharing can be disabled
+		When parameter "shareapi_allow_group_sharing" of app "core" is set to "no"
+		Then the capabilities setting of "files_sharing" path "group_sharing" is ""
 
 	Scenario: getting capabilities with admin user
-		Given as an "admin"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		When the capabilities are retrieved
+		Then fields of capabilities match with
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -27,11 +42,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing public upload
-		Given as an "admin"
-		And parameter "shareapi_allow_public_upload" of app "core" is set to "no"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "shareapi_allow_public_upload" of app "core" is set to "no"
+		When the capabilities are retrieved
+		Then fields of capabilities match with
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -52,11 +65,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Disabling share api
-		Given as an "admin"
-		And parameter "shareapi_enabled" of app "core" is set to "no"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "shareapi_enabled" of app "core" is set to "no"
+		When the capabilities are retrieved
+		Then fields of capabilities match with
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -71,11 +82,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Disabling public links
-		Given as an "admin"
-		And parameter "shareapi_allow_links" of app "core" is set to "no"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "shareapi_allow_links" of app "core" is set to "no"
+		When the capabilities are retrieved
+		Then fields of capabilities match with
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -94,11 +103,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing resharing
-		Given as an "admin"
-		And parameter "shareapi_allow_resharing" of app "core" is set to "no"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "shareapi_allow_resharing" of app "core" is set to "no"
+		When the capabilities are retrieved
+		Then fields of capabilities match with
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -119,11 +126,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing federation outgoing
-		Given as an "admin"
-		And parameter "outgoing_server2server_share_enabled" of app "files_sharing" is set to "no"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "outgoing_server2server_share_enabled" of app "files_sharing" is set to "no"
+		When the capabilities are retrieved
+		Then fields of capabilities match with
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -144,11 +149,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing federation incoming
-		Given as an "admin"
-		And parameter "incoming_server2server_share_enabled" of app "files_sharing" is set to "no"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "incoming_server2server_share_enabled" of app "files_sharing" is set to "no"
+		When the capabilities are retrieved
+		Then fields of capabilities match with
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -169,11 +172,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing password enforce
-		Given as an "admin"
-		And parameter "shareapi_enforce_links_password" of app "core" is set to "yes"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "shareapi_enforce_links_password" of app "core" is set to "yes"
+		When the capabilities are retrieved
+		Then fields of capabilities match with
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -195,11 +196,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing public notifications
-		Given as an "admin"
-		And parameter "shareapi_allow_public_notification" of app "core" is set to "yes"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "shareapi_allow_public_notification" of app "core" is set to "yes"
+		When the capabilities are retrieved
+		Then fields of capabilities match with
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -220,8 +219,7 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing public social share
-		Given as an "admin"
-		And parameter "shareapi_allow_social_share" of app "core" is set to "no"
+		Given parameter "shareapi_allow_social_share" of app "core" is set to "no"
 		When sending "GET" to "/cloud/capabilities"
 		Then the HTTP status code should be "200"
 		And fields of capabilities match with
@@ -245,11 +243,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing expire date
-		Given as an "admin"
-		And parameter "shareapi_default_expire_date" of app "core" is set to "yes"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "shareapi_default_expire_date" of app "core" is set to "yes"
+		When the capabilities are retrieved
+		Then fields of capabilities match with
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -271,12 +267,10 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing expire date enforcing
-		Given as an "admin"
-		And parameter "shareapi_default_expire_date" of app "core" is set to "yes"
+		Given parameter "shareapi_default_expire_date" of app "core" is set to "yes"
 		And parameter "shareapi_enforce_expire_date" of app "core" is set to "yes"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		When the capabilities are retrieved
+		Then fields of capabilities match with
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -299,11 +293,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing group sharing allowed
-		Given as an "admin"
-		And parameter "shareapi_allow_group_sharing" of app "core" is set to "no"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "shareapi_allow_group_sharing" of app "core" is set to "no"
+		When the capabilities are retrieved
+		Then fields of capabilities match with
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -324,8 +316,7 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing only share with group member
-		Given as an "admin"
-		And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
+		Given parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
 		When sending "GET" to "/cloud/capabilities"
 		Then the HTTP status code should be "200"
 		And fields of capabilities match with
@@ -349,8 +340,7 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing allow share dialog user enumeration
-		Given as an "admin"
-		And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
+		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
 		When sending "GET" to "/cloud/capabilities"
 		Then the HTTP status code should be "200"
 		And fields of capabilities match with
@@ -373,8 +363,7 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing allow share dialog user enumeration for group members only
-		Given as an "admin"
-		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" is set to "yes"
+		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" is set to "yes"
 		When sending "GET" to "/cloud/capabilities"
 		Then the HTTP status code should be "200"
 		And fields of capabilities match with

--- a/tests/integration/features/bootstrap/AppConfiguration.php
+++ b/tests/integration/features/bootstrap/AppConfiguration.php
@@ -147,25 +147,41 @@ trait AppConfiguration {
 	 * @param string $capabilitiesApp the "app" name in the capabilities response
 	 * @param string $capabilitiesParameter the parameter name in the
 	 *                                      capabilities response
-	 * @param string $testingApp the "app" name as understood by "testing"
-	 * @param string $testingParameter the parameter name as understood by
-	 *                                 "testing"
-	 * @return void
+	 * @return boolean
 	 */
-	public function resetCapability(
-		$capabilitiesApp, $capabilitiesParameter, $testingApp, $testingParameter
-	) {
-		$savedValue = $this->getParameterValueFromXml(
+	public function wasCapabilitySet($capabilitiesApp, $capabilitiesParameter) {
+		return $this->getParameterValueFromXml(
 			$this->savedCapabilitiesXml,
 			$capabilitiesApp,
 			$capabilitiesParameter
 		);
+	}
 
-		$this->modifyServerConfig(
-			$testingApp,
-			$testingParameter,
-			$savedValue ? 'yes' : 'no'
+	/**
+	 * @param string $capabilitiesApp the "app" name in the capabilities response
+	 * @param string $capabilitiesParameter the parameter name in the
+	 *                                      capabilities response
+	 * @param string $testingApp the "app" name as understood by "testing"
+	 * @param string $testingParameter the parameter name as understood by
+	 *                                 "testing"
+	 * @param boolean $testingState the on|off state the parameter was set to for the test
+	 * @return void
+	 */
+	public function resetCapability(
+		$capabilitiesApp, $capabilitiesParameter, $testingApp, $testingParameter, $testingState
+	) {
+		$savedState = $this->wasCapabilitySet(
+			$capabilitiesApp,
+			$capabilitiesParameter
 		);
+
+		if ($savedState !== $testingState) {
+			$this->modifyServerConfig(
+				$testingApp,
+				$testingParameter,
+				$savedState ? 'yes' : 'no'
+			);
+		}
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/AppConfiguration.php
+++ b/tests/integration/features/bootstrap/AppConfiguration.php
@@ -6,6 +6,9 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 trait AppConfiguration {
 
+	/** @var string the original capabilities in XML format */
+	private $savedCapabilitiesXml;
+
 	abstract public function sendingTo($verb, $url);
 	abstract public function sendingToWith($verb, $url, $body);
 	abstract public function theOCSStatusCodeShouldBe($statusCode);
@@ -24,6 +27,103 @@ trait AppConfiguration {
 		$this->modifyServerConfig($app, $parameter, $value);
 
 		$this->currentUser = $user;
+	}
+
+	/**
+	 * @Then the capabilities setting of :capabilitiesApp path :capabilitiesPath is :expectedValue
+	 * @param string $capabilitiesApp the name of the "app" in the capabilities response
+	 * @param string $capabilitiesPath the path to the element
+	 * @param string $expectedValue
+	 */
+	public function theCapabilitiesSettingOfAppParameterIs(
+		$capabilitiesApp,
+		$capabilitiesPath,
+		$expectedValue
+	) {
+		$this->getCapabilitiesCheckResponse();
+
+		PHPUnit_Framework_Assert::assertEquals(
+			$expectedValue,
+			$this->getAppParameter($capabilitiesApp, $capabilitiesPath)
+		);
+	}
+
+	/**
+	 * @param string $capabilitiesApp the name of the "app" in the capabilities response
+	 * @param string $capabilitiesPath the path to the element
+	 * @return string
+	 */
+	public function getAppParameter(
+		$capabilitiesApp,
+		$capabilitiesPath
+	) {
+		$answeredValue = $this->getParameterValueFromXml(
+			$this->getCapabilitiesXml(),
+			$capabilitiesApp,
+			$capabilitiesPath
+		);
+
+		return (string)$answeredValue;
+	}
+
+	/**
+	 * @When the capabilities are retrieved
+	 * @return void
+	 */
+	public function getCapabilitiesCheckResponse() {
+		$this->sendingTo('GET', '/cloud/capabilities');
+
+		PHPUnit_Framework_Assert::assertEquals(
+			200,
+			$this->response->getStatusCode()
+		);
+	}
+
+	/**
+	 * @return string latest retrieved capabilities in XML format
+	 */
+	public function getCapabilitiesXml() {
+		return $this->response->xml()->data->capabilities;
+	}
+
+	/**
+	 * @param string $xml of the capabilities
+	 * @param string $capabilitiesApp the name of the "app" in the capabilities response
+	 * @param string $capabilitiesPath the path to the element
+	 * @return string
+	 */
+	public function getParameterValueFromXml(
+		$xml,
+		$capabilitiesApp,
+		$capabilitiesPath
+	) {
+		$path_to_element = explode('@@@', $capabilitiesPath);
+		$answeredValue = $xml->{$capabilitiesApp};
+
+		for ($i = 0; $i < count($path_to_element); $i++) {
+			$answeredValue = $answeredValue->{$path_to_element[$i]};
+		}
+
+		return (string)$answeredValue;
+	}
+
+	/**
+	 * @param string $capabilitiesApp the name of the "app" in the capabilities response
+	 * @param string $capabilitiesParameter the name of the parameter in the capabilities response
+	 * @param string $testingApp the name of the "app" as understood by "testing"
+	 * @param string $testingParameter the name of the parameter as understood by "testing"
+	 * @return void
+	 */
+	public function resetCapability($capabilitiesApp, $capabilitiesParameter, $testingApp, $testingParameter) {
+		$savedValue = $this->getParameterValueFromXml(
+			$this->savedCapabilitiesXml,
+			$capabilitiesApp,
+			$capabilitiesParameter);
+
+		$this->modifyServerConfig(
+			$testingApp,
+			$testingParameter,
+			$savedValue ? 'yes' : 'no');
 	}
 
 	/**
@@ -56,7 +156,9 @@ trait AppConfiguration {
 		}
 	}
 
-	abstract protected function resetAppConfigs();
+	abstract protected function setupAppConfigs();
+
+	abstract protected function restoreAppConfigs();
 
 	/**
 	 * @BeforeScenario
@@ -64,7 +166,17 @@ trait AppConfiguration {
 	public function prepareParametersBeforeScenario() {
 		$user = $this->currentUser;
 		$this->currentUser = 'admin';
-		$this->resetAppConfigs();
+		$this->setupAppConfigs();
+		$this->currentUser = $user;
+	}
+
+	/**
+	 * @AfterScenario
+	 */
+	public function restoreParametersAfterScenario() {
+		$user = $this->currentUser;
+		$this->currentUser = 'admin';
+		$this->restoreAppConfigs();
 		$this->currentUser = $user;
 	}
 }

--- a/tests/integration/features/bootstrap/AppConfiguration.php
+++ b/tests/integration/features/bootstrap/AppConfiguration.php
@@ -1,17 +1,66 @@
 <?php
+/**
+ * ownCloud
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ * @author Sergio Bertolin <sbertolin@owncloud.com>
+ * @author Phillip Davis <phil@jankaritech.com>
+ * @copyright 2017 ownCloud GmbH
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 use GuzzleHttp\Message\ResponseInterface;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
+/**
+ * AppConfiguration trait
+ */
 trait AppConfiguration {
 
-	/** @var string the original capabilities in XML format */
+	/**
+	 * @var string the original capabilities in XML format
+	 */
 	private $savedCapabilitiesXml;
 
+	/**
+	 * @param string $verb
+	 * @param string $url
+	 * @return void
+	 */
 	abstract public function sendingTo($verb, $url);
+
+	/**
+	 * @param string $verb
+	 * @param string $url
+	 * @param \Behat\Gherkin\Node\TableNode $body
+	 * @return void
+	 */
 	abstract public function sendingToWith($verb, $url, $body);
+
+	/**
+	 * @param mixed $statusCode
+	 * @return void
+	 */
 	abstract public function theOCSStatusCodeShouldBe($statusCode);
+
+	/**
+	 * @param mixed $statusCode
+	 * @return void
+	 */
 	abstract public function theHTTPStatusCodeShouldBe($statusCode);
 
 	/**
@@ -19,6 +68,7 @@ trait AppConfiguration {
 	 * @param string $parameter
 	 * @param string $app
 	 * @param string $value
+	 * @return void
 	 */
 	public function serverParameterIsSetTo($parameter, $app, $value) {
 		$user = $this->currentUser;
@@ -31,15 +81,12 @@ trait AppConfiguration {
 
 	/**
 	 * @Then the capabilities setting of :capabilitiesApp path :capabilitiesPath is :expectedValue
-	 * @param string $capabilitiesApp the name of the "app" in the capabilities response
+	 * @param string $capabilitiesApp the "app" name in the capabilities response
 	 * @param string $capabilitiesPath the path to the element
 	 * @param string $expectedValue
+	 * @return void
 	 */
-	public function theCapabilitiesSettingOfAppParameterIs(
-		$capabilitiesApp,
-		$capabilitiesPath,
-		$expectedValue
-	) {
+	public function theCapabilitiesSettingOfAppParameterIs($capabilitiesApp, $capabilitiesPath, $expectedValue) {
 		$this->getCapabilitiesCheckResponse();
 
 		PHPUnit_Framework_Assert::assertEquals(
@@ -49,14 +96,11 @@ trait AppConfiguration {
 	}
 
 	/**
-	 * @param string $capabilitiesApp the name of the "app" in the capabilities response
+	 * @param string $capabilitiesApp the "app" name in the capabilities response
 	 * @param string $capabilitiesPath the path to the element
 	 * @return string
 	 */
-	public function getAppParameter(
-		$capabilitiesApp,
-		$capabilitiesPath
-	) {
+	public function getAppParameter($capabilitiesApp, $capabilitiesPath) {
 		$answeredValue = $this->getParameterValueFromXml(
 			$this->getCapabilitiesXml(),
 			$capabilitiesApp,
@@ -72,11 +116,7 @@ trait AppConfiguration {
 	 */
 	public function getCapabilitiesCheckResponse() {
 		$this->sendingTo('GET', '/cloud/capabilities');
-
-		PHPUnit_Framework_Assert::assertEquals(
-			200,
-			$this->response->getStatusCode()
-		);
+		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
 	}
 
 	/**
@@ -88,15 +128,11 @@ trait AppConfiguration {
 
 	/**
 	 * @param string $xml of the capabilities
-	 * @param string $capabilitiesApp the name of the "app" in the capabilities response
+	 * @param string $capabilitiesApp the "app" name in the capabilities response
 	 * @param string $capabilitiesPath the path to the element
 	 * @return string
 	 */
-	public function getParameterValueFromXml(
-		$xml,
-		$capabilitiesApp,
-		$capabilitiesPath
-	) {
+	public function getParameterValueFromXml($xml, $capabilitiesApp, $capabilitiesPath) {
 		$path_to_element = explode('@@@', $capabilitiesPath);
 		$answeredValue = $xml->{$capabilitiesApp};
 
@@ -108,38 +144,54 @@ trait AppConfiguration {
 	}
 
 	/**
-	 * @param string $capabilitiesApp the name of the "app" in the capabilities response
-	 * @param string $capabilitiesParameter the name of the parameter in the capabilities response
-	 * @param string $testingApp the name of the "app" as understood by "testing"
-	 * @param string $testingParameter the name of the parameter as understood by "testing"
+	 * @param string $capabilitiesApp the "app" name in the capabilities response
+	 * @param string $capabilitiesParameter the parameter name in the
+	 *                                      capabilities response
+	 * @param string $testingApp the "app" name as understood by "testing"
+	 * @param string $testingParameter the parameter name as understood by
+	 *                                 "testing"
 	 * @return void
 	 */
-	public function resetCapability($capabilitiesApp, $capabilitiesParameter, $testingApp, $testingParameter) {
+	public function resetCapability(
+		$capabilitiesApp, $capabilitiesParameter, $testingApp, $testingParameter
+	) {
 		$savedValue = $this->getParameterValueFromXml(
 			$this->savedCapabilitiesXml,
 			$capabilitiesApp,
-			$capabilitiesParameter);
+			$capabilitiesParameter
+		);
 
 		$this->modifyServerConfig(
 			$testingApp,
 			$testingParameter,
-			$savedValue ? 'yes' : 'no');
+			$savedValue ? 'yes' : 'no'
+		);
 	}
 
 	/**
 	 * @param string $app
 	 * @param string $parameter
 	 * @param string $value
+	 * @return void
 	 */
 	protected function modifyServerConfig($app, $parameter, $value) {
 		$body = new \Behat\Gherkin\Node\TableNode([['value', $value]]);
-		$this->sendingToWith('post', "/apps/testing/api/v1/app/{$app}/{$parameter}", $body);
+		$this->sendingToWith(
+			'post',
+			"/apps/testing/api/v1/app/{$app}/{$parameter}",
+			$body
+		);
 		$this->theHTTPStatusCodeShouldBe('200');
 		if ($this->apiVersion == 1) {
 			$this->theOCSStatusCodeShouldBe('100');
 		}
 	}
 
+	/**
+	 * @param boolean $enabled if true, then enable the testing app
+	 *                         otherwise disable the testing app
+	 * @return void
+	 */
 	protected function setStatusTestingApp($enabled) {
 		$this->sendingTo(($enabled ? 'post' : 'delete'), '/cloud/apps/testing');
 		$this->theHTTPStatusCodeShouldBe('200');
@@ -150,18 +202,37 @@ trait AppConfiguration {
 		$this->sendingTo('get', '/cloud/apps?filter=enabled');
 		$this->theHTTPStatusCodeShouldBe('200');
 		if ($enabled) {
-			PHPUnit_Framework_Assert::assertContains('testing', $this->response->getBody()->getContents());
+			PHPUnit_Framework_Assert::assertContains(
+				'testing',
+				$this->response->getBody()->getContents()
+			);
 		} else {
-			PHPUnit_Framework_Assert::assertNotContains('testing', $this->response->getBody()->getContents());
+			PHPUnit_Framework_Assert::assertNotContains(
+				'testing',
+				$this->response->getBody()->getContents()
+			);
 		}
 	}
 
+	/**
+	 * Setup any app config state.
+	 * This will be called before each scenario.
+	 *
+	 * @return void
+	 */
 	abstract protected function setupAppConfigs();
 
+	/**
+	 * Restore any app config state.
+	 * This will be called before each scenario.
+	 *
+	 * @return void
+	 */
 	abstract protected function restoreAppConfigs();
 
 	/**
 	 * @BeforeScenario
+	 * @return void
 	 */
 	public function prepareParametersBeforeScenario() {
 		$user = $this->currentUser;
@@ -172,6 +243,7 @@ trait AppConfiguration {
 
 	/**
 	 * @AfterScenario
+	 * @return void
 	 */
 	public function restoreParametersAfterScenario() {
 		$user = $this->currentUser;

--- a/tests/integration/features/bootstrap/CapabilitiesContext.php
+++ b/tests/integration/features/bootstrap/CapabilitiesContext.php
@@ -17,35 +17,76 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 	 * @param \Behat\Gherkin\Node\TableNode|null $formData
 	 */
 	public function checkCapabilitiesResponse(\Behat\Gherkin\Node\TableNode $formData) {
-		$capabilitiesXML = $this->response->xml()->data->capabilities;
+		$capabilitiesXML = $this->getCapabilitiesXml();
 
 		foreach ($formData->getHash() as $row) {
-			$path_to_element = explode('@@@', $row['path_to_element']);
-			$answeredValue = $capabilitiesXML->{$row['capability']};
-			for ($i = 0; $i < count($path_to_element); $i++) {
-				$answeredValue = $answeredValue->{$path_to_element[$i]};
-			}
-			$answeredValue = (string)$answeredValue;
 			PHPUnit_Framework_Assert::assertEquals(
 				$row['value'] === "EMPTY" ? '' : $row['value'],
-				$answeredValue,
+				$this->getParameterValueFromXml(
+					$capabilitiesXML,
+					$row['capability'],
+					$row['path_to_element']
+				),
 				"Failed field " . $row['capability'] . " " . $row['path_to_element']
 			);
 
 		}
 	}
 
-	protected function resetAppConfigs() {
-		$this->resetCommonSharingAppConfigs();
+	protected function setupAppConfigs() {
+		// Remember the current capabilities
+		$this->getCapabilitiesCheckResponse();
+		$this->savedCapabilitiesXml = $this->getCapabilitiesXml();
+		// Set the required starting values for testing
+		$this->setupCommonSharingConfigs();
+		$this->setupCommonFederationConfigs();
 		$this->modifyServerConfig('core', 'shareapi_allow_resharing', 'yes');
-		$this->modifyServerConfig('files_sharing', 'outgoing_server2server_share_enabled', 'yes');
-		$this->modifyServerConfig('files_sharing', 'incoming_server2server_share_enabled', 'yes');
 		$this->modifyServerConfig('core', 'shareapi_enforce_links_password', 'no');
 		$this->modifyServerConfig('core', 'shareapi_allow_public_notification', 'no');
 		$this->modifyServerConfig('core', 'shareapi_allow_social_share', 'yes');
 		$this->modifyServerConfig('core', 'shareapi_default_expire_date', 'no');
 		$this->modifyServerConfig('core', 'shareapi_enforce_expire_date', 'no');
-		$this->modifyServerConfig('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_share_dialog_user_enumeration_group_members', 'no');
+	}
+
+	protected function restoreAppConfigs() {
+		// Restore the previous capabilities settings
+		$this->restoreCommonSharingConfigs();
+		$this->restoreCommonFederationConfigs();
+		$this->resetCapability(
+			'files_sharing',
+			'resharing',
+			'core',
+			'shareapi_allow_resharing'
+		);
+		$this->resetCapability(
+			'files_sharing',
+			'public@@@password@@@enforced',
+			'core',
+			'shareapi_enforce_links_password'
+		);
+		$this->resetCapability(
+			'files_sharing',
+			'public@@@send_mail',
+			'core',
+			'shareapi_allow_public_notification'
+		);
+		$this->resetCapability(
+			'files_sharing',
+			'public@@@social_share',
+			'core',
+			'shareapi_allow_social_share'
+		);
+		$this->resetCapability(
+			'files_sharing',
+			'public@@@expire_date@@@enabled',
+			'core',
+			'shareapi_default_expire_date'
+		);
+		$this->resetCapability(
+			'files_sharing',
+			'public@@@expire_date@@@enforced',
+			'core',
+			'shareapi_enforce_expire_date'
+		);
 	}
 }

--- a/tests/integration/features/bootstrap/CapabilitiesContext.php
+++ b/tests/integration/features/bootstrap/CapabilitiesContext.php
@@ -66,12 +66,24 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 		// Set the required starting values for testing
 		$this->setupCommonSharingConfigs();
 		$this->setupCommonFederationConfigs();
-		$this->modifyServerConfig('core', 'shareapi_allow_resharing', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_enforce_links_password', 'no');
-		$this->modifyServerConfig('core', 'shareapi_allow_public_notification', 'no');
-		$this->modifyServerConfig('core', 'shareapi_allow_social_share', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_default_expire_date', 'no');
-		$this->modifyServerConfig('core', 'shareapi_enforce_expire_date', 'no');
+		if (!$this->wasCapabilitySet('files_sharing', 'resharing')) {
+			$this->modifyServerConfig('core', 'shareapi_allow_resharing', 'yes');
+		}
+		if ($this->wasCapabilitySet('files_sharing', 'public@@@password@@@enforced')) {
+			$this->modifyServerConfig('core', 'shareapi_enforce_links_password', 'no');
+		}
+		if ($this->wasCapabilitySet('files_sharing', 'public@@@send_mail')) {
+			$this->modifyServerConfig('core', 'shareapi_allow_public_notification', 'no');
+		}
+		if (!$this->wasCapabilitySet('files_sharing', 'public@@@social_share')) {
+			$this->modifyServerConfig('core', 'shareapi_allow_social_share', 'yes');
+		}
+		if ($this->wasCapabilitySet('files_sharing', 'public@@@expire_date@@@enabled')) {
+			$this->modifyServerConfig('core', 'shareapi_default_expire_date', 'no');
+		}
+		if ($this->wasCapabilitySet('files_sharing', 'public@@@expire_date@@@enforced')) {
+			$this->modifyServerConfig('core', 'shareapi_enforce_expire_date', 'no');
+		}
 	}
 
 	/**
@@ -85,37 +97,43 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 			'files_sharing',
 			'resharing',
 			'core',
-			'shareapi_allow_resharing'
+			'shareapi_allow_resharing',
+			true
 		);
 		$this->resetCapability(
 			'files_sharing',
 			'public@@@password@@@enforced',
 			'core',
-			'shareapi_enforce_links_password'
+			'shareapi_enforce_links_password',
+			false
 		);
 		$this->resetCapability(
 			'files_sharing',
 			'public@@@send_mail',
 			'core',
-			'shareapi_allow_public_notification'
+			'shareapi_allow_public_notification',
+			false
 		);
 		$this->resetCapability(
 			'files_sharing',
 			'public@@@social_share',
 			'core',
-			'shareapi_allow_social_share'
+			'shareapi_allow_social_share',
+			true
 		);
 		$this->resetCapability(
 			'files_sharing',
 			'public@@@expire_date@@@enabled',
 			'core',
-			'shareapi_default_expire_date'
+			'shareapi_default_expire_date',
+			false
 		);
 		$this->resetCapability(
 			'files_sharing',
 			'public@@@expire_date@@@enforced',
 			'core',
-			'shareapi_enforce_expire_date'
+			'shareapi_enforce_expire_date',
+			false
 		);
 	}
 }

--- a/tests/integration/features/bootstrap/CapabilitiesContext.php
+++ b/tests/integration/features/bootstrap/CapabilitiesContext.php
@@ -1,4 +1,26 @@
 <?php
+/**
+ * ownCloud
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ * @author Sergio Bertolin <sbertolin@owncloud.com>
+ * @author Phillip Davis <phil@jankaritech.com>
+ * @copyright 2017 ownCloud GmbH
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
@@ -15,6 +37,7 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 	/**
 	 * @Then /^fields of capabilities match with$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $formData
+	 * @return void
 	 */
 	public function checkCapabilitiesResponse(\Behat\Gherkin\Node\TableNode $formData) {
 		$capabilitiesXML = $this->getCapabilitiesXml();
@@ -33,6 +56,9 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 		}
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function setupAppConfigs() {
 		// Remember the current capabilities
 		$this->getCapabilitiesCheckResponse();
@@ -48,6 +74,9 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 		$this->modifyServerConfig('core', 'shareapi_enforce_expire_date', 'no');
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function restoreAppConfigs() {
 		// Restore the previous capabilities settings
 		$this->restoreCommonSharingConfigs();

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -13,7 +13,16 @@ require_once 'bootstrap.php';
 class FeatureContext implements Context, SnippetAcceptingContext {
 	use BasicStructure;
 
-	protected function resetAppConfigs() {
-		$this->resetCommonSharingAppConfigs();
+	protected function setupAppConfigs() {
+		// Remember the current capabilities
+		$this->getCapabilitiesCheckResponse();
+		$this->savedCapabilitiesXml = $this->getCapabilitiesXml();
+		// Set the required starting values for testing
+		$this->setupCommonSharingConfigs();
+	}
+
+	protected function restoreAppConfigs() {
+		// Restore the previous capabilities settings
+		$this->restoreCommonSharingConfigs();
 	}
 }

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * ownCloud
+ *
+ * @author Sergio Bertolin <sbertolin@owncloud.com>
+ * @author Phillip Davis <phil@jankaritech.com>
+ * @copyright 2017 ownCloud GmbH
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
@@ -13,6 +34,9 @@ require_once 'bootstrap.php';
 class FeatureContext implements Context, SnippetAcceptingContext {
 	use BasicStructure;
 
+	/**
+	 * @return void
+	 */
 	protected function setupAppConfigs() {
 		// Remember the current capabilities
 		$this->getCapabilitiesCheckResponse();
@@ -21,6 +45,9 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 		$this->setupCommonSharingConfigs();
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function restoreAppConfigs() {
 		// Restore the previous capabilities settings
 		$this->restoreCommonSharingConfigs();

--- a/tests/integration/features/bootstrap/FederationContext.php
+++ b/tests/integration/features/bootstrap/FederationContext.php
@@ -1,4 +1,26 @@
 <?php
+/**
+ * ownCloud
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ * @author Sergio Bertolin <sbertolin@owncloud.com>
+ * @author Phillip Davis <phil@jankaritech.com>
+ * @copyright 2017 ownCloud GmbH
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
@@ -21,15 +43,20 @@ class FederationContext implements Context, SnippetAcceptingContext {
 	 * @param string $sharerPath
 	 * @param string $shareeUser
 	 * @param string $shareeServer "LOCAL" or "REMOTE"
+	 * @return void
 	 */
-	public function federateSharing($sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer) {
+	public function federateSharing(
+		$sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer
+	) {
 		if ($shareeServer == "REMOTE") {
 			$shareWith = "$shareeUser@" . substr($this->remoteBaseUrl, 0, -4);
 		} else {
 			$shareWith = "$shareeUser@" . substr($this->localBaseUrl, 0, -4);
 		}
 		$previous = $this->usingServer($sharerServer);
-		$this->createShare($sharerUser, $sharerPath, 6, $shareWith, null, null, null);
+		$this->createShare(
+			$sharerUser, $sharerPath, 6, $shareWith, null, null, null
+		);
 		$this->usingServer($previous);
 	}
 
@@ -37,20 +64,32 @@ class FederationContext implements Context, SnippetAcceptingContext {
 	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" accepts last pending share$/
 	 * @param string $user
 	 * @param string $server
+	 * @return void
 	 */
 	public function acceptLastPendingShare($user, $server) {
 		$previous = $this->usingServer($server);
 		$this->asAn($user);
-		$this->sendingToWith('GET', "/apps/files_sharing/api/v1/remote_shares/pending", null);
+		$this->sendingToWith(
+			'GET',
+			"/apps/files_sharing/api/v1/remote_shares/pending",
+			null
+		);
 		$this->theHTTPStatusCodeShouldBe('200');
 		$this->theOCSStatusCodeShouldBe('100');
 		$share_id = $this->response->xml()->data[0]->element[0]->id;
-		$this->sendingToWith('POST', "/apps/files_sharing/api/v1/remote_shares/pending/{$share_id}", null);
+		$this->sendingToWith(
+			'POST',
+			"/apps/files_sharing/api/v1/remote_shares/pending/{$share_id}",
+			null
+		);
 		$this->theHTTPStatusCodeShouldBe('200');
 		$this->theOCSStatusCodeShouldBe('100');
 		$this->usingServer($previous);
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function setupAppConfigs() {
 		// Remember the current capabilities
 		$this->getCapabilitiesCheckResponse();
@@ -61,6 +100,9 @@ class FederationContext implements Context, SnippetAcceptingContext {
 		$this->modifyServerConfig('core', 'shareapi_allow_resharing', 'yes');
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function restoreAppConfigs() {
 		$this->restoreCommonSharingConfigs();
 		$this->restoreCommonFederationConfigs();

--- a/tests/integration/features/bootstrap/FederationContext.php
+++ b/tests/integration/features/bootstrap/FederationContext.php
@@ -51,8 +51,24 @@ class FederationContext implements Context, SnippetAcceptingContext {
 		$this->usingServer($previous);
 	}
 
-	protected function resetAppConfigs() {
-		$this->modifyServerConfig('files_sharing', 'outgoing_server2server_share_enabled', 'yes');
-		$this->modifyServerConfig('files_sharing', 'incoming_server2server_share_enabled', 'yes');
+	protected function setupAppConfigs() {
+		// Remember the current capabilities
+		$this->getCapabilitiesCheckResponse();
+		$this->savedCapabilitiesXml = $this->getCapabilitiesXml();
+		// Set the required starting values for testing
+		$this->setupCommonSharingConfigs();
+		$this->setupCommonFederationConfigs();
+		$this->modifyServerConfig('core', 'shareapi_allow_resharing', 'yes');
+	}
+
+	protected function restoreAppConfigs() {
+		$this->restoreCommonSharingConfigs();
+		$this->restoreCommonFederationConfigs();
+		$this->resetCapability(
+			'files_sharing',
+			'resharing',
+			'core',
+			'shareapi_allow_resharing'
+		);
 	}
 }

--- a/tests/integration/features/bootstrap/FederationContext.php
+++ b/tests/integration/features/bootstrap/FederationContext.php
@@ -97,7 +97,9 @@ class FederationContext implements Context, SnippetAcceptingContext {
 		// Set the required starting values for testing
 		$this->setupCommonSharingConfigs();
 		$this->setupCommonFederationConfigs();
-		$this->modifyServerConfig('core', 'shareapi_allow_resharing', 'yes');
+		if (!$this->wasCapabilitySet('files_sharing', 'resharing')) {
+			$this->modifyServerConfig('core', 'shareapi_allow_resharing', 'yes');
+		}
 	}
 
 	/**
@@ -110,7 +112,8 @@ class FederationContext implements Context, SnippetAcceptingContext {
 			'files_sharing',
 			'resharing',
 			'core',
-			'shareapi_allow_resharing'
+			'shareapi_allow_resharing',
+			true
 		);
 	}
 }

--- a/tests/integration/features/bootstrap/ShareesContext.php
+++ b/tests/integration/features/bootstrap/ShareesContext.php
@@ -1,4 +1,26 @@
 <?php
+/**
+ * ownCloud
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ * @author Sergio Bertolin <sbertolin@owncloud.com>
+ * @author Phillip Davis <phil@jankaritech.com>
+ * @copyright 2017 ownCloud GmbH
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
@@ -15,6 +37,7 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 	/**
 	 * @When /^getting sharees for$/
 	 * @param \Behat\Gherkin\Node\TableNode $body
+	 * @return void
 	 */
 	public function whenGettingShareesFor($body) {
 		$url = '/apps/files_sharing/api/v1/sharees';
@@ -36,19 +59,31 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 	 * @param string $shareeType
 	 * @param string $isEmpty
 	 * @param \Behat\Gherkin\Node\TableNode|null $shareesList
+	 * @return void
 	 */
 	public function thenListOfSharees($shareeType, $isEmpty, $shareesList = null) {
 		if ($isEmpty !== 'is empty') {
 			$sharees = $shareesList->getRows();
-			$respondedArray = $this->getArrayOfShareesResponded($this->response, $shareeType);
+			$respondedArray = $this->getArrayOfShareesResponded(
+				$this->response, $shareeType
+			);
 			PHPUnit_Framework_Assert::assertEquals($sharees, $respondedArray);
 		} else {
-			$respondedArray = $this->getArrayOfShareesResponded($this->response, $shareeType);
+			$respondedArray = $this->getArrayOfShareesResponded(
+				$this->response, $shareeType
+			);
 			PHPUnit_Framework_Assert::assertEmpty($respondedArray);
 		}
 	}
 
-	public function getArrayOfShareesResponded(ResponseInterface $response, $shareeType) {
+	/**
+	 * @param ResponseInterface $response
+	 * @param string $shareeType
+	 * @return array
+	 */
+	public function getArrayOfShareesResponded(
+		ResponseInterface $response, $shareeType
+	) {
 		$elements = $response->xml()->data;
 		$elements = json_decode(json_encode($elements), 1);
 		if (strpos($shareeType, 'exact ') === 0) {
@@ -58,11 +93,18 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 
 		$sharees = [];
 		foreach ($elements[$shareeType] as $element) {
-			$sharees[] = [$element['label'], $element['value']['shareType'], $element['value']['shareWith']];
+			$sharees[] = [
+				$element['label'],
+				$element['value']['shareType'],
+				$element['value']['shareWith']
+			];
 		}
 		return $sharees;
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function setupAppConfigs() {
 		// Remember the current capabilities
 		$this->getCapabilitiesCheckResponse();
@@ -72,6 +114,9 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 		$this->setupCommonFederationConfigs();
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function restoreAppConfigs() {
 		// Restore the previous capabilities settings
 		$this->restoreCommonSharingConfigs();

--- a/tests/integration/features/bootstrap/ShareesContext.php
+++ b/tests/integration/features/bootstrap/ShareesContext.php
@@ -63,11 +63,18 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 		return $sharees;
 	}
 
-	protected function resetAppConfigs() {
-		$this->resetCommonSharingAppConfigs();
-		$this->modifyServerConfig('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_share_dialog_user_enumeration_group_members', 'no');
-		$this->modifyServerConfig('files_sharing', 'outgoing_server2server_share_enabled', 'yes');
-		$this->modifyServerConfig('files_sharing', 'incoming_server2server_share_enabled', 'yes');
+	protected function setupAppConfigs() {
+		// Remember the current capabilities
+		$this->getCapabilitiesCheckResponse();
+		$this->savedCapabilitiesXml = $this->getCapabilitiesXml();
+		// Set the required starting values for testing
+		$this->setupCommonSharingConfigs();
+		$this->setupCommonFederationConfigs();
+	}
+
+	protected function restoreAppConfigs() {
+		// Restore the previous capabilities settings
+		$this->restoreCommonSharingConfigs();
+		$this->restoreCommonFederationConfigs();
 	}
 }

--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -1,4 +1,26 @@
 <?php
+/**
+ * ownCloud
+ *
+ * @author Joas Schilling <coding@schilljs.com>
+ * @author Sergio Bertolin <sbertolin@owncloud.com>
+ * @author Phillip Davis <phil@jankaritech.com>
+ * @copyright 2017 ownCloud GmbH
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
@@ -6,26 +28,36 @@ use TestHelpers\SharingHelper;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
-
-
+/**
+ * Sharing trait
+ */
 trait Sharing {
 
-	/** @var int */
+	/**
+	 * @var int
+	 */
 	private $sharingApiVersion = 1;
 
-	/** @var SimpleXMLElement */
+	/**
+	 * @var SimpleXMLElement
+	 */
 	private $lastShareData = null;
 
-	/** @var int */
+	/**
+	 * @var int
+	 */
 	private $savedShareId = null;
 
-	/** @var int */
+	/**
+	 * @var int
+	 */
 	private $lastShareTime = null;
 
 	/**
 	 * @Given /^as "([^"]*)" creating a share with$/
 	 * @param string $user
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 * @return void
 	 */
 	public function asCreatingAShareWith($user, $body) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
@@ -47,7 +79,9 @@ trait Sharing {
 		}
 
 		try {
-			$this->response = $client->send($client->createRequest("POST", $fullUrl, $options));
+			$this->response = $client->send(
+				$client->createRequest("POST", $fullUrl, $options)
+			);
 		} catch (\GuzzleHttp\Exception\ClientException $ex) {
 			$this->response = $ex->getResponse();
 		}
@@ -58,6 +92,7 @@ trait Sharing {
 	/**
 	 * @When /^creating a share with$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 * @return void
 	 */
 	public function creatingShare($body) {
 		$this->asCreatingAShareWith($this->currentUser, $body);
@@ -65,7 +100,8 @@ trait Sharing {
 
 	/**
 	 * @When /^public shared file "([^"]*)" cannot be downloaded$/
-	 * @param string $fileName
+	 * @param string $path
+	 * @return void
 	 */
 	public function publicSharedFileCannotDownload($path) {
 		$token = $this->getLastShareToken();
@@ -90,6 +126,8 @@ trait Sharing {
 
 	/**
 	 * @Then /^public shared file "([^"]*)" can be downloaded$/
+	 * @param string $filename unused
+	 * @return void
 	 */
 	public function checkPublicSharedFile($filename) {
 		if (count($this->lastShareData->data->element) > 0) {
@@ -103,6 +141,9 @@ trait Sharing {
 
 	/**
 	 * @Then /^public shared file "([^"]*)" with password "([^"]*)" can be downloaded$/
+	 * @param string $filename unused
+	 * @param string $password
+	 * @return void
 	 */
 	public function checkPublicSharedFileWithPassword($filename, $password) {
 		$token = $this->getLastShareToken();
@@ -110,6 +151,12 @@ trait Sharing {
 		$this->checkDownload($fullUrl, [$token, $password], 'text/plain');
 	}
 
+	/**
+	 * @param string $url
+	 * @param string $auth
+	 * @param string $mimeType
+	 * @return void
+	 */
 	private function checkDownload($url, $auth = null, $mimeType = null) {
 		if ($auth !== null) {
 			$options['auth'] = $auth;
@@ -118,7 +165,10 @@ trait Sharing {
 
 		$client = new Client();
 		$this->response = $client->get($url, $options);
-		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+		PHPUnit_Framework_Assert::assertEquals(
+			200,
+			$this->response->getStatusCode()
+		);
 
 		$buf = '';
 		$body = $this->response->getBody();
@@ -130,7 +180,10 @@ trait Sharing {
 
 		if ($mimeType !== null) {
 			$finfo = new finfo;
-			PHPUnit_Framework_Assert::assertEquals($mimeType, $finfo->buffer($buf, FILEINFO_MIME_TYPE));
+			PHPUnit_Framework_Assert::assertEquals(
+				$mimeType,
+				$finfo->buffer($buf, FILEINFO_MIME_TYPE)
+			);
 		}
 	}
 
@@ -138,6 +191,7 @@ trait Sharing {
 	 * @When publicly uploading file ":filename" with content ":body"
 	 * @param string $filename target file name
 	 * @param string $body content to upload
+	 * @return void
 	 */
 	public function publiclyUploadingContent($filename, $body = 'test') {
 		$this->publicUploadContent($filename, '', $body);
@@ -146,9 +200,13 @@ trait Sharing {
 	/**
 	 * @When publicly uploading file ":filename" with password ":password" and content ":body"
 	 * @param string $filename target file name
+	 * @param string $password
 	 * @param string $body content to upload
+	 * @return void
 	 */
-	public function publiclyUploadingContentWithPassword($filename, $password = '', $body = 'test') {
+	public function publiclyUploadingContentWithPassword(
+		$filename, $password = '', $body = 'test'
+	) {
 		$this->publicUploadContent($filename, $password, $body);
 	}
 
@@ -156,6 +214,7 @@ trait Sharing {
 	 * @When publicly uploading file ":filename" with content ":body" with autorename mode
 	 * @param string $filename target file name
 	 * @param string $body content to upload
+	 * @return void
 	 */
 	public function publiclyUploadingContentAutorename($filename, $body = 'test') {
 		$this->publicUploadContent($filename, '', $body, true);
@@ -163,6 +222,7 @@ trait Sharing {
 
 	/**
 	 * @When publicly uploading a file does not work
+	 * @return void
 	 */
 	public function publiclyUploadingDoesNotWork() {
 		try {
@@ -176,7 +236,16 @@ trait Sharing {
 		}
 	}
 
-	private function publicUploadContent($filename, $password = '', $body = 'test', $autorename = false) {
+	/**
+	 * @param string $filename
+	 * @param string $password
+	 * @param string $body
+	 * @param bool $autorename
+	 * @return void
+	 */
+	private function publicUploadContent(
+		$filename, $password = '', $body = 'test', $autorename = false
+	) {
 		$url = substr($this->baseUrl, 0, -4) . "public.php/webdav/";
 		$url .= rawurlencode(ltrim($filename, '/'));
 		$token = $this->getLastShareToken();
@@ -189,12 +258,18 @@ trait Sharing {
 		}
 
 		$client = new Client();
-		$this->response = $client->send($client->createRequest('PUT', $url, $options));
-		PHPUnit_Framework_Assert::assertEquals(201, $this->response->getStatusCode());
+		$this->response = $client->send(
+			$client->createRequest('PUT', $url, $options)
+		);
+		PHPUnit_Framework_Assert::assertEquals(
+			201,
+			$this->response->getStatusCode()
+		);
 	}
 
 	/**
 	 * @When /^adding expiration date to last share$/
+	 * @return void
 	 */
 	public function addingExpirationDate() {
 		$share_id = (string) $this->lastShareData->data[0]->id;
@@ -208,13 +283,19 @@ trait Sharing {
 		}
 		$date = date('Y-m-d', strtotime("+3 days"));
 		$options['body'] = ['expireDate' => $date];
-		$this->response = $client->send($client->createRequest("PUT", $fullUrl, $options));
-		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+		$this->response = $client->send(
+			$client->createRequest("PUT", $fullUrl, $options)
+		);
+		PHPUnit_Framework_Assert::assertEquals(
+			200,
+			$this->response->getStatusCode()
+		);
 	}
 
 	/**
 	 * @When /^updating last share with$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 * @return void
 	 */
 	public function updatingLastShare($body) {
 		$share_id = (string) $this->lastShareData->data[0]->id;
@@ -237,22 +318,40 @@ trait Sharing {
 		}
 
 		try {
-			$this->response = $client->send($client->createRequest("PUT", $fullUrl, $options));
+			$this->response = $client->send(
+				$client->createRequest("PUT", $fullUrl, $options)
+			);
 		} catch (\GuzzleHttp\Exception\ClientException $ex) {
 			$this->response = $ex->getResponse();
 		}
 
-		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+		PHPUnit_Framework_Assert::assertEquals(
+			200,
+			$this->response->getStatusCode()
+		);
 	}
 
-	public function createShare($user,
-								$path = null,
-								$shareType = null,
-								$shareWith = null,
-								$publicUpload = null,
-								$password = null,
-								$permissions = null,
-								$linkName = null) {
+	/**
+	 * @param string $user
+	 * @param string $path
+	 * @param string $shareType
+	 * @param string $shareWith
+	 * @param string $publicUpload
+	 * @param string $password
+	 * @param int $permissions
+	 * @param string $linkName
+	 * @return void
+	 */
+	public function createShare(
+		$user,
+		$path = null,
+		$shareType = null,
+		$shareWith = null,
+		$publicUpload = null,
+		$password = null,
+		$permissions = null,
+		$linkName = null
+	) {
 
 		try {
 			$this->response = SharingHelper::createShare(
@@ -267,13 +366,19 @@ trait Sharing {
 				$permissions,
 				$linkName,
 				$this->apiVersion,
-				$this->sharingApiVersion);
+				$this->sharingApiVersion
+			);
 			$this->lastShareData = $this->response->xml();
 		} catch (\GuzzleHttp\Exception\ClientException $ex) {
 			$this->response = $ex->getResponse();
 		}
 	}
 
+	/**
+	 * @param string $field
+	 * @param string $contentExpected
+	 * @return bool
+	 */
 	public function isFieldInResponse($field, $contentExpected) {
 		$data = $this->response->xml()->data[0];
 		if ((string)$field == 'expiration') {
@@ -288,24 +393,27 @@ trait Sharing {
 				} elseif ($contentExpected == "AN_URL") {
 					return $this->isExpectedUrl((string)$element->$field, "index.php/s/");
 				} elseif ((string)$element->$field == $contentExpected) {
-					return True;
+					return true;
 				} else {
 					print($element->$field);
 				}
 			}
 
-			return False;
+			return false;
 		} else {
 			if ($contentExpected == "A_TOKEN") {
 					return (strlen((string)$data->$field) == 15);
 			} elseif ($contentExpected == "A_NUMBER") {
 					return is_numeric((string)$data->$field);
 			} elseif ($contentExpected == "AN_URL") {
-					return $this->isExpectedUrl((string)$data->$field, "index.php/s/");
+					return $this->isExpectedUrl(
+						(string)$data->$field,
+						"index.php/s/"
+					);
 			} elseif ($data->$field == $contentExpected) {
-					return True;
+					return true;
 			}
-			return False;
+			return false;
 		}
 	}
 
@@ -313,78 +421,113 @@ trait Sharing {
 	 * @Then /^file "([^"]*)" should be included in the response$/
 	 *
 	 * @param string $filename
+	 * @return void
 	 */
 	public function checkSharedFileInResponse($filename) {
 		$filename = ltrim($filename, '/');
-		PHPUnit_Framework_Assert::assertEquals(True, $this->isFieldInResponse('file_target', "/$filename"));
+		PHPUnit_Framework_Assert::assertEquals(
+			true,
+			$this->isFieldInResponse('file_target', "/$filename")
+		);
 	}
 
 	/**
 	 * @Then /^file "([^"]*)" should not be included in the response$/
 	 *
 	 * @param string $filename
+	 * @return void
 	 */
 	public function checkSharedFileNotInResponse($filename) {
 		$filename = ltrim($filename, '/');
-		PHPUnit_Framework_Assert::assertEquals(False, $this->isFieldInResponse('file_target', "/$filename"));
+		PHPUnit_Framework_Assert::assertEquals(
+			false,
+			$this->isFieldInResponse('file_target', "/$filename")
+		);
 	}
 
 	/**
 	 * @Then /^file "([^"]*)" should be included as path in the response$/
 	 *
 	 * @param string $filename
+	 * @return void
 	 */
 	public function checkSharedFileAsPathInResponse($filename) {
 		$filename = ltrim($filename, '/');
-		PHPUnit_Framework_Assert::assertEquals(True, $this->isFieldInResponse('path', "/$filename"));
+		PHPUnit_Framework_Assert::assertEquals(
+			true,
+			$this->isFieldInResponse('path', "/$filename")
+		);
 	}
 
 	/**
 	 * @Then /^file "([^"]*)" should not be included as path in the response$/
 	 *
 	 * @param string $filename
+	 * @return void
 	 */
 	public function checkSharedFileAsPathNotInResponse($filename) {
 		$filename = ltrim($filename, '/');
-		PHPUnit_Framework_Assert::assertEquals(False, $this->isFieldInResponse('path', "/$filename"));
+		PHPUnit_Framework_Assert::assertEquals(
+			false,
+			$this->isFieldInResponse('path', "/$filename")
+		);
 	}
 
 	/**
 	 * @Then /^user "([^"]*)" should be included in the response$/
 	 *
 	 * @param string $user
+	 * @return void
 	 */
 	public function checkSharedUserInResponse($user) {
-		PHPUnit_Framework_Assert::assertEquals(True, $this->isFieldInResponse('share_with', "$user"));
+		PHPUnit_Framework_Assert::assertEquals(
+			true,
+			$this->isFieldInResponse('share_with', "$user")
+		);
 	}
 
 	/**
 	 * @Then /^user "([^"]*)" should not be included in the response$/
 	 *
 	 * @param string $user
+	 * @return void
 	 */
 	public function checkSharedUserNotInResponse($user) {
-		PHPUnit_Framework_Assert::assertEquals(False, $this->isFieldInResponse('share_with', "$user"));
+		PHPUnit_Framework_Assert::assertEquals(
+			false,
+			$this->isFieldInResponse('share_with', "$user")
+		);
 	}
 
+	/**
+	 * @param string $userOrGroup
+	 * @param int $permissions
+	 * @return bool
+	 */
 	public function isUserOrGroupInSharedData($userOrGroup, $permissions = null) {
 		$data = $this->response->xml()->data[0];
 		foreach ($data as $element) {
 			if ($element->share_with == $userOrGroup && ($permissions === null || $permissions == $element->permissions)) {
-				return True;
+				return true;
 			}
 		}
-		return False;
+		return false;
 	}
 
 	/**
 	 * @Given /^(file|folder|entry) "([^"]*)" of user "([^"]*)" is shared with user "([^"]*)"( with permissions ([\d]*))?$/
 	 *
+	 * @param string $entry unused
 	 * @param string $filepath
 	 * @param string $user1
 	 * @param string $user2
+	 * @param null $withPerms unused
+	 * @param int $permissions
+	 * @return void
 	 */
-	public function assureFileIsShared($entry, $filepath, $user1, $user2, $withPerms = null, $permissions = null) {
+	public function assureFileIsShared(
+		$entry, $filepath, $user1, $user2, $withPerms = null, $permissions = null
+	) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
 		$client = new Client();
 		$options = [];
@@ -399,26 +542,37 @@ trait Sharing {
 		} else {
 			$time = time();
 			if ($this->lastShareTime !== null && $time - $this->lastShareTime < 1) {
-				// prevent creating two shares with the same "stime" which is based on
-				// seconds, this affects share merging order and could affect expected test
-				// result order
+				// prevent creating two shares with the same "stime" which is
+				// based on seconds, this affects share merging order and could
+				// affect expected test result order
 				sleep(1);
 			}
 			$this->lastShareTime = $time;
-			$this->createShare($user1, $filepath, 0, $user2, null, null, $permissions);
+			$this->createShare(
+				$user1, $filepath, 0, $user2, null, null, $permissions
+			);
 		}
 		$this->response = $client->get($fullUrl, $options);
-		PHPUnit_Framework_Assert::assertEquals(True, $this->isUserOrGroupInSharedData($user2, $permissions));
+		PHPUnit_Framework_Assert::assertEquals(
+			true,
+			$this->isUserOrGroupInSharedData($user2, $permissions)
+		);
 	}
 
 	/**
 	 * @Given /^(file|folder|entry) "([^"]*)" of user "([^"]*)" is shared with group "([^"]*)"( with permissions ([\d]*))?$/
 	 *
+	 * @param string $entry unused
 	 * @param string $filepath
 	 * @param string $user
 	 * @param string $group
+	 * @param null $withPerms unused
+	 * @param int $permissions
+	 * @return void
 	 */
-	public function assureFileIsSharedWithGroup($entry, $filepath, $user, $group, $withPerms = null, $permissions = null) {
+	public function assureFileIsSharedWithGroup(
+		$entry, $filepath, $user, $group, $withPerms = null, $permissions = null
+	) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
 		$client = new Client();
 		$options = [];
@@ -431,14 +585,20 @@ trait Sharing {
 		if ($this->isUserOrGroupInSharedData($group, $permissions)) {
 			return;
 		} else {
-			$this->createShare($user, $filepath, 1, $group, null, null, $permissions);
+			$this->createShare(
+				$user, $filepath, 1, $group, null, null, $permissions
+			);
 		}
 		$this->response = $client->get($fullUrl, $options);
-		PHPUnit_Framework_Assert::assertEquals(True, $this->isUserOrGroupInSharedData($group, $permissions));
+		PHPUnit_Framework_Assert::assertEquals(
+			true,
+			$this->isUserOrGroupInSharedData($group, $permissions)
+		);
 	}
 
 	/**
 	 * @When /^deleting last share$/
+	 * @return void
 	 */
 	public function deletingLastShare() {
 		$share_id = $this->lastShareData->data[0]->id;
@@ -448,6 +608,7 @@ trait Sharing {
 
 	/**
 	 * @When /^getting info of last share$/
+	 * @return void
 	 */
 	public function gettingInfoOfLastShare() {
 		$share_id = $this->lastShareData->data[0]->id;
@@ -457,26 +618,34 @@ trait Sharing {
 
 	/**
 	 * @Then /^last share_id is included in the answer$/
+	 * @return void
 	 */
 	public function checkingLastShareIDIsIncluded() {
 		$share_id = $this->lastShareData->data[0]->id;
 		if (!$this->isFieldInResponse('id', $share_id)) {
-			PHPUnit_Framework_Assert::fail("Share id $share_id not found in response");
+			PHPUnit_Framework_Assert::fail(
+				"Share id $share_id not found in response"
+			);
 		}
 	}
 
 	/**
 	 * @Then /^last share_id is not included in the answer$/
+	 * @return void
 	 */
 	public function checkingLastShareIDIsNotIncluded() {
 		$share_id = $this->lastShareData->data[0]->id;
 		if ($this->isFieldInResponse('id', $share_id)) {
-			PHPUnit_Framework_Assert::fail("Share id $share_id has been found in response");
+			PHPUnit_Framework_Assert::fail(
+				"Share id $share_id has been found in response"
+			);
 		}
 	}
 
 	/**
 	 * @Then /^the response contains ([0-9]+) entries$/
+	 * @param int $count
+	 * @return void
 	 */
 	public function checkingTheResponseEntriesCount($count) {
 		$actualCount = count($this->response->xml()->data[0]);
@@ -486,22 +655,40 @@ trait Sharing {
 	/**
 	 * @Then /^share fields of last share match with$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 * @return void
 	 */
 	public function checkShareFields($body) {
 		if ($body instanceof \Behat\Gherkin\Node\TableNode) {
 			$fd = $body->getRowsHash();
 
 			foreach ($fd as $field => $value) {
-				if (substr($field, 0, 10 ) === "share_with") {
-					$value = str_replace("REMOTE", substr($this->remoteBaseUrl, 0, -5), $value);
-					$value = str_replace("LOCAL", substr($this->localBaseUrl, 0, -5), $value);
+				if (substr($field, 0, 10) === "share_with") {
+					$value = str_replace(
+						"REMOTE",
+						substr($this->remoteBaseUrl, 0, -5),
+						$value
+					);
+					$value = str_replace(
+						"LOCAL", substr($this->localBaseUrl, 0, -5),
+						$value
+					);
 				}
-				if (substr($field, 0, 6 ) === "remote") {
-					$value = str_replace("REMOTE", substr($this->remoteBaseUrl, 0, -4), $value);
-					$value = str_replace("LOCAL", substr($this->localBaseUrl, 0, -4), $value);
+				if (substr($field, 0, 6) === "remote") {
+					$value = str_replace(
+						"REMOTE",
+						substr($this->remoteBaseUrl, 0, -4),
+						$value
+					);
+					$value = str_replace(
+						"LOCAL",
+						substr($this->localBaseUrl, 0, -4),
+						$value
+					);
 				}
 				if (!$this->isFieldInResponse($field, $value)) {
-					PHPUnit_Framework_Assert::fail("$field" . " doesn't have value " . "$value");
+					PHPUnit_Framework_Assert::fail(
+						"$field" . " doesn't have value " . "$value"
+					);
 				}
 			}
 		}
@@ -509,6 +696,10 @@ trait Sharing {
 
 	/**
 	 * @Then as :user remove all shares from the file named :fileName
+	 * @param string $user
+	 * @param string $fileName
+	 * @throws Exception
+	 * @return void
 	 */
 	public function asRemoveAllSharesFromTheFileNamed($user, $fileName) {
 		$url = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares?format=json";
@@ -553,23 +744,29 @@ trait Sharing {
 
 	/**
 	 * @When save last share id
+	 * @return void
 	 */
-	public function saveLastShareId()
-	{
+	public function saveLastShareId() {
 		$this->savedShareId = $this->lastShareData['data']['id'];
 	}
 
 	/**
 	 * @Then share ids should match
+	 * @return void
 	 */
-	public function shareIdsShouldMatch()
-	{
+	public function shareIdsShouldMatch() {
 		if ($this->savedShareId !== $this->lastShareData['data']['id']) {
 			throw new \Exception('Expected the same link share to be returned');
 		}
 	}
 
-	/* Returns shares of a file or folders as an array of elements */
+	/**
+	 * Returns shares of a file or folders as an array of elements
+	 *
+	 * @param string $user
+	 * @param string $path
+	 * @return array
+	 */
 	public function getShares($user, $path) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
 		$fullUrl = $fullUrl . '?path=' . $path;
@@ -583,7 +780,9 @@ trait Sharing {
 			$options['auth'] = [$user, $this->regularUser];
 		}
 
-		$this->response = $client->send($client->createRequest("GET", $fullUrl, $options));
+		$this->response = $client->send(
+			$client->createRequest("GET", $fullUrl, $options)
+		);
 		return $this->response->xml()->data->element;
 	}
 
@@ -592,7 +791,8 @@ trait Sharing {
 	 * @param string $user
 	 * @param string $type
 	 * @param string $path
-	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 * @param \Behat\Gherkin\Node\TableNode|null $TableNode
+	 * @return int|void
 	 */
 	public function checkPublicShares($user, $type, $path, $TableNode) {
 		$dataResponded = $this->getShares($user, $path);
@@ -611,17 +811,32 @@ trait Sharing {
 				$nameFound = false;
 				foreach ($dataResponded as $elementResponded) {
 					if ((string)$elementResponded->name[0] === $expectedElementsArray[2]) {
-						PHPUnit_Framework_Assert::assertEquals($expectedElementsArray[0], (string)$elementResponded->path[0]);
-						PHPUnit_Framework_Assert::assertEquals($expectedElementsArray[1], (string)$elementResponded->permissions[0]);
+						PHPUnit_Framework_Assert::assertEquals(
+							$expectedElementsArray[0],
+							(string)$elementResponded->path[0]
+						);
+						PHPUnit_Framework_Assert::assertEquals(
+							$expectedElementsArray[1],
+							(string)$elementResponded->permissions[0]
+						);
 						$nameFound = true;
 						break;
 					}
 				}
-				PHPUnit_Framework_Assert::assertTrue($nameFound, "Shared link name " . $expectedElementsArray[2] . " not found");
+				PHPUnit_Framework_Assert::assertTrue(
+					$nameFound,
+					"Shared link name " . $expectedElementsArray[2] . " not found"
+				);
 			}
 		}
 	}
 
+	/**
+	 * @param string $user
+	 * @param string $path to share
+	 * @param string $name of share
+	 * @return int|null
+	 */
 	public function getPublicShareIDByName($user, $path, $name) {
 		$dataResponded = $this->getShares($user, $path);
 		foreach ($dataResponded as $elementResponded) {
@@ -638,6 +853,7 @@ trait Sharing {
 	 * @param string $name
 	 * @param string $type
 	 * @param string $path
+	 * @return void
 	 */
 	public function deletingPublicShareNamed($user, $name, $type, $path) {
 		$share_id = $this->getPublicShareIDByName($user, $path, $name);
@@ -645,6 +861,9 @@ trait Sharing {
 		$this->sendingToWith("DELETE", $url, null);
 	}
 
+	/**
+	 * @return string authorization token
+	 */
 	private function getLastShareToken() {
 		if (count($this->lastShareData->data->element) > 0) {
 			return $this->lastShareData->data[0]->token;
@@ -653,16 +872,36 @@ trait Sharing {
 		return $this->lastShareData->data->token;
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function setupCommonSharingConfigs() {
-		$this->modifyServerConfig('core', 'shareapi_enabled', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_allow_links', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_allow_public_upload', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_allow_group_sharing', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_only_share_with_group_members', 'no');
-		$this->modifyServerConfig('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_share_dialog_user_enumeration_group_members', 'no');
+		$this->modifyServerConfig(
+			'core', 'shareapi_enabled', 'yes'
+		);
+		$this->modifyServerConfig(
+			'core', 'shareapi_allow_links', 'yes'
+		);
+		$this->modifyServerConfig(
+			'core', 'shareapi_allow_public_upload', 'yes'
+		);
+		$this->modifyServerConfig(
+			'core', 'shareapi_allow_group_sharing', 'yes'
+		);
+		$this->modifyServerConfig(
+			'core', 'shareapi_only_share_with_group_members', 'no'
+		);
+		$this->modifyServerConfig(
+			'core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'
+		);
+		$this->modifyServerConfig(
+			'core', 'shareapi_share_dialog_user_enumeration_group_members', 'no'
+		);
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function restoreCommonSharingConfigs() {
 		$this->resetCapability(
 			'files_sharing',
@@ -708,11 +947,21 @@ trait Sharing {
 		);
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function setupCommonFederationConfigs() {
-		$this->modifyServerConfig('files_sharing', 'outgoing_server2server_share_enabled', 'yes');
-		$this->modifyServerConfig('files_sharing', 'incoming_server2server_share_enabled', 'yes');
+		$this->modifyServerConfig(
+			'files_sharing', 'outgoing_server2server_share_enabled', 'yes'
+		);
+		$this->modifyServerConfig(
+			'files_sharing', 'incoming_server2server_share_enabled', 'yes'
+		);
 	}
 
+	/**
+	 * @return void
+	 */
 	protected function restoreCommonFederationConfigs() {
 		$this->resetCapability(
 			'federation',

--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -653,12 +653,78 @@ trait Sharing {
 		return $this->lastShareData->data->token;
 	}
 
-	protected function resetCommonSharingAppConfigs() {
+	protected function setupCommonSharingConfigs() {
 		$this->modifyServerConfig('core', 'shareapi_enabled', 'yes');
 		$this->modifyServerConfig('core', 'shareapi_allow_links', 'yes');
 		$this->modifyServerConfig('core', 'shareapi_allow_public_upload', 'yes');
 		$this->modifyServerConfig('core', 'shareapi_allow_group_sharing', 'yes');
 		$this->modifyServerConfig('core', 'shareapi_only_share_with_group_members', 'no');
+		$this->modifyServerConfig('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
+		$this->modifyServerConfig('core', 'shareapi_share_dialog_user_enumeration_group_members', 'no');
+	}
+
+	protected function restoreCommonSharingConfigs() {
+		$this->resetCapability(
+			'files_sharing',
+			'api_enabled',
+			'core',
+			'shareapi_enabled'
+		);
+		$this->resetCapability(
+			'files_sharing',
+			'public@@@enabled',
+			'core',
+			'shareapi_allow_links'
+		);
+		$this->resetCapability(
+			'files_sharing',
+			'public@@@upload',
+			'core',
+			'shareapi_allow_public_upload'
+		);
+		$this->resetCapability(
+			'files_sharing',
+			'group_sharing',
+			'core',
+			'shareapi_allow_group_sharing'
+		);
+		$this->resetCapability(
+			'files_sharing',
+			'share_with_group_members_only',
+			'core',
+			'shareapi_only_share_with_group_members'
+		);
+		$this->resetCapability(
+			'files_sharing',
+			'user_enumeration@@@enabled',
+			'core',
+			'shareapi_allow_share_dialog_user_enumeration'
+		);
+		$this->resetCapability(
+			'files_sharing',
+			'user_enumeration@@@group_members_only',
+			'core',
+			'shareapi_share_dialog_user_enumeration_group_members'
+		);
+	}
+
+	protected function setupCommonFederationConfigs() {
+		$this->modifyServerConfig('files_sharing', 'outgoing_server2server_share_enabled', 'yes');
+		$this->modifyServerConfig('files_sharing', 'incoming_server2server_share_enabled', 'yes');
+	}
+
+	protected function restoreCommonFederationConfigs() {
+		$this->resetCapability(
+			'federation',
+			'outgoing',
+			'files_sharing',
+			'outgoing_server2server_share_enabled'
+		);
+		$this->resetCapability(
+			'federation',
+			'incoming',
+			'files_sharing',
+			'incoming_server2server_share_enabled'
+		);
 	}
 }
-

--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -876,27 +876,41 @@ trait Sharing {
 	 * @return void
 	 */
 	protected function setupCommonSharingConfigs() {
-		$this->modifyServerConfig(
-			'core', 'shareapi_enabled', 'yes'
-		);
-		$this->modifyServerConfig(
-			'core', 'shareapi_allow_links', 'yes'
-		);
-		$this->modifyServerConfig(
-			'core', 'shareapi_allow_public_upload', 'yes'
-		);
-		$this->modifyServerConfig(
-			'core', 'shareapi_allow_group_sharing', 'yes'
-		);
-		$this->modifyServerConfig(
-			'core', 'shareapi_only_share_with_group_members', 'no'
-		);
-		$this->modifyServerConfig(
-			'core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'
-		);
-		$this->modifyServerConfig(
-			'core', 'shareapi_share_dialog_user_enumeration_group_members', 'no'
-		);
+		if (!$this->wasCapabilitySet('files_sharing', 'api_enabled')) {
+			$this->modifyServerConfig(
+				'core', 'shareapi_enabled', 'yes'
+			);
+		}
+		if (!$this->wasCapabilitySet('files_sharing', 'public@@@enabled')) {
+			$this->modifyServerConfig(
+				'core', 'shareapi_allow_links', 'yes'
+			);
+		}
+		if (!$this->wasCapabilitySet('files_sharing', 'public@@@upload')) {
+			$this->modifyServerConfig(
+				'core', 'shareapi_allow_public_upload', 'yes'
+			);
+		}
+		if (!$this->wasCapabilitySet('files_sharing', 'group_sharing')) {
+			$this->modifyServerConfig(
+				'core', 'shareapi_allow_group_sharing', 'yes'
+			);
+		}
+		if ($this->wasCapabilitySet('files_sharing', 'share_with_group_members_only')) {
+			$this->modifyServerConfig(
+				'core', 'shareapi_only_share_with_group_members', 'no'
+			);
+		}
+		if (!$this->wasCapabilitySet('files_sharing', 'user_enumeration@@@enabled')) {
+			$this->modifyServerConfig(
+				'core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'
+			);
+		}
+		if ($this->wasCapabilitySet('files_sharing', 'user_enumeration@@@group_members_only')) {
+			$this->modifyServerConfig(
+				'core', 'shareapi_share_dialog_user_enumeration_group_members', 'no'
+			);
+		}
 	}
 
 	/**
@@ -907,43 +921,50 @@ trait Sharing {
 			'files_sharing',
 			'api_enabled',
 			'core',
-			'shareapi_enabled'
+			'shareapi_enabled',
+			true
 		);
 		$this->resetCapability(
 			'files_sharing',
 			'public@@@enabled',
 			'core',
-			'shareapi_allow_links'
+			'shareapi_allow_links',
+			true
 		);
 		$this->resetCapability(
 			'files_sharing',
 			'public@@@upload',
 			'core',
-			'shareapi_allow_public_upload'
+			'shareapi_allow_public_upload',
+			true
 		);
 		$this->resetCapability(
 			'files_sharing',
 			'group_sharing',
 			'core',
-			'shareapi_allow_group_sharing'
+			'shareapi_allow_group_sharing',
+			true
 		);
 		$this->resetCapability(
 			'files_sharing',
 			'share_with_group_members_only',
 			'core',
-			'shareapi_only_share_with_group_members'
+			'shareapi_only_share_with_group_members',
+			false
 		);
 		$this->resetCapability(
 			'files_sharing',
 			'user_enumeration@@@enabled',
 			'core',
-			'shareapi_allow_share_dialog_user_enumeration'
+			'shareapi_allow_share_dialog_user_enumeration',
+			true
 		);
 		$this->resetCapability(
 			'files_sharing',
 			'user_enumeration@@@group_members_only',
 			'core',
-			'shareapi_share_dialog_user_enumeration_group_members'
+			'shareapi_share_dialog_user_enumeration_group_members',
+			false
 		);
 	}
 
@@ -951,12 +972,16 @@ trait Sharing {
 	 * @return void
 	 */
 	protected function setupCommonFederationConfigs() {
-		$this->modifyServerConfig(
-			'files_sharing', 'outgoing_server2server_share_enabled', 'yes'
-		);
-		$this->modifyServerConfig(
-			'files_sharing', 'incoming_server2server_share_enabled', 'yes'
-		);
+		if (!$this->wasCapabilitySet('federation', 'outgoing')) {
+			$this->modifyServerConfig(
+				'files_sharing', 'outgoing_server2server_share_enabled', 'yes'
+			);
+		}
+		if (!$this->wasCapabilitySet('federation', 'incoming')) {
+			$this->modifyServerConfig(
+				'files_sharing', 'incoming_server2server_share_enabled', 'yes'
+			);
+		}
 	}
 
 	/**
@@ -967,13 +992,15 @@ trait Sharing {
 			'federation',
 			'outgoing',
 			'files_sharing',
-			'outgoing_server2server_share_enabled'
+			'outgoing_server2server_share_enabled',
+			true
 		);
 		$this->resetCapability(
 			'federation',
 			'incoming',
 			'files_sharing',
-			'incoming_server2server_share_enabled'
+			'incoming_server2server_share_enabled',
+			true
 		);
 	}
 }


### PR DESCRIPTION
## Description
1) Make generic step definitions for ``When the capabilities are retrieved`` and thus be able to hide the repeated detail about doing a ``GET`` and checking for status ``200``.
2) Move ``Given as an "admin"`` into background since it starts every capabilities scenario.
3) Add code that can check an individual setting rather than a whole set, and make a few tests that use that code (so we know it works)
4) Save the existing capabilities at the start of a scenario.
5) Set the desired starting capabilities relevant to the context (pretty much as in master)
6) Put back the saved capabilities on the way out.
7) Various methods added along the way do reduce duplication of lists of "common" "standard" groups of settings.

After this, I can run any suite/feature/scenario by itself and it sets up the sharing/federation settings that it wants to start with, then puts things back the way they were on the way out. This lets me run "random" bits of integration tests in among other tests and playing in the UI trying to track down bugs, without having to think about what happened to settings.

## Related Issue

## Motivation and Context
Be nice to people running all different unit, integration and UI tests in their dev environment.

## How Has This Been Tested?
Try starting by first manually turning off "important" settings (like turn off file sharing completely, turn off group sharing). Run just an individual suite or feature from each suite and make sure they pass. Confirm that the previous settings come back as the test exits.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
Helpful stuff to make integration tests a bit more robust about their environment, and more friendly to everyday developers.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

