### PR TITLE
use consequently is_null() to check return of find()

### DIFF
--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -89,7 +89,7 @@ class FilesPage extends FilesPageBasic {
 
 		$newButtonElement = $this->find("xpath", $this->newFileFolderButtonXpath);
 
-		if ($newButtonElement === null) {
+		if (is_null($newButtonElement)) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->newFileFolderButtonXpath " .
@@ -101,7 +101,7 @@ class FilesPage extends FilesPageBasic {
 
 		$newFolderButtonElement = $this->find("xpath", $this->newFolderButtonXpath);
 
-		if ($newFolderButtonElement === null) {
+		if (is_null($newFolderButtonElement)) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->newFolderButtonXpath " .

--- a/tests/ui/features/lib/PersonalSecuritySettingsPage.php
+++ b/tests/ui/features/lib/PersonalSecuritySettingsPage.php
@@ -57,7 +57,7 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 			$this->createNewAppPasswordButtonId
 		);
 
-		if ($createNewAppPasswordButton === null) {
+		if (is_null($createNewAppPasswordButton)) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" id $this->createNewAppPasswordButtonId " .
@@ -71,7 +71,7 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 			$this->createNewAppPasswordButtonId
 		);
 
-		if ($createNewAppPasswordButton === null) {
+		if (is_null($createNewAppPasswordButton)) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" id $this->createNewAppPasswordButtonId " .

--- a/tests/ui/features/lib/UsersPage.php
+++ b/tests/ui/features/lib/UsersPage.php
@@ -88,7 +88,7 @@ class UsersPage extends OwncloudPage {
 		$userTr = $this->findUserInTable($username);
 		$selectField = $userTr->find('xpath', $this->quotaSelectXpath);
 
-		if ($selectField === null) {
+		if (is_null($selectField)) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->quotaSelectXpath " .
@@ -99,7 +99,7 @@ class UsersPage extends OwncloudPage {
 		$xpathLocator = "//option[@value='" . $selectField->getValue() . "']";
 		$selectField = $selectField->find('xpath', $xpathLocator);
 
-		if ($selectField === null) {
+		if (is_null($selectField)) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $xpathLocator " .


### PR DESCRIPTION
## Description
uses consequently `is_null()` instead of ` === null` in the UI tests

## Motivation and Context
make @phil-davis happy when he stares at the code

## How Has This Been Tested?
travis will do the job

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

