### PR TITLE
Show full new file name while waiting for rename AJAX

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2044,11 +2044,7 @@
 						// mark as loading (temp element)
 						self.showFileBusyState(tr, true);
 						tr.attr('data-file', newName);
-						var basename = newName;
-						if (newName.indexOf('.') > 0 && tr.data('type') !== 'dir') {
-							basename = newName.substr(0, newName.lastIndexOf('.'));
-						}
-						td.find('a.name span.nametext').text(basename);
+						td.find('a.name span.nametext').text(newName);
 						td.children('a.name').show();
 
 						var path = tr.attr('data-path') || self.getCurrentDirectory();


### PR DESCRIPTION
## Description
Show the full file name after the file name input has been accepted and while waiting for the AJAX to do the actual rename on the server.

## Related Issue
#29600 

## Motivation and Context
Showing just the file name without file extension looks odd (for half a second). I made me wonder what was really going on.

## How Has This Been Tested?
Manually watching. Travis will do a range of renames to check it out.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

