### PR TITLE
[stable10] Handle invalid storage when getting storage root id

### DIFF
--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -245,9 +245,20 @@ class MountPoint implements IMountPoint {
 	/**
 	 * Get the file id of the root of the storage
 	 *
-	 * @return int
+	 * @return int storage numeric id or -1 in case of invalid storage
 	 */
 	public function getStorageRootId() {
-		return (int)$this->getStorage()->getCache()->getId('');
+		$storage = $this->getStorage();
+		if ($storage === null || $this->invalidStorage) {
+			return -1;
+		}
+
+		$cache = $storage->getCache();
+
+		if ($cache === null) {
+			return -1;
+		}
+
+		return (int)$cache->getId('');
 	}
 }

--- a/lib/public/Files/Mount/IMountPoint.php
+++ b/lib/public/Files/Mount/IMountPoint.php
@@ -98,7 +98,7 @@ interface IMountPoint {
 	/**
 	 * Get the file id of the root of the storage
 	 *
-	 * @return int
+	 * @return int storage numeric id or -1 in case of invalid storage
 	 * @since 9.1.0
 	 */
 	public function getStorageRootId();


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/29210 to stable10