### PR TITLE
Remove double quotes from boolean values in status.php output

### DIFF
--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -726,9 +726,9 @@ class Util {
 		# for description and defaults
 		$defaults = new \OCP\Defaults();
 		$values = [
-			'installed'=> $installed ? 'true' : 'false',
-			'maintenance' => $maintenance ? 'true' : 'false',
-			'needsDbUpgrade' => self::needUpgrade() ? 'true' : 'false',
+			'installed'=> $installed ? true : false,
+			'maintenance' => $maintenance ? true : false,
+			'needsDbUpgrade' => self::needUpgrade() ? true : false,
 			'version' => '',
 			'versionstring' => '',
 			'edition' => '',


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
This PR removes double quotes unintentionally added in the boolean result values from status.php
An QA issue has been raised https://github.com/owncloud/QA/issues/500 (Add scenario to check status.php output)
A documentation release note PR follows asap

## Related Issue
#29228 (Change in status.php from 9.1.x to 10.x)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Access yourdomain/status.php
```
{"installed":true,"maintenance":false,"needsDbUpgrade":true,"version":"10.0.3.3","versionstring":"10.0.3","edition":"Community","productname":"ownCloud"}
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

