### PR TITLE
[stable10] Remove deprecated API warning as it needlessly pollutes logs

### DIFF
--- a/apps/files_sharing/ajax/shareinfo.php
+++ b/apps/files_sharing/ajax/shareinfo.php
@@ -31,11 +31,6 @@
 
 OCP\JSON::checkAppEnabled('files_sharing');
 
-OC::$server->getLogger()->warning(
-	'Deprecated api access from '.OC::$server->getRequest()->getRemoteAddress().
-	'. Ask remote to upgrade.', ['app' => 'files_sharing']
-);
-
 if (!isset($_GET['t'])) {
 	\OC_Response::setStatus(400); //400 Bad Request
 	exit;


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/29363 to stable10