### PR TITLE
Insulate scenarios

### DIFF
--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -260,14 +260,6 @@ else
 	$OCC config:system:set skeletondirectory --value="$PREVIOUS_SKELETON_DIR" >/dev/null
 fi
 
-if [ ! -z "$SAUCE_USERNAME" ] && [ ! -z "$SAUCE_ACCESS_KEY" ] && [ -e /tmp/saucelabs_sessionid ]
-then
-	SAUCELABS_SESSIONID=`cat /tmp/saucelabs_sessionid`
-	curl -X PUT -s -d "{\"passed\": $PASSED}" -u $SAUCE_USERNAME:$SAUCE_ACCESS_KEY https://saucelabs.com/rest/v1/$SAUCE_USERNAME/jobs/$SAUCELABS_SESSIONID 2>&1 | tee -a $TEST_LOG_FILE 
-
-	printf "\n${RED}SAUCELABS RESULTS:${BLUE} https://saucelabs.com/jobs/$SAUCELABS_SESSIONID\n${NC}" | tee -a $TEST_LOG_FILE
-fi
-
 #upload log file for later analysis
 if [ "$PASSED" = false ] && [ ! -z "$REPORTING_WEBDAV_USER" ] && [ ! -z "$REPORTING_WEBDAV_PWD" ] && [ ! -z "$REPORTING_WEBDAV_URL" ]
 then

--- a/tests/ui/features/files/files.feature
+++ b/tests/ui/features/files/files.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: files
 
 	Background:

--- a/tests/ui/features/moveFilesFolders/moveFiles.feature
+++ b/tests/ui/features/moveFilesFolders/moveFiles.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: moveFiles
 
 	Background:

--- a/tests/ui/features/moveFilesFolders/moveFolders.feature
+++ b/tests/ui/features/moveFilesFolders/moveFolders.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: moveFolders
 
 	Background:

--- a/tests/ui/features/other/login.feature
+++ b/tests/ui/features/other/login.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: login
 
 	Scenario: simple user login

--- a/tests/ui/features/other/personalGeneralSettings.feature
+++ b/tests/ui/features/other/personalGeneralSettings.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: personalGeneralSettings
 
 	Scenario: change language

--- a/tests/ui/features/other/personalSecuritySettings.feature
+++ b/tests/ui/features/other/personalSecuritySettings.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: personalSecuritySettings
 
 	Scenario: create new app password

--- a/tests/ui/features/other/users.feature
+++ b/tests/ui/features/other/users.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: users
 
 	Background:

--- a/tests/ui/features/renameFiles/renameFiles.feature
+++ b/tests/ui/features/renameFiles/renameFiles.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: renameFiles
 
 	Background:

--- a/tests/ui/features/renameFolders/renameFolders.feature
+++ b/tests/ui/features/renameFolders/renameFolders.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: renameFolders
 
 	Background:

--- a/tests/ui/features/sharing/federationSharing.feature
+++ b/tests/ui/features/sharing/federationSharing.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: FederationSharing
 
 	Background:

--- a/tests/ui/features/sharing/shareeAutocompletion.feature
+++ b/tests/ui/features/sharing/shareeAutocompletion.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: Sharee - autocompletion
 
 	Background:

--- a/tests/ui/features/sharing/sharing.feature
+++ b/tests/ui/features/sharing/sharing.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: Sharing
 
 	Background:

--- a/tests/ui/features/trashbin/delete.feature
+++ b/tests/ui/features/trashbin/delete.feature
@@ -1,3 +1,4 @@
+@insulated
 Feature: delete
 
 	Background:


### PR DESCRIPTION
## Description
1) "insulate" all scenarios. This causes Mink-Selenium-webDriver to do more of a "proper" browser reset between scenarios. the previous action (without insulate) just does a delete cookies. "insulate" will be needed when running on Edge, because the Edge webDriver has a problem with doing ``deleteAllCookies``
2) as a result of "insulate", each scenario has its own set of screen shots and video recorded on SauceLabs. Actually this is nicer when you want to view the video of a test to see what went wrong. Previously there was 1 long video (10 to 30 minutes) in which you had to find the relevant place. With this change, you can go straight to the short video of the scenario you want. The scripts are changed to log the scenario result (pass-fail) and SauceLabs link for each scenario.

## Related Issue
#29138 Make UI tests run on Edge browser
This PR is a change that will be required to run tests on Edge, but in any case seems useful.

## Motivation and Context
1) support running tests on Edge browser
2) have more manageable short videos of SauceLabs results for each scenario

## How Has This Been Tested?
Travis

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

