### PR TITLE
UI tests to check that the file conflict dialogue disappears again

### DIFF
--- a/tests/ui/features/upload/upload.feature
+++ b/tests/ui/features/upload/upload.feature
@@ -27,7 +27,8 @@ So that I can store files in ownCloud
 		When I upload the file "lorem.txt"
 		And I choose to keep the new files
 		And I click the "Continue" button
-		Then the file "lorem.txt" should be listed
+		Then no dialog should be displayed
+		And the file "lorem.txt" should be listed
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"
 		But the file "lorem (2).txt" should not be listed
 
@@ -36,7 +37,8 @@ So that I can store files in ownCloud
 		And I choose to keep the new files
 		And I choose to keep the existing files
 		And I click the "Continue" button
-		Then the file "lorem.txt" should be listed
+		Then no dialog should be displayed
+		And the file "lorem.txt" should be listed
 		And the content of "lorem.txt" should not have changed
 		And the file "lorem (2).txt" should be listed
 		And the content of "lorem (2).txt" should be the same as the local "lorem.txt"
@@ -44,6 +46,7 @@ So that I can store files in ownCloud
 	Scenario: cancel conflict dialog
 		When I upload the file "lorem.txt"
 		And I click the "Cancel" button
-		Then the file "lorem.txt" should be listed
+		Then no dialog should be displayed
+		And the file "lorem.txt" should be listed
 		And the content of "lorem.txt" should not have changed
 		And the file "lorem (2).txt" should not be listed


### PR DESCRIPTION
## Description
UI tests to check if the file-conflict pop-up  disappears again

## Related Issue
https://github.com/owncloud/core/issues/29459

## Motivation and Context
prevent future issues like https://github.com/owncloud/core/issues/29459

## How Has This Been Tested?
run locally and on travis

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

