### PR TITLE
[stable9.1] Backport of filecache repair step OLD

### DIFF
--- a/apps/files/appinfo/app.php
+++ b/apps/files/appinfo/app.php
@@ -42,6 +42,9 @@
 
 \OC::$server->getSearch()->registerProvider('OC\Search\Provider\File', array('apps' => array('files')));
 
+// instantiate to make sure services get registered
+$app = new \OCA\Files\AppInfo\Application();
+
 $templateManager = \OC_Helper::getFileTemplateManager();
 $templateManager->registerTemplate('text/html', 'core/templates/filetemplates/template.html');
 $templateManager->registerTemplate('application/vnd.oasis.opendocument.presentation', 'core/templates/filetemplates/template.odp');

--- a/apps/files/appinfo/register_command.php
+++ b/apps/files/appinfo/register_command.php
@@ -26,8 +26,11 @@ $dbConnection = \OC::$server->getDatabaseConnection();
 $userManager = OC::$server->getUserManager();
 $shareManager = \OC::$server->getShareManager();
 $mountManager = \OC::$server->getMountManager();
+$lockingProvider = \OC::$server->getLockingProvider();
+$mimeTypeLoader = \OC::$server->getMimeTypeLoader();
+$config = \OC::$server->getConfig();
 
 /** @var Symfony\Component\Console\Application $application */
-$application->add(new OCA\Files\Command\Scan($userManager));
+$application->add(new OCA\Files\Command\Scan($userManager, $lockingProvider, $mimeTypeLoader, $config));
 $application->add(new OCA\Files\Command\DeleteOrphanedFiles($dbConnection));
 $application->add(new OCA\Files\Command\TransferOwnership($userManager, $shareManager, $mountManager));

--- a/apps/files/lib/AppInfo/Application.php
+++ b/apps/files/lib/AppInfo/Application.php
@@ -87,6 +87,13 @@ class Application extends App {
 			);
 		});
 
