### PR TITLE
#27854 non existing folder skeletondirectory

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -417,8 +417,7 @@ class Session implements IUserSession, Emitter {
 				\OC::$server->getLogger()->warning(
 					'Skeleton not created due to missing write permission'
 				);
-			}
-			catch(\OC\HintException $hintEx) {
+			} catch(\OC\HintException $hintEx) {
 				// only if Skeleton no existing Dir
 				\OC::$server->getLogger()->error($hintEx->getMessage());
 			}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -418,6 +418,10 @@ class Session implements IUserSession, Emitter {
 					'Skeleton not created due to missing write permission'
 				);
 			}
+			catch(\OC\HintException $hintEx) {
+				// only if Skeleton no existing Dir
+				\OC::$server->getLogger()->error($hintEx->getMessage());
+			}
 
 			// trigger any other initialization
 			\OC::$server->getEventDispatcher()->dispatch(IUser::class . '::firstLogin', new GenericEvent($this->getUser()));

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -395,7 +395,7 @@ class OC_Util {
 		$skeletonDirectory = \OCP\Config::getSystemValue('skeletondirectory', \OC::$SERVERROOT . '/core/skeleton');
 
 		if(!is_dir($skeletonDirectory))  {
-			throw new OC\HintException('Can not Access to Skeleton Folder, check for right Path in config.php');
+			throw new OC\HintException('The skeleton folder '.$skeletonDirectory.' is not accessible');
 		}
 
 		if (!empty($skeletonDirectory)) {

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -395,7 +395,7 @@ class OC_Util {
 		$skeletonDirectory = \OCP\Config::getSystemValue('skeletondirectory', \OC::$SERVERROOT . '/core/skeleton');
 
 		if (!is_dir($skeletonDirectory))  {
-			throw new OC\HintException('The skeleton folder '.$skeletonDirectory.' is not accessible');
+			throw new \OC\HintException('The skeleton folder '.$skeletonDirectory.' is not accessible');
 		}
 
 		if (!empty($skeletonDirectory)) {

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -388,10 +388,15 @@ class OC_Util {
 	 *
 	 * @param String $userId
 	 * @param \OCP\Files\Folder $userDirectory
+	 * @throws \OC\HintException
 	 */
 	public static function copySkeleton($userId, \OCP\Files\Folder $userDirectory) {
 
 		$skeletonDirectory = \OCP\Config::getSystemValue('skeletondirectory', \OC::$SERVERROOT . '/core/skeleton');
+
+		if(!is_dir($skeletonDirectory))  {
+			throw new OC\HintException('Can not Access to Skeleton Folder, check for right Path in config.php');
+		}
 
 		if (!empty($skeletonDirectory)) {
 			\OCP\Util::writeLog(

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -394,7 +394,7 @@ class OC_Util {
 
 		$skeletonDirectory = \OCP\Config::getSystemValue('skeletondirectory', \OC::$SERVERROOT . '/core/skeleton');
 
-		if(!is_dir($skeletonDirectory))  {
+		if (!is_dir($skeletonDirectory))  {
 			throw new OC\HintException('The skeleton folder '.$skeletonDirectory.' is not accessible');
 		}
 

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -8,7 +8,6 @@
 
 namespace Test;
 
-use \OC\HintException;
 use OC_Util;
 
 /**
@@ -415,7 +414,7 @@ class UtilTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @expectedException HintException
+	 * @expectedException \OC\HintException
 	 * @expectedExceptionMessage The skeleton folder /not/existing/Directory is not accessible
 	 */
 	public function testCopySkeletonDirectory() {

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -420,7 +420,9 @@ class UtilTest extends \Test\TestCase {
 	public function testCopySkeletonDirectory() {
 		$config = \OC::$server->getConfig();
 		$config->setSystemValue('skeletondirectory', '/not/existing/Directory');
-		$user = $this->getMockBuilder('OCP\IUser')->disableOriginalConstructor()->getMock();
+		$userId = $this->getUniqueID('user_');
+		$user = \OC::$server->getUserManager()->createUser($userId, 'password');
+		\OC_Util::setupFS($user);
 		$userFolder = \OC::$server->getUserFolder($user);
 
 		\OC_Util::copySkeleton($config, $userFolder);

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -416,17 +416,11 @@ class UtilTest extends \Test\TestCase {
 
 	/**
 	 * @expectedException HintException
-	 *
-	 * @throws HintException
+	 * @expectedExceptionMessage The skeleton folder /not/existing/Directory is not accessible
 	 */
 	public function testCopySkeletonDirectory() {
-		$notExistingDirectory = '/not/existing/Directory';
-
-		$this->expectException(HintException::class);
-		$this->expectExceptionMessage('The skeleton folder '.$notExistingDirectory.' is not accessible');
-
 		$config = \OC::$server->getConfig();
-		$config->setSystemValue('skeletondirectory',$notExistingDirectory);
+		$config->setSystemValue('skeletondirectory', '/not/existing/Directory');
 		$user = $this->getMockBuilder('OCP\IUser')->disableOriginalConstructor()->getMock();
 		$userFolder = \OC::$server->getUserFolder($user);
 

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -420,11 +420,7 @@ class UtilTest extends \Test\TestCase {
 	public function testCopySkeletonDirectory() {
 		$config = \OC::$server->getConfig();
 		$config->setSystemValue('skeletondirectory', '/not/existing/Directory');
-		$userId = $this->getUniqueID('user_');
-		$user = \OC::$server->getUserManager()->createUser($userId, 'password');
-		\OC_Util::setupFS($user);
-		$userFolder = \OC::$server->getUserFolder($user);
-
+		$userFolder = $this->createMock('\OCP\Files\Folder');
 		\OC_Util::copySkeleton($config, $userFolder);
 
 		$config->deleteSystemValue('skeletondirectory');

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -414,11 +414,19 @@ class UtilTest extends \Test\TestCase {
 		$this->assertNotEmpty($errors);
 	}
 
+	/**
+	 * @expectedException HintException
+	 *
+	 * @throws HintException
+	 */
 	public function testCopySkeletonDirectory() {
+		$notExistingDirectory = '/not/existing/Directory';
+
 		$this->expectException(HintException::class);
+		$this->expectExceptionMessage('The skeleton folder '.$notExistingDirectory.' is not accessible');
 
 		$config = \OC::$server->getConfig();
-		$config->setSystemValue('skeletondirectory','\/not\existing\/Directory');
+		$config->setSystemValue('skeletondirectory',$notExistingDirectory);
 		$user = $this->getMockBuilder('OCP\IUser')->disableOriginalConstructor()->getMock();
 		$userFolder = \OC::$server->getUserFolder($user);
 

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -414,7 +414,7 @@ class UtilTest extends \Test\TestCase {
 		$this->assertNotEmpty($errors);
 	}
 
-	public function testCopySceletonDirectory() {
+	public function testCopySkeletonDirectory() {
 		$this->expectException(HintException::class);
 
 		$config = \OC::$server->getConfig();

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -8,6 +8,7 @@
 
 namespace Test;
 
+use \OC\HintException;
 use OC_Util;
 
 /**
@@ -411,6 +412,19 @@ class UtilTest extends \Test\TestCase {
 
 		$errors = \OC_Util::checkDataDirectoryValidity('relative/path');
 		$this->assertNotEmpty($errors);
+	}
+
+	public function testCopySceletonDirectory() {
+		$this->expectException(HintException::class);
+
+		$config = \OC::$server->getConfig();
+		$config->setSystemValue('skeletondirectory','\/not\existing\/Directory');
+		$user = $this->getMockBuilder('OCP\IUser')->disableOriginalConstructor()->getMock();
+		$userFolder = \OC::$server->getUserFolder($user);
+
+		\OC_Util::copySkeleton($config, $userFolder);
+
+		$config->deleteSystemValue('skeletondirectory');
 	}
 
 	protected function setUp() {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

