### PR TITLE
Expose XHR response in share dialog autocomplete callback

### DIFF
--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -251,7 +251,7 @@
 							$('.shareWithField').removeClass('error')
 								.tooltip('hide')
 								.autocomplete("option", "autoFocus", true);
-							response(suggestions);
+							response(suggestions, result);
 						} else {
 							var title = t('core', 'No users or groups found for {search}', {search: $('.shareWithField').val()});
 							if (!view.configModel.get('allowGroupSharing')) {
@@ -266,10 +266,10 @@
 								})
 								.tooltip('fixTitle')
 								.tooltip('show');
-							response();
+							response(undefined, result);
 						}
 					} else {
-						response();
+						response(undefined, result);
 					}
 				}
 			).fail(function() {

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -279,7 +279,7 @@ describe('OC.Share.ShareDialogView', function() {
 				jsonData
 			);
 
-			expect(response.calledWithExactly([
+			expect(response.getCall(0).args[0]).toEqual([
 				{
 					"label": "Peter A.",
 					"value": {
@@ -301,7 +301,8 @@ describe('OC.Share.ShareDialogView', function() {
 						"shareWith": "Petra"
 					}
 				}
-			])).toEqual(true);
+			]);
+			expect(response.getCall(0).args[1].ocs).toBeDefined();
 		});
 		it('triggers autocomplete display and focus with data when ajax search succeeds', function () {
 			dialog.render();
@@ -331,7 +332,7 @@ describe('OC.Share.ShareDialogView', function() {
 					{'Content-Type': 'application/json'},
 					jsonData
 			);
-			expect(response.calledWithExactly(JSON.parse(jsonData).ocs.data.users)).toEqual(true);
+			expect(response.getCall(0).args[0]).toEqual(JSON.parse(jsonData).ocs.data.users);
 			expect(autocompleteStub.calledWith("option", "autoFocus", true)).toEqual(true);
 		});
 
@@ -379,10 +380,10 @@ describe('OC.Share.ShareDialogView', function() {
 					{'Content-Type': 'application/json'},
 					jsonData
 				);
-				expect(response.calledWithExactly([{
+				expect(response.getCall(0).args[0]).toEqual([{
 					'label': 'bobby',
 					'value': {'shareType': 0, 'shareWith': 'imbob'}
-				}])).toEqual(true);
+				}]);
 				expect(autocompleteStub.calledWith("option", "autoFocus", true)).toEqual(true);
 			});
 
@@ -437,10 +438,10 @@ describe('OC.Share.ShareDialogView', function() {
 					{'Content-Type': 'application/json'},
 					jsonData
 				);
-				expect(response.calledWithExactly([{
+				expect(response.getCall(0).args[0]).toEqual([{
 					'label': 'bobby',
 					'value': {'shareType': 0, 'shareWith': 'imbob'}
-				}])).toEqual(true);
+				}]);
 				expect(autocompleteStub.calledWith("option", "autoFocus", true)).toEqual(true);
 			});
 
@@ -517,10 +518,10 @@ describe('OC.Share.ShareDialogView', function() {
 						{'Content-Type': 'application/json'},
 						jsonData
 					);
-					expect(response.calledWithExactly([{
+					expect(response.getCall(0).args[0]).toEqual([{
 						'label': 'bobby',
 						'value': {'shareType': OC.Share.SHARE_TYPE_USER, 'shareWith': 'imbob'}
-					}])).toEqual(true);
+					}]);
 					expect(autocompleteStub.calledWith("option", "autoFocus", true)).toEqual(true);
 				});
 
@@ -567,10 +568,10 @@ describe('OC.Share.ShareDialogView', function() {
 						{'Content-Type': 'application/json'},
 						jsonData
 					);
-					expect(response.calledWithExactly([{
+					expect(response.getCall(0).args[0]).toEqual([{
 						'label': 'group2',
 						'value': {'shareType': OC.Share.SHARE_TYPE_GROUP, 'shareWith': 'group2'}
-					}])).toEqual(true);
+					}]);
 					expect(autocompleteStub.calledWith("option", "autoFocus", true)).toEqual(true);
 				});
 
@@ -617,10 +618,10 @@ describe('OC.Share.ShareDialogView', function() {
 						{'Content-Type': 'application/json'},
 						jsonData
 					);
-					expect(response.calledWithExactly([{
+					expect(response.getCall(0).args[0]).toEqual([{
 						'label': 'foo2@bar.com/baz',
 						'value': {'shareType': OC.Share.SHARE_TYPE_REMOTE, 'shareWith': 'foo2@bar.com/baz'}
-					}])).toEqual(true);
+					}]);
 					expect(autocompleteStub.calledWith("option", "autoFocus", true)).toEqual(true);
 				});
 			});
@@ -643,7 +644,8 @@ describe('OC.Share.ShareDialogView', function() {
 					{'Content-Type': 'application/json'},
 					jsonData
 			);
-			expect(response.calledWithExactly()).toEqual(true);
+			expect(response.getCall(0).args[0]).not.toBeDefined();
+			expect(response.getCall(0).args[1].ocs).toBeDefined();
 		});
 
 		it('throws a notification when the ajax search lookup fails', function () {


### PR DESCRIPTION
## Description
This makes it possible for apps that override the handler to have access
to the actual response and also exact matches.

## Related Issue
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
JS unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