+		$container->registerService('OCP\Lock\ILockingProvider', function(IContainer $c)  {
+			return $c->query('ServerContainer')->getLockingProvider();
+		});
+		$container->registerService('OCP\Files\IMimeTypeLoader', function(IContainer $c)  {
+			return $c->query('ServerContainer')->getMimeTypeLoader();
+		});
+
 		/*
 		 * Register capabilities
 		 */

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -238,9 +238,7 @@ class Scan extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$inputPath = $input->getOption('path');
-		if ($input->getOption('repair')) {
-			$shouldRepairStoragesIndividually = true;
-		}
+		$shouldRepairStoragesIndividually = (bool) $input->getOption('repair');
 
 		if ($inputPath) {
 			$inputPath = '/' . trim($inputPath, '/');
@@ -304,7 +302,8 @@ class Scan extends Base {
 			if ($this->userManager->userExists($user)) {
 				# add an extra line when verbose is set to optical separate users
 				if ($verbose) {$output->writeln(""); }
-				$output->writeln("Starting scan for user $user_count out of $users_total ($user)");
+				$r = $shouldRepairStoragesIndividually ? ' (and repair)' : '';
+				$output->writeln("Starting scan$r for user $user_count out of $users_total ($user)");
 				# full: printout data if $verbose was set
 				$this->scanFiles($user, $path, $verbose, $output, $input->getOption('unscanned'), $shouldRepairStoragesIndividually);
 			} else {

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -254,8 +254,8 @@ class Scan extends Base {
 				// don't fix individually
 				$shouldRepairStoragesIndividually = false;
 			} else {
-				$output->writeln("<error>Repairing every storage individually is slower than repairing in bulk</error>");
-				$output->writeln("<error>To repair in bulk, please switch to single user mode first: occ maintenance:singleuser --on</error>");
+				$output->writeln("<comment>Repairing every storage individually is slower than repairing in bulk</comment>");
+				$output->writeln("<comment>To repair in bulk, please switch to single user mode first: occ maintenance:singleuser --on</comment>");
 			}
 			$users = $this->userManager->search('');
 		} else {

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -44,6 +44,7 @@ use OC\Migration\ConsoleOutput;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Files\IMimeTypeLoader;
+use OCP\IConfig;
 
 class Scan extends Base {
 
@@ -53,6 +54,8 @@ class Scan extends Base {
 	private $lockingProvider;
 	/** @var IMimeTypeLoader */
 	private $mimeTypeLoader;
+	/** @var IConfig */
+	private $config;
 	/** @var float */
 	protected $execTime = 0;
 	/** @var int */
@@ -63,11 +66,13 @@ class Scan extends Base {
 	public function __construct(
 		IUserManager $userManager,
 		ILockingProvider $lockingProvider,
-		IMimeTypeLoader $mimeTypeLoader
+		IMimeTypeLoader $mimeTypeLoader,
+		IConfig $config
 	) {
 		$this->userManager = $userManager;
 		$this->lockingProvider = $lockingProvider;
 		$this->mimeTypeLoader = $mimeTypeLoader;
+		$this->config = $config;
 		parent::__construct();
 	}
 
@@ -128,6 +133,22 @@ class Scan extends Base {
 		}
 	}
 
+	/**
+	 * Repair all storages at once
+	 *
+	 * @param OutputInterface $output
+	 */
+	protected function repairAll(OutputInterface $output) {
+		$connection = $this->reconnectToDatabase($output);
+		$repairStep = new RepairMismatchFileCachePath(
+			$connection,
+			$this->mimeTypeLoader
+		);
+		$repairStep->setStorageNumericId(null);
+		$repairStep->setCountOnly(false);
+		$repairStep->run(new ConsoleOutput($output));
+	}
+
 	protected function scanFiles($user, $path, $verbose, OutputInterface $output, $backgroundScan = false, $shouldRepair = false) {
 		$connection = $this->reconnectToDatabase($output);
 		$scanner = new \OC\Files\Utils\Scanner($user, $connection, \OC::$server->getLogger());
@@ -143,7 +164,7 @@ class Scan extends Base {
 				try {
 					$repairStep = new RepairMismatchFileCachePath(
 						$connection,
-						$mimeTypeLoader
+						$this->mimeTypeLoader
 					);
 					$repairStep->setStorageNumericId($storage->getCache()->getNumericStorageId());
 					$repairStep->setCountOnly(false);
@@ -217,11 +238,27 @@ class Scan extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$inputPath = $input->getOption('path');
+		if ($input->getOption('repair')) {
+			$shouldRepairStoragesIndividually = true;
+		}
+
 		if ($inputPath) {
 			$inputPath = '/' . trim($inputPath, '/');
 			list (, $user,) = explode('/', $inputPath, 3);
 			$users = array($user);
 		} else if ($input->getOption('all')) {
+			// we can only repair all storages in bulk (more efficient) if singleuser or maintenance mode
+			// is enabled to prevent concurrent user access
+			if ($input->getOption('repair') &&
+				($this->config->getSystemValue('singleuser', false) || $this->config->getSystemValue('maintenance', false))) {
+				// repair all storages at once
+				$this->repairAll($output);
+				// don't fix individually
+				$shouldRepairStoragesIndividually = false;
+			} else {
+				$output->writeln("<error>Repairing every storage individually is slower than repairing in bulk</error>");
+				$output->writeln("<error>To repair in bulk, please switch to single user mode first: occ maintenance:singleuser --on</error>");
+			}
 			$users = $this->userManager->search('');
 		} else {
 			$users = $input->getArgument('user_id');
@@ -269,7 +306,7 @@ class Scan extends Base {
 				if ($verbose) {$output->writeln(""); }
 				$output->writeln("Starting scan for user $user_count out of $users_total ($user)");
 				# full: printout data if $verbose was set
-				$this->scanFiles($user, $path, $verbose, $output, $input->getOption('unscanned'), $input->getOption('repair'));
+				$this->scanFiles($user, $path, $verbose, $output, $input->getOption('unscanned'), $shouldRepairStoragesIndividually);
 			} else {
 				$output->writeln("<error>Unknown user $user_count $user</error>");
 			}

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -157,7 +157,7 @@ class Scan extends Base {
 				try {
 					// FIXME: this will lock the storage even if there is nothing to repair
 					$storage->acquireLock('', ILockingProvider::LOCK_EXCLUSIVE, $this->lockingProvider);
-				} catch (OCP\Lock\LockedException $e) {
+				} catch (LockedException $e) {
 					$output->writeln("\t<error>Storage \"" . $storage->getCache()->getNumericStorageId() . '" cannot be repaired as it is currently in use, please try again later</error>');
 					return;
 				}

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -195,7 +195,8 @@ class Scanner extends PublicEmitter {
 			}
 
 			// if the home storage isn't writable then the scanner is run as the wrong user
-			if ($storage->instanceOfStorage('\OC\Files\Storage\Home') and
+			$isHome = $storage->instanceOfStorage('\OC\Files\Storage\Home');
+			if ($isHome and
 				(!$storage->isCreatable('') or !$storage->isCreatable('files'))
 			) {
 				if ($storage->file_exists('') or $storage->getCache()->inCache('')) {
@@ -210,6 +211,9 @@ class Scanner extends PublicEmitter {
 			if ($storage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
 				continue;
 			}
+
+			$this->emit('\OC\Files\Utils\Scanner', 'beforeScanStorage', [$storage]);
+
 			$relativePath = $mount->getInternalPath($dir);
 			$scanner = $storage->getScanner();
 			$scanner->setUseTransactions(false);
@@ -246,6 +250,7 @@ class Scanner extends PublicEmitter {
 			if ($this->useTransaction) {
 				$this->db->commit();
 			}
+			$this->emit('\OC\Files\Utils\Scanner', 'afterScanStorage', [$storage]);
 		}
 	}
 

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -195,8 +195,7 @@ class Scanner extends PublicEmitter {
 			}
 
 			// if the home storage isn't writable then the scanner is run as the wrong user
-			$isHome = $storage->instanceOfStorage('\OC\Files\Storage\Home');
-			if ($isHome and
+			if ($storage->instanceOfStorage('\OC\Files\Storage\Home') and
 				(!$storage->isCreatable('') or !$storage->isCreatable('files'))
 			) {
 				if ($storage->file_exists('') or $storage->getCache()->inCache('')) {

--- a/lib/private/Migration/ConsoleOutput.php
+++ b/lib/private/Migration/ConsoleOutput.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Migration;
+
+use OCP\Migration\IOutput;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class SimpleOutput
+ *
+ * Just a simple IOutput implementation with writes messages to the log file.
+ * Alternative implementations will write to the console or to the web ui (web update case)
+ *
+ * @package OC\Migration
+ */
+class ConsoleOutput implements IOutput {
+
+	/** @var OutputInterface */
+	private $output;
+
+	/** @var ProgressBar */
+	private $progressBar;
+
+	public function __construct(OutputInterface $output) {
+		$this->output = $output;
+	}
+
+	/**
+	 * @param string $message
+	 */
+	public function info($message) {
+		$this->output->writeln("<info>$message</info>");
+	}
+
+	/**
+	 * @param string $message
+	 */
+	public function warning($message) {
+		$this->output->writeln("<comment>$message</comment>");
+	}
+
+	/**
+	 * @param int $max
+	 */
+	public function startProgress($max = 0) {
+		if (!is_null($this->progressBar)) {
+			$this->progressBar->finish();
+		}
+		$this->progressBar = new ProgressBar($this->output);
+		$this->progressBar->start($max);
+	}
+
+	/**
+	 * @param int $step
+	 * @param string $description
+	 */
+	public function advance($step = 1, $description = '') {
+		if (!is_null($this->progressBar)) {
+			$this->progressBar = new ProgressBar($this->output);
+			$this->progressBar->start();
+		}
+		$this->progressBar->advance($step);
+	}
+
+	public function finishProgress() {
+		if (is_null($this->progressBar)) {
+			return;
+		}
+		$this->progressBar->finish();
+	}
+}

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -52,6 +52,8 @@ use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use OC\Repair\MoveAvatarOutsideHome;
+use OC\Repair\RepairMismatchFileCachePath;
 
 class Repair implements IOutput{
 	/* @var IRepairStep[] */
@@ -126,6 +128,7 @@ class Repair implements IOutput{
 		return [
 			new RepairMimeTypes(\OC::$server->getConfig()),
 			new AssetCache(),
+			new RepairMismatchFileCachePath(\OC::$server->getDatabaseConnection(), \OC::$server->getMimeTypeLoader()),
 			new FillETags(\OC::$server->getDatabaseConnection()),
 			new CleanTags(\OC::$server->getDatabaseConnection(), \OC::$server->getUserManager()),
 			new DropOldTables(\OC::$server->getDatabaseConnection()),

--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -1,0 +1,407 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Repair;
+
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use OCP\Files\IMimeTypeLoader;
+use OCP\IDBConnection;
+
+/**
+ * Repairs file cache entry which path do not match the parent-child relationship
+ */
+class RepairMismatchFileCachePath implements IRepairStep {
+
+	const CHUNK_SIZE = 10000;
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	/** @var IMimeTypeLoader */
+	protected $mimeLoader;
+
+	/** @var int */
+	protected $dirMimeTypeId;
+
+	/** @var int */
+	protected $dirMimePartId;
+
+	/**
+	 * @param \OCP\IDBConnection $connection
+	 */
+	public function __construct(IDBConnection $connection, IMimeTypeLoader $mimeLoader) {
+		$this->connection = $connection;
+		$this->mimeLoader = $mimeLoader;
+	}
+
+	public function getName() {
+		return 'Repair file cache entries with path that does not match parent-child relationships';
+	}
+
+	/**
+	 * Fixes the broken entry's path.
+	 *
+	 * @param IOutput $out repair output
+	 * @param int $fileId file id of the entry to fix
+	 * @param string $wrongPath wrong path of the entry to fix
+	 * @param int $correctStorageNumericId numeric idea of the correct storage
+	 * @param string $correctPath value to which to set the path of the entry 
+	 * @return bool true for success
+	 */
+	private function fixEntryPath(IOutput $out, $fileId, $wrongPath, $correctStorageNumericId, $correctPath) {
+		// delete target if exists
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('filecache')
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($correctStorageNumericId)))
+			->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($correctPath)));
+		$entryExisted = $qb->execute() > 0;
+
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('filecache')
+			->set('path', $qb->createNamedParameter($correctPath))
+			->set('path_hash', $qb->createNamedParameter(md5($correctPath)))
+			->set('storage', $qb->createNamedParameter($correctStorageNumericId))
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)));
+		$qb->execute();
+
+		$text = "Fixed file cache entry with fileid $fileId, set wrong path \"$wrongPath\" to \"$correctPath\"";
+		if ($entryExisted) {
+			$text = " (replaced an existing entry)";
+		}
+		$out->advance(1, $text);
+	}
+
+	private function addQueryConditions($qb) {
+		// thanks, VicDeo!
+		if ($this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
+			$concatFunction = $qb->createFunction("CONCAT(fcp.path, '/', fc.name)");
+		} else {
+			$concatFunction = $qb->createFunction("(fcp.`path` || '/' || fc.`name`)");
+		}
+
+		if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+			$emptyPathExpr = $qb->expr()->isNotNull('fcp.path');
+		} else {
+			$emptyPathExpr = $qb->expr()->neq('fcp.path', $qb->expr()->literal(''));
+		}
+
+		$qb
+			->from('filecache', 'fc')
+			->from('filecache', 'fcp')
+			->where($qb->expr()->eq('fc.parent', 'fcp.fileid'))
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->neq(
+						$qb->createFunction($concatFunction),
+						'fc.path'
+					),
+					$qb->expr()->neq('fc.storage', 'fcp.storage')
+				)
+			)
+			->andWhere($emptyPathExpr)
+			// yes, this was observed in the wild...
+			->andWhere($qb->expr()->neq('fc.fileid', 'fcp.fileid'));
+	}
+
+	private function countResultsToProcess() {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select($qb->createFunction('COUNT(*)'));
+		$this->addQueryConditions($qb);
+		$results = $qb->execute();
+		$count = $results->fetchColumn(0);
+		$results->closeCursor();
+		return $count;
+	}
+
+	/**
+	 * Repair all entries for which the parent entry exists but the path
+	 * value doesn't match the parent's path.
+	 *
+	 * @param IOutput $out
+	 * @return int number of results that were fixed
+	 */
+	private function fixEntriesWithCorrectParentIdButWrongPath(IOutput $out) {
+		$totalResultsCount = 0;
+
+		// find all entries where the path entry doesn't match the path value that would
+		// be expected when following the parent-child relationship, basically
+		// concatenating the parent's "path" value with the name of the child
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('fc.storage', 'fc.fileid', 'fc.name')
+			->selectAlias('fc.path', 'path')
+			->selectAlias('fc.parent', 'wrongparentid')
+			->selectAlias('fcp.storage', 'parentstorage')
+			->selectAlias('fcp.path', 'parentpath');
+		$this->addQueryConditions($qb);
+		$qb->setMaxResults(self::CHUNK_SIZE);
+
+		do {
+			$results = $qb->execute();
+			// since we're going to operate on fetched entry, better cache them
+			// to avoid DB lock ups
+			$rows = $results->fetchAll();
+			$results->closeCursor();
+
+			$this->connection->beginTransaction();
+			$lastResultsCount = 0;
+			foreach ($rows as $row) {
+				$wrongPath = $row['path'];
+				$correctPath = $row['parentpath'] . '/' . $row['name'];
+				// make sure the target is on a different subtree
+				if (substr($correctPath, 0, strlen($wrongPath)) === $wrongPath) {
+					// the path based parent entry is referencing one of its own children, skipping
+					// fix the entry's parent id instead
+					// note: fixEntryParent cannot fail to find the parent entry by path
+					// here because the reason we reached this code is because we already
+					// found it
+					$this->fixEntryParent(
+						$out,
+						$row['storage'],
+						$row['fileid'],
+						$row['path'],
+						$row['wrongparentid'],
+						true
+					);
+				} else {
+					$this->fixEntryPath(
+						$out,
+						$row['fileid'],
+						$wrongPath,
+						$row['parentstorage'],
+						$correctPath
+					);
+				}
+				$lastResultsCount++;
+			}
+			$this->connection->commit();
+
+			$totalResultsCount += $lastResultsCount;
+
+			// note: this is not pagination but repeating the query over and over again
+			// until all possible entries were fixed
+		} while ($lastResultsCount > 0);
+
+		if ($totalResultsCount > 0) {
+			$out->info("Fixed $totalResultsCount file cache entries with wrong path");
+		}
+
+		return $totalResultsCount;
+	}
+
+	/**
+	 * Gets the file id of the entry. If none exists, create it
+	 * up to the root if needed.
+	 *
+	 * @param int $storageId storage id
+	 * @param string $path path for which to create the parent entry
+	 * @return int file id of the newly created parent
+	 */
+	private function getOrCreateEntry($storageId, $path, $reuseFileId = null) {
+		if ($path === '.') {
+			$path = '';
+		}
+		// find the correct parent
+		$qb = $this->connection->getQueryBuilder();
+		// select fileid as "correctparentid"
+		$qb->select('fileid')
+			// from oc_filecache
+			->from('filecache')
+			// where storage=$storage and path='$parentPath'
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($storageId)))
+			->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($path)));
+		$results = $qb->execute();
+		$rows = $results->fetchAll();
+		$results->closeCursor();
+
+		if (!empty($rows)) {
+			return $rows[0]['fileid'];
+		}
+
+		if ($path !== '') {
+			$parentId = $this->getOrCreateEntry($storageId, dirname($path));
+		} else {
+			// root entry missing, create it
+			$parentId = -1;
+		}
+
+		$qb = $this->connection->getQueryBuilder();
+		$values = [
+			'storage' => $qb->createNamedParameter($storageId),
+			'path' => $qb->createNamedParameter($path),
+			'path_hash' => $qb->createNamedParameter(md5($path)),
+			'name' => $qb->createNamedParameter(basename($path)),
+			'parent' => $qb->createNamedParameter($parentId),
+			'size' => $qb->createNamedParameter(-1),
+			'etag' => $qb->createNamedParameter('zombie'),
+			'mimetype' => $qb->createNamedParameter($this->dirMimeTypeId),
+			'mimepart' => $qb->createNamedParameter($this->dirMimePartId),
+		];
+
+		if ($reuseFileId !== null) {
+			// purpose of reusing the fileid of the parent is to salvage potential
+			// metadata that might have previously been linked to this file id
+			$values['fileid'] = $qb->createNamedParameter($reuseFileId);
+		}
+		$qb->insert('filecache')->values($values);
+		$qb->execute();
+		return $this->connection->lastInsertId('*PREFIX*filecache');
+	}
+
+	/**
+	 * Fixes the broken entry's path.
+	 *
+	 * @param IOutput $out repair output
+	 * @param int $storageId storage id of the entry to fix
+	 * @param int $fileId file id of the entry to fix
+	 * @param string $path path from the entry to fix
+	 * @param int $wrongParentId wrong parent id
+	 * @param bool $parentIdExists true if the entry from the $wrongParentId exists (but is the wrong one),
+	 * false if it doesn't
+	 * @return bool true if the entry was fixed, false otherwise
+	 */
+	private function fixEntryParent(IOutput $out, $storageId, $fileId, $path, $wrongParentId, $parentIdExists = false) {
+		if (!$parentIdExists) {
+			// if the parent doesn't exist, let us reuse its id in case there is metadata to salvage
+			$correctParentId = $this->getOrCreateEntry($storageId, dirname($path), $wrongParentId);
+		} else {
+			// parent exists and is the wrong one, so recreating would need a new fileid
+			$correctParentId = $this->getOrCreateEntry($storageId, dirname($path));
+		}
+
+		$this->connection->beginTransaction();
+
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('filecache')
+			->set('parent', $qb->createNamedParameter($correctParentId))
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)));
+		$qb->execute();
+
+		$text = "Fixed file cache entry with fileid $fileId, set wrong parent \"$wrongParentId\" to \"$correctParentId\"";
+		$out->advance(1, $text);
+
+		$this->connection->commit();
+
+		return true;
+	}
+
+	/**
+	 * Repair entries where the parent id doesn't point to any existing entry
+	 * by finding the actual parent entry matching the entry's path dirname.
+	 * 
+	 * @param IOutput $out output
+	 * @return int number of results that were fixed
+	 */
+	private function fixEntriesWithNonExistingParentIdEntry(IOutput $out) {
+		// Subquery for parent existence
+		$qbe = $this->connection->getQueryBuilder();
+		$qbe->select($qbe->expr()->literal('1'))
+			->from('filecache', 'fce')
+			->where($qbe->expr()->eq('fce.fileid', 'fc.parent'));
+
+		$qb = $this->connection->getQueryBuilder();
+
+		// Find entries to repair
+		// select fc.storage,fc.fileid,fc.parent as "wrongparent",fc.path,fc.etag
+		// and not exists (select 1 from oc_filecache fc2 where fc2.fileid = fc.parent)
+		$qb->select('storage', 'fileid', 'path', 'parent')
+			// from oc_filecache fc
+			->from('filecache', 'fc')
+			// where fc.parent <> -1
+			->where($qb->expr()->neq('fc.parent', $qb->createNamedParameter(-1)))
+			// and not exists (select 1 from oc_filecache fc2 where fc2.fileid = fc.parent)
+			->andWhere(
+				$qb->expr()->orX(
+					$qb->expr()->eq('fc.fileid', 'fc.parent'),
+					$qb->createFunction('NOT EXISTS (' . $qbe->getSQL() . ')'))
+				);
+		$qb->setMaxResults(self::CHUNK_SIZE);
+
+		$totalResultsCount = 0;
+		do {
+			$results = $qb->execute();
+			// since we're going to operate on fetched entry, better cache them
+			// to avoid DB lock ups
+			$rows = $results->fetchAll();
+			$results->closeCursor();
+
+			$lastResultsCount = 0;
+			foreach ($rows as $row) {
+				$this->fixEntryParent(
+					$out,
+					$row['storage'],
+					$row['fileid'],
+					$row['path'],
+					$row['parent'],
+					// in general the parent doesn't exist except
+					// for the one condition where parent=fileid
+					$row['parent'] === $row['fileid']
+				);
+				$lastResultsCount++;
+			}
+
+			$totalResultsCount += $lastResultsCount;
+
+			// note: this is not pagination but repeating the query over and over again
+			// until all possible entries were fixed
+		} while ($lastResultsCount > 0);
+
+		if ($totalResultsCount > 0) {
+			$out->info("Fixed $totalResultsCount file cache entries with wrong path");
+		}
+
+		return $totalResultsCount;
+	}
+
+	/**
+	 * Run the repair step
+	 *
+	 * @param IOutput $out output
+	 */
+	public function run(IOutput $out) {
+
+		$this->dirMimeTypeId = $this->mimeLoader->getId('httpd/unix-directory');
+		$this->dirMimePartId = $this->mimeLoader->getId('httpd');
+
+		$out->startProgress($this->countResultsToProcess());
+
+		$totalFixed = 0;
+
+		/*
+		 * This repair itself might overwrite existing target parent entries and create
+		 * orphans where the parent entry of the parent id doesn't exist but the path matches.
+		 * This needs to be repaired by fixEntriesWithNonExistingParentIdEntry(), this is why
+		 * we need to keep this specific order of repair.
+		 */
+		$totalFixed += $this->fixEntriesWithCorrectParentIdButWrongPath($out);
+
+		$totalFixed += $this->fixEntriesWithNonExistingParentIdEntry($out);
+
+		$out->finishProgress();
+
+		if ($totalFixed > 0) {
+			$out->warning('Please run `occ files:scan --all` once to complete the repair');
+		}
+	}
+}

--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -523,6 +523,7 @@ class RepairMismatchFileCachePath implements IRepairStep {
 				$this->fixEntriesWithNonExistingParentIdEntry($out);
 			}
 			$out->finishProgress();
+			$out->info('');
 		}
 	}
 }

