### PR TITLE
Fixup check if file folder is listed

### DIFF
--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -385,6 +385,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	/**
 	 * After Scenario. Report the pass/fail status to SauceLabs.
 	 *
+	 * @param AfterScenarioScope $afterScenarioScope
 	 * @return void
 	 * @AfterScenario
 	 */

--- a/tests/ui/features/bootstrap/SharingContext.php
+++ b/tests/ui/features/bootstrap/SharingContext.php
@@ -157,7 +157,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * @param string $name
 	 * @param TableNode $settings table with the settings and no header
 	 *                            possible settings: name, permission,
-	 *                                               password, expiration, email
+	 *                            password, expiration, email
 	 *                            the permissions values has to be written exactly
 	 *                            the way its written in the UI
 	 * @return void
@@ -417,7 +417,9 @@ class SharingContext extends RawMinkContext implements Context {
 	/**
 	 * @Then /^it should not be possible to share the (?:file|folder) "([^"]*)"(?: with "([^"]*)")?$/
 	 * @param string $fileName
+	 * @param string|null $shareWith
 	 * @return void
+	 * @throws Exception
 	 */
 	public function itShouldNotBePossibleToShare($fileName, $shareWith = null) {
 		$sharingWasPossible = false;


### PR DESCRIPTION
## Description
1) Make use of ``setCurrentPageObject()`` to keep track of when we are on the files page and trashbin page (as well as the public links page, which it does already)
2) Pass around the word "trashbin" to indicate when a step should be using the trashbin. This will be easier to extend when we want to do things on the "favourites", "tags" etc files pages.
3) Refactor a bit in ``checkIfFileFolderIsListed()`` to handle the trashbin case more cleanly.
4) Fix stuff that ``phpcs`` complains about. (2nd commit)

## Related Issue

## Motivation and Context
As we add trashbin tests and then other tests for favourites, tagged files etc. it is good to sort out the structure of the code.

## How Has This Been Tested?
Travis passes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

