### PR TITLE
Add test with external storage and quota

### DIFF
--- a/tests/integration/features/external-storage.feature
+++ b/tests/integration/features/external-storage.feature
@@ -59,3 +59,11 @@ Feature: external-storage
     Then the HTTP status code should be "404"
     And as "user0" the file "local_storage/foo3/textfile0.txt" does not exist
 
+  @local_storage
+  Scenario: Upload a file to external storage while quota is set on home storage
+    Given user "user0" exists
+    And user "user0" has a quota of "1 B"
+    And as an "user0"
+    When user "user0" uploads file "data/textfile.txt" to "/local_storage/testquota.txt" with all mechanisms
+    Then the HTTP status code of all upload responses should be "201"
+    And as "user0" the file "local_storage/textquota.txt" exists

--- a/tests/integration/federation_features/federated.feature
+++ b/tests/integration/federation_features/federated.feature
@@ -221,3 +221,17 @@ Feature: federated
 		Then using server "LOCAL"
 		And as an "user0"
 		And etag of element "/PARENT" of user "user0" has changed
+
+	@local_storage
+	Scenario: Upload file to received federated share while quota is set on home storage
+		Given using server "REMOTE"
+		And user "user1" exists
+		And using server "LOCAL"
+		And user "user0" exists
+		And user "user0" from server "LOCAL" shares "/PARENT" with user "user1" from server "REMOTE"
+		And user "user1" from server "REMOTE" accepts last pending share
+		And using server "REMOTE"
+		When user "user1" uploads file "data/textfile.txt" to "/PARENT/testquota.txt" with all mechanisms
+		Then the HTTP status code of all upload responses should be "201"
+		And as "user0" the file "/PARENT/textquota.txt" exists
+


### PR DESCRIPTION
## Description
Test to assert that user quota does not apply to external storages.

## Related Issue
Trying to reproduce https://github.com/owncloud/core/issues/29103

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

