### PR TITLE
Fixup some gherkin when-then words

### DIFF
--- a/tests/ui/features/other/users.feature
+++ b/tests/ui/features/other/users.feature
@@ -27,7 +27,7 @@ Feature: users
 	Scenario Outline: change quota to an invalid value
 		When quota of user "%regularuser%" is changed to "<wished_quota>"
 		Then a notification should be displayed with the text 'Invalid quota value "<wished_quota>"'
-		Then quota of user "%regularuser%" should be set to "Default"
+		And quota of user "%regularuser%" should be set to "Default"
 
 		Examples:
 		|wished_quota|

--- a/tests/ui/features/sharing/shareByPublicLink.feature
+++ b/tests/ui/features/sharing/shareByPublicLink.feature
@@ -17,12 +17,12 @@ So that the user is forced to obey the policies of the server operator
 		And I login with username "user1" and password "1234"
 
 	Scenario: simple sharing by public link
-		And I create a new public link for the folder "simple-folder"
+		When I create a new public link for the folder "simple-folder"
 		And I access the last created public link
 		Then the file "lorem.txt" should be listed
 
 	Scenario: creating a public link with read & write permissions makes it possible to delete files via the link
-		And I create a new public link for the folder "simple-folder" with
+		When I create a new public link for the folder "simple-folder" with
 		| permission | Read & Write |
 		And I access the last created public link
 		And I delete the elements
@@ -35,7 +35,7 @@ So that the user is forced to obey the policies of the server operator
 		And the deleted elements should not be listed after a page reload
 
 	Scenario: creating a public link with read permissions only makes it impossible to delete files via the link
-		And I create a new public link for the folder "simple-folder" with
+		When I create a new public link for the folder "simple-folder" with
 		| permission | Read |
 		And I access the last created public link
 		Then it should not be possible to delete the file "lorem.txt"

--- a/tests/ui/features/sharing/shareeAutocompletion.feature
+++ b/tests/ui/features/sharing/shareeAutocompletion.feature
@@ -11,46 +11,46 @@ Feature: Sharee - autocompletion
 		
 	Scenario: autocompletion of regular existing users
 		And the share dialog for the folder "simple-folder" is open
-		And I type "user" in the share-with-field
+		When I type "user" in the share-with-field
 		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list
 		And my own name should not be listed in the autocomplete list
 		
 	Scenario: autocompletion of regular existing groups
 		And the share dialog for the folder "simple-folder" is open
-		And I type "grp" in the share-with-field
+		When I type "grp" in the share-with-field
 		Then all users and groups that contain the string "grp" in their name should be listed in the autocomplete list
 		And my own name should not be listed in the autocomplete list
 		
 	Scenario: autocompletion for a pattern that does not match any user or group
 		And the share dialog for the folder "simple-folder" is open
-		And I type "doesnotexist" in the share-with-field
+		When I type "doesnotexist" in the share-with-field
 		Then a tooltip with the text "No users or groups found for doesnotexist" should be shown near the share-with-field
 		And the autocomplete list should not be displayed
 		
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
 		And the folder "simple-folder" is shared with the user "user1"
 		And the share dialog for the folder "simple-folder" is open
-		And I type "user" in the share-with-field
+		When I type "user" in the share-with-field
 		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list except user "user1"
 		And my own name should not be listed in the autocomplete list
 
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user whith whom the item is already shared (file)
 		And the file "data.zip" is shared with the user "usergrp"
 		And the share dialog for the file "data.zip" is open
-		And I type "user" in the share-with-field
+		When I type "user" in the share-with-field
 		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list except user "usergrp"
 		And my own name should not be listed in the autocomplete list
 		
 	Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
 		And the folder "simple-folder" is shared with the group "grp1"
 		And the share dialog for the folder "simple-folder" is open
-		And I type "grp" in the share-with-field
+		When I type "grp" in the share-with-field
 		Then all users and groups that contain the string "grp" in their name should be listed in the autocomplete list except group "grp1"
 		And my own name should not be listed in the autocomplete list
 
 	Scenario: autocompletion of a pattern that matches regular existing groups but also a group whith whom the item is already shared (file)
 		And the file "data.zip" is shared with the group "grpuser"
 		And the share dialog for the file "data.zip" is open
-		And I type "grp" in the share-with-field
+		When I type "grp" in the share-with-field
 		Then all users and groups that contain the string "grp" in their name should be listed in the autocomplete list except group "grpuser"
 		And my own name should not be listed in the autocomplete list

--- a/tests/ui/features/sharing/sharing.feature
+++ b/tests/ui/features/sharing/sharing.feature
@@ -18,7 +18,7 @@ Feature: Sharing
 		And I login with username "user2" and password "1234"
 
 	Scenario: share a file & folder with another internal user
-		And the folder "simple-folder" is shared with the user "User One"
+		When the folder "simple-folder" is shared with the user "User One"
 		And the file "testimage.jpg" is shared with the user "User One"
 		And I logout
 		And I login with username "user1" and password "1234"
@@ -33,7 +33,7 @@ Feature: Sharing
 	Scenario: share a folder with an internal group
 		And I logout
 		And I login with username "user3" and password "1234"
-		And the folder "simple-folder" is shared with the group "grp1"
+		When the folder "simple-folder" is shared with the group "grp1"
 		And the file "testimage.jpg" is shared with the group "grp1"
 		And I logout
 		And I login with username "user1" and password "1234"


### PR DESCRIPTION
## Description
Fixup use of Gherkin "When" and "Then" in various places in the UI tests

## Related Issue

## Motivation and Context
After looking at PR #29521 I realised that a few feature files were missing "When" keywords in the appropriate places.

## How Has This Been Tested?
Travis knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

