### PR TITLE
Test rename and delete of last file

### DIFF
--- a/tests/ui/features/renameFiles/renameFiles.feature
+++ b/tests/ui/features/renameFiles/renameFiles.feature
@@ -88,6 +88,16 @@ Feature: renameFiles
 		|Could not rename "data.zip"|
 		And the file "data.zip" should be listed
 
+	Scenario: Rename the last file in a folder
+		When I rename the file "testimagelarge.svg" to "atestimagelarge.svg"
+		And the files page is reloaded
+		Then the file "atestimagelarge.svg" should be listed
+
+	Scenario: Rename a file to become the last file in a folder
+		When I rename the file "lorem.txt" to "zzz.txt"
+		And the files page is reloaded
+		Then the file "zzz.txt" should be listed
+
 	Scenario: Rename a file putting a name of a file which already exists
 		When I rename the file "data.zip" to "lorem.txt"
 		Then near the file "data.zip" a tooltip with the text 'lorem.txt already exists' should be displayed

--- a/tests/ui/features/trashbin/delete.feature
+++ b/tests/ui/features/trashbin/delete.feature
@@ -76,3 +76,8 @@ Feature: delete
 		But the folder "my-other-empty-folder" should not be listed in the trashbin
 		When I open the trashbin folder "my-empty-folder"
 		Then there are no files/folders listed
+
+	Scenario: Delete the last file in a folder
+		When I delete the file "testimagelarge.svg"
+		Then the file "testimagelarge.svg" should not be listed
+		But the file "testimagelarge.svg" should be listed in the trashbin


### PR DESCRIPTION
## Description
Add tests that check the rename and delete actions for the last file in a folder.

## Related Issue
#29118 

## Motivation and Context
The change for #29118 affected the actions menu for the last file(s) in the folder, preventing delete, rename etc. It would be good to have some explicit tests for that.

## How Has This Been Tested?
Local running of these tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
