### PR TITLE
Correctly detect that an empty files page is loaded

### DIFF
--- a/tests/ui/features/files/files.feature
+++ b/tests/ui/features/files/files.feature
@@ -20,3 +20,11 @@ Feature: files
 		|'सिमप्ले फोल्देर $%#?&@'|
 		|'"somequotes1"'|
 		|"'somequotes2'"|
+
+	Scenario: Create a folder inside another folder
+		When I create a folder with the name "top-folder"
+		And I open the folder "top-folder"
+		And I create a folder with the name "sub-folder"
+		Then the folder "sub-folder" should be listed
+		And the files page is reloaded
+		Then the folder "sub-folder" should be listed

--- a/tests/ui/features/files/files.feature
+++ b/tests/ui/features/files/files.feature
@@ -11,20 +11,27 @@ Feature: files
 		Then the filesactionmenu should be completely visible after clicking on it
 
 	Scenario Outline: Create a folder using special characters
-		When I create a folder with the name <folder_name>
-		Then the folder <folder_name> should be listed
+		When I create a folder with the following name
+			| name-parts      |
+			| <folder_name>   |
+		Then the following folder should be listed
+			| name-parts      |
+			| <folder_name>   |
 		And the files page is reloaded
-		Then the folder <folder_name> should be listed
+		Then the following folder should be listed
+			| name-parts      |
+			| <folder_name>   |
 		Examples:
 		|folder_name    |
-		|'सिमप्ले फोल्देर $%#?&@'|
-		|'"somequotes1"'|
-		|"'somequotes2'"|
+		|सिमप्ले फोल्देर $%#?&@|
+		|"somequotes1"|
+		|'somequotes2'|
 
 	Scenario: Create a folder inside another folder
 		When I create a folder with the name "top-folder"
 		And I open the folder "top-folder"
