### PR TITLE
[master] Fix OC.webroot to be the path only just like the real code -…

### DIFF
--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -750,13 +750,13 @@ describe('OCA.Files.FileList tests', function() {
 			doRename();
 
 			expect(OC.TestUtil.getImageUrl(fileList.findFileEl('Tu_after_three.txt').find('.thumbnail')))
-				.toEqual(OC.imagePath('core', 'loading.gif'));
+				.toEqual(OC.TestUtil.buildAbsoluteUrl(OC.imagePath('core', 'loading.gif')));
 
 			deferredRename.reject(409);
 
 			expect(fileList.findFileEl('One.txt').length).toEqual(1);
 			expect(OC.TestUtil.getImageUrl(fileList.findFileEl('One.txt').find('.thumbnail')))
-				.toEqual(OC.imagePath('core', 'filetypes/text.svg'));
+				.toEqual(OC.TestUtil.buildAbsoluteUrl(OC.imagePath('core', 'filetypes/text.svg')));
 		});
 	});
 	describe('Moving files', function() {
@@ -838,7 +838,7 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.move('One.txt', '/somedir');
 
 			expect(OC.TestUtil.getImageUrl(fileList.findFileEl('One.txt').find('.thumbnail')))
-				.toEqual(OC.imagePath('core', 'loading.gif'));
+				.toEqual(OC.TestUtil.buildAbsoluteUrl(OC.imagePath('core', 'loading.gif')));
 
 			expect(moveStub.calledOnce).toEqual(true);
 
@@ -850,7 +850,7 @@ describe('OCA.Files.FileList tests', function() {
 			expect(notificationStub.getCall(0).args[0]).toEqual('Could not move "One.txt"');
 
 			expect(OC.TestUtil.getImageUrl(fileList.findFileEl('One.txt').find('.thumbnail')))
-				.toEqual(OC.imagePath('core', 'filetypes/text.svg'));
+				.toEqual(OC.TestUtil.buildAbsoluteUrl(OC.imagePath('core', 'filetypes/text.svg')));
 		});
 	});
 	describe('Update file', function() {
@@ -1249,7 +1249,8 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $imgDiv = $tr.find('td.filename .thumbnail');
-			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.webroot + '/core/img/filetypes/file.svg');
+			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(
+				OC.TestUtil.buildAbsoluteUrl(OC.webroot + '/core/img/filetypes/file.svg'));
 			// tries to load preview
 			expect(previewLoadStub.calledOnce).toEqual(true);
 		});
@@ -1261,7 +1262,8 @@ describe('OCA.Files.FileList tests', function() {
 
 			var $tr = fileList.add(fileData);
 			var $imgDiv = $tr.find('td.filename .thumbnail');
-			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.webroot + '/core/img/filetypes/folder.svg');
+			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(
+				OC.TestUtil.buildAbsoluteUrl(OC.webroot + '/core/img/filetypes/folder.svg'));
 			// no preview since it's a directory
 			expect(previewLoadStub.notCalled).toEqual(true);
 		});
@@ -1274,7 +1276,8 @@ describe('OCA.Files.FileList tests', function() {
 			});
 			var $tr = fileList.add(fileData);
 			var $imgDiv = $tr.find('td.filename .thumbnail');
-			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.webroot + '/core/img/filetypes/application-pdf.svg');
+			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(
+				OC.TestUtil.buildAbsoluteUrl(OC.webroot + '/core/img/filetypes/application-pdf.svg'));
 			// try loading preview
 			expect(previewLoadStub.calledOnce).toEqual(true);
 		});
@@ -1286,7 +1289,8 @@ describe('OCA.Files.FileList tests', function() {
 
 			var $tr = fileList.add(fileData);
 			var $imgDiv = $tr.find('td.filename .thumbnail');
-			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.webroot + '/core/img/filetypes/application-pdf.svg');
+			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(
+				OC.TestUtil.buildAbsoluteUrl(OC.webroot + '/core/img/filetypes/application-pdf.svg'));
 			// try loading preview
 			expect(previewLoadStub.calledOnce).toEqual(true);
 		});
@@ -1299,7 +1303,8 @@ describe('OCA.Files.FileList tests', function() {
 
 			var $tr = fileList.add(fileData);
 			var $imgDiv = $tr.find('td.filename .thumbnail');
-			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(OC.webroot + '/core/img/filetypes/folder-alt.svg');
+			expect(OC.TestUtil.getImageUrl($imgDiv)).toEqual(
+				OC.TestUtil.buildAbsoluteUrl(OC.webroot + '/core/img/filetypes/folder-alt.svg'));
 			// do not load preview for folders
 			expect(previewLoadStub.notCalled).toEqual(true);
 		});
