### PR TITLE
Add regex for single quotes to UI tests

### DIFF
--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -89,8 +89,18 @@ class FilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When I create a folder with the name :name
+	 * @When /^I create a folder with the name ((?:'[^']*')|(?:"[^"]*"))$/
 	 *
+	 * @param string|array $name enclosed in single or double quotes
+	 * @return void
+	 */
+	public function iCreateAFolder($name) {
+		// The capturing group of the regex always includes the quotes at each
+		// end of the captured string, so trim them.
+		$this->createAFolder(trim($name, $name[0]));
+	}
+
+	/**
 	 * @param string $name
 	 * @return void
 	 */
@@ -294,12 +304,12 @@ class FilesContext extends RawMinkContext implements Context {
 	public function theDeletedMovedElementsShouldBeListed($shouldOrNot) {
 		if (!is_null($this->deletedElementsTable)) {
 			foreach ($this->deletedElementsTable as $file) {
-				$this->theFileFolderShouldBeListed($file['name'], $shouldOrNot);
+				$this->checkIfFileFolderIsListed($file['name'], $shouldOrNot);
 			}
 		}
 		if (!is_null($this->movedElementsTable)) {
 			foreach ($this->movedElementsTable as $file) {
-				$this->theFileFolderShouldBeListed($file['name'], $shouldOrNot);
+				$this->checkIfFileFolderIsListed($file['name'], $shouldOrNot);
 			}
 		}
 	}
@@ -325,7 +335,7 @@ class FilesContext extends RawMinkContext implements Context {
 		$this->trashbinPage->waitTillPageIsLoaded($this->getSession());
 
 		foreach ($this->deletedElementsTable as $file) {
-			$this->theFileFolderShouldBeListed($file['name'], "", $this->trashbinPage);
+			$this->checkIfFileFolderIsListed($file['name'], "", $this->trashbinPage);
 		}
 	}
 
@@ -387,8 +397,8 @@ class FilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the (?:file|folder) "([^"]*)" should (not|)\s?be listed\s?(in the trashbin|)$/
-	 * @param string|array $name
+	 * @Then /^the (?:file|folder) ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(in the trashbin|)$/
+	 * @param string|array $name enclosed in single or double quotes
 	 * @param string $shouldOrNot
 	 * @param string|null $trashbin
 	 * @param PageObject|null $pageObject if null $this->filesPage will be used
