### PR TITLE
Switch to deepdiver/zipstreamer 1.1.0 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     "require": {
         "php": ">=5.4.1",
         "doctrine/dbal": "^2.5",
-        "mcnetic/zipstreamer": "^1.0",
         "phpseclib/phpseclib": "^2.0",
         "rackspace/php-opencloud": "v1.9.2",
         "jeremeamia/superclosure": "2.1.0",
@@ -55,6 +54,7 @@
         "patchwork/jsqueeze": "^2.0",
         "symfony/polyfill-php70": "^1.0",
         "lukasreschke/id3parser": "^0.0.1",
-        "sabre/dav": "^3.2"
+        "sabre/dav": "^3.2",
+        "deepdiver/zipstreamer": "^1.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b3430b12b915630c5f2e62914db5ec1a",
+    "content-hash": "11a7da4bd28c890e0be43cf4ff1c1244",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -35,6 +35,66 @@
             ],
             "description": "Convenience wrapper around ini_get()",
             "time": "2014-09-15T13:12:35+00:00"
+        },
+        {
+            "name": "deepdiver/zipstreamer",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DeepDiver1975/PHPZipStreamer.git",
+                "reference": "96813f84abde82a93dbf0739005648ebd030a93c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DeepDiver1975/PHPZipStreamer/zipball/96813f84abde82a93dbf0739005648ebd030a93c",
+                "reference": "96813f84abde82a93dbf0739005648ebd030a93c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZipStreamer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolai Ehemann",
+                    "email": "en@enlightened.de",
+                    "role": "Author/Maintainer"
+                },
+                {
+                    "name": "André Rothe",
+                    "email": "arothe@zks.uni-leipzig.de",
+                    "role": "Contributor"
+                },
+                {
+                    "name": "Lukas Reschke",
+                    "email": "lukas@owncloud.com",
+                    "role": "Contributor"
+                },
+                {
+                    "name": "Thomas Müller",
+                    "email": "thomas.mueller@tmit.eu",
+                    "role": "Contributor"
+                }
+            ],
+            "description": "Stream zip files without i/o overhead",
+            "homepage": "https://github.com/DeepDiver1975/PHPZipStreamer",
+            "keywords": [
+                "stream",
+                "zip"
+            ],
+            "time": "2017-09-28T09:23:17+00:00"
         },
         {
             "name": "deepdiver1975/tarstreamer",
@@ -1172,58 +1232,6 @@
                 "tags"
             ],
             "time": "2016-04-04T09:34:50+00:00"
-        },
-        {
-            "name": "mcnetic/zipstreamer",
-            "version": "v1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/McNetic/PHPZipStreamer.git",
-                "reference": "e57c198486242476587d04844084adbe8330581d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/McNetic/PHPZipStreamer/zipball/e57c198486242476587d04844084adbe8330581d",
-                "reference": "e57c198486242476587d04844084adbe8330581d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "ZipStreamer\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-3.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolai Ehemann",
-                    "email": "en@enlightened.de",
-                    "role": "Author/Maintainer"
-                },
-                {
-                    "name": "André Rothe",
-                    "email": "arothe@zks.uni-leipzig.de",
-                    "role": "Contributor"
-                },
-                {
-                    "name": "Lukas Reschke",
-                    "email": "lukas@owncloud.com",
-                    "role": "Contributor"
-                }
-            ],
-            "description": "Stream zip files without i/o overhead",
-            "homepage": "https://github.com/McNetic/PHPZipStreamer",
-            "keywords": [
-                "stream",
-                "zip"
-            ],
-            "time": "2016-02-17T22:47:09+00:00"
         },
         {
             "name": "natxet/CssMin",
@@ -3357,7 +3365,7 @@
                 "testing",
                 "webdriver"
             ],
-            "time": "2017-02-06 08:22:23"
+            "time": "2017-02-06T08:22:23+00:00"
         },
         {
             "name": "behat/transliterator",


### PR DESCRIPTION
## Description
Use fork of zipstreamer library which fixes warning about the archive being corrupted

## Related Issue
https://github.com/owncloud/core/issues/25580

## Motivation and Context
Show no error ...

## How Has This Been Tested?
Manual testing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

