### PR TITLE
catch the right exception

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -157,7 +157,7 @@ class Scan extends Base {
 				try {
 					// FIXME: this will lock the storage even if there is nothing to repair
 					$storage->acquireLock('', ILockingProvider::LOCK_EXCLUSIVE, $this->lockingProvider);
-				} catch (OCP\Lock\LockedException $e) {
+				} catch (LockedException $e) {
 					$output->writeln("\t<error>Storage \"" . $storage->getCache()->getNumericStorageId() . '" cannot be repaired as it is currently in use, please try again later</error>');
 					return;
 				}


### PR DESCRIPTION
OCP\Lock\LockedException is relative to the current namespace. so this can never be caught. must be `\OCP\Lock\LockedException` or better `LockedException` because it is in the use stamtements

related to the repair steps so I figure this is kind of important