### PR TITLE
Move 64bit mtime migration from dav to core

### DIFF
--- a/core/Migrations/Version20170928120000.php
+++ b/core/Migrations/Version20170928120000.php
@@ -1,5 +1,5 @@
 <?php
-namespace OCA\dav\Migrations;
+namespace OC\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
@@ -8,7 +8,7 @@ use OCP\Migration\ISchemaMigration;
 /**
  * changes mtime fields to be able to store 64bit time stamps
  */
-class Version20170607100912 implements ISchemaMigration {
+class Version20170928120000 implements ISchemaMigration {
 
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];


### PR DESCRIPTION
## Description
Remove the migration from dav and put it in core.

## Related Issue
#23228
and PR #28067 

## Motivation and Context
The migration was originally put in ``app/dav`` but it is for a core table.
So far the change only got to ``stable10`` after 10.0.3 and has not been released - so it can be changed here easily.

## How Has This Been Tested?
None yet.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

