### PR TITLE
Add missing files_sharing capabilities

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -67,6 +67,7 @@ class Capabilities implements ICapability {
 				}
 
 				$public['send_mail'] = $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no') === 'yes';
+				$public['social_share'] = $this->config->getAppValue('core', 'shareapi_allow_social_share', 'yes') === 'yes';
 				$public['upload'] = $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes') === 'yes';
 				$public['multiple'] = true;
 				$public['supports_upload_only'] = true;
@@ -78,6 +79,15 @@ class Capabilities implements ICapability {
 			$res['resharing'] = $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes') === 'yes';
 
 			$res['group_sharing'] = $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes') === 'yes';
+
+			$res['share_with_group_members_only'] = $this->config->getAppValue('core', 'shareapi_only_share_with_group_members', 'yes') === 'yes';
+
+			$user_enumeration = [];
+			$user_enumeration['enabled'] = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
+			if ($user_enumeration['enabled']) {
+				$user_enumeration['group_members_only'] = $this->config->getAppValue('core', 'shareapi_share_dialog_user_enumeration_group_members', 'no') === 'yes';
+			}
+			$res["user_enumeration"] = $user_enumeration;
 
 			$res['default_permissions'] = (int)$this->config->getAppValue('core', 'shareapi_default_permissions', \OCP\Constants::PERMISSION_ALL);
 		}

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -23,7 +23,6 @@
 namespace OCA\Files_Sharing\Tests;
 
 use OCA\Files_Sharing\Capabilities;
