### PR TITLE
Remove duplicated integration test trait properties

### DIFF
--- a/tests/integration/features/bootstrap/AppConfiguration.php
+++ b/tests/integration/features/bootstrap/AppConfiguration.php
@@ -5,11 +5,6 @@ use GuzzleHttp\Message\ResponseInterface;
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 trait AppConfiguration {
-	/** @var string */
-	private $currentUser = '';
-
-	/** @var ResponseInterface */
-	private $response = null;
 
 	abstract public function sendingTo($verb, $url);
 	abstract public function sendingToWith($verb, $url, $body);

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -15,8 +15,6 @@ trait WebDav {
 	private $davPath = "remote.php/webdav";
 	/** @var boolean*/
 	private $usingOldDavPath = true;
-	/** @var ResponseInterface */
-	private $response;
 	/** @var ResponseInterface[] */
 	private $uploadResponses;
 	/** @var map with user as key and another map as value, which has path as key and etag as value */


### PR DESCRIPTION
## Description
Some properties in ``BasicStructure`` are also defined in other trait files. Remove the extra definitions - one central property is what is needed.

## Related Issue

## Motivation and Context
Integration test logs can have messages like:
```
PHP Strict standards:  AppConfiguration and WebDav define the same property ($response) in the composition of BasicStructure. This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed in /home/travis/build/owncloud/core/tests/integration/features/bootstrap/BasicStructure.php on line 416
```
Some properties are "shared" by multiple traits. Already there are some properties  that are defined in just 1 trait file and used from multiple trait files, so that works.

This warning may have came after I re-organized the trait hierarchy into a "flat tree" with ``BasicStructure`` at the top, and everything else "use"d in there. Previous to that there were various different ways to "use" into the cyclical "use" include "tree" and perhaps those sub-trees did not have this happen.

## How Has This Been Tested?
Jenkins knows

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