--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -232,7 +232,9 @@ class RepairMismatchFileCachePath implements IRepairStep {
 
 		if (!empty($storageIds)) {
 			$out->warning('The file cache contains entries with invalid path values for the following storage numeric ids: ' . implode(' ', $storageIds));
-			$out->warning('Please run `occ files:scan --all --repair` to repair all affected storages');
+			$out->warning('Please run `occ files:scan --all --repair` to repair'
+			.'all affected storages or run `occ files:scan userid --repair for '
+			.'each user with affected storages');
 		}
 	}
 

--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -413,6 +413,20 @@ class RepairMismatchFileCachePath implements IRepairStep {
 
 		// If we reused the fileid then this is the id to return
 		if($reuseFileId !== null) {
+			// with Oracle, the trigger gets in the way and does not let us specify
+			// a fileid value on insert
+			if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+				$lastFileId = $this->connection->lastInsertId('*PREFIX*filecache');
+				if ($reuseFileId !== $lastFileId) {
+					// use update to set it directly
+					$qb = $this->connection->getQueryBuilder();
+					$qb->update('filecache')
+						->set('fileid', $qb->createNamedParameter($reuseFileId))
+						->where($qb->expr()->eq('fileid', $qb->createNamedParameter($lastFileId)));
+					$qb->execute();
+				}
+			}
+
 			return $reuseFileId;
 		} else {
 			// Else we inserted a new row with auto generated id, use that

--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -103,8 +103,13 @@ class RepairMismatchFileCachePath implements IRepairStep {
 		// delete target if exists
 		$qb = $this->connection->getQueryBuilder();
 		$qb->delete('filecache')
-			->where($qb->expr()->eq('storage', $qb->createNamedParameter($correctStorageNumericId)))
-			->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($correctPath)));
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($correctStorageNumericId)));
+
+		if ($correctPath === '' && $this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+			$qb->andWhere($qb->expr()->isNull('path'));
+		} else {
+			$qb->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($correctPath)));
+		}
 		$entryExisted = $qb->execute() > 0;
 
 		$qb = $this->connection->getQueryBuilder();
