### PR TITLE
Add setup check for overwrite.cli.url setting

### DIFF
--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -296,6 +296,28 @@
 			}
 
 			return messages;
+		},
+
+		checkCliUrl: function(cliUrl) {
+			var deferred = $.Deferred();
+			var afterCall = function(result, status) {
+				var messages = [];
+				if (status === 'error' || _.isUndefined(result.installed)) {
+					messages.push({
+						msg: t('core', 'Please check the "overwrite.cli.url" setting: it must point to a server URL accessible from the outside as it will be used in emails, notifications, etc'),
+						type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+					});
+				}
+				deferred.resolve(messages);
+			};
+
+			$.ajax({
+				type: 'GET',
+				url: cliUrl + '/status.php',
+				allowAuthErrors: true
+			}).then(afterCall, afterCall);
+
+			return deferred.promise();
 		}
 	};
 })();

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -318,6 +318,28 @@
 			}).then(afterCall, afterCall);
 
 			return deferred.promise();
+		},
+
+		checkAbsoluteUrl: function(url) {
+			var deferred = $.Deferred();
+			var afterCall = function(result, status) {
+				var messages = [];
+				if (status === 'error' || _.isUndefined(result.installed)) {
+					messages.push({
+						msg: t('core', 'Please check the "overwrite" settings in config.php as it is used to create absolute URLs accessible from the outside as it will be used in emails, notificactions, etc'),
+						type: OC.SetupChecks.MESSAGE_TYPE_ERROR
+					});
+				}
+				deferred.resolve(messages);
+			};
+
+			$.ajax({
+				type: 'GET',
+				url: url,
+				allowAuthErrors: true
+			}).then(afterCall, afterCall);
+
+			return deferred.promise();
 		}
 	};
 })();

--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -289,7 +289,8 @@ class SettingsManager implements ISettingsManager {
 				$this->config,
 				$this->dbconnection,
 				$this->helper,
-				$this->lockingProvider),
+				$this->lockingProvider,
+				$this->urlGenerator),
 			Tips::class => new Tips(),
 			LegacyAdmin::class => new LegacyAdmin($this->helper),
 			Apps::class => new Apps($this->config)

--- a/settings/Panels/Admin/SecurityWarning.php
+++ b/settings/Panels/Admin/SecurityWarning.php
@@ -29,6 +29,7 @@ use OCP\IL10N;
 use OCP\Lock\ILockingProvider;
 use OCP\Settings\ISettings;
 use OCP\Template;
