### PR TITLE
Implementation of delta-sync support on server-side.

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -142,7 +142,6 @@ class Server {
 		));
 
 		$this->server->addPlugin(new CopyEtagHeaderPlugin());
-		$this->server->addPlugin(new ChunkingPlugin());
 
 		// Some WebDAV clients do require Class 2 WebDAV support (locking), since
 		// we do not provide locking we emulate it using a fake locking plugin.
@@ -164,6 +163,14 @@ class Server {
 			$userSession = \OC::$server->getUserSession();
 			$user = $userSession->getUser();
 			if (!is_null($user)) {
+				$rootFolder =  \OC::$server->getRootFolder();
+				$this->server->addPlugin(
+					new ChunkingPlugin(
+						$rootFolder->get($user->getUID()),
+						$user->getUID()
+					)
+				);
+
 				$view = \OC\Files\Filesystem::getView();
 				$this->server->addPlugin(
 					new FilesPlugin(

--- a/apps/dav/lib/Upload/AssemblyStream.php
+++ b/apps/dav/lib/Upload/AssemblyStream.php
@@ -37,22 +37,22 @@ use Sabre\DAV\IFile;
 class AssemblyStream implements \Icewind\Streams\File {
 
 	/** @var resource */
-	private $context;
+	protected $context;
 
 	/** @var IFile[] */
-	private $nodes;
+	protected $nodes;
 
 	/** @var int */
-	private $pos = 0;
+	protected $pos = 0;
 
 	/** @var array */
-	private $sortedNodes;
+	protected $sortedNodes;
 
 	/** @var int */
-	private $size;
+	protected $size;
 
 	/** @var resource */
-	private $currentStream = null;
+	protected $currentStream = null;
 
 	/**
 	 * @param string $path
@@ -78,6 +78,9 @@ class AssemblyStream implements \Icewind\Streams\File {
 		foreach($this->nodes as $node) {
 			$size = $node->getSize();
 			$name = $node->getName();
+			// ignore .zsync metadata file
+			if (!strcmp($name,".zsync"))
+				continue;
 			$this->sortedNodes[$name] = ['node' => $node, 'start' => $start, 'end' => $start + $size];
 			$start += $size;
 			$this->size = $start;
@@ -233,7 +236,7 @@ class AssemblyStream implements \Icewind\Streams\File {
 	 *
 	 * @throws \BadMethodCallException
 	 */
-	public static function wrap(array $nodes) {
+	public static function wrap(array $nodes, IFile $backingFile = null, $length = null) {
 		$context = stream_context_create([
 			'assembly' => [
 				'nodes' => $nodes]
@@ -253,7 +256,7 @@ class AssemblyStream implements \Icewind\Streams\File {
 	 * @param $pos
 	 * @return IFile | null
 	 */
-	private function getNodeForPosition($pos) {
+	protected function getNodeForPosition($pos) {
 		foreach($this->sortedNodes as $node) {
 			if ($pos >= $node['start'] && $pos < $node['end']) {
 				return [$node['node'], $pos - $node['start']];
@@ -266,7 +269,7 @@ class AssemblyStream implements \Icewind\Streams\File {
 	 * @param IFile $node
 	 * @return resource
 	 */
-	private function getStream(IFile $node) {
+	protected function getStream(IFile $node) {
 		$data = $node->get();
 		if (is_resource($data)) {
 			return $data;

--- a/apps/dav/lib/Upload/AssemblyStreamZsync.php
+++ b/apps/dav/lib/Upload/AssemblyStreamZsync.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * @author Ahmed Ammar <ahmed.a.ammar@gmail.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Upload;
+
+use Sabre\DAV\IFile;
+
+/**
+ * Class AssemblyStreamZsync
+ *
+ * The assembly stream is a virtual stream that wraps multiple chunks.
+ * Reading from the stream transparently accessed the underlying chunks and
+ * give a representation as if they were already merged together.
+ *
+ * @package OCA\DAV\Upload
+ */
+class AssemblyStreamZsync extends AssemblyStream {
+	/** @var array */
+	private $backingNode = null;
+
+	/** @var array */
+	private $currentNode = null;
+
+	/** @var int */
+	private $next = 0;
+
+	/**
+	 * @param string $path
+	 * @param string $mode
+	 * @param int $options
+	 * @param string &$opened_path
+	 * @return bool
+	 */
+	public function stream_open($path, $mode, $options, &$opened_path) {
+		$this->loadContext('assembly');
+
+		// sort the nodes
+		$nodes = $this->nodes;
+		// http://stackoverflow.com/a/10985500
+		@usort($nodes, function(IFile $a, IFile $b) {
+			return strnatcmp($a->getName(), $b->getName());
+		});
+		$this->nodes = $nodes;
+
+		// build additional information
+		$this->sortedNodes = [];
+		foreach($this->nodes as $node) {
+			$size = $node->getSize();
+			$name = $node->getName();
+			// ignore .zsync metadata file
+			if (!strcmp($name,".zsync"))
+				continue;
+			if ($size == 0)
+				continue;
+			$this->sortedNodes[$name] = ['node' => $node, 'start' => (int)$name, 'end' => (int)$name + $size];
+		}
+
+		$this->backingNode = ["node" => $this->backingFile, "start" => 0, "end" => $this->backingFile->getSize()];
+		$this->currentNode = $this->backingNode;
+		return true;
+	}
+
+	/**
+	 * @param int $count
+	 * @return string
+	 */
+	public function stream_read($count) {
+		// we're done if we've reached the end of where we need to be
+		if ($this->pos >= $this->size)
+			return;
+
+		// change the node/stream when we've reached the point we need to be at
+		if ($this->currentStream === null || $this->pos == $this->next) {
+			list($node, $posInNode) = $this->getNodeForPosition($this->pos);
+			$this->currentStream = $this->getStream($node['node']);
+			fseek($this->currentStream, $posInNode);
+			$this->currentNode = $node;
+		}
+
+		// get the next byte offset when we need to change node/stream again
+		$this->next = $this->getNextNodeStart($this->pos);
+
+		// don't read beyond the expected file size
+		if ($count + $this->pos >= $this->size)
+			$count = $this->size - $this->pos;
+
+		// don't read beyond the next marker
+		if ($count + $this->pos >= $this->next)
+			$count = $this->next - $this->pos;
+
+		// read the data
+		$data = fread($this->currentStream, $count);
+		if (isset($data[$count - 1])) {
+			// we read the full count
+			$read = $count;
+		} else {
+			// reaching end of stream, which happens less often so strlen is ok
+			$read = strlen($data);
+		}
+
+		// update position
+		$this->pos += $read;
+
+		// if we couldn't read as much as expected we are done
+		if ($read != $count) {
+			$this->pos = $this->size;
+		}
+
+		// ensure we close the last stream or else we'll cause a locking issue
+		if ($this->pos == $this->size) {
+			$this->currentStream = null;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Load the source from the stream context and return the context options
+	 *
+	 * @param string $name
+	 * @return array
+	 * @throws \Exception
+	 */
+	protected function loadContext($name) {
+		$context = stream_context_get_options($this->context);
+		if (isset($context[$name])) {
+			$context = $context[$name];
+		} else {
+			throw new \BadMethodCallException('Invalid context, "' . $name . '" options not set');
+		}
+		if (isset($context['nodes']) and is_array($context['nodes'])) {
+			$this->nodes = $context['nodes'];
+		} else {
+			throw new \BadMethodCallException('Invalid context, nodes not set');
+		}
+		if (isset($context['backingFile'])) {
+			$this->backingFile = $context['backingFile'];
+		} else {
+			throw new \BadMethodCallException('Invalid context, backingFile not set');
+		}
+		if (isset($context['fileLength'])) {
+			$this->size = $context['fileLength'];
+		} else {
+			throw new \BadMethodCallException('Invalid context, fileLength not set');
+		}
+
+		return $context;
+	}
+
+	/**
+	 * @param IFile[] $nodes
+	 * @param IFile $backingFile
+	 * @param $fileLength
+	 * @return resource
+	 *
+	 * @throws \BadMethodCallException
+	 */
+	public static function wrap(array $nodes, IFile $backingFile = null, $fileLength = null) {
+		$context = stream_context_create([
+			'assembly' => [
+				'nodes' => $nodes,
+				'backingFile' => $backingFile,
+				'fileLength' => $fileLength
+			]
+		]);
+		stream_wrapper_register('assembly', '\OCA\DAV\Upload\AssemblyStreamZsync');
+		try {
+			$wrapped = fopen('assembly://', 'r', null, $context);
+		} catch (\BadMethodCallException $e) {
+			stream_wrapper_unregister('assembly');
+			throw $e;
+		}
+		stream_wrapper_unregister('assembly');
+		return $wrapped;
+	}
+
+	protected function getNextNodeStart($current) {
+		foreach($this->sortedNodes as $node) {
+			if ($current >= $node['start'] && $current < $node['end'])
+				return $node['end'];
+			if ($current < $node['start'])
+				return $node['start'];
+		}
+		return $this->currentNode['end'];
+	}
+
+	/**
+	 * @param $pos
+	 */
+	protected function getNodeForPosition($pos) {
+		foreach($this->sortedNodes as $node) {
+			if ($pos >= $node['start'] && $pos < $node['end']) {
+				return [$node, 0];
+			}
+		}
+		return [$this->backingNode, $pos];
+	}
+}

--- a/apps/dav/lib/Upload/FutureFile.php
+++ b/apps/dav/lib/Upload/FutureFile.php
@@ -39,6 +39,10 @@ class FutureFile implements \Sabre\DAV\IFile {
 	private $root;
 	/** @var string */
 	private $name;
+	/** @var IFile */
+	private $backingFile = null;
+	/** @var string */
+	private $fileLength = 0;
 
 	static public function getFutureFileName() {
 		return '.file';
@@ -78,7 +82,9 @@ class FutureFile implements \Sabre\DAV\IFile {
 	 */
 	function get() {
 		$nodes = $this->root->getChildren();
-		return AssemblyStream::wrap($nodes);
+		return $this->backingFile && $this->fileLength ?
+			AssemblyStreamZsync::wrap($nodes, $this->backingFile, $this->fileLength) :
+			AssemblyStream::wrap($nodes);
 	}
 
 	/**
@@ -134,5 +140,19 @@ class FutureFile implements \Sabre\DAV\IFile {
 	 */
 	function getLastModified() {
 		return $this->root->getLastModified();
+	}
+
+	/**
+	 * @param IFile $file
+	 */
+	function setBackingFile(IFile $file) {
+		$this->backingFile = $file;
+	}
+
+	/**
+	 * @param string $fileLength
+	 */
+	function setFileLength($fileLength) {
+		$this->fileLength = $fileLength;
 	}
 }

--- a/apps/dav/tests/unit/Upload/AssemblyStreamZsyncTest.php
+++ b/apps/dav/tests/unit/Upload/AssemblyStreamZsyncTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * @author Ahmed Ammar <ahmed.a.ammar@gmail.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\unit\Upload;
+
+use OC\Files\View;
+use OCA\DAV\Connector\Sabre\File;
+
+class AssemblyStreamZsyncTest extends \Test\TestCase {
+
+	/**
+	 * @dataProvider providesNodes()
+	 */
+	public function testGetContents($expected, $nodes, $backingFile, $length) {
+		$stream = \OCA\DAV\Upload\AssemblyStreamZsync::wrap($nodes, $backingFile, $length);
+		$content = stream_get_contents($stream);
+
+		$this->assertEquals($expected, $content);
+	}
+
+	/**
+	 * @dataProvider providesNodes()
+	 */
+	public function testGetContentsFread($expected, $nodes, $backingFile, $length) {
+		$stream = \OCA\DAV\Upload\AssemblyStreamZsync::wrap($nodes, $backingFile, $length);
+
+		$content = '';
+		while (!feof($stream)) {
+			$content .= fread($stream, 3);
+		}
+
+		$this->assertEquals($expected, $content);
+	}
+
+	function providesNodes() {
+		$data512k = $this->makeData(512*1024);
+		$data16k = $this->makeData(16*1024);
+		$data8k = $this->makeData(8*1024);
+		$data4k = $this->makeData(4*1024);
+		$dataLess8k = $this->makeData((8*1024)-1);
+
+		$tonofnodes = [];
+		$tonofdata = "";
+		$start = 0;
+		for ($i = 0; $i < 101; $i++) {
+			$thisdata =  rand(0,100); // variable length and content
+			$tonofdata .= $thisdata;
+			array_push($tonofnodes, $this->buildNode($start,$thisdata));
+			$start += strlen($thisdata);
+		}
+		array_push($tonofnodes, $this->buildNode('.zsync','zsync metadata'));
+
+		$file4k = $this->buildNode('file4k', $data4k);
+		$file8k = $this->buildNode('file8k', $data8k);
+		$file512k = $this->buildNode('file512k', $data512k);
+
+		return[
+			'one node zero bytes 4k backing 4k length' => [
+				$data4k, [
+				$this->buildNode('0', '')
+			], $file4k, 4096],
+			'one node zero bytes 4k backing 0 length' => [
+				'', [
+				$this->buildNode('0', '')
+			], $file4k, 0],
+			'one node with one byte offset' => [
+				$data4k[0].'123456789', [
+				$this->buildNode('1', '1234567890')
+			], $file4k, 10],
+			'two nodes multiple splices' => [
+				substr($data8k, 0, 1024).
+				$data4k.
+				substr($data8k, 5120, 214).
+				substr($data4k, -1521).
+				substr($data8k, 6855),
+			[
+				$this->buildNode('1024', $data4k),
+				$this->buildNode('5334', substr($data4k, -1521))
+			], $file8k, 8*1024],
+			'two nodes with smaller length' => [
+				substr($data512k, 0, 4).
+				$data8k.
+				substr($data512k, 8196, 7164),
+			[
+				$this->buildNode('16352', $dataLess8k),
+				$this->buildNode('4', $data8k)
+			], $file512k, 15*1024],
+			'two nodes with large gaps' => [
+				substr($data512k, 0, 4).
+				$data8k.
+				substr($data512k, (8*1024)+4, (128*1024)-((8*1024)+4)).
+				$data16k.
+				substr($data512k, (8*1024)+4 + (128*1024)-((8*1024)+4) + (16*1024),
+				       (512*1024)-((8*1024)+4 + (128*1024)-((8*1024)+4) + (16*1024))),
+			[
+				$this->buildNode(128*1024, $data16k),
+				$this->buildNode('4', $data8k)
+			], $file512k, 512*1024],
+			'a ton of nodes' => [
+				$tonofdata, $tonofnodes, $this->buildNode('empty', ''), strlen($tonofdata)
+			],
+			'a backing file that is smaller than expected, creating a hole (30k-31k)' => [
+				substr($data512k, 0, 12*1024).
+				$data16k.
+				substr($data512k, (16+12)*1024, 2*1024),
+			[
+				$this->buildNode(12*1024, $data16k),
+				$this->buildNode(31*1024, $data16k)
+			], $this->buildNode('file30k', substr($data512k, 0, 30*1024)), 32*1024]
+		];
+	}
+
+	function makeData($count) {
+		$characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		$charactersLength = strlen($characters);
+		$data = '';
+		for ($i = 0; $i < $count; $i++) {
+			$data .= $characters[rand(0, $charactersLength - 1)];
+		}
+		return $data;
+	}
+
+	private function buildNode($name, $data) {
+		$node = $this->getMockBuilder('\Sabre\DAV\File')
+			->setMethods(['getName', 'get', 'getSize'])
+			->getMockForAbstractClass();
+
+		$node->expects($this->any())
+			->method('getName')
+			->willReturn($name);
+
+		$node->expects($this->any())
+			->method('get')
+			->willReturn($data);
+
+		$node->expects($this->any())
+			->method('getSize')
+			->willReturn(strlen($data));
+
+		return $node;
+	}
+}
+

--- a/apps/dav/tests/unit/Upload/FutureFileTest.php
+++ b/apps/dav/tests/unit/Upload/FutureFileTest.php
@@ -55,6 +55,16 @@ class FutureFileTest extends \Test\TestCase {
 		$this->assertTrue(is_resource($stream));
 	}
 
+	public function testGetZsync() {
+		$file = $this->createMock('Sabre\DAV\IFile');
+		$f = $this->mockFutureFile();
+		$f->setBackingFile($file);
+		$f->setFileLength(1231);
+		$stream = $f->get();
+		$this->assertTrue(is_resource($stream));
+
+	}
+
 	public function testDelete() {
 		$d = $this->getMockBuilder('OCA\DAV\Connector\Sabre\Directory')
 			->disableOriginalConstructor()
@@ -90,7 +100,7 @@ class FutureFileTest extends \Test\TestCase {
 	private function mockFutureFile() {
 		$d = $this->getMockBuilder('OCA\DAV\Connector\Sabre\Directory')
 			->disableOriginalConstructor()
-			->setMethods(['getETag', 'getLastModified', 'getChildren'])
+			->setMethods(['getETag', 'getLastModified', 'getChildren', 'childExists'])
 			->getMock();
 
 		$d->expects($this->any())
@@ -104,6 +114,10 @@ class FutureFileTest extends \Test\TestCase {
 		$d->expects($this->any())
 			->method('getChildren')
 			->willReturn([]);
+
+		$d->expects($this->any())
+			->method('childExists')
+			->willReturn(true);
 
 		return new \OCA\DAV\Upload\FutureFile($d, 'foo.txt');
 	}

--- a/apps/files/appinfo/app.php
+++ b/apps/files/appinfo/app.php
@@ -62,4 +62,4 @@ $templateManager->registerTemplate('application/vnd.oasis.opendocument.spreadshe
 	);
 });
 
-\OCP\Util::connectHook('\OCP\Config', 'js', '\OCA\Files\App', 'extendJsConfig');
+\OCA\Files\Hooks::connectHooks();

--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -59,7 +59,12 @@ $application->registerRoutes(
 				'url' => '/',
 				'verb' => 'GET',
 			],
-
+			[
+				'name' => 'zsync_api#show',
+				'url' => '/api/v1/zsync/{path}',
+				'verb' => 'GET',
+				'requirements' => ['path' => '.+']
+			],
 		]
 	]
 );

--- a/apps/files/lib/AppInfo/Application.php
+++ b/apps/files/lib/AppInfo/Application.php
@@ -26,6 +26,7 @@ namespace OCA\Files\AppInfo;
 
 use OCA\Files\Controller\ApiController;
 use OCA\Files\Controller\ViewController;
+use OCA\Files\Controller\ZsyncApiController;
 use OCP\AppFramework\App;
 use \OCA\Files\Service\TagService;
 use \OCP\IContainer;
@@ -62,6 +63,15 @@ class Application extends App {
 				$server->getUserSession(),
 				$server->getAppManager(),
 				$server->getRootFolder()
+			);
+		});
+
+		$container->registerService('ZsyncApiController', function (IContainer $c) use ($server) {
+			return new ZsyncApiController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$server->getUserSession(),
+				$c->query('ServerContainer')->getRootFolder()
 			);
 		});
 

--- a/apps/files/lib/Capabilities.php
+++ b/apps/files/lib/Capabilities.php
@@ -59,6 +59,7 @@ class Capabilities implements ICapability {
 			'files' => [
 				'privateLinks' => true,
 				'bigfilechunking' => true,
+				'zsync' => true,
 				'blacklisted_files' => $this->config->getSystemValue('blacklisted_files', ['.htaccess']),
 			],
 		];

--- a/apps/files/lib/Controller/ZsyncApiController.php
+++ b/apps/files/lib/Controller/ZsyncApiController.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @author Ahmed Ammar <ahmed.a.ammar@gmail.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\Controller;
+
+use OCP\IRequest;
+use OCP\Files\Folder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\IUserSession;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\DataDisplayResponse;
+use OCP\AppFramework\Http\Response;
+use OCP\AppFramework\Controller;
+use \Exception;
+
+class ZsyncApiController extends Controller {
+	/* @var Folder */
+	private $rootFolder;
+	/* @var Folder */
+	private $zsyncFolder;
+
+	public function __construct($AppName,
+								IRequest $request,
+								IUserSession $userSession,
+								Folder $rootFolder){
+		parent::__construct($AppName, $request);
+		$userId = $userSession->getUser()->getUID();
+		$this->rootFolder = $rootFolder->get($userId);
+		$dir = 'files_zsync';
+		try {
+			$folder = $this->rootFolder->get($dir);
+		} catch (NotFoundException $e) {
+			$folder = $this->rootFolder->newFolder($dir);
+		}
+		$this->zsyncFolder = $folder;
+	}
+
+	/**
+	 * @NoCSRFRequired
+	 * @NoAdminRequired
+	 *
+	 * @param string $path
+	 */
+	public function show($path) {
+		/* If basefile not found this is an error */
+		try {
+			$node = $this->rootFolder->get('files/'.$path);
+		} catch (Exception $exception) {
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		$zsyncFile = $path . '.zsync';
+		try {
+			$node = $this->zsyncFolder->get($zsyncFile);
+			$content = $node->getContent();
+			return new DataDisplayResponse($content);
+		} catch (NotFoundException $exception) {
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		} catch (NotPermittedException $e) {
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		}
+	}
+}

--- a/apps/files/lib/Hooks.php
+++ b/apps/files/lib/Hooks.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @author Ahmed Ammar <ahmed.a.ammar@gmail.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+/**
+ * This class contains all hooks.
+ */
+
+namespace OCA\Files;
+
+use OC\Files\View;
+use OCP\User;
+
+class Hooks {
+
+	public static function connectHooks() {
+		\OCP\Util::connectHook('\OCP\Config', 'js', '\OCA\Files\App', 'extendJsConfig');
+		\OCP\Util::connectHook('OC_Filesystem', 'post_rename', 'OCA\Files\Hooks', 'zsync_rename_hook');
+		\OCP\Util::connectHook('OC_Filesystem', 'post_copy', 'OCA\Files\Hooks', 'zsync_copy_hook');
+		\OCP\Util::connectHook('OC_Filesystem', 'write', 'OCA\Files\Hooks', 'zsync_delete_hook');
+		\OCP\Util::connectHook('OC_Filesystem', 'delete', 'OCA\Files\Hooks', 'zsync_delete_hook');
+		\OCP\Util::connectHook('\OCP\Versions', 'rollback', 'OCA\Files\Hooks', 'zsync_delete_hook');
+	}
+
+	public static function zsync_delete_hook( $params ) {
+		$path = $params[\OC\Files\Filesystem::signal_param_path];
+		$view = new View('/'.User::getUser());
+
+		$path = 'files_zsync/' . ltrim($path, '/');
+		if ($view->is_file($path.'.zsync')) {
+			$path = $path.'.zsync';
+			$view->unlink($path);
+
+			// delete directory if empty
+			$zsync_dir = dirname($path);
+			$content = $view->getDirectoryContent($zsync_dir);
+			if (!count($content))
+				$view->rmdir($zsync_dir);
+		} else if ($view->is_dir($path))
+			$view->rmdir($path);
+	}
+
+	private static function zsync_copy_rename_get_paths( $params ) {
+		$from = $params[\OC\Files\Filesystem::signal_param_oldpath];
+		$to = $params[\OC\Files\Filesystem::signal_param_newpath];
+		$view = new View('/'.User::getUser());
+
+		$from_path = 'files_zsync/' . ltrim($from, '/');
+		$to_path = 'files_zsync/' . ltrim($to, '/');
+
+		if ($view->is_dir($from_path))
+			return [$from_path, $to_path];
+
+		if ($view->is_file($from_path.'.zsync')) {
+			$from_path = $from_path.'.zsync';
+			$to_path = $to_path.'.zsync';
+			return [$from_path, $to_path];
+		}
+
+		return [null, null];
+	}
+
+	public static function zsync_copy_hook( $params ) {
+		$view = new View('/'.User::getUser());
+		list($from_path, $to_path) = self::zsync_copy_rename_get_paths($params);
+		if (!empty($from_path) && !empty($to_path))
+			$view->copy($from_path, $to_path);
+	}
+
+	public static function zsync_rename_hook( $params ) {
+		$view = new View('/'.User::getUser());
+		list($from_path, $to_path) = self::zsync_copy_rename_get_paths($params);
+		if (!empty($from_path) && !empty($to_path))
+			$view->rename($from_path, $to_path);
+	}
+}

--- a/apps/files/tests/Controller/ZsyncApiControllerTest.php
+++ b/apps/files/tests/Controller/ZsyncApiControllerTest.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * @author Ahmed Ammar <ahmed.a.ammar@gmail.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\Controller;
+
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use Test\TestCase;
+use OCP\IRequest;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\DataDisplayResponse;
+
+/**
+ * Class ZsyncApiController
+ *
+ * @package OCA\Files\Controller
+ */
+class ZsyncApiControllerTest extends TestCase {
+	/** @var string */
+	private $appName = 'files';
+	/** @var \OCP\IUser */
+	private $user;
+	/** @var \OCP\IUserSession */
+	private $userSession;
+	/** @var IRequest */
+	private $request;
+	/** @var ZsyncApiController */
+	private $zsyncApiController;
+	/** @var \OC\Files\Folder */
+	private $rootFolder;
+	/** @var \OC\Files\Folder */
+	private $zsyncFolder;
+
+	public function setUp() {
+		$this->request = $this->getMockBuilder('\OCP\IRequest')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->user = $this->createMock('\OCP\IUser');
+		$this->user->expects($this->any())
+			->method('getUID')
+			->willReturn('testuser1');
+		$this->userSession = $this->createMock('\OCP\IUserSession');
+		$this->userSession->expects($this->any())
+			->method('getUser')
+			->willReturn($this->user);
+
+		$this->rootFolder = $this->createMock('\OCP\Files\Folder');
+		$this->zsyncFolder = $this->createMock('\OCP\Files\Folder');
+	}
+
+	private function construct() {
+		$folder = $this->createMock('\OCP\Files\Folder');
+		$folder->expects($this->once())
+			->method('get')
+			->with('testuser1')
+			->willReturn($this->rootFolder);
+
+		$this->zsyncApiController = new ZsyncApiController(
+				$this->appName,
+				$this->request,
+				$this->userSession,
+				$folder);
+	}
+
+	public function testShowRouteWithExistsFile() {
+		$file = $this->createMock('\OCP\Files\File');
+		$file->expects($this->once())
+			->method('getContent')
+			->willReturn('bar');
+
+		$this->rootFolder->expects($this->exactly(2))
+			->method('get')
+			->withConsecutive(
+				['files_zsync'],
+				['files/file'])
+			->willReturnOnConsecutiveCalls(
+				$this->zsyncFolder,
+				$file);
+
+		$this->zsyncFolder->expects($this->once())
+			->method('get')
+			->with('file.zsync')
+			->willReturn($file);
+
+		$this->construct();
+
+		$expected = new DataDisplayResponse('bar');
+		$this->assertEquals($expected, $this->zsyncApiController->show('file'));
+	}
+
+	public function testShowRouteWithMissingZsyncFolder() {
+		$file = $this->createMock('\OCP\Files\File');
+		$file->expects($this->once())
+			->method('getContent')
+			->willReturn('bar');
+
+		$this->rootFolder->expects($this->once())
+			->method('newFolder')
+			->willReturn($this->zsyncFolder);
+
+		$this->rootFolder->expects($this->exactly(2))
+			->method('get')
+			->withConsecutive(
+				['files_zsync'],
+				['files/file'])
+			->willReturnOnConsecutiveCalls(
+				$this->throwException(new NotFoundException),
+				$file);
+
+		$this->zsyncFolder->expects($this->once())
+			->method('get')
+			->with('file.zsync')
+			->willReturn($file);
+
+		$this->construct();
+
+		$expected = new DataDisplayResponse('bar');
+		$this->zsyncApiController->show('file');
+	}
+
+	public function testShowRouteWithMissingBaseFile() {
+		$this->rootFolder->expects($this->exactly(2))
+			->method('get')
+			->withConsecutive(
+				['files_zsync'],
+				['files/file'])
+			->willReturnOnConsecutiveCalls(
+				$this->zsyncFolder,
+				$this->throwException(new NotFoundException));
+
+		$this->construct();
+
+		$expected = new JSONResponse([], Http::STATUS_NOT_FOUND);
+		$this->assertEquals($expected, $this->zsyncApiController->show('file'));
+	}
+
+	public function testShowRouteWithMissingZsyncFile() {
+		$file = $this->createMock('\OCP\Files\File');
+		$this->rootFolder->expects($this->exactly(2))
+			->method('get')
+			->withConsecutive(
+				['files_zsync'],
+				['files/file'])
+			->willReturnOnConsecutiveCalls(
+				$this->zsyncFolder,
+				$file);
+
+		$this->zsyncFolder->expects($this->once())
+			->method('get')
+			->with('file.zsync')
+			->will($this->throwException(new NotFoundException));
+
+		$this->construct();
+
+		$expected = new JSONResponse([], Http::STATUS_NOT_FOUND);
+		$this->assertEquals($expected, $this->zsyncApiController->show('file'));
+	}
+
+	public function testShowRouteWithBadPermissionsZsyncFile() {
+		$file = $this->createMock('\OCP\Files\File');
+		$this->rootFolder->expects($this->exactly(2))
+			->method('get')
+			->withConsecutive(
+				['files_zsync'],
+				['files/file'])
+			->willReturnOnConsecutiveCalls(
+				$this->zsyncFolder,
+				$file);
+
+		$this->zsyncFolder->expects($this->once())
+			->method('get')
+			->with('file.zsync')
+			->will($this->throwException(new NotPermittedException));
+
+		$this->construct();
+
+		$expected = new JSONResponse([], Http::STATUS_FORBIDDEN);
+		$this->assertEquals($expected, $this->zsyncApiController->show('file'));
+	}
+}

--- a/apps/files/tests/HooksZsyncTest.php
+++ b/apps/files/tests/HooksZsyncTest.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * @author Ahmed Ammar <ahmed.a.ammar@gmail.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\Tests;
+
+require_once __DIR__ . '/../appinfo/app.php';
+
+use Test\TestCase;
+use OCP\Files\NotFoundException;
+
+/**
+ * Class Test_Files_zsynchooks
+ * this class provide basic files zsync hooks test
+ *
+ * @group DB
+ */
+class HooksZsyncTest extends TestCase {
+
+	const TEST_FILES_HOOKS_USER = 'test-files-user';
+	const TEST_FILES_HOOKS_USER2 = 'test-files-user2';
+	const USERS_FILES_ZSYNC_ROOT = '/test-files-user/files_zsync';
+
+	/**
+	 * @var \OC\Files\View
+	 */
+	private $rootView;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		$application = new \OCA\Files_Sharing\AppInfo\Application();
+		$application->registerMountProviders();
+
+		// create test user
+		self::loginHelper(self::TEST_FILES_HOOKS_USER2, true);
+		self::loginHelper(self::TEST_FILES_HOOKS_USER, true);
+	}
+
+	public static function tearDownAfterClass() {
+		// cleanup test user
+		$user = \OC::$server->getUserManager()->get(self::TEST_FILES_HOOKS_USER);
+		if ($user !== null) { $user->delete(); }
+		$user = \OC::$server->getUserManager()->get(self::TEST_FILES_HOOKS_USER2);
+		if ($user !== null) { $user->delete(); }
+
+		parent::tearDownAfterClass();
+	}
+
+	protected function setUp() {
+		parent::setUp();
+
+		$config = \OC::$server->getConfig();
+		$mockConfig = $this->createMock('\OCP\IConfig');
+		$mockConfig->expects($this->any())
+			->method('getSystemValue')
+			->will($this->returnCallback(function ($key, $default) use ($config) {
+				if ($key === 'filesystem_check_changes') {
+					return \OC\Files\Cache\Watcher::CHECK_ONCE;
+				} else {
+					return $config->getSystemValue($key, $default);
+				}
+			}));
+		$this->overwriteService('AllConfig', $mockConfig);
+
+		// clear hooks
+		\OC_Hook::clear();
+		\OC::registerShareHooks();
+		\OCA\Files\Hooks::connectHooks();
+
+		self::loginHelper(self::TEST_FILES_HOOKS_USER);
+		$this->rootView = new \OC\Files\View();
+		if (!$this->rootView->file_exists(self::USERS_FILES_ZSYNC_ROOT)) {
+			$this->rootView->mkdir(self::USERS_FILES_ZSYNC_ROOT);
+		}
+	}
+
+	protected function tearDown() {
+		$this->restoreService('AllConfig');
+
+		if ($this->rootView) {
+			$this->rootView->deleteAll(self::TEST_FILES_HOOKS_USER . '/files/');
+			$this->rootView->deleteAll(self::TEST_FILES_HOOKS_USER2 . '/files/');
+			$this->rootView->deleteAll(self::TEST_FILES_HOOKS_USER . '/files_zsync/');
+			$this->rootView->deleteAll(self::TEST_FILES_HOOKS_USER2 . '/files_zsync/');
+		}
+
+		\OC_Hook::clear();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @param string $user
+	 * @param bool $create
+	 */
+	public static function loginHelper($user, $create = false) {
+
+		if ($create) {
+			\OC::$server->getUserManager()->createUser($user, $user);
+		}
+
+		$storage = new \ReflectionClass('\OCA\Files_Sharing\SharedStorage');
+		$isInitialized = $storage->getProperty('initialized');
+		$isInitialized->setAccessible(true);
+		$isInitialized->setValue($storage, false);
+		$isInitialized->setAccessible(false);
+
+		\OC_Util::tearDownFS();
+		\OC_User::setUserId('');
+		\OC\Files\Filesystem::tearDown();
+		\OC_User::setUserId($user);
+		\OC_Util::setupFS($user);
+		\OC::$server->getUserFolder($user);
+	}
+
+	public function testRenameFile() {
+		\OC\Files\Filesystem::file_put_contents("test.txt", "test file");
+
+		$z1 = self::USERS_FILES_ZSYNC_ROOT . '/test.txt.zsync';
+		$z1Renamed = self::USERS_FILES_ZSYNC_ROOT . '/test.txt.renamed.zsync';
+
+		$this->rootView->file_put_contents($z1, 'zsync');
+
+		\OC\Files\Filesystem::rename("test.txt", "test.txt.renamed");
+
+		$this->assertFalse($this->rootView->file_exists($z1));
+		$this->assertTrue($this->rootView->file_exists($z1Renamed));
+	}
+
+	public function testDeleteFile() {
+		\OC\Files\Filesystem::file_put_contents("test.txt", "test file");
+
+		$z1 = self::USERS_FILES_ZSYNC_ROOT . '/test.txt.zsync';
+
+		$this->rootView->file_put_contents($z1, 'zsync');
+
+		\OC\Files\Filesystem::unlink("test.txt");
+
+		$this->assertFalse($this->rootView->file_exists($z1));
+		$this->assertFalse($this->rootView->file_exists(self::USERS_FILES_ZSYNC_ROOT . '/test'));
+	}
+
+	public function testCopyFile() {
+		\OC\Files\Filesystem::file_put_contents("test.txt", "test file");
+
+		$z1 = self::USERS_FILES_ZSYNC_ROOT . '/test.txt.zsync';
+		$z1Copied = self::USERS_FILES_ZSYNC_ROOT . '/test.txt.copied.zsync';
+
+		$this->rootView->file_put_contents($z1, 'zsync');
+
+		\OC\Files\Filesystem::copy("test.txt", "test.txt.copied");
+
+		$this->assertTrue($this->rootView->file_exists($z1));
+		$this->assertTrue($this->rootView->file_exists($z1Copied));
+	}
+
+	public function testRenameFolder() {
+		\OC\Files\Filesystem::mkdir("test");
+		\OC\Files\Filesystem::file_put_contents("test/test.txt", "test file");
+
+		$z1 = self::USERS_FILES_ZSYNC_ROOT . '/test/test.txt.zsync';
+		$z1Renamed = self::USERS_FILES_ZSYNC_ROOT . '/test.renamed/test.txt.zsync';
+
+		$this->rootView->mkdir(self::USERS_FILES_ZSYNC_ROOT . '/test');
+		$this->rootView->file_put_contents($z1, 'zsync');
+
+		\OC\Files\Filesystem::rename("test", "test.renamed");
+
+		$this->assertFalse($this->rootView->file_exists($z1));
+		$this->assertTrue($this->rootView->file_exists($z1Renamed));
+	}
+
+	public function testDeleteFolder() {
+		\OC\Files\Filesystem::mkdir("test");
+		\OC\Files\Filesystem::file_put_contents("test/test.txt", "test file");
+
+		$z1 = self::USERS_FILES_ZSYNC_ROOT . '/test/test.txt.zsync';
+
+		$this->rootView->mkdir(self::USERS_FILES_ZSYNC_ROOT . '/test');
+		$this->rootView->file_put_contents($z1, 'zsync');
+
+		\OC\Files\Filesystem::rmdir("test");
+
+		$this->assertFalse($this->rootView->file_exists(self::USERS_FILES_ZSYNC_ROOT . '/test'));
+	}
+
+	public function testCopyFolder() {
+		\OC\Files\Filesystem::mkdir("test");
+		\OC\Files\Filesystem::file_put_contents("test/test.txt", "test file");
+
+		$z1 = self::USERS_FILES_ZSYNC_ROOT . '/test/test.txt.zsync';
+		$z1Copied = self::USERS_FILES_ZSYNC_ROOT . '/test.copied/test.txt.zsync';
+
+		$this->rootView->mkdir(self::USERS_FILES_ZSYNC_ROOT . '/test');
+		$this->rootView->file_put_contents($z1, 'zsync');
+
+		\OC\Files\Filesystem::copy("test", "test.copied");
+
+		$this->assertTrue($this->rootView->file_exists($z1));
+		$this->assertTrue($this->rootView->file_exists($z1Copied));
+	}
+
+	public function testCopyFileNotExist() {
+		\OC\Files\Filesystem::file_put_contents("test.txt", "test file");
+		\OC\Files\Filesystem::copy("test.txt", "test.txt.copied");
+
+		$z1 = self::USERS_FILES_ZSYNC_ROOT . '/test.txt.zsync';
+		$z1Copied = self::USERS_FILES_ZSYNC_ROOT . '/test.txt.copied.zsync';
+
+		$this->assertFalse($this->rootView->file_exists($z1));
+		$this->assertFalse($this->rootView->file_exists($z1Copied));
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
This commit adds server-side support for delta-sync, this extends the core files app.

The basic approach is to store zsync metadata files in a folder called `files_zsync/` which mirrors the structure and layout of the `files/` folder but appends `.zsync` to the metadata files. These files can be requested by the client via a new route `api/v1/zsync/$path`.

Filesystem hooks are used to mirror any `move/copy/delete` operation on the base file onto the metadata file.

The upload path is implemented by modifying the `ChunkingPlugin`, the chunk files are now assumed to be named as the offsets into the original file. The implemenation copies adds a new class `AssemblyStreamZsync` which extends `AssemblyStrem` with support to fill in the missing data in between chunk offsets from a `backingFile`.

A new `zsync` capability is added to the files app, which can be checked by the client to know if delta-sync is supported or not.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
owncloud/core#16162.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Mostly tested by using the owncloud command line client and macOS application. With some randomly generated files using `dd` and various modifications to those files:
```
dd if=/dev/urandom of=1g.rand.img bs=$[1024*1024] count=1024

cp 1g.rand.img 1g.rand.add300m.img
dd if=/dev/urandom of=1g.rand.add300m.img bs=$[1024*1024] count=300 oseek=1024

cp 1g.rand.img 1g.rand.mod200m.img
dd if=/dev/urandom of=1g.rand.mod200m.img bs=$[1024*1024] count=100 oseek=123 conv=notrunc 
dd if=/dev/urandom of=1g.rand.mod200m.img bs=$[1024*1024] count=100 oseek=532 conv=notrunc

cp 1g.rand.img 1g.rand.mov200m.img
dd if=1g.rand.img of=1g.rand.mov200m.img bs=$[1024*1024] count=200 iseek=118 oseek=418 conv=notrunc

cp 1g.rand.img 1g.rand.del200m.img
dd if=1g.rand.img of=1g.rand.del200m.img bs=$[1024*1024] count=622
dd if=1g.rand.img of=1g.rand.del200m.img bs=$[1024*1024] iseek=822 oseek=622
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.