### PR TITLE
Update minimum supported browser versions

### DIFF
--- a/core/js/browser-update.js
+++ b/core/js/browser-update.js
@@ -10,7 +10,7 @@ $(document).ready(function() {
 
 	// You can Customize here
 	window.$buoop = {
-		vs: { i: 10, f: 45, o: 0, s: 8, c: 45 },
+		vs: { i: 10, f: 54, o: 0, s: 9, c: 60 },
 		reminder: 0,                  // after how many hours should the message reappear
 		test: false,                    // true = always show the bar (for testing)
 		newwindow: true,                // open link in new window/tab


### PR DESCRIPTION
## Description
Update the minimum supported browser versions. Note that this code expects the number of the last version that is NOT supported.

1) IE - no change, <=10 is not supported, need IE11
2) Firefox - current release is 56 and previous 55, <=54 is not supported
3) Safari - bump minimum to 10, <=9 is not supported
4) Chrome - current release is 62, previous 61, <=60 is not supported

Note: The JScript that uses these numbers also has code for FirefoxESR and already knows that Firefox ESR 52 is the "OK" version. So it should also pass anyone running Firefox ESR 52.

## Related Issue
#28016 

## Motivation and Context
ownCloud is tested with currently supported browser versions, so warn users if they are using an older browser version.

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Doc update is required once the exact versions are agreed here.