### PR TITLE
do not reset quota if it was not provided

### DIFF
--- a/lib/private/User/SyncService.php
+++ b/lib/private/User/SyncService.php
@@ -148,7 +148,10 @@ class SyncService {
 			}
 		}
 		if ($this->backend instanceof IProvidesQuotaBackend) {
-			$a->setQuota($this->backend->getQuota($uid));
+			$quota = $this->backend->getQuota($uid);
+			if ($quota !== null) {
+				$a->setQuota($quota);
+			}
 		} else {
 			list($hasKey, $value) = $this->readUserConfig($uid, 'files', 'quota');
 			if ($hasKey) {


### PR DESCRIPTION
if the backend returns null this will overwrite the quota in the account table, eg if neither ldap quota is defined nor an ldap quota attribute. This causes a quota that has been configured in the web ui to be reset to the default.

related https://github.com/owncloud/user_ldap/pull/137 - exposes this bug

cc @cdamken 