### PR TITLE
Handle invalid storage when getting storage root id

### DIFF
--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -245,9 +245,20 @@ class MountPoint implements IMountPoint {
 	/**
 	 * Get the file id of the root of the storage
 	 *
-	 * @return int
+	 * @return int storage numeric id or -1 in case of invalid storage
 	 */
 	public function getStorageRootId() {
-		return (int)$this->getStorage()->getCache()->getId('');
+		$storage = $this->getStorage();
+		if ($storage === null || $this->invalidStorage) {
+			return -1;
+		}
+
+		$cache = $storage->getCache();
+
+		if ($cache === null) {
+			return -1;
+		}
+
+		return (int)$cache->getId('');
 	}
 }

--- a/lib/public/Files/Mount/IMountPoint.php
+++ b/lib/public/Files/Mount/IMountPoint.php
@@ -98,7 +98,7 @@ interface IMountPoint {
 	/**
 	 * Get the file id of the root of the storage
 	 *
-	 * @return int
+	 * @return int storage numeric id or -1 in case of invalid storage
 	 * @since 9.1.0
 	 */
 	public function getStorageRootId();


### PR DESCRIPTION
## Description
Whenever an invalid storage is present like a remote storage with invalid certificate, the mount point handling code will fail hard because the storage could not be instantiated.

Steps here: https://github.com/owncloud/core/issues/28763#issuecomment-335845129
Analysis here: https://github.com/owncloud/core/issues/28763#issuecomment-335847993

## Related Issue
https://github.com/owncloud/core/issues/28763

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
See steps

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

