### PR TITLE
fix app_type check

### DIFF
--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -153,7 +153,8 @@ class ThemeService implements IThemeService {
 	 */
 	private function getAllAppThemes() {
 		$themes = [];
-		foreach (\OC::$server->getAppManager()->getAllApps() as $app) {
+
+		foreach (\OC_App::getAllApps() as $app) {
 			if (\OC_App::isType($app, 'theme')) {
 				$themes[$app] = $this->makeTheme($app);
 			}

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -264,6 +264,10 @@ class OC_App {
 			$types = [$types];
 		}
 		$appTypes = self::getAppTypes($app);
+		if (count($appTypes) === 0) {
+			self::setAppTypes($app);
+			$appTypes = self::getAppTypes($app);
+		}
 		foreach ($types as $type) {
 			if (array_search($type, $appTypes) !== false) {
 				return true;
@@ -302,6 +306,7 @@ class OC_App {
 
 		if (isset($appData['types'])) {
 			$appTypes = implode(',', $appData['types']);
+			self::$appTypes[$app] = $appTypes;
 		} else {
 			$appTypes = '';
 		}


### PR DESCRIPTION
## Description
Currently we have no way to get all apps of a certain type that includes apps that have never been enabled before.

When getting a list of all themes, the AppManager does only look into the appconfig table to get a list of apps. This means apps that have never been enabled will not get returned by the AppManager. That's why i am using the legacy `OC_App::getAllApps()` which iterates over the fs.

When checking if an app has a specific app_type, we only ever look into the appconfig table as well. That is why I included a check to also look into the info.xml whenever there is nothing in the appconfig table and also add the found types to the static list of app types, so they will be available through `self::getAppTypes($app)`.

To be clear, *this is a hack*. It will add unreasonable fs reads, but it is necessary for the Templateeditor to work properly.

@DeepDiver1975 @PVince81 we should talk about a small refactoring of the app structure or how to extend the AppManager so even never enabled apps are properly available in the code.

## Related Issue
https://github.com/owncloud/templateeditor/pull/52

## How Has This Been Tested?
manual only

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

