### PR TITLE
[Central group table] Make getAllSharedWith aware of membership table to optimize fs setup

### DIFF
--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -442,6 +442,7 @@ class Filesystem {
 
 		// Chance to mount for other storages
 		if ($userObject) {
+			// TODO: Optimize me please after central group table
 			$mounts = $mountConfigManager->getMountsForUser($userObject);
 			array_walk($mounts, [self::$mounts, 'addMount']);
 			$mounts[] = $homeMount;

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -865,6 +865,7 @@ class DefaultShareProvider implements IShareProvider {
 	 * @inheritdoc
 	 */
 	public function getAllSharedWith($userId, $node) {
+		// TODO: Optimize me after central group table please
 		// Create array of sharedWith objects (target user -> $userId or group of which user is a member
 		$user = $this->userManager->get($userId);
 

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -225,7 +225,7 @@ class OC_Util {
 		\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper(true);
 
 		// Make users storage readonly if he is a guest or in a read_only group
-
+		$readOnlyGroupMemberships = [];
 		$isGuest = \OC::$server->getConfig()->getUserValue(
 			$user,
 			'owncloud',
@@ -240,19 +240,18 @@ class OC_Util {
 				'[]'
 			), true);
 
-			if (!is_array($readOnlyGroups)) {
-				$readOnlyGroups = [];
+			// Find read only groups that are also user groups
+			if (is_array($readOnlyGroups) && !empty($readOnlyGroups)) {
+				// FIXME: move this functionality to group manager to resolve intersection on DB level
+				$userGroups = array_keys(
+					\OC::$server->getGroupManager()->getUserIdGroups($user)
+				);
+
+				$readOnlyGroupMemberships = array_intersect(
+					$readOnlyGroups,
+					$userGroups
+				);
 			}
-
-
-			$userGroups = array_keys(
-				\OC::$server->getGroupManager()->getUserIdGroups($user)
-			);
-
-			$readOnlyGroupMemberships = array_intersect(
-				$readOnlyGroups,
-				$userGroups
-			);
 		}
 
 


### PR DESCRIPTION
This should avoid unecessairy queries by making queries smarter after having membership table. 