### PR TITLE
Revert hard coded Name string in templates

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -56,7 +56,7 @@ OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $_['previewI
 		 data-owner-display-name="<?php p($_['displayName']) ?>" data-owner="<?php p($_['owner']) ?>" data-name="<?php p($_['filename']) ?>">
 		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud">
 			<h1 class="logo-icon">
-				<?php $theme->getName(); ?>
+				<?php p($theme->getName()); ?>
 			</h1>
 		</a>
 

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -56,7 +56,7 @@ OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $_['previewI
 		 data-owner-display-name="<?php p($_['displayName']) ?>" data-owner="<?php p($_['owner']) ?>" data-name="<?php p($_['filename']) ?>">
 		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud">
 			<h1 class="logo-icon">
-				<span class="own">own</span><span class="cloud">Cloud</span>
+				<?php $theme->getName(); ?>
 			</h1>
 		</a>
 

--- a/core/css/header.css
+++ b/core/css/header.css
@@ -49,9 +49,8 @@
 #owncloud {
 	position: absolute;
 	top: 0;
-	left: -webkit-calc(50% - 75px); /* @TODO: Remove if FF 14 support is dropped */
-	left:    -moz-calc(50% - 75px); /* @TODO: Remove if FF 14 support is dropped */
-	left:         calc(50% - 75px);
+	left: 50%;
+	transform: translateX(-50%);
 	padding: 5px;
 	padding-bottom: 0;
 	height: 45px; /* header height */
@@ -95,7 +94,6 @@
 	background-image: url(../img/logo-icon.svg);
 	background-repeat: no-repeat;
 	background-size: 61px 34px;
-	width: 84px;
 	height: 34px;
 	color: #fff;
 	margin: 0;

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -41,10 +41,9 @@
 			<div id="header">
 				<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" id="owncloud" tabindex="1">
 					<h1 class="logo-icon">
-						<span class="own">own</span><span class="cloud">Cloud</span>
+						<?php p($theme->getName()); ?>
 					</h1>
 				</a>
-
 				<a href="#" class="header-appname-container menutoggle" tabindex="2">
 					<button class="burger">
 						<?php echo $l->t('Menu'); ?>
@@ -53,7 +52,6 @@
 						<?php p(!empty($_['application']) ? $_['application'] : $l->t('Apps')); ?>
 					</h1>
 				</a>
-
 				<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
 				<div id="settings">
 					<div id="expand" tabindex="6" role="link" class="menutoggle">


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Revert back hard-coded name string in core template files

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/enterprise/issues/2271

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visual test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

