### PR TITLE
Update the help output for the occ files:scan command

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -85,42 +85,42 @@ class Scan extends Base {
 			->addArgument(
 				'user_id',
 				InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
-				'will rescan all files of the given user(s)'
+				'Will rescan all files of the given user(s).'
 			)
 			->addOption(
 				'path',
 				'p',
 				InputArgument::OPTIONAL,
-				'limit rescan to this path, eg. --path="/alice/files/Music", the user_id is determined by the path and the user_id parameter and --all are ignored'
+				'Limit rescan to this path, e.g., --path="/alice/files/Music", the user_id is determined by the path and the user_id parameter and --all are ignored.'
 			)
 			->addOption(
 				'quiet',
 				'q',
 				InputOption::VALUE_NONE,
-				'suppress any output'
+				'Suppress any output.'
 			)
 			->addOption(
 				'verbose',
 				'-v|vv|vvv',
 				InputOption::VALUE_NONE,
-				'verbose the output'
+				"Increase the output's verbosity."
 			)
 			->addOption(
 				'all',
 				null,
 				InputOption::VALUE_NONE,
-				'will rescan all files of all known users'
+				'Will rescan all files of all known users.'
 			)
 			->addOption(
 				'repair',
 				null,
 				InputOption::VALUE_NONE,
-				'will repair detached filecache entries (slow)'
+				'Will repair detached filecache entries (slow).'
 			)->addOption(
 				'unscanned',
 				null,
 				InputOption::VALUE_NONE,
-				'only scan files which are marked as not fully scanned'
+				'Only scan files which are marked as not fully scanned.'
 			);
 	}
 

