### PR TITLE
fixed exception, if $node is type SimpleCollection

### DIFF
--- a/apps/dav/lib/DAV/FileCustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/FileCustomPropertiesBackend.php
@@ -25,6 +25,7 @@ namespace OCA\DAV\DAV;
 
 use Doctrine\DBAL\Connection;
 use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Connector\Sabre\Node;
 use Sabre\DAV\INode;
 
 /**
@@ -199,6 +200,18 @@ class FileCustomPropertiesBackend extends AbstractCustomPropertiesBackend {
 		}
 
 		$result->closeCursor();
+	}
+
+	/**
+	 * @param string $path
+	 * @return INode|null
+	 */
+	protected function getNodeForPath($path){
+		$node = parent::getNodeForPath($path);
+		if (!$node instanceof Node) {
+			return null;
+		}
+		return $node;
 	}
 
 }

--- a/apps/dav/tests/unit/DAV/FileCustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/FileCustomPropertiesBackendTest.php
@@ -23,7 +23,9 @@
 
 namespace OCA\DAV\Tests\unit\DAV;
 
-use \OCA\DAV\DAV\FileCustomPropertiesBackend;
+use OCA\DAV\DAV\FileCustomPropertiesBackend;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\SimpleCollection;
 
 /**
  * Class FileCustomPropertiesBackendTest
@@ -138,6 +140,43 @@ class FileCustomPropertiesBackendTest extends \Test\TestCase {
 		$this->assertEquals(200, $result['customprop2']);
 	}
 
+	
+	/**
+	 * Test getting properties when node has no fileId
+	 * Should fail gracefully with no error
+	 */
+	public function testGetPropertiesForCollection() {
+		$node = $this->getMockBuilder(SimpleCollection::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$node->expects($this->any())
+			->method('getPath')
+			->will($this->returnValue('/dummypath'));
+			
+		$this->tree->expects($this->any())
+			->method('getNodeForPath')
+			->with('/dummypath')
+			->will($this->returnValue($node));
+
+		$propFind = new PropFind(
+			'/dummypath',
+			[
+				'customprop',
+				'customprop2',
+				'unsetprop',
+			],
+			0
+		);
+
+		$this->plugin->propFind(
+			'/dummypath',
+			$propFind
+		);
+
+		$this->assertNull($propFind->get('customprop'));
+	}
+
 	/**
 	 * Test that propFind on a missing file soft fails
 	 */
@@ -152,7 +191,7 @@ class FileCustomPropertiesBackendTest extends \Test\TestCase {
 			->with('/dummypath')
 			->will($this->throwException(new \Sabre\DAV\Exception\ServiceUnavailable()));
 
-		$propFind = new \Sabre\DAV\PropFind(
+		$propFind = new PropFind(
 			'/dummypath',
 			[
 				'customprop',
@@ -188,7 +227,7 @@ class FileCustomPropertiesBackendTest extends \Test\TestCase {
 
 		$this->applyDefaultProps();
 
-		$propFind = new \Sabre\DAV\PropFind(
+		$propFind = new PropFind(
 			'/dummypath',
 			[
 				'customprop',
@@ -258,13 +297,13 @@ class FileCustomPropertiesBackendTest extends \Test\TestCase {
 			'unsetprop',
 		];
 
-		$propFindRoot = new \Sabre\DAV\PropFind(
+		$propFindRoot = new PropFind(
 			'/dummypath',
 			$propNames,
 			1
 		);
 
-		$propFindSub = new \Sabre\DAV\PropFind(
+		$propFindSub = new PropFind(
 			'/dummypath/test.txt',
 			$propNames,
 			0


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Fixed Exception, if $node is type Sabre\DAV\SimpleCollection

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
I don't like exceptions

## How Has This Been Tested?
After the change, i can see remote.php/dav/files again, without an exception

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

