### PR TITLE
Refactor delete and trashbin tests

### DIFF
--- a/tests/ui/features/files/deleteFilesFolders.feature
+++ b/tests/ui/features/files/deleteFilesFolders.feature
@@ -18,7 +18,6 @@ So that I can keep my filing system clean and tidy
 		| strängé filename (duplicate #2).txt |
 		Then the deleted elements should not be listed
 		And the deleted elements should not be listed after a page reload
-		But the deleted elements should be listed in the trashbin
 
 	Scenario: Delete a file with problematic characters
 		When I rename the following file to
@@ -53,13 +52,7 @@ So that I can keep my filing system clean and tidy
 			| "double" quotes |
 			| question?       |
 			| &and#hash       |
-		But the following file should be listed in the trashbin
-			| name-parts      |
-			| 'single'        |
-			| "double" quotes |
-			| question?       |
-			| &and#hash       |
-	
+
 	Scenario: Delete multiple files at once
 		When I batch delete these files
 		| name          |
@@ -68,7 +61,6 @@ So that I can keep my filing system clean and tidy
 		| simple-folder |
 		Then the deleted elements should not be listed
 		And the deleted elements should not be listed after a page reload
-		But the deleted elements should be listed in the trashbin
 
 	Scenario: Delete an empty folder
 		When I create a folder with the name "my-empty-folder"
@@ -76,12 +68,7 @@ So that I can keep my filing system clean and tidy
 		And I delete the folder "my-empty-folder"
 		Then the folder "my-other-empty-folder" should be listed
 		But the folder "my-empty-folder" should not be listed
-		And the folder "my-empty-folder" should be listed in the trashbin
-		But the folder "my-other-empty-folder" should not be listed in the trashbin
-		When I open the trashbin folder "my-empty-folder"
-		Then there are no files/folders listed
 
 	Scenario: Delete the last file in a folder
 		When I delete the file "zzzz-must-be-last-file-in-folder.txt"
 		Then the file "zzzz-must-be-last-file-in-folder.txt" should not be listed
-		But the file "zzzz-must-be-last-file-in-folder.txt" should be listed in the trashbin

--- a/tests/ui/features/trashbin/trashbinFilesFolders.feature
+++ b/tests/ui/features/trashbin/trashbinFilesFolders.feature
@@ -1,0 +1,58 @@
+@insulated
+Feature: files and folders exist in the trashbin after being deleted
+  As a user
+  I want deleted files and folders to be available in the trashbin
+  So that I can recover data easily
+
+  Background:
+    Given a regular user exists
+    And I am logged in as a regular user
+    And I am on the files page
+
+  Scenario: Delete files & folders one by one and check that they are all in the trashbin
+    When I delete the elements
+      | name                                |
+      | simple-folder                       |
+      | lorem.txt                           |
+      | strängé नेपाली folder                  |
+      | strängé filename (duplicate #2).txt |
+    Then the deleted elements should be listed in the trashbin
+    And the file "lorem.txt" should be listed in the trashbin folder "simple-folder"
+
+  Scenario: Delete a file with problematic characters and check it is in the trashbin
+    When I rename the following file to
+      | from-name-parts | to-name-parts   |
+      | lorem.txt       | 'single'        |
+      |                 | "double" quotes |
+      |                 | question?       |
+      |                 | &and#hash       |
+    And I delete the following file
+      | name-parts      |
+      | 'single'        |
+      | "double" quotes |
+      | question?       |
+      | &and#hash       |
+    Then the following file should be listed in the trashbin
+      | name-parts      |
+      | 'single'        |
+      | "double" quotes |
+      | question?       |
+      | &and#hash       |
+
+  Scenario: Delete multiple files at once and check that they are all in the trashbin
+    When I batch delete these files
+      | name          |
+      | data.zip      |
+      | lorem.txt     |
+      | simple-folder |
+    Then the deleted elements should be listed in the trashbin
+    And the file "lorem.txt" should be listed in the trashbin folder "simple-folder"
+
+  Scenario: Delete an empty folder and check it is in the trashbin
+    When I create a folder with the name "my-empty-folder"
+    And I create a folder with the name "my-other-empty-folder"
+    And I delete the folder "my-empty-folder"
+    Then the folder "my-empty-folder" should be listed in the trashbin
+    But the folder "my-other-empty-folder" should not be listed in the trashbin
+    When I open the trashbin folder "my-empty-folder"
+    Then there are no files/folders listed


### PR DESCRIPTION
## Description
1) Take trashbin test steps out of the ordinary "delete file" tests. move the "delete" feature to the files suite.
2) Make a new ``trashbinFilesFolders.feature`` that tests to make sure items get into the trashbin.
3) Refactor ``theFileFolderShouldBeListed()`` so it can cope with combinations of "in the trashbin" in the folder xyz" "in the trashbin folder xyz"... making it the Swiss army knife of test steps :)
4) Refactor the "I open the" test steps so the same step works for the trashbin or files page

## Related Issue

## Motivation and Context
1) Trashbin, although bundled with core, is an app that can be enabled/disabled. So we want ordinary delete tests that will work even if the trashbin is disabled.
2) Prepare test step formats so we can also easily test deleting from the trashbin.

## How Has This Been Tested?
Travis

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

