### PR TITLE
[WIP] Replace hooks with symfony eventdispatcher

### DIFF
--- a/apps/dav/appinfo/app.php
+++ b/apps/dav/appinfo/app.php
@@ -47,6 +47,34 @@ $eventDispatcher->addListener('OCP\Federation\TrustedServerEvent::remove',
 	}
 );
 
+$eventDispatcher->addListener('\OC\User\Manager::post_createUser',
+	function(GenericEvent $event) use ($app) {
+		$hookManager = $app->getContainer()->query(\OCA\DAV\HookManager::class);
+		$hookManager->postCreateUser($event);
+	}
+);
+
+$eventDispatcher->addListener('\OC\User\User::pre_delete',
+	function(GenericEvent $event) use ($app) {
+		$hookManager = $app->getContainer()->query(\OCA\DAV\HookManager::class);
+		$hookManager->preDeleteUser($event);
+	}
+);
+
+$eventDispatcher->addListener('\OC\User\User::post_delete',
+	function(GenericEvent $event) use ($app) {
+		$hookManager = $app->getContainer()->query(\OCA\DAV\HookManager::class);
+		$hookManager->postDeleteUser($event);
+	}
+);
+
+$eventDispatcher->addListener('\OC\User\User::triggerChangeUser',
+	function(GenericEvent $event) use ($app) {
+		$hookManager = $app->getContainer()->query(\OCA\DAV\HookManager::class);
+		$hookManager->changeUser($event);
+	}
+);
+
 $cm = \OC::$server->getContactsManager();
 $cm->register(function() use ($cm, $app) {
 	$user = \OC::$server->getUserSession()->getUser();

--- a/apps/dav/lib/HookManager.php
+++ b/apps/dav/lib/HookManager.php
@@ -69,22 +69,6 @@ class HookManager {
 	}
 
 	public function setup() {
-		Util::connectHook('OC_User',
-			'post_createUser',
-			$this,
-			'postCreateUser');
-		Util::connectHook('OC_User',
-			'pre_deleteUser',
-			$this,
-			'preDeleteUser');
-		Util::connectHook('OC_User',
-			'post_deleteUser',
-			$this,
-			'postDeleteUser');
-		Util::connectHook('OC_User',
-			'changeUser',
-			$this,
-			'changeUser');
 	}
 
 	public function postCreateUser($params) {

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -38,7 +38,8 @@ use OCP\User;
 class Helper {
 
 	public static function registerHooks() {
-		\OCP\Util::connectHook('OC_Filesystem', 'post_rename', '\OCA\Files_Sharing\Updater', 'renameHook');
+		//\OCP\Util::connectHook('OC_Filesystem', 'post_rename', '\OCA\Files_Sharing\Updater', 'renameHook');
+		\OC::$server->getEventDispatcher()->addListener(Filesystem::signal_post_rename, [\OCA\Files_Sharing\Updater::class, 'renameHook']);
 		\OCP\Util::connectHook('OC_Filesystem', 'post_delete', '\OCA\Files_Sharing\Hooks', 'unshareChildren');
 
 		\OCP\Util::connectHook('OC_User', 'post_deleteUser', '\OCA\Files_Sharing\Hooks', 'deleteUser');

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -1003,8 +1003,10 @@ class Trashbin {
 		\OCP\Util::connectHook('OC_Filesystem', 'post_write', 'OCA\Files_Trashbin\Hooks', 'post_write_hook');
 		// pre and post-rename, disable trash logic for the copy+unlink case
 		\OCP\Util::connectHook('OC_Filesystem', 'delete', 'OCA\Files_Trashbin\Trashbin', 'ensureFileScannedHook');
-		\OCP\Util::connectHook('OC_Filesystem', 'rename', 'OCA\Files_Trashbin\Storage', 'preRenameHook');
-		\OCP\Util::connectHook('OC_Filesystem', 'post_rename', 'OCA\Files_Trashbin\Storage', 'postRenameHook');
+		//\OCP\Util::connectHook('OC_Filesystem', 'rename', 'OCA\Files_Trashbin\Storage', 'preRenameHook');
+		\OC::$server->getEventDispatcher()->addListener('\OC\Filesystem::rename', [\OCA\Files_Trashbin\Storage::class, 'preRenameHook']);
+		//\OCP\Util::connectHook('OC_Filesystem', 'post_rename', 'OCA\Files_Trashbin\Storage', 'postRenameHook');
+		\OC::$server->getEventDispatcher()->addListener(Filesystem::signal_post_rename, [\OCA\Files_Trashbin\Storage::class, 'postRenameHook']);
 	}
 
 	/**

--- a/apps/files_versions/lib/Hooks.php
+++ b/apps/files_versions/lib/Hooks.php
@@ -32,6 +32,8 @@
 
 namespace OCA\Files_Versions;
 
+use OC\Files\Filesystem;
+
 class Hooks {
 
 	public static function connectHooks() {
@@ -40,9 +42,11 @@ class Hooks {
 		// Listen to delete and rename signals
 		\OCP\Util::connectHook('OC_Filesystem', 'post_delete', 'OCA\Files_Versions\Hooks', 'remove_hook');
 		\OCP\Util::connectHook('OC_Filesystem', 'delete', 'OCA\Files_Versions\Hooks', 'pre_remove_hook');
-		\OCP\Util::connectHook('OC_Filesystem', 'post_rename', 'OCA\Files_Versions\Hooks', 'rename_hook');
+		//\OCP\Util::connectHook('OC_Filesystem', 'post_rename', 'OCA\Files_Versions\Hooks', 'rename_hook');
+		\OC::$server->getEventDispatcher()->addListener(Filesystem::signal_post_rename, [\OCA\Files_Versions\Hooks::class, 'rename_hook']);
 		\OCP\Util::connectHook('OC_Filesystem', 'post_copy', 'OCA\Files_Versions\Hooks', 'copy_hook');
-		\OCP\Util::connectHook('OC_Filesystem', 'rename', 'OCA\Files_Versions\Hooks', 'pre_renameOrCopy_hook');
+		//\OCP\Util::connectHook('OC_Filesystem', 'rename', 'OCA\Files_Versions\Hooks', 'pre_renameOrCopy_hook');
+		\OC::$server->getEventDispatcher()->addListener('\OC\Filesystem::rename', [\OCA\Files_Versions\Hooks::class, 'pre_renameOrCopy_hook']);
 		\OCP\Util::connectHook('OC_Filesystem', 'copy', 'OCA\Files_Versions\Hooks', 'pre_renameOrCopy_hook');
 
 		$eventDispatcher = \OC::$server->getEventDispatcher();

--- a/lib/base.php
+++ b/lib/base.php
@@ -759,7 +759,8 @@ class OC {
 		if ($enabled) {
 			\OCP\Util::connectHook('OCP\Share', 'post_shared', 'OC\Encryption\HookManager', 'postShared');
 			\OCP\Util::connectHook('OCP\Share', 'post_unshare', 'OC\Encryption\HookManager', 'postUnshared');
-			\OCP\Util::connectHook('OC_Filesystem', 'post_rename', 'OC\Encryption\HookManager', 'postRename');
+			//\OCP\Util::connectHook('OC_Filesystem', 'post_rename', 'OC\Encryption\HookManager', 'postRename');
+			OC::$server->getEventDispatcher()->addListener(Filesystem::signal_post_rename, [\OC\Encryption\HookManager::class, 'postRename']);
 			\OCP\Util::connectHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', 'OC\Encryption\HookManager', 'postRestore');
 		}
 	}
@@ -782,7 +783,8 @@ class OC {
 	public static function registerFilesystemHooks() {
 		// Check for blacklisted files
 		OC_Hook::connect('OC_Filesystem', 'write', 'OC\Files\Filesystem', 'isForbiddenFileOrDir_Hook');
-		OC_Hook::connect('OC_Filesystem', 'rename', 'OC\Files\Filesystem', 'isForbiddenFileOrDir_Hook');
+		//OC_Hook::connect('OC_Filesystem', 'rename', 'OC\Files\Filesystem', 'isForbiddenFileOrDir_Hook');
+		OC::$server->getEventDispatcher()->addListener('\OC\Filesystem::rename', [\OC\Files\Filesystem::class, 'isForbiddenFileOrDir_Hook']);
 	}
 
 	/**

--- a/lib/private/Files/Node/HookConnector.php
+++ b/lib/private/Files/Node/HookConnector.php
@@ -63,11 +63,15 @@ class HookConnector {
 		Util::connectHook('OC_Filesystem', 'delete', $this, 'delete');
 		Util::connectHook('OC_Filesystem', 'post_delete', $this, 'postDelete');
 
-		Util::connectHook('OC_Filesystem', 'rename', $this, 'rename');
-		Util::connectHook('OC_Filesystem', 'post_rename', $this, 'postRename');
+		//Util::connectHook('OC_Filesystem', 'rename', $this, 'rename');
+		\OC::$server->getEventDispatcher()->addListener('\OC\Filesystem::rename', [$this, 'rename']);
+		//Util::connectHook('OC_Filesystem', 'post_rename', $this, 'postRename');
+		\OC::$server->getEventDispatcher()->addListener(Filesystem::signal_post_rename, [$this, 'postRename']);
 
-		Util::connectHook('OC_Filesystem', 'copy', $this, 'copy');
-		Util::connectHook('OC_Filesystem', 'post_copy', $this, 'postCopy');
+		//Util::connectHook('OC_Filesystem', 'copy', $this, 'copy');
+		\OC::$server->getEventDispatcher()->addListener('\OC\Filesystem::copy', [$this, 'copy']);
+		//Util::connectHook('OC_Filesystem', 'post_copy', $this, 'postCopy');
+		\OC::$server->getEventDispatcher()->addListener('post_copy', [$this, 'postCopy']);
 
 		Util::connectHook('OC_Filesystem', 'touch', $this, 'touch');
 		Util::connectHook('OC_Filesystem', 'post_touch', $this, 'postTouch');

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -246,24 +246,28 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 		$this->registerService('GroupManager', function (Server $c) {
 			$groupManager = new \OC\Group\Manager($this->getUserManager());
 			$groupManager->listen('\OC\Group', 'preCreate', function ($gid) {
-				\OC_Hook::emit('OC_Group', 'pre_createGroup', ['run' => true, 'gid' => $gid]);
+				$event = new GenericEvent(null, ['run' => true, 'gid' => $gid]);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\Group\Manager::preCreate_createGroup', $event);
 			});
 			$groupManager->listen('\OC\Group', 'postCreate', function (\OC\Group\Group $gid) {
-				\OC_Hook::emit('OC_User', 'post_createGroup', ['gid' => $gid->getGID()]);
+				$event = new GenericEvent(null, ['gid' => $gid->getGID()]);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\Group\Manager::postCreate_createGroup', $event);
 			});
 			$groupManager->listen('\OC\Group', 'preDelete', function (\OC\Group\Group $group) {
-				\OC_Hook::emit('OC_Group', 'pre_deleteGroup', ['run' => true, 'gid' => $group->getGID()]);
+				$event = new GenericEvent(null, ['run' => true, 'gid' => $group->getGID()]);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\Group\Group::predelete_delete', $event);
 			});
 			$groupManager->listen('\OC\Group', 'postDelete', function (\OC\Group\Group $group) {
-				\OC_Hook::emit('OC_User', 'post_deleteGroup', ['gid' => $group->getGID()]);
+				$event = new GenericEvent(null, ['gid' => $group->getGID()]);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\Group\Group::postdelete_delete', $event);
 			});
 			$groupManager->listen('\OC\Group', 'preAddUser', function (\OC\Group\Group $group, \OC\User\User $user) {
-				\OC_Hook::emit('OC_Group', 'pre_addToGroup', ['run' => true, 'uid' => $user->getUID(), 'gid' => $group->getGID()]);
+				$event = new GenericEvent(null, ['run' => true, 'uid' => $user->getUID(), 'gid' => $group->getGID()]);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\Group\Group::preadduser_addUser', $event);
 			});
 			$groupManager->listen('\OC\Group', 'postAddUser', function (\OC\Group\Group $group, \OC\User\User $user) {
-				\OC_Hook::emit('OC_Group', 'post_addToGroup', ['uid' => $user->getUID(), 'gid' => $group->getGID()]);
-				//Minimal fix to keep it backward compatible TODO: clean up all the GroupManager hooks
-				\OC_Hook::emit('OC_User', 'post_addToGroup', ['uid' => $user->getUID(), 'gid' => $group->getGID()]);
+				$event = new GenericEvent(null, ['uid' => $user->getUID(), 'gid' => $group->getGID()]);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\Group\Group::postadduser_addUser', $event);
 			});
 			return $groupManager;
 		});
@@ -302,42 +306,44 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				\OC_Hook::emit('OC_User', 'pre_createUser', ['run' => true, 'uid' => $uid, 'password' => $password]);
 			});
 			$userSession->listen('\OC\User', 'postCreateUser', function ($user, $password) {
-				/** @var $user \OC\User\User */
-				\OC_Hook::emit('OC_User', 'post_createUser', ['uid' => $user->getUID(), 'password' => $password]);
+				$event = new GenericEvent(null, ['uid' => $user->getUID(), 'password' => $password]);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\User\Manager::post_createUser', $event);
 			});
 			$userSession->listen('\OC\User', 'preDelete', function ($user) {
-				/** @var $user \OC\User\User */
-				\OC_Hook::emit('OC_User', 'pre_deleteUser', ['run' => true, 'uid' => $user->getUID()]);
+				$event = new GenericEvent(null, ['run' => true, 'uid' => $user->getUID()]);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\User\User::pre_delete', $event);
 			});
 			$userSession->listen('\OC\User', 'postDelete', function ($user) {
-				/** @var $user \OC\User\User */
-				\OC_Hook::emit('OC_User', 'post_deleteUser', ['uid' => $user->getUID()]);
+				$event = new GenericEvent(null, ['uid' => $user->getUID()]);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\User\User::post_delete', $event);
 			});
 			$userSession->listen('\OC\User', 'preSetPassword', function ($user, $password, $recoveryPassword) {
 				/** @var $user \OC\User\User */
 				\OC_Hook::emit('OC_User', 'pre_setPassword', ['run' => true, 'uid' => $user->getUID(), 'password' => $password, 'recoveryPassword' => $recoveryPassword]);
 			});
 			$userSession->listen('\OC\User', 'postSetPassword', function ($user, $password, $recoveryPassword) {
-				/** @var $user \OC\User\User */
-				\OC_Hook::emit('OC_User', 'post_setPassword', ['run' => true, 'uid' => $user->getUID(), 'password' => $password, 'recoveryPassword' => $recoveryPassword]);
+				$event = new GenericEvent(null, ['run' => true, 'user' => $user ,'uid' => $user->getUID(), 'password' => $password, 'recoveryPassword' => $recoveryPassword]);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\User\User::post_setPassword', $event);
 			});
 			$userSession->listen('\OC\User', 'preLogin', function ($uid, $password) {
-				\OC_Hook::emit('OC_User', 'pre_login', ['run' => true, 'uid' => $uid, 'password' => $password]);
+				$event = new GenericEvent(null, ['run' => true, 'uid' => $uid, 'password' => $password]);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\User\Session::pre_login', $event);
 			});
 			$userSession->listen('\OC\User', 'postLogin', function ($user, $password) {
-				/** @var $user \OC\User\User */
-				\OC_Hook::emit('OC_User', 'post_login', ['run' => true, 'uid' => $user->getUID(), 'password' => $password]);
+				$event = new GenericEvent(null, ['run' => true, 'uid' => $user->getUID(), 'password' => $password]);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\User\Session::post_login', $event);
 			});
 			$userSession->listen('\OC\User', 'preLogout', function () {
 				$event = new GenericEvent(null, []);
 				\OC::$server->getEventDispatcher()->dispatch('\OC\User\Session::pre_logout', $event);
 			});
 			$userSession->listen('\OC\User', 'logout', function () {
-				\OC_Hook::emit('OC_User', 'logout', []);
+				$event = new GenericEvent(null);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\User\Session::logout', $event);
 			});
 			$userSession->listen('\OC\User', 'changeUser', function ($user, $feature, $value) {
-				/** @var $user \OC\User\User */
-				\OC_Hook::emit('OC_User', 'changeUser', ['run' => true, 'user' => $user, 'feature' => $feature, 'value' => $value]);
+				$event = new GenericEvent(null, ['run' => true, 'user' => $user, 'feature' => $feature, 'value' => $value]);
+				\OC::$server->getEventDispatcher()->dispatch('\OC\User\User::triggerChangeUser',$event);
 			});
 			return $userSession;
 		});

--- a/tests/lib/Files/Node/HookConnectorTest.php
+++ b/tests/lib/Files/Node/HookConnectorTest.php
@@ -160,6 +160,7 @@ class HookConnectorTest extends TestCase {
 	 * @dataProvider viewToNodeProviderCopyRename
 	 */
 	public function testViewToNodeCopyRename(callable $operation, $expectedHook) {
+		$this->loginAsUser($this->userId);
 		$connector = new \OC\Files\Node\HookConnector($this->root, $this->view);
 		$connector->viewToNode();
 		$hookCalled = false;

--- a/tests/lib/HelperStorageTest.php
+++ b/tests/lib/HelperStorageTest.php
@@ -114,6 +114,7 @@ class HelperStorageTest extends TestCase {
 	 * Test getting the storage info, including extra mount points
 	 */
 	function testGetStorageInfoIncludingExtStorage() {
+		$this->loginAsUser($this->user);
 		$homeStorage = new Temporary([]);
 		Filesystem::mount($homeStorage, [], '/' . $this->user . '/files');
 		$homeStorage->file_put_contents('test.txt', '01234');


### PR DESCRIPTION
Replace hooks with symfony eventdispatcher

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Replace OC_Hook::emit with symfony eventdispatcher

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/29174

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Replace old hooks with Symfony dispatcher events.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

