### PR TITLE
Remove readdir implementation from View.php, unused and broken.

### DIFF
--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -686,10 +686,6 @@ class Filesystem {
 		return self::$defaultInstance->opendir($path);
 	}
 
-	static public function readdir($path) {
-		return self::$defaultInstance->readdir($path);
-	}
-
 	static public function is_dir($path) {
 		return self::$defaultInstance->is_dir($path);
 	}

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -361,15 +361,6 @@ class View {
 	}
 
 	/**
-	 * @param $handle
-	 * @return mixed
-	 */
-	public function readdir($handle) {
-		$fsLocal = new Storage\Local(['datadir' => '/']);
-		return $fsLocal->readdir($handle);
-	}
-
-	/**
 	 * @param string $path
 	 * @return bool|mixed
 	 */


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
`readdir` implemention in View.php seems pretty broken, possibly left-over from some old approach. No one even uses it. Should just remove since `View::opendir` and system `readdir` is a perfectly functional alternative.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removing dead code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
