### PR TITLE
Use path hash in selects from filecache to speed things up

### DIFF
--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -108,7 +108,7 @@ class RepairMismatchFileCachePath implements IRepairStep {
 		if ($correctPath === '' && $this->connection->getDatabasePlatform() instanceof OraclePlatform) {
 			$qb->andWhere($qb->expr()->isNull('path'));
 		} else {
-			$qb->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($correctPath)));
+			$qb->andWhere($qb->expr()->eq('path_hash', $qb->createNamedParameter(md5($correctPath))));
 		}
 		$entryExisted = $qb->execute() > 0;
 
@@ -373,7 +373,7 @@ class RepairMismatchFileCachePath implements IRepairStep {
 		if ($path === '' && $this->connection->getDatabasePlatform() instanceof OraclePlatform) {
 			$qb->andWhere($qb->expr()->isNull('path'));
 		} else {
-			$qb->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($path)));
+			$qb->andWhere($qb->expr()->eq('path_hash', $qb->createNamedParameter(md5($path))));
 		}
 		$results = $qb->execute();
 		$rows = $results->fetchAll();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
During the repair step we do some queries on the file cache - and we should use the path_hash column as this has an index and will be much faster than doing a full table scan :)

## Related Issue
Slow repair step progress reported in the wild 🌵 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

