### PR TITLE
[stable9] Fix files scan repair in bulk warning

### DIFF
--- a/apps/files/command/scan.php
+++ b/apps/files/command/scan.php
@@ -36,6 +36,7 @@ use OCP\IUserManager;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Helper\Table;
 use OC\Repair\RepairMismatchFileCachePath;

--- a/apps/files/command/scan.php
+++ b/apps/files/command/scan.php
@@ -230,16 +230,19 @@ class Scan extends Base {
 		} else if ($input->getOption('all')) {
 			// we can only repair all storages in bulk (more efficient) if singleuser or maintenance mode
 			// is enabled to prevent concurrent user access
-			if ($input->getOption('repair') && ($this->config->getSystemValue('singleuser', false) || $this->config->getSystemValue('maintenance', false))) {
-				// repair all storages at once
-				$this->repairAll($output);
-				// don't fix individually
-				$shouldRepairStoragesIndividually = false;
-			} else {
-				$output->writeln("<comment>Repairing every storage individually is slower than repairing in bulk</comment>");
-				$output->writeln("<comment>To repair in bulk, please switch to single user mode first: occ maintenance:singleuser --on</comment>");
-				$users = $this->userManager->search('');
+			if ($input->getOption('repair')) {
+				if ($this->config->getSystemValue('singleuser', false) || $this->config->getSystemValue('maintenance', false)) {
+					// repair all storages at once
+					$this->repairAll($output);
+					// don't fix individually
+					$shouldRepairStoragesIndividually = false;
+				} else {
+					$output->writeln("<comment>Please switch to single user mode to repair all storages: occ maintenance:singleuser --on</comment>");
+					$output->writeln("<comment>Alternatively, you can specify a user to repair. Please note that this is slower than repairing in bulk</comment>");
+					return 1;
+				}
 			}
+			$users = $this->userManager->search('');
 		} else {
 			$users = $input->getArgument('user_id');
 		}


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/29629 to stable9.

I had to move out the `$users = $this->userManager->...` call. Not sure why it was in the `else` here while it wasn't on master.