### PR TITLE
UI tests waitTillFileRowsAreReady after rename

### DIFF
--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -215,6 +215,8 @@ class FilesPage extends FilesPageBasic {
 			echo $message;
 			error_log($message);
 		}
+
+		$this->waitTillFileRowsAreReady($session);
 	}
 
 	/**

--- a/tests/ui/features/lib/FilesPageElement/FileRow.php
+++ b/tests/ui/features/lib/FilesPageElement/FileRow.php
@@ -74,6 +74,16 @@ class FileRow extends OwnCloudPage {
 	}
 
 	/**
+	 * checks if the file row is busy,
+	 * for example waiting for a rename to be finished
+	 *
+	 * @return boolean
+	 */
+	public function isBusy() {
+		return $this->rowElement->hasClass('busy');
+	}
+
+	/**
 	 * finds the Action Button
 	 *
 	 * @return \Behat\Mink\Element\NodeElement


### PR DESCRIPTION
## Description
After a file rename, wait until the file row(s) are no longer "busy" before proceeding.

## Related Issue

## Motivation and Context
UI tests that do a file rename, and then the next step is to take some action on the file such as sharing the file, sometimes fail trying to click the "sharing", "file actions menu" etc button. The error given is that the "element is not clickable". Indeed this is true. When a file is renamed, AJAX goes off to do the rename on the server. While waiting for the server response (success or fail), the row of the file list is set "busy". The sharing and file actions menus are hidden and the thumbnail is replaced with a spinner.

This was observed running UI tests locally. It does not seem to happen (very often) when running on Travis-SauceLabs. Probably that is because of round-trip times between Travis and SauceLabs which create a "natural" wait that avoids seeing the issue.

We need to pro-actively wait until the file list is properly ready for the next action.

## How Has This Been Tested?
Repeated local runs of sharing UI tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

