### PR TITLE
Always have a "page file is reloaded" check after rename

### DIFF
--- a/tests/ui/features/files/renameFiles.feature
+++ b/tests/ui/features/files/renameFiles.feature
@@ -8,6 +8,8 @@ Feature: renameFiles
 	Scenario Outline: Rename a file using special characters
 		When I rename the file "lorem.txt" to <to_file_name>
 		Then the file <to_file_name> should be listed
+		And the files page is reloaded
+		Then the file <to_file_name> should be listed
 		Examples:
 		|to_file_name    |
 		|'लोरेम।तयक्स्त? $%#&@' |
@@ -16,6 +18,8 @@ Feature: renameFiles
 
 	Scenario Outline: Rename a file that has special characters in its name
 		When I rename the file <from_name> to <to_name>
+		Then the file <to_name> should be listed
+		And the files page is reloaded
 		Then the file <to_name> should be listed
 		Examples:
 		|from_name                            |to_name                              |

--- a/tests/ui/features/files/renameFolders.feature
+++ b/tests/ui/features/files/renameFolders.feature
@@ -8,6 +8,8 @@ Feature: renameFolders
 	Scenario Outline: Rename a folder using special characters
 		When I rename the folder "simple-folder" to <to_folder_name>
 		Then the folder <to_folder_name> should be listed
+		And the files page is reloaded
+		Then the folder <to_folder_name> should be listed
 		Examples:
 		|to_folder_name|
 		|'सिमप्ले फोल्देर$%#?&@' |
@@ -16,6 +18,8 @@ Feature: renameFolders
 
 	Scenario Outline: Rename a folder that has special characters in its name
 		When I rename the folder <from_name> to <to_name>
+		Then the folder <to_name> should be listed
+		And the files page is reloaded
 		Then the folder <to_name> should be listed
 		Examples:
 		|from_name           |to_name                 |


### PR DESCRIPTION
## Description
In each renaming UI test, make sure to reload the files page and check the existence of the expected renamed file. This seems to leave the browser in a "better" more consistent state, from which Selenium and the "CSRF check" cope better.

Read the related issue for various alternatives that were tested and reasoning...

## Related Issue
#28920 

## Motivation and Context
Fix intermittent fails of rename tests.

## How Has This Been Tested?
Multiple Travis UI test runs have been done in temporary branches on top of this to confirm it works. 8 complete UI test runs were all successful.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

