### PR TITLE
Make sure the folder name is editable (if required) after reloading or going back from oAuth2 flow

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -812,7 +812,9 @@ MountConfigListView.prototype = _.extend({
 
 		// FIXME: Replace with a proper Handlebar template
 		var $tr = this.$el.find('tr#addMountPoint');
-		this.$el.find('tbody').append($tr.clone());
+		var $trCloned = $tr.clone();
+		$trCloned.find('td.mountPoint input').removeAttr('disabled');
+		this.$el.find('tbody').append($trCloned);
 
 		$tr.data('storageConfig', storageConfig);
 		$tr.show();
@@ -820,7 +822,6 @@ MountConfigListView.prototype = _.extend({
 		$tr.find('td.mountOptionsToggle').removeClass('hidden');
 		$tr.find('td').last().removeAttr('style');
 		$tr.removeAttr('id');
-		$tr.find('select#selectBackend');
 		addSelect2($tr.find('.applicableUsers'), this._userListLimit);
 
 		if (storageConfig.id) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Try to keep the same page state when we go out and come back from other site via back button (such as during oAuth2 flow) or when we reload the page

## Related Issue
https://github.com/owncloud/core/issues/28480

## Motivation and Context
folder names might not be editable as described and shown in the issue

## How Has This Been Tested?
Manually tested in the personal page, storage section: 3 admin mounts plus 1 additional personal mount.
* Reloading works, although the folder name of the new mount point might be prefilled, but it can be edited, which wasn't possible before
* Clicking in the "grant access" button from any oAuth2 storage and going back with the browser has the same behaviour as the point above.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
