### PR TITLE
All amazon locations support v4 now - v3 depreceated

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -568,15 +568,12 @@ class AmazonS3 extends \OCP\Files\Storage\StorageAdapter {
 		$scheme = ($this->params['use_ssl'] === false) ? 'http' : 'https';
 		$base_url = $scheme . '://' . $this->params['hostname'] . ':' . $this->params['port'] . '/';
 
-		$isLondon = !(strpos($this->params['region'], 'eu-west-2') === false);
-		$signature = $isLondon ? 'v4' : null;
-
 		$this->connection = S3Client::factory([
 			'key' => $this->params['key'],
 			'secret' => $this->params['secret'],
 			'base_url' => $base_url,
 			'region' => $this->params['region'],
-			'signature' => $signature,
+			'signature' => 'v4',
 			S3Client::COMMAND_PARAMS => [
 				'PathStyle' => $this->params['use_path_style'],
 			],


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Since our AWS S3 lib is out of date, we have old mappings of supported signature versions so we are having to manually change these when things change on amazons side.

This PR defaults all signatures to V4 since now all regions support this: http://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html

Stops us having to make hacks like this: https://github.com/owncloud/core/pull/28283

