### PR TITLE
implement getTrimmedText wrapper for UI tests

### DIFF
--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -59,7 +59,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	 */
 	public function aNotificationShouldBeDisplayedWithTheText($notificationText) {
 		PHPUnit_Framework_Assert::assertEquals(
-			$notificationText, trim($this->owncloudPage->getNotificationText())
+			$notificationText, $this->owncloudPage->getNotificationText()
 		);
 	}
 
@@ -80,7 +80,7 @@ class FeatureContext extends RawMinkContext implements Context {
 		foreach ($tableRows as $row) {
 			PHPUnit_Framework_Assert::assertEquals(
 				$row[0],
-				trim($notifications[$notificationCounter])
+				$notifications[$notificationCounter]
 			);
 			$notificationCounter++;
 		}

--- a/tests/ui/features/bootstrap/SharingContext.php
+++ b/tests/ui/features/bootstrap/SharingContext.php
@@ -255,7 +255,7 @@ class SharingContext extends RawMinkContext implements Context {
 		$row = $this->filesPage->findFileRowByName($itemName, $this->getSession());
 		$sharingBtn = $row->findSharingButton();
 		PHPUnit_Framework_Assert::assertSame(
-			$sharerName, $sharingBtn->getText()
+			$sharerName, $this->filesPage->getTrimmedText($sharingBtn)
 		);
 		$sharingDialog = $this->filesPage->openSharingDialog(
 			$itemName, $this->getSession()

--- a/tests/ui/features/bootstrap/UsersContext.php
+++ b/tests/ui/features/bootstrap/UsersContext.php
@@ -187,7 +187,7 @@ class UsersContext extends RawMinkContext implements Context {
 	 * @throws ExpectationException
 	 */
 	public function quotaOfUserShouldBeSetTo($username, $quota) {
-		$setQuota = trim($this->usersPage->getQuotaOfUser($username));
+		$setQuota = $this->usersPage->getQuotaOfUser($username);
 		if ($setQuota !== $quota) {
 			throw new ExpectationException(
 				'Users quota is set to "' . $setQuota . '" expected "' .

--- a/tests/ui/features/lib/FilesPageElement/FileRow.php
+++ b/tests/ui/features/lib/FilesPageElement/FileRow.php
@@ -216,7 +216,7 @@ class FileRow extends OwnCloudPage {
 	 * @return string
 	 */
 	public function getTooltip() {
-		return $this->findTooltipElement()->getText();
+		return $this->getTrimmedText($this->findTooltipElement());
 	}
 
 	/**

--- a/tests/ui/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/ui/features/lib/FilesPageElement/SharingDialog.php
@@ -142,7 +142,7 @@ class SharingDialog extends OwncloudPage {
 			$this->autocompleteItemsTextXpath
 		);
 		foreach ($itemElements as $item) {
-			array_push($itemsArray, $item->getText());
+			array_push($itemsArray, $this->getTrimmedText($item));
 		}
 		return $itemsArray;
 	}
@@ -166,7 +166,7 @@ class SharingDialog extends OwncloudPage {
 	
 			$userFound = false;
 			foreach ($userElements as $user) {
-				if ($user->getText() === $nameToMatch) {
+				if ($this->getTrimmedText($user) === $nameToMatch) {
 					$user->click();
 					$this->waitForAjaxCallsToStartAndFinish($session);
 					$userFound = true;
@@ -322,7 +322,7 @@ class SharingDialog extends OwncloudPage {
 				"could not find share-with-tooltip"
 			);
 		}
-		return $shareWithTooltip->getText();
+		return $this->getTrimmedText($shareWithTooltip);
 	}
 
 	/**
@@ -353,7 +353,7 @@ class SharingDialog extends OwncloudPage {
 	 */
 	public function getSharedWithGroupAndSharerName() {
 		if (is_null($this->sharedWithGroupAndSharerName)) {
-			$text = $this->findSharerInformationItem()->getText();
+			$text = $this->getTrimmedText($this->findSharerInformationItem());
 			if (preg_match("/" . $this->sharedWithAndByRegEx . "/", $text, $matches)) {
 				$this->sharedWithGroupAndSharerName = [
 					"sharedWithGroup" => $matches [1],

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -153,7 +153,7 @@ class OwncloudPage extends Page {
 			);
 		}
 
-		return $notificationElement->getText();
+		return $this->getTrimmedText($notificationElement);
 	}
 
 	/**
@@ -173,7 +173,7 @@ class OwncloudPage extends Page {
 		}
 
 		foreach ($notifications->findAll("xpath", "div") as $notification) {
-			array_push($notificationsText, $notification->getText());
+			array_push($notificationsText, $this->getTrimmedText($notification));
 		}
 		return $notificationsText;
 	}
@@ -232,7 +232,7 @@ class OwncloudPage extends Page {
 			);
 		}
 
-		return $userNameDisplayElement->getText();
+		return $this->getTrimmedText($userNameDisplayElement);
 	}
 
 	/**
@@ -454,6 +454,19 @@ class OwncloudPage extends Page {
 			$inputField->keyUp(27); //send escape
 			throw new \Exception("value of input field is not what we expect");
 		}
+	}
+
+	/**
+	 * Edge often returns whitespace before or after element text.
+	 * This is a convenient wrapper to ensure that text is trimmed
+	 * before using it in tests.
+	 *
+	 * @param NodeElement $element
+	 * @throws \Exception
+	 * @return string text of the element with any whitespace trimmed
+	 */
+	public function getTrimmedText(NodeElement $element) {
+		return trim($element->getText());
 	}
 
 	/**

--- a/tests/ui/features/lib/OwncloudPageElement/OCDialog.php
+++ b/tests/ui/features/lib/OwncloudPageElement/OCDialog.php
@@ -74,7 +74,7 @@ class OCDialog extends OwncloudPage {
 				"could not find title"
 			);
 		}
-		return $title->getText();
+		return $this->getTrimmedText($title);
 	}
 
 	/**
@@ -91,7 +91,7 @@ class OCDialog extends OwncloudPage {
 				"could not find content element"
 			);
 		}
-		return $contentElement->getText();
+		return $this->getTrimmedText($contentElement);
 	}
 
 	/**

--- a/tests/ui/features/lib/PersonalSecuritySettingsPage.php
+++ b/tests/ui/features/lib/PersonalSecuritySettingsPage.php
@@ -101,7 +101,7 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 		$appTrs = $this->findAll("xpath", $this->linkedAppsTrXpath);
 		foreach ($appTrs as $appTr) {
 			$app = $appTr->find("xpath", $this->linkedAppNameXpath);
-			if (!is_null($app) && ($app->getText() === $appName)) {
+			if (!is_null($app) && ($this->getTrimmedText($app) === $appName)) {
 				return $appTr;
 			}
 		}

--- a/tests/ui/features/lib/UserPageElement/GroupList.php
+++ b/tests/ui/features/lib/UserPageElement/GroupList.php
@@ -108,7 +108,7 @@ class GroupList extends OwncloudPage {
 		);
 		$allGroups = [];
 		foreach ($allGroupElements as $element) {
-			$allGroups[] = $element->getText();
+			$allGroups[] = $this->getTrimmedText($element);
 		}
 		return $allGroups;
 	}

--- a/tests/ui/features/lib/UsersPage.php
+++ b/tests/ui/features/lib/UsersPage.php
@@ -72,7 +72,7 @@ class UsersPage extends OwncloudPage {
 
 		foreach ($userTrs as $userTr) {
 			$user = $userTr->find("css", ".name");
-			if ($user->getText() === $username) {
+			if ($this->getTrimmedText($user) === $username) {
 				return $userTr;
 			}
 		}
@@ -107,7 +107,7 @@ class UsersPage extends OwncloudPage {
 			);
 		}
 
-		return $selectField->getText();
+		return $this->getTrimmedText($selectField);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Provide a common wrapper ``getTrimmedText()`` so that it is easy to always trim the results of ``getText()`` before using it in comparing results of tests.

## Related Issue
#29138 Make UI tests run on Edge browser
this PR is more stuff that helps Edge, and is not bad for existing browsers

## Motivation and Context
Edge sometimes returns whitespace at the ends of UI text returned by the ``getText()`` method. We do not want that - it messes up comparisons in tests.

## How Has This Been Tested?
Travis

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

