### PR TITLE
Lazy connect to federated share, not in storage constructor

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -132,7 +132,7 @@ class DAV extends Common {
 		}
 	}
 
-	private function init() {
+	protected function init() {
 		if ($this->ready) {
 			return;
 		}


### PR DESCRIPTION
## Description
Don't connect directly to the remote share inside the storage
constructor. Defer this to the lazy initialization routine, which will
then correctly configure the remote root using the discovery manager.

## Related Issue
Ref https://github.com/owncloud/core/issues/28763#issuecomment-335851401

## Motivation and Context
To avoid having to wait for time outs for not yet memcached federated share connections. This could slow down upgrade processes because setting up FS calls the constructor of storages.
Also would improve performance when no memcache is configured when setting up FS for operations not relevant to the federated share, where it would previously still construct the storage and trigger a network connection.

## How Has This Been Tested?
I just retested that federated shares still work, unit test also works.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

