### PR TITLE
Fix breadcrumb size calculation

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1805,7 +1805,7 @@
 		 * @param show true for enabling, false for disabling
 		 */
 		showActions: function(show){
-			this.$el.find('.actions,#file_action_panel').toggleClass('hidden', !show);
+			this.$el.find('.actions').toggleClass('hidden', !show);
 			if (show){
 				// make sure to display according to permissions
 				var permissions = this.getDirectoryPermissions();

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -537,10 +537,16 @@
 				actionsWidth += $(action).outerWidth();
 			});
 
+			var customWidth = 0;
+			// custom controls
+			this.$el.find('#controls>div:not(.actions):not(.breadcrumb):not(.hidden)').each(function(index, el) {
+				customWidth += $(el).outerWidth();
+			});
+
 			// subtract app navigation toggle when visible
 			containerWidth -= $('#app-navigation-toggle').width();
 
-			this.breadcrumb.setMaxWidth(containerWidth - actionsWidth - 10);
+			this.breadcrumb.setMaxWidth(containerWidth - actionsWidth - customWidth - 10);
 
 			this.$table.find('>thead').width($('#app-content').width() - OC.Util.getScrollBarWidth());
 		},

--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -243,9 +243,6 @@
 		initialize: function() {
 			Files.bindKeyboardShortcuts(document, $);
 
-			// TODO: move file list related code (upload) to OCA.Files.FileList
-			$('#file_action_panel').attr('activeAction', false);
-
 			// drag&drop support using jquery.fileupload
 			// TODO use OC.dialogs
 			$(document).bind('drop dragover', function (e) {

--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -7,7 +7,6 @@
 				<input type="button" class="stop icon-close" style="display:none" value="" />
 			</div>
 		</div>
-		<div id="file_action_panel"></div>
 		<div class="notCreatable notPublic hidden">
 			<?php p($l->t('You don’t have permission to upload or create files here'))?>
 		</div>

--- a/apps/files_external/templates/list.php
+++ b/apps/files_external/templates/list.php
@@ -1,7 +1,5 @@
 <?php /** @var $l \OCP\IL10N */ ?>
-<div id="controls">
-	<div id="file_action_panel"></div>
-</div>
+<div id="controls"></div>
 <div id='notification'></div>
 
 <div id="emptycontent" class="hidden">

--- a/apps/files_trashbin/templates/index.php
+++ b/apps/files_trashbin/templates/index.php
@@ -1,7 +1,5 @@
 <?php /** @var $l \OCP\IL10N */ ?>
-<div id="controls">
-	<div id="file_action_panel"></div>
-</div>
+<div id="controls"></div>
 <div id='notification'></div>
 
 <div id="emptycontent" class="hidden">


### PR DESCRIPTION
## Description
Include extra controls when calculating breadcrumb size
    
Fix onResize in file list to also substract the width of custom controls in the controls bar that might have been added by apps like gallery.

## Related Issue
None raised

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

1. Enable gallery app
1. Create folder sequence as per screenshot
1. Set resolution to 1920x1080 with maximized Chromium/Firefox window.
1. Refresh page

## Screenshots (if appropriate):
Before:
![screenshot_20171106_124052](https://user-images.githubusercontent.com/277525/32439592-bb3ee246-c2ef-11e7-860e-f11950535470.png)
This is Chromium. On Firefox the button wraps to the next line.

After:
![screenshot_20171106_124241](https://user-images.githubusercontent.com/277525/32439673-fb8ee774-c2ef-11e7-8fba-44e63a534b9f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

