### PR TITLE
#27854 non existing folder skeletondirectory

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -417,6 +417,9 @@ class Session implements IUserSession, Emitter {
 				\OC::$server->getLogger()->warning(
 					'Skeleton not created due to missing write permission'
 				);
+			} catch(\OC\HintException $hintEx) {
+				// only if Skeleton no existing Dir
+				\OC::$server->getLogger()->error($hintEx->getMessage());
 			}
 
 			// trigger any other initialization
@@ -829,7 +832,7 @@ class Session implements IUserSession, Emitter {
 			try {
 				$this->tokenProvider->invalidateToken($this->session->getId());
 			} catch (SessionNotAvailableException $ex) {
-				
+
 			}
 		}
 		$this->setUser(null);

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -388,10 +388,15 @@ class OC_Util {
 	 *
 	 * @param String $userId
 	 * @param \OCP\Files\Folder $userDirectory
+	 * @throws \OC\HintException
 	 */
 	public static function copySkeleton($userId, \OCP\Files\Folder $userDirectory) {
 
 		$skeletonDirectory = \OCP\Config::getSystemValue('skeletondirectory', \OC::$SERVERROOT . '/core/skeleton');
+
+		if (!is_dir($skeletonDirectory))  {
+			throw new \OC\HintException('The skeleton folder '.$skeletonDirectory.' is not accessible');
+		}
 
 		if (!empty($skeletonDirectory)) {
 			\OCP\Util::writeLog(
@@ -458,8 +463,8 @@ class OC_Util {
 	}
 
 	/**
-	 * @description get the current installed edition of ownCloud. 
-	 * There is the community edition that returns "Community" and 
+	 * @description get the current installed edition of ownCloud.
+	 * There is the community edition that returns "Community" and
 	 * the enterprise edition that returns "Enterprise".
 	 * @return string
 	 */
@@ -569,7 +574,7 @@ class OC_Util {
 	 *
 	 * @param string $application application id
 	 * @param string $languageCode language code, defaults to the current language
-	 * @param bool $prepend prepend the Script to the beginning of the list 
+	 * @param bool $prepend prepend the Script to the beginning of the list
 	 */
 	public static function addTranslations($application, $languageCode = null, $prepend = false) {
 		if (is_null($languageCode)) {
@@ -614,7 +619,7 @@ class OC_Util {
 	 *
 	 * @param string $application application id
 	 * @param bool $prepend prepend the file to the beginning of the list
-	 * @param string $path 
+	 * @param string $path
 	 * @param string $type (script or style)
 	 * @return void
 	 */

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -413,6 +413,19 @@ class UtilTest extends \Test\TestCase {
 		$this->assertNotEmpty($errors);
 	}
 
+	/**
+	 * @expectedException \OC\HintException
+	 * @expectedExceptionMessage The skeleton folder /not/existing/Directory is not accessible
+	 */
+	public function testCopySkeletonDirectory() {
+		$config = \OC::$server->getConfig();
+		$config->setSystemValue('skeletondirectory', '/not/existing/Directory');
+		$userFolder = $this->createMock('\OCP\Files\Folder');
+		\OC_Util::copySkeleton($config, $userFolder);
+
+		$config->deleteSystemValue('skeletondirectory');
+	}
+
 	protected function setUp() {
 		parent::setUp();
 


### PR DESCRIPTION
added new test
throw Exception on false config
catch Exception and write error to Log

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually  by setting up Owncloud and Creating Admin Account
changed config -> skeleton directory to not existing path
creating new User
logged out
login with new user
-> got loop

changed Code & Tests

Creating new User
login with new user2 -> got blank Owncloud directory without skeleton data.
-> no Loop

Testet with Macbook Pro 15" Early 2011 OS X Sierra High with XAMPP and mysql Database

tests run in Ubuntu 16.04. 

-- checked out Core from GitLab and installed MariaDB with NodeJS and PHPUnit 
running make & make test


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

