### PR TITLE
Reset FilesContext on logout

### DIFF
--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -78,6 +78,7 @@ trait BasicStructure {
 		$settingsMenu = $this->owncloudPage->openSettingsMenu();
 		$settingsMenu->logout();
 		$this->loginPage->waitTillPageIsLoaded($this->getSession());
+		$this->filesContext->resetFilesContext();
 	}
 
 	/**

--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -46,6 +46,12 @@ class FeatureContext extends RawMinkContext implements Context {
 	private $currentUser = null;
 
 	/**
+	 *
+	 * @var FilesContext
+	 */
+	private $filesContext;
+
+	/**
 	 * 
 	 * @var Page\OwncloudPage
 	 */
@@ -347,6 +353,11 @@ class FeatureContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function setUpSuite(BeforeScenarioScope $scope) {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->filesContext = $environment->getContext('FilesContext');
+
 		SetupHelper::setOcPath($scope);
 		$suiteParameters = SetupHelper::getSuiteParameters($scope);
 		$this->adminPassword = (string)$suiteParameters['adminPassword'];

--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -110,6 +110,18 @@ class FilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * reset any context remembered about where we are or what we have done on
+	 * the files-like pages
+	 *
+	 * @return void
+	 */
+	public function resetFilesContext() {
+		$this->currentFolder = "";
+		$this->deletedElementsTable = null;
+		$this->movedElementsTable = null;
+	}
+
+	/**
 	 * @Given I am on the files page
 	 * @return void
 	 */


### PR DESCRIPTION
## Description
When a test step logs out, notify FilesContext so that it can reset anything that it has been remembering about where it is or what has been done on the files page.

## Related Issue

## Motivation and Context
If I write UI test steps that navigate into ``foldera`` as user1, check some stuff, then logout and login as user1 and navigate into ``folderb`` and check some stuff, then FilesContext keeps appending the folders that I have navigated into.

That makes FilesContext think that the test is now in ``foldera/folderb`` - which causes issues for any test steps that try to download a file from the "current folder".

## How Has This Been Tested?
UI tests run locally, including with future test steps for sharing with groups (that is how I discovered this bug)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Bug fix to UI test infrastructure only - no bug in end-user code.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

