### PR TITLE
UI tests hardening

### DIFF
--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -203,6 +203,21 @@ else
 	PASSED=false
 fi
 
+if [ "$PASSED" = false ]
+then
+	PASSED=true
+	FAILED_FEATURES=`awk '/Failed scenarios:/',0 $TEST_LOG_FILE | grep feature`
+	for FEATURE in $FAILED_FEATURES
+		do
+			echo rerun failed tests: $FEATURE
+			lib/composer/bin/behat -c $BEHAT_YML $BEHAT_SUITE_OPTION $BEHAT_TAG_OPTION $BEHAT_TAGS $FEATURE -v  2>&1 | tee -a $TEST_LOG_FILE
+			if [ ${PIPESTATUS[0]} -ne 0 ]
+			then
+				PASSED=false
+			fi
+		done
+fi
+
 if [ "$BEHAT_TAGS_OPTION_FOUND" != true ]
 then
 	# The behat run above specified to skip scenarios tagged @skip

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -184,7 +184,7 @@ class FilesPage extends FilesPageBasic {
 			$this->waitForAjaxCallsToStartAndFinish($session);
 			$countXHRRequests = $session->evaluateScript("jQuery.countXHRRequests");
 			if ($countXHRRequests === 0) {
-				error_log("Error while moving file file");
+				error_log("Error while moving file");
 			} else {
 				break;
 			}

--- a/tests/ui/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/ui/features/lib/FilesPageElement/SharingDialog.php
@@ -151,23 +151,34 @@ class SharingDialog extends OwncloudPage {
 	 * @return void
 	 */
 	private function shareWithUserOrGroup(
-		$nameToType, $nameToMatch, Session $session
+		$nameToType, $nameToMatch, Session $session, $maxRetries = 5
 	) {
-		$autocompleteNodeElement = $this->fillShareWithField($nameToType, $session);
-		$userElements = $autocompleteNodeElement->findAll(
-			"xpath", $this->autocompleteItemsTextXpath
-		);
-
-		$userFound = false;
-		foreach ($userElements as $user) {
-			if ($user->getText() === $nameToMatch) {
-				$user->click();
-				$this->waitForAjaxCallsToStartAndFinish($session);
-				$userFound = true;
+		for ($retryCounter = 0; $retryCounter < $maxRetries; $retryCounter++) {
+			$autocompleteNodeElement = $this->fillShareWithField($nameToType, $session);
+			$userElements = $autocompleteNodeElement->findAll(
+				"xpath", $this->autocompleteItemsTextXpath
+			);
+	
+			$userFound = false;
+			foreach ($userElements as $user) {
+				if ($user->getText() === $nameToMatch) {
+					$user->click();
+					$this->waitForAjaxCallsToStartAndFinish($session);
+					$userFound = true;
+					break;
+				}
+			}
+			if ($userFound === true) {
 				break;
+			} else {
+				error_log("Error while sharing file");
 			}
 		}
-
+		if ($retryCounter > 0) {
+			$message = "INFORMATION: retried to share file " . $retryCounter . " times";
+			echo $message;
+			error_log($message);
+		}
 		if ($userFound !== true) {
 			throw new ElementNotFoundException(
 				"could not share with '$nameToMatch'"


### PR DESCRIPTION
## Description
eliminate false positives on UI tests runs
1. retry to share a file/folder if it failed for some reason (sometimes the drop-down never appears)
2. rerun tests that did fail, if they fail also the second time report a failure

## Motivation and Context
we want to CI to run as stable as possible

## How Has This Been Tested?
travis, travis, travis


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

