### PR TITLE
[stable9.1] Upgrade node package versions

### DIFF
--- a/autotest-js.sh
+++ b/autotest-js.sh
@@ -19,6 +19,8 @@ then
 	exit 1
 fi
 
+echo "Node version: "$(node -v)
+
 # update/install test packages
 mkdir -p "$PREFIX" && $NPM install --link --prefix "$PREFIX" || exit 3
 

--- a/build/package.json
+++ b/build/package.json
@@ -11,13 +11,18 @@
   "contributors": [],
   "dependencies": {},
   "devDependencies": {
-    "karma": "~0.12.0",
-    "karma-jasmine": "~0.3.0",
+    "jasmine-core": "^2.5.2",
+    "jasmine-sinon": "^0.4.0",
+    "sinon": "^2.0.0",
+    "jsdoc": "~3.4.0",
+    "karma": "^1.5.0",
+    "karma-coverage": "*",
+    "karma-jasmine": "^1.1.0",
+    "karma-jasmine-sinon": "^1.0.4",
     "karma-junit-reporter": "*",
     "karma-coverage": "*",
     "karma-phantomjs-launcher": "*",
-    "phantomjs": "*",
-    "jasmine-core": "~2.3.4"
+    "phantomjs-prebuilt": "*"
   },
-  "engine": "node >= 0.8"
+  "engine": "node >= 6.9"
 }


### PR DESCRIPTION
Upgrade node package versions to be compatible with node v8.9.0 and avoid CI failure due to npm setup...

@DeepDiver1975 @tomneedham 