### PR TITLE
Allow 0 byte quota to be entered on UI

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -542,7 +542,7 @@ var UserList = {
 		}
 		if (
 			['default', 'none'].indexOf(quota) === -1
-			&& (!OC.Util.computerFileSize(quota))
+			&& (OC.Util.computerFileSize(quota) === null)
 		) {
 			// the select component has added the bogus value, delete it again
 			$select.find('option[selected]').remove();

--- a/tests/ui/features/other/users.feature
+++ b/tests/ui/features/other/users.feature
@@ -21,6 +21,7 @@ Feature: users
 		|Unlimited  |5B          |5 B           |
 		|Unlimited  |55kB        |55 KB         |
 		|Unlimited  |45Kb        |45 KB         |
+		|Unlimited  |0 Kb        |0 B           |
 
 	Scenario Outline: change quota to an invalid value
 		When quota of user "%regularuser%" is changed to "<wished_quota>"
@@ -34,6 +35,7 @@ Feature: users
 		|30/40GB     |
 		|30/40       |
 		|3+56 B      |
+		|-1 B        |
 
 	Scenario: create simple user
 		When I create a user with the name "guiusr1" and the password "pwd"


### PR DESCRIPTION
## Description
1) Add a test for entering 0 byte quota (note: 0 can be entered as "0" "0 B" "0 KB" etc)
2) While we are here, add a test to make sure entering a quota of "-1" fails.
3) Improve the check of the return value from ``computerFileSize()``

## Related Issue
#29105 
also improves on old closed issue #25358

## Motivation and Context
It be broke.

## How Has This Been Tested?
Run automated UI tests in a local dev VM. Watch it work.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
