### PR TITLE
Exclude mimetypelist.js from integrity check

### DIFF
--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -179,6 +179,22 @@ class Checker {
 				continue;
 			}
 
+			$exclusionList = [
+				'/core/js/mimetypelist.js'
+			];
+
+			$found = false;
+			foreach ($exclusionList as $entry) {
+				if($filename === $this->environmentHelper->getServerRoot() . $entry) {
+					$found = true;
+					break;
+				}
+			}
+
+			if ($found) {
+				continue;
+			}
+
 			// The .user.ini and the .htaccess file of ownCloud can contain some
 			// custom modifications such as for example the maximum upload size
 			// to ensure that this will not lead to false positives this will


### PR DESCRIPTION
## Description
Because this file can be regenerated with additional entries with `occ maintenance:mimetype:update-js`

## Related Issue
Fixes https://github.com/owncloud/core/issues/28967

## Motivation and Context
Because admins need to be able to theme their instances without being annoyed by integrity failures.

## How Has This Been Tested?
This cannot be tested without merging because the signature file needs to be regenerated without this one entry. After merging, verify on daily master that after running the occ command above there are no integrity failures. Or modify the JS file manually and do a `occ integrity:check-core`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

