### PR TITLE
Stable10 prevent .part creation by user

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -107,6 +107,7 @@ class File extends Node implements IFile {
 	 * @return string|null
 	 */
 	public function put($data) {
+
 		try {
 			$exists = $this->fileView->file_exists($this->path);
 			if ($this->info && $exists && !$this->info->isUpdateable()) {
@@ -116,7 +117,14 @@ class File extends Node implements IFile {
 			throw new ServiceUnavailable("File is not updatable: " . $e->getMessage());
 		}
 
-		// verify path of the target
+		if (pathinfo($this->getFileInfo()->getPath(), PATHINFO_EXTENSION) == 'part') {
+			throw new BadRequest(
+				'Can`t upload files with extension .part because this extension is used internally by owncloud.'
+			);
+		}
+
+
+			// verify path of the target
 		$this->verifyPath();
 
 		// chunked handling

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -117,13 +117,6 @@ class File extends Node implements IFile {
 			throw new ServiceUnavailable("File is not updatable: " . $e->getMessage());
 		}
 
-		if (pathinfo($this->getFileInfo()->getPath(), PATHINFO_EXTENSION) == 'part') {
-			throw new BadRequest(
-				'Can`t upload files with extension .part because this extension is used internally by owncloud.'
-			);
-		}
-
-
 			// verify path of the target
 		$this->verifyPath();
 

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -177,10 +177,6 @@ class FilesPlugin extends ServerPlugin {
 			return;
 		}
 
-		if (pathinfo($destination, PATHINFO_EXTENSION) == 'part') {
-			throw new BadRequest("A file can`t have the extension part, because .part is used by ownCloud internally.");
-		}
-
 		list($sourceDir,) = \Sabre\HTTP\URLUtil::splitPath($source);
 		list($destinationDir,) = \Sabre\HTTP\URLUtil::splitPath($destination);
 

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -32,6 +32,7 @@ namespace OCA\DAV\Connector\Sabre;
 
 use OC\AppFramework\Http\Request;
 use OCP\Files\ForbiddenException;
+use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\IFile;
@@ -168,12 +169,18 @@ class FilesPlugin extends ServerPlugin {
 	 * @param string $destination destination path
 	 * @throws Forbidden
 	 * @throws NotFound
+	 * @throws BadRequest
 	 */
 	function checkMove($source, $destination) {
 		$sourceNode = $this->tree->getNodeForPath($source);
 		if (!$sourceNode instanceof Node) {
 			return;
 		}
+
+		if (pathinfo($destination, PATHINFO_EXTENSION) == 'part') {
+			throw new BadRequest("A file can`t have the extension part, because .part is used by ownCloud internally.");
+		}
+
 		list($sourceDir,) = \Sabre\HTTP\URLUtil::splitPath($source);
 		list($destinationDir,) = \Sabre\HTTP\URLUtil::splitPath($destination);
 

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1798,6 +1798,12 @@ class View {
 			throw new InvalidPathException($l10n->t('Dot files are not allowed'));
 		}
 
+		if (pathinfo($fileName, PATHINFO_EXTENSION) == 'part') {
+			throw new InvalidPathException(
+				'Can`t upload files with extension .part because this extension is used internally by owncloud.'
+			);
+		}
+
 		if (!\OC::$server->getDatabaseConnection()->allows4ByteCharacters()) {
 			// verify database - e.g. mysql only 3-byte chars
 			if (preg_match('%(?:

--- a/tests/integration/features/webdav-related-new-endpoint.feature
+++ b/tests/integration/features/webdav-related-new-endpoint.feature
@@ -598,3 +598,25 @@ Feature: webdav-related-new-endpoint
 		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
 		When user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with size 15
 		Then the HTTP status code should be "201"
+
+
+	Scenario: Copying file to a path with extension .part should not be possible
+		Given using new dav path
+		And user "user0" exists
+		And As an "user0"
+		When User "user0" copies file "/welcome.txt" to "/welcome.part"
+		Then the HTTP status code should be "400"
+
+	Scenario: Uploading file to path with extension .part should not be possible
+		Given using new dav path
+		And user "user0" exists
+		And As an "user0"
+		And User "user0" uploads file "data/textfile.txt" to "/textfile.part"
+		Then the HTTP status code should be "400"
+
+	Scenario: Renaming a file to a path with extension .part should not be possible
+		Given using new dav path
+		And user "user0" exists
+		And As an "user0"
+		When User "user0" moves file "/welcome.txt" to "/welcome.part"
+		Then the HTTP status code should be "400"

--- a/tests/integration/features/webdav-related-old-endpoint.feature
+++ b/tests/integration/features/webdav-related-old-endpoint.feature
@@ -516,3 +516,23 @@ Feature: webdav-related-old-endpoint
 		And as "user1" the folder "/folderB/ONE/TWO" exists
 		And User "user1" checks id of file "/folderB/ONE"
 
+	Scenario: Copying file to a path with extension .part should not be possible
+		Given using new dav path
+		And user "user0" exists
+		And As an "user0"
+		When User "user0" copies file "/welcome.txt" to "/welcome.part"
+		Then the HTTP status code should be "400"
+
+	Scenario: Uploading file to path with extension .part should not be possible
+		Given using new dav path
+		And user "user0" exists
+		And As an "user0"
+		And User "user0" uploads file "data/textfile.txt" to "/textfile.part"
+		Then the HTTP status code should be "400"
+
+	Scenario: Renaming a file to a path with extension .part should not be possible
+		Given using new dav path
+		And user "user0" exists
+		And As an "user0"
+		When User "user0" moves file "/welcome.txt" to "/welcome.part"
+		Then the HTTP status code should be "400"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Prevent creating, moving, copying to paths with .part
## Related Issue
#7496 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

