### PR TITLE
UI tests use is_null and consistent ElementNotFoundException messages

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -52,10 +52,10 @@ class SetupHelper {
 		$email = null
 	) {
 		$occCommand = ['user:add', '--password-from-env'];
-		if ($displayName !== null) {
+		if (!is_null($displayName)) {
 			$occCommand = array_merge($occCommand, ["--display-name", $displayName]);
 		}
-		if ($email !== null) {
+		if (!is_null($email)) {
 			$occCommand = array_merge($occCommand, ["--email", $email]);
 		}
 		putenv("OC_PASS=" . $password);

--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -158,7 +158,7 @@ class TagsHelper {
 			'userAssignable' => $userAssignable,
 		];
 
-		if ($groups !== null) {
+		if (!is_null($groups)) {
 			$body['groups'] = $groups;
 		}
 

--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -64,7 +64,7 @@ class UploadHelper {
 	) {
 
 		//simple upload with no chunking
-		if ($chunkingVersion === null) {
+		if (is_null($chunkingVersion)) {
 			$data = Stream::factory(fopen($source, 'r'));
 			return WebDavHelper::makeDavRequest(
 				$baseUrl,

--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -178,7 +178,7 @@ class FeatureContext extends RawMinkContext implements Context {
 		SetupHelper::setOcPath($scope);
 		$jobId = $this->getSessionId();
 		file_put_contents("/tmp/saucelabs_sessionid", $jobId);
-		if ($this->oldCSRFSetting === null) {
+		if (is_null($this->oldCSRFSetting)) {
 			$oldCSRFSetting = SetupHelper::runOcc(
 				['config:system:get', 'csrf.disabled']
 			)['stdOut'];
@@ -215,7 +215,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	public function tearDownSuite() {
 		if ($this->oldCSRFSetting === "") {
 			SetupHelper::runOcc(['config:system:delete', 'csrf.disabled']);
-		} elseif ($this->oldCSRFSetting !== null) {
+		} elseif (!is_null($this->oldCSRFSetting)) {
 			SetupHelper::runOcc(
 				[
 					'config:system:set',

--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -453,7 +453,7 @@ class FilesContext extends RawMinkContext implements Context {
 				$name = implode($name);
 			}
 
-			PHPUnit_Framework_Assert::assertEquals(
+			PHPUnit_Framework_Assert::assertContains(
 				"could not find file with the name '" . $name . "'",
 				$message
 			);
@@ -558,7 +558,7 @@ class FilesContext extends RawMinkContext implements Context {
 		try {
 			$this->iDeleteTheFile($name);
 		} catch (ElementNotFoundException $e) {
-			PHPUnit_Framework_Assert::assertSame(
+			PHPUnit_Framework_Assert::assertContains(
 				"could not find button 'Delete' in action Menu",
 				$e->getMessage()
 			);

--- a/tests/ui/features/bootstrap/Logging.php
+++ b/tests/ui/features/bootstrap/Logging.php
@@ -174,17 +174,17 @@ trait Logging {
 	 * @AfterScenario
 	 */
 	public function tearDownScenarioLogging() {
-		if ($this->oldLogLevel !== null
+		if (!is_null($this->oldLogLevel)
 			&& $this->oldLogLevel !== LoggingHelper::getLogLevel()
 		) {
 			LoggingHelper::setLogLevel($this->oldLogLevel);
 		}
-		if ($this->oldLogBackend !== null
+		if (!is_null($this->oldLogBackend)
 			&& $this->oldLogBackend !== LoggingHelper::getLogBackend()
 		) {
 			LoggingHelper::setLogBackend($this->oldLogBackend);
 		}
-		if ($this->oldLogTimezone !== null
+		if (!is_null($this->oldLogTimezone)
 			&& $this->oldLogTimezone !== LoggingHelper::getLogTimezone()
 		) {
 			LoggingHelper::setLogTimezone($this->oldLogTimezone);

--- a/tests/ui/features/bootstrap/SharingContext.php
+++ b/tests/ui/features/bootstrap/SharingContext.php
@@ -290,7 +290,7 @@ class SharingContext extends RawMinkContext implements Context {
 		try {
 			$this->theFileFolderIsSharedWithTheUser($name, null, null);
 		} catch (ElementNotFoundException $e) {
-			PHPUnit_Framework_Assert::assertSame(
+			PHPUnit_Framework_Assert::assertContains(
 				'could not find share-with-field',
 				$e->getMessage()
 			);

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -22,6 +22,7 @@
 
 namespace Page;
 
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\UnexpectedPageException;
 use Page\FilesPageElement\SharingDialog;
 use Behat\Mink\Session;
@@ -78,14 +79,38 @@ class FilesPage extends FilesPageBasic {
 	 * If name is not given a random one is chosen
 	 *
 	 * @param string $name
+	 * @throws ElementNotFoundException
 	 * @return string name of the created file
 	 */
 	public function createFolder($name = null) {
 		if (is_null($name)) {
 			$name = substr(str_shuffle($this->strForNormalFileName), 0, 8);
 		}
-		$this->find("xpath", $this->newFileFolderButtonXpath)->click();
-		$this->find("xpath", $this->newFolderButtonXpath)->click();
+
+		$newButtonElement = $this->find("xpath", $this->newFileFolderButtonXpath);
+
+		if ($newButtonElement === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->newFileFolderButtonXpath " .
+				"could not find new file-folder button"
+			);
+		}
+
+		$newButtonElement->click();
+
+		$newFolderButtonElement = $this->find("xpath", $this->newFolderButtonXpath);
+
+		if ($newFolderButtonElement === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->newFolderButtonXpath " .
+				"could not find new folder button"
+			);
+		}
+
+		$newFolderButtonElement->click();
+
 		try {
 			$this->fillField($this->newFolderNameInputLabel, $name . Key::ENTER);
 		} catch (NoSuchElement $e) {

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -81,7 +81,7 @@ class FilesPage extends FilesPageBasic {
 	 * @return string name of the created file
 	 */
 	public function createFolder($name = null) {
-		if ($name === null) {
+		if (is_null($name)) {
 			$name = substr(str_shuffle($this->strForNormalFileName), 0, 8);
 		}
 		$this->find("xpath", $this->newFileFolderButtonXpath)->click();

--- a/tests/ui/features/lib/FilesPageBasic.php
+++ b/tests/ui/features/lib/FilesPageBasic.php
@@ -126,7 +126,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 		do {
 			$fileListElement = $this->waitTillElementIsNotNull($this->getFileListXpath());
 
-			if ($fileListElement === null) {
+			if (is_null($fileListElement)) {
 				throw new ElementNotFoundException(
 					"findFileRowByName:could not find fileListXpath"
 				);
@@ -204,7 +204,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	 */
 	public function findFileActionMenuElement() {
 		$actionMenu = $this->waitTillElementIsNotNull($this->fileActionMenuXpath);
-		if ($actionMenu === null) {
+		if (is_null($actionMenu)) {
 			throw new ElementNotFoundException("could not find open fileActionMenu");
 		} else {
 			return $actionMenu;
@@ -282,7 +282,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	public function findFileActionsMenuBtnByNo($number) {
 		$xpath = sprintf($this->fileActionMenuBtnXpathByNo, $number);
 		$actionMenuBtn = $this->find("xpath", $xpath);
-		if ($actionMenuBtn === null) {
+		if (is_null($actionMenuBtn)) {
 			throw new ElementNotFoundException(
 				"could not find action menu button of file #$number"
 			);
@@ -329,7 +329,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 		while ($currentTime <= $end) {
 			$fileList = $this->find('xpath', $this->getFileListXpath());
 
-			if ($fileList !== null) {
+			if (!is_null($fileList)) {
 				if ($fileList->isVisible()
 					&& $fileList->has("xpath", "//a")
 				) {
@@ -341,7 +341,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 					$this->getEmptyContentXpath()
 				);
 
-				if ($emptyContentElement !== null) {
+				if (!is_null($emptyContentElement)) {
 					if (!$emptyContentElement->hasClass("hidden")) {
 						break;
 					}

--- a/tests/ui/features/lib/FilesPageBasic.php
+++ b/tests/ui/features/lib/FilesPageBasic.php
@@ -128,7 +128,9 @@ abstract class FilesPageBasic extends OwnCloudPage {
 
 			if (is_null($fileListElement)) {
 				throw new ElementNotFoundException(
-					"findFileRowByName:could not find fileListXpath"
+					__METHOD__ .
+					" xpath " . $this->getFileListXpath() .
+					" could not find file list"
 				);
 			}
 
@@ -160,7 +162,8 @@ abstract class FilesPageBasic extends OwnCloudPage {
 
 		if (is_null($fileNameMatch)) {
 			throw new ElementNotFoundException(
-				"could not find file with the name '" . $name . "'"
+				__METHOD__ .
+				" could not find file with the name '" . $name . "'"
 			);
 		}
 
@@ -168,8 +171,9 @@ abstract class FilesPageBasic extends OwnCloudPage {
 
 		if (is_null($fileRowElement)) {
 			throw new ElementNotFoundException(
-				"could not find fileRow with xpath '"
-				. $this->fileRowFromNameXpath . "'"
+				__METHOD__ .
+				" xpath $this->fileRowFromNameXpath " .
+				"could not find file row"
 			);
 		}
 		$fileRow = $this->getPage('FilesPageElement\\FileRow');
@@ -205,7 +209,11 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	public function findFileActionMenuElement() {
 		$actionMenu = $this->waitTillElementIsNotNull($this->fileActionMenuXpath);
 		if (is_null($actionMenu)) {
-			throw new ElementNotFoundException("could not find open fileActionMenu");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->fileActionMenuXpath " .
+				"could not find open fileActionMenu"
+			);
 		} else {
 			return $actionMenu;
 		}
@@ -246,6 +254,8 @@ abstract class FilesPageBasic extends OwnCloudPage {
 		);
 		if (is_null($deleteAllSelectedBtn)) {
 			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->deleteAllSelectedBtnXpath " .
 				"could not find button to delete all selected files"
 			);
 		}
@@ -280,10 +290,12 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	 * @return \Behat\Mink\Element\NodeElement
 	 */
 	public function findFileActionsMenuBtnByNo($number) {
-		$xpath = sprintf($this->fileActionMenuBtnXpathByNo, $number);
-		$actionMenuBtn = $this->find("xpath", $xpath);
+		$xpathLocator = sprintf($this->fileActionMenuBtnXpathByNo, $number);
+		$actionMenuBtn = $this->find("xpath", $xpathLocator);
 		if (is_null($actionMenuBtn)) {
 			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $xpathLocator " .
 				"could not find action menu button of file #$number"
 			);
 		}
@@ -354,7 +366,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 
 		if ($currentTime > $end) {
 			throw new \Exception(
-				"FilesPageBasic:waitTillPageIsLoaded:timeout waiting for page to load"
+				__METHOD__ . " timeout waiting for page to load"
 			);
 		}
 

--- a/tests/ui/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/ui/features/lib/FilesPageElement/FileActionsMenu.php
@@ -59,12 +59,19 @@ class FileActionsMenu extends OwnCloudPage {
 	 * 
 	 * @param string $xpathToWaitFor wait for this element to appear before returning
 	 * @param int $timeout_msec
+	 * @throws ElementNotFoundException
 	 * @return void
 	 */
 	public function rename(
 		$xpathToWaitFor = null, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
 	) {
 		$renameBtn = $this->findButton($this->renameActionLabel);
+		if (is_null($renameBtn)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" could not find action button with label " . $this->renameActionLabel
+			);
+		}
 		$renameBtn->click();
 		if (!is_null($xpathToWaitFor)) {
 			$this->waitTillElementIsNotNull($xpathToWaitFor, $timeout_msec);
@@ -78,6 +85,12 @@ class FileActionsMenu extends OwnCloudPage {
 	 */
 	public function delete() {
 		$deleteBtn = $this->findButton($this->deleteActionLabel);
+		if (is_null($deleteBtn)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" could not find action button with label " . $this->deleteActionLabel
+			);
+		}
 		$deleteBtn->click();
 	}
 	
@@ -89,14 +102,16 @@ class FileActionsMenu extends OwnCloudPage {
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 */
 	public function findButton($action) {
-		$this->waitTillElementIsNotNull(sprintf($this->fileActionXpath, $action));
+		$xpathLocator = sprintf($this->fileActionXpath, $action);
+		$this->waitTillElementIsNotNull($xpathLocator);
 		$button = $this->menuElement->find(
 			"xpath",
-			sprintf($this->fileActionXpath, $action)
+			$xpathLocator
 		);
 		if (is_null($button)) {
 			throw new ElementNotFoundException(
-				"could not find button '$action' in action Menu"
+				__METHOD__ .
+				" xpath $xpathLocator could not find button '$action' in action Menu"
 			);
 		} else {
 			return $button;

--- a/tests/ui/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/ui/features/lib/FilesPageElement/FileActionsMenu.php
@@ -66,7 +66,7 @@ class FileActionsMenu extends OwnCloudPage {
 	) {
 		$renameBtn = $this->findButton($this->renameActionLabel);
 		$renameBtn->click();
-		if ($xpathToWaitFor !== null) {
+		if (!is_null($xpathToWaitFor)) {
 			$this->waitTillElementIsNotNull($xpathToWaitFor, $timeout_msec);
 		}
 	}
@@ -94,7 +94,7 @@ class FileActionsMenu extends OwnCloudPage {
 			"xpath",
 			sprintf($this->fileActionXpath, $action)
 		);
-		if ($button === null) {
+		if (is_null($button)) {
 			throw new ElementNotFoundException(
 				"could not find button '$action' in action Menu"
 			);

--- a/tests/ui/features/lib/FilesPageElement/FileRow.php
+++ b/tests/ui/features/lib/FilesPageElement/FileRow.php
@@ -83,7 +83,7 @@ class FileRow extends OwnCloudPage {
 		$actionButton = $this->rowElement->find(
 			"xpath", $this->fileActionMenuBtnXpath
 		);
-		if ($actionButton === null) {
+		if (is_null($actionButton)) {
 			throw new ElementNotFoundException(
 				"could not find actionButton in fileRow"
 			);
@@ -154,7 +154,7 @@ class FileRow extends OwnCloudPage {
 		$inputField = $this->rowElement->find(
 			"xpath", $this->fileRenameInputXpath
 		);
-		if ($inputField === null) {
+		if (is_null($inputField)) {
 			throw new ElementNotFoundException("could not find input field");
 		}
 		return $inputField;
@@ -195,7 +195,7 @@ class FileRow extends OwnCloudPage {
 	 */
 	public function findTooltipElement() {
 		$element = $this->rowElement->find("xpath", $this->fileTooltipXpath);
-		if ($element === null) {
+		if (is_null($element)) {
 			throw new ElementNotFoundException(
 				"could not find tooltip element of file " . $this->name
 			);

--- a/tests/ui/features/lib/FilesPageElement/FileRow.php
+++ b/tests/ui/features/lib/FilesPageElement/FileRow.php
@@ -85,7 +85,8 @@ class FileRow extends OwnCloudPage {
 		);
 		if (is_null($actionButton)) {
 			throw new ElementNotFoundException(
-				"could not find actionButton in fileRow"
+				__METHOD__ .
+				" xpath $this->fileActionMenuBtnXpath could not find actionButton in fileRow"
 			);
 		}
 		return $actionButton;
@@ -126,7 +127,8 @@ class FileRow extends OwnCloudPage {
 		$shareBtn = $this->rowElement->find("xpath", $this->shareBtnXpath);
 		if (is_null($shareBtn)) {
 			throw new ElementNotFoundException(
-				"could not find sharing button in fileRow"
+				__METHOD__ .
+				" xpath $this->shareBtnXpath could not find sharing button in fileRow"
 			);
 		}
 		return $shareBtn;
@@ -155,7 +157,10 @@ class FileRow extends OwnCloudPage {
 			"xpath", $this->fileRenameInputXpath
 		);
 		if (is_null($inputField)) {
-			throw new ElementNotFoundException("could not find input field");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->fileRenameInputXpath could not find rename input field in fileRow"
+			);
 		}
 		return $inputField;
 	}
@@ -197,7 +202,9 @@ class FileRow extends OwnCloudPage {
 		$element = $this->rowElement->find("xpath", $this->fileTooltipXpath);
 		if (is_null($element)) {
 			throw new ElementNotFoundException(
-				"could not find tooltip element of file " . $this->name
+				__METHOD__ .
+				" xpath $this->fileTooltipXpath could not find tooltip element of file " .
+				$this->name
 			);
 		}
 		return $element;
@@ -222,7 +229,9 @@ class FileRow extends OwnCloudPage {
 		$thumbnail = $this->rowElement->find("xpath", $this->thumbnailXpath);
 		if (is_null($thumbnail)) {
 			throw new ElementNotFoundException(
-				"could not find thumbnail of file " . $this->name
+				__METHOD__ .
+				" xpath $this->thumbnailXpath could not find thumbnail of file " .
+				$this->name
 			);
 		}
 		return $thumbnail;
@@ -247,7 +256,9 @@ class FileRow extends OwnCloudPage {
 		$linkElement = $this->rowElement->find("xpath", $this->fileLinkXpath);
 		if (is_null($linkElement)) {
 			throw new ElementNotFoundException(
-				"could not find link to " . $this->name
+				__METHOD__ .
+				" xpath $this->fileLinkXpath could not find link to " .
+				$this->name
 			);
 		}
 		return $linkElement;

--- a/tests/ui/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/ui/features/lib/FilesPageElement/SharingDialog.php
@@ -65,7 +65,10 @@ class SharingDialog extends OwncloudPage {
 	private function _findShareWithField() {
 		$shareWithField = $this->find("xpath", $this->shareWithFieldXpath);
 		if (is_null($shareWithField)) {
-			throw new ElementNotFoundException("could not find share-with-field");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->shareWithFieldXpath could not find share-with-field"
+			);
 		}
 		return $shareWithField;
 	}
@@ -100,6 +103,8 @@ class SharingDialog extends OwncloudPage {
 		);
 		if (is_null($autocompleteNodeElement)) {
 			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->shareWithAutocompleteListXpath " .
 				"could not find autocompleteNodeElement"
 			);
 		}
@@ -181,7 +186,7 @@ class SharingDialog extends OwncloudPage {
 		}
 		if ($userFound !== true) {
 			throw new ElementNotFoundException(
-				"could not share with '$nameToMatch'"
+				__METHOD__ . " could not share with '$nameToMatch'"
 			);
 		}
 	}
@@ -234,20 +239,20 @@ class SharingDialog extends OwncloudPage {
 		$shareReceiverName,
 		$permissions
 	) {
-		$permissionsField = $this->find(
-			"xpath",
-			sprintf($this->permissionsFieldByUserName, $shareReceiverName)
-		);
+		$xpathLocator = sprintf($this->permissionsFieldByUserName, $shareReceiverName);
+		$permissionsField = $this->find("xpath", $xpathLocator);
 		if (is_null($permissionsField)) {
 			throw new ElementNotFoundException(
-				"could not find share permissions field for user "
+				__METHOD__
+				. " xpath $xpathLocator could not find share permissions field for user "
 				. $shareReceiverName
 			);
 		}
 		$showCrudsBtn = $permissionsField->find("xpath", $this->showCrudsXpath);
 		if (is_null($showCrudsBtn)) {
 			throw new ElementNotFoundException(
-				"could not find show-cruds button for user "
+				__METHOD__
+				. " xpath $this->showCrudsXpath could not find show-cruds button for user "
 				. $shareReceiverName
 			);
 		}
@@ -265,6 +270,7 @@ class SharingDialog extends OwncloudPage {
 			$permissionCheckBox = $permissionsField->findField($permission);
 			if (is_null($permissionCheckBox)) {
 				throw new ElementNotFoundException(
+					__METHOD__ .
 					"could not find the permission check box for permission " .
 					"'$permission' and user '$shareReceiverName'"
 				);
@@ -272,16 +278,19 @@ class SharingDialog extends OwncloudPage {
 			$checkBoxId = $permissionCheckBox->getAttribute("id");
 			if (is_null($checkBoxId)) {
 				throw new ElementNotFoundException(
+					__METHOD__ .
 					"could not find the id of the permission check box of " .
 					"permission '$permission' and user '$shareReceiverName'"
 				);
 			}
-			$permissionLabel = $permissionsField->find(
-				"xpath", sprintf($this->permissionLabelXpath, $checkBoxId)
-			);
+
+			$xpathLocator = sprintf($this->permissionLabelXpath, $checkBoxId);
+			$permissionLabel = $permissionsField->find("xpath", $xpathLocator);
 
 			if (is_null($permissionLabel)) {
 				throw new ElementNotFoundException(
+					__METHOD__ .
+					" xpath $xpathLocator " .
 					"could not find the label of the permission check box of " .
 					"permission '$permission' and user '$shareReceiverName'"
 				);
@@ -307,7 +316,11 @@ class SharingDialog extends OwncloudPage {
 			"xpath", $this->shareWithTooltipXpath
 		);
 		if (is_null($shareWithTooltip)) {
-			throw new ElementNotFoundException("could not find share-with-tooltip");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->shareWithTooltipXpath " .
+				"could not find share-with-tooltip"
+			);
 		}
 		return $shareWithTooltip->getText();
 	}
@@ -322,7 +335,11 @@ class SharingDialog extends OwncloudPage {
 	public function findSharerInformationItem() {
 		$sharerInformation = $this->find("xpath", $this->sharerInformationXpath);
 		if (is_null($sharerInformation)) {
-			throw new ElementNotFoundException("could not find sharer information");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->sharerInformationXpath " .
+				"could not find sharer information"
+			);
 		}
 		return $sharerInformation;
 	}
@@ -344,6 +361,7 @@ class SharingDialog extends OwncloudPage {
 				];
 			} else {
 				throw new \Exception(
+					__METHOD__ .
 					"could not find shared with group or sharer name"
 				);
 			}
@@ -378,7 +396,11 @@ class SharingDialog extends OwncloudPage {
 	public function findThumbnailContainer() {
 		$thumbnailContainer = $this->find("xpath", $this->thumbnailContainerXpath);
 		if (is_null($thumbnailContainer)) {
-			throw new ElementNotFoundException("could not find thumbnailContainer");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->thumbnailContainerXpath " .
+				"could not find thumbnailContainer"
+			);
 		}
 		return $thumbnailContainer;
 	}
@@ -394,7 +416,11 @@ class SharingDialog extends OwncloudPage {
 			"xpath", $this->thumbnailFromContainerXpath
 		);
 		if (is_null($thumbnail)) {
-			throw new ElementNotFoundException("could not find thumbnail");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->thumbnailFromContainerXpath " .
+				"could not find thumbnail"
+			);
 		}
 		return $thumbnail;
 	}
@@ -409,6 +435,8 @@ class SharingDialog extends OwncloudPage {
 		$shareDialogCloseButton = $this->find("xpath", $this->shareWithCloseXpath);
 		if (is_null($shareDialogCloseButton)) {
 			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->shareWithCloseXpath " .
 				"could not find share-dialog-close-button"
 			);
 		}

--- a/tests/ui/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/ui/features/lib/FilesPageElement/SharingDialog.php
@@ -64,7 +64,7 @@ class SharingDialog extends OwncloudPage {
 	 */
 	private function _findShareWithField() {
 		$shareWithField = $this->find("xpath", $this->shareWithFieldXpath);
-		if ($shareWithField === null) {
+		if (is_null($shareWithField)) {
 			throw new ElementNotFoundException("could not find share-with-field");
 		}
 		return $shareWithField;
@@ -98,7 +98,7 @@ class SharingDialog extends OwncloudPage {
 			"xpath",
 			$this->shareWithAutocompleteListXpath
 		);
-		if ($autocompleteNodeElement === null) {
+		if (is_null($autocompleteNodeElement)) {
 			throw new ElementNotFoundException(
 				"could not find autocompleteNodeElement"
 			);
@@ -306,7 +306,7 @@ class SharingDialog extends OwncloudPage {
 		$shareWithTooltip = $shareWithField->find(
 			"xpath", $this->shareWithTooltipXpath
 		);
-		if ($shareWithTooltip === null) {
+		if (is_null($shareWithTooltip)) {
 			throw new ElementNotFoundException("could not find share-with-tooltip");
 		}
 		return $shareWithTooltip->getText();
@@ -407,7 +407,7 @@ class SharingDialog extends OwncloudPage {
 	 */
 	public function closeSharingDialog() {
 		$shareDialogCloseButton = $this->find("xpath", $this->shareWithCloseXpath);
-		if ($shareDialogCloseButton === null) {
+		if (is_null($shareDialogCloseButton)) {
 			throw new ElementNotFoundException(
 				"could not find share-dialog-close-button"
 			);

--- a/tests/ui/features/lib/LoginPage.php
+++ b/tests/ui/features/lib/LoginPage.php
@@ -65,8 +65,8 @@ class LoginPage extends OwncloudPage {
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
-			if (($this->findById($this->userInputId) !== null)
-				&& ($this->findById($this->passwordInputId) !== null)
+			if ((!is_null($this->findById($this->userInputId)))
+				&& (!is_null($this->findById($this->passwordInputId)))
 			) {
 				break;
 			}

--- a/tests/ui/features/lib/LoginPage.php
+++ b/tests/ui/features/lib/LoginPage.php
@@ -22,6 +22,7 @@
 
 namespace Page;
 
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 use Behat\Mink\Session;
 
@@ -36,17 +37,30 @@ class LoginPage extends OwncloudPage {
 	protected $path = '/index.php/login';
 	protected $userInputId = "user";
 	protected $passwordInputId = "password";
+	protected $submitLoginId = "submit";
 
 	/**
 	 * @param string $username
 	 * @param string $password
 	 * @param string $target
+	 * @throws ElementNotFoundException
 	 * @return Page
 	 */
 	public function loginAs($username, $password, $target = 'FilesPage') {
 		$this->fillField($this->userInputId, $username);
 		$this->fillField($this->passwordInputId, $password);
-		$this->findById("submit")->click();
+		$submitElement = $this->findById($this->submitLoginId);
+
+		if ($submitElement === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" id $this->submitLoginId " .
+				"could not find login submit button"
+			);
+		}
+
+		$submitElement->click();
+
 		return $this->getPage($target);
 	}
 
@@ -76,7 +90,7 @@ class LoginPage extends OwncloudPage {
 
 		if ($currentTime > $end) {
 			throw new \Exception(
-				"LoginPage:waitTillPageIsLoaded:timeout waiting for page to load"
+				__METHOD__ . " timeout waiting for page to load"
 			);
 		}
 

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -98,7 +98,7 @@ class OwncloudPage extends Page {
 			} catch (WebDriverException $e) {
 				break;
 			}
-			if ($element === null) {
+			if (is_null($element)) {
 				break;
 			}
 			usleep(STANDARDSLEEPTIMEMICROSEC);
@@ -123,7 +123,7 @@ class OwncloudPage extends Page {
 				 * @var NodeElement $element
 				 */
 				$element = $this->find("xpath", $xpath);
-				if ($element === null || !$element->isValid()) {
+				if (is_null($element) || !$element->isValid()) {
 					usleep(STANDARDSLEEPTIMEMICROSEC);
 				} else {
 					return $element;
@@ -146,7 +146,7 @@ class OwncloudPage extends Page {
 	public function getNotificationText() {
 		$notificationElement = $this->findById("notification");
 
-		if ($notificationElement === null) {
+		if (is_null($notificationElement)) {
 			throw new ElementNotFoundException(
 				"getNotificationText:could not find notification element"
 			);
@@ -165,7 +165,7 @@ class OwncloudPage extends Page {
 		$notificationsText = array();
 		$notifications = $this->findById("notification");
 
-		if ($notifications === null) {
+		if (is_null($notifications)) {
 			throw new ElementNotFoundException(
 				"getNotifications:could not find notification element"
 			);
@@ -206,7 +206,7 @@ class OwncloudPage extends Page {
 	public function openSettingsMenu() {
 		$userNameDisplayElement = $this->findById($this->userNameDisplayId);
 
-		if ($userNameDisplayElement === null) {
+		if (is_null($userNameDisplayElement)) {
 			throw new ElementNotFoundException(
 				"openSettingsMenu:could not find userNameDisplay element"
 			);
@@ -225,7 +225,7 @@ class OwncloudPage extends Page {
 	public function getMyUsername() {
 		$userNameDisplayElement = $this->findById($this->userNameDisplayId);
 
-		if ($userNameDisplayElement === null) {
+		if (is_null($userNameDisplayElement)) {
 			throw new ElementNotFoundException(
 				"getMyUsername:could not find userNameDisplay element"
 			);
@@ -249,7 +249,7 @@ class OwncloudPage extends Page {
 	 * @return void
 	 */
 	public function setPagePath($path) {
-		if ($this->originalPath === null) {
+		if (is_null($this->originalPath)) {
 			$this->originalPath = $this->path;
 		}
 		$this->path = $path;
@@ -261,7 +261,7 @@ class OwncloudPage extends Page {
 	 * @return string
 	 */
 	public function getOriginalPath() {
-		if ($this->originalPath !== null) {
+		if (!is_null($this->originalPath)) {
 			return $this->originalPath;
 		} else {
 			return $this->getPath();

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -37,6 +37,7 @@ use Page\OwncloudPageElement\OCDialog;
 class OwncloudPage extends Page {
 
 	protected $userNameDisplayId = "expandDisplayName";
+	protected $notificationId = "notification";
 	protected $ocDialogXpath = ".//*[@class='oc-dialog']";
 
 	/**
@@ -73,7 +74,7 @@ class OwncloudPage extends Page {
 
 		if ($currentTime > $end) {
 			throw new \Exception(
-				"OwncloudPage:waitTillPageIsLoaded:timeout waiting for page to load"
+				__METHOD__ . " timeout waiting for page to load"
 			);
 		}
 
@@ -144,11 +145,11 @@ class OwncloudPage extends Page {
 	 * @return string
 	 */
 	public function getNotificationText() {
-		$notificationElement = $this->findById("notification");
+		$notificationElement = $this->findById($this->notificationId);
 
 		if (is_null($notificationElement)) {
 			throw new ElementNotFoundException(
-				"getNotificationText:could not find notification element"
+				__METHOD__ . " could not find element with id $this->notificationId"
 			);
 		}
 
@@ -163,11 +164,11 @@ class OwncloudPage extends Page {
 	 */
 	public function getNotifications() {
 		$notificationsText = array();
-		$notifications = $this->findById("notification");
+		$notifications = $this->findById($this->notificationId);
 
 		if (is_null($notifications)) {
 			throw new ElementNotFoundException(
-				"getNotifications:could not find notification element"
+				__METHOD__ . " could not find element with id $this->notificationId"
 			);
 		}
 
@@ -208,7 +209,7 @@ class OwncloudPage extends Page {
 
 		if (is_null($userNameDisplayElement)) {
 			throw new ElementNotFoundException(
-				"openSettingsMenu:could not find userNameDisplay element"
+				__METHOD__ . " could not find element with id $this->userNameDisplayId"
 			);
 		}
 
@@ -227,7 +228,7 @@ class OwncloudPage extends Page {
 
 		if (is_null($userNameDisplayElement)) {
 			throw new ElementNotFoundException(
-				"getMyUsername:could not find userNameDisplay element"
+				__METHOD__ . " could not find element with id $this->userNameDisplayId"
 			);
 		}
 
@@ -411,7 +412,7 @@ class OwncloudPage extends Page {
 	 * @return NodeElement|bool
 	 *   The NodeElement selected if true, FALSE otherwise.
 	 */
-	protected function elementHasCSSValue($element, $property, $value) {
+	protected function elementHasCSSValue(NodeElement $element, $property, $value) {
 		$exists = false;
 		$style = $element->getAttribute('style');
 		if ($style) {

--- a/tests/ui/features/lib/OwncloudPageElement/OCDialog.php
+++ b/tests/ui/features/lib/OwncloudPageElement/OCDialog.php
@@ -68,7 +68,11 @@ class OCDialog extends OwncloudPage {
 	public function getTitle() {
 		$title = $this->dialogElement->find("xpath", $this->titleClassXpath);
 		if (is_null($title)) {
-			throw new ElementNotFoundException("could not find title");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->titleClassXpath " .
+				"could not find title"
+			);
 		}
 		return $title->getText();
 	}
@@ -81,7 +85,11 @@ class OCDialog extends OwncloudPage {
 	public function getMessage() {
 		$contentElement = $this->dialogElement->find("xpath", $this->contentClassXpath);
 		if (is_null($contentElement)) {
-			throw new ElementNotFoundException("could not find content element");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->contentClassXpath " .
+				"could not find content element"
+			);
 		}
 		return $contentElement->getText();
 	}
@@ -98,7 +106,11 @@ class OCDialog extends OwncloudPage {
 			"xpath", $this->primaryButtonXpath
 		);
 		if (is_null($primaryButton)) {
-			throw new ElementNotFoundException("could not find primary button");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->primaryButtonXpath " .
+				"could not find primary button"
+			);
 		}
 		$primaryButton->click();
 		$this->waitForOutstandingAjaxCalls($session);

--- a/tests/ui/features/lib/OwncloudPageElement/SettingsMenu.php
+++ b/tests/ui/features/lib/OwncloudPageElement/SettingsMenu.php
@@ -41,7 +41,11 @@ class SettingsMenu extends OwncloudPage {
 	public function logout() {
 		$logoutButton = $this->findById($this->logoutButtonId);
 		if (is_null($logoutButton)) {
-			throw new ElementNotFoundException("could not find logout button");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" id $this->logoutButtonId " .
+				"could not find logout button"
+			);
 		}
 		$logoutButton->click();
 	}

--- a/tests/ui/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/ui/features/lib/PersonalGeneralSettingsPage.php
@@ -60,7 +60,7 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
-			if ($this->findById($this->personalProfilePanelId) !== null) {
+			if (!is_null($this->findById($this->personalProfilePanelId))) {
 				break;
 			}
 			usleep(STANDARDSLEEPTIMEMICROSEC);

--- a/tests/ui/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/ui/features/lib/PersonalGeneralSettingsPage.php
@@ -69,7 +69,7 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 
 		if ($currentTime > $end) {
 			throw new \Exception(
-				"PersonalGeneralSettingsPage:waitTillPageIsLoaded:timeout waiting for page to load"
+				__METHOD__ . " timeout waiting for page to load"
 			);
 		}
 

--- a/tests/ui/features/lib/PersonalSecuritySettingsPage.php
+++ b/tests/ui/features/lib/PersonalSecuritySettingsPage.php
@@ -23,6 +23,7 @@
 namespace Page;
 
 use Behat\Mink\Element\NodeElement;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**
  * Personal Security Settings page.
@@ -47,14 +48,36 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 	 * create a new app password for the app named $appName
 	 *
 	 * @param string $appName
+	 * @throws ElementNotFoundException
 	 * @return void
 	 */
 	public function createNewAppPassword($appName) {
 		$this->fillField($this->appPasswordNameInputId, $appName);
-		$this->findById($this->createNewAppPasswordButtonId)->click();
 		$createNewAppPasswordButton = $this->findById(
 			$this->createNewAppPasswordButtonId
 		);
+
+		if ($createNewAppPasswordButton === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" id $this->createNewAppPasswordButtonId " .
+				"could not find create new app password button (1)"
+			);
+		}
+
+		$createNewAppPasswordButton->click();
+
+		$createNewAppPasswordButton = $this->findById(
+			$this->createNewAppPasswordButtonId
+		);
+
+		if ($createNewAppPasswordButton === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" id $this->createNewAppPasswordButtonId " .
+				"could not find create new app password button (2)"
+			);
+		}
 
 		while (strpos(
 			$createNewAppPasswordButton->getAttribute("class"),

--- a/tests/ui/features/lib/UserPageElement/GroupList.php
+++ b/tests/ui/features/lib/UserPageElement/GroupList.php
@@ -62,11 +62,16 @@ class GroupList extends OwncloudPage {
 	 */
 	public function selectGroup($name) {
 		$name = $this->quotedText($name);
+		$xpathLocator = sprintf($this->groupLiXpath, $name);
 		$groupLi = $this->groupListElement->find(
-			"xpath", sprintf($this->groupLiXpath, $name)
+			"xpath", $xpathLocator
 		);
 		if (is_null($groupLi)) {
-			throw new ElementNotFoundException("cannot find group list element");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $xpathLocator " .
+				"could not find group list element"
+			);
 		}
 		$groupLi->click();
 		return $groupLi;
@@ -83,7 +88,11 @@ class GroupList extends OwncloudPage {
 		$groupLi = $this->selectGroup($name);
 		$deleteButton = $groupLi->find("xpath", $this->deleteBtnXpath);
 		if (is_null($deleteButton)) {
-			throw new ElementNotFoundException("cannot find delete button");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->deleteBtnXpath " .
+				"could not find delete button"
+			);
 		}
 		$deleteButton->click();
 	}

--- a/tests/ui/features/lib/UserPageElement/GroupList.php
+++ b/tests/ui/features/lib/UserPageElement/GroupList.php
@@ -65,7 +65,7 @@ class GroupList extends OwncloudPage {
 		$groupLi = $this->groupListElement->find(
 			"xpath", sprintf($this->groupLiXpath, $name)
 		);
-		if ($groupLi === null) {
+		if (is_null($groupLi)) {
 			throw new ElementNotFoundException("cannot find group list element");
 		}
 		$groupLi->click();
@@ -82,7 +82,7 @@ class GroupList extends OwncloudPage {
 	public function deleteGroup($name) {
 		$groupLi = $this->selectGroup($name);
 		$deleteButton = $groupLi->find("xpath", $this->deleteBtnXpath);
-		if ($deleteButton === null) {
+		if (is_null($deleteButton)) {
 			throw new ElementNotFoundException("cannot find delete button");
 		}
 		$deleteButton->click();

--- a/tests/ui/features/lib/UsersPage.php
+++ b/tests/ui/features/lib/UsersPage.php
@@ -245,7 +245,7 @@ class UsersPage extends OwncloudPage {
 		$selectOption = $selectField->find(
 			'xpath', sprintf($this->quotaOptionXpath, $quota)
 		);
-		if ($selectOption === null) {
+		if (is_null($selectOption)) {
 			$selectOption = $selectField->find(
 				'xpath', sprintf($this->quotaOptionXpath, "Other")
 			);
@@ -264,7 +264,7 @@ class UsersPage extends OwncloudPage {
 	 */
 	private function getGroupListElement() {
 		$groupListElement = $this->findById($this->groupListId);
-		if ($groupListElement === null) {
+		if (is_null($groupListElement)) {
 			throw new ElementNotFoundException("cannot find group list element");
 		}
 

--- a/tests/ui/features/lib/UsersPage.php
+++ b/tests/ui/features/lib/UsersPage.php
@@ -81,14 +81,31 @@ class UsersPage extends OwncloudPage {
 
 	/**
 	 * @param string $username
+	 * @throws ElementNotFoundException
 	 * @return string text describing the quota
 	 */
 	public function getQuotaOfUser($username) {
 		$userTr = $this->findUserInTable($username);
 		$selectField = $userTr->find('xpath', $this->quotaSelectXpath);
-		$selectField = $selectField->find(
-			'xpath', "//option[@value='" . $selectField->getValue() . "']"
-		);
+
+		if ($selectField === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->quotaSelectXpath " .
+				"could not find quota select element"
+			);
+		}
+
+		$xpathLocator = "//option[@value='" . $selectField->getValue() . "']";
+		$selectField = $selectField->find('xpath', $xpathLocator);
+
+		if ($selectField === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $xpathLocator " .
+				"could not find quota element"
+			);
+		}
 
 		return $selectField->getText();
 	}
@@ -102,7 +119,11 @@ class UsersPage extends OwncloudPage {
 	public function openSettingsMenu() {
 		$settingsBtn = $this->find("xpath", $this->settingsBtnXpath);
 		if (is_null($settingsBtn)) {
-			throw new ElementNotFoundException("cannot find settings button");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->settingsBtnXpath " .
+				"could not find settings button"
+			);
 		}
 		$settingsBtn->click();
 	}
@@ -118,17 +139,23 @@ class UsersPage extends OwncloudPage {
 	public function setSetting($setting, $value = true) {
 		$settingContent = $this->findById($this->settingContentId);
 		if (is_null($settingContent)) {
-			throw new ElementNotFoundException("cannot find setting content");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" id $this->settingContentId " .
+				"could not find setting content"
+			);
 		}
 		if (!$settingContent->isVisible()) {
 			$this->openSettingsMenu();
 		}
-		$settingLabel = $this->find(
-			"xpath", sprintf($this->settingByTextXpath, $setting)
-		);
+
+		$xpathLocator = sprintf($this->settingByTextXpath, $setting);
+		$settingLabel = $this->find("xpath", $xpathLocator);
 		if (is_null($settingLabel)) {
 			throw new ElementNotFoundException(
-				"cannot find setting '" . $setting . "'"
+				__METHOD__ .
+				" xpath $xpathLocator " .
+				"could not find setting '" . $setting . "'"
 			);
 		}
 		//the checkbox is not visible, but we need it to find the status
@@ -136,7 +163,8 @@ class UsersPage extends OwncloudPage {
 		$checkBox = $this->findById($checkBoxId);
 		if (is_null($checkBox)) {
 			throw new ElementNotFoundException(
-				"cannot find checkbox with the id '" . $checkBoxId . "'"
+				__METHOD__ .
+				" could not find checkbox with the id '" . $checkBoxId . "'"
 			);
 		}
 		if ($checkBox->isChecked() !== $value) {
@@ -168,7 +196,9 @@ class UsersPage extends OwncloudPage {
 		$createUserBtn = $this->find("xpath", $this->createUserBtnXpath);
 		if (is_null($createUserBtn)) {
 			throw new ElementNotFoundException(
-				"cannot find create user button"
+				__METHOD__ .
+				" xpath $this->createUserBtnXpath " .
+				"could not find create user button"
 			);
 		}
 		$newUserGroupsDropDown = $this->find(
@@ -176,11 +206,20 @@ class UsersPage extends OwncloudPage {
 		);
 		if (is_null($newUserGroupsDropDown)) {
 			throw new ElementNotFoundException(
-				"cannot find groups dropdown for new user"
+				__METHOD__ .
+				" xpath $this->newUserGroupsDropDownXpath " .
+				"could not find groups dropdown for new user"
 			);
 		}
 		$newUserGroupsDropDown->click();
 		$groupDropDownList = $this->find("xpath", $this->newUserGroupsListXpath);
+		if (is_null($groupDropDownList)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->newUserGroupsListXpath " .
+				"could not find groups dropdown list"
+			);
+		}
 		$groupsInDropDown = $groupDropDownList->findAll(
 			"xpath", $this->newUserGroupsDropDownListTag
 		);
@@ -206,7 +245,9 @@ class UsersPage extends OwncloudPage {
 					);
 					if (is_null($newUserAddGroupBtn)) {
 						throw new ElementNotFoundException(
-							"cannot find add-group button while creating a new user"
+							__METHOD__ .
+							" xpath $this->newUserAddGroupBtnXpath " .
+							"could not find add-group button while creating a new user"
 						);
 					}
 					$newUserAddGroupBtn->click();
@@ -215,7 +256,9 @@ class UsersPage extends OwncloudPage {
 					);
 					if (is_null($createUserInput)) {
 						throw new ElementNotFoundException(
-							"cannot find add-group input while creating a new user"
+							__METHOD__ .
+							" xpath $this->createGroupWithNewUserInputXpath " .
+							"could not find add-group input while creating a new user"
 						);
 					}
 					try {
@@ -236,21 +279,48 @@ class UsersPage extends OwncloudPage {
 	 * @param string $username
 	 * @param string $quota text form of quota to be input
 	 * @param Session $session
+	 * @throws ElementNotFoundException
 	 * @return void
 	 */
 	public function setQuotaOfUserTo($username, $quota, Session $session) {
 		$userTr = $this->findUserInTable($username);
 		$selectField = $userTr->find('xpath', $this->quotaSelectXpath);
 
+		if (is_null($selectField)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->quotaSelectXpath " .
+				"could not find quota select element"
+			);
+		}
+
 		$selectOption = $selectField->find(
 			'xpath', sprintf($this->quotaOptionXpath, $quota)
 		);
 		if (is_null($selectOption)) {
-			$selectOption = $selectField->find(
-				'xpath', sprintf($this->quotaOptionXpath, "Other")
-			);
+			$xpathLocator = sprintf($this->quotaOptionXpath, "Other");
+			$selectOption = $selectField->find('xpath', $xpathLocator);
+
+			if (is_null($selectOption)) {
+				throw new ElementNotFoundException(
+					__METHOD__ .
+					" xpath $xpathLocator " .
+					"could not find quota option element"
+				);
+			}
+
 			$selectOption->click();
-			$this->find('xpath', $this->manualQuotaInputXpath)->setValue($quota);
+			$manualQuotaInputElement = $this->find('xpath', $this->manualQuotaInputXpath);
+
+			if (is_null($manualQuotaInputElement)) {
+				throw new ElementNotFoundException(
+					__METHOD__ .
+					" xpath $this->manualQuotaInputXpath " .
+					"could not find manual quota input element"
+				);
+			}
+
+			$manualQuotaInputElement->setValue($quota);
 		} else {
 			$selectOption->click();
 		}
@@ -265,7 +335,11 @@ class UsersPage extends OwncloudPage {
 	private function getGroupListElement() {
 		$groupListElement = $this->findById($this->groupListId);
 		if (is_null($groupListElement)) {
-			throw new ElementNotFoundException("cannot find group list element");
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" id $this->groupListId " .
+				"could not find group list element"
+			);
 		}
 
 		/**


### PR DESCRIPTION
## Description
1) Use ``is_null()`` everywhere rather than mixing it up with ``=== null``
2) Make all ``ElementNotFoundException`` messages have a "standard" format that puts the method, the xpath used and some message text, so that we get easy to read exceptions logged when something goes wrong.
3) Find all the remaining places that do things like:
```
$this->find("xpath", "some xpath locator")->click();
```
and first get the result of the ``find()`` - if it is null then throw a "nice" exception rather than crashing out doing a "click on null object".

## Related Issue
This is more stuff noted while trying to reduce problems running tests on Edge issue #29138 
but enhances/improves the existing UI tests.

## Motivation and Context
Have nicer more consistent exception messages when an element is not found in the UI.
Be more careful to check elements are found before clicking/actioning them.

## How Has This Been Tested?
Travis

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

