### PR TITLE
don't assume the theme directory exists

### DIFF
--- a/core/Command/Maintenance/Mimetype/UpdateJS.php
+++ b/core/Command/Maintenance/Mimetype/UpdateJS.php
@@ -122,15 +122,17 @@ class UpdateJS extends Command {
 	private function getLegacyThemes() {
 		$themes = [];
 
-		$legacyThemeDirectories = new \DirectoryIterator(\OC::$SERVERROOT . '/themes/');
+		if (is_dir(\OC::$SERVERROOT . '/themes/')) {
+			$legacyThemeDirectories = new \DirectoryIterator(\OC::$SERVERROOT . '/themes/');
 
-		foreach($legacyThemeDirectories as $legacyThemeDirectory) {
-			if ($legacyThemeDirectory->isFile() || $legacyThemeDirectory->isDot()) {
-				continue;
+			foreach($legacyThemeDirectories as $legacyThemeDirectory) {
+				if ($legacyThemeDirectory->isFile() || $legacyThemeDirectory->isDot()) {
+					continue;
+				}
+				$themes[$legacyThemeDirectory->getFilename()] = $this->getFileTypeIcons(
+					$legacyThemeDirectory->getPathname()
+				);
 			}
-			$themes[$legacyThemeDirectory->getFilename()] = $this->getFileTypeIcons(
-				$legacyThemeDirectory->getPathname()
-			);
 		}
 
 		return $themes;

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -166,17 +166,19 @@ class ThemeService implements IThemeService {
 	 */
 	private function getAllLegacyThemes() {
 		$themes = [];
-		if ($handle = opendir(\OC::$SERVERROOT . '/themes')) {
-			while (false !== ($entry = readdir($handle))) {
-				if ($entry === '.' || $entry === '..') {
-					continue;
+		if (is_dir(\OC::$SERVERROOT . '/themes')) {
+			if ($handle = opendir(\OC::$SERVERROOT . '/themes')) {
+				while (false !== ($entry = readdir($handle))) {
+					if ($entry === '.' || $entry === '..') {
+						continue;
+					}
+					if (is_dir(\OC::$SERVERROOT . '/themes/' . $entry)) {
+						$themes[$entry] = $this->makeTheme($entry, false);
+					}
 				}
-				if (is_dir(\OC::$SERVERROOT . '/themes/' . $entry)) {
-					$themes[$entry] = $this->makeTheme($entry, false);
-				}
+				closedir($handle);
+				return $themes;
 			}
-			closedir($handle);
-			return $themes;
 		}
 		return $themes;
 	}


### PR DESCRIPTION
## Description
Since the `theme` directory in the owncloud root was deleted, both `ThemeService` and the command `maintenance:mimetype:update-js` should not assume that this directory exists. This did produce some error logs, and the command was not executable without this directory.

## Related Issue
https://github.com/owncloud/core/issues/28966

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

