### PR TITLE
Set a minimum timeout for UI test waits

### DIFF
--- a/tests/ui/features/bootstrap/bootstrap.php
+++ b/tests/ui/features/bootstrap/bootstrap.php
@@ -34,3 +34,5 @@ const STANDARDSLEEPTIMEMICROSEC = STANDARDSLEEPTIMEMILLISEC * 1000;
 
 // Default timeout for use in code that needs to wait for the UI
 const STANDARDUIWAITTIMEOUTMILLISEC = 10000;
+// Minimum timeout for use in code that needs to wait for the UI
+const MINIMUMUIWAITTIMEOUTMILLISEC = 500;

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -54,6 +54,7 @@ class OwncloudPage extends Page {
 		Session $session,
 		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
 	) {
+		$timeout_msec = max($timeout_msec, MINIMUMUIWAITTIMEOUTMILLISEC);
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
@@ -82,6 +83,7 @@ class OwncloudPage extends Page {
 		$xpath,
 		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
 	) {
+		$timeout_msec = max($timeout_msec, MINIMUMUIWAITTIMEOUTMILLISEC);
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
@@ -107,6 +109,7 @@ class OwncloudPage extends Page {
 	public function waitTillElementIsNotNull(
 		$xpath, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
 	) {
+		$timeout_msec = max($timeout_msec, MINIMUMUIWAITTIMEOUTMILLISEC);
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
@@ -342,6 +345,7 @@ class OwncloudPage extends Page {
 		$this->waitForAjaxCallsToStart($session);
 		$end = microtime(true);
 		$timeout_msec = $timeout_msec - (($end - $start) * 1000);
+		$timeout_msec = max($timeout_msec, MINIMUMUIWAITTIMEOUTMILLISEC);
 		$this->waitForOutstandingAjaxCalls($session, $timeout_msec);
 	}
 

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -54,7 +54,6 @@ class OwncloudPage extends Page {
 		Session $session,
 		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
 	) {
-		$timeout_msec = max($timeout_msec, MINIMUMUIWAITTIMEOUTMILLISEC);
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
@@ -83,7 +82,6 @@ class OwncloudPage extends Page {
 		$xpath,
 		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
 	) {
-		$timeout_msec = max($timeout_msec, MINIMUMUIWAITTIMEOUTMILLISEC);
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
@@ -109,7 +107,6 @@ class OwncloudPage extends Page {
 	public function waitTillElementIsNotNull(
 		$xpath, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
 	) {
-		$timeout_msec = max($timeout_msec, MINIMUMUIWAITTIMEOUTMILLISEC);
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {


### PR DESCRIPTION
## Description
Ensure that anything calling a method to do a wait in the UI tests will have some reasonable minimum timeout.

## Related Issue

## Motivation and Context
This sort of test crash:
```
  Scenario: share a folder with another internal user and prohibit deleting  # /home/travis/build/owncloud/core/tests/ui/features/other/sharing.feature:58
    When the folder "simple-folder" is shared with the user "User One"       # SharingContext::theFileFolderIsSharedWithTheUser()
      exception 'InvalidArgumentException' with message 'negative or zero timeout' in /home/travis/build/owncloud/core/tests/ui/features/lib/OwncloudPage.php:278
      Stack trace:
      #0 /home/travis/build/owncloud/core/tests/ui/features/lib/OwncloudPage.php(345): Page\OwncloudPage->waitForOutstandingAjaxCalls(Object(Behat\Mink\Session), -2843.9090251923)
      #1 /home/travis/build/owncloud/core/tests/ui/features/lib/FilesPageElement/SharingDialog.php(85): Page\OwncloudPage->waitForAjaxCallsToStartAndFinish(Object(Behat\Mink\Session), 10000)
      #2 /home/travis/build/owncloud/core/tests/ui/features/lib/FilesPageElement/SharingDialog.php(155): Page\FilesPageElement\SharingDialog->fillShareWithField('User One', Object(Behat\Mink\Session))
      #3 /home/travis/build/owncloud/core/tests/ui/features/lib/FilesPageElement/SharingDialog.php(185): Page\FilesPageElement\SharingDialog->shareWithUserOrGroup('User One', 'User One', Object(Behat\Mink\Session))
      #4 /home/travis/build/owncloud/core/tests/ui/features/bootstrap/SharingContext.php(70): Page\FilesPageElement\SharingDialog->shareWithUser('User One', Object(Behat\Mink\Session))
```

## How Has This Been Tested?
Travis will tell.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
