### PR TITLE
Fix getCoordinatesOfElement double quotes problem

### DIFF
--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -227,9 +227,11 @@ class OwncloudPage extends Page {
 	 * @return Array
 	 */
 	public function getCoordinatesOfElement($session, $element) {
+		$elementXpath = str_replace('"', '\"', $element->getXpath());
+
 		return $session->evaluateScript(
 			'return document.evaluate( "' .
-			$element->getXpath() .
+			$elementXpath .
 			'",document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)' .
 			'.singleNodeValue.getBoundingClientRect();'
 		);


### PR DESCRIPTION
## Description
Escape any literal double quotes in the element Xpath before trying to use it in an evaluate.

## Related Issue


## Motivation and Context
Potential to break a UI test one day if it calls ``getCoordinatesOfElement()`` with an element that is, for example, a file name with double quotes, or anything else that might generate an Xpath containing double quotes.

## How Has This Been Tested?
See https://github.com/phil-davis/core/pull/93 for some example code that makes this latent bug happen. I happened to find the bug when doing other investigations into trying to scroll file rows into view - which has not yet resulted in any code in master that triggers this bug.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
