### PR TITLE
decrypt seen users only

### DIFF
--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -30,6 +30,7 @@ use OC\Encryption\Exceptions\DecryptionFailedException;
 use OC\Files\View;
 use \OCP\Encryption\IEncryptionModule;
 use OCP\ILogger;
+use OCP\IUser;
 use OCP\IUserManager;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -145,7 +146,7 @@ class DecryptAll {
 	}
 
 	/**
-	 * iterate over all user and encrypt their files
+	 * iterate over all seen users and decrypt their files
 	 *
 	 * @param string $user which users files should be decrypted, default = all users
 	 * @return bool
@@ -154,53 +155,28 @@ class DecryptAll {
 
 		$this->output->writeln("\n");
 
-		$userList = [];
-		if ($user === '') {
-
-			$fetchUsersProgress = new ProgressBar($this->output);
-			$fetchUsersProgress->setFormat(" %message% \n [%bar%]");
-			$fetchUsersProgress->start();
-			$fetchUsersProgress->setMessage("Fetch list of users...");
-			$fetchUsersProgress->advance();
-
-			foreach ($this->userManager->getBackends() as $backend) {
-				$limit = 500;
-				$offset = 0;
-				do {
-					$users = $backend->getUsers('', $limit, $offset);
-					foreach ($users as $user) {
-						$userList[] = $user;
-					}
-					$offset += $limit;
-					$fetchUsersProgress->advance();
-				} while (count($users) >= $limit);
-				$fetchUsersProgress->setMessage("Fetch list of users... finished");
-				$fetchUsersProgress->finish();
-			}
-		} else {
-			$userList[] = $user;
-		}
-
-		$this->output->writeln("\n\n");
-
 		$progress = new ProgressBar($this->output);
 		$progress->setFormat(" %message% \n [%bar%]");
 		$progress->start();
 		$progress->setMessage("starting to decrypt files...");
 		$progress->advance();
 
-		$numberOfUsers = count($userList);
-		$userNo = 1;
-		foreach ($userList as $uid) {
-			$userCount = "$uid ($userNo of $numberOfUsers)";
-			if (\OC::$server->getAppConfig()->getValue('encryption', 'userSpecificKey', '0') !== '0') {
-				if ($this->prepareEncryptionModules($uid) === false) {
-					return false;
-				}
-			}
-			$this->decryptUsersFiles($uid, $progress, $userCount);
-			$userNo++;
+		if ($user === '') {
+			$userNo = 1;
+			$numberOfUsers = $this->userManager->countSeenUsers();
+			$this->userManager->callForSeenUsers(function(IUser $user) use ($progress, &$userNo, $numberOfUsers) {
+				$this->decryptUsersFiles(
+					$user->getUID(),
+					$progress,
+					"{$user->getUID()} ($userNo of $numberOfUsers)"
+				);
+				$userNo++;
+			});
+		} else {
+			$this->decryptUsersFiles($user, $progress, "$user (1 of 1)");
 		}
+
+		$this->output->writeln("\n\n");
 
 		$progress->setMessage("starting to decrypt files... finished");
 		$progress->finish();

--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -164,6 +164,9 @@ class DecryptAll {
 		if ($user === '') {
 			$userNo = 1;
 			$numberOfUsers = $this->userManager->countSeenUsers();
+			if ($numberOfUsers === 0) {
+				return false;
+			}
 			$this->userManager->callForSeenUsers(function(IUser $user) use ($progress, &$userNo, $numberOfUsers) {
 				$this->decryptUsersFiles(
 					$user->getUID(),


### PR DESCRIPTION
It does not make sense to iterate aver all backends individually, now that we have the account table. Saves a lot of time when having an ldap with 100k users. Also romoves the dependency on a live ldap server.

