### PR TITLE
Refactor UI tests user creation

### DIFF
--- a/tests/ui/features/other/login.feature
+++ b/tests/ui/features/other/login.feature
@@ -9,7 +9,7 @@ I want only authorised users to log in
 So that unauthorised access is impossible
 
 	Scenario: simple user login
-		Given a regular user exists
+		Given a regular user exists but is not initialized
 		And I am on the login page
 		When I login as a regular user with a correct password
 		Then I should be redirected to a page with the title "Files - ownCloud"

--- a/tests/ui/features/restrictSharing/restrictReSharing.feature
+++ b/tests/ui/features/restrictSharing/restrictReSharing.feature
@@ -17,8 +17,6 @@ I want to be able to forbid a user that received a share from me to share it fur
 		And the user "user1" is in the group "grp1"
 		And the user "user2" is in the group "grp1"
 		And I am on the login page
-		And I login with username "user1" and password "1234"
-		And I logout
 		And I login with username "user2" and password "1234"
 
 	@skipOnMICROSOFTEDGE

--- a/tests/ui/features/restrictSharing/restrictSharing.feature
+++ b/tests/ui/features/restrictSharing/restrictSharing.feature
@@ -18,10 +18,6 @@ So that users can only share files with specific users and groups
 		And the user "user2" is in the group "grp1"
 		And the user "user3" is in the group "grp2"
 		And I am on the login page
-		And I login with username "user1" and password "1234"
-		And I logout
-		And I login with username "user3" and password "1234"
-		And I logout
 		And I login with username "user2" and password "1234"
 		
 	Scenario: Restrict users to only share with users in their groups

--- a/tests/ui/features/sharing/federationSharing.feature
+++ b/tests/ui/features/sharing/federationSharing.feature
@@ -10,8 +10,6 @@ So that other users have access to these files
 		|user1   |1234    |User One   |u1@oc.com.np|
 		|user2   |1234    |User Two   |u2@oc.com.np|
 		And I am on the login page
-		And I login with username "user1" and password "1234"
-		And I logout
 		And I login with username "user2" and password "1234"
 
 	Scenario: test the single steps of federation sharing

--- a/tests/ui/features/sharing/sharing.feature
+++ b/tests/ui/features/sharing/sharing.feature
@@ -16,11 +16,9 @@ So that those groups and users can access the files and folders
 		And the user "user1" is in the group "grp1"
 		And the user "user2" is in the group "grp1"
 		And I am on the login page
-		And I login with username "user1" and password "1234"
-		And I logout
-		And I login with username "user2" and password "1234"
 
 	Scenario: share a file & folder with another internal user
+		And I login with username "user2" and password "1234"
 		When the folder "simple-folder" is shared with the user "User One"
 		And the file "testimage.jpg" is shared with the user "User One"
 		And I logout
@@ -34,7 +32,6 @@ So that those groups and users can access the files and folders
 		But the folder "simple-folder (2)" should not be listed
 
 	Scenario: share a folder with an internal group
-		And I logout
 		And I login with username "user3" and password "1234"
 		When the folder "simple-folder" is shared with the group "grp1"
 		And the file "testimage.jpg" is shared with the group "grp1"
@@ -53,6 +50,7 @@ So that those groups and users can access the files and folders
 
 	@skipOnMICROSOFTEDGE
 	Scenario: share a folder with another internal user and prohibit deleting
+		And I login with username "user2" and password "1234"
 		When the folder "simple-folder" is shared with the user "User One"
 		And the sharing permissions of "User One" for "simple-folder" are set to
 		| delete | no |


### PR DESCRIPTION
## Description
When creating users, download a little file for the user - that triggers the user account initialization (e.g. creating the skeleton files). In special cases (like when really testing first-time webUI login) then override this.

## Related Issue

## Motivation and Context
Some UI tests have steps that login and logout each newly-created user via the webUI just so that they get their skeleton files etc. set up. This is a waste of browser steps, it could be faster to do the skeleton file setup another way and also avoid having these odd-looking steps in the Behat-Gherkin.

## How Has This Been Tested?
Travis

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

