### PR TITLE
[Backport] Stable10 cacheable storage adapter

### DIFF
--- a/lib/private/Files/Storage/CacheableFlysystem.php
+++ b/lib/private/Files/Storage/CacheableFlysystem.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * @author Hemant Mann <hemant.mann121@gmail.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Storage;
+
+use League\Flysystem\FileNotFoundException;
+use Icewind\Streams\IteratorDirectory;
+
+/**
+ * Generic Cacheable adapter between flysystem adapters and owncloud's storage system
+ *
+ * To use: subclass and call $this->buildFlysystem with the flysystem adapter of choice
+ */
+abstract class CacheableFlysystem extends \OC\Files\Storage\Flysystem {
+	/**
+	 * Stores the results in cache for the current request to prevent multiple requests to the API
+	 * @var array
+	 */
+	protected $cacheContents = [];
+
+	/**
+	 * Get the location which will be used as a key in cache
+	 * If Storage is not case sensitive then convert the key to lowercase
+	 * @param  string $path Path to file/folder
+	 * @return string
+	 */
+	public function getCacheLocation($path) {
+		$location = $this->buildPath($path);
+		if ($location === '') {
+			$location = '/';
+		}
+
+		if ($this->isCaseInsensitiveStorage) {
+			$location = strtolower($location);
+		}
+		return $location;
+	}
+
+	/**
+	 * Check if Cache Contains the data for given path, if not then get the data
+	 * from flysystem and store it in cache for this request lifetime
+	 * @param  string $path Path to file/folder
+	 * @return array|boolean
+	 */
+	public function getFlysystemMetadata($path) {
+		$location = $this->getCacheLocation($path);
+		if (!isset($this->cacheContents[$location])) {
+			try {
+				$this->cacheContents[$location] = $this->flysystem->getMetadata($location);
+			} catch (FileNotFoundException $e) {
+				$this->cacheContents[$location] = false;
+			}
+		}
+		return $this->cacheContents[$location];
+	}
+
+	/**
+	 * Store the list of files/folders in the cache so that subsequent requests in the
+	 * same request life cycle does not call the flysystem API
+	 * @param  array $contents Return value of $this->flysystem->listContents
+	 */
+	public function updateCache($contents) {
+		foreach ($contents as $object) {
+			$path = $object['path'];
+			$this->cacheContents[$path] = $object;
+		}
+	}
+
+	/**
+	 * Check for existence of file/folder for the given path
+	 * @param  string  $path Path to file/folder
+	 * @return boolean
+	 */
+	public function hasPath($path) {
+		return (bool) $this->getFlysystemMetadata($path);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function opendir($path) {
+		try {
+			$content = $this->flysystem->listContents($this->buildPath($path));
+			$this->updateCache($content);
+		} catch (FileNotFoundException $e) {
+			return false;
+		}
+		$names = array_map(function ($object) {
+			return $object['basename'];
+		}, $content);
+		return IteratorDirectory::wrap($names);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function file_exists($path) {
+		return $this->hasPath($path);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function filesize($path) {
+		if ($this->is_dir($path)) {
+			return 0;
+		} else {
+			$info = $this->getFlysystemMetadata($path);
+			return $info['size'];
+		}
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function filemtime($path) {
+		$info = $this->getFlysystemMetadata($path);
+		return $info['timestamp'];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function stat($path) {
+		$info = $this->getFlysystemMetadata($path);
+		return [
+			'mtime' => $info['timestamp'],
+			'size' => $info['size']
+		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function filetype($path) {
+		if ($path === '' or $path === '/' or $path === '.') {
+			return 'dir';
+		}
+		$info = $this->getFlysystemMetadata($path);
+		return $info['type'];
+	}
+}

--- a/lib/private/Files/Storage/CacheableFlysystem.php
+++ b/lib/private/Files/Storage/CacheableFlysystem.php
@@ -29,7 +29,7 @@ use Icewind\Streams\IteratorDirectory;
  *
  * To use: subclass and call $this->buildFlysystem with the flysystem adapter of choice
  */
-abstract class CacheableFlysystem extends \OC\Files\Storage\Flysystem {
+abstract class CacheableFlysystem extends \OCP\Files\Storage\FlysystemStorageAdapter {
 	/**
 	 * Stores the results in cache for the current request to prevent multiple requests to the API
 	 *
@@ -65,6 +65,7 @@ abstract class CacheableFlysystem extends \OC\Files\Storage\Flysystem {
 	 * from flysystem and store it in cache for this request lifetime
 	 *
 	 * @param  string $path Path to file/folder
+	 * @param boolean $overRideCache Whether to fetch the contents from Cache or directly from the API
 	 * @return array|boolean
 	 */
 	public function getFlysystemMetadata($path, $overRideCache = false) {

--- a/lib/private/Files/Storage/CacheableFlysystem.php
+++ b/lib/private/Files/Storage/CacheableFlysystem.php
@@ -32,6 +32,7 @@ use Icewind\Streams\IteratorDirectory;
 abstract class CacheableFlysystem extends \OC\Files\Storage\Flysystem {
 	/**
 	 * Stores the results in cache for the current request to prevent multiple requests to the API
+	 *
 	 * @var array
 	 */
 	protected $cacheContents = [];
@@ -39,6 +40,7 @@ abstract class CacheableFlysystem extends \OC\Files\Storage\Flysystem {
 	/**
 	 * Get the location which will be used as a key in cache
 	 * If Storage is not case sensitive then convert the key to lowercase
+	 *
 	 * @param  string $path Path to file/folder
 	 * @return string
 	 */
@@ -61,6 +63,7 @@ abstract class CacheableFlysystem extends \OC\Files\Storage\Flysystem {
 	/**
 	 * Check if Cache Contains the data for given path, if not then get the data
 	 * from flysystem and store it in cache for this request lifetime
+	 *
 	 * @param  string $path Path to file/folder
 	 * @return array|boolean
 	 */
@@ -71,7 +74,7 @@ abstract class CacheableFlysystem extends \OC\Files\Storage\Flysystem {
 				$this->cacheContents[$location] = $this->flysystem->getMetadata($location);
 			} catch (FileNotFoundException $e) {
 				// do not store this info in cache as it might interfere with Upload process
-                return false;
+				return false;
 			}
 		}
 		return $this->cacheContents[$location];
@@ -80,6 +83,7 @@ abstract class CacheableFlysystem extends \OC\Files\Storage\Flysystem {
 	/**
 	 * Store the list of files/folders in the cache so that subsequent requests in the
 	 * same request life cycle does not call the flysystem API
+	 *
 	 * @param  array $contents Return value of $this->flysystem->listContents
 	 */
 	public function updateCache($contents) {

--- a/lib/public/Files/Storage/CacheableFlysystemAdapter.php
+++ b/lib/public/Files/Storage/CacheableFlysystemAdapter.php
@@ -25,7 +25,7 @@ namespace OCP\Files\Storage;
  * Public Cacheable storage adapter to be extended to connect to
  * flysystem adapters
  *
- * @since 10.0.x
+ * @since 10.0.4
  */
 abstract class CacheableFlysystemAdapter extends \OC\Files\Storage\CacheableFlysystem {
 	/**
@@ -33,14 +33,4 @@ abstract class CacheableFlysystemAdapter extends \OC\Files\Storage\CacheableFlys
 	 * @var boolean
 	 */
 	protected $isCaseInsensitiveStorage = false;
-
-	/**
-	 * Get the identifier for the storage,
-	 * the returned id should be the same for every storage object that is created with the same parameters
-	 * and two storage objects with the same id should refer to two storages that display the same files.
-	 *
-	 * @return string storage id
-	 * @since 10.0
-	 */
-	abstract public function getId();
 }

--- a/lib/public/Files/Storage/CacheableFlysystemAdapter.php
+++ b/lib/public/Files/Storage/CacheableFlysystemAdapter.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @author Hemant Mann <hemant.mann121@gmail.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Files\Storage;
+
+/**
+ * Public Cacheable storage adapter to be extended to connect to
+ * flysystem adapters
+ *
+ * @since 10.0.x
+ */
+abstract class CacheableFlysystemAdapter extends \OC\Files\Storage\CacheableFlysystem {
+	/**
+	 * Check that if storage is case insensitive or not
+	 * @var boolean
+	 */
+	protected $isCaseInsensitiveStorage = false;
+
+	/**
+	 * Get the identifier for the storage,
+	 * the returned id should be the same for every storage object that is created with the same parameters
+	 * and two storage objects with the same id should refer to two storages that display the same files.
+	 *
+	 * @return string storage id
+	 * @since 10.0
+	 */
+	abstract public function getId();
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Back porting changes to stable 10

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#29077 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

