### PR TITLE
Preload app-themes while collecting status info. Replace oldschool co…

### DIFF
--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -722,8 +722,10 @@ class Util {
 
 		$installed = (bool) $systemConfig->getValue('installed', false);
 		$maintenance = (bool) $systemConfig->getValue('maintenance', false);
-		# see core/lib/private/legacy/defaults.php and core/themes/example/defaults.php
-		# for description and defaults
+		\OC_App::loadApps(['theme']);
+
+		// see core/lib/private/legacy/defaults.php and core/themes/example/defaults.php
+		// for description and defaults
 		$defaults = new \OCP\Defaults();
 		$values = [
 			'installed'=> $installed ? true : false,
@@ -734,13 +736,13 @@ class Util {
 			'edition' => '',
 			'productname' => ''];
 
-		# expose version and servername details 
+		// expose version and servername details
 		if ($includeVersion || (bool) $systemConfig->getValue('version.hide', false) === false) {
 			$values['version'] = implode('.', self::getVersion());
 			$values['versionstring'] = \OC_Util::getVersionString();
 			$values['edition'] = \OC_Util::getEditionString();
 			$values['productname'] = $defaults->getName();
-			# expose the servername only if allowed via version, but never when called via status.php
+			// expose the servername only if allowed via version, but never when called via status.php
 			if ($serverHide === false) {
 				$values['hostname'] = gethostname();
 			}

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -516,6 +516,12 @@ class UtilTest extends \Test\TestCase {
 			'myApp/vendor/myFancyCSSFile2',
 		], \OC_Util::$styles);
 	}
+	
+	public function testGetStatusInfo() {
+		$statusInfo = \OCP\Util::getStatusInfo();
+		$this->assertArrayHasKey('productname', $statusInfo);
+		$this->assertEquals($statusInfo['productname'], 'ownCloud');
+	}
 }
 
 /**


### PR DESCRIPTION
…mments


## Description
- Preload app-themes while collecting status info
- Replace oldschool comments


## Related Issue
https://github.com/owncloud/core/issues/29066

## Motivation and Context
When app-theme is active `status.php` doesn't respect product name.

## How Has This Been Tested?
http://mycloud/status.php

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
