### PR TITLE
[stable10] Handle invalid ext storage backend to keep mount point visible

### DIFF
--- a/apps/files_external/css/settings.css
+++ b/apps/files_external/css/settings.css
@@ -102,3 +102,13 @@ td.mountPoint, td.backend { width:160px; }
 #externalStorage .mountOptionsDropdown {
 	margin-right: 40px;
 }
+
+#externalStorage td.configuration .error-invalid,
+#externalStorage td.authentication .error-invalid {
+	white-space: normal;
+
+}
+
+#externalStorage tr.invalid {
+	background-color: #F2DEDE;
+}

--- a/lib/private/Files/External/InvalidStorage.php
+++ b/lib/private/Files/External/InvalidStorage.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\External;
+
+use OCP\Files\StorageNotAvailableException;
+use OC\Files\Storage\FailedStorage;
+
+class InvalidStorage extends FailedStorage {
+	public function __construct($params) {
+		throw new StorageNotAvailableException();
+	}
+}

--- a/lib/public/Files/External/Auth/InvalidAuth.php
+++ b/lib/public/Files/External/Auth/InvalidAuth.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Files\External\Auth;
+
+/**
+ * Invalid authentication representing an auth mechanism
+ * that could not be resolved
+ *
+ * @since 10.0.5
+ */
+class InvalidAuth extends AuthMechanism {
+
+	/**
+	 * Constructs a new InvalidAuth with the id of the invalid auth
+	 * for display purposes
+	 *
+	 * @param string $invalidId invalid id
+	 *
+	 * @since 10.0.5
+	 */
+	public function __construct($invalidId) {
+		$this->setIdentifier($invalidId)
+			->setScheme(self::SCHEME_NULL)
+			->setText('Unknown auth mechanism backend ' . $invalidId)
+		;
+	}
+
+}

--- a/lib/public/Files/External/Backend/InvalidBackend.php
+++ b/lib/public/Files/External/Backend/InvalidBackend.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Files\External\Backend;
+
+use \OCP\IL10N;
+
+/**
+ * Invalid storage backend representing a backend
+ * that could not be resolved
+ *
+ * @since 10.0.5
+ */
+class InvalidBackend extends Backend {
+
+	/** @var string Invalid backend id */
+	private $invalidId;
+
+	/**
+	 * Constructs a new InvalidBackend with the id of the invalid backend
+	 * for display purposes
+	 *
+	 * @param string $invalidId id of the backend that did not exist
+	 *
+	 * @since 10.0.5
+	 */
+	function __construct($invalidId) {
+		$this->invalidId = $invalidId;
+		$this->setIdentifier($invalidId)
+			->setStorageClass('\OC\Files\External\InvalidStorage')
+			->setText('Unknown storage backend ' . $invalidId)
+		;
+	}
+
+	/**
+	 * Returns the invalid backend id
+	 *
+	 * @return string invalid backend id
+	 *
+	 * @since 10.0.5
+	 */
+	public function getInvalidId() {
+		return $this->invalidId;
+	}
+}
+

--- a/tests/lib/Files/External/InvalidStorageTest.php
+++ b/tests/lib/Files/External/InvalidStorageTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace Test\Files\External;
+
+use Test\TestCase;
+use OC\Files\External\InvalidStorage;
+
+class InvalidStorageTest extends TestCase {
+
+	/**
+	 * @expectedException OCP\Files\StorageNotAvailableException
+	 */
+	public function testCannotInstantiate() {
+		new InvalidStorage([]);
+	}
+}

--- a/tests/lib/Files/External/Service/StoragesServiceTest.php
+++ b/tests/lib/Files/External/Service/StoragesServiceTest.php
@@ -31,6 +31,9 @@ use OC\Files\External\Service\StoragesService;
 use OCP\Files\External\NotFoundException;
 use OCP\Files\External\IStoragesBackendService;
 use Test\TestCase;
+use OCP\Files\External\Backend\InvalidBackend;
+use OCP\Files\External\Auth\InvalidAuth;
+use OCP\Files\External\Backend\Backend;
 
 /**
  * @group DB
@@ -66,6 +69,11 @@ abstract class StoragesServiceTest extends TestCase {
 	 * @var \PHPUnit_Framework_MockObject_MockObject | \OCP\Files\Config\IUserMountCache
 	 */
 	protected $mountCache;
