### PR TITLE
[stable10] Use X-Request-ID header as request id if provided by clien…

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -477,10 +477,22 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 
 	/**
 	 * Returns an ID for the request, value is not guaranteed to be unique and is mostly meant for logging
+	 * If an X-Request-ID header is sent by the client this value will be taken.
 	 * If `mod_unique_id` is installed this value will be taken.
 	 * @return string
 	 */
 	public function getId() {
+		// allow clients to provide a request id
+		if(isset($this->server['HTTP_X_REQUEST_ID'])) {
+			$reqId = $this->server['HTTP_X_REQUEST_ID'];
+			if (strlen($reqId) > 19
+				&& strlen($reqId) < 200
+				&& preg_match('%^[a-zA-Z0-9-+/_=.:]+$%', $reqId)) {
+				return $this->server['HTTP_X_REQUEST_ID'];
+			} else {
+				throw new \InvalidArgumentException('X-Request-ID must be 20-200 bytes of chars, numbers and -+/_=.:');
+			}
+		}
 		if(isset($this->server['UNIQUE_ID'])) {
 			return $this->server['UNIQUE_ID'];
 		}

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -373,6 +373,78 @@ class RequestTest extends TestCase {
 		$this->assertSame('GeneratedUniqueIdByModUnique', $request->getId());
 	}
 
+	public function providesGetIdWithValidXRequestID() {
+		return [
+			['6241e4ae-ca5d-49e6-948c-6c9e20624361'],
+			['6241e4ae+ca5d+49e6+948c+6c9e20624361'],
+			['6241e4ae/ca5d/49e6/948c/6c9e20624361'],
+			['6241e4ae_ca5d_49e6_948c_6c9e20624361'],
+			['6241e4ae=ca5d=49e6=948c=6c9e20624361'],
+			['6241e4ae.ca5d.49e6.948c.6c9e20624361'],
+			['6241e4ae:ca5d:49e6:948c:6c9e20624361'],
+			['12-34-56-78-9A-BC_1985-04-12T23:20:50.52Z'],
+		];
+	}
+
+	/**
+	 * @dataProvider providesGetIdWithValidXRequestID
+	 */
+	public function testGetIdWithValidXRequestID($xRequestID) {
+		$vars = [
+			'server' => [
+				'HTTP_X_REQUEST_ID' => $xRequestID
+			],
+		];
+
+		$request = new Request(
+			$vars,
+			$this->secureRandom,
+			$this->config,
+			$this->csrfTokenManager,
+			$this->stream
+		);
+
+		$this->assertSame($xRequestID, $request->getId());
+	}
+	public function providesGetIdWithInvalidXRequestID() {
+		return [
+			['too-short'],
+			[
+				'too-long--too-long--too-long--too-long--too-long--'.
+				'too-long--too-long--too-long--too-long--too-long--'.
+				'too-long--too-long--too-long--too-long--too-long--'.
+				'too-long--too-long--too-long--too-long--too-long--x'
+			],
+			['6241e4ae ca5d 49e6 948c 6c9e20624361'],
+			['6241e4ae#ca5d#49e6#948c#6c9e20624361'],
+			['6241e4ae%ca5d%49e6%948c%6c9e20624361'],
+			['6241e4ae"ca5d"49e6"948c"6c9e20624361'],
+			['6241e4ae\'ca5d\'49e6\'948c\'6c9e20624361'],
+		];
+	}
+
+	/**
+	 * @dataProvider providesGetIdWithInvalidXRequestID
+	 * @expectedException \InvalidArgumentException
+	 */
+	public function testGetIdWithInvalidXRequestID($xRequestID) {
+		$vars = [
+			'server' => [
+				'HTTP_X_REQUEST_ID' => $xRequestID
+			],
+		];
+
+		$request = new Request(
+			$vars,
+			$this->secureRandom,
+			$this->config,
+			$this->csrfTokenManager,
+			$this->stream
+		);
+
+		$request->getId();
+	}
+
 	public function testGetIdWithoutModUnique() {
 		$this->secureRandom->expects($this->once())
 			->method('generate')


### PR DESCRIPTION
backport of 28144 to stable10