### PR TITLE
Bump version in master to 10.0.4.2

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 0, 3, 3];
+$OC_Version = [10, 0, 4, 2];
 
 // The human readable string
-$OC_VersionString = '10.0.3';
+$OC_VersionString = '10.0.4 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
because the code in master has whatever migrations... might occur up to 10.0.4.2
and it is annoying when doing ``git checkout stable10`` and ``git checkout master`` to find the UI telling that you attempt to downgrade when you switch to master branch.

``stable10`` already has version set to 10.0.4.2