### PR TITLE
[stable10] Update davclient.js to 0.1.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "underscore": "1.8.3",
     "bootstrap": "3.3.6",
     "backbone": "1.2.3",
-    "davclient.js": "https://github.com/evert/davclient.js.git#0.1.1",
+    "davclient.js": "https://github.com/evert/davclient.js.git#0.1.2",
     "es6-promise": "https://github.com/jakearchibald/es6-promise.git#2.3.0",
     "base64": "0.3.0",
     "clipboard": "1.5.12",


### PR DESCRIPTION
Fixes issues when app devs are using frameworks that might extend the
Array prototype

backport of #28997 to stable10