### PR TITLE
Consider error 22 as an AlreadyExistsException

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -266,6 +266,17 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			$this->removeFromCache($this->root . $source);
 			$this->removeFromCache($this->root . $target);
 			$this->swallow(__FUNCTION__, $e);
+		} catch (Exception $e) {
+			// Icewind\SMB\Exception\Exception, not a plain exception
+			if ($e->getCode() === 22) {
+				$this->unlink($target);
+				$result = $this->share->rename($this->root . $source, $this->root . $target);
+				$this->removeFromCache($this->root . $source);
+				$this->removeFromCache($this->root . $target);
+			} else {
+				$result = false;
+			}
+			$this->swallow(__FUNCTION__, $e);
 		} catch (\Exception $e) {
 			$this->swallow(__FUNCTION__, $e);
 			$result = false;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Trying to rename a file to another one whose name already exists seems to be problematic in some servers. We're expecting an "AlreadyExistsException" but we get an exception with code 22 instead.

```
libsmbclient: 2:4.3.11+dfsg-0ubuntu0.16.04.11

smbclient

smbclient Support => enabled
smbclient extension Version => 0.8.0RC1
libsmbclient library Version => 4.3.11-Ubuntu
```

## Related Issue


## Motivation and Context
Several issues have poped up related with the following error uploading files in SMB server:
```
{"reqId":"grx4F5PrrJmr2FUc4\/qq","remoteAddr":"10.0.2.4","app":"webdav","message":"\\OC\\Files\\Filesystem::rename() failed ......
{"reqId":"grx4F5PrrJmr2FUc4\/qq","remoteAddr":"10.0.2.4","app":"webdav","message":"Exception: {\"Message\":\"HTTP\\\/1.1 500 Could n
ot rename part file assembled from chunks\",\"Exception\":\"Sabre\\\\DAV\\\\Exception\",\"Code\":0,\"Trace\":\"#0 \\\/opt\\\/ownclou
d\\\/apps\\\/dav\\\/lib\\\/Connector\\\/Sabre\\\/File.php(103): OCA\\\\DAV\\\\Connector\\\\Sabre\\\\File->createFileChunked(Resource
 id #71)\\n#1 \\\/opt\\\/owncloud\\\/apps\\\/dav\\\/lib\\\/Connector\\\/Sabre\\\/Directory.php(136): OCA\\\\DAV\\\\Connector\\\\Sabr
e\\\\File->put(Resource id #71)\\n#2 \\\/opt\\\/owncloud\\\/3rdparty\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(1036): OCA\\\\DAV\\
\\Connector\\\\Sabre\\\\Directory->createFile(......
```

## How Has This Been Tested?
Tested same patch against stable9.1. Master and stable10 haven't been tested yet.

1. Upload a big file (>10MB) through the desktop client in order to force chunking to be used
2. Edit the same file and let the desktop client upload it

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@butonic please review.

Backports to stable10 and stable9.1 will be needed