@@ -363,8 +368,13 @@ class RepairMismatchFileCachePath implements IRepairStep {
 			// from oc_filecache
 			->from('filecache')
 			// where storage=$storage and path='$parentPath'
-			->where($qb->expr()->eq('storage', $qb->createNamedParameter($storageId)))
-			->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($path)));
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($storageId)));
+
+		if ($path === '' && $this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+			$qb->andWhere($qb->expr()->isNull('path'));
+		} else {
+			$qb->andWhere($qb->expr()->eq('path', $qb->createNamedParameter($path)));
+		}
 		$results = $qb->execute();
 		$rows = $results->fetchAll();
 		$results->closeCursor();

--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -21,8 +21,6 @@
 
 namespace OC\Repair;
 
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
-use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
@@ -56,7 +54,8 @@ class RepairMismatchFileCachePath implements IRepairStep {
 	protected $countOnly = true;
 
 	/**
-	 * @param \OCP\IDBConnection $connection
+	 * @param IDBConnection $connection
+	 * @param IMimeTypeLoader $mimeLoader
 	 */
 	public function __construct(IDBConnection $connection, IMimeTypeLoader $mimeLoader) {
 		$this->connection = $connection;

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -590,6 +590,7 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 			return new NoopLockingProvider();
 		});
+		$this->registerAlias('OCP\Lock\ILockingProvider', 'LockingProvider');
 		$this->registerService('MountManager', function () {
 			return new \OC\Files\Mount\Manager();
 		});
@@ -605,6 +606,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getDatabaseConnection()
 			);
 		});
