### PR TITLE
Handle case of empty folder in userDeletesEverythingInFolder

### DIFF
--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -1078,14 +1078,16 @@ trait WebDav {
 	 */
 	public function userDeletesEverythingInFolder($user, $folder)  {
 		$elementList = $this->listFolder($user, $folder, 1);
-		$elementListKeys = array_keys($elementList);
-		array_shift($elementListKeys);
-		$davPrefix =  "/" . $this->getDavFilesPath($user);
-		foreach ($elementListKeys as $element) {
-			if (substr($element, 0, strlen($davPrefix)) == $davPrefix) {
-				$element = substr($element, strlen($davPrefix));
+		if (is_array($elementList) && count($elementList)) {
+			$elementListKeys = array_keys($elementList);
+			array_shift($elementListKeys);
+			$davPrefix = "/" . $this->getDavFilesPath($user);
+			foreach ($elementListKeys as $element) {
+				if (substr($element, 0, strlen($davPrefix)) == $davPrefix) {
+					$element = substr($element, strlen($davPrefix));
+				}
+				$this->userDeletesFile($user, "element", $element);
 			}
-			$this->userDeletesFile($user, "element", $element);
 		}
 	}
 


### PR DESCRIPTION
## Description
If there are no files in a folder, then do not attempt to traverse the "array" of files deleting them - in ``userDeletesEverythingInFolder``

## Related Issue
#29139 

## Motivation and Context
A test cleanup step in a set of app integration tests was using ``userDeletesEverythingInFolder`` and it would spit out warnings for scenarios that never actually created any files:
```
Warning: array_keys() expects parameter 1 to be array, object given in /home/travis/build/owncloud/core/tests/integration/features/bootstrap/WebDav.php line 1081
```

## How Has This Been Tested?
Jenkins will tell.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Fixing this in core will allow callers to use it cleanly even if the folder happens to already have nothing in it.