### PR TITLE
Remove karma warnings output

### DIFF
--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -238,9 +238,9 @@ module.exports = function(config) {
 
 		proxies: {
 			// prevent warnings for images
-			'/context.html//core/img/': 'http://localhost:9876/base/core/img/',
-			'/context.html//core/css/': 'http://localhost:9876/base/core/css/',
-			'/context.html//core/fonts/': 'http://localhost:9876/base/core/fonts/'
+			'/owncloud/core/img/': 'http://localhost:9876/base/core/img/',
+			'/owncloud/core/css/': 'http://localhost:9876/base/core/css/',
+			'/owncloud/core/fonts/': 'http://localhost:9876/base/core/fonts/'
 		},
 
 		// test results reporter to use


### PR DESCRIPTION
Removes annoying and useless karma warnings when some code is loading images.

This adjusts the filter for expected HTTP calls to serve from the test server to the new one.

The warnings came back after https://github.com/owncloud/core/pull/29286 got merged.