+		$this->registerAlias('OCP\Files\IMimeTypeLoader', 'MimeTypeLoader');
 		$this->registerService('NotificationManager', function () {
 			return new Manager();
 		});

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -90,6 +90,9 @@ interface IDBConnection {
 
 	/**
 	 * Used to get the id of the just inserted element
+	 * Note: On postgres platform, this will return the last sequence id which
+	 * may not be the id last inserted if you were reinserting a previously
+	 * used auto_increment id.
 	 * @param string $table the name of the table where we inserted the item
 	 * @return int the id of the inserted element
 	 * @since 6.0.0

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -42,6 +42,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 				['httpd/unix-directory', 2],
 			]));
 		$this->repair = new RepairMismatchFileCachePath($this->connection, $mimeLoader);
+		$this->repair->setCountOnly(false);
 	}
 
 	protected function tearDown() {

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -1,0 +1,495 @@
+<?php
+/**
+ * Copyright (c) 2017 Vincent Petry <pvince81@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Repair;
+
+
+use OC\Repair\RepairMismatchFileCachePath;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Test\TestCase;
+use OCP\Files\IMimeTypeLoader;
+
+/**
+ * Tests for repairing mismatch file cache paths
+ *
+ * @group DB
+ *
+ * @see \OC\Repair\RepairMismatchFileCachePath
+ */
+class RepairMismatchFileCachePathTest extends TestCase {
+
+	/** @var IRepairStep */
+	private $repair;
+
+	/** @var \OCP\IDBConnection */
+	private $connection;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->connection = \OC::$server->getDatabaseConnection();
+
+		$mimeLoader = $this->createMock(IMimeTypeLoader::class);
+		$mimeLoader->method('getId')
+			->will($this->returnValueMap([
+				['httpd', 1],
+				['httpd/unix-directory', 2],
+			]));
+		$this->repair = new RepairMismatchFileCachePath($this->connection, $mimeLoader);
+	}
+
+	protected function tearDown() {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('filecache')->execute();
+		parent::tearDown();
+	}
+
+	private function createFileCacheEntry($storage, $path, $parent = -1) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->insert('filecache')
+			->values([
+				'storage' => $qb->createNamedParameter($storage),
+				'path' => $qb->createNamedParameter($path),
+				'path_hash' => $qb->createNamedParameter(md5($path)),
+				'name' => $qb->createNamedParameter(basename($path)),
+				'parent' => $qb->createNamedParameter($parent),
+			]);
+		$qb->execute();
+		return $this->connection->lastInsertId('*PREFIX*filecache');
+	}
+
+	/**
+	 * Returns autoincrement compliant fileid for an entry that might
+	 * have existed
+	 *
+	 * @return int fileid
+	 */
+	private function createNonExistingId() {
+		// why are we doing this ? well, if we just pick an arbitrary
+		// value ahead of the autoincrement, this will not reflect real scenarios
+		// and also will likely cause potential collisions as some newly inserted entries
+		// might receive said arbitrary id through autoincrement
+		//
+		// So instead, we insert a dummy entry and delete it afterwards so we have
+		// "reserved" the fileid and also somehow simulated whatever might have happened
+		// on a real system when a file cache entry suddenly disappeared for whatever
+		// mysterious reasons
+		$entryId = $this->createFileCacheEntry(1, 'goodbye-entry');
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('filecache')
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($entryId)));
+		$qb->execute();
+		return $entryId;
+	}
+
+	private function getFileCacheEntry($fileId) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('*')
+			->from('filecache')
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)));
+		$results = $qb->execute();
+		$result = $results->fetch();
+		$results->closeCursor();
+		return $result;
+	}
+
+	/**
+	 * Sets the parent of the given file id to the given parent id
+	 *
+	 * @param int $fileId file id of the entry to adjust
+	 * @param int $parentId parent id to set to
+	 */
+	private function setFileCacheEntryParent($fileId, $parentId) {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('filecache')
+			->set('parent', $qb->createNamedParameter($parentId))
+			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)));
+		$qb->execute();
+	}
+
+	public function repairCasesProvider() {
+		return [
+			// same storage, different target dir
+			[1, 1, 'target'],
+			// different storage, same target dir name
+			[1, 2, 'source'],
+			// different storage, different target dir
+			[1, 2, 'target'],
+
+			// same storage, different target dir, target exists
+			[1, 1, 'target', true],
+			// different storage, same target dir name, target exists
+			[1, 2, 'source', true],
+			// different storage, different target dir, target exists
+			[1, 2, 'target', true],
+		];
+	}
+
+	/**
+	 * Test repair
+	 *
+	 * @dataProvider repairCasesProvider
+	 */
+	public function testRepairEntry($sourceStorageId, $targetStorageId, $targetDir, $targetExists = false) {
+		/*
+		 * Tree:
+		 *
+		 * source storage:
+		 *     - files/
+		 *     - files/source/
+		 *     - files/source/to_move (not created as we simulate that it was already moved)
+		 *     - files/source/to_move/content_to_update (bogus entry to fix)
+		 *     - files/source/to_move/content_to_update/sub (bogus subentry to fix)
+		 *     - files/source/do_not_touch (regular entry outside of the repair scope)
+		 *
+		 * target storage:
+		 *     - files/
+		 *     - files/target/
+		 *     - files/target/moved_renamed (already moved target)
+		 *     - files/target/moved_renamed/content_to_update (missing until repair)
+		 *
+		 * if $targetExists: pre-create these additional entries:
+		 *     - files/target/moved_renamed/content_to_update (will be overwritten)
+		 *     - files/target/moved_renamed/content_to_update/sub (will be overwritten)
+		 *     - files/target/moved_renamed/content_to_update/unrelated (will be reparented)
+		 *
+		 */
+
+		// source storage entries
+		$rootId1 = $this->createFileCacheEntry($sourceStorageId, '');
+		$baseId1 = $this->createFileCacheEntry($sourceStorageId, 'files', $rootId1);
+		if ($sourceStorageId !== $targetStorageId) {
+			$rootId2 = $this->createFileCacheEntry($targetStorageId, '');
+			$baseId2 = $this->createFileCacheEntry($targetStorageId, 'files', $rootId2);
+		} else {
+			$rootId2 = $rootId1;
+			$baseId2 = $baseId1;
+		}
+		$sourceId = $this->createFileCacheEntry($sourceStorageId, 'files/source', $baseId1);
+
+		// target storage entries
+		$targetParentId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir, $baseId2);
+
+		// the move does create the parent in the target
+		$targetId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir . '/moved_renamed', $targetParentId);
+
+		// bogus entry: any children of the source are not properly updated
+		$movedId = $this->createFileCacheEntry($sourceStorageId, 'files/source/to_move/content_to_update', $targetId);
+		$movedSubId = $this->createFileCacheEntry($sourceStorageId, 'files/source/to_move/content_to_update/sub', $movedId);
+
+		if ($targetExists) {
+			// after the bogus move happened, some code path recreated the parent under a
+			// different file id
+			$existingTargetId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir . '/moved_renamed/content_to_update', $targetId);
+			$existingTargetSubId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir . '/moved_renamed/content_to_update/sub', $existingTargetId);
+			$existingTargetUnrelatedId = $this->createFileCacheEntry($targetStorageId, 'files/' . $targetDir . '/moved_renamed/content_to_update/unrelated', $existingTargetId);
+		}
+
+		$doNotTouchId = $this->createFileCacheEntry($sourceStorageId, 'files/source/do_not_touch', $sourceId);
+
+		$outputMock = $this->createMock(IOutput::class);
+		$this->repair->run($outputMock);
+
+		$entry = $this->getFileCacheEntry($movedId);
+		$this->assertEquals($targetId, $entry['parent']);
+		$this->assertEquals((string)$targetStorageId, $entry['storage']);
+		$this->assertEquals('files/' . $targetDir . '/moved_renamed/content_to_update', $entry['path']);
+		$this->assertEquals(md5('files/' . $targetDir . '/moved_renamed/content_to_update'), $entry['path_hash']);
+
+		$entry = $this->getFileCacheEntry($movedSubId);
+		$this->assertEquals($movedId, $entry['parent']);
+		$this->assertEquals((string)$targetStorageId, $entry['storage']);
+		$this->assertEquals('files/' . $targetDir . '/moved_renamed/content_to_update/sub', $entry['path']);
+		$this->assertEquals(md5('files/' . $targetDir . '/moved_renamed/content_to_update/sub'), $entry['path_hash']);
+
+		if ($targetExists) {
+			$this->assertFalse($this->getFileCacheEntry($existingTargetId));
+			$this->assertFalse($this->getFileCacheEntry($existingTargetSubId));
+
+			// unrelated folder has been reparented
+			$entry = $this->getFileCacheEntry($existingTargetUnrelatedId);
+			$this->assertEquals($movedId, $entry['parent']);
+			$this->assertEquals((string)$targetStorageId, $entry['storage']);
+			$this->assertEquals('files/' . $targetDir . '/moved_renamed/content_to_update/unrelated', $entry['path']);
+			$this->assertEquals(md5('files/' . $targetDir . '/moved_renamed/content_to_update/unrelated'), $entry['path_hash']);
+		}
+
+		// root entries left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$sourceStorageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+
+		$entry = $this->getFileCacheEntry($rootId2);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$targetStorageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+
+		// "do not touch" entry left untouched
+		$entry = $this->getFileCacheEntry($doNotTouchId);
+		$this->assertEquals($sourceId, $entry['parent']);
+		$this->assertEquals((string)$sourceStorageId, $entry['storage']);
+		$this->assertEquals('files/source/do_not_touch', $entry['path']);
+		$this->assertEquals(md5('files/source/do_not_touch'), $entry['path_hash']);
+
+		// root entry left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$sourceStorageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+	}
+
+	/**
+	 * Test repair self referencing entries
+	 */
+	public function testRepairSelfReferencing() {
+		/**
+		 * Self-referencing:
+		 *     - files/all_your_zombies (parent=fileid must be reparented)
+		 *
+		 * Referencing child one level:
+		 *     - files/ref_child1 (parent=fileid of the child)
+		 *     - files/ref_child1/child (parent=fileid of the child)
+		 *
+		 * Referencing child two levels:
+		 *     - files/ref_child2/ (parent=fileid of the child's child)
+		 *     - files/ref_child2/child
+		 *     - files/ref_child2/child/child
+		 *
+		 * Referencing child two levels detached:
+		 *     - detached/ref_child3/ (parent=fileid of the child, "detached" has no entry)
+		 *     - detached/ref_child3/child
+		 */
+		$storageId = 1;
+		$rootId1 = $this->createFileCacheEntry($storageId, '');
+		$baseId1 = $this->createFileCacheEntry($storageId, 'files', $rootId1);
+
+		$selfRefId = $this->createFileCacheEntry($storageId, 'files/all_your_zombies', $baseId1);
+		$this->setFileCacheEntryParent($selfRefId, $selfRefId);
+
+		$refChild1Id = $this->createFileCacheEntry($storageId, 'files/ref_child1', $baseId1);
+		$refChild1ChildId = $this->createFileCacheEntry($storageId, 'files/ref_child1/child', $refChild1Id);
+		// make it reference its own child
+		$this->setFileCacheEntryParent($refChild1Id, $refChild1ChildId);
+
+		$refChild2Id = $this->createFileCacheEntry($storageId, 'files/ref_child2', $baseId1);
+		$refChild2ChildId = $this->createFileCacheEntry($storageId, 'files/ref_child2/child', $refChild2Id);
+		$refChild2ChildChildId = $this->createFileCacheEntry($storageId, 'files/ref_child2/child/child', $refChild2ChildId);
+		// make it reference its own sub child
+		$this->setFileCacheEntryParent($refChild2Id, $refChild2ChildChildId);
+
+		$refChild3Id = $this->createFileCacheEntry($storageId, 'detached/ref_child3', $baseId1);
+		$refChild3ChildId = $this->createFileCacheEntry($storageId, 'detached/ref_child3/child', $refChild3Id);
+		// make it reference its own child
+		$this->setFileCacheEntryParent($refChild3Id, $refChild3ChildId);
+
+		$outputMock = $this->createMock(IOutput::class);
+		$this->repair->run($outputMock);
+
+		// self-referencing updated
+		$entry = $this->getFileCacheEntry($selfRefId);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/all_your_zombies', $entry['path']);
+		$this->assertEquals(md5('files/all_your_zombies'), $entry['path_hash']);
+
+		// ref child 1 case was reparented to "files"
+		$entry = $this->getFileCacheEntry($refChild1Id);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child1', $entry['path']);
+		$this->assertEquals(md5('files/ref_child1'), $entry['path_hash']);
+
+		// ref child 1 child left alone
+		$entry = $this->getFileCacheEntry($refChild1ChildId);
+		$this->assertEquals($refChild1Id, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child1/child', $entry['path']);
+		$this->assertEquals(md5('files/ref_child1/child'), $entry['path_hash']);
+
+		// ref child 2 case was reparented to "files"
+		$entry = $this->getFileCacheEntry($refChild2Id);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child2', $entry['path']);
+		$this->assertEquals(md5('files/ref_child2'), $entry['path_hash']);
+
+		// ref child 2 child left alone
+		$entry = $this->getFileCacheEntry($refChild2ChildId);
+		$this->assertEquals($refChild2Id, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child2/child', $entry['path']);
+		$this->assertEquals(md5('files/ref_child2/child'), $entry['path_hash']);
+
+		// ref child 2 child child left alone
+		$entry = $this->getFileCacheEntry($refChild2ChildChildId);
+		$this->assertEquals($refChild2ChildId, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/ref_child2/child/child', $entry['path']);
+		$this->assertEquals(md5('files/ref_child2/child/child'), $entry['path_hash']);
+
+		// root entry left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+
+		// ref child 3 child left alone
+		$entry = $this->getFileCacheEntry($refChild3ChildId);
+		$this->assertEquals($refChild3Id, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('detached/ref_child3/child', $entry['path']);
+		$this->assertEquals(md5('detached/ref_child3/child'), $entry['path_hash']);
+
+		// ref child 3 case was reparented to a new "detached" entry
+		$entry = $this->getFileCacheEntry($refChild3Id);
+		$this->assertTrue(isset($entry['parent']));
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('detached/ref_child3', $entry['path']);
+		$this->assertEquals(md5('detached/ref_child3'), $entry['path_hash']);
+
+		// entry "detached" was restored
+		$entry = $this->getFileCacheEntry($entry['parent']);
+		$this->assertEquals($rootId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('detached', $entry['path']);
+		$this->assertEquals(md5('detached'), $entry['path_hash']);
+	}
+
+	/**
+	 * Test repair wrong parent id
+	 */
+	public function testRepairParentIdPointingNowhere() {
+		/**
+		 * Wrong parent id
+		 *     - wrongparentroot
+		 *     - files/wrongparent
+		 */
+		$storageId = 1;
+		$rootId1 = $this->createFileCacheEntry($storageId, '');
+		$baseId1 = $this->createFileCacheEntry($storageId, 'files', $rootId1);
+
+		$nonExistingParentId = $this->createNonExistingId();
+		$wrongParentRootId = $this->createFileCacheEntry($storageId, 'wrongparentroot', $nonExistingParentId);
+		$wrongParentId = $this->createFileCacheEntry($storageId, 'files/wrongparent', $nonExistingParentId);
+
+		$outputMock = $this->createMock(IOutput::class);
+		$this->repair->run($outputMock);
+
+		// wrong parent root reparented to actual root
+		$entry = $this->getFileCacheEntry($wrongParentRootId);
+		$this->assertEquals($rootId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('wrongparentroot', $entry['path']);
+		$this->assertEquals(md5('wrongparentroot'), $entry['path_hash']);
+
+		// wrong parent subdir reparented to "files"
+		$entry = $this->getFileCacheEntry($wrongParentId);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/wrongparent', $entry['path']);
+		$this->assertEquals(md5('files/wrongparent'), $entry['path_hash']);
+
+		// root entry left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+	}
+
+	/**
+	 * Test repair detached subtree
+	 */
+	public function testRepairDetachedSubtree() {
+		/**
+		 * other:
+		 *     - files/missingdir/orphaned1 (orphaned entry as "missingdir" is missing)
+		 *     - missingdir/missingdir1/orphaned2 (orphaned entry two levels up to root)
+		 *     - noroot (orphaned entry on a storage that has no root entry)
+		 */
+		$storageId = 1;
+		$storageId2 = 2;
+		$rootId1 = $this->createFileCacheEntry($storageId, '');
+		$baseId1 = $this->createFileCacheEntry($storageId, 'files', $rootId1);
+
+		$nonExistingParentId = $this->createNonExistingId();
+		$orphanedId1 = $this->createFileCacheEntry($storageId, 'files/missingdir/orphaned1', $nonExistingParentId);
+
+		$nonExistingParentId2 = $this->createNonExistingId();
+		$orphanedId2 = $this->createFileCacheEntry($storageId, 'missingdir/missingdir1/orphaned2', $nonExistingParentId2);
+
+		$nonExistingParentId3 = $this->createNonExistingId();
+		$orphanedId3 = $this->createFileCacheEntry($storageId2, 'noroot', $nonExistingParentId3);
+
+		$outputMock = $this->createMock(IOutput::class);
+		$this->repair->run($outputMock);
+
+		// orphaned entry reattached
+		$entry = $this->getFileCacheEntry($orphanedId1);
+		$this->assertEquals($nonExistingParentId, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/missingdir/orphaned1', $entry['path']);
+		$this->assertEquals(md5('files/missingdir/orphaned1'), $entry['path_hash']);
+
+		// non existing id exists now
+		$entry = $this->getFileCacheEntry($entry['parent']);
+		$this->assertEquals($baseId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('files/missingdir', $entry['path']);
+		$this->assertEquals(md5('files/missingdir'), $entry['path_hash']);
+
+		// orphaned entry reattached
+		$entry = $this->getFileCacheEntry($orphanedId2);
+		$this->assertEquals($nonExistingParentId2, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('missingdir/missingdir1/orphaned2', $entry['path']);
+		$this->assertEquals(md5('missingdir/missingdir1/orphaned2'), $entry['path_hash']);
+
+		// non existing id exists now
+		$entry = $this->getFileCacheEntry($entry['parent']);
+		$this->assertTrue(isset($entry['parent']));
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('missingdir/missingdir1', $entry['path']);
+		$this->assertEquals(md5('missingdir/missingdir1'), $entry['path_hash']);
+
+		// non existing id parent exists now
+		$entry = $this->getFileCacheEntry($entry['parent']);
+		$this->assertEquals($rootId1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('missingdir', $entry['path']);
+		$this->assertEquals(md5('missingdir'), $entry['path_hash']);
+
+		// root entry left alone
+		$entry = $this->getFileCacheEntry($rootId1);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$storageId, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+
+		// orphaned entry with no root reattached
+		$entry = $this->getFileCacheEntry($orphanedId3);
+		$this->assertTrue(isset($entry['parent']));
+		$this->assertEquals((string)$storageId2, $entry['storage']);
+		$this->assertEquals('noroot', $entry['path']);
+		$this->assertEquals(md5('noroot'), $entry['path_hash']);
+
+		// recreated root entry
+		$entry = $this->getFileCacheEntry($entry['parent']);
+		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals((string)$storageId2, $entry['storage']);
+		$this->assertEquals('', $entry['path']);
+		$this->assertEquals(md5(''), $entry['path_hash']);
+	}
+}
+

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -599,7 +599,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		// orphaned entry reattached
 		$entry = $this->getFileCacheEntry($orphanedId1);
-		$this->assertEquals($nonExistingParentId, $entry['parent']); // this row fails, $entry['parent'] seems to equal a similar but different value
+		$this->assertEquals($nonExistingParentId, $entry['parent']);
 		$this->assertEquals((string)$storageId, $entry['storage']);
 		$this->assertEquals('files/missingdir/orphaned1', $entry['path']);
 		$this->assertEquals(md5('files/missingdir/orphaned1'), $entry['path_hash']);
@@ -713,7 +713,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		// recreated root entry
 		$entry = $this->getFileCacheEntry($entry['parent']);
-		$this->assertEquals(-1, $entry['parent']); // this row fails, it appears to get attached to another entry, not the root (fileid ~ 4000)
+		$this->assertEquals(-1, $entry['parent']);
 		$this->assertEquals((string)$storageId, $entry['storage']);
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -583,6 +583,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		// end corrupt storage
 
 		// Parallel test storage
+		/*
 		$storageId_parallel = 2;
 		$rootId1_parallel = $this->createFileCacheEntry($storageId_parallel, '');
 		$baseId1_parallel = $this->createFileCacheEntry($storageId_parallel, 'files', $rootId1_parallel);
@@ -592,6 +593,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$notOrphanedFolderChild2_parallel = $this->createFileCacheEntry($storageId_parallel, 'missingdir/missingdir1', $notOrphanedFolder2_parallel);
 		$notOrphanedId2_parallel = $this->createFileCacheEntry($storageId_parallel, 'missingdir/missingdir1/orphaned2', $notOrphanedFolder2_parallel);
 		// end parallel test storage
+		*/
 
 		$outputMock = $this->createMock(IOutput::class);
 		$this->repair->setStorageNumericId($storageId);
@@ -599,7 +601,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		// orphaned entry reattached
 		$entry = $this->getFileCacheEntry($orphanedId1);
-		$this->assertEquals($nonExistingParentId, $entry['parent']);
+		$this->assertEquals($nonExistingParentId, $entry['parent']); // this row fails, $entry['parent'] seems to equal a similar but different value
 		$this->assertEquals((string)$storageId, $entry['storage']);
 		$this->assertEquals('files/missingdir/orphaned1', $entry['path']);
 		$this->assertEquals(md5('files/missingdir/orphaned1'), $entry['path_hash']);
@@ -640,6 +642,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals(md5(''), $entry['path_hash']);
 
 		// now check the parallel storage is intact
+		/*
 		// orphaned entry reattached
 		$entry = $this->getFileCacheEntry($notOrphanedId1_parallel);
 		$this->assertEquals($notOrphanedFolder_parallel, $entry['parent']);
@@ -681,6 +684,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals((string)$storageId_parallel, $entry['storage']);
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);
+		*/
 	}
 
 	/**
@@ -695,9 +699,11 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$orphanedId = $this->createFileCacheEntry($storageId, 'noroot', $nonExistingParentId);
 
 		// Test parallel storage which should be untouched by the repair operation
+		/*
 		$testStorageId = 2;
 		$baseId = $this->createFileCacheEntry($testStorageId, '');
 		$noRootid = $this->createFileCacheEntry($testStorageId, 'noroot', $baseId);
+		*/
 
 
 		$outputMock = $this->createMock(IOutput::class);
@@ -713,11 +719,12 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		// recreated root entry
 		$entry = $this->getFileCacheEntry($entry['parent']);
-		$this->assertEquals(-1, $entry['parent']);
+		$this->assertEquals(-1, $entry['parent']); // this row fails, it appears to get attached to another entry, not the root (fileid ~ 4000)
 		$this->assertEquals((string)$storageId, $entry['storage']);
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);
 
+		/*
 		// Check that the parallel test storage is still intact
 		$entry = $this->getFileCacheEntry($noRootid);
 		$this->assertEquals($baseId, $entry['parent']);
@@ -729,6 +736,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals((string)$testStorageId, $entry['storage']);
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);
+		*/
 	}
 }
 

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -583,7 +583,6 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		// end corrupt storage
 
 		// Parallel test storage
-		/*
 		$storageId_parallel = 2;
 		$rootId1_parallel = $this->createFileCacheEntry($storageId_parallel, '');
 		$baseId1_parallel = $this->createFileCacheEntry($storageId_parallel, 'files', $rootId1_parallel);
@@ -593,7 +592,6 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$notOrphanedFolderChild2_parallel = $this->createFileCacheEntry($storageId_parallel, 'missingdir/missingdir1', $notOrphanedFolder2_parallel);
 		$notOrphanedId2_parallel = $this->createFileCacheEntry($storageId_parallel, 'missingdir/missingdir1/orphaned2', $notOrphanedFolder2_parallel);
 		// end parallel test storage
-		*/
 
 		$outputMock = $this->createMock(IOutput::class);
 		$this->repair->setStorageNumericId($storageId);
@@ -642,7 +640,6 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals(md5(''), $entry['path_hash']);
 
 		// now check the parallel storage is intact
-		/*
 		// orphaned entry reattached
 		$entry = $this->getFileCacheEntry($notOrphanedId1_parallel);
 		$this->assertEquals($notOrphanedFolder_parallel, $entry['parent']);
@@ -684,7 +681,6 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals((string)$storageId_parallel, $entry['storage']);
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);
-		*/
 	}
 
 	/**
@@ -699,11 +695,9 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$orphanedId = $this->createFileCacheEntry($storageId, 'noroot', $nonExistingParentId);
 
 		// Test parallel storage which should be untouched by the repair operation
-		/*
 		$testStorageId = 2;
 		$baseId = $this->createFileCacheEntry($testStorageId, '');
 		$noRootid = $this->createFileCacheEntry($testStorageId, 'noroot', $baseId);
-		*/
 
 
 		$outputMock = $this->createMock(IOutput::class);
@@ -724,7 +718,6 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);
 
-		/*
 		// Check that the parallel test storage is still intact
 		$entry = $this->getFileCacheEntry($noRootid);
 		$this->assertEquals($baseId, $entry['parent']);
@@ -736,7 +729,6 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals((string)$testStorageId, $entry['storage']);
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);
-		*/
 	}
 }
 

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -35,7 +35,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		$this->connection = \OC::$server->getDatabaseConnection();
 
-		$mimeLoader = $this->createMock(IMimeTypeLoader::class);
+		$mimeLoader = $this->getMockBuilder(IMimeTypeLoader::class)->getMock();
 		$mimeLoader->method('getId')
 			->will($this->returnValueMap([
 				['httpd', 1],
@@ -205,7 +205,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		$doNotTouchId = $this->createFileCacheEntry($sourceStorageId, 'files/source/do_not_touch', $sourceId);
 
-		$outputMock = $this->createMock(IOutput::class);
+		$outputMock = $this->getMockBuilder(IOutput::class)->getMock();
 		if (is_null($repairStoragesOrder)) {
 			// no storage selected, full repair
 			$this->repair->setStorageNumericId(null);
@@ -345,7 +345,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		// End parallel storage
 
 
-		$outputMock = $this->createMock(IOutput::class);
+		$outputMock = $this->getMockBuilder(IOutput::class)->getMock();
 		$this->repair->setStorageNumericId($storageId);
 		$this->repair->run($outputMock);
 
@@ -535,7 +535,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$wrongParentRootId = $this->createFileCacheEntry($storageId, 'wrongparentroot', $nonExistingParentId);
 		$wrongParentId = $this->createFileCacheEntry($storageId, 'files/wrongparent', $nonExistingParentId);
 
-		$outputMock = $this->createMock(IOutput::class);
+		$outputMock = $this->getMockBuilder(IOutput::class)->getMock();
 		$this->repair->setStorageNumericId($storageId);
 		$this->repair->run($outputMock);
 
@@ -593,7 +593,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$notOrphanedId2_parallel = $this->createFileCacheEntry($storageId_parallel, 'missingdir/missingdir1/orphaned2', $notOrphanedFolder2_parallel);
 		// end parallel test storage
 
-		$outputMock = $this->createMock(IOutput::class);
+		$outputMock = $this->getMockBuilder(IOutput::class)->getMock();
 		$this->repair->setStorageNumericId($storageId);
 		$this->repair->run($outputMock);
 
@@ -700,7 +700,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$noRootid = $this->createFileCacheEntry($testStorageId, 'noroot', $baseId);
 
 
-		$outputMock = $this->createMock(IOutput::class);
+		$outputMock = $this->getMockBuilder(IOutput::class)->getMock();
 		$this->repair->setStorageNumericId($storageId);
 		$this->repair->run($outputMock);
 

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -220,9 +220,6 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		$dataDir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data-autotest');
 		if (self::$wasDatabaseAllowed && \OC::$server->getDatabaseConnection()) {
 			$connection = \OC::$server->getDatabaseConnection();
-			if ($connection->inTransaction()) {
-				//throw new \Exception('Stray transaction in test class ' . get_called_class());
-			}
 			$queryBuilder = $connection->getQueryBuilder();
 
 			self::tearDownAfterClassCleanShares($queryBuilder);

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -221,7 +221,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		if (self::$wasDatabaseAllowed && \OC::$server->getDatabaseConnection()) {
 			$connection = \OC::$server->getDatabaseConnection();
 			if ($connection->inTransaction()) {
-				throw new \Exception('Stray transaction in test class ' . get_called_class());
+				//throw new \Exception('Stray transaction in test class ' . get_called_class());
 			}
 			$queryBuilder = $connection->getQueryBuilder();
 

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -219,7 +219,11 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		}
 		$dataDir = \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data-autotest');
 		if (self::$wasDatabaseAllowed && \OC::$server->getDatabaseConnection()) {
-			$queryBuilder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+			$connection = \OC::$server->getDatabaseConnection();
+			if ($connection->inTransaction()) {
+				throw new \Exception('Stray transaction in test class ' . get_called_class());
+			}
+			$queryBuilder = $connection->getQueryBuilder();
 
 			self::tearDownAfterClassCleanShares($queryBuilder);
 			self::tearDownAfterClassCleanStorages($queryBuilder);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Backport of https://github.com/owncloud/core/pull/28253 to stable9.1. Attempts to repair oc_filecache and retain metadata whilst doing so.

## Motivation and Context
Underlying filecache corruption caused by a bug in 9.

## How Has This Been Tested?
Manually using occ scan commands.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

