### PR TITLE
Put attributes into generated XML

### DIFF
--- a/lib/private/legacy/api.php
+++ b/lib/private/legacy/api.php
@@ -436,7 +436,13 @@ class OC_API {
 	private static function toXML($array, $writer) {
 		foreach($array as $k => $v) {
 			if ($k[0] === '@') {
-				$writer->writeAttribute(substr($k, 1), $v);
+				if (is_array($v)) {
+					foreach ($v as $name => $value) {
+						$writer->writeAttribute($name, $value);
+					}
+				} else {
+					$writer->writeAttribute(substr($k, 1), $v);
+				}
 				continue;
 			} else if (is_numeric($k)) {
 				$k = 'element';

--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -125,6 +125,45 @@ trait BasicStructure {
 	}
 
 	/**
+	 * Parses the xml answer to get the requested key and sub-key
+	 *
+	 * @param ResponseInterface $response
+	 * @param string $key1
+	 * @param string $key2
+	 * @return string
+	 */
+	public function getXMLKey1Key2Value($response, $key1, $key2) {
+		return $response->xml()->$key1->$key2;
+	}
+
+	/**
+	 * Parses the xml answer to get the requested key sequence
+	 *
+	 * @param ResponseInterface $response
+	 * @param string $key1
+	 * @param string $key2
+	 * @param string $key3
+	 * @return string
+	 */
+	public function getXMLKey1Key2Key3Value($response, $key1, $key2, $key3) {
+		return $response->xml()->$key1->$key2->$key3;
+	}
+
+	/**
+	 * Parses the xml answer to get the requested attribute value
+	 *
+	 * @param ResponseInterface $response
+	 * @param string $key1
+	 * @param string $key2
+	 * @param string $key3
+	 * @param string $attribute
+	 * @return string
+	 */
+	public function getXMLKey1Key2Key3AttributeValue($response, $key1, $key2, $key3, $attribute) {
+		return (string) $response->xml()->$key1->$key2->$key3->attributes()->$attribute;
+	}
+
+	/**
 	 * This function is needed to use a vertical fashion in the gherkin tables.
 	 * @param array $arrayOfArrays
 	 * @return array
@@ -222,6 +261,49 @@ trait BasicStructure {
 	 */
 	public function theHTTPStatusCodeShouldBe($statusCode) {
 		PHPUnit_Framework_Assert::assertEquals($statusCode, $this->response->getStatusCode());
+	}
+
+	/**
+	 * @Then /^the XML "([^"]*)" "([^"]*)" value should be "([^"]*)"$/
+	 * @param string $key1
+	 * @param string $key2
+	 * @param string $idText
+	 */
+	public function theXMLKey1Key2ValueShouldBe($key1, $key2, $idText) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$idText,
+			$this->getXMLKey1Key2Value($this->response, $key1, $key2)
+		);
+	}
+
+	/**
+	 * @Then /^the XML "([^"]*)" "([^"]*)" "([^"]*)" value should be "([^"]*)"$/
+	 * @param string $key1
+	 * @param string $key2
+	 * @param string $key3
+	 * @param string $idText
+	 */
+	public function theXMLKey1Key2Key3ValueShouldBe($key1, $key2, $key3, $idText) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$idText,
+			$this->getXMLKey1Key2Key3Value($this->response, $key1, $key2, $key3)
+		);
+	}
+
+	/**
+	 * @Then /^the XML "([^"]*)" "([^"]*)" "([^"]*)" "([^"]*)" attribute value should be a valid version string$/
+	 * @param string $key1
+	 * @param string $key2
+	 * @param string $key3
+	 * @param string $attribute
+	 * @param string $idText
+	 */
+	public function theXMLKey1Key2AttributeValueShouldBe($key1, $key2, $key3, $attribute) {
+		$value = $this->getXMLKey1Key2Key3AttributeValue($this->response, $key1, $key2, $key3, $attribute);
+		PHPUnit_Framework_Assert::assertTrue(
+			version_compare($value, '0.0.1') >= 0,
+			'attribute ' . $attribute . ' value ' . $value . ' is not a valid version string'
+		);
 	}
 
 	/**

--- a/tests/integration/features/provisioning-v1.feature
+++ b/tests/integration/features/provisioning-v1.feature
@@ -301,6 +301,11 @@ Feature: provisioning
 		When sending "GET" to "/cloud/apps/files"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
+		And the XML "data" "id" value should be "files"
+		And the XML "data" "name" value should be "Files"
+		And the XML "data" "types" "element" value should be "filesystem"
+		And the XML "data" "dependencies" "owncloud" "min-version" attribute value should be a valid version string
+		And the XML "data" "dependencies" "owncloud" "max-version" attribute value should be a valid version string
 
 #	Scenario: enable an app
 #		Given as an "admin"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Related Issue
#29229 

## Motivation and Context
Get rid of a warning message.
Make the min and max version show in the XML response.

## How Has This Been Tested?
1) Run the integration test that produced the warning and confirm that the is no warning.
```
~/core/tests/integration$ ./run.sh features/provisioning-v1.feature:299
```
2) Browse to:
```
http://localhost:8080/ocs/v1.php/cloud/apps/comments
```
and see content including:
```
<dependencies><owncloud min-version="10.0" max-version="10.0"/></dependencies>
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

If this is the thing to do, then it needs additional integration tests in ``provisioning-v1.feature`` to validate the returned content of the app info XML.