@@ -1311,11 +1316,13 @@ describe('OCA.Files.FileList tests', function() {
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
 			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail')))
-				.toEqual(OC.webroot + '/core/img/filetypes/file.svg');
+				.toEqual(
+					OC.TestUtil.buildAbsoluteUrl(OC.webroot + '/core/img/filetypes/file.svg'));
 			expect(previewLoadStub.calledOnce).toEqual(true);
 			// third argument is callback
 			previewLoadStub.getCall(0).args[0].callback(OC.webroot + '/somepath.png');
-			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.webroot + '/somepath.png');
+			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(
+				OC.TestUtil.buildAbsoluteUrl(OC.webroot + '/somepath.png'));
 		});
 		it('does not render preview for directories', function() {
 			var fileData = {
@@ -1325,7 +1332,8 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
-			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.webroot + '/core/img/filetypes/folder.svg');
+			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(
+				OC.TestUtil.buildAbsoluteUrl(OC.webroot + '/core/img/filetypes/folder.svg'));
 			expect(previewLoadStub.notCalled).toEqual(true);
 		});
 		it('render external storage icon for external storage root', function() {
@@ -1337,7 +1345,8 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
-			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.webroot + '/core/img/filetypes/folder-external.svg');
+			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(
+				OC.TestUtil.buildAbsoluteUrl(OC.webroot + '/core/img/filetypes/folder-external.svg'));
 			expect(previewLoadStub.notCalled).toEqual(true);
 		});
 		it('render external storage icon for external storage subdir', function() {
@@ -1349,7 +1358,8 @@ describe('OCA.Files.FileList tests', function() {
 			};
 			var $tr = fileList.add(fileData);
 			var $td = $tr.find('td.filename');
-			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(OC.webroot + '/core/img/filetypes/folder-external.svg');
+			expect(OC.TestUtil.getImageUrl($td.find('.thumbnail'))).toEqual(
+				OC.TestUtil.buildAbsoluteUrl(OC.webroot + '/core/img/filetypes/folder-external.svg'));
 			expect(previewLoadStub.notCalled).toEqual(true);
 			// default icon override
 			expect($tr.attr('data-icon')).toEqual(OC.webroot + '/core/img/filetypes/folder-external.svg');
@@ -2892,12 +2902,14 @@ describe('OCA.Files.FileList tests', function() {
 			fileList.showFileBusyState('Two.jpg', true);
 			expect($tr.hasClass('busy')).toEqual(true);
 			expect(OC.TestUtil.getImageUrl($tr.find('.thumbnail')))
-				.toEqual(OC.imagePath('core', 'loading.gif'));
+				.toEqual(
+					OC.TestUtil.buildAbsoluteUrl(OC.imagePath('core', 'loading.gif')));
 
 			fileList.showFileBusyState('Two.jpg', false);
 			expect($tr.hasClass('busy')).toEqual(false);
 			expect(OC.TestUtil.getImageUrl($tr.find('.thumbnail')))
-				.toEqual(OC.imagePath('core', 'filetypes/image.svg'));
+				.toEqual(
+					OC.TestUtil.buildAbsoluteUrl(OC.imagePath('core', 'filetypes/image.svg')));
 		});
 		it('accepts multiple input formats', function() {
 			_.each([

--- a/core/js/tests/specHelper.js
+++ b/core/js/tests/specHelper.js
@@ -87,8 +87,7 @@ window.firstDay = 0;
 /* jshint camelcase: false */
 window.oc_debug = true;
 window.oc_isadmin = false;
-// FIXME: oc_webroot is supposed to be only the path!!!
-window.oc_webroot = location.href + '/';
+window.oc_webroot = '/owncloud';
 window.oc_appswebroots = {
 	"files": window.oc_webroot + '/apps/files/'
 };
@@ -137,6 +136,9 @@ window.isPhantom = /phantom/i.test(navigator.userAgent);
 				return url;
 			}
 			return r[1];
+		},
+		buildAbsoluteUrl: function(relativeUrl) {
+			return window.location.protocol + '//' + window.location.host + relativeUrl;
 		}
 	};
 

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -255,7 +255,6 @@ describe('Core base tests', function() {
 	});
 	describe('filePath', function() {
 		beforeEach(function() {
-			OC.webroot = 'http://localhost';
 			OC.appswebroots['files'] = OC.webroot + '/apps3/files';
 		});
 		afterEach(function() {
@@ -263,14 +262,14 @@ describe('Core base tests', function() {
 		});
 
 		it('Uses a direct link for css and images,' , function() {
-			expect(OC.filePath('core', 'css', 'style.css')).toEqual('http://localhost/core/css/style.css');
-			expect(OC.filePath('files', 'css', 'style.css')).toEqual('http://localhost/apps3/files/css/style.css');
-			expect(OC.filePath('core', 'img', 'image.png')).toEqual('http://localhost/core/img/image.png');
-			expect(OC.filePath('files', 'img', 'image.png')).toEqual('http://localhost/apps3/files/img/image.png');
+			expect(OC.filePath('core', 'css', 'style.css')).toEqual('/owncloud/core/css/style.css');
+			expect(OC.filePath('files', 'css', 'style.css')).toEqual('/owncloud/apps3/files/css/style.css');
+			expect(OC.filePath('core', 'img', 'image.png')).toEqual('/owncloud/core/img/image.png');
+			expect(OC.filePath('files', 'img', 'image.png')).toEqual('/owncloud/apps3/files/img/image.png');
 		});
 		it('Routes PHP files via index.php,' , function() {
-			expect(OC.filePath('core', 'ajax', 'test.php')).toEqual('http://localhost/index.php/core/ajax/test.php');
-			expect(OC.filePath('files', 'ajax', 'test.php')).toEqual('http://localhost/index.php/apps/files/ajax/test.php');
+			expect(OC.filePath('core', 'ajax', 'test.php')).toEqual('/owncloud/index.php/core/ajax/test.php');
+			expect(OC.filePath('files', 'ajax', 'test.php')).toEqual('/owncloud/index.php/apps/files/ajax/test.php');
 		});
 	});
 	describe('Link functions', function() {

--- a/core/js/tests/specs/jquery.avatarSpec.js
+++ b/core/js/tests/specs/jquery.avatarSpec.js
@@ -126,7 +126,7 @@ describe('jquery.avatar tests', function() {
 			$div.avatar('foo', 32);
 
 			expect(fakeServer.requests[0].method).toEqual('GET');
-			expect(fakeServer.requests[0].url).toEqual('http://localhost/index.php/avatar/foo/32');
+			expect(fakeServer.requests[0].url).toEqual('/owncloud/index.php/avatar/foo/32');
 		});
 
 		it('high DPI icon', function() {
@@ -134,7 +134,7 @@ describe('jquery.avatar tests', function() {
 			$div.avatar('foo', 32);
 
 			expect(fakeServer.requests[0].method).toEqual('GET');
-			expect(fakeServer.requests[0].url).toEqual('http://localhost/index.php/avatar/foo/128');
+			expect(fakeServer.requests[0].url).toEqual('/owncloud/index.php/avatar/foo/128');
 		});
 
 		it('high DPI icon round up size', function() {
@@ -142,7 +142,7 @@ describe('jquery.avatar tests', function() {
 			$div.avatar('foo', 32);
 
 			expect(fakeServer.requests[0].method).toEqual('GET');
-			expect(fakeServer.requests[0].url).toEqual('http://localhost/index.php/avatar/foo/61');
+			expect(fakeServer.requests[0].url).toEqual('/owncloud/index.php/avatar/foo/61');
 		});
 	});
 
@@ -164,7 +164,7 @@ describe('jquery.avatar tests', function() {
 
 			expect(img.height).toEqual(32);
 			expect(img.width).toEqual(32);
-			expect(img.src).toEqual('http://localhost/index.php/avatar/foo/32');
+			expect(img.src).toEqual(OC.TestUtil.buildAbsoluteUrl('/owncloud/index.php/avatar/foo/32'));
 		});
 
 		it('default high DPI icon', function() {
@@ -182,7 +182,7 @@ describe('jquery.avatar tests', function() {
 
 			expect(img.height).toEqual(32);
 			expect(img.width).toEqual(32);
-			expect(img.src).toEqual('http://localhost/index.php/avatar/foo/61');
+			expect(img.src).toEqual(OC.TestUtil.buildAbsoluteUrl('/owncloud/index.php/avatar/foo/61'));
 		});
 
 		it('with ie8 fix', function() {
@@ -202,7 +202,7 @@ describe('jquery.avatar tests', function() {
 
 			expect(img.height).toEqual(32);
 			expect(img.width).toEqual(32);
-			expect(img.src).toEqual('http://localhost/index.php/avatar/foo/32#500');
+			expect(img.src).toEqual(OC.TestUtil.buildAbsoluteUrl('/owncloud/index.php/avatar/foo/32#500'));
 		});
 
 		it('unhide div', function() {

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -100,7 +100,7 @@ describe('OC.Share tests', function() {
 		describe('displaying the folder icon', function() {
 			function checkIcon(expectedImage) {
 				var imageUrl = OC.TestUtil.getImageUrl($file.find('.filename .thumbnail'));
-				expectedIcon = OC.imagePath('core', expectedImage);
+				expectedIcon = OC.TestUtil.buildAbsoluteUrl(OC.imagePath('core', expectedImage));
 				expect(imageUrl).toEqual(expectedIcon);
 			}
 


### PR DESCRIPTION
## Description
Use the correct behavior for OC.webroot in tests.
OC.webroot is a reltative path like /owncloud/ - the tests have been initializing it as absolute path like http://localhost

## Related Issue
fixes #17537

## Motivation and Context
Have proper tests in place

## How Has This Been Tested?
make test-js

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

