### PR TITLE
Remove alternate keys storage during user delete

### DIFF
--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -182,6 +182,27 @@ class Storage implements IStorage {
 	}
 
 	/**
+	 * @inheritdoc
+	 */
+
+	public function deleteAltUserStorageKeys($uid) {
+		if (\OC::$server->getEncryptionManager()->isEnabled()) {
+			/**
+			 * If the key storage is not the default
+			 * location, then we need to remove the keys
+			 * in the alternate key location
+			 */
+			$keyStorageRoot = $this->util->getKeyStorageRoot();
+			if ($keyStorageRoot !== '') {
+				$this->view->rmdir($keyStorageRoot . '/' . $uid);
+				return true;
+			}
+
+			return false;
+		}
+	}
+
+	/**
 	 * construct path to users key
 	 *
 	 * @param string $encryptionModuleId

--- a/lib/public/Encryption/Keys/IStorage.php
+++ b/lib/public/Encryption/Keys/IStorage.php
@@ -169,4 +169,14 @@ interface IStorage {
 	 */
 	public function copyKeys($source, $target);
 
+	/**
+	 * delete user keys from alternate storage location when
+	 * a user is deleted
+	 *
+	 * @param $uid
+	 * @return boolean
+	 * @since 10.0.4
+	 */
+	public function deleteAltUserStorageKeys($uid);
+
 }


### PR DESCRIPTION
When user is deleted the alternate key storage location
does have folder with username. So while deleting user
this should also be cleaned up.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Remove alternate key storage location during user delete process.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/26936

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When user is deleted, the alternate key storage location which has folder name with username should
also be deleted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] enable encryption with user keys
- [x] Using change-key-storage-root command move the keys to folder `enckeys`
- [x] Create another user `user1` apart from user `admin`
- [x] Login as `user1`
- [x] Logout from `user1` and login as `admin`
- [x] Delete the `user1`, there shouldn't be any traces of `user1` inside the folder `enckeys`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