+
+	/**
+	 * @var Backend[]
+	 */
+	protected $backends;
 
 	public function setUp() {
 		parent::setUp();
@@ -108,21 +116,24 @@ abstract class StoragesServiceTest extends TestCase {
 
 		$sftpBackend = $this->getBackendMock('\OCA\Files_External\Lib\Backend\SFTP', '\OCA\Files_External\Lib\Storage\SFTP');
 		$dummyBackend = $this->getBackendMock('\Test\Files\External\Backend\DummyBackend', '\Test\Files\External\Backend\DummyStorage');
-		$backends = [
+		$this->backends = [
 			'identifier:\OCA\Files_External\Lib\Backend\SMB' => $this->getBackendMock('\OCA\Files_External\Lib\Backend\SMB', '\OCA\Files_External\Lib\Storage\SMB'),
 			'identifier:\OCA\Files_External\Lib\Backend\SFTP' => $sftpBackend,
 			'identifier:\Test\Files\External\Backend\DummyBackend' => $dummyBackend,
 			'identifier:sftp_alias' => $sftpBackend,
 		];
 		$this->backendService->method('getBackend')
-			->will($this->returnCallback(function ($backendClass) use ($backends) {
-				if (isset($backends[$backendClass])) {
-					return $backends[$backendClass];
+			->will($this->returnCallback(function ($backendClass) {
+				if (isset($this->backends[$backendClass])) {
+					return $this->backends[$backendClass];
 				}
 				return null;
 			}));
 		$this->backendService->method('getBackends')
-			->will($this->returnValue($backends));
+			->will($this->returnCallback(function () {
+				// in case they changed
+				return $this->backends;
+			}));
 
 		\OCP\Util::connectHook(
 			Filesystem::CLASSNAME,
@@ -349,27 +360,29 @@ abstract class StoragesServiceTest extends TestCase {
 	}
 
 	/**
-	 * @expectedException \InvalidArgumentException
 	 */
 	public function testCreateStorageInvalidClass() {
-		$this->service->createStorage(
+		$storageConfig = $this->service->createStorage(
 			'mount',
 			'identifier:\OC\Not\A\Backend',
 			'identifier:\Auth\Mechanism',
 			[]
 		);
+
+		$this->assertInstanceOf(InvalidBackend::class, $storageConfig->getBackend());
+
 	}
 
 	/**
-	 * @expectedException \InvalidArgumentException
 	 */
 	public function testCreateStorageInvalidAuthMechanismClass() {
-		$this->service->createStorage(
+		$storageConfig = $this->service->createStorage(
 			'mount',
 			'identifier:\OCA\Files_External\Lib\Backend\SMB',
 			'identifier:\Not\An\Auth\Mechanism',
 			[]
 		);
+		$this->assertInstanceOf(InvalidAuth::class, $storageConfig->getAuthMechanism());
 	}
 
 	public function testGetStoragesBackendNotVisible() {
@@ -485,5 +498,29 @@ abstract class StoragesServiceTest extends TestCase {
 		$this->assertEquals('/mountpoint2', $savedStorage->getMountPoint());
 		$this->assertEquals($newAuthMechanism, $savedStorage->getAuthMechanism());
 		$this->assertEquals('password2', $savedStorage->getBackendOption('password'));
+	}
+
+	/**
+	 * @expectedException OCP\Files\External\NotFoundException
+	 */
+	public function testCannotEditInvalidBackend() {
+		$backend = $this->backendService->getBackend('identifier:\Test\Files\External\Backend\DummyBackend');
+		$authMechanism = $this->backendService->getAuthMechanism('identifier:\Auth\Mechanism');
+
+		$storage = new StorageConfig();
+		$storage->setMountPoint('mountpoint');
+		$storage->setBackend($backend);
+		$storage->setAuthMechanism($authMechanism);
+		$storage->setBackendOptions(['password' => 'testPassword']);
+
+		$savedStorage = $this->service->addStorage($storage);
+
+		// make it invalid
+		$this->backends['identifier:\Test\Files\External\Backend\DummyBackend'] = new InvalidBackend('identifier:\Test\Files\External\Backend\DummyBackend');
+
+		$updatedStorage = new StorageConfig($savedStorage->getId());
+		$updatedStorage->setBackendOptions(['password' => 'password2']);
+
+		$this->service->updateStorage($updatedStorage);
 	}
 }

--- a/tests/lib/Files/External/Service/UserGlobalStoragesServiceTest.php
+++ b/tests/lib/Files/External/Service/UserGlobalStoragesServiceTest.php
@@ -366,4 +366,9 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 		// we don't test this here
 		$this->assertTrue(true);
 	}
+
+	public function testCannotEditInvalidBackend() {
+		// we don't test this here
+		$this->assertTrue(true);
+	}
 }


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/26539 to stable10