### PR TITLE
Set files_app table head position to fixed

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -48,8 +48,12 @@
 
 #filestable thead {
 	transform: translateY(-50px);
-	position: fixed;
+	position: absolute;
 	z-index: 10;
+}
+
+body:not(.snapjs-left) #filestable thead {
+	position: fixed;
 }
 
 #filestable.has-controls {

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -41,22 +41,19 @@
 
 /* FILE TABLE */
 #filestable {
+	top: 50px;
 	position: relative;
 	width: 100%;
 }
 
 #filestable thead {
+	transform: translateY(-50px);
 	position: fixed;
 	z-index: 10;
 }
 
-#filestable tbody,
-#filestable tfoot {
-	transform: translateY(50px);
-}
-
 #filestable.has-controls {
-	top: 44px;
+	top: 94px;
 }
 
 /* make sure there's enough room for the file actions */
@@ -621,7 +618,7 @@ html.ie8 .column-mtime .selectedActions {
 }
 
 #fileList .popovermenu {
-	margin-right: -5px;
+	transform: translate(22px, 5px);
 }
 .ie8 #fileList .popovermenu {
 	margin-top: -10px;

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -48,13 +48,24 @@
 
 #filestable thead {
 	transform: translateY(-50px);
-	position: absolute;
+	position: fixed;
 	z-index: 10;
 }
 
 body:not(.snapjs-left) #filestable thead {
 	position: fixed;
 }
+
+/* IE 11 only */
+@media all and (-ms-high-contrast:none) {
+
+	.snapjs-left #controls,
+	.snapjs-left #app-navigation-toggle,
+	.snapjs-left #filestable thead {
+		position: absolute;
+	}
+}
+
 
 #filestable.has-controls {
 	top: 94px;

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -45,6 +45,16 @@
 	width: 100%;
 }
 
+#filestable thead {
+	position: fixed;
+	z-index: 10;
+}
+
+#filestable tbody,
+#filestable tfoot {
+	transform: translateY(50px);
+}
+
 #filestable.has-controls {
 	top: 44px;
 }

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -131,7 +131,7 @@ a.two-factor-cancel {
 	width: 100%;
 	padding: 0;
 	margin: 0;
-	background-color: rgba(255, 255, 255, .95);
+	background-color: #fff;
 	z-index: 50;
 	-webkit-user-select: none;
 	-moz-user-select: none;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
The table head in files-app stays put if files list is scrolled.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes: https://github.com/owncloud/core/issues/29118
Fixes: https://github.com/owncloud/enterprise/issues/1776

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If you have many items in the file view you have to scroll. Currently the top bar (with column names) vanishes when scrolling down.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visual test in MacOS / Windows Firefox, Chrome and IE11

## Screenshots (if appropriate):
![29118-filesapp-fixed-top-bar](https://user-images.githubusercontent.com/12717530/32379898-0a1a1964-c0af-11e7-863e-a293d683d3ed.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

