### PR TITLE
UI tests on Microsoft Edge browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -211,6 +211,55 @@ matrix:
         sauce_connect: true
     - if: type = cron
       php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - if: type = cron
+      php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - if: type = cron
+      php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - if: type = cron
+      php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="renameFiles" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - if: type = cron
+      php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="renameFolders" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - if: type = cron
+      php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - if: type = cron
+      php: 5.6
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="sharing" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - if: type = cron
+      php: 5.6
       env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="other" PLATFORM="Windows 7" TEST_DAV=0
       addons:
         apt: *common_apt

--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -92,7 +92,7 @@ BEHAT_TAG_OPTION="--tags"
 
 #we need to skip some tests in certain browsers
 #and also skip tests if tags were given in the call of this script
-if [ "$BROWSER" == "internet explorer" ] || ([ "$BROWSER" == "firefox" ] && verlt "47.0" "$BROWSER_VERSION")
+if [ "$BROWSER" == "internet explorer" ] || [ "$BROWSER" == "MicrosoftEdge" ] || ([ "$BROWSER" == "firefox" ] && verlt "47.0" "$BROWSER_VERSION")
 then
 	BROWSER_IN_CAPITALS=${BROWSER//[[:blank:]]/}
 	BROWSER_IN_CAPITALS=${BROWSER_IN_CAPITALS^^}

--- a/tests/ui/features/bootstrap/bootstrap.php
+++ b/tests/ui/features/bootstrap/bootstrap.php
@@ -33,7 +33,7 @@ const STANDARDSLEEPTIMEMILLISEC = 10;
 const STANDARDSLEEPTIMEMICROSEC = STANDARDSLEEPTIMEMILLISEC * 1000;
 
 // Long timeout for use in code that needs to wait for known slow UI
-const LONGUIWAITTIMEOUTMILLISEC = 20000;
+const LONGUIWAITTIMEOUTMILLISEC = 60000;
 // Default timeout for use in code that needs to wait for the UI
 const STANDARDUIWAITTIMEOUTMILLISEC = 10000;
 // Minimum timeout for use in code that needs to wait for the UI

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -109,7 +109,20 @@ class FilesPage extends FilesPageBasic {
 			);
 		}
 
