### PR TITLE
[stable10] Improve public link sharing permissions for folders

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -254,9 +254,6 @@
 }
 /* ---------------------------------------------------- PUBLIC LINK MODAL --- */
 
-.public-link-modal {
-  width: 340px;
-}
 .public-link-modal--item {
   margin-bottom: 20px;
 }

--- a/core/css/jquery.ocdialog.css
+++ b/core/css/jquery.ocdialog.css
@@ -8,13 +8,28 @@
 	-webkit-box-sizing: border-box;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
-	min-width: 200px;
-
-	/* Center positioning */
-	left: 50%;
-	top: 50%;
-	transform: translate(-50%,-50%);
+	min-width: 340px;
 }
+
+@media (max-width: 512px) {
+	.oc-dialog {
+		position: absolute;
+		top: 55px;
+		right: 10px;
+		left: 10px;
+	}
+}
+
+@media (min-width: 513px) {
+	/* Center positioning */
+	.oc-dialog {
+		position: fixed;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%,-50%);
+	}
+}
+
 .oc-dialog-title {
 	background: white;
 	font-weight: bold;

--- a/core/js/jquery.ocdialog.js
+++ b/core/js/jquery.ocdialog.js
@@ -10,12 +10,6 @@
 		_create: function() {
 			var self = this;
 
-			this.originalCss = {
-				display: this.element[0].style.display,
-				width: this.element[0].style.width,
-				height: this.element[0].style.height
-			};
-
 			this.originalTitle = this.element.attr('title');
 			this.options.title = this.options.title || this.originalTitle;
 
@@ -28,11 +22,6 @@
 				.insertBefore(this.element);
 			this.$dialog.append(this.element.detach());
 			this.element.removeAttr('title').addClass('oc-dialog-content').appendTo(this.$dialog);
-
-			this.$dialog.css({
-				display: 'inline-block',
-				position: 'fixed'
-			});
 
 			$(document).on('keydown keyup', function(event) {
 				if (
@@ -138,12 +127,6 @@
 						this.$dialog.find('.oc-dialog-close').remove();
 					}
 					break;
-				case 'width':
-					this.$dialog.css('width', value);
-					break;
-				case 'height':
-					this.$dialog.css('height', value);
-					break;
 				case 'close':
 					this.closeCB = value;
 					break;
@@ -154,27 +137,6 @@
 		_setOptions: function(options) {
 			//this._super(options);
 			$.Widget.prototype._setOptions.apply(this, arguments);
-		},
-		_setSizes: function() {
-			// var content_height = this.$dialog.height();
-			// if(this.$title) {
-			// 	content_height -= this.$title.outerHeight(true);
-			// }
-			// if(this.$buttonrow) {
-			// 	content_height -= this.$buttonrow.outerHeight(true);
-			// }
-			// this.parent = this.$dialog.parent().length > 0 ? this.$dialog.parent() : $('body');
-			// content_height = Math.min(content_height, this.parent.height()-20);
-			// if (content_height> 0) {
-			// 	this.element.css({
-			// 		height: content_height + 'px',
-			// 		width: this.$dialog.innerWidth()-20 + 'px'
-			// 	});
-			// } else {
-			// 	this.element.css({
-			// 		width : this.$dialog.innerWidth() - 20 + 'px'
-			// 	});
-			// }
 		},
 		_createOverlay: function() {
 			if(!this.options.modal) {

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -22,19 +22,19 @@
 				'<label class="public-link-modal--label">Link Name</label>' +
 				'<input class="public-link-modal--input" type="text" name="linkName" placeholder="{{namePlaceholder}}" value="{{name}}" maxlength="64" />' +
 			'</div>' +
-			'{{#if publicUploadPossible}}' +
 			'<div id="allowPublicRead-{{cid}}" class="public-link-modal--item">' +
-				'<input type="radio" value="1" name="publicPermissions" id="sharingDialogAllowPublicRead-{{cid}}" class="checkbox publicPermissions publicReadCheckbox" {{#if publicReadSelected}}checked{{/if}} />' +
+				'<input type="radio" value="{{publicReadValue}}" name="publicPermissions" id="sharingDialogAllowPublicRead-{{cid}}" class="checkbox publicPermissions" {{#if publicReadSelected}}checked{{/if}} />' +
 				'<label class="bold" for="sharingDialogAllowPublicRead-{{cid}}">{{publicReadLabel}}</label>' +
 				'<p>{{publicReadDescription}}</p>' +
 			'</div>' +
+			'{{#if publicUploadPossible}}' +
 			'<div id="allowPublicReadWrite-{{cid}}" class="public-link-modal--item">' +
-				'<input type="radio" value="15" name="publicPermissions" id="sharingDialogAllowPublicReadWrite-{{cid}}" class="checkbox publicPermissions publicReadWriteCheckbox" {{#if publicReadWriteSelected}}checked{{/if}} />' +
+				'<input type="radio" value="{{publicReadWriteValue}}" name="publicPermissions" id="sharingDialogAllowPublicReadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicReadWriteSelected}}checked{{/if}} />' +
 				'<label class="bold" for="sharingDialogAllowPublicReadWrite-{{cid}}">{{publicReadWriteLabel}}</label>' +
 				'<p>{{publicReadWriteDescription}}</p>' +
 			'</div>' +
 			'<div id="allowPublicUploadWrapper-{{cid}}" class="public-link-modal--item">' +
-				'<input type="radio" value="4" name="publicPermissions" id="sharingDialogAllowPublicUpload-{{cid}}" class="checkbox publicPermissions publicUploadCheckbox" {{#if publicUploadSelected}}checked{{/if}} />' +
+				'<input type="radio" value="{{publicUploadValue}}" name="publicPermissions" id="sharingDialogAllowPublicUpload-{{cid}}" class="checkbox publicPermissions" {{#if publicUploadSelected}}checked{{/if}} />' +
 				'<label class="bold" for="sharingDialogAllowPublicUpload-{{cid}}">{{publicUploadLabel}}</label>' +
 				'<p>{{publicUploadDescription}}</p>' +
 			'</div>' +
@@ -99,9 +99,9 @@
 		 * @return {int} permissions
 		 */
 		_getPermissions: function() {
-			var $permissionRadio = this.$('input[name="publicPermissions"]:checked');
-			var permissions      = $permissionRadio.val();
-			return permissions;
+			var permissions = this.$('input[name="publicPermissions"]:checked').val();
+
+			return (permissions) ? permissions : OC.PERMISSION_READ;
 		},
 
 		_save: function () {
@@ -230,17 +230,21 @@
 				passwordLabel              : t('core', 'Password'),
 
 				publicUploadPossible       : this._isPublicUploadPossible(),
-				publicUploadSelected       : this.model.get('permissions') === 4,
+
 				publicUploadLabel          : t('core', 'Upload only (File Drop)'),
 				publicUploadDescription    : t('core', 'Receive files from others without revealing the contents of the folder.'),
+				publicUploadValue          : OC.PERMISSION_CREATE,
+				publicUploadSelected       : this.model.get('permissions') === OC.PERMISSION_CREATE,
 
-				publicReadSelected         : this.model.get('permissions') === 1,
 				publicReadLabel            : t('core', 'Read only'),
 				publicReadDescription      : t('core', 'Users can view and download contents.'),
+				publicReadValue            : OC.PERMISSION_READ,
+				publicReadSelected         : this.model.get('permissions') === OC.PERMISSION_READ,
 
-				publicReadWriteSelected    : this.model.get('permissions') === 15,
 				publicReadWriteLabel       : t('core', 'Read & Write'),
 				publicReadWriteDescription : t('core', 'Users can view, download, edit and upload contents.'),
+				publicReadWriteValue       : OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE,
+				publicReadWriteSelected    : this.model.get('permissions') >= (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE),
 
 				isMailEnabled: showEmailField
 			}));

--- a/core/js/tests/specs/sharedialoglinkshareviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinkshareviewSpec.js
@@ -135,18 +135,18 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 			publicUploadConfigStub.returns(true);
 			view.render();
 			expect(view.$('[name=linkName]').val()).toEqual('first link');
-			expect(view.$('.publicUploadCheckbox').prop('checked')).toEqual(false);
+			expect(view.$('.publicPermissions').prop('checked')).toEqual(true);
 			expect(view.$('.linkPassText').val()).toEqual('');
 			expect(view.$('.expirationDate').val()).toEqual('');
 
 			model.set({
 				password: 'set',
 				expireDate: '2017-10-12',
-				permissions: OC.PERMISSION_ALL
+				permissions: OC.PERMISSION_CREATE
 			});
 			view.render();
 
-			expect(view.$('.publicUploadCheckbox').prop('checked')).toEqual(true);
+			expect(parseInt(view.$('.publicPermissions:checked').val())).toBe(OC.PERMISSION_CREATE);
 			expect(view.$('.linkPassText').val()).toEqual('');
 			expect(view.$('.expirationDate').val()).toEqual('12-10-2017');
 		});
@@ -208,37 +208,15 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 					permissions: OC.PERMISSION_READ | OC.PERMISSION_CREATE
 				});
 				view.render();
