### PR TITLE
[stable10] Add dispatcher event for remote fed shares

### DIFF
--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -60,12 +60,13 @@ class Application extends App {
 				$server->getRootFolder()
 			);
 		});
-		$container->registerService('ExternalSharesController', function (SimpleContainer $c) {
+		$container->registerService('ExternalSharesController', function (SimpleContainer $c) use ($server) {
 			return new ExternalSharesController(
 				$c->query('AppName'),
 				$c->query('Request'),
 				$c->query('ExternalManager'),
-				$c->query('HttpClientService')
+				$c->query('HttpClientService'),
+				$server->getEventDispatcher()
 			);
 		});
 

--- a/apps/files_sharing/lib/Controllers/ExternalSharesController.php
+++ b/apps/files_sharing/lib/Controllers/ExternalSharesController.php
@@ -30,6 +30,8 @@ use OCP\IRequest;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Http\Client\IClientService;
 use OCP\AppFramework\Http\DataResponse;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Class ExternalSharesController
@@ -42,20 +44,29 @@ class ExternalSharesController extends Controller {
 	private $externalManager;
 	/** @var IClientService */
 	private $clientService;
+	/**
+	 * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+	 */
+	private $dispatcher;
 
 	/**
+	 * ExternalSharesController constructor.
+	 *
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param \OCA\Files_Sharing\External\Manager $externalManager
 	 * @param IClientService $clientService
+	 * @param EventDispatcherInterface $eventDispatcher
 	 */
 	public function __construct($appName,
 								IRequest $request,
 								\OCA\Files_Sharing\External\Manager $externalManager,
-								IClientService $clientService) {
+								IClientService $clientService,
+								EventDispatcherInterface $eventDispatcher) {
 		parent::__construct($appName, $request);
 		$this->externalManager = $externalManager;
 		$this->clientService = $clientService;
+		$this->dispatcher = $eventDispatcher;
 	}
 
 	/**
@@ -76,6 +87,16 @@ class ExternalSharesController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function create($id) {
+		$shareInfo = $this->externalManager->getShare($id);
+		$event = new GenericEvent(null,
+			[
+				'shareAcceptedFrom' => $shareInfo['owner'],
+				'sharedAcceptedBy' => $shareInfo['user'],
+				'sharedItem' => $shareInfo['name'],
+				'remoteUrl' => $shareInfo['remote']
+			]
+		);
+		$this->dispatcher->dispatch('remoteshare.accepted', $event);
 		$this->externalManager->acceptShare($id);
 		return new JSONResponse();
 	}
@@ -88,6 +109,16 @@ class ExternalSharesController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function destroy($id) {
+		$shareInfo = $this->externalManager->getShare($id);
+		$event = new GenericEvent(null,
+			[
+				'shareAcceptedFrom' => $shareInfo['owner'],
+				'sharedAcceptedBy' => $shareInfo['user'],
+				'sharedItem' => $shareInfo['name'],
+				'remoteUrl' => $shareInfo['remote']
+			]
+		);
+		$this->dispatcher->dispatch('remoteshare.declined', $event);
 		$this->externalManager->declineShare($id);
 		return new JSONResponse();
 	}


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/29481

Adding dispatcher events for remote fed shares

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Dispatcher event for remote fed shares.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change will help users to catch the events and log it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Create a fed1 folder from a remote oC instance1
- [x] Share to another oC instance2.
- [x] When oC instance2 accepts/rejects the share the logs are available at oC2 instance.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

