### PR TITLE
Test rename and delete of last file

### DIFF
--- a/tests/ui/features/renameFiles/renameFiles.feature
+++ b/tests/ui/features/renameFiles/renameFiles.feature
@@ -89,6 +89,16 @@ Feature: renameFiles
 		|Could not rename "data.zip"|
 		And the file "data.zip" should be listed
 
+	Scenario: Rename the last file in a folder
+		When I rename the file "zzzz-must-be-last-file-in-folder.txt" to "a-file.txt"
+		And the files page is reloaded
+		Then the file "a-file.txt" should be listed
+
+	Scenario: Rename a file to become the last file in a folder
+		When I rename the file "lorem.txt" to "zzzz-z-this-is-now-the-last-file.txt"
+		And the files page is reloaded
+		Then the file "zzzz-z-this-is-now-the-last-file.txt" should be listed
+
 	Scenario: Rename a file putting a name of a file which already exists
 		When I rename the file "data.zip" to "lorem.txt"
 		Then near the file "data.zip" a tooltip with the text 'lorem.txt already exists' should be displayed

--- a/tests/ui/features/trashbin/delete.feature
+++ b/tests/ui/features/trashbin/delete.feature
@@ -77,3 +77,8 @@ Feature: delete
 		But the folder "my-other-empty-folder" should not be listed in the trashbin
 		When I open the trashbin folder "my-empty-folder"
 		Then there are no files/folders listed
+
+	Scenario: Delete the last file in a folder
+		When I delete the file "zzzz-must-be-last-file-in-folder.txt"
+		Then the file "zzzz-must-be-last-file-in-folder.txt" should not be listed
+		But the file "zzzz-must-be-last-file-in-folder.txt" should be listed in the trashbin

--- a/tests/ui/skeleton/zzzz-must-be-last-file-in-folder.txt
+++ b/tests/ui/skeleton/zzzz-must-be-last-file-in-folder.txt
@@ -1,0 +1,3 @@
+This must be the last skeleton file in this folder, when sorted alphabetically.
+Tests for performing actions on the last file in the folder try to find and use
+this file name.


### PR DESCRIPTION
## Description
Add UI tests to perform actions on the last file in a folder (rename and delete)

## Related Issue
#29118 Files view: Freeze top bar

## Motivation and Context
The actions menu for a file row drops down below the file, and for the last (or nearly last) file it drops into empty space. This has the potential to cause issues with the behavior - so it is good to test this case.

## How Has This Been Tested?
Running these UI tests locally.
Travis should confirm.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

