### PR TITLE
[Central group table] Remove duplicate of isInGroup from group manager

### DIFF
--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -480,13 +480,4 @@ class Manager extends PublicEmitter implements IGroupManager {
 
 		return $this->subAdmin;
 	}
-
-	public function inGroup($uid, $gid) {
-		$group = $this->get($gid);
-		$user = $this->userManager->get($uid);
-		if ($group and $user) {
-			return $group->inGroup($user);
-		}
-		return false;
-	}
 }

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -770,7 +770,7 @@ class Share extends Constants {
 				\OCP\Util::writeLog('OCP\Share', sprintf($message, $itemSourceName, $shareWith), \OCP\Util::DEBUG);
 				throw new \Exception($message_t);
 			}
-			if ($shareWithinGroupOnly && !\OC::$server->getGroupManager()->inGroup($uidOwner, $shareWith)) {
+			if ($shareWithinGroupOnly && !\OC::$server->getGroupManager()->isInGroup($uidOwner, $shareWith)) {
 				$message = 'Sharing %s failed, because '
 					.'%s is not a member of the group %s';
 				$message_t = $l->t('Sharing %s failed, because %s is not a member of the group %s', [$itemSourceName, $uidOwner, $shareWith]);
@@ -1050,7 +1050,7 @@ class Share extends Constants {
 				$itemUnshared = true;
 				break;
 			} elseif ((int)$share['share_type'] === \OCP\Share::SHARE_TYPE_GROUP) {
-				if (\OC::$server->getGroupManager()->inGroup($uid, $share['share_with'])) {
+				if (\OC::$server->getGroupManager()->isInGroup($uid, $share['share_with'])) {
 					$groupShare = $share;
 				}
 			} elseif ((int)$share['share_type'] === self::$shareTypeGroupUserUnique &&

--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -330,7 +330,7 @@ class OC_User {
 	 * @return bool
 	 */
 	public static function isAdminUser($uid) {
-		if (\OC::$server->getGroupManager()->inGroup($uid, 'admin') && self::$incognitoMode === false) {
+		if (\OC::$server->getGroupManager()->isInGroup($uid, 'admin') && self::$incognitoMode === false) {
 			return true;
 		}
 		return false;

--- a/settings/ajax/togglegroups.php
+++ b/settings/ajax/togglegroups.php
@@ -68,7 +68,7 @@ $l = \OC::$server->getL10N('settings');
 $action = "add";
 
 // Toggle group
-if( \OC::$server->getGroupManager()->inGroup( $username, $group )) {
+if( \OC::$server->getGroupManager()->isInGroup( $username, $group )) {
 	$action = "remove";
 	$targetGroupObject->removeUser($targetUserObject);
 	$usersInGroup = $targetGroupObject->getUsers();


### PR DESCRIPTION
This function is not in the interface of IGroupManager and is a duplicate of https://github.com/owncloud/core/blob/master/lib/public/IGroupManager.php#L153. After optimizing that function in GroupManager with central group table, this function should be removed. 

- [x] Requires unit tests adjustments