### PR TITLE
Fix duplicated storage mounts in the settings view during oAuth2 flow

### DIFF
--- a/apps/files_external/js/oauth2.js
+++ b/apps/files_external/js/oauth2.js
@@ -34,7 +34,7 @@ $(document).ready(function() {
 						&& typeof client_secret === "string"
 						&& client_secret !== ''
 					) {
-						$('.configuration').trigger('oauth_step2', [{
+						$tr.find('.configuration').trigger('oauth_step2', [{
 							backend_id: $tr.attr('class'),
 							client_id: client_id,
 							client_secret: client_secret,
@@ -55,12 +55,21 @@ $(document).ready(function() {
 		var client_secret = $(this).parent().find('[data-parameter="client_secret"]').val();
 		
 		if (client_id !== '' && client_secret !== '') {
-			$('.configuration').trigger('oauth_step1', [{
+			var button = $(event.target);
+			button.prop('disabled', true);
+
+			var onCompletion = $.Deferred();
+			onCompletion.fail(function() {
+				button.prop('disabled', false);
+			});
+
+			tr.find('.configuration').trigger('oauth_step1', [{
 				backend_id: tr.attr('class'),
 				client_id: client_id,
 				client_secret: client_secret,
 				redirect: location.protocol + '//' + location.host + location.pathname + '?sectionid=storage',
-				tr: tr
+				tr: tr,
+				onCompletion: onCompletion
 			}]);
 		}
 	});

--- a/apps/files_external/js/oauth2.js
+++ b/apps/files_external/js/oauth2.js
@@ -58,9 +58,10 @@ $(document).ready(function() {
 			var button = $(event.target);
 			button.prop('disabled', true);
 
-			var onCompletion = $.Deferred();
-			onCompletion.fail(function() {
-				button.prop('disabled', false);
+			tr.one('oauth_step1_finished', function(event, data){
+				if (!data['success']) {
+					button.prop('disabled', false);
+				}
 			});
 
 			tr.find('.configuration').trigger('oauth_step1', [{
@@ -68,8 +69,7 @@ $(document).ready(function() {
 				client_id: client_id,
 				client_secret: client_secret,
 				redirect: location.protocol + '//' + location.host + location.pathname + '?sectionid=storage',
-				tr: tr,
-				onCompletion: onCompletion
+				tr: tr
 			}]);
 		}
 	});

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -1452,7 +1452,13 @@ OCA.External.Settings.OAuth2.getAuthUrl = function (backendUrl, data) {
 						OC.dialogs.alert('Auth URL not set',
 							t('files_external', 'No URL provided by backend ' + data['backend_id'])
 						);
+						if (data['onCompletion']) {
+							data['onCompletion'].reject();
+						}
 					} else {
+						if (data['onCompletion']) {
+							data['onCompletion'].resolve();
+						}
 						window.location = result.data.url;
 					}
 				});
@@ -1460,6 +1466,9 @@ OCA.External.Settings.OAuth2.getAuthUrl = function (backendUrl, data) {
 				OC.dialogs.alert(result.data.message,
 					t('files_external', 'Error getting OAuth2 URL for ' + data['backend_id'])
 				);
+				if (data['onCompletion']) {
+					data['onCompletion'].reject();
+				}
 			}
 		}
 	);

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -1452,13 +1452,17 @@ OCA.External.Settings.OAuth2.getAuthUrl = function (backendUrl, data) {
 						OC.dialogs.alert('Auth URL not set',
 							t('files_external', 'No URL provided by backend ' + data['backend_id'])
 						);
-						if (data['onCompletion']) {
-							data['onCompletion'].reject();
-						}
+						$tr.trigger('oauth_step1_finished', [{
+							success: false,
+							tr: $tr,
+							data: data
+						}]);
 					} else {
-						if (data['onCompletion']) {
-							data['onCompletion'].resolve();
-						}
+						$tr.trigger('oauth_step1_finished', [{
+							success: true,
+							tr: $tr,
+							data: data
+						}]);
 						window.location = result.data.url;
 					}
 				});
@@ -1466,9 +1470,11 @@ OCA.External.Settings.OAuth2.getAuthUrl = function (backendUrl, data) {
 				OC.dialogs.alert(result.data.message,
 					t('files_external', 'Error getting OAuth2 URL for ' + data['backend_id'])
 				);
-				if (data['onCompletion']) {
-					data['onCompletion'].reject();
-				}
+				$tr.trigger('oauth_step1_finished', [{
+					success: false,
+					tr: $tr,
+					data: data
+				}]);
 			}
 		}
 	);


### PR DESCRIPTION
## Description
Fix duplicated mount that could happen during oAuth2 flow. This has been partially tested with google drive but should fix other oAuth2 storages. Note that oAuth1 storages will likely present the same problem, which isn't fixed by this PR.

## Related Issue
https://github.com/owncloud/core/issues/28479

## Motivation and Context
Duplicated mounts shouldn't be saved

## How Has This Been Tested?
Manual testing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
