### PR TITLE
Only run Firefox 47 UI tests in Travis cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,37 +91,43 @@ matrix:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - if: type = cron
+      php: 5.6
       env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - if: type = cron
+      php: 5.6
       env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - if: type = cron
+      php: 5.6
       env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - if: type = cron
+      php: 5.6
       env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="renameFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - if: type = cron
+      php: 5.6
       env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - if: type = cron
+      php: 5.6
       env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="sharing" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt


### PR DESCRIPTION
## Description
Move the existing Firefox47 UI test Travis jobs into the daily cron, instead of running them on every PR.

## Related Issue
#29199 

## Motivation and Context
- make Travis CI runs from PRs complete at more PRs per hour
- Firefox 47 is old and so the tests are not so meaningful ( Issue #29284 and PR #29285 address getting UI tests running with current Firefox.)

## How Has This Been Tested?
Travis tells.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
