### PR TITLE
Remove encryption from unignored gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,8 @@
 !/apps/comments
 !/apps/dav
 !/apps/files
-!/apps/federation
 !/apps/federatedfilesharing
-!/apps/encryption
+!/apps/federation
 !/apps/files_external
 !/apps/files_sharing
 !/apps/files_trashbin
@@ -24,8 +23,8 @@
 !/apps/provisioning_api
 !/apps/systemtags
 !/apps/testing
-!/apps/updatenotification
 !/apps/theme-example
+!/apps/updatenotification
 /apps/files_external/3rdparty/irodsphp/PHPUnitTest
 /apps/files_external/3rdparty/irodsphp/web
 /apps/files_external/3rdparty/irodsphp/prods/test


### PR DESCRIPTION
## Description
``encryption`` is a separate app nowadays. It is not still in the ``core`` repo. So make sure it is ignored in the ``.gitignore`` list. (i.e. remove it from being "unignored").

While I am at it, sort the list into strict alphabetical order so it is easily verified to be the same as the list of folders at https://github.com/owncloud/core/tree/master/apps

## Related Issue

## Motivation and Context
When I clone the ``encryption`` app into the ``core/apps`` folder of a dev environment, ``git`` thinks they are added files for the next commit.

## How Has This Been Tested?
See that ``git`` does ignore the ``encryption`` app files after this change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