@@ -397,8 +407,25 @@ class FilesContext extends RawMinkContext implements Context {
 	public function theFileFolderShouldBeListed(
 		$name, $shouldOrNot, $trashbin = "", $pageObject = null
 	) {
-		$message = null;
+		// The capturing group of the regex always includes the quotes at each
+		// end of the captured string, so trim them.
+		$this->checkIfFileFolderIsListed(
+			trim($name, $name[0]), $shouldOrNot, $trashbin, $pageObject
+		);
+	}
+
+	/**
+	 * @param string|array $name
+	 * @param string $shouldOrNot
+	 * @param string|null $trashbin
+	 * @param PageObject|null $pageObject if null $this->filesPage will be used
+	 * @return void
+	 */
+	public function checkIfFileFolderIsListed(
+		$name, $shouldOrNot, $trashbin = "", $pageObject = null
+	) {
 		$should = ($shouldOrNot !== "not");
+		$message = null;
 
 		if ($trashbin !== "") {
 			$this->trashbinPage->open();
@@ -444,7 +471,7 @@ class FilesContext extends RawMinkContext implements Context {
 	) {
 		$this->iOpenTheFolder($folderName);
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
-		$this->theFileFolderShouldBeListed($itemToBeListed, "");
+		$this->checkIfFileFolderIsListed($itemToBeListed, "");
 	}
 
 	/**
@@ -503,7 +530,7 @@ class FilesContext extends RawMinkContext implements Context {
 			$fileNameParts[] = $namePartsRow['name-parts'];
 		}
 
-		$this->theFileFolderShouldBeListed($fileNameParts, $shouldOrNot, $trashbin);
+		$this->checkIfFileFolderIsListed($fileNameParts, $shouldOrNot, $trashbin);
 	}
 
 	/**

--- a/tests/ui/features/files/files.feature
+++ b/tests/ui/features/files/files.feature
@@ -11,21 +11,15 @@ Feature: files
 		Then the filesactionmenu should be completely visible after clicking on it
 
 	Scenario Outline: Create a folder using special characters
-		When I create a folder with the following name
-			| name-parts      |
-			| <folder_name>   |
-		Then the following folder should be listed
-			| name-parts      |
-			| <folder_name>   |
+		When I create a folder with the name <folder_name>
+		Then the folder <folder_name> should be listed
 		And the files page is reloaded
-		Then the following folder should be listed
-			| name-parts      |
-			| <folder_name>   |
+		Then the folder <folder_name> should be listed
 		Examples:
 		|folder_name    |
-		|सिमप्ले फोल्देर $%#?&@|
-		|"somequotes1"|
-		|'somequotes2'|
+		|'सिमप्ले फोल्देर $%#?&@'|
+		|'"somequotes1"'|
+		|"'somequotes2'"|
 
 	Scenario: Create a folder inside another folder
 		When I create a folder with the name "top-folder"

--- a/tests/ui/features/renameFilesFolders/renameFiles.feature
+++ b/tests/ui/features/renameFilesFolders/renameFiles.feature
@@ -6,21 +6,15 @@ Feature: renameFiles
 		And I am on the files page
 
 	Scenario Outline: Rename a file using special characters
-		When I rename the following file to
-			|from-name-parts |to-name-parts  |
-			|lorem.txt       |<to_file_name> |
-		Then the following file should be listed
-			|name-parts     |
-			|<to_file_name> |
+		When I rename the file "lorem.txt" to <to_file_name>
+		Then the file <to_file_name> should be listed
 		And the files page is reloaded
-		Then the following file should be listed
-			|name-parts     |
-			|<to_file_name> |
+		Then the file <to_file_name> should be listed
 		Examples:
 		|to_file_name |
-		|लोरेम।तयक्स्त? $%#&@ |
-		|"quotes1"    |
-		|'quotes2'    |
+		|'लोरेम।तयक्स्त? $%#&@' |
+		|'"quotes1"'  |
+		|"'quotes2'"  |
 
 	Scenario Outline: Rename a file that has special characters in its name
 		When I rename the file <from_name> to <to_name>
@@ -38,9 +32,7 @@ Feature: renameFiles
 		Then the file "लोरेम।तयक्स्त $%&" should be listed
 		When I rename the file "लोरेम।तयक्स्त $%&" to '"double"quotes.txt'
 		And the files page is reloaded
-		Then the following file should be listed
-			|name-parts         |
-			|"double"quotes.txt |
+		Then the file '"double"quotes.txt' should be listed
 		When I rename the file '"double"quotes.txt' to "no-double-quotes.txt"
 		And the files page is reloaded
 		Then the file "no-double-quotes.txt" should be listed

--- a/tests/ui/features/renameFilesFolders/renameFolders.feature
+++ b/tests/ui/features/renameFilesFolders/renameFolders.feature
@@ -6,21 +6,15 @@ Feature: renameFolders
 		And I am on the files page
 
 	Scenario Outline: Rename a folder using special characters
-		When I rename the following folder to
-			|from-name-parts |to-name-parts    |
-			|simple-folder   |<to_folder_name> |
-		Then the following folder should be listed
-			|name-parts       |
-			|<to_folder_name> |
+		When I rename the folder "simple-folder" to <to_folder_name>
+		Then the folder <to_folder_name> should be listed
 		And the files page is reloaded
-		Then the following folder should be listed
-			|name-parts       |
-			|<to_folder_name> |
+		Then the folder <to_folder_name> should be listed
 		Examples:
 		|to_folder_name |
-		|सिमप्ले फोल्देर$%#?&@ |
-		|"quotes1"      |
-		|'quotes2'      |
+		|'सिमप्ले फोल्देर$%#?&@' |
+		|'"quotes1"'    |
+		|"'quotes2'"    |
 
 	Scenario Outline: Rename a folder that has special characters in its name
 		When I rename the folder <from_name> to <to_name>
@@ -38,9 +32,7 @@ Feature: renameFolders
 		Then the folder "लोरेम।तयक्स्त $%&" should be listed
 		When I rename the folder "लोरेम।तयक्स्त $%&" to '"double"quotes'
 		And the files page is reloaded
-		Then the following folder should be listed
-			|name-parts      |
-			|"double"quotes  |
+		Then the folder '"double"quotes' should be listed
 		When I rename the folder '"double"quotes' to "no-double-quotes"
 		And the files page is reloaded
 		Then the folder "no-double-quotes" should be listed


### PR DESCRIPTION
## Description
1) Enhance regex for steps that currently look for a file/folder name in double-quotes so that they accept it in single or double quotes.
2) Revert core gherkin test step detail changed recently, putting it back like it was, since now the steps with enhanced regex cope with either double or single-quoted file/folder names.

## Related Issue

## Motivation and Context
Changes to step ``theFileFolderShouldBeListed`` meant that the file/folder name had to now always be passed in double-quotes. This broke some ``files_texteditor`` tests. It would be nice to maintain the behavior of this step so that app UI tests continue to work without needing to be touched.

``files_texteditor`` tests happen to have exactly the extra bit of regex needed to match either double or single quoted file/folder names. So it is easy to apply an example from there to core code.

## How Has This Been Tested?
Local UI test runs. Travis will confirm.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
