### PR TITLE
Improve error handling in UI test conflict dialog detection

### DIFF
--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -425,6 +425,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 */
 	public function choiceInUploadConflict($choice) {
 		$dialogs = $this->filesPage->getOcDialogs();
+		$isConflictDialog = false;
 		foreach ($dialogs as $dialog) {
 			$isConflictDialog = strstr(
 				$dialog->getTitle(), $this->uploadConflictDialogTitle
@@ -434,14 +435,22 @@ class FilesContext extends RawMinkContext implements Context {
 				break;
 			}
 		}
+		if ($isConflictDialog === false) {
+			throw new Exception(
+				__METHOD__ .
+				" file upload conflict dialog expected but not found"
+			);
+		}
 		if ($choice === "new") {
 			$this->conflictDialog->keepNewFiles();
 		} elseif ($choice === "existing") {
 			$this->conflictDialog->keepExistingFiles();
 		} else {
-			throw new Exception("the choice can only be 'new' or 'existing'");
+			throw new Exception(
+				__METHOD__ .
+				" the choice can only be 'new' or 'existing'"
+			);
 		}
-		
 	}
 
 	/**


### PR DESCRIPTION
## Description
Throw a (nice) exception when uploading a file if the conflict dialog is expected but is not found.

## Related Issue

## Motivation and Context
It is easier to understand the test result, rather than just crashing on null.

## How Has This Been Tested?
Local UI test run.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