-		$newFolderButtonElement->click();
+		try {
+			$newFolderButtonElement->click();
+		} catch (NoSuchElement $e) {
+			// Edge sometimes reports NoSuchElement even though we just found it.
+			// Log the event and continue, because maybe the button was clicked.
+			// TODO: Edge - if it keeps happening then find out why.
+			error_log(
+				__METHOD__
+				. " NoSuchElement while doing newFolderButtonElement->click()"
+				. "\n-------------------------\n"
+				. $e->getMessage()
+				. "\n-------------------------\n"
+			);
+		}
 
 		try {
 			$this->fillField($this->newFolderNameInputLabel, $name . Key::ENTER);

--- a/tests/ui/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/ui/features/lib/FilesPageElement/SharingDialog.php
@@ -27,6 +27,7 @@ use Behat\Mink\Element\NodeElement;
 use Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
+use WebDriver\Exception\UnknownError;
 
 /**
  * The Sharing Dialog
@@ -458,6 +459,22 @@ class SharingDialog extends OwncloudPage {
 				"could not find share-dialog-close-button"
 			);
 		}
-		$shareDialogCloseButton->click();
+
+		try {
+			$shareDialogCloseButton->click();
+		} catch (UnknownError $e) {
+			// Edge often throws UnknownError 'Invalid Argument' when trying to
+			// click the close button, even though the button was found above.
+			// Ignore it for now. Many tests could keep working without having
+			// closed the share dialog.
+			// TODO: Edge - if it keeps happening then find out why.
+			error_log(
+				__METHOD__
+				. " UnknownError while doing shareDialogCloseButton->click()"
+				. "\n-------------------------\n"
+				. $e->getMessage()
+				. "\n-------------------------\n"
+			);
+		}
 	}
 }

--- a/tests/ui/features/lib/UsersPage.php
+++ b/tests/ui/features/lib/UsersPage.php
@@ -145,7 +145,24 @@ class UsersPage extends OwncloudPage {
 				"could not find setting content"
 			);
 		}
-		if (!$settingContent->isVisible()) {
+
+		try {
+			$settingContentIsVisible = $settingContent->isVisible();
+		} catch (NoSuchElement $e) {
+			// Somehow on Edge this can throw NoSuchElement even though
+			// we just found the element.
+			// TODO: Edge - if it keeps happening then find out why.
+			error_log(
+				__METHOD__
+				. " NoSuchElement while doing settingContent->isVisible()"
+				. "\n-------------------------\n"
+				. $e->getMessage()
+				. "\n-------------------------\n"
+			);
+			$settingContentIsVisible = false;
+		}
+
+		if (!$settingContentIsVisible) {
 			$this->openSettingsMenu();
 		}
 

--- a/tests/ui/features/sharing/federationSharing.feature
+++ b/tests/ui/features/sharing/federationSharing.feature
@@ -25,6 +25,7 @@ Feature: FederationSharing
 		When I open the folder "simple-folder (2)"
 		Then the file "lorem.txt" should be listed
 
+	@skipOnMICROSOFTEDGE
 	Scenario: share a folder with an remote user and prohibit deleting
 		When the folder "simple-folder" is shared with the remote user "user1@%remote_server%"
 		And the sharing permissions of "user1@%remote_server% (remote)" for "simple-folder" are set to

--- a/tests/ui/features/sharing/restrictReSharing.feature
+++ b/tests/ui/features/sharing/restrictReSharing.feature
@@ -22,6 +22,7 @@ I would like to be able to forbid a user that received a share from me to share 
 		And I logout
 		And I login with username "user2" and password "1234"
 
+	@skipOnMICROSOFTEDGE
 	Scenario: share a folder with another internal user and prohibit resharing
 		And the setting "Allow resharing" in the section "Sharing" is enabled
 		And I am on the files page

--- a/tests/ui/features/sharing/sharing.feature
+++ b/tests/ui/features/sharing/sharing.feature
@@ -48,6 +48,7 @@ Feature: Sharing
 		And the file "testimage (2).jpg" should be listed
 		And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three"
 
+	@skipOnMICROSOFTEDGE
 	Scenario: share a folder with another internal user and prohibit deleting
 		When the folder "simple-folder" is shared with the user "User One"
 		And the sharing permissions of "User One" for "simple-folder" are set to


### PR DESCRIPTION
## Description
1) Lengthen the files page wait till page is loaded timeout to 60 seconds. When using Edge, particularly in the sharing tests when the test logs in and out as user1, user2 and user3, things get slow in calculating and transferring... all the skeleton files with thumbnails at the 1st login of each user. It does actually work if it is given time. There is no point throwing a timeout exception "early" and there is no real loss in having the longer timeout. All the regular tests that work "quickly" in each browser will wait just like they used to. It is only if something goes wrong that we will now wait 60 seconds rather than 20 seconds before giving up.

2) The Edge webDriver is still rather stupid and unreliable. when calling ``$element->isVisible()`` or ``$element->click()`` it often throws back with ``NoSuchElement`` even though we just found the element. Catch this rubbish and do something reasonable (or just keep going, because sometimes it worked)

3) Run the Edge tests in the daily Travis cron job, like is done for Firefox and IE11.

4) Skip tests that try to navigate and click the sharing permissions buttons. Those tests require clicking on "label" elements, and Edge webDriver currently has trouble with clicking on stuff like that (it seems that thrying to click on a "label", "span", "a" and goodness knows what other tags is not working with Edge webDriver, but it works fine on Chrome and Firefox)

Some references for 4:
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/10290683/
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12306419/
https://github.com/SeleniumHQ/selenium/issues/4843
https://groups.google.com/forum/#!topic/selenium-users/xukryAZfpbc

## Related Issue
#29138 UI tests on Edge browser
#28016 Review supported browser versions

## Motivation and Context
Run the automated UI tests on as many supported browsers as reasonably possible.
That gives more confidence in finding annoying UI issues.

## How Has This Been Tested?
Successful runs of the Edge Travis matrix jobs have been done in a separate test PR in my fork.
e.g. https://github.com/phil-davis/core/pull/120

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I will also make a test PR on top of this to run the Edge Travis matrix jobs here in the owncloud core repo.