-		And I create a folder with the name "sub-folder"
+		Then there are no files/folders listed
+		When I create a folder with the name "sub-folder"
 		Then the folder "sub-folder" should be listed
 		And the files page is reloaded
 		Then the folder "sub-folder" should be listed

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -38,6 +38,7 @@ class FilesPage extends FilesPageBasic {
 	//we need @id='app-content-files' because id='fileList' is used multiple times
 	//see https://github.com/owncloud/core/issues/27870
 	protected $fileListXpath = ".//div[@id='app-content-files']//tbody[@id='fileList']";
+	protected $emptyContentXpath = ".//div[@id='app-content-files']//div[@id='emptycontent']";
 	protected $newFileFolderButtonXpath = './/*[@id="controls"]//a[@class="button new"]';
 	protected $newFolderButtonXpath = './/div[contains(@class, "newFileMenu")]//a[@data-templatename="New folder"]';
 	protected $newFolderNameInputLabel = 'New folder';
@@ -63,6 +64,13 @@ class FilesPage extends FilesPageBasic {
 	 */
 	protected function getFileNameMatchXpath() {
 		return $this->fileNameMatchXpath;
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function getEmptyContentXpath() {
+		return $this->emptyContentXpath;
 	}
 
 	/**

--- a/tests/ui/features/lib/FilesPageBasic.php
+++ b/tests/ui/features/lib/FilesPageBasic.php
@@ -100,17 +100,22 @@ abstract class FilesPageBasic extends OwnCloudPage {
 		$this->scrollToPosition('#' . $this->appContentId, 0, $session);
 
 		if (is_array($name)) {
-			// Concatenating separate parts of the file name allows
-			// some parts to contain single quotes and the others to contain
-			// double quotes.
-			$comma = '';
-			$xpathString = "concat(";
+			if (count($name) === 1) {
+				$xpathString = $this->quotedText($name[0]);
+			} else {
+				// Concatenating separate parts of the file name allows
+				// some parts to contain single quotes and the others to contain
+				// double quotes.
+				$comma = '';
+				$xpathString = "concat(";
 
-			foreach ($name as $nameComponent) {
-				$xpathString .= $comma . $this->quotedText($nameComponent);
-				$comma = ',';
+				foreach ($name as $nameComponent) {
+					$xpathString .= $comma . $this->quotedText($nameComponent);
+					$comma = ',';
+				}
+				$xpathString .= ")";
 			}
-			$xpathString .= ")";
+
 			$name = implode($name);
 		} else {
 			$xpathString = $this->quotedText($name);

--- a/tests/ui/features/lib/FilesPageBasic.php
+++ b/tests/ui/features/lib/FilesPageBasic.php
@@ -32,11 +32,6 @@ use Behat\Mink\Session;
  */
 abstract class FilesPageBasic extends OwnCloudPage {
 
-	/**
-	 *
-	 * @var string $path
-	 */
-	protected $emptyContentXpath = ".//*[@id='emptycontent']";
 	protected $fileActionMenuBtnXpathByNo = ".//*[@id='fileList']/tr[%d]//a[@data-action='menu']";
 	protected $fileActionMenuBtnXpath = "//a[@data-action='menu']";
 	protected $fileActionMenuXpath = "//div[contains(@class,'fileActionsMenu')]";
@@ -61,6 +56,11 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	 * @return string
 	 */
 	abstract protected function getFileNameMatchXpath();
+
+	/**
+	 * @return string
+	 */
+	abstract protected function getEmptyContentXpath();
 
 	/**
 	 * @return int the number of files and folders listed on the page
@@ -323,16 +323,17 @@ abstract class FilesPageBasic extends OwnCloudPage {
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
 			$fileList = $this->find('xpath', $this->getFileListXpath());
-			if ($fileList !== null
-				&& $fileList->isVisible()
-			) {
-				if ($fileList->has("xpath", "//a")) {
+
+			if ($fileList !== null) {
+				if ($fileList->isVisible()
+					&& $fileList->has("xpath", "//a")
+				) {
 					break;
 				}
 
 				$emptyContentElement = $this->find(
 					"xpath",
-					$this->emptyContentXpath
+					$this->getEmptyContentXpath()
 				);
 
 				if ($emptyContentElement !== null) {

--- a/tests/ui/features/lib/FilesPageElement/FileRow.php
+++ b/tests/ui/features/lib/FilesPageElement/FileRow.php
@@ -49,7 +49,7 @@ class FileRow extends OwnCloudPage {
 	protected $fileBusyIndicatorXpath = ".//*[@class='thumbnail' and contains(@style,'loading')]";
 	protected $fileTooltipXpath = ".//*[@class='tooltip-inner']";
 	protected $thumbnailXpath = "//*[@class='thumbnail']";
-	protected $fileLinkXpath = "//span[@class='nametext']";
+	protected $fileLinkXpath = "//span[contains(@class,'nametext')]";
 
 	/**
 	 * sets the NodeElement for the current file row

--- a/tests/ui/features/lib/TrashbinPage.php
+++ b/tests/ui/features/lib/TrashbinPage.php
@@ -35,6 +35,7 @@ class TrashbinPage extends FilesPageBasic {
 	protected $fileNamesXpath = "//span[contains(@class,'nametext')]";
 	protected $fileNameMatchXpath = "//span[contains(@class,'nametext') and .=%s]";
 	protected $fileListXpath = ".//div[@id='app-content-trashbin']//tbody[@id='fileList']";
+	protected $emptyContentXpath = ".//div[@id='app-content-trashbin']//*[@id='emptycontent']";
 
 	/**
 	 * @return string
@@ -55,5 +56,12 @@ class TrashbinPage extends FilesPageBasic {
 	 */
 	protected function getFileNameMatchXpath() {
 		return $this->fileNameMatchXpath;
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function getEmptyContentXpath() {
+		return $this->emptyContentXpath;
 	}
 }

--- a/tests/ui/features/lib/TrashbinPage.php
+++ b/tests/ui/features/lib/TrashbinPage.php
@@ -35,7 +35,7 @@ class TrashbinPage extends FilesPageBasic {
 	protected $fileNamesXpath = "//span[contains(@class,'nametext')]";
 	protected $fileNameMatchXpath = "//span[contains(@class,'nametext') and .=%s]";
 	protected $fileListXpath = ".//div[@id='app-content-trashbin']//tbody[@id='fileList']";
-	protected $emptyContentXpath = ".//div[@id='app-content-trashbin']//*[@id='emptycontent']";
+	protected $emptyContentXpath = ".//div[@id='app-content-trashbin']//div[@id='emptycontent']";
 
 	/**
 	 * @return string

--- a/tests/ui/features/renameFilesFolders/renameFiles.feature
+++ b/tests/ui/features/renameFilesFolders/renameFiles.feature
@@ -6,15 +6,21 @@ Feature: renameFiles
 		And I am on the files page
 
 	Scenario Outline: Rename a file using special characters
-		When I rename the file "lorem.txt" to <to_file_name>
-		Then the file <to_file_name> should be listed
+		When I rename the following file to
+			|from-name-parts |to-name-parts  |
+			|lorem.txt       |<to_file_name> |
+		Then the following file should be listed
+			|name-parts     |
+			|<to_file_name> |
 		And the files page is reloaded
-		Then the file <to_file_name> should be listed
+		Then the following file should be listed
+			|name-parts     |
+			|<to_file_name> |
 		Examples:
-		|to_file_name    |
-		|'लोरेम।तयक्स्त? $%#&@' |
-		|'"quotes1"'     |
-		|"'quotes2'"     |
+		|to_file_name |
+		|लोरेम।तयक्स्त? $%#&@ |
+		|"quotes1"    |
+		|'quotes2'    |
 
 	Scenario Outline: Rename a file that has special characters in its name
 		When I rename the file <from_name> to <to_name>
@@ -32,7 +38,9 @@ Feature: renameFiles
 		Then the file "लोरेम।तयक्स्त $%&" should be listed
 		When I rename the file "लोरेम।तयक्स्त $%&" to '"double"quotes.txt'
 		And the files page is reloaded
-		Then the file '"double"quotes.txt' should be listed
+		Then the following file should be listed
+			|name-parts         |
+			|"double"quotes.txt |
 		When I rename the file '"double"quotes.txt' to "no-double-quotes.txt"
 		And the files page is reloaded
 		Then the file "no-double-quotes.txt" should be listed

--- a/tests/ui/features/renameFilesFolders/renameFolders.feature
+++ b/tests/ui/features/renameFilesFolders/renameFolders.feature
@@ -6,15 +6,21 @@ Feature: renameFolders
 		And I am on the files page
 
 	Scenario Outline: Rename a folder using special characters
-		When I rename the folder "simple-folder" to <to_folder_name>
-		Then the folder <to_folder_name> should be listed
+		When I rename the following folder to
+			|from-name-parts |to-name-parts    |
+			|simple-folder   |<to_folder_name> |
+		Then the following folder should be listed
+			|name-parts       |
+			|<to_folder_name> |
 		And the files page is reloaded
-		Then the folder <to_folder_name> should be listed
+		Then the following folder should be listed
+			|name-parts       |
+			|<to_folder_name> |
 		Examples:
-		|to_folder_name|
-		|'सिमप्ले फोल्देर$%#?&@' |
-		|'"quotes1"'    |
-		|"'quotes2'"    |
+		|to_folder_name |
+		|सिमप्ले फोल्देर$%#?&@ |
+		|"quotes1"      |
+		|'quotes2'      |
 
 	Scenario Outline: Rename a folder that has special characters in its name
 		When I rename the folder <from_name> to <to_name>
@@ -32,7 +38,9 @@ Feature: renameFolders
 		Then the folder "लोरेम।तयक्स्त $%&" should be listed
 		When I rename the folder "लोरेम।तयक्स्त $%&" to '"double"quotes'
 		And the files page is reloaded
-		Then the folder '"double"quotes' should be listed
+		Then the following folder should be listed
+			|name-parts      |
+			|"double"quotes  |
 		When I rename the folder '"double"quotes' to "no-double-quotes"
 		And the files page is reloaded
 		Then the folder "no-double-quotes" should be listed

--- a/tests/ui/features/trashbin/delete.feature
+++ b/tests/ui/features/trashbin/delete.feature
@@ -65,3 +65,14 @@ Feature: delete
 		Then the deleted elements should not be listed
 		And the deleted elements should not be listed after a page reload
 		But the deleted elements should be listed in the trashbin
+
+	Scenario: Delete an empty folder
+		When I create a folder with the name "my-empty-folder"
+		And I create a folder with the name "my-other-empty-folder"
+		And I delete the folder "my-empty-folder"
+		Then the folder "my-other-empty-folder" should be listed
+		But the folder "my-empty-folder" should not be listed
+		And the folder "my-empty-folder" should be listed in the trashbin
+		But the folder "my-other-empty-folder" should not be listed in the trashbin
+		When I open the trashbin folder "my-empty-folder"
+		Then there are no files/folders listed


### PR DESCRIPTION
## Description
1) Be more specific about which div the ``emptycontent`` id is contained in (there are lots of ``emptycontent`` divs in different parts of the page)
2) Move check for fileList being visible so it only applies when there are files.
3) Add a core files test creating an empty folder and navigating into it.
4) Add a core trashbin test that checks that an empty delete folder goes to the trashbin as an empty folder
5) For the "name-parts" code, correctly handle the case when there is only 1 part given (it was crashing in that case, we do not use that because it is a bit odd to specify file name parts and then only put 1 part, but may as well fix it)
6) In ``FileRow`` match the ``fileLinkXpath`` differently so that it works on TrashbinPage as well as FilesPage.

## Related Issue
#29138 
(this PR is a "downstream" thing that was noticed while getting Edge tests running)

## Motivation and Context
When a folder is empty, the UI test code is not correctly detecting that the (empty) files page for that folder is loaded. The "wait till page is loaded" logic was timing out (10 seconds). Now that we throw an exception on page load timeout, this was causing test fails in the ``files_texteditor`` tests, because those tests navigated into an empty folder and then created a file in the folder.

There were no core UI tests that navigated into an empty folder. We should have at least one such test so that the empty files page logic is exercised in core testing.

## How Has This Been Tested?
Run ``files_texteditor`` UI tests locally and confirm they now pass.'
Run the new core test locally and confirm it fails before the change, and passes with the changed code.
Travis will do a full test run for us.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
