### PR TITLE
Trigger eventdispatcher for federated share

### DIFF
--- a/apps/federatedfilesharing/lib/RequestHandler.php
+++ b/apps/federatedfilesharing/lib/RequestHandler.php
@@ -34,6 +34,8 @@ use OCP\IDBConnection;
 use OCP\IRequest;
 use OCP\IUserManager;
 use OCP\Share;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Class RequestHandler
@@ -65,6 +67,9 @@ class RequestHandler {
 	/** @var  IUserManager */
 	private $userManager;
 
+	/** @var EventDispatcherInterface  */
+	private $eventDispatcher;
+
 	/** @var string */
 	private $shareTable = 'share';
 
@@ -78,6 +83,7 @@ class RequestHandler {
 	 * @param Notifications $notifications
 	 * @param AddressHandler $addressHandler
 	 * @param IUserManager $userManager
+	 * @param EventDispatcherInterface $eventDispatcher
 	 */
 	public function __construct(FederatedShareProvider $federatedShareProvider,
 								IDBConnection $connection,
@@ -85,7 +91,8 @@ class RequestHandler {
 								IRequest $request,
 								Notifications $notifications,
 								AddressHandler $addressHandler,
-								IUserManager $userManager
+								IUserManager $userManager,
+								EventDispatcherInterface $eventDispatcher
 	) {
 		$this->federatedShareProvider = $federatedShareProvider;
 		$this->connection = $connection;
@@ -94,6 +101,7 @@ class RequestHandler {
 		$this->notifications = $notifications;
 		$this->addressHandler = $addressHandler;
 		$this->userManager = $userManager;
+		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	/**
@@ -165,6 +173,10 @@ class RequestHandler {
 					$sharedByFederatedId = $ownerFederatedId;
 				}
 
+				$event = new GenericEvent(null, ['name' => $name, 'targetuser' => $sharedByFederatedId,
+								'owner' => $owner, 'sharewith' => $shareWith,
+								'sharedby' => $sharedBy, 'remoteid' => $remoteId]);
+				$this->eventDispatcher->dispatch('\OCA\FederatedFileSharing::remote_shareReceived', $event);
 				\OC::$server->getActivityManager()->publishActivity(
 					Activity::FILES_SHARING_APP, Activity::SUBJECT_REMOTE_SHARE_RECEIVED, [$ownerFederatedId, trim($name, '/')], '', [],
 					'', '', $shareWith, Activity::TYPE_REMOTE_SHARE, Activity::PRIORITY_LOW);

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -35,6 +35,7 @@ use OCP\Notification\IManager;
 use OCP\Share\Events\AcceptShare;
 use OCP\Share\Events\DeclineShare;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Manager {
 	const STORAGE = '\OCA\Files_Sharing\External\Storage';
@@ -342,6 +343,8 @@ class Manager {
 
 		if($result) {
 			$this->removeReShares($id);
+			$event = new GenericEvent(null, ['user' => $this->uid, 'targetmount' => $mountPoint]);
+			$this->eventDispatcher->dispatch('\OCA\Files_Sharing::unshareEvent', $event);
 		}
 
 		return $result;

--- a/ocs/routes.php
+++ b/ocs/routes.php
@@ -101,7 +101,8 @@ if (\OC::$server->getAppManager()->isEnabledForUser('files_sharing')) {
 		\OC::$server->getRequest(),
 		$notification,
 		$addressHandler,
-		\OC::$server->getUserManager()
+		\OC::$server->getUserManager(),
+		\OC::$server->getEventDispatcher()
 	);
 	API::register('post',
 		'/cloud/shares',


### PR DESCRIPTION
Trigger event dispatcher for federated share
receiving.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Change to trigger event dispatcher event for federated share receive.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will help users to log events for fed share receive.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

