### PR TITLE
Replace notify user for local shares with button

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -101,6 +101,12 @@
   margin-top: 20px;
 }
 
+.shareTabView .shareWithList .mailNotificationSpinner {
+	position: relative;
+	vertical-align: middle;
+	margin-right: 10px;
+}
+
 .subTabHeaders .tabHeaders {
   margin-left: 0px;
   margin-right: 0px;

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -131,7 +131,11 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 			);
 			$result = $mailNotification->sendInternalShareMail($recipientList, $itemSource, $itemType);
 
-			\OCP\Share::setSendMailStatus($itemType, $itemSource, $shareType, $recipient, true);
+			// if we were able to send to at least one recipient, mark as sent
+			// allowing the user to resend would spam users who already got a notification
+			if (count($result) < count($recipientList)) {
+				\OCP\Share::setSendMailStatus($itemType, $itemSource, $shareType, $recipient, true);
+			}
 
 			if (empty($result)) {
 				OCP\JSON::success();

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -24,8 +24,10 @@
 			'<span class="has-tooltip username" title="{{shareWith}}">{{shareWithDisplayName}}</span>' +
 			'{{#if mailNotificationEnabled}}  {{#unless isRemoteShare}}' +
 			'<span class="shareOption">' +
-			'<input id="mail-{{cid}}-{{shareWith}}" type="checkbox" name="mailNotification" class="mailNotification checkbox" {{#if wasMailSent}}checked="checked"{{/if}} />' +
-			'<label for="mail-{{cid}}-{{shareWith}}">{{notifyByMailLabel}}</label>' +
+			'{{#unless wasMailSent}}' +
+			'<span class="mailNotificationSpinner icon-loading-small hidden"></span>' +
+			'<input id="mail-{{cid}}-{{shareWith}}" type="button" name="mailNotification" value="{{notifyByMailLabel}}" class="mailNotification checkbox" />' +
+			'{{/unless}}' +
 			'</span>' +
 			'{{/unless}} {{/if}}' +
 			'{{#if isResharingAllowed}} {{#if sharePermissionPossible}}' +
@@ -287,7 +289,23 @@
 			var shareType = $li.data('share-type');
 			var shareWith = $li.attr('data-share-with');
 
-			this.model.sendNotificationForShare(shareType, shareWith, $target.is(':checked'));
+			var $loading = $target.prev('.icon-loading-small');
+
+			$target.addClass('hidden');
+			$loading.removeClass('hidden');
+
+			this.model.sendNotificationForShare(shareType, shareWith, true).then(function(result) {
+				if (result.status === 'success') {
+					OC.Notification.showTemporary(t('core', 'Email notification was sent!'));
+					$target.remove();
+				} else {
+					// sending was successful but some users might not have any email address
+					OC.dialogs.alert(t('core', result.data.message), t('core', 'Email notification not sent'));
+				}
+
+				$target.removeClass('hidden');
+				$loading.addClass('hidden');
+			});
 		}
 	});
 

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -426,12 +426,6 @@
 					shareType: shareType,
 					itemSource: itemSource,
 					itemType: itemType
-				},
-				function(result) {
-					if (result.status !== 'success') {
-						// FIXME: a model should not show dialogs
-						OC.dialogs.alert(t('core', result.data.message), t('core', 'Warning'));
-					}
 				}
 			);
 		},

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -102,7 +102,7 @@ class MailNotifications {
 			$recipientDisplayName = $recipient->getDisplayName();
 			$to = $recipient->getEMailAddress();
 
-			if ($to === '') {
+			if ($to === null || $to === '') {
 				$noMail[] = $recipientDisplayName;
 				continue;
 			}

--- a/tests/lib/Share/MailNotificationsTest.php
+++ b/tests/lib/Share/MailNotificationsTest.php
@@ -71,7 +71,7 @@ class MailNotificationsTest extends TestCase {
 			}));
 
 		$this->defaults
-				->expects($this->once())
+				->expects($this->any())
 				->method('getName')
 				->will($this->returnValue('UnitTestCloud'));
 
@@ -255,6 +255,57 @@ class MailNotificationsTest extends TestCase {
 		$recipientList = [$recipient];
 		$result = $mailNotifications->sendInternalShareMail($recipientList, '3', 'file');
 		$this->assertSame([], $result);
+
+	}
+
+	public function emptinessProvider() {
+		return [
+			[null],
+			[''],
+		];
+	}
+
+	/**
+	 * @dataProvider emptinessProvider
+	 */
+	public function testSendInternalShareMailNoMail($emptiness) {
+		/** @var MailNotifications | \PHPUnit_Framework_MockObject_MockObject $mailNotifications */
+		$mailNotifications = $this->getMockBuilder('OC\Share\MailNotifications')
+			->setMethods(['getItemSharedWithUser'])
+			->setConstructorArgs([
+				$this->user,
+				$this->l10n,
+				$this->mailer,
+				$this->logger,
+				$this->defaults,
+				$this->urlGenerator
+			])
+			->getMock();
+
+		$recipient = $this->getMockBuilder('\OCP\IUser')
+				->disableOriginalConstructor()->getMock();
+		$recipient
+				->expects($this->once())
+				->method('getEMailAddress')
+				->willReturn($emptiness);
+		$recipient
+				->expects($this->once())
+				->method('getDisplayName')
+				->willReturn('No mail 1');
+		$recipient2 = $this->getMockBuilder('\OCP\IUser')
+				->disableOriginalConstructor()->getMock();
+		$recipient2
+				->expects($this->once())
+				->method('getEMailAddress')
+				->willReturn('');
+		$recipient2
+				->expects($this->once())
+				->method('getDisplayName')
+				->willReturn('No mail 2');
+
+		$recipientList = [$recipient, $recipient2];
+		$result = $mailNotifications->sendInternalShareMail($recipientList, '3', 'file');
+		$this->assertSame(['No mail 1', 'No mail 2'], $result);
 
 	}
 


### PR DESCRIPTION
## Description
Replace the checkbox with a button.
Changed logic to only send the mail_send flag if email could be sent to at least one recipient.

## Related Issue
Fixes https://github.com/owncloud/core/issues/29318

## Motivation and Context
See ticket

## How Has This Been Tested?
Manual testing so far

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODOs:
- [ ] BUG: fix spinner position
- [ ] TODO: add/adjust unit tests
- [ ] TODO: fading tickmark on success?!

