### PR TITLE
Force alphabetical ordering of app installation to fix on osx 10.13

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -457,7 +457,8 @@ class Installer {
 		$errors = [];
 		foreach(\OC::$APPSROOTS as $app_dir) {
 			if($dir = opendir( $app_dir['path'] )) {
-				while( false !== ( $filename = readdir( $dir ))) {
+				$nodes = scandir($dir);
+				foreach($nodes as $filename) {
 					if( substr( $filename, 0, 1 ) != '.' and is_dir($app_dir['path']."/$filename") ) {
 						if( file_exists( $app_dir['path']."/$filename/appinfo/info.xml" )) {
 							if(!Installer::isInstalled($filename)) {

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -38,9 +38,8 @@
 
 namespace OC;
 
-use OC\App\CodeChecker\CodeChecker;
-use OC\App\CodeChecker\EmptyCheck;
-use OC\App\CodeChecker\PrivateCheck;
+use Doctrine\DBAL\Exception\TableExistsException;
+use OC\DB\MigrationService;
 use OC_App;
 use OC_DB;
 use OC_Helper;
@@ -414,8 +413,9 @@ class Installer {
 
 	/**
 	 * Removes an app
-	 * @param string $name name of the application to remove
+	 * @param string $appId name of the application to remove
 	 * @return boolean
+	 * @throws AppAlreadyInstalledException
 	 *
 	 *
 	 * This function works as follows
@@ -445,6 +445,37 @@ class Installer {
 		return false;
 	}
 
+	protected static function getShippedApps() {
+		$shippedApps = [];
+		foreach(\OC::$APPSROOTS as $app_dir) {
+			if($dir = opendir( $app_dir['path'] )) {
+				$nodes = scandir($app_dir['path']);
+				foreach($nodes as $filename) {
+					if( substr( $filename, 0, 1 ) != '.' and is_dir($app_dir['path']."/$filename") ) {
+						if( file_exists( $app_dir['path']."/$filename/appinfo/info.xml" )) {
+							if(!Installer::isInstalled($filename)) {
+								$info=OC_App::getAppInfo($filename);
+								$enabled = isset($info['default_enable']);
+								if (($enabled || in_array($filename, \OC::$server->getAppManager()->getAlwaysEnabledApps()))
+									&& \OC::$server->getConfig()->getAppValue($filename, 'enabled') !== 'no') {
+									$shippedApps[] = $filename;
+								}
+							}
+						}
+					}
+				}
+				closedir( $dir );
+			}
+		}
+
+
+		// Fix the order - make files first
+		$shippedApps = array_diff($shippedApps,['files', 'dav']);
+		array_unshift($shippedApps, 'dav');
+		array_unshift($shippedApps, 'files');
+		return $shippedApps;
+	}
+
 	/**
 	 * Installs shipped apps
 	 *
@@ -455,46 +486,37 @@ class Installer {
 	 */
 	public static function installShippedApps($softErrors = false) {
 		$errors = [];
-		foreach(\OC::$APPSROOTS as $app_dir) {
-			if($dir = opendir( $app_dir['path'] )) {
-				$nodes = scandir($dir);
-				foreach($nodes as $filename) {
-					if( substr( $filename, 0, 1 ) != '.' and is_dir($app_dir['path']."/$filename") ) {
-						if( file_exists( $app_dir['path']."/$filename/appinfo/info.xml" )) {
-							if(!Installer::isInstalled($filename)) {
-								$info=OC_App::getAppInfo($filename);
-								$enabled = isset($info['default_enable']);
-								if (($enabled || in_array($filename, \OC::$server->getAppManager()->getAlwaysEnabledApps()))
-									  && \OC::$server->getConfig()->getAppValue($filename, 'enabled') !== 'no') {
-									if ($softErrors) {
-										try {
-											Installer::installShippedApp($filename);
-										} catch (\Doctrine\DBAL\Exception\TableExistsException $e) {
-											$errors[$filename] = $e;
-											continue;
-										}
-									} else {
-										Installer::installShippedApp($filename);
-									}
-									\OC::$server->getConfig()->setAppValue($filename, 'enabled', 'yes');
-								}
-							}
-						}
+		$appsToInstall = Installer::getShippedApps();
+
+		foreach($appsToInstall as $appToInstall) {
+			if(!Installer::isInstalled($appToInstall)) {
+				if ($softErrors) {
+					try {
+						Installer::installShippedApp($appToInstall);
+					} catch (TableExistsException $e) {
+						\OC::$server->getLogger()->logException($e, ['app' => __CLASS__]);
+						$errors[$appToInstall] = $e;
+						continue;
 					}
+				} else {
+					Installer::installShippedApp($appToInstall);
 				}
-				closedir( $dir );
+				\OC::$server->getConfig()->setAppValue($appToInstall, 'enabled', 'yes');
 			}
 		}
 
 		return $errors;
+
 	}
 
 	/**
 	 * install an app already placed in the app folder
 	 * @param string $app id of the app to install
-	 * @return integer
+	 * @return integer|false
 	 */
 	public static function installShippedApp($app) {
+
+		\OC::$server->getLogger()->info('Attempting to install shipped app: '.$app);
 
 		$info = OC_App::getAppInfo($app);
 		if (is_null($info)) {
@@ -504,20 +526,25 @@ class Installer {
 		//install the database
 		$appPath = OC_App::getAppPath($app);
 		if (isset($info['use-migrations']) && $info['use-migrations'] === 'true') {
-			$ms = new \OC\DB\MigrationService($app, \OC::$server->getDatabaseConnection());
+			\OC::$server->getLogger()->debug('Running app database migrations');
+			$ms = new MigrationService($app, \OC::$server->getDatabaseConnection());
 			$ms->migrate();
 		} else {
 			if(is_file($appPath.'/appinfo/database.xml')) {
+				\OC::$server->getLogger()->debug('Create app database from schema file');
 				OC_DB::createDbFromStructure($appPath . '/appinfo/database.xml');
 			}
 		}
 
 		//run appinfo/install.php
 		\OC_App::registerAutoloading($app, $appPath);
+
+		\OC::$server->getLogger()->debug('Running app install script');
 		self::includeAppScript("$appPath/appinfo/install.php");
 
 		\OC_App::setupBackgroundJobs($info['background-jobs']);
 
+		\OC::$server->getLogger()->debug('Running app install repair steps');
 		OC_App::executeRepairSteps($app, $info['repair-steps']['install']);
 
 		$config = \OC::$server->getConfig();

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -63,6 +63,8 @@ class Setup {
 	 * @param IConfig $config
 	 * @param IniGetWrapper $iniWrapper
 	 * @param \OC_Defaults $defaults
+	 * @param ILogger $logger
+	 * @param ISecureRandom $random
 	 */
 	function __construct(IConfig $config,
 						 IniGetWrapper $iniWrapper,


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Well this was an interesting one to find. PHP `readdir` returns in order that the filesystem stores a directory - which is _not_ necessarily alphabetical ordering. However, apparently we require this ordering, since apps with names `files_` typically rely on `files` to already be installed.

Since updating to OSX High Sierra 10.13, they now use a new 'optimised filesystem' which appears to affect the listing order. This caused the install to fail because trashbin was installed before files and there was an autoloading exception. 

The fix forces the installer to use an alphabetical ordering when listing the contents of app folders.


## Motivation and Context
Install of core fails since OSX High Sierra upgrade.

## How Has This Been Tested?
UI and OCC installs on OSX High Sierra.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

