### PR TITLE
Rationalize integration test use traits and resetAppConfigs

### DIFF
--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -7,12 +7,16 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 trait BasicStructure {
 
+	use AppConfiguration;
 	use Auth;
-	use Trashbin;
 	use Checksums;
 	use Comments;
 	use MailTool;
+	use Provisioning;
+	use Sharing;
 	use Tags;
+	use Trashbin;
+	use WebDav;
 
 	/** @var string */
 	private $currentUser = '';

--- a/tests/integration/features/bootstrap/CapabilitiesContext.php
+++ b/tests/integration/features/bootstrap/CapabilitiesContext.php
@@ -11,7 +11,6 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 class CapabilitiesContext implements Context, SnippetAcceptingContext {
 
 	use BasicStructure;
-	use AppConfiguration;
 
 	/**
 	 * @Then /^fields of capabilities match with$/
@@ -37,9 +36,7 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 	}
 
 	protected function resetAppConfigs() {
-		$this->modifyServerConfig('core', 'shareapi_enabled', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_allow_links', 'yes');
-		$this->modifyServerConfig('core', 'shareapi_allow_public_upload', 'yes');
+		$this->resetCommonSharingAppConfigs();
 		$this->modifyServerConfig('core', 'shareapi_allow_resharing', 'yes');
 		$this->modifyServerConfig('files_sharing', 'outgoing_server2server_share_enabled', 'yes');
 		$this->modifyServerConfig('files_sharing', 'incoming_server2server_share_enabled', 'yes');
@@ -47,6 +44,5 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 		$this->modifyServerConfig('core', 'shareapi_allow_public_notification', 'no');
 		$this->modifyServerConfig('core', 'shareapi_default_expire_date', 'no');
 		$this->modifyServerConfig('core', 'shareapi_enforce_expire_date', 'no');
-		$this->modifyServerConfig('core', 'shareapi_allow_group_sharing', 'yes');
 	}
 }

--- a/tests/integration/features/bootstrap/Checksums.php
+++ b/tests/integration/features/bootstrap/Checksums.php
@@ -6,8 +6,6 @@ use GuzzleHttp\Client;
 
 trait Checksums {
 
-	use Webdav;
-
 	/**
 	 * @When user :user uploads file :source to :destination with checksum :checksum
 	 * @param string $user

--- a/tests/integration/features/bootstrap/Comments.php
+++ b/tests/integration/features/bootstrap/Comments.php
@@ -25,7 +25,6 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 //class CommentsContext implements \Behat\Behat\Context\Context {
 
 trait Comments {
-	use Sharing;
 
 	/** @var int */
 	private $lastCommentId;

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -11,5 +11,9 @@ require_once 'bootstrap.php';
  * Features context.
  */
 class FeatureContext implements Context, SnippetAcceptingContext {
-	use WebDav;
+	use BasicStructure;
+
+	protected function resetAppConfigs() {
+		$this->resetCommonSharingAppConfigs();
+	}
 }

--- a/tests/integration/features/bootstrap/FederationContext.php
+++ b/tests/integration/features/bootstrap/FederationContext.php
@@ -4,13 +4,14 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
+require_once 'bootstrap.php';
 
 /**
  * Federation context.
  */
 class FederationContext implements Context, SnippetAcceptingContext {
 
-	use WebDav;
+	use BasicStructure;
 
 	/**
 	 * @Given /^user "([^"]*)" from server "(LOCAL|REMOTE)" shares "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)"$/
@@ -48,5 +49,10 @@ class FederationContext implements Context, SnippetAcceptingContext {
 		$this->theHTTPStatusCodeShouldBe('200');
 		$this->theOCSStatusCodeShouldBe('100');
 		$this->usingServer($previous);
+	}
+
+	protected function resetAppConfigs() {
+		$this->modifyServerConfig('files_sharing', 'outgoing_server2server_share_enabled', 'yes');
+		$this->modifyServerConfig('files_sharing', 'incoming_server2server_share_enabled', 'yes');
 	}
 }

--- a/tests/integration/features/bootstrap/Provisioning.php
+++ b/tests/integration/features/bootstrap/Provisioning.php
@@ -6,7 +6,6 @@ use GuzzleHttp\Message\ResponseInterface;
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 trait Provisioning {
-	use BasicStructure;
 
 	/** @var array */
 	private $createdUsers = [];

--- a/tests/integration/features/bootstrap/ShareesContext.php
+++ b/tests/integration/features/bootstrap/ShareesContext.php
@@ -7,11 +7,10 @@ use GuzzleHttp\Message\ResponseInterface;
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 /**
- * Features context.
+ * Sharees context.
  */
 class ShareesContext implements Context, SnippetAcceptingContext {
-	use Provisioning;
-	use AppConfiguration;
+	use BasicStructure;
 
 	/**
 	 * @When /^getting sharees for$/
@@ -65,9 +64,10 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 	}
 
 	protected function resetAppConfigs() {
-		$this->modifyServerConfig('core', 'shareapi_only_share_with_group_members', 'no');
+		$this->resetCommonSharingAppConfigs();
 		$this->modifyServerConfig('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
 		$this->modifyServerConfig('core', 'shareapi_share_dialog_user_enumeration_group_members', 'no');
-		$this->modifyServerConfig('core', 'shareapi_allow_group_sharing', 'yes');
+		$this->modifyServerConfig('files_sharing', 'outgoing_server2server_share_enabled', 'yes');
+		$this->modifyServerConfig('files_sharing', 'incoming_server2server_share_enabled', 'yes');
 	}
 }

--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -9,8 +9,6 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 
 trait Sharing {
-	use Provisioning;
-	use AppConfiguration;
 
 	/** @var int */
 	private $sharingApiVersion = 1;
@@ -655,8 +653,12 @@ trait Sharing {
 		return $this->lastShareData->data->token;
 	}
 
-	protected function resetAppConfigs() {
+	protected function resetCommonSharingAppConfigs() {
+		$this->modifyServerConfig('core', 'shareapi_enabled', 'yes');
+		$this->modifyServerConfig('core', 'shareapi_allow_links', 'yes');
 		$this->modifyServerConfig('core', 'shareapi_allow_public_upload', 'yes');
+		$this->modifyServerConfig('core', 'shareapi_allow_group_sharing', 'yes');
+		$this->modifyServerConfig('core', 'shareapi_only_share_with_group_members', 'no');
 	}
 }
 

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -10,7 +10,6 @@ use TestHelpers\WebDavHelper;
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 trait WebDav {
-	use Sharing;
 
 	/** @var string*/
 	private $davPath = "remote.php/webdav";


### PR DESCRIPTION
## Description
1) Put the traits in a flat "tree" under BasicStructure.
2) ``use BasicStructure`` from each "top-level" suite context.
3) require ``bootstrap.php`` for "top-level" suite contexts that need TestHelpers (that make it autoload the TestHelpers if the suite is run by itself)
4) make ``resetCommonSharingAppConfigs()`` that can set the sharing settings that every suite wants as a basic starting point.
5) adjust ``resetAppConfigs()`` in each "top-level" suite context so that it calls ``resetCommonSharingAppConfigs()`` and then also sets up any other sharing etc configs that it cares about.

## Related Issue

## Motivation and Context
1) The "use" traits in the integration tests are used in a loop. (I will make a diagram of the current structure...)
2) Some integration tests suites give failures when run standalone, because their individual ``resetAppConfigs()`` does not really make all the settings they need.
3) The branching of the "use" traits is confusing.

## How Has This Been Tested?
Run test runs on Jenkins with each of the suites individually (cutting down behat.yml) to demonstrate that each suite will run on its own.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

