### PR TITLE
Get SFTP key pair mode working

### DIFF
--- a/apps/files_external/lib/Lib/Auth/PublicKey/RSA.php
+++ b/apps/files_external/lib/Lib/Auth/PublicKey/RSA.php
@@ -60,9 +60,11 @@ class RSA extends AuthMechanism {
 	public function manipulateStorageConfig(IStorageConfig &$storage, IUser $user = null) {
 		$auth = new RSACrypt();
 		$auth->setPassword($this->config->getSystemValue('secret', ''));
-		if (!$auth->loadKey($storage->getBackendOption('private_key'))) {
+		$privateKey =  $storage->getBackendOption('private_key');
+		if (!$auth->loadKey($privateKey)) {
 			throw new \RuntimeException('unable to load private key');
 		}
+		$storage->setBackendOption('private_key', base64_encode($privateKey));
 		$storage->setBackendOption('public_key_auth', $auth);
 	}
 

--- a/lib/private/Files/External/FrontendDefinitionTrait.php
+++ b/lib/private/Files/External/FrontendDefinitionTrait.php
@@ -150,7 +150,11 @@ trait FrontendDefinitionTrait {
 				if (!$parameter->validateValue($value)) {
 					return false;
 				}
-				$storage->setBackendOption($name, $value);
+				if (($name === 'public_key') || ($name === 'private_key')) {
+					$storage->setBackendOption($name, base64_encode($value));
+				} else {
+					$storage->setBackendOption($name, $value);
+				}
 			}
 		}
 		return true;

--- a/lib/private/Files/External/StorageConfig.php
+++ b/lib/private/Files/External/StorageConfig.php
@@ -222,6 +222,12 @@ class StorageConfig implements IStorageConfig {
 					$backendOptions[$key] = $value;
 				}
 				if(is_string($backendOptions[$key])) {
+					if (($key === 'public_key') || ($key === 'private_key')) {
+						if (base64_decode($backendOptions[$key], true) === false) {
+							$backendOptions[$key] = base64_encode($backendOptions[$key]);
+						}
+					}
+
 					$backendOptions[$key] = str_replace(["\n", "\r"], "", $backendOptions[$key]);
 				}
 			}
@@ -236,6 +242,13 @@ class StorageConfig implements IStorageConfig {
 	 */
 	public function getBackendOption($key) {
 		if (isset($this->backendOptions[$key])) {
+			if (($key === 'private_key') || ($key === 'public_key')) {
+				$decodedString = base64_decode($this->backendOptions[$key], true);
+				if ($decodedString !== false) {
+					return $decodedString;
+				}
+			}
+
 			return $this->backendOptions[$key];
 		}
 		return null;


### PR DESCRIPTION
Due to removal of '\n' and '\r' from
the backendoptions the private keys were affected.
And hence resulted in failure to login. So as an
alternative in this patch we use base64_encode
and base64_decode to convert both the public and
private keys. Another advantage is that we don't
expose the private keys in the database.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
SFTP was failing to work with the change made https://github.com/owncloud/core/commit/9b88fa6c8c0ebaa7d471476821cfc70778620ce9 . The key problem found was failure to authenticate with the private key.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/28669

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The issue was caused due to the strip of value in backendoptions. And due to this the private key was modified. Hence authentication failure. This change helps users to convert public key and private key using base64_encode and retrieve the data using base64_decode. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Enable SFTP storage
- [x] Select the public key option
- [x] Copy the public key option shown in the UI to the destination server.
- [x] The green light is shown in the ui
Migration test:
With the migration I have noticed the old data remains the same. So if new key is copied to the server using generate keys option in the UI, it works. So both the old keys work as well as the new one generated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