-				expect(view.$('.showListingCheckbox').length).toEqual(1);
-				expect(view.$('.showListingCheckbox').is(':checked')).toEqual(true);
-				expect(view.$('.showListingCheckbox').is(':disabled')).toEqual(false);
+				expect(view.$('.publicPermissions').length).toEqual(3);
 			});
-			it('renders listing checkbox disabled when public upload is disallowed by user', function() {
+			it('renders checkbox disabled when public upload is disallowed by user', function() {
 				publicUploadConfigStub.returns(true);
 				model.set({
 					permissions: OC.PERMISSION_READ
 				});
 				view.render();
-				expect(view.$('.showListingCheckbox').length).toEqual(1);
-				expect(view.$('.showListingCheckbox').is(':checked')).toEqual(true);
-				expect(view.$('.showListingCheckbox').is(':disabled')).toEqual(true);
-			});
-			it('disables listing checkbox when ticking public upload', function() {
-				publicUploadConfigStub.returns(true);
-				model.set({
-					permissions: OC.PERMISSION_CREATE
-				});
-				view.render();
-
-				expect(view.$('.showListingCheckbox').length).toEqual(1);
-				expect(view.$('.showListingCheckbox').is(':checked')).toEqual(false);
-				expect(view.$('.showListingCheckbox').is(':disabled')).toEqual(false);
-
-				expect(view.$('.publicUploadCheckbox').length).toEqual(1);
-				expect(view.$('.publicUploadCheckbox').is(':checked')).toEqual(true);
-				view.$('.publicUploadCheckbox').trigger(new $.Event('click'));
-				expect(view.$('.publicUploadCheckbox').is(':checked')).toEqual(false);
-				expect(view.$('.showListingCheckbox').is(':checked')).toEqual(true);
-				expect(view.$('.showListingCheckbox').is(':disabled')).toEqual(true);
+				expect(view.$('.showListingCheckbox').length).toEqual(0);
 			});
 		});
 		describe('password logic', function() {
@@ -293,7 +271,7 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 				name: 'first link',
 				expireDate: '',
 				password: 'newpassword',
-				permissions: OC.PERMISSION_READ,
+				permissions: OC.PERMISSION_READ.toString(),
 				shareType: OC.Share.SHARE_TYPE_LINK
 			});
 		});
