### PR TITLE
Fix Sabre\DAV\Client use statement for older PHP

### DIFF
--- a/lib/private/Http/Client/WebDavClientService.php
+++ b/lib/private/Http/Client/WebDavClientService.php
@@ -24,7 +24,6 @@ namespace OC\Http\Client;
 use OCP\Http\Client\IWebDavClientService;
 use OCP\IConfig;
 use OCP\ICertificateManager;
-use Sabre\DAV\Client;
 
 /**
  * Class WebDavClientService
@@ -86,7 +85,7 @@ class WebDavClientService implements IWebDavClientService {
 			}
 		}
 
-		$client = new Client($settings);
+		$client = new \Sabre\DAV\Client($settings);
 		$client->setThrowExceptions(true);
 
 		if ($certPath !== null) {


### PR DESCRIPTION
## Description
For some reason, when instantiating the class in PHP 5.6 during an
upgrade, the use statement causes a conflict.

## Related Issue
None raised.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Discovered with steps like these:
1. Setup two OC instances with PHP 5.6: OC_A with OC 10.0.3, and OC_B with OC 9.1.6
1. Fed share from OC_A to OC_B
1. Upgrade OC_B code to stable10 daily from a few days ago
1. `occ upgrade`.

Before fix: `PHP Fatal error:  Cannot use Sabre\DAV\Client as Client because the name is already in use in /srv/www/htdocs/owncloud-enterprise/lib/private/Http/Client/WebDavClientService.php on line 27` in "move avatars" repair step.
After fix: upgrade goes through.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

