### PR TITLE
Return privatelink via DAV

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -61,6 +61,7 @@ class FilesPlugin extends ServerPlugin {
 	const OWNER_DISPLAY_NAME_PROPERTYNAME = '{http://owncloud.org/ns}owner-display-name';
 	const CHECKSUMS_PROPERTYNAME = '{http://owncloud.org/ns}checksums';
 	const DATA_FINGERPRINT_PROPERTYNAME = '{http://owncloud.org/ns}data-fingerprint';
+	const PRIVATE_LINK_PROPERTYNAME = '{http://owncloud.org/ns}privatelink';
 
 	/**
 	 * Reference to main server object
@@ -140,6 +141,7 @@ class FilesPlugin extends ServerPlugin {
 		$server->protectedProperties[] = self::OWNER_DISPLAY_NAME_PROPERTYNAME;
 		$server->protectedProperties[] = self::CHECKSUMS_PROPERTYNAME;
 		$server->protectedProperties[] = self::DATA_FINGERPRINT_PROPERTYNAME;
+		$server->protectedProperties[] = self::PRIVATE_LINK_PROPERTYNAME;
 
 		// normally these cannot be changed (RFC4918), but we want them modifiable through PROPPATCH
 		$allowedProperties = ['{DAV:}getetag'];
@@ -307,6 +309,11 @@ class FilesPlugin extends ServerPlugin {
 			});
 			$propFind->handle(self::SIZE_PROPERTYNAME, function() use ($node) {
 				return $node->getSize();
+			});
+
+			$propFind->handle(self::PRIVATE_LINK_PROPERTYNAME, function() use ($node) {
+				return \OC::$server->getURLGenerator()
+					->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileId' => $node->getInternalFileId()]);
 			});
 		}
 

--- a/apps/files/lib/Capabilities.php
+++ b/apps/files/lib/Capabilities.php
@@ -57,6 +57,7 @@ class Capabilities implements ICapability {
 				'preferredUploadType' => 'SHA1'
 			],
 			'files' => [
+				'privateLinks' => true,
 				'bigfilechunking' => true,
 				'blacklisted_files' => $this->config->getSystemValue('blacklisted_files', ['.htaccess']),
 			],

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -394,6 +394,36 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then the single response should contain a property :key with value like :regex
+	 * @param string $key
+	 * @param string $regex
+	 * @throws \Exception
+	 */
+	public function theSingleResponseShouldContainAPropertyWithValueLike($key, $regex) {
+		$keys = $this->response;
+		if (!array_key_exists($key, $keys)) {
+			throw new \Exception("Cannot find property \"$key\" with \"$regex\"");
+		}
+
+		$value = $keys[$key];
+		if ($value instanceof ResourceType) {
+			$value = $value->getValue();
+			if (empty($value)) {
+				$value = '';
+			} else {
+				$value = $value[0];
+			}
+		}
+
+		if (preg_match($regex, $value)) {
+			return 0;
+		} else {
+			throw new \Exception("Property \"$key\" found with value \"$value\", expected \"$regex\"");
+		}
+	}
+
+
+	/**
 	 * @Then the response should contain a share-types property with
 	 */
 	public function theResponseShouldContainAShareTypesPropertyWith($table)

--- a/tests/integration/features/webdav-related-new-endpoint.feature
+++ b/tests/integration/features/webdav-related-new-endpoint.feature
@@ -593,3 +593,12 @@ Feature: webdav-related-new-endpoint
 		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
 		When user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with size 15
 		Then the HTTP status code should be "201"
+
+	Scenario: Retrieving private link
+		Given using new dav path
+		And user "user0" exists
+		And as an "user0"
+		And user "user0" uploads file "data/textfile.txt" to "/somefile.txt"
+		Then as "user0" gets properties of file "/somefile.txt" with
+			|{http://owncloud.org/ns}privatelink|
+		And the single response should contain a property "{http://owncloud.org/ns}privatelink" with value like "/(\/index.php\/f\/[0-9]*)/"

--- a/tests/integration/features/webdav-related-old-endpoint.feature
+++ b/tests/integration/features/webdav-related-old-endpoint.feature
@@ -507,3 +507,14 @@ Feature: webdav-related-old-endpoint
 		And as "user1" the folder "/folderB/ONE" exists
 		And as "user1" the folder "/folderB/ONE/TWO" exists
 		And user "user1" checks id of file "/folderB/ONE"
+
+
+	Scenario: Retrieving private link
+		Given using old dav path
+		And user "user0" exists
+		And as an "user0"
+		And user "user0" uploads file "data/textfile.txt" to "/somefile.txt"
+		Then as "user0" gets properties of file "/somefile.txt" with
+			|{http://owncloud.org/ns}privatelink|
+		And the single response should contain a property "{http://owncloud.org/ns}privatelink" with value like "/(\/index.php\/f\/[0-9]*)/"
+


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Possibility to retrieve privatelinks via dav, to facilitate better integration with clients
## Related Issue
#28984 

## How Has This Been Tested?
- Manually (mitmproxy, cadaver)
- Integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

