### PR TITLE
Disable nginx buffering for file downloads

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -251,6 +251,9 @@ class FilesPlugin extends ServerPlugin {
 			if ($checksum !== null && $checksum !== '') {
 				$response->addHeader('OC-Checksum', $checksum);
 			}
+			// disable nginx buffering so big downloads through ownCloud won't
+			// cause memory problems in the nginx process.
+			$response->addHeader('X-Accel-Buffering', 'no');
 		}
 	}
 

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -541,9 +541,12 @@ class FilesPluginTest extends TestCase {
 			->will($this->returnValue($isClumsyAgent));
 
 		$response
-			->expects($this->once())
+			->expects($this->exactly(2))
 			->method('addHeader')
-			->with('Content-Disposition', $contentDispositionHeader);
+			->withConsecutive(
+				['Content-Disposition', $contentDispositionHeader],
+				['X-Accel-Buffering', 'no']
+			);
 
 		$this->plugin->httpGet($request, $response);
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
nginx buffering seems to be causing memory problems while a big file download is happening (big file upload hasn't been checked). The memory usage of the nginx process (not the php-fpm) keeps growing which might crash the server at some point depending on the file size and the memory available in the server.

Note that this behaviour isn't present in apache or in nginx without buffering the response

## Related Issue
https://github.com/owncloud/core/issues/29328

## Motivation and Context
This solution should disable the nginx buffering only for file downloads. The rest of the operation should behave normally depending on the specific nginx configuration.
While modifying the nginx configuration should be possible, it might be complex to disable just the buffering for file downloads, so you might disable the it for the whole server or for a specific location context.

## How Has This Been Tested?
Tested manually with a 4.4GB file (check https://github.com/owncloud/core/issues/29328#issuecomment-340718926 for set up)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@DeepDiver1975 @PVince81 To be decided if this will be the solution. Not happy to include server-specific code but it's probably the easiest solution.