### PR TITLE
[Stable10] Splitting integration tests stage into three

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,24 +142,32 @@ timestampedNode('SLAVE') {
 		   '''
 		}
 
+	stage 'Integration Testing Encrypted'
 		if (isOnReleaseBranch()) {
-			executeAndReport('tests/integration/output/*.xml') {
-				sh '''phpenv local 7.0
-				rm -rf config/config.php data/*
-				./occ maintenance:install --admin-pass=admin
-				make clean-test-integration
-				make test-integration OC_TEST_ALT_HOME=1 OC_TEST_ENCRYPTION_ENABLED=1
-			   '''
+				executeAndReport('tests/integration/output/*.xml') {
+					sh '''phpenv local 7.0
+					rm -rf config/config.php data/*
+					./occ maintenance:install --admin-pass=admin
+					make clean-test-integration
+					make test-integration OC_TEST_ALT_HOME=1 OC_TEST_ENCRYPTION_ENABLED=1
+				   '''
+				}
 			}
-			executeAndReport('tests/integration/output/*.xml') {
-				sh '''phpenv local 7.0
-				rm -rf config/config.php data/*
-				./occ maintenance:install --admin-pass=admin
-				make clean-test-integration
-				make test-integration OC_TEST_ALT_HOME=1 OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED=1
-			   '''
+
+
+	stage 'Integration Testing Encrypted with master key'
+		if (isOnReleaseBranch()) {
+				executeAndReport('tests/integration/output/*.xml') {
+					sh '''phpenv local 7.0
+					rm -rf config/config.php data/*
+					./occ maintenance:install --admin-pass=admin
+					make clean-test-integration
+					make test-integration OC_TEST_ALT_HOME=1 OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED=1
+				   '''
+				}
 			}
-		}
+
+		
 }
 
 def isOnReleaseBranch ()  {


### PR DESCRIPTION
Splitting integration tests stage into three stages to avoid timeouts and be able to run encryption tests.