### PR TITLE
Log out when resetting password

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -74,7 +74,8 @@ class Application extends App {
 				$c->query('IsEncryptionEnabled'),
 				$c->query('Mailer'),
 				$c->query('TimeFactory'),
-				$c->query('Logger')
+				$c->query('Logger'),
+				$c->query('UserSession')
 			);
 		});
 		$container->registerService('UserController', function(SimpleContainer $c) {

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -40,6 +40,7 @@ use OCP\IUserManager;
 use OCP\Mail\IMailer;
 use OCP\Security\ISecureRandom;
 use \OC_Defaults;
+use OC\User\Session;
 
 /**
  * Class LostController
@@ -73,6 +74,8 @@ class LostController extends Controller {
 	protected $timeFactory;
 	/** @var ILogger */
 	protected $logger;
+	/** @var Session */
+	private $userSession;
 
 	/**
 	 * @param string $appName
@@ -88,6 +91,7 @@ class LostController extends Controller {
 	 * @param IMailer $mailer
 	 * @param ITimeFactory $timeFactory
 	 * @param ILogger $logger
+	 * @param Session $userSession
 	 */
 	public function __construct($appName,
 								IRequest $request,
@@ -101,7 +105,8 @@ class LostController extends Controller {
 								$isDataEncrypted,
 								IMailer $mailer,
 								ITimeFactory $timeFactory,
-								ILogger $logger) {
+								ILogger $logger,
+								Session $userSession) {
 		parent::__construct($appName, $request);
 		$this->urlGenerator = $urlGenerator;
 		$this->userManager = $userManager;
@@ -114,6 +119,7 @@ class LostController extends Controller {
 		$this->mailer = $mailer;
 		$this->timeFactory = $timeFactory;
 		$this->logger = $logger;
+		$this->userSession = $userSession;
 	}
 
 	/**
@@ -240,6 +246,8 @@ class LostController extends Controller {
 			return $this->error($e->getMessage());
 		}
 
+		$this->logout();
+
 		return $this->success();
 	}
 
@@ -338,6 +346,14 @@ class LostController extends Controller {
 		}
 
 		return true;
+	}
+
+	private function logout() {
+		$loginToken = $this->request->getCookie('oc_token');
+		if (!is_null($loginToken)) {
+			$this->config->deleteUserValue($this->userSession->getUser()->getUID(), 'login_token', $loginToken);
+		}
+		$this->userSession->logout();
 	}
 
 }

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -33,6 +33,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Mail\IMailer;
 use OCP\Security\ISecureRandom;
+use OC\User\Session;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**
@@ -66,6 +67,8 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 	private $request;
 	/** @var ILogger */
 	private $logger;
+	/** @var Session */
+	private $userSession;
 
 	protected function setUp() {
 
@@ -103,6 +106,8 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->logger = $this->getMockBuilder('OCP\ILogger')
 			->disableOriginalConstructor()->getMock();
+		$this->userSession = $this->getMockBuilder('OC\User\Session')
+			->disableOriginalConstructor()->getMock();
 		$this->lostController = new LostController(
 			'Core',
 			$this->request,
@@ -116,7 +121,8 @@ class LostControllerTest extends \PHPUnit_Framework_TestCase {
 			true,
 			$this->mailer,
 			$this->timeFactory,
-			$this->logger
+			$this->logger,
+			$this->userSession
 		);
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Log a user out (if already logged in), after the password is reset
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Partly fixes #27612 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my server @ http://163.172.11.243:8080/owncloud/
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

