### PR TITLE
[WIP] Fix missing owner in share tab for fed share

### DIFF
--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -118,9 +118,13 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreate() {
 		$share = $this->shareManager->newShare();
 
+		$user = $this->createMock('\OCP\IUser');
+		$user->method('getDisplayName')->willReturn('user@server.com');
 		$node = $this->createMock('\OCP\Files\File');
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
+		$node->method('getOwner')->willReturn($user);
+		$node->method('getPath')->willReturn('/user/foo/myFile');
 
 		$share->setSharedWith('user@server.com')
 			->setSharedBy('sharedBy')
@@ -189,9 +193,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreateCouldNotFindServer() {
 		$share = $this->shareManager->newShare();
 
+		$user = $this->createMock('\OCP\IUser');
+		$user->method('getDisplayName')->willReturn('user@server.com');
+
 		$node = $this->createMock('\OCP\Files\File');
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
+		$node->method('getOwner')->willReturn($user);
+		$node->method('getPath')->willReturn('/user/foo/myFile');
 
 		$share->setSharedWith('user@server.com')
 			->setSharedBy('sharedBy')
@@ -245,9 +254,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreateException() {
 		$share = $this->shareManager->newShare();
 
+		$user = $this->createMock('\OCP\IUser');
+		$user->method('getDisplayName')->willReturn('user@server.com');
+
 		$node = $this->createMock('\OCP\Files\File');
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
+		$node->method('getOwner')->willReturn($user);
+		$node->method('getPath')->willReturn('/user/foo/myFile');
 
 		$share->setSharedWith('user@server.com')
 			->setSharedBy('sharedBy')
@@ -301,9 +315,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreateShareWithSelf() {
 		$share = $this->shareManager->newShare();
 
+		$user = $this->createMock('\OCP\IUser');
+		$user->method('getDisplayName')->willReturn('user@server.com');
+
 		$node = $this->createMock('\OCP\Files\File');
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
+		$node->method('getOwner')->willReturn($user);
+		$node->method('getPath')->willReturn('/user/foo/myFile');
 
 		$this->addressHandler->expects($this->any())->method('compareAddresses')
 			->willReturn(true);
@@ -340,9 +359,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	public function testCreateAlreadyShared() {
 		$share = $this->shareManager->newShare();
 
+		$user = $this->createMock('\OCP\IUser');
+		$user->method('getDisplayName')->willReturn('user@server.com');
+
 		$node = $this->createMock('\OCP\Files\File');
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
+		$node->method('getOwner')->willReturn($user);
+		$node->method('getPath')->willReturn('/user/foo/myFile');
 
 
 		$this->addressHandler->expects($this->any())->method('splitUserRemote')
@@ -372,7 +396,12 @@ class FederatedShareProviderTest extends \Test\TestCase {
 				'sharedBy@http://localhost/'
 			)->willReturn(true);
 
-		$this->rootFolder->expects($this->never())->method($this->anything());
+		$folder = $this->createMock('\OCP\Files\Folder');
+		$folder->method('getById')->willReturn([$node]);
+
+		$this->rootFolder->expects($this->any())->method('getUserFolder')
+			->with('user')
+			->willReturn($folder);
 
 		$this->provider->create($share);
 
@@ -406,9 +435,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 
 		$share = $this->shareManager->newShare();
 
+		$user = $this->createMock('\OCP\IUser');
+		$user->method('getDisplayName')->willReturn('user@server.com');
+
 		$node = $this->createMock('\OCP\Files\File');
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
+		$node->method('getOwner')->willReturn($user);
+		$node->method('getPath')->willReturn('/user/foo/myFile');
 
 
 		$this->addressHandler->expects($this->any())->method('splitUserRemote')
@@ -469,9 +503,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 
 
 	public function testGetAllSharesByNodes() {
+		$user = $this->createMock('\OCP\IUser');
+		$user->method('getDisplayName')->willReturn('user@server.com');
+
 		$node = $this->createMock('\OCP\Files\File');
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
+		$node->method('getOwner')->willReturn($user);
+		$node->method('getPath')->willReturn('/user/foo/myFile');
 
 		$this->tokenHandler->method('generateToken')->willReturn('token');
 		$this->notifications
@@ -491,6 +530,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$node2 = $this->createMock('\OCP\Files\File');
 		$node2->method('getId')->willReturn(43);
 		$node2->method('getName')->willReturn('myOtherFile');
+		$node2->method('getOwner')->willReturn($user);
+		$node2->method('getPath')->willReturn('/user/foo/myOtherFile');
 
 		$share2 = $this->shareManager->newShare();
 		$share2->setSharedWith('user@server.com')
@@ -507,9 +548,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetAllSharedByWithReshares() {
+		$user = $this->createMock('\OCP\IUser');
+		$user->method('getDisplayName')->willReturn('user@server.com');
+
 		$node = $this->createMock('\OCP\Files\File');
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
+		$node->method('getOwner')->willReturn($user);
+		$node->method('getPath')->willReturn('/user/foo/myFile');
 
 		$this->tokenHandler->method('generateToken')->willReturn('token');
 		$this->notifications
@@ -551,9 +597,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharedBy() {
+		$user = $this->createMock('\OCP\IUser');
+		$user->method('getDisplayName')->willReturn('user@server.com');
+
 		$node = $this->createMock('\OCP\Files\File');
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
+		$node->method('getOwner')->willReturn($user);
+		$node->method('getPath')->willReturn('/user/foo/myFile');
 
 		$this->addressHandler->expects($this->at(0))->method('splitUserRemote')
 			->willReturn(['user', 'server.com']);
@@ -566,7 +617,15 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->method('sendRemoteShare')
 			->willReturn(true);
 
-		$this->rootFolder->expects($this->never())->method($this->anything());
+		$node2 = $this->createMock('\OCP\Files\File');
+		$node->method('getPath')->willReturn('/user/foo/myFile1');
+
+		$folder = $this->createMock('\OCP\Files\Folder');
+		$folder->method('getById')->willReturn([$node2]);
+
+		$this->rootFolder->expects($this->any())->method('getUserFolder')
+			->with('user')
+			->willReturn($folder);
 
 		$share = $this->shareManager->newShare();
 		$share->setSharedWith('user@server.com')
@@ -592,9 +651,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharedByWithNode() {
+		$user = $this->createMock('\OCP\IUser');
+		$user->method('getDisplayName')->willReturn('user@server.com');
+
 		$node = $this->createMock('\OCP\Files\File');
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
+		$node->method('getOwner')->willReturn($user);
+		$node->method('getPath')->willReturn('/user/foo/myFile');
 
 		$this->tokenHandler->method('generateToken')->willReturn('token');
 		$this->notifications
@@ -611,9 +675,13 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setNode($node);
 		$this->provider->create($share);
 
+		$user2 = $this->createMock('\OCP\IUser');
+		$user2->method('getDisplayName')->willReturn('user@server.com');
 		$node2 = $this->createMock('\OCP\Files\File');
 		$node2->method('getId')->willReturn(43);
 		$node2->method('getName')->willReturn('myOtherFile');
+		$node2->method('getOwner')->willReturn($user2);
+		$node2->method('getPath')->willReturn('/user/foo/myOtherFile');
 
 		$share2 = $this->shareManager->newShare();
 		$share2->setSharedWith('user@server.com')
@@ -630,9 +698,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharedByWithReshares() {
+		$user = $this->createMock('\OCP\IUser');
+		$user->method('getDisplayName')->willReturn('user@server.com');
+
 		$node = $this->createMock('\OCP\Files\File');
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
+		$node->method('getOwner')->willReturn($user);
+		$node->method('getPath')->willReturn('/user/foo/myFile');
 
 		$this->tokenHandler->method('generateToken')->willReturn('token');
 		$this->notifications
@@ -663,9 +736,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharedByWithLimit() {
+		$user = $this->createMock('\OCP\IUser');
+		$user->method('getDisplayName')->willReturn('user@server.com');
+
 		$node = $this->createMock('\OCP\Files\File');
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
+		$node->method('getOwner')->willReturn($user);
+		$node->method('getPath')->willReturn('/user/foo/myFile');
 
 		$this->addressHandler->expects($this->any())->method('splitUserRemote')
 			->willReturnCallback(function ($uid) {
@@ -680,7 +758,15 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->method('sendRemoteShare')
 			->willReturn(true);
 
-		$this->rootFolder->expects($this->never())->method($this->anything());
+		$node2 = $this->createMock('\OCP\Files\File');
+		$node->method('getPath')->willReturn('/user/foo/myFile1');
+
+		$folder = $this->createMock('\OCP\Files\Folder');
+		$folder->method('getById')->willReturn([$node2]);
+
+		$this->rootFolder->expects($this->any())->method('getUserFolder')
+			->with('user')
+			->willReturn($folder);
 
 		$share = $this->shareManager->newShare();
 		$share->setSharedWith('user@server.com')

--- a/apps/files_sharing/tests/API/Share20OCSTest.php
+++ b/apps/files_sharing/tests/API/Share20OCSTest.php
@@ -2647,10 +2647,15 @@ class Share20OCSTest extends TestCase {
 			->with('files_sharing.sharecontroller.showShare', ['token' => 'myToken'])
 			->willReturn('myLink');
 
-
-		$this->rootFolder->method('getUserFolder')
-			->with($this->currentUser->getUID())
-			->will($this->returnSelf());
+		if ($share->getShareType() === 6) {
+			$this->rootFolder->method('getUserFolder')
+				->with($share->getSharedBy())
+				->will($this->returnSelf());
+		} else {
+			$this->rootFolder->method('getUserFolder')
+				->with($this->currentUser->getUID())
+				->will($this->returnSelf());
+		}
 
 		if (!$exception) {
 			$this->rootFolder->method('getById')


### PR DESCRIPTION
When files or folders are shared using federated
share, the owner of the share was missing in the
share tab. This change helps to fix it.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
This change helps to fix the missing owner information in the share tab.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/24902

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When files/folders are shared using federated share, owner information was missing in the recipient users share tab. This change tries to fix the same.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

