### PR TITLE
Call getFullPath only if its defined in storage

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -782,8 +782,9 @@ class Encryption extends Wrapper {
 		} else {
 			try {
 				$source = $sourceStorage->fopen($sourceInternalPath, 'r');
-				if ($isRename) {
-					$this->sourcePath[$targetInternalPath] = $sourceStorage->getFullPath($sourceInternalPath);
+				if ($isRename && (count($mount) === 1)) {
+					$sourceStorageMountPoint = $mount[0]->getMountPoint();
+					$this->sourcePath[$targetInternalPath] = $sourceStorageMountPoint . '/' . $sourceInternalPath;
 				} else {
 					unset($this->sourcePath[$targetInternalPath]);
 				}


### PR DESCRIPTION
Call getFullPath only if its defined in storage.
Else use mount point to resolve the full path.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
This change adds getFullPath method to shared external storage file.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/29167

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Setup to recreate the issue:
1) Create 2 instances of oC. Lets say oC1 and oC2.
2) oC1 is not encrypted and oC2 is encrypted ( tested with masterkey ). oC2 is added as an external storage to oC1.
3) Create a folder in oC2 name `test`
4) Share the folder to an oC1 user `user1` using federated share
5) Now login as `user1` in oC1 and create a file under `test`
6) Try to delete the file. The log file in oC1, can see message mentioned in the issue.
Since oC1 is non encrypted and when file under `test` is being deleted, the https://github.com/owncloud/core/blob/v10.0.3/lib/private/Files/Storage/Wrapper/Encryption.php#L786 code is hit. The reason is its a cross storage move. And getFullPath is defined only in Encryption storage. Its not available in other storages. So during the iteration to find the getFullPath method under storage wrappers, it couldn't find and throws the error. This change helps us to resolve that issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Recreated the issue with the steps mentioned above. After applying this change when the file is deleted, the log file doesn't spit the error message.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