+use OCP\IURLGenerator;
 
 class SecurityWarning implements ISettings {
 
@@ -42,17 +43,21 @@ class SecurityWarning implements ISettings {
 	protected $helper;
 	/** @var ILockingProvider */
 	protected $lockingProvider;
+	/** @var IURLGenerator */
+	protected $urlGenerator;
 
 	public function __construct(IL10N $l,
 								IConfig $config,
 								IDBConnection $dbconnection,
 								Helper $helper,
-								ILockingProvider $lockingProvider) {
+								ILockingProvider $lockingProvider,
+								IURLGenerator $urlGenerator) {
 		$this->l = $l;
 		$this->config = $config;
 		$this->dbconnection = $dbconnection;
 		$this->helper = $helper;
 		$this->lockingProvider = $lockingProvider;
+		$this->urlGenerator = $urlGenerator;
 	}
 
 	public function getPriority() {
@@ -115,6 +120,8 @@ class SecurityWarning implements ISettings {
 		$template->assign('backgroundjobs_mode', $this->config->getAppValue('core', 'backgroundjobs_mode', 'ajax'));
 		$template->assign('cronErrors', $this->config->getAppValue('core', 'cronErrors'));
 		$template->assign('checkForWorkingWellKnownSetup', $this->config->getSystemValue('check_for_working_wellknown_setup', true));
+		$cliUrl = rtrim($this->config->getSystemValue('overwrite.cli.url'), '/');
+		$template->assign('cliUrl', $cliUrl);
 		return $template;
 	}
 

--- a/settings/Panels/Admin/SecurityWarning.php
+++ b/settings/Panels/Admin/SecurityWarning.php
@@ -122,6 +122,7 @@ class SecurityWarning implements ISettings {
 		$template->assign('checkForWorkingWellKnownSetup', $this->config->getSystemValue('check_for_working_wellknown_setup', true));
 		$cliUrl = rtrim($this->config->getSystemValue('overwrite.cli.url'), '/');
 		$template->assign('cliUrl', $cliUrl);
+		$template->assign('absoluteUrl', $this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkTo('', 'status.php')));
 		return $template;
 	}
 

--- a/settings/js/panels/setupchecks.js
+++ b/settings/js/panels/setupchecks.js
@@ -8,9 +8,10 @@ $(document).ready(function() {
 		OC.SetupChecks.checkSetup(),
 		OC.SetupChecks.checkGeneric(),
 		OC.SetupChecks.checkDataProtected(),
-		OC.SetupChecks.checkCliUrl($('#postsetupchecks').attr('data-cli-url'))
-	).then(function (check1, check2, check3, check4, check5, check6, check7) {
-		var messages = [].concat(check1, check2, check3, check4, check5, check6, check7);
+		OC.SetupChecks.checkCliUrl($('#postsetupchecks').attr('data-cli-url')),
+		OC.SetupChecks.checkAbsoluteUrl($('#postsetupchecks').attr('data-absolute-url'))
+	).then(function (check1, check2, check3, check4, check5, check6, check7, check8) {
+		var messages = [].concat(check1, check2, check3, check4, check5, check6, check7, check8);
 		var $el = $('#postsetupchecks');
 		$el.find('.loading').addClass('hidden');
 

--- a/settings/js/panels/setupchecks.js
+++ b/settings/js/panels/setupchecks.js
@@ -7,9 +7,10 @@ $(document).ready(function() {
 		OC.SetupChecks.checkWellKnownUrl('/.well-known/carddav/', oc_defaults.docPlaceholderUrl, $('#postsetupchecks').data('check-wellknown') === 'true'),
 		OC.SetupChecks.checkSetup(),
 		OC.SetupChecks.checkGeneric(),
-		OC.SetupChecks.checkDataProtected()
-	).then(function (check1, check2, check3, check4, check5, check6) {
-		var messages = [].concat(check1, check2, check3, check4, check5, check6);
+		OC.SetupChecks.checkDataProtected(),
+		OC.SetupChecks.checkCliUrl($('#postsetupchecks').attr('data-cli-url'))
+	).then(function (check1, check2, check3, check4, check5, check6, check7) {
+		var messages = [].concat(check1, check2, check3, check4, check5, check6, check7);
 		var $el = $('#postsetupchecks');
 		$el.find('.loading').addClass('hidden');
 

--- a/settings/templates/panels/admin/securitywarning.php
+++ b/settings/templates/panels/admin/securitywarning.php
@@ -137,7 +137,7 @@ script('settings', 'panels/setupchecks');
 	?>
 	</ul>
 
-	<div id="postsetupchecks" data-cli-url="<?php p($_['cliUrl']) ?>" data-check-wellknown="<?php if($_['checkForWorkingWellKnownSetup']) { p('true'); } else { p('false'); } ?>">
+	<div id="postsetupchecks" data-cli-url="<?php p($_['cliUrl']) ?>" data-absolute-url="<?php p($_['absoluteUrl']) ?>" data-check-wellknown="<?php if($_['checkForWorkingWellKnownSetup']) { p('true'); } else { p('false'); } ?>">
 		<div class="loading"></div>
 		<ul class="errors hidden"></ul>
 		<ul class="warnings hidden"></ul>

--- a/settings/templates/panels/admin/securitywarning.php
+++ b/settings/templates/panels/admin/securitywarning.php
@@ -137,7 +137,7 @@ script('settings', 'panels/setupchecks');
 	?>
 	</ul>
 
-	<div id="postsetupchecks" data-check-wellknown="<?php if($_['checkForWorkingWellKnownSetup']) { p('true'); } else { p('false'); } ?>">
+	<div id="postsetupchecks" data-cli-url="<?php p($_['cliUrl']) ?>" data-check-wellknown="<?php if($_['checkForWorkingWellKnownSetup']) { p('true'); } else { p('false'); } ?>">
 		<div class="loading"></div>
 		<ul class="errors hidden"></ul>
 		<ul class="warnings hidden"></ul>


### PR DESCRIPTION
## Description
Checks that "overwrite.cli.url" is set and is usable by calling status.php.
If no status.php response, displays a warning message in setup checks section in settings page.

## Related Issue
Fixes https://github.com/owncloud/core/issues/29606

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] TEST: when not set at all, message appears
- [x] TEST: when set to wrong URL, message appears
- [x] TEST: when set to correct URL, no message

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODO:
- [ ] double check how the CLI URL influences notification URLs. it seems that when it's not set it still works fine, but might not work in all scenarios. (needed to decide whether to keep the warning when it's not set)
- [ ] add unit tests
