### PR TITLE
[stable10] Integration test for recreate masterkey command

### DIFF
--- a/tests/integration/features/bootstrap/CommandLine.php
+++ b/tests/integration/features/bootstrap/CommandLine.php
@@ -212,6 +212,15 @@ trait CommandLine {
 	}
 
 	/**
+	 * @When /^recreating masterkey by deleting old one and encrypting the filesystem/
+	 */
+	public function recreateMasterKey() {
+		if ($this->runOcc(['encryption:recreate-master-key', '-y']) === 0) {
+			return $this->lastCode;
+		}
+	}
+
+	/**
 	 * @When /^transferring ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)"/
 	 */
 	public function transferringOwnershipPath($path, $user1, $user2) {

--- a/tests/integration/features/recreatemasterkey.feature
+++ b/tests/integration/features/recreatemasterkey.feature
@@ -1,0 +1,24 @@
+Feature: recreate-master-key
+
+	@masterkey_encryption
+	Scenario: recreate masterkey
+		Given user "admin" exists
+		And user "admin" uploads file "data/textfile.txt" to "/somefile.txt"
+		When recreating masterkey by deleting old one and encrypting the filesystem
+		Then the command was successful
+		And logging in using web as "admin"
+		And logging in using web as "admin"
+		And as an "admin"
+		And downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
+
+	@masterkey_encryption
+	Scenario: recreate masterkey and upload data
+		Given user "user0" exists
+		And user "user0" uploads file "data/textfile.txt" to "/somefile.txt"
+		And recreating masterkey by deleting old one and encrypting the filesystem
+		And the command was successful
+		And logging in using web as "admin"
+		And logging in using web as "user0"
+		And as an "user0"
+		When user "user0" uploads chunk file "1" of "1" with "AA" to "/somefile.txt"
+		Then downloaded content when downloading file "/somefile.txt" with range "bytes=0-3" should be "AA"

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -117,7 +117,7 @@ if test "$BEHAT_FILTER_TAGS"; then
     	BEHAT_FILTER_TAGS="$BEHAT_FILTER_TAGS&&~@skip"
    	fi
 else
-	BEHAT_FILTER_TAGS="~@skip"
+	BEHAT_FILTER_TAGS="~@skip&&~@masterkey_encryption"
 fi
 
 if test "$BEHAT_FILTER_TAGS"; then


### PR DESCRIPTION
Integration test for recreate masterkey command

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Integration test for recreate masterkey occ command

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Integration test for recreate masterkey occ command.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

