### PR TITLE
Fix files scan repair in bulk warning

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -247,15 +247,17 @@ class Scan extends Base {
 		} else if ($input->getOption('all')) {
 			// we can only repair all storages in bulk (more efficient) if singleuser or maintenance mode
 			// is enabled to prevent concurrent user access
-			if ($input->getOption('repair') &&
-				($this->config->getSystemValue('singleuser', false) || $this->config->getSystemValue('maintenance', false))) {
-				// repair all storages at once
-				$this->repairAll($output);
-				// don't fix individually
-				$shouldRepairStoragesIndividually = false;
-			} else {
-				$output->writeln("<comment>Repairing every storage individually is slower than repairing in bulk</comment>");
-				$output->writeln("<comment>To repair in bulk, please switch to single user mode first: occ maintenance:singleuser --on</comment>");
+			if ($input->getOption('repair')) {
+				if ($this->config->getSystemValue('singleuser', false) || $this->config->getSystemValue('maintenance', false)) {
+					// repair all storages at once
+					$this->repairAll($output);
+					// don't fix individually
+					$shouldRepairStoragesIndividually = false;
+				} else {
+					$output->writeln("<comment>Please switch to single user mode to repair all storages: occ maintenance:singleuser --on</comment>");
+					$output->writeln("<comment>Alternatively, you can specify a user to repair. Please note that this is slower than repairing in bulk</comment>");
+					return 1;
+				}
 			}
 			$users = $this->userManager->search('');
 		} else {


### PR DESCRIPTION
## Description
Fix warning when running `occ files:scan --repair --all` without single user mode.
The message now only appears when `--repair` is actually passed.
Additionally, the message was improved to make more sense when read in this context.
The command now exits with an error code as it doesn't make sense to scan since the precondition was not met.

## Related Issue
Found during smoke testing for 9.0.11RC1: https://github.com/owncloud/core/issues/29627

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual testing of command with and without single user mode.
Without repair switch, no message must appear.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Backports:
- [x] stable10
- [x] stable9.1
- [x] stable9

