### PR TITLE
fix backend js loading error, issue https://github.com/owncloud/files…

### DIFF
--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -19,11 +19,12 @@
 		$scripts = $backend->getCustomJs();
 		foreach ($scripts as $script) {
 			if (is_array($script)) {
-				list($appName, $script) = $script;
+				list($appName, $tmpScript) = $script;
 			} else {
 				$appName = 'files_external';
+				$tmpScript = $script;
 			}
-			script($appName, $script);
+			script($appName, $tmpScript);
 		}
 	}
 	foreach ($_['authMechanisms'] as $authMechanism) {


### PR DESCRIPTION
## Description
some backend scripts do not load right.

## Related Issue
https://github.com/owncloud/files_external_dropbox/issues/13

## Motivation and Context
In some php version, modification of the array during list() execution (e.g. using list($a, $b) = $b) results in undefined behavior.
