### PR TITLE
[stable10] Corrected namespace for OC\Memcache\ArrayCache

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -38,7 +38,7 @@ use GuzzleHttp\Message\ResponseInterface;
 use OC\Files\Filesystem;
 use OC\Files\Stream\Close;
 use Icewind\Streams\IteratorDirectory;
-use OC\MemCache\ArrayCache;
+use OC\Memcache\ArrayCache;
 use OCP\AppFramework\Http;
 use OCP\Constants;
 use OCP\Files;


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/29213 to stable10