### PR TITLE
Kill a route to removed script

### DIFF
--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -72,8 +72,6 @@ $this->create('files_ajax_getstoragestats', 'ajax/getstoragestats.php')
 	->actionInclude('files/ajax/getstoragestats.php');
 $this->create('files_ajax_list', 'ajax/list.php')
 	->actionInclude('files/ajax/list.php');
-$this->create('files_ajax_setupload', 'ajax/setupload.php')
-	->actionInclude('files/ajax/setupload.php');
 
 $this->create('download', 'download{file}')
 	->requirements(['file' => '.*'])


### PR DESCRIPTION
## Description
Remove a route to `apps/files/ajax/setupload.php` script removed in https://github.com/owncloud/core/pull/27929

## Motivation and Context
Clean route list

## How Has This Been Tested?
```
>grep -R setupload
apps/files/appinfo/routes.php:$this->create('files_ajax_setupload', 'ajax/setupload.php')
apps/files/appinfo/routes.php:  ->actionInclude('files/ajax/setupload.php');

> ls -la apps/files/ajax/setupload.php
ls: cannot access 'apps/files/ajax/setupload.php': No such file or directory
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

