### PR TITLE
 allow group named "0" to be deleted 

### DIFF
--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -19,6 +19,7 @@ GroupList = {
 		var $li = $userGroupList.find('.isgroup:last-child').clone();
 		$li
 			.data('gid', gid)
+			.attr('data-gid', gid)
 			.find('.groupname').text(gid);
 		GroupList.setUserCount($li, usercount);
 
@@ -294,7 +295,7 @@ GroupList = {
 	},
 
 	getElementGID: function (element) {
-		return ($(element).closest('li').data('gid') || '').toString();
+		return ($(element).closest('li').attr('data-gid') || '').toString();
 	},
 	getEveryoneCount: function () {
 		$.ajax({

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -135,6 +135,13 @@ class SetupHelper {
 	}
 
 	/**
+	 * 
+	 * @return string[]
+	 */
+	public static function getGroups() {
+		return json_decode(self::runOcc(['group:list', '--output=json'])['stdOut']);
+	}
+	/**
 	 *
 	 * @param HookScope $scope
 	 * @return array of suite context parameters

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -360,8 +360,22 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function addGroupToCreatedGroupsList($group) {
-		if (!in_array($group, $this->createdGroupNames)) {
+		if (!in_array($group, $this->createdGroupNames, true)) {
 			array_push($this->createdGroupNames, $group);
+		}
+	}
+
+	/**
+	 * deletes a group from the lists of groups that were created during test runs
+	 * useful if a group got created during the setup phase but got deleted in a
+	 * test run. We don't want to try to delete this group again in the tear-down phase
+	 * 
+	 * @param string $group
+	 * @return void
+	 */
+	public function deleteGroupFromCreatedGroupsList($group) {
+		if (($key = array_search($group, $this->createdGroupNames, true)) !== false) {
+			unset($this->createdGroupNames[$key]);
 		}
 	}
 

--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -28,6 +28,7 @@ use Behat\Gherkin\Node\TableNode;
 use Page\OwncloudPage;
 use Page\LoginPage;
 use TestHelpers\SetupHelper;
+use OC\Setup;
 
 require_once 'bootstrap.php';
 
@@ -134,6 +135,37 @@ class FeatureContext extends RawMinkContext implements Context {
 			'xpath', './/title'
 		)->getHtml();
 		PHPUnit_Framework_Assert::assertEquals($title, trim($actualTitle));
+	}
+
+	/**
+	 * @Then the group named :name should not exist
+	 * @return void
+	 */
+	public function theGroupNamedShouldNotExist($name) {
+		if (in_array($name, SetupHelper::getGroups(), true)) {
+			throw new Exception("group '" . $name . "' exists but should not");
+		}
+	}
+
+	/**
+	 * @Then /^these groups should (not|)\s?exist:$/
+	 * expects a table of groups with the heading "groupname"
+	 * @param string $shouldOrNot (not|)
+	 * @param TableNode $table
+	 * @return void
+	 */
+	public function theseGroupsShouldNotExist($shouldOrNot, TableNode $table) {
+		$should = ($shouldOrNot !== "not");
+		$groups = SetupHelper::getGroups();
+		foreach ($table as $row) {
+			if (in_array($row['groupname'], $groups, true) !== $should) {
+				throw new Exception(
+					"group '" . $row['groupname'] .
+					"' does" . ($should ? " not" : "") .
+					" exist but should" . ($should ? "" : " not")
+				);
+			}
+		}
 	}
 
 	/**

--- a/tests/ui/features/bootstrap/UsersContext.php
+++ b/tests/ui/features/bootstrap/UsersContext.php
@@ -37,6 +37,10 @@ class UsersContext extends RawMinkContext implements Context {
 
 
 	private $usersPage;
+	/**
+	 * 
+	 * @var FeatureContext
+	 */
 	private $featureContext;
 
 	/**
@@ -105,6 +109,59 @@ class UsersContext extends RawMinkContext implements Context {
 		if (is_array($groups)) {
 			foreach ($groups as $group) {
 				$this->featureContext->addGroupToCreatedGroupsList($group);
+			}
+		}
+	}
+
+	/**
+	 * @When I delete the group named :name
+	 * @return void
+	 */
+	public function iDeleteTheGroupNamed($name) {
+		$this->usersPage->deleteGroup($name, $this->getSession());
+		$this->featureContext->deleteGroupFromCreatedGroupsList($name);
+	}
+
+	/**
+	 * @When I delete these groups:
+	 * expects a table of groups with the heading "groupname"
+	 * @param TableNode $table
+	 * @return void
+	 */
+	public function iDeleteTheseGroups(TableNode $table) {
+		foreach ($table as $row) {
+			$this->iDeleteTheGroupNamed($row['groupname']);
+		}
+	}
+
+	/**
+	 * @Then the group named :name should not be listed
+	 * @param string $name
+	 * @return void
+	 */
+	public function theGroupNamedShouldNotBeListed($name) {
+		if (in_array($name, $this->usersPage->getAllGroups(), true)) {
+			throw new Exception("group '" . $name . "' is listed but should not");
+		}
+	}
+
+	/**
+	 * @Then /^these groups should (not|)\s?be listed:$/
+	 * expects a table of groups with the heading "groupname"
+	 * @param string $shouldOrNot (not|)
+	 * @param TableNode $table
+	 * @return void
+	 */
+	public function theseGroupsShouldBeListed($shouldOrNot, TableNode $table) {
+		$should = ($shouldOrNot !== "not");
+		$groups = $this->usersPage->getAllGroups();
+		foreach ($table as $row) {
+			if (in_array($row['groupname'], $groups, true) !== $should) {
+				throw new Exception(
+					"group '" . $row['groupname'] .
+					"' is" . ($should ? " not" : "") .
+					" listed but should" . ($should ? "" : " not") . " be"
+				);
 			}
 		}
 	}

--- a/tests/ui/features/lib/FilesPageBasic.php
+++ b/tests/ui/features/lib/FilesPageBasic.php
@@ -60,35 +60,6 @@ class FilesPageBasic extends OwnCloudPage {
 	}
 
 	/**
-	 * Surround the text with single or double quotes, whichever does not
-	 * already appear in the text. If the text contains both single and
-	 * double quotes, then throw an InvalidArgumentException.
-	 *
-	 * The returned string is intended for use as part of an xpath (v1).
-	 * xpath (v1) has no way to escape the quote character within a string
-	 * literal. So there is no way to directly use a string containing
-	 * both single and double quotes.
-	 *
-	 * @param string $text
-	 * @return string the text surrounded by single or double quotes
-	 * @throws \InvalidArgumentException
-	 */
-	public function quotedText($text) {
-		if (strstr($text, "'") === false) {
-			return "'" . $text . "'";
-		} else if (strstr($text, '"') === false) {
-			return '"' . $text . '"';
-		} else {
-			// The text contains both single and double quotes.
-			// With current xpath v1 there is no way to encode that.
-			throw new \InvalidArgumentException(
-				"mixing both single and double quotes is unsupported - '"
-				. $text . "'"
-			);
-		}
-	}
-
-	/**
 	 * @param int $number
 	 * @return \Behat\Mink\Element\NodeElement|null
 	 */

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -406,4 +406,33 @@ class OwncloudPage extends Page {
 			throw new \Exception("value of input field is not what we expect");
 		}
 	}
+
+	/**
+	 * Surround the text with single or double quotes, whichever does not
+	 * already appear in the text. If the text contains both single and
+	 * double quotes, then throw an InvalidArgumentException.
+	 *
+	 * The returned string is intended for use as part of an xpath (v1).
+	 * xpath (v1) has no way to escape the quote character within a string
+	 * literal. So there is no way to directly use a string containing
+	 * both single and double quotes.
+	 *
+	 * @param string $text
+	 * @return string the text surrounded by single or double quotes
+	 * @throws \InvalidArgumentException
+	 */
+	public function quotedText($text) {
+		if (strstr($text, "'") === false) {
+			return "'" . $text . "'";
+		} else if (strstr($text, '"') === false) {
+			return '"' . $text . '"';
+		} else {
+			// The text contains both single and double quotes.
+			// With current xpath v1 there is no way to encode that.
+			throw new \InvalidArgumentException(
+				"mixing both single and double quotes is unsupported - '"
+				. $text . "'"
+			);
+		}
+	}
 }

--- a/tests/ui/features/lib/UserPageElement/GroupList.php
+++ b/tests/ui/features/lib/UserPageElement/GroupList.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page\UserPageElement;
+
+use Behat\Mink\Element\NodeElement;
+use Page\OwncloudPage;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+
+/**
+ * The list of groups
+ *
+ */
+class GroupList extends OwncloudPage {
+
+	/**
+	 * @var NodeElement of this element
+	 */
+	protected $groupListElement;
+	protected $allGroupsXpath = "//li[@class='isgroup']";
+	protected $groupLiXpath = "//li[@data-gid=%s]";
+	protected $deleteBtnXpath = "//a[@class='action delete']";
+
+	/**
+	 * sets the NodeElement for the current group list
+	 * a little bit like __construct() but as we access this "sub-page-object"
+	 * from an other Page Object by $this->getPage("OwncloudPageElement\\GroupList")
+	 * there is no real __construct() that can take arguments
+	 *
+	 * @param \Behat\Mink\Element\NodeElement $groupListElement
+	 * @return void
+	 */
+	public function setElement(NodeElement $groupListElement) {
+		$this->groupListElement = $groupListElement;
+	}
+
+	/**
+	 * 
+	 * @param string $name
+	 * @throws ElementNotFoundException
+	 * @return \Behat\Mink\Element\NodeElement
+	 */
+	public function selectGroup($name) {
+		$name = $this->quotedText($name);
+		$groupLi = $this->groupListElement->find(
+			"xpath", sprintf($this->groupLiXpath, $name)
+		);
+		if ($groupLi === null) {
+			throw new ElementNotFoundException("cannot find group list element");
+		}
+		$groupLi->click();
+		return $groupLi;
+	}
+
+	/**
+	 * deletes a group in the UI
+	 * 
+	 * @param string $name
+	 * @throws ElementNotFoundException
+	 * @return void
+	 */
+	public function deleteGroup($name) {
+		$groupLi = $this->selectGroup($name);
+		$deleteButton = $groupLi->find("xpath", $this->deleteBtnXpath);
+		if ($deleteButton === null) {
+			throw new ElementNotFoundException("cannot find delete button");
+		}
+		$deleteButton->click();
+	}
+
+	/**
+	 * returns all group names in an array
+	 * 
+	 * @return string[]
+	 */
+	public function namesToArray() {
+		$allGroupElements = $this->groupListElement->findAll(
+			"xpath", $this->allGroupsXpath
+		);
+		$allGroups = [];
+		foreach ($allGroupElements as $element) {
+			$allGroups[] = $element->getText();
+		}
+		return $allGroups;
+	}
+}
+	

--- a/tests/ui/features/lib/UsersPage.php
+++ b/tests/ui/features/lib/UsersPage.php
@@ -24,7 +24,6 @@ namespace Page;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
-use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**
@@ -61,6 +60,7 @@ class UsersPage extends OwncloudPage {
 	protected $newUserGroupXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']//label[@title='%s']/..";
 	protected $newUserAddGroupBtnXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']//li[@title='add group']";
 	protected $createGroupWithNewUserInputXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']//input[@type='text']";
+	protected $groupListId = "usergrouplist";
 	/**
 	 * @param string $username
 	 * @return NodeElement for the requested user in the table
@@ -254,5 +254,47 @@ class UsersPage extends OwncloudPage {
 			$selectOption->click();
 		}
 		$this->waitForOutstandingAjaxCalls($session);
+	}
+
+	/**
+	 * 
+	 * @throws ElementNotFoundException
+	 * @return \Page\UserPageElement\GroupList
+	 */
+	private function getGroupListElement() {
+		$groupListElement = $this->findById($this->groupListId);
+		if ($groupListElement === null) {
+			throw new ElementNotFoundException("cannot find group list element");
+		}
+		
+		/**
+		 * 
+		 * @var \Page\UserPageElement\GroupList $groupList
+		 */
+		$groupList = $this->getPage("UserPageElement\\GroupList");
+		$groupList->setElement($groupListElement);
+		return $groupList;
+	}
+
+	/**
+	 * returns all group names as an array
+	 * 
+	 * @return string[]
+	 */
+	public function getAllGroups() {
+		$groupList = $this->getGroupListElement();
+		return $groupList->namesToArray();
+	}
+
+	/**
+	 * 
+	 * @param string $name
+	 * @param Session $session
+	 * @return void
+	 */
+	public function deleteGroup($name, Session $session) {
+		$groupList = $this->getGroupListElement();
+		$groupList->deleteGroup($name);
+		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
 }

--- a/tests/ui/features/other/users.feature
+++ b/tests/ui/features/other/users.feature
@@ -42,4 +42,45 @@ Feature: users
 		And I logout
 		And I login with username "guiusr1" and password "pwd"
 		Then I should be redirected to a page with the title "Files - ownCloud"
-		
+
+	Scenario: delete groups
+		And these groups exist:
+		|groupname     |
+		|do-not-delete |
+		|grp1          |
+		|0             |
+		|false         |
+		|quotes'       |
+		|quotes"       |
+		|do-not-delete2|
+		And I am on the users page
+		When I delete these groups:
+		|groupname|
+		|grp1     |
+		|0        |
+		|false    |
+		|quotes'  |
+		|quotes"  |
+		And the users page is reloaded
+		Then these groups should be listed:
+		|groupname     |
+		|do-not-delete |
+		|do-not-delete2|
+		But these groups should not be listed:
+		|groupname|
+		|grp1     |
+		|0        |
+		|false    |
+		|quotes'  |
+		|quotes"  |
+		And these groups should exist:
+		|groupname     |
+		|do-not-delete |
+		|do-not-delete2|
+		But these groups should not exist:
+		|groupname|
+		|grp1     |
+		|0        |
+		|false    |
+		|quotes'  |
+		|quotes"  |


### PR DESCRIPTION
## Description
allow a group that is called `0` to be deleted in the UI
additionally some basic UI tests to delete groups

## Related Issue
#29051

## Motivation and Context
see issue

## How Has This Been Tested?
- manual testing in FF & Chrome
- made automatic UI tests
- run new UI tests in FF and Chrome

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.