-use OCA\Files_Sharing\Tests\TestCase;
 
 /**
  * Class CapabilitiesTest
@@ -34,7 +33,7 @@ class CapabilitiesTest extends \Test\TestCase {
 
 	/**
 	 * Test for the general part in each return statement and assert.
-	 * Strip of the general part on the way.
+	 * Strip off the general part on the way.
 	 *
 	 * @param string[] $data Capabilities
 	 * @return string[]
@@ -45,7 +44,7 @@ class CapabilitiesTest extends \Test\TestCase {
 	}
 
 	/**
-	 * Create a mock config object and insert the values in $map tot the getAppValue
+	 * Create a mock config object and insert the values in $map to the getAppValue
 	 * function. Then obtain the capabilities and extract the first few
 	 * levels in the array
 	 *
@@ -187,6 +186,25 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertFalse($result['public']['send_mail']);
 	}
 
+	public function testLinkSocial_Share() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+			['core', 'shareapi_allow_social_share', 'yes', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['public']['social_share']);
+	}
+	public function testLinkNoSocial_Share() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_allow_links', 'yes', 'yes'],
+			['core', 'shareapi_allow_social_share', 'yes', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertFalse($result['public']['social_share']);
+	}
+
 	public function testUserSendMail() {
 		$map = [
 			['core', 'shareapi_enabled', 'yes', 'yes'],
@@ -259,6 +277,62 @@ class CapabilitiesTest extends \Test\TestCase {
 		];
 		$result = $this->getResults($map);
 		$this->assertTrue($result['group_sharing']);
+	}
+
+	public function testNoShareWithGroupMembersOnly() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_only_share_with_group_members', 'yes', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertFalse($result['share_with_group_members_only']);
+	}
+
+	public function testShareWithGroupMembersOnly() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_only_share_with_group_members', 'yes', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['share_with_group_members_only']);
+	}
+
+	public function testNoUserEnumeration() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertFalse($result['user_enumeration']['enabled']);
+	}
+
+	public function testUserEnumeration() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['user_enumeration']['enabled']);
+	}
+
+	public function testUserEnumerationNoGroupMembersOnly() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
+			['core', 'shareapi_share_dialog_user_enumeration_group_members', 'no', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertFalse($result['user_enumeration']['group_members_only']);
+	}
+
+	public function testUserEnumerationGroupMembersOnly() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes', 'yes'],
+			['core', 'shareapi_share_dialog_user_enumeration_group_members', 'no', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['user_enumeration']['group_members_only']);
 	}
 
 	public function testFederatedSharingIncomming() {

--- a/tests/integration/capabilities_features/capabilities.feature
+++ b/tests/integration/capabilities_features/capabilities.feature
@@ -13,10 +13,15 @@ Feature: capabilities
 			| files_sharing | api_enabled | 1 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
+			| files_sharing | public@@@send_mail | EMPTY |
+			| files_sharing | public@@@social_share | 1 |
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
 			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -33,10 +38,15 @@ Feature: capabilities
 			| files_sharing | api_enabled | 1 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | EMPTY |
+			| files_sharing | public@@@send_mail | EMPTY |
+			| files_sharing | public@@@social_share | 1 |
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
 			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -76,6 +86,9 @@ Feature: capabilities
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
 			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -92,10 +105,15 @@ Feature: capabilities
 			| files_sharing | api_enabled | 1 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
+			| files_sharing | public@@@send_mail | EMPTY |
+			| files_sharing | public@@@social_share | 1 |
 			| files_sharing | resharing | EMPTY |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
 			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -112,10 +130,15 @@ Feature: capabilities
 			| files_sharing | api_enabled | 1 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
+			| files_sharing | public@@@send_mail | EMPTY |
+			| files_sharing | public@@@social_share | 1 |
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | EMPTY |
 			| files_sharing | federation@@@incoming | 1 |
 			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -132,10 +155,15 @@ Feature: capabilities
 			| files_sharing | api_enabled | 1 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
+			| files_sharing | public@@@send_mail | EMPTY |
+			| files_sharing | public@@@social_share | 1 |
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | EMPTY |
 			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -152,11 +180,16 @@ Feature: capabilities
 			| files_sharing | api_enabled | 1 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
+			| files_sharing | public@@@send_mail | EMPTY |
+			| files_sharing | public@@@social_share | 1 |
 			| files_sharing | public@@@password@@@enforced | 1 |
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
 			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -174,10 +207,39 @@ Feature: capabilities
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
 			| files_sharing | public@@@send_mail | 1 |
+			| files_sharing | public@@@social_share | 1 |
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
 			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
+			| files | bigfilechunking | 1 |
+			| files | undelete | 1 |
+			| files | versioning | 1 |
+
+	Scenario: Changing public social share
+		Given as an "admin"
+		And parameter "shareapi_allow_social_share" of app "core" is set to "no"
+		When sending "GET" to "/cloud/capabilities"
+		Then the HTTP status code should be "200"
+		And fields of capabilities match with
+			| capability | path_to_element | value |
+			| core | pollinterval | 60 |
+			| core | webdav-root | remote.php/webdav |
+			| files_sharing | api_enabled | 1 |
+			| files_sharing | public@@@enabled | 1 |
+			| files_sharing | public@@@upload | 1 |
+			| files_sharing | public@@@send_mail | EMPTY |
+			| files_sharing | public@@@social_share | EMPTY |
+			| files_sharing | resharing | 1 |
+			| files_sharing | federation@@@outgoing | 1 |
+			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -194,11 +256,16 @@ Feature: capabilities
 			| files_sharing | api_enabled | 1 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
+			| files_sharing | public@@@send_mail | EMPTY |
+			| files_sharing | public@@@social_share | 1 |
 			| files_sharing | public@@@expire_date@@@enabled | 1 |
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
 			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -216,12 +283,17 @@ Feature: capabilities
 			| files_sharing | api_enabled | 1 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
+			| files_sharing | public@@@send_mail | EMPTY |
+			| files_sharing | public@@@social_share | 1 |
 			| files_sharing | public@@@expire_date@@@enabled | 1 |
 			| files_sharing | public@@@expire_date@@@enforced | 1 |
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
 			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |
@@ -238,10 +310,89 @@ Feature: capabilities
 			| files_sharing | api_enabled | 1 |
 			| files_sharing | public@@@enabled | 1 |
 			| files_sharing | public@@@upload | 1 |
+			| files_sharing | public@@@send_mail | EMPTY |
+			| files_sharing | public@@@social_share | 1 |
 			| files_sharing | resharing | 1 |
 			| files_sharing | federation@@@outgoing | 1 |
 			| files_sharing | federation@@@incoming | 1 |
 			| files_sharing | group_sharing         | EMPTY |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
+			| files | bigfilechunking | 1 |
+			| files | undelete | 1 |
+			| files | versioning | 1 |
+
+	Scenario: Changing only share with group member
+		Given as an "admin"
+		And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
+		When sending "GET" to "/cloud/capabilities"
+		Then the HTTP status code should be "200"
+		And fields of capabilities match with
+			| capability | path_to_element | value |
+			| core | pollinterval | 60 |
+			| core | webdav-root | remote.php/webdav |
+			| files_sharing | api_enabled | 1 |
+			| files_sharing | public@@@enabled | 1 |
+			| files_sharing | public@@@upload | 1 |
+			| files_sharing | public@@@send_mail | EMPTY |
+			| files_sharing | public@@@social_share | 1 |
+			| files_sharing | resharing | 1 |
+			| files_sharing | federation@@@outgoing | 1 |
+			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | 1 |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
+			| files | bigfilechunking | 1 |
+			| files | undelete | 1 |
+			| files | versioning | 1 |
+
+	Scenario: Changing allow share dialog user enumeration
+		Given as an "admin"
+		And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
+		When sending "GET" to "/cloud/capabilities"
+		Then the HTTP status code should be "200"
+		And fields of capabilities match with
+			| capability | path_to_element | value |
+			| core | pollinterval | 60 |
+			| core | webdav-root | remote.php/webdav |
+			| files_sharing | api_enabled | 1 |
+			| files_sharing | public@@@enabled | 1 |
+			| files_sharing | public@@@upload | 1 |
+			| files_sharing | public@@@send_mail | EMPTY |
+			| files_sharing | public@@@social_share | 1 |
+			| files_sharing | resharing | 1 |
+			| files_sharing | federation@@@outgoing | 1 |
+			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | EMPTY |
+			| files | bigfilechunking | 1 |
+			| files | undelete | 1 |
+			| files | versioning | 1 |
+
+	Scenario: Changing allow share dialog user enumeration for group members only
+		Given as an "admin"
+		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" is set to "yes"
+		When sending "GET" to "/cloud/capabilities"
+		Then the HTTP status code should be "200"
+		And fields of capabilities match with
+			| capability | path_to_element | value |
+			| core | pollinterval | 60 |
+			| core | webdav-root | remote.php/webdav |
+			| files_sharing | api_enabled | 1 |
+			| files_sharing | public@@@enabled | 1 |
+			| files_sharing | public@@@upload | 1 |
+			| files_sharing | public@@@send_mail | EMPTY |
+			| files_sharing | public@@@social_share | 1 |
+			| files_sharing | resharing | 1 |
+			| files_sharing | federation@@@outgoing | 1 |
+			| files_sharing | federation@@@incoming | 1 |
+			| files_sharing | group_sharing         | 1 |
+			| files_sharing | share_with_group_members_only | EMPTY |
+			| files_sharing | user_enumeration@@@enabled | 1 |
+			| files_sharing | user_enumeration@@@group_members_only | 1 |
 			| files | bigfilechunking | 1 |
 			| files | undelete | 1 |
 			| files | versioning | 1 |

--- a/tests/integration/features/bootstrap/CapabilitiesContext.php
+++ b/tests/integration/features/bootstrap/CapabilitiesContext.php
@@ -42,7 +42,10 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 		$this->modifyServerConfig('files_sharing', 'incoming_server2server_share_enabled', 'yes');
 		$this->modifyServerConfig('core', 'shareapi_enforce_links_password', 'no');
 		$this->modifyServerConfig('core', 'shareapi_allow_public_notification', 'no');
+		$this->modifyServerConfig('core', 'shareapi_allow_social_share', 'yes');
 		$this->modifyServerConfig('core', 'shareapi_default_expire_date', 'no');
 		$this->modifyServerConfig('core', 'shareapi_enforce_expire_date', 'no');
+		$this->modifyServerConfig('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
+		$this->modifyServerConfig('core', 'shareapi_share_dialog_user_enumeration_group_members', 'no');
 	}
 }


### PR DESCRIPTION
## Description
Add capabilities that are checkboxes on the admin settings sharing panel but are not currently published in the capabilities.

## Related Issue

## Motivation and Context
I was looking at integration tests and wondered why these were not tested, and how to (easily) find their current values.

## How Has This Been Tested?
Looking at the response from the ``/cloud/capabilities`` endpoint.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

