### PR TITLE
Adding mode of operations - either single-instance or clustered-instance

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -581,6 +581,15 @@ $CONFIG = array(
 'config_is_read_only' => false,
 
 /**
+ * This defines the mode of operations. The default value is 'single-instance'
+ * which means that ownCloud is running on a single node, which might be the
+ * most common operations mode. The only other possible value for now is
+ * 'clustered-instance' which means that ownCloud is running on at least 2
+ * nodes. The mode of operations has various impact on the behavior of ownCloud.
+ */
+'operation.mode' => 'single-instance',
+
+/**
  * Logging
  */
 

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -37,6 +37,7 @@ use OCP\App\ManagerEvent;
 use OCP\Files;
 use OCP\IAppConfig;
 use OCP\ICacheFactory;
+use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -72,6 +73,8 @@ class AppManager implements IAppManager {
 	private $alwaysEnabled;
 	/** @var EventDispatcherInterface */
 	private $dispatcher;
+	/** @var IConfig */
+	private $config;
 
 	/**
 	 * @param IUserSession $userSession
@@ -79,17 +82,20 @@ class AppManager implements IAppManager {
 	 * @param IGroupManager $groupManager
 	 * @param ICacheFactory $memCacheFactory
 	 * @param EventDispatcherInterface $dispatcher
+	 * @param IConfig $config
 	 */
 	public function __construct(IUserSession $userSession = null,
 								IAppConfig $appConfig,
 								IGroupManager $groupManager,
 								ICacheFactory $memCacheFactory,
-								EventDispatcherInterface $dispatcher) {
+								EventDispatcherInterface $dispatcher,
+								IConfig $config) {
 		$this->userSession = $userSession;
 		$this->appConfig = $appConfig;
 		$this->groupManager = $groupManager;
 		$this->memCacheFactory = $memCacheFactory;
 		$this->dispatcher = $dispatcher;
+		$this->config = $config;
 	}
 
 	/**
@@ -435,6 +441,10 @@ class AppManager implements IAppManager {
 	 * @since 10.0.3
 	 */
 	public function canInstall() {
+		if ($this->config->getSystemValue('operation.mode', 'single-instance') !== 'single-instance') {
+			return false;
+		}
+
 		$appsFolder = OC_App::getInstallPath();
 		return $appsFolder !== null && is_writable($appsFolder) && is_readable($appsFolder);
 	}

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -286,6 +286,10 @@ class Config {
 		if (!$this->getValue('installed', false)) {
 			return false;
 		}
+		if ($this->getValue('operation.mode', 'single-instance') !== 'single-instance') {
+			return false;
+		}
+
 		return $this->getValue('config_is_read_only', false);
 	}
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -537,7 +537,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->getAppConfig(),
 				$c->getGroupManager(),
 				$c->getMemCacheFactory(),
-				$c->getEventDispatcher()
+				$c->getEventDispatcher(),
+				$c->getConfig()
 			);
 		});
 		$this->registerService('DateTimeZone', function (Server $c) {

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -506,7 +506,9 @@ class AppTest extends \Test\TestCase {
 			return $appConfig;
 		});
 		\OC::$server->registerService('AppManager', function (\OC\Server $c) use ($appConfig) {
-			return new \OC\App\AppManager($c->getUserSession(), $appConfig, $c->getGroupManager(), $c->getMemCacheFactory(), $c->getEventDispatcher());
+			return new \OC\App\AppManager($c->getUserSession(), $appConfig,
+				$c->getGroupManager(), $c->getMemCacheFactory(),
+				$c->getEventDispatcher(), $c->getConfig());
 		});
 	}
 
@@ -518,7 +520,9 @@ class AppTest extends \Test\TestCase {
 			return new \OC\AppConfig($c->getDatabaseConnection());
 		});
 		\OC::$server->registerService('AppManager', function (\OC\Server $c) {
-			return new \OC\App\AppManager($c->getUserSession(), $c->getAppConfig(), $c->getGroupManager(), $c->getMemCacheFactory(), $c->getEventDispatcher());
+			return new \OC\App\AppManager($c->getUserSession(), $c->getAppConfig(),
+				$c->getGroupManager(), $c->getMemCacheFactory(),
+				$c->getEventDispatcher(), $c->getConfig());
 		});
 
 		// Remove the cache of the mocked apps list with a forceRefresh


### PR DESCRIPTION
## Description
Adds config switch let owncloud know if the instance is part of a cluster or not.
Instead of adding yet another boolean flag we will use two different values for the mode of operations.
This allows us to extend the operation modes in the future if necessary.

## Related Issue
fixes #29444

## How Has This Been Tested?
- [ ] market app UI
- [ ] market occ commands

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

