### PR TITLE
Better control of which jobs run only for Travis CRON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ addons:
     - owncloud
 
 before_install:
-  - if [ "$TC" = "syntax" ] || [ "$TEST_DAV" = "1" ] || { [ "$TC" = "selenium" ] && [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && { [ "$CRON_ONLY" = "0" ] || [ "$TRAVIS_EVENT_TYPE" = "cron" ]; }; }; then echo "There is real work to do"; else exit 0; fi
   - make
   - sh -c "if [ '$TEST_DAV' = '1' ] || [ '$TC' = 'selenium' ]; then bash tests/travis/before_install.sh $DB; fi"
 
@@ -55,37 +54,37 @@ script:
 matrix:
   include:
     - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=0
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=0
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=0
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=0
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=0
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=0
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
@@ -104,38 +103,44 @@ matrix:
       env: DB=sqlite TC=syntax TEST_DAV=0
     - php: 7.0
       env: DB=sqlite TC=syntax TEST_DAV=0
-    - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=1
+    - if: type = cron
+      php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=1
+    - if: type = cron
+      php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0 CRON_ONLY=1
+    - if: type = cron
+      php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="other" PLATFORM="Windows 7" TEST_DAV=0 CRON_ONLY=1
+    - if: type = cron
+      php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="other" PLATFORM="Windows 7" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="files" PLATFORM="Windows 7" TEST_DAV=0 CRON_ONLY=1
+    - if: type = cron
+      php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="files" PLATFORM="Windows 7" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="trashbin" PLATFORM="Windows 7" TEST_DAV=0 CRON_ONLY=1
+    - if: type = cron
+      php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="trashbin" PLATFORM="Windows 7" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts


### PR DESCRIPTION
## Description
Use the new "if:" feature in the matrix to control which jobs even get created by Travis.

## Related Issue

## Motivation and Context
Travis creates a job for each item in the matrix. Then if we only want the job to run in the context of a Travis CRON job (rather than with every PR) we had put the env var ``CRON_ONLY`` to indicate if we really want the job to do something. The ``CRON_ONLY`` jobs could exit early when run from ordinary PRs. But they still wasted time in the Travis job queue.

Travis has now released a (beta) feature to allow the starting of jobs in the matrix to be controlled by various conditions. See:
https://github.com/travis-ci/travis-ci/issues/7181#issuecomment-331099035
https://blog.travis-ci.com/2017-09-12-build-stages-order-and-conditions
https://docs.travis-ci.com/user/conditional-builds-stages-jobs#Specifying-conditions

## How Has This Been Tested?
Trying some combinations in my own forked repo.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

The Travis CI here will tell if it really works.