### PR TITLE
AccountMapper get by email is now case insensitive

### DIFF
--- a/lib/private/User/AccountMapper.php
+++ b/lib/private/User/AccountMapper.php
@@ -108,9 +108,11 @@ class AccountMapper extends Mapper {
 			throw new \InvalidArgumentException('$email must be defined');
 		}
 		$qb = $this->db->getQueryBuilder();
+		// RFC 5321 says that only domain name is case insensitive, but in practice
+		// it's the whole email
 		$qb->select('*')
 			->from($this->getTableName())
-			->where($qb->expr()->eq('email', $qb->createNamedParameter($email)));
+			->where($qb->expr()->eq($qb->createFunction('LOWER(`email`)'), $qb->createFunction('LOWER(' . $qb->createNamedParameter($email) . ')')));
 
 		return $this->findEntities($qb->getSQL(), $qb->getParameters());
 	}

--- a/tests/lib/User/AccountMapperTest.php
+++ b/tests/lib/User/AccountMapperTest.php
@@ -120,11 +120,32 @@ class AccountMapperTest extends TestCase {
 		$this->assertEquals("TestFind2", array_shift($result)->getUserId());
 	}
 
+	public function findByEmailDataProvider() {
+		return [
+			['test3@find.tld'],
+			['Test3@find.tld'],
+			['test3@Find.tld'],
+		];
+	}
+
 	/**
 	 * find by email
+	 *
+	 * @dataProvider findByEmailDataProvider
 	 */
-	public function testFindByEmail() {
-		$result= $this->mapper->find('test3@find.tld');
+	public function testFindByEmail($email) {
+		$result = $this->mapper->find($email);
+		$this->assertEquals(1, count($result));
+		$this->assertEquals("TestFind3", array_shift($result)->getUserId());
+	}
+
+	/**
+	 * get by email
+	 *
+	 * @dataProvider findByEmailDataProvider
+	 */
+	public function testGetByEmail($email) {
+		$result = $this->mapper->getByEmail($email);
 		$this->assertEquals(1, count($result));
 		$this->assertEquals("TestFind3", array_shift($result)->getUserId());
 	}


### PR DESCRIPTION
## Description
AccountMapper::getByEmail() is now case insensitive.
This is important to be able to detect duplicates through this method.

## Related Issue
Required for https://github.com/owncloud/guests/pull/168

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual testing guests app + unit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