@@ -306,7 +284,7 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 			expect(saveStub.getCall(0).args[0]).toEqual({
 				name: 'first link',
 				expireDate: '',
-				permissions: OC.PERMISSION_READ,
+				permissions: OC.PERMISSION_READ.toString(),
 				shareType: OC.Share.SHARE_TYPE_LINK
 			});
 		});
@@ -394,30 +372,22 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 			});
 
 			var dataProvider = [
-				// globally enabled
-				[true, true, true, OC.PERMISSION_READ | OC.PERMISSION_CREATE | OC.PERMISSION_UPDATE | OC.PERMISSION_DELETE],
-				[true, true, false, OC.PERMISSION_CREATE],
-				[true, false, true, OC.PERMISSION_READ],
-				[true, false, false, OC.PERMISSION_READ],
-
-				// globally disabled, permission stays regardless
-				[false, false, false, OC.PERMISSION_READ],
-				[false, true, false, OC.PERMISSION_READ],
-				[false, true, false, OC.PERMISSION_READ],
-				[false, true, true, OC.PERMISSION_READ],
+				[true, OC.PERMISSION_READ | OC.PERMISSION_CREATE | OC.PERMISSION_UPDATE | OC.PERMISSION_DELETE],
+				[true, OC.PERMISSION_CREATE],
+				[true, OC.PERMISSION_READ],
+				[false, OC.PERMISSION_READ], // globally disabled, permission stays regardless
 			];
 
-			function testPermissions(globalEnabled, uploadChecked, listingChecked, expectedPerms) {
+			function testPermissions(globalEnabled, expectedPerms) {
+				expectedPerms = expectedPerms.toString();
 				it('sets permissions to ' + expectedPerms +
 					' if global enabled is ' + globalEnabled +
-					' and public upload checkbox is ' + uploadChecked +
-					' and listing checkbox is ' + listingChecked, function() {
+					' and corresponding radiobutton is checked', function() {
 
 					publicUploadConfigStub.returns(globalEnabled);
 					view.render();
 
-					view.$('.publicUploadCheckbox').prop('checked', uploadChecked);
-					view.$('.showListingCheckbox').prop('checked', listingChecked);
+					view.$('input[name="publicPermissions"]:checked').val(expectedPerms);
 
 					view._save();
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
- Rework permissions in UX friendlier radio-button style.
- Improve modal behavior on mobile devices.

## Related Issue
Original PR: https://github.com/owncloud/core/pull/29376

## Motivation and Context
Currently the meaning of the option "Allow editing" (Download/Upload/Rename/Delete/Move) essentially changes to "Allow upload" (Upload only) when the second option "Show file listing" is unticked. This is inconsistent and can be very confusing for users. Moreover we thought a lot about how to make the file drop feature better understandable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visual test only

## Screenshots (if appropriate):
![bildschirmfoto vom 2017-10-27 16-30-06](https://user-images.githubusercontent.com/12717530/32109172-3460e192-bb34-11e7-9f91-6f02710c95dc.png)