--- a/core/Command/App/CheckCode.php
+++ b/core/Command/App/CheckCode.php
@@ -53,24 +53,24 @@ class CheckCode extends Command {
 	protected function configure() {
 		$this
 			->setName('app:check-code')
-			->setDescription('check code to be compliant')
+			->setDescription('Check code compliance.')
 			->addArgument(
 				'app-id',
 				InputArgument::REQUIRED,
-				'check the specified app'
+				'Check the specified app.'
 			)
 			->addOption(
 				'checker',
 				'c',
 				InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-				'enable the specified checker(s)',
+				'Enable the specified checker(s).',
 				[ 'private', 'deprecation', 'strong-comparison' ]
 			)
 			->addOption(
 				'--skip-validate-info',
 				null,
 				InputOption::VALUE_NONE,
-				'skips the info.xml/version check'
+				'Skip the info.xml/version check.'
 			);
 	}
 

--- a/core/Command/App/Disable.php
+++ b/core/Command/App/Disable.php
@@ -46,11 +46,11 @@ class Disable extends Command {
 	protected function configure() {
 		$this
 			->setName('app:disable')
-			->setDescription('disable an app')
+			->setDescription('Disable an app.')
 			->addArgument(
 				'app-id',
 				InputArgument::REQUIRED,
-				'disable the specified app'
+				'Disable the specified app.'
 			);
 	}
 

--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -47,17 +47,17 @@ class Enable extends Command {
 	protected function configure() {
 		$this
 			->setName('app:enable')
-			->setDescription('enable an app')
+			->setDescription('Enable an app.')
 			->addArgument(
 				'app-id',
 				InputArgument::REQUIRED,
-				'enable the specified app'
+				'Enable the specified app.'
 			)
 			->addOption(
 				'groups',
 				'g',
 				InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-				'enable the app only for a list of groups'
+				'Enable the app only for a specific list of groups.'
 			)
 		;
 	}

--- a/core/Command/App/GetPath.php
+++ b/core/Command/App/GetPath.php
@@ -32,11 +32,11 @@ class GetPath extends Base {
 
 		$this
 			->setName('app:getpath')
-			->setDescription('Get an absolute path to the app directory')
+			->setDescription('Get the absolute path to the app directory.')
 			->addArgument(
 				'app',
 				InputArgument::REQUIRED,
-				'Name of the app'
+				'The name of the app.'
 			)
 		;
 	}

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -49,17 +49,17 @@ class ListApps extends Base {
 
 		$this
 			->setName('app:list')
-			->setDescription('List all available apps')
+			->setDescription('List all available apps.')
 			->addArgument(
 				'search-pattern',
 				InputArgument::OPTIONAL,
-				'Restrict the list of apps to those whose name matches the given regular expression'
+				'Restrict the list of apps to those whose name matches the given regular expression.'
 			)
 			->addOption(
 				'shipped',
 				null,
 				InputOption::VALUE_REQUIRED,
-				'true - limit to shipped apps only, false - limit to non-shipped apps only'
+				'true - limit to shipped apps only, false - limit to non-shipped apps only.'
 			)
 		;
 	}

--- a/core/Command/Background/Base.php
+++ b/core/Command/Background/Base.php
@@ -58,7 +58,7 @@ abstract class Base extends Command {
 		$mode = $this->getMode();
 		$this
 			->setName("background:$mode")
-			->setDescription("Use $mode to run background jobs");
+			->setDescription("Use $mode to run background jobs.");
 	}
 
 	/**

--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -47,7 +47,7 @@ class Base extends Command {
 				'output',
 				null,
 				InputOption::VALUE_OPTIONAL,
-				'Output format (plain, json or json_pretty, default is plain)',
+				'The output format to use (plain, json or json_pretty, default is plain).',
 				$this->defaultOutputFormat
 			)
 		;

--- a/core/Command/Check.php
+++ b/core/Command/Check.php
@@ -42,7 +42,7 @@ class Check extends Base {
 
 		$this
 			->setName('check')
-			->setDescription('check dependencies of the server environment')
+			->setDescription('Check the server environment\'s dependencies.')
 		;
 	}
 

--- a/core/Command/Config/App/DeleteConfig.php
+++ b/core/Command/Config/App/DeleteConfig.php
@@ -45,22 +45,22 @@ class DeleteConfig extends Base {
 
 		$this
 			->setName('config:app:delete')
-			->setDescription('Delete an app config value')
+			->setDescription('Delete an app config value.')
 			->addArgument(
 				'app',
 				InputArgument::REQUIRED,
-				'Name of the app'
+				'Name of the app.'
 			)
 			->addArgument(
 				'name',
 				InputArgument::REQUIRED,
-				'Name of the config to delete'
+				'Name of the config to delete.'
 			)
 			->addOption(
 				'error-if-not-exists',
 				null,
 				InputOption::VALUE_NONE,
-				'Checks whether the config exists before deleting it'
+				'Checks whether the config exists before deleting it.'
 			)
 		;
 	}

--- a/core/Command/Config/App/GetConfig.php
+++ b/core/Command/Config/App/GetConfig.php
@@ -45,22 +45,22 @@ class GetConfig extends Base {
 
 		$this
 			->setName('config:app:get')
-			->setDescription('Get an app config value')
+			->setDescription('Get an app config value.')
 			->addArgument(
 				'app',
 				InputArgument::REQUIRED,
-				'Name of the app'
+				'Name of the app.'
 			)
 			->addArgument(
 				'name',
 				InputArgument::REQUIRED,
-				'Name of the config to get'
+				'Name of the config to get.'
 			)
 			->addOption(
 				'default-value',
 				null,
 				InputOption::VALUE_OPTIONAL,
-				'If no default value is set and the config does not exist, the command will exit with 1'
+				'If no default value is set and the config does not exist, the command will exit with 1.'
 			)
 		;
 	}

--- a/core/Command/Config/App/SetConfig.php
+++ b/core/Command/Config/App/SetConfig.php
@@ -45,28 +45,28 @@ class SetConfig extends Base {
 
 		$this
 			->setName('config:app:set')
-			->setDescription('Set an app config value')
+			->setDescription('Set an app config value.')
 			->addArgument(
 				'app',
 				InputArgument::REQUIRED,
-				'Name of the app'
+				'Name of the app.'
 			)
 			->addArgument(
 				'name',
 				InputArgument::REQUIRED,
-				'Name of the config to set'
+				'Name of the config to set.'
 			)
 			->addOption(
 				'value',
 				null,
 				InputOption::VALUE_REQUIRED,
-				'The new value of the config'
+				'The new value of the config.'
 			)
 			->addOption(
 				'update-only',
 				null,
 				InputOption::VALUE_NONE,
-				'Only updates the value, if it is not set before, it is not being added'
+				'Only updates the value, if it has not already been set, it will not be added.'
 			)
 		;
 	}

--- a/core/Command/Config/Import.php
+++ b/core/Command/Config/Import.php
@@ -44,11 +44,11 @@ class Import extends Command {
 	protected function configure() {
 		$this
 			->setName('config:import')
-			->setDescription('Import a list of configs')
+			->setDescription('Import a list of configs.')
 			->addArgument(
 				'file',
 				InputArgument::OPTIONAL,
-				'File with the json array to import'
+				'File with the JSON array to import.'
 			)
 		;
 	}

--- a/core/Command/Config/ListConfigs.php
+++ b/core/Command/Config/ListConfigs.php
@@ -53,18 +53,18 @@ class ListConfigs extends Base {
 
 		$this
 			->setName('config:list')
-			->setDescription('List all configs')
+			->setDescription('List all configs.')
 			->addArgument(
 				'app',
 				InputArgument::OPTIONAL,
-				'Name of the app ("system" to get the config.php values, "all" for all apps and system)',
+				'Name of the app ("system" to get the config.php values, "all" for all apps and system).',
 				'all'
 			)
 			->addOption(
 				'private',
 				null,
 				InputOption::VALUE_NONE,
-				'Use this option when you want to include sensitive configs like passwords, salts, ...'
+				'Use this option when you want to include sensitive configs like passwords and salts.'
 			)
 		;
 	}

--- a/core/Command/Config/System/DeleteConfig.php
+++ b/core/Command/Config/System/DeleteConfig.php
@@ -45,17 +45,17 @@ class DeleteConfig extends Base {
 
 		$this
 			->setName('config:system:delete')
-			->setDescription('Delete a system config value')
+			->setDescription('Delete a system config value.')
 			->addArgument(
 				'name',
 				InputArgument::REQUIRED | InputArgument::IS_ARRAY,
-				'Name of the config to delete, specify multiple for array parameter'
+				'Name of the config to delete, specify multiple for array parameter.'
 			)
 			->addOption(
 				'error-if-not-exists',
 				null,
 				InputOption::VALUE_NONE,
-				'Checks whether the config exists before deleting it'
+				'Checks whether the config exists before deleting it.'
 			)
 		;
 	}

--- a/core/Command/Config/System/GetConfig.php
+++ b/core/Command/Config/System/GetConfig.php
@@ -45,17 +45,17 @@ class GetConfig extends Base {
 
 		$this
 			->setName('config:system:get')
-			->setDescription('Get a system config value')
+			->setDescription('Get a system config value.')
 			->addArgument(
 				'name',
 				InputArgument::REQUIRED | InputArgument::IS_ARRAY,
-				'Name of the config to get, specify multiple for array parameter'
+				'Name of the config to get. Specify multiple for array parameter.'
 			)
 			->addOption(
 				'default-value',
 				null,
 				InputOption::VALUE_OPTIONAL,
-				'If no default value is set and the config does not exist, the command will exit with 1'
+				'If no default value is set and the config does not exist, the command will exit with 1.'
 			)
 		;
 	}

--- a/core/Command/Config/System/SetConfig.php
+++ b/core/Command/Config/System/SetConfig.php
@@ -46,30 +46,30 @@ class SetConfig extends Base {
 
 		$this
 			->setName('config:system:set')
-			->setDescription('Set a system config value')
+			->setDescription('Set a system config value.')
 			->addArgument(
 				'name',
 				InputArgument::REQUIRED | InputArgument::IS_ARRAY,
-				'Name of the config parameter, specify multiple for array parameter'
+				'Name of the config parameter, specify multiple for array parameter.'
 			)
 			->addOption(
 				'type',
 				null,
 				InputOption::VALUE_REQUIRED,
-				'Value type [string, integer, double, boolean]',
+				'Value type [string, integer, double, boolean].',
 				'string'
 			)
 			->addOption(
 				'value',
 				null,
 				InputOption::VALUE_REQUIRED,
-				'The new value of the config'
+				'The new value of the config.'
 			)
 			->addOption(
 				'update-only',
 				null,
 				InputOption::VALUE_NONE,
-				'Only updates the value, if it is not set before, it is not being added'
+				'Only updates the value, if it is not set before, it is not being added.'
 			)
 		;
 	}

--- a/core/Command/Db/ConvertMysqlToMB4.php
+++ b/core/Command/Db/ConvertMysqlToMB4.php
@@ -56,7 +56,7 @@ class ConvertMysqlToMB4 extends Command {
 	protected function configure() {
 		$this
 			->setName('db:convert-mysql-charset')
-			->setDescription('Convert charset of MySQL/MariaDB to use utf8mb4');
+			->setDescription('Convert charset of MySQL/MariaDB to use utf8mb4.');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -61,56 +61,56 @@ class ConvertType extends Command {
 	protected function configure() {
 		$this
 			->setName('db:convert-type')
-			->setDescription('Convert the ownCloud database to the newly configured one')
+			->setDescription('Convert the ownCloud database to the newly configured one.')
 			->addArgument(
 				'type',
 				InputArgument::REQUIRED,
-				'the type of the database to convert to'
+				'The type of the database to convert to.'
 			)
 			->addArgument(
 				'username',
 				InputArgument::REQUIRED,
-				'the username of the database to convert to'
+				'The username of the database to convert to.'
 			)
 			->addArgument(
 				'hostname',
 				InputArgument::REQUIRED,
-				'the hostname of the database to convert to'
+				'The hostname of the database to convert to.'
 			)
 			->addArgument(
 				'database',
 				InputArgument::REQUIRED,
-				'the name of the database to convert to'
+				'The name of the database to convert to.'
 			)
 			->addOption(
 				'port',
 				null,
 				InputOption::VALUE_REQUIRED,
-				'the port of the database to convert to'
+				'The port of the database to convert to.'
 			)
 			->addOption(
 				'password',
 				null,
 				InputOption::VALUE_REQUIRED,
-				'the password of the database to convert to. Will be asked when not specified. Can also be passed via stdin.'
+				'The password of the database to convert to. Will be asked when not specified. Can also be passed via stdin.'
 			)
 			->addOption(
 				'clear-schema',
 				null,
 				InputOption::VALUE_NONE,
-				'remove all tables from the destination database'
+				'Remove all tables from the destination database.'
 			)
 			->addOption(
 				'all-apps',
 				null,
 				InputOption::VALUE_NONE,
-				'whether to create schema for all apps instead of only installed apps'
+				'Whether to create schema for all apps instead of only installed apps.'
 			)
 			->addOption(
 				'chunk-size',
 				null,
 				InputOption::VALUE_REQUIRED,
-				'the maximum number of database rows to handle in a single query, bigger tables will be handled in chunks of this size. Lower this if the process runs out of memory during conversion.',
+				'The maximum number of database rows to handle in a single query, bigger tables will be handled in chunks of this size. Lower this if the process runs out of memory during conversion.',
 				1000
 			)
 		;

--- a/core/Command/Db/GenerateChangeScript.php
+++ b/core/Command/Db/GenerateChangeScript.php
@@ -31,11 +31,11 @@ class GenerateChangeScript extends Command {
 	protected function configure() {
 		$this
 			->setName('db:generate-change-script')
-			->setDescription('generates the change script from the current connected db to db_structure.xml')
+			->setDescription('Generates the change script from the current connected db to db_structure.xml.')
 			->addArgument(
 				'schema-xml',
 				InputArgument::OPTIONAL,
-				'the schema xml to be used as target schema',
+				'The XML schema to be used as the target schema.',
 				\OC::$SERVERROOT . '/db_structure.xml'
 			)
 		;

--- a/core/Command/Encryption/ChangeKeyStorageRoot.php
+++ b/core/Command/Encryption/ChangeKeyStorageRoot.php
@@ -73,11 +73,11 @@ class ChangeKeyStorageRoot extends Command {
 		parent::configure();
 		$this
 			->setName('encryption:change-key-storage-root')
-			->setDescription('Change key storage root')
+			->setDescription('Change key storage root.')
 			->addArgument(
 				'newRoot',
 				InputArgument::OPTIONAL,
-				'new root of the key storage relative to the data folder'
+				'New root of the key storage relative to the data folder.'
 			);
 	}
 

--- a/core/Command/Encryption/DecryptAll.php
+++ b/core/Command/Encryption/DecryptAll.php
@@ -105,7 +105,7 @@ class DecryptAll extends Command {
 		parent::configure();
 
 		$this->setName('encryption:decrypt-all');
-		$this->setDescription('Disable server-side encryption and decrypt all files');
+		$this->setDescription('Disable server-side encryption and decrypt all files.');
 		$this->setHelp(
 			'This will disable server-side encryption and decrypt all files for '
 			. 'all users if it is supported by your encryption module. '
@@ -114,7 +114,7 @@ class DecryptAll extends Command {
 		$this->addArgument(
 			'user',
 			InputArgument::OPTIONAL,
-			'user for which you want to decrypt all files (optional)',
+			'User for whom you want to decrypt all files (optional).',
 			''
 		);
 	}

--- a/core/Command/Encryption/Disable.php
+++ b/core/Command/Encryption/Disable.php
@@ -41,7 +41,7 @@ class Disable extends Command {
 	protected function configure() {
 		$this
 			->setName('encryption:disable')
-			->setDescription('Disable encryption')
+			->setDescription('Disable encryption.')
 		;
 	}
 

--- a/core/Command/Encryption/Enable.php
+++ b/core/Command/Encryption/Enable.php
@@ -48,7 +48,7 @@ class Enable extends Command {
 	protected function configure() {
 		$this
 			->setName('encryption:enable')
-			->setDescription('Enable encryption')
+			->setDescription('Enable encryption.')
 		;
 	}
 

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -94,7 +94,7 @@ class EncryptAll extends Command {
 		parent::configure();
 
 		$this->setName('encryption:encrypt-all');
-		$this->setDescription('Encrypt all files for all users');
+		$this->setDescription('Encrypt all files for all users.');
 		$this->setHelp(
 			'This will encrypt all files for all users. '
 			. 'Please make sure that no user access his files during this process!'

--- a/core/Command/Encryption/ListModules.php
+++ b/core/Command/Encryption/ListModules.php
@@ -44,7 +44,7 @@ class ListModules extends Base {
 
 		$this
 			->setName('encryption:list-modules')
-			->setDescription('List all available encryption modules')
+			->setDescription('List all available encryption modules.')
 		;
 	}
 

--- a/core/Command/Encryption/SetDefaultModule.php
+++ b/core/Command/Encryption/SetDefaultModule.php
@@ -45,11 +45,11 @@ class SetDefaultModule extends Command {
 
 		$this
 			->setName('encryption:set-default-module')
-			->setDescription('Set the encryption default module')
+			->setDescription('Set the encryption default module.')
 			->addArgument(
 				'module',
 				InputArgument::REQUIRED,
-				'ID of the encryption module that should be used'
+				'The ID of the encryption module that should be used.'
 			)
 		;
 	}

--- a/core/Command/Encryption/ShowKeyStorageRoot.php
+++ b/core/Command/Encryption/ShowKeyStorageRoot.php
@@ -44,7 +44,7 @@ class ShowKeyStorageRoot extends Command{
 		parent::configure();
 		$this
 			->setName('encryption:show-key-storage-root')
-			->setDescription('Show current key storage root');
+			->setDescription('Show current key storage root.');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {

--- a/core/Command/Encryption/Status.php
+++ b/core/Command/Encryption/Status.php
@@ -43,7 +43,7 @@ class Status extends Base {
 
 		$this
 			->setName('encryption:status')
-			->setDescription('Lists the current status of encryption')
+			->setDescription('Lists the current encryption status.')
 		;
 	}
 

--- a/core/Command/Group/Add.php
+++ b/core/Command/Group/Add.php
@@ -43,11 +43,11 @@ class Add extends Command {
 	protected function configure() {
 		$this
 			->setName('group:add')
-			->setDescription('adds a group')
+			->setDescription('Adds a group.')
 			->addArgument(
 				'group',
 				InputArgument::REQUIRED,
-				'Name of the group'
+				'Name of the group.'
 			);
 	}
 

--- a/core/Command/Group/AddMember.php
+++ b/core/Command/Group/AddMember.php
@@ -45,17 +45,17 @@ class AddMember extends Command {
 	protected function configure() {
 		$this
 			->setName('group:add-member')
-			->setDescription('add members to a group')
+			->setDescription('Add members to a group.')
 			->addArgument(
 				'group',
 				InputArgument::REQUIRED,
-				'Name of the group'
+				'Name of the group.'
 			)
 			->addOption(
 				'member',
 				'm',
 				InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
-				'member that should be added to the group'
+				'The member that should be added to the group.'
 			);
 	}
 

--- a/core/Command/Group/Delete.php
+++ b/core/Command/Group/Delete.php
@@ -42,11 +42,11 @@ class Delete extends Command {
 	protected function configure() {
 		$this
 			->setName('group:delete')
-			->setDescription('deletes the specified group')
+			->setDescription('Deletes the specified group.')
 			->addArgument(
 				'group',
 				InputArgument::REQUIRED,
-				'the group name'
+				'The group name.'
 			);
 	}
 

--- a/core/Command/Group/ListGroupMembers.php
+++ b/core/Command/Group/ListGroupMembers.php
@@ -44,11 +44,11 @@ class ListGroupMembers extends Base {
 
 		$this
 			->setName('group:list-members')
-			->setDescription('list group members')
+			->setDescription('List group members.')
 			->addArgument(
 				'group',
 				InputArgument::REQUIRED,
-				'Name of the group'
+				'The name of the group.'
 			)
 		;
 	}

--- a/core/Command/Group/ListGroups.php
+++ b/core/Command/Group/ListGroups.php
@@ -44,11 +44,11 @@ class ListGroups extends Base {
 
 		$this
 			->setName('group:list')
-			->setDescription('list groups')
+			->setDescription('List groups.')
 			->addArgument(
 				'search-pattern',
 				InputArgument::OPTIONAL,
-				'Restrict the list to groups whose name contains the string'
+				'Restrict the list to groups whose name contains the string.'
 			)
 		;
 	}

--- a/core/Command/Group/RemoveMember.php
+++ b/core/Command/Group/RemoveMember.php
@@ -45,17 +45,17 @@ class RemoveMember extends Command {
 	protected function configure() {
 		$this
 			->setName('group:remove-member')
-			->setDescription('remove member(s) from a group')
+			->setDescription('Remove member(s) from a group.')
 			->addArgument(
 				'group',
 				InputArgument::REQUIRED,
-				'Name of the group'
+				'Name of the group.'
 			)
 			->addOption(
 				'member',
 				'm',
 				InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
-				'member that should be removed from the group'
+				'The member that should be removed from the group.'
 			);
 	}
 

--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -52,9 +52,9 @@ class CheckApp extends Base {
 		parent::configure();
 		$this
 			->setName('integrity:check-app')
-			->setDescription('Check integrity of an app using a signature.')
-			->addArgument('appid', null, InputArgument::REQUIRED, 'Application to check')
-			->addOption('path', null, InputOption::VALUE_OPTIONAL, 'Path to application. If none is given it will be guessed.');
+			->setDescription('Check the integrity of an app using a signature.')
+			->addArgument('appid', null, InputArgument::REQUIRED, 'Application to check.')
+			->addOption('path', null, InputOption::VALUE_OPTIONAL, 'Path to the application. If none is given it will be guessed.');
 	}
 
 	/**

--- a/core/Command/Integrity/SignApp.php
+++ b/core/Command/Integrity/SignApp.php
@@ -63,9 +63,9 @@ class SignApp extends Command {
 		$this
 			->setName('integrity:sign-app')
 			->setDescription('Signs an app using a private key.')
-			->addOption('path', null, InputOption::VALUE_REQUIRED, 'Application to sign')
-			->addOption('privateKey', null, InputOption::VALUE_REQUIRED, 'Path to private key to use for signing')
-			->addOption('certificate', null, InputOption::VALUE_REQUIRED, 'Path to certificate to use for signing');
+			->addOption('path', null, InputOption::VALUE_REQUIRED, 'Application to sign.')
+			->addOption('privateKey', null, InputOption::VALUE_REQUIRED, 'Path to private key to use for signing.')
+			->addOption('certificate', null, InputOption::VALUE_REQUIRED, 'Path to certificate to use for signing.');
 	}
 
 	/**

--- a/core/Command/Integrity/SignCore.php
+++ b/core/Command/Integrity/SignCore.php
@@ -57,9 +57,9 @@ class SignCore extends Command {
 		$this
 			->setName('integrity:sign-core')
 			->setDescription('Sign core using a private key.')
-			->addOption('privateKey', null, InputOption::VALUE_REQUIRED, 'Path to private key to use for signing')
-			->addOption('certificate', null, InputOption::VALUE_REQUIRED, 'Path to certificate to use for signing')
-			->addOption('path', null, InputOption::VALUE_REQUIRED, 'Path of core to sign');
+			->addOption('privateKey', null, InputOption::VALUE_REQUIRED, 'Path to private key to use for signing.')
+			->addOption('certificate', null, InputOption::VALUE_REQUIRED, 'Path to certificate to use for signing.')
+			->addOption('path', null, InputOption::VALUE_REQUIRED, 'Path of core to sign.');
 	}
 
 	/**

--- a/core/Command/L10n/CreateJs.php
+++ b/core/Command/L10n/CreateJs.php
@@ -39,12 +39,12 @@ class CreateJs extends Command {
 			->addArgument(
 				'app',
 				InputOption::VALUE_REQUIRED,
-				'name of the app'
+				'The name of the app.'
 			)
 			->addArgument(
 				'lang',
 				InputOption::VALUE_OPTIONAL,
-				'name of the language'
+				'The name of the language.'
 			);
 	}
 

--- a/core/Command/Maintenance/DataFingerprint.php
+++ b/core/Command/Maintenance/DataFingerprint.php
@@ -44,7 +44,7 @@ class DataFingerprint extends Command {
 	protected function configure() {
 		$this
 			->setName('maintenance:data-fingerprint')
-			->setDescription('update the systems data-fingerprint after a backup is restored');
+			->setDescription('Update the systems data-fingerprint after a backup is restored.');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {

--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -48,16 +48,16 @@ class Install extends Command {
 	protected function configure() {
 		$this
 			->setName('maintenance:install')
-			->setDescription('install ownCloud')
-			->addOption('database', null, InputOption::VALUE_REQUIRED, 'Supported database type', 'sqlite')
-			->addOption('database-name', null, InputOption::VALUE_REQUIRED, 'Name of the database')
-			->addOption('database-host', null, InputOption::VALUE_REQUIRED, 'Hostname of the database', 'localhost')
-			->addOption('database-user', null, InputOption::VALUE_REQUIRED, 'User name to connect to the database')
-			->addOption('database-pass', null, InputOption::VALUE_OPTIONAL, 'Password of the database user', null)
-			->addOption('database-table-prefix', null, InputOption::VALUE_OPTIONAL, 'Prefix for all tables (default: oc_)', null)
-			->addOption('admin-user', null, InputOption::VALUE_REQUIRED, 'User name of the admin account', 'admin')
-			->addOption('admin-pass', null, InputOption::VALUE_REQUIRED, 'Password of the admin account')
-			->addOption('data-dir', null, InputOption::VALUE_REQUIRED, 'Path to data directory', \OC::$SERVERROOT."/data");
+			->setDescription('Install ownCloud.')
+			->addOption('database', null, InputOption::VALUE_REQUIRED, 'Supported database type.', 'sqlite')
+			->addOption('database-name', null, InputOption::VALUE_REQUIRED, 'Name of the database.')
+			->addOption('database-host', null, InputOption::VALUE_REQUIRED, 'Hostname of the database.', 'localhost')
+			->addOption('database-user', null, InputOption::VALUE_REQUIRED, 'User name to connect to the database.')
+			->addOption('database-pass', null, InputOption::VALUE_OPTIONAL, 'Password of the database user.', null)
+			->addOption('database-table-prefix', null, InputOption::VALUE_OPTIONAL, 'Prefix for all tables (default: oc_).', null)
+			->addOption('admin-user', null, InputOption::VALUE_REQUIRED, 'User name of the admin account.', 'admin')
+			->addOption('admin-pass', null, InputOption::VALUE_REQUIRED, 'Password of the admin account.')
+			->addOption('data-dir', null, InputOption::VALUE_REQUIRED, 'Path to the data directory.', \OC::$SERVERROOT."/data");
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {

--- a/core/Command/Maintenance/Mimetype/UpdateDB.php
+++ b/core/Command/Maintenance/Mimetype/UpdateDB.php
@@ -51,12 +51,12 @@ class UpdateDB extends Command {
 	protected function configure() {
 		$this
 			->setName('maintenance:mimetype:update-db')
-			->setDescription('Update database mimetypes and update filecache')
+			->setDescription('Update database mimetypes and file cache.')
 			->addOption(
 				'repair-filecache',
 				null,
 				InputOption::VALUE_NONE,
-				'Repair filecache for all mimetypes, not just new ones'
+				'Repair the file cache for all mimetypes, not just the new ones.'
 			)
 		;
 	}

--- a/core/Command/Maintenance/Mimetype/UpdateJS.php
+++ b/core/Command/Maintenance/Mimetype/UpdateJS.php
@@ -44,7 +44,7 @@ class UpdateJS extends Command {
 	protected function configure() {
 		$this
 			->setName('maintenance:mimetype:update-js')
-			->setDescription('Update mimetypelist.js');
+			->setDescription('Update mimetypelist.js.');
 	}
 
 	/**

--- a/core/Command/Maintenance/Mode.php
+++ b/core/Command/Maintenance/Mode.php
@@ -42,18 +42,18 @@ class Mode extends Command {
 	protected function configure() {
 		$this
 			->setName('maintenance:mode')
-			->setDescription('set maintenance mode')
+			->setDescription('Set maintenance mode.')
 			->addOption(
 				'on',
 				null,
 				InputOption::VALUE_NONE,
-				'enable maintenance mode'
+				'Enable maintenance mode.'
 			)
 			->addOption(
 				'off',
 				null,
 				InputOption::VALUE_NONE,
-				'disable maintenance mode'
+				'Disable maintenance mode.'
 			);
 	}
 

--- a/core/Command/Maintenance/Repair.php
+++ b/core/Command/Maintenance/Repair.php
@@ -62,12 +62,12 @@ class Repair extends Command {
 	protected function configure() {
 		$this
 			->setName('maintenance:repair')
-			->setDescription('repair this installation')
+			->setDescription('Repair the installation.')
 			->addOption(
 				'include-expensive',
 				null,
 				InputOption::VALUE_NONE,
-				'Use this option when you want to include resource and load expensive tasks');
+				'Use this option when you want to include resource and load expensive tasks.');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {

--- a/core/Command/Maintenance/SingleUser.php
+++ b/core/Command/Maintenance/SingleUser.php
@@ -45,18 +45,18 @@ class SingleUser extends Command {
 	protected function configure() {
 		$this
 			->setName('maintenance:singleuser')
-			->setDescription('set single user mode')
+			->setDescription('Set single user mode.')
 			->addOption(
 				'on',
 				null,
 				InputOption::VALUE_NONE,
-				'enable single user mode'
+				'Enable single user mode.'
 			)
 			->addOption(
 				'off',
 				null,
 				InputOption::VALUE_NONE,
-				'disable single user mode'
+				'Disable single user mode.'
 			);
 	}
 

--- a/core/Command/Maintenance/UpdateHtaccess.php
+++ b/core/Command/Maintenance/UpdateHtaccess.php
@@ -33,7 +33,7 @@ class UpdateHtaccess extends Command {
 	protected function configure() {
 		$this
 			->setName('maintenance:update:htaccess')
-			->setDescription('Updates the .htaccess file');
+			->setDescription('Updates the .htaccess file.');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {

--- a/core/Command/Security/ImportCertificate.php
+++ b/core/Command/Security/ImportCertificate.php
@@ -43,11 +43,11 @@ class ImportCertificate extends Base {
 	protected function configure() {
 		$this
 			->setName('security:certificates:import')
-			->setDescription('import trusted certificate')
+			->setDescription('Import a trusted certificate.')
 			->addArgument(
 				'path',
 				InputArgument::REQUIRED,
-				'path to the certificate to import'
+				'Path to the certificate to import.'
 			);
 	}
 

--- a/core/Command/Security/ListCertificates.php
+++ b/core/Command/Security/ListCertificates.php
@@ -47,7 +47,7 @@ class ListCertificates extends Base {
 	protected function configure() {
 		$this
 			->setName('security:certificates')
-			->setDescription('list trusted certificates');
+			->setDescription('List trusted certificates.');
 		parent::configure();
 	}
 

--- a/core/Command/Security/ListRoutes.php
+++ b/core/Command/Security/ListRoutes.php
@@ -46,7 +46,7 @@ class ListRoutes extends Base {
 	protected function configure() {
 		$this
 			->setName('security:routes')
-			->setDescription('list used routes')
+			->setDescription('List used routes.')
 			->addOption('with-details', 'd', InputOption::VALUE_NONE);
 		parent::configure();
 	}

--- a/core/Command/Security/RemoveCertificate.php
+++ b/core/Command/Security/RemoveCertificate.php
@@ -44,11 +44,11 @@ class RemoveCertificate extends Base {
 	protected function configure() {
 		$this
 			->setName('security:certificates:remove')
-			->setDescription('remove trusted certificate')
+			->setDescription('Remove a trusted certificate.')
 			->addArgument(
 				'name',
 				InputArgument::REQUIRED,
-				'the file name of the certificate to remove'
+				'The file name of the certificate to remove.'
 			);
 	}
 

--- a/core/Command/Status.php
+++ b/core/Command/Status.php
@@ -33,7 +33,7 @@ class Status extends Base {
 
 		$this
 			->setName('status')
-			->setDescription('show some status information')
+			->setDescription('Show status information.')
 		;
 	}
 

--- a/core/Command/TwoFactorAuth/Disable.php
+++ b/core/Command/TwoFactorAuth/Disable.php
@@ -46,7 +46,7 @@ class Disable extends Base {
 		parent::configure();
 
 		$this->setName('twofactorauth:disable');
-		$this->setDescription('Disable two-factor authentication for a user');
+		$this->setDescription('Disable two-factor authentication for a user.');
 		$this->addArgument('uid', InputArgument::REQUIRED);
 	}
 

--- a/core/Command/TwoFactorAuth/Enable.php
+++ b/core/Command/TwoFactorAuth/Enable.php
@@ -46,7 +46,7 @@ class Enable extends Base {
 		parent::configure();
 
 		$this->setName('twofactorauth:enable');
-		$this->setDescription('Enable two-factor authentication for a user');
+		$this->setDescription('Enable two-factor authentication for a user.');
 		$this->addArgument('uid', InputArgument::REQUIRED);
 	}
 

--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -68,12 +68,12 @@ class Upgrade extends Command {
 	protected function configure() {
 		$this
 			->setName('upgrade')
-			->setDescription('run upgrade routines after installation of a new release. The release has to be installed before.')
+			->setDescription('Run upgrade routines after upgrading to a new release.')
 			->addOption(
 				'--no-app-disable',
 				null,
 				InputOption::VALUE_NONE,
-				'skips the disable of third party apps'
+				'Skip disabling of third party apps.'
 			);
 	}
 

--- a/core/Command/User/Add.php
+++ b/core/Command/User/Add.php
@@ -64,31 +64,31 @@ class Add extends Command {
 			->addArgument(
 				'uid',
 				InputArgument::REQUIRED,
-				'User ID used to login (must only contain a-z, A-Z, 0-9, -, _ and @)'
+				'User ID used to login (must only contain a-z, A-Z, 0-9, -, _ and @).'
 			)
 			->addOption(
 				'password-from-env',
 				null,
 				InputOption::VALUE_NONE,
-				'read password from environment variable OC_PASS'
+				'Read password from the OC_PASS environment variable.'
 			)
 			->addOption(
 				'display-name',
 				null,
 				InputOption::VALUE_OPTIONAL,
-				'User name used in the web UI (can contain any characters)'
+				'User name used in the web UI (can contain any characters).'
 			)
 			->addOption(
 				'email',
 				null,
 				InputOption::VALUE_OPTIONAL,
-				'Email address for the user'
+				'Email address for the user.'
 			)
 			->addOption(
 				'group',
 				'g',
 				InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
-				'groups the user should be added to (The group will be created if it does not exist)'
+				'The groups the user should be added to (The group will be created if it does not exist).'
 			);
 	}
 

--- a/core/Command/User/Delete.php
+++ b/core/Command/User/Delete.php
@@ -45,11 +45,11 @@ class Delete extends Command {
 	protected function configure() {
 		$this
 			->setName('user:delete')
-			->setDescription('deletes the specified user')
+			->setDescription('Deletes the specified user.')
 			->addArgument(
 				'uid',
 				InputArgument::REQUIRED,
-				'the username'
+				'The username.'
 			);
 	}
 

--- a/core/Command/User/Disable.php
+++ b/core/Command/User/Disable.php
@@ -43,11 +43,11 @@ class Disable extends Command {
 	protected function configure() {
 		$this
 			->setName('user:disable')
-			->setDescription('disables the specified user')
+			->setDescription('Disables the specified user.')
 			->addArgument(
 				'uid',
 				InputArgument::REQUIRED,
-				'the username'
+				'The username.'
 			);
 	}
 

--- a/core/Command/User/Enable.php
+++ b/core/Command/User/Enable.php
@@ -43,11 +43,11 @@ class Enable extends Command {
 	protected function configure() {
 		$this
 			->setName('user:enable')
-			->setDescription('enables the specified user')
+			->setDescription('Enables the specified user.')
 			->addArgument(
 				'uid',
 				InputArgument::REQUIRED,
-				'the username'
+				'The username.'
 			);
 	}
 

--- a/core/Command/User/Inactive.php
+++ b/core/Command/User/Inactive.php
@@ -44,11 +44,11 @@ class Inactive extends Base {
 	protected function configure() {
 		$this
 			->setName('user:inactive')
-			->setDescription('reports users who are known to owncloud, but have not logged in for a certain number of days')
+			->setDescription('Reports users who are known to ownCloud, but have not logged in for a certain number of days.')
 			->addArgument(
 				'days',
 				InputArgument::REQUIRED,
-				'Integer number of days that the user has not logged in since'
+				'The number of days (integer) that the user has not logged in since.'
 			);
 		parent::configure();
 	}

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -45,11 +45,11 @@ class LastSeen extends Command {
 	protected function configure() {
 		$this
 			->setName('user:lastseen')
-			->setDescription('shows when the user was logged in last time')
+			->setDescription('Shows when the user was last logged in.')
 			->addArgument(
 				'uid',
 				InputArgument::REQUIRED,
-				'the username'
+				'The username.'
 			);
 	}
 

--- a/core/Command/User/ListUserGroups.php
+++ b/core/Command/User/ListUserGroups.php
@@ -50,11 +50,11 @@ class ListUserGroups extends Base {
 
 		$this
 			->setName('user:list-groups')
-			->setDescription('list groups for a user')
+			->setDescription("Lists the groups a user belongs to")
 			->addArgument(
 				'uid',
 				InputArgument::REQUIRED,
-				'User ID'
+				'User ID.'
 			)
 		;
 	}

--- a/core/Command/User/ListUsers.php
+++ b/core/Command/User/ListUsers.php
@@ -44,11 +44,11 @@ class ListUsers extends Base {
 
 		$this
 			->setName('user:list')
-			->setDescription('list users')
+			->setDescription('List users.')
 			->addArgument(
 				'search-pattern',
 				InputArgument::OPTIONAL,
-				'Restrict the list to users whose User ID contains the string'
+				'Restrict the list to users whose user ID contains the optional search pattern.'
 			)
 		;
 	}

--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -48,17 +48,17 @@ class ResetPassword extends Command {
 	protected function configure() {
 		$this
 			->setName('user:resetpassword')
-			->setDescription('Resets the password of the named user')
+			->setDescription('Resets the password of the named user.')
 			->addArgument(
 				'user',
 				InputArgument::REQUIRED,
-				'Username to reset password'
+				'The user\'s name.'
 			)
 			->addOption(
 				'password-from-env',
 				null,
 				InputOption::VALUE_NONE,
-				'read password from environment variable OC_PASS'
+				'Read the password from the OC_PASS environment variable.'
 			)
 		;
 	}

--- a/core/Command/User/Setting.php
+++ b/core/Command/User/Setting.php
@@ -56,16 +56,16 @@ class Setting extends Base {
 		parent::configure();
 		$this
 			->setName('user:setting')
-			->setDescription('Read and modify user settings')
+			->setDescription('Read and modify user settings.')
 			->addArgument(
 				'uid',
 				InputArgument::REQUIRED,
-				'User ID used to login'
+				'User ID used to login.'
 			)
 			->addArgument(
 				'app',
 				InputArgument::OPTIONAL,
-				'Restrict the settings to a given app',
+				'Restrict the settings to a given app.',
 				''
 			)
 			->addArgument(
@@ -78,7 +78,7 @@ class Setting extends Base {
 				'ignore-missing-user',
 				null,
 				InputOption::VALUE_NONE,
-				'Use this option to ignore errors when the user does not exist'
+				'Use this option to ignore errors when the user does not exist.'
 			)
 
 			// Get
@@ -86,7 +86,7 @@ class Setting extends Base {
 				'default-value',
 				null,
 				InputOption::VALUE_REQUIRED,
-				'(Only applicable on get) If no default value is set and the config does not exist, the command will exit with 1'
+				'If no default value is set and the config does not exist, the command will exit with 1. Only applicable on get.'
 			)
 
 			// Set
@@ -94,13 +94,13 @@ class Setting extends Base {
 				'value',
 				null,
 				InputOption::VALUE_REQUIRED,
-				'The new value of the setting'
+				'The new value of the setting.'
 			)
 			->addOption(
 				'update-only',
 				null,
 				InputOption::VALUE_NONE,
-				'Only updates the value, if it is not set before, it is not being added'
+				'Only updates the value, if it is not set before, it is not being added.'
 			)
 
 			// Delete
@@ -108,13 +108,13 @@ class Setting extends Base {
 				'delete',
 				null,
 				InputOption::VALUE_NONE,
-				'Specify this option to delete the config'
+				'Specify this option to delete the config.'
 			)
 			->addOption(
 				'error-if-not-exists',
 				null,
 				InputOption::VALUE_NONE,
-				'Checks whether the setting exists before deleting it'
+				'Checks whether the setting exists before deleting it.'
 			)
 		;
 	}

--- a/core/Command/User/SyncBackend.php
+++ b/core/Command/User/SyncBackend.php
@@ -68,14 +68,24 @@ class SyncBackend extends Command {
 	protected function configure() {
 		$this
 			->setName('user:sync')
-			->setDescription('synchronize users from a given backend to the accounts table')
+			->setDescription('Synchronize users from a given backend to the accounts table.')
 			->addArgument(
 				'backend-class',
 				InputArgument::OPTIONAL,
-				'The php class name - e.g. "OCA\User_LDAP\User_Proxy". Please wrap the class name into double quotes. You can use the option --list to list all known backend classes'
+				'The PHP class name - e.g., "OCA\User_LDAP\User_Proxy". Please wrap the class name in double quotes. You can use the option --list to list all known backend classes.'
 			)
-			->addOption('list', 'l', InputOption::VALUE_NONE, 'list all known backend classes')
-			->addOption('missing-account-action', 'm', InputOption::VALUE_REQUIRED, 'action to do if the account isn\'t connected to a backend any longer. Options are "disable" and "remove". Use quotes. Note that removing the account will also remove the stored data and files for that account');
+			->addOption(
+				'list',
+				'l',
+				InputOption::VALUE_NONE,
+				'List all known backend classes'
+			)
+			->addOption(
+				'missing-account-action',
+				'm',
+				InputOption::VALUE_REQUIRED,
+				'Action to take if the account isn\'t connected to a backend any longer. Options are "disable" and "remove". Use quotes. Note that removing the account will also remove the stored data and files for that account.'
+			);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {


### PR DESCRIPTION
## Description

Ensures that the descriptions for all commands in `occ help files:scan` are rendered consistently, and grammatically correct.

## Related Issue

#29580.

## Motivation and Context

The help output for `occ files:scan` renders inconsistently, both for capitalisation at the start of sentences, as well as for full-stops at the end of sentences. This decreases the readability of the command's output and detracts from a completely professional appearance.

## How Has This Been Tested?

Re-ran the test suite.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests have passed.

### Also Relates To 

https://github.com/owncloud/documentation/pull/3542