### PR TITLE
[stable10] Disable background scan for home storage/cache

### DIFF
--- a/lib/private/Files/Cache/HomeCache.php
+++ b/lib/private/Files/Cache/HomeCache.php
@@ -84,4 +84,13 @@ class HomeCache extends Cache {
 		}
 		return $data;
 	}
+
+	/**
+	 * Returns false because the home cache shouldn't have any relevant incomplete entries.
+	 *
+	 * @return false
+	 */
+	public function getIncomplete() {
+		return false;
+	}
 }

--- a/tests/lib/Files/Cache/HomeCacheTest.php
+++ b/tests/lib/Files/Cache/HomeCacheTest.php
@@ -136,4 +136,16 @@ class HomeCacheTest extends \Test\TestCase {
 
 		$this->assertFalse($this->cache->inCache($dir1));
 	}
+
+	public function testGetIncompleteFalse() {
+		$fileData[''] = ['size' => -1, 'mtime' => 20, 'mimetype' => 'httpd/unix-directory'];
+		$fileData['files'] = ['size' => -1, 'mtime' => 20, 'mimetype' => 'httpd/unix-directory'];
+		$fileData['files/a'] = ['size' => -1, 'mtime' => 20, 'mimetype' => 'httpd/unix-directory'];
+
+		$this->cache->put('', $fileData['']);
+		$this->cache->put('files', $fileData['files']);
+		$this->cache->put('files/a', $fileData['files/a']);
+
+		$this->assertFalse($this->cache->getIncomplete());
+	}
 }


### PR DESCRIPTION
The home cache might have entries with size=-1 that are outside of
"files/" due to encryption or other metadata that generally do not
require the size to be set or accurate.

Instead of adjusting the HomeCache to ignore entries outside of
"files/", let's just disable it completely. The home storage is in the
data folder and must not receive external changes, so it should never
have any entries with size=-1 in "files/".

backport of #28987 to stable10