### PR TITLE
Mock getName instead of getPath 

### DIFF
--- a/apps/dav/tests/unit/DAV/FileCustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/FileCustomPropertiesBackendTest.php
@@ -151,8 +151,8 @@ class FileCustomPropertiesBackendTest extends \Test\TestCase {
 			->getMock();
 
 		$node->expects($this->any())
-			->method('getPath')
-			->will($this->returnValue('/dummypath'));
+			->method('getName')
+			->will($this->returnValue('dummypath'));
 			
 		$this->tree->expects($this->any())
 			->method('getNodeForPath')


### PR DESCRIPTION
Drone output:
https://drone.owncloud.com/owncloud/core/287/7
```
...........W................................................. 7137 / 8163 ( 87%)
1) OCA\DAV\Tests\unit\DAV\FileCustomPropertiesBackendTest::testGetPropertiesForCollection
339s
176
Trying to configure method "getPath" which cannot be configured because it does not exist, has not been specified, is final, or is static
```

## Description


## Motivation and Context
Clean tests, no warnings

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

