### PR TITLE
Don't send back the mime svg image in previews

### DIFF
--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -800,12 +800,8 @@ class Preview {
 		if (is_null($this->preview)) {
 			$this->getPreview();
 		}
-		if ($this->preview instanceof \OCP\IImage) {
-			if ($this->preview->valid()) {
-				\OCP\Response::enableCaching(3600 * 24); // 24 hours
-			} else {
-				$this->getMimeIcon();
-			}
+		if ($this->preview instanceof \OCP\IImage && $this->preview->valid()) {
+			\OCP\Response::enableCaching(3600 * 24); // 24 hours
 			$this->preview->show($mimeTypeForHeaders);
 		}
 	}
@@ -1167,22 +1163,6 @@ class Preview {
 		if ($preview) {
 			$this->resizeAndStore($fileId);
 		}
-	}
-
-	/**
-	 * Defines the media icon, for the media type of the original file, as the preview
-	 */
-	private function getMimeIcon() {
-		$image = new \OC_Image();
-		$mimeIconWebPath = \OC::$server->getMimeTypeDetector()->mimeTypeIcon($this->mimeType);
-		if (empty(\OC::$WEBROOT)) {
-			$mimeIconServerPath = \OC::$SERVERROOT . $mimeIconWebPath;
-		} else {
-			$mimeIconServerPath = str_replace(\OC::$WEBROOT, \OC::$SERVERROOT, $mimeIconWebPath);
-		}
-		$image->loadFromFile($mimeIconServerPath);
-
-		$this->preview = $image;
 	}
 
 	/**


### PR DESCRIPTION
## Description
Long time back we killed all png images for file types.
As a result the fallback mime based previews are now svgs and OC_Image does not understand SVG.
In order to add SVG support to OC_IMage we would need to add a hard dependency to imagick which we don't want to.

This PR simply returns an empty response for now. 

## ToDo
- [ ] add js based fallback on files_versions

## Related Issue
fixes #27770

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

