### PR TITLE
Unify the core sync logic

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
@@ -31,24 +31,21 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
  * @package OCA\DAV\Tests\unit\Connector\Sabre\RequestTest
  */
 class PartFileInRootUploadTest extends UploadTest {
+
+	protected $original;
+
 	protected function setUp() {
 		$config = \OC::$server->getConfig();
-		$mockConfig = $this->createMock('\OCP\IConfig');
-		$mockConfig->expects($this->any())
-			->method('getSystemValue')
-			->will($this->returnCallback(function ($key, $default) use ($config) {
-				if ($key === 'part_file_in_storage') {
-					return false;
-				} else {
-					return $config->getSystemValue($key, $default);
-				}
-			}));
-		$this->overwriteService('AllConfig', $mockConfig);
+		$this->original = $config->getSystemValue('part_file_in_storage', null);
+		$config->setSystemValue('part_file_in_storage', false);
 		parent::setUp();
 	}
 
 	protected function tearDown() {
-		$this->restoreService('AllConfig');
+		if($this->original !== null) {
+			$config = \OC::$server->getConfig();
+			$this->original = $config->setSystemValue('part_file_in_storage', $this->original);
+		}
 		return parent::tearDown();
 	}
 }

--- a/core/Command/User/SyncBackend.php
+++ b/core/Command/User/SyncBackend.php
@@ -130,10 +130,10 @@ class SyncBackend extends Command {
 			$missingAccountsAction = $helper->ask($input, $output, $question);
 		}
 
-		$syncService = new SyncService($this->accountMapper, $backend, $this->config, $this->logger);
+		$syncService = new SyncService($this->config, $this->logger, $this->accountMapper);
 
 		// analyse unknown users
-		$this->handleUnknownUsers($input, $output, $syncService, $missingAccountsAction, $validActions);
+		$this->handleUnknownUsers($input, $output, $backend, $syncService, $missingAccountsAction, $validActions);
 
 		// insert/update known users
 		$output->writeln("Insert new and update existing users ...");
@@ -143,7 +143,7 @@ class SyncBackend extends Command {
 			$max = $backend->countUsers();
 		}
 		$p->start($max);
-		$syncService->run(function () use ($p) {
+		$syncService->run($backend, function () use ($p) {
 			$p->advance();
 		});
 		$p->finish();
@@ -189,14 +189,15 @@ class SyncBackend extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @param $syncService
+	 * @param UserInterface $backend
+	 * @param SyncService $syncService
 	 * @param $missingAccountsAction
 	 * @param $validActions
 	 */
-	private function handleUnknownUsers(InputInterface $input, OutputInterface $output, $syncService, $missingAccountsAction, $validActions) {
+	private function handleUnknownUsers(InputInterface $input, OutputInterface $output, UserInterface $backend, SyncService $syncService, $missingAccountsAction, $validActions) {
 		$output->writeln("Analyse unknown users ...");
 		$p = new ProgressBar($output);
-		$toBeDeleted = $syncService->getNoLongerExistingUsers(function () use ($p) {
+		$toBeDeleted = $syncService->getNoLongerExistingUsers($backend, function () use ($p) {
 			$p->advance();
 		});
 		$p->finish();

--- a/core/Migrations/Version20170221114437.php
+++ b/core/Migrations/Version20170221114437.php
@@ -19,12 +19,12 @@ class Version20170221114437 implements ISimpleMigration {
 		$logger = \OC::$server->getLogger();
 		$connection = \OC::$server->getDatabaseConnection();
 		$accountMapper = new AccountMapper($config, $connection, new AccountTermMapper($connection));
-		$syncService = new SyncService($accountMapper, $backend, $config, $logger);
+		$syncService = new SyncService($config, $logger, $accountMapper);
 
 		// insert/update known users
 		$out->info("Insert new users ...");
 		$out->startProgress($backend->countUsers());
-		$syncService->run(function () use ($out) {
+		$syncService->run($backend, function () use ($out) {
 			$out->advance();
 		});
 		$out->finishProgress();

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -85,6 +85,7 @@ use OC\Tagging\TagMapper;
 use OC\Theme\ThemeService;
 use OC\User\AccountMapper;
 use OC\User\AccountTermMapper;
+use OC\User\SyncService;
 use OCP\App\IServiceLoader;
 use OCP\AppFramework\QueryException;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -239,9 +240,16 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			return new AccountMapper($c->getConfig(), $c->getDatabaseConnection(), new AccountTermMapper($c->getDatabaseConnection()));
 		});
 		$this->registerService('UserManager', function (Server $c) {
-			$config = $c->getConfig();
-			$logger = $c->getLogger();
-			return new \OC\User\Manager($config, $logger, $c->getAccountMapper());
+			return new \OC\User\Manager(
+				$c->getConfig(),
+				$c->getLogger(),
+				$c->getAccountMapper(),
+				new SyncService(
+					$c->getConfig(),
+					$c->getLogger(),
+					$c->getAccountMapper()
+				)
+			);
 		});
 		$this->registerService('GroupManager', function (Server $c) {
 			$groupManager = new \OC\Group\Manager($this->getUserManager());
@@ -296,8 +304,10 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$defaultTokenProvider = null;
 			}
 
+			$userSyncService = new SyncService($c->getConfig(), $c->getLogger(), $c->getAccountMapper());
+
 			$userSession = new \OC\User\Session($manager, $session, $timeFactory,
-				$defaultTokenProvider, $c->getConfig(), $this);
+				$defaultTokenProvider, $c->getConfig(), $this, $userSyncService);
 			$userSession->listen('\OC\User', 'preCreateUser', function ($uid, $password) {
 				\OC_Hook::emit('OC_User', 'pre_createUser', ['run' => true, 'uid' => $uid, 'password' => $password]);
 			});

--- a/lib/private/User/Account.php
+++ b/lib/private/User/Account.php
@@ -28,7 +28,7 @@ use OCP\UserInterface;
 /**
  * Class Account
  *
- * @method int getUserId()
+ * @method string getUserId()
  * @method string getDisplayName()
  * @method void setDisplayName(string $displayName)
  * @method string getEmail()
@@ -71,6 +71,9 @@ class Account extends Entity {
 		$this->addType('lastLogin', 'integer');
 	}
 
+	/**
+	 * @param string $uid
+	 */
 	public function setUserId($uid) {
 		parent::setter('lowerUserId', [strtolower($uid)]);
 		parent::setter('userId', [$uid]);

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -52,12 +52,15 @@ namespace OC\User;
 
 use OC\Cache\CappedMemoryCache;
 use OCP\IUserBackend;
+use OCP\User\IProvidesDisplayNameBackend;
+use OCP\User\IProvidesEMailBackend;
+use OCP\User\IProvidesHomeBackend;
 use OCP\Util;
 
 /**
  * Class for user management in a SQL Database (e.g. MySQL, SQLite)
  */
-class Database extends Backend implements IUserBackend {
+class Database extends Backend implements IUserBackend, IProvidesHomeBackend, IProvidesDisplayNameBackend {
 	/** @var CappedMemoryCache */
 	private $cache;
 
@@ -290,14 +293,10 @@ class Database extends Backend implements IUserBackend {
 	/**
 	 * get the user's home directory
 	 * @param string $uid the username
-	 * @return string|false
+	 * @return string
 	 */
 	public function getHome($uid) {
-		if ($this->userExists($uid)) {
-			return \OC::$server->getConfig()->getSystemValue("datadirectory", \OC::$SERVERROOT . "/data") . '/' . $uid;
-		}
-
-		return false;
+		return \OC::$server->getConfig()->getSystemValue("datadirectory", \OC::$SERVERROOT . "/data") . '/' . $uid;
 	}
 
 	/**

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -46,6 +46,7 @@ use OC_Util;
 use OCA\DAV\Connector\Sabre\Auth;
 use OCP\App\IServiceLoader;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\IApacheBackend;
 use OCP\Authentication\IAuthModule;
 use OCP\Events\EventEmitterTrait;
 use OCP\Files\NoReadAccessException;
@@ -54,9 +55,11 @@ use OCP\IConfig;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
+use OCP\IUserBackend;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Session\Exceptions\SessionNotAvailableException;
+use OCP\UserInterface;
 use OCP\Util;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -104,6 +107,9 @@ class Session implements IUserSession, Emitter {
 	/** @var IServiceLoader */
 	private $serviceLoader;
 
+	/** @var SyncService */
+	protected $userSyncService;
+
 	/**
 	 * @param IUserManager $manager
 	 * @param ISession $session
@@ -111,16 +117,19 @@ class Session implements IUserSession, Emitter {
 	 * @param IProvider $tokenProvider
 	 * @param IConfig $config
 	 * @param IServiceLoader $serviceLoader
+	 * @param SyncService $userSyncService
 	 */
 	public function __construct(IUserManager $manager, ISession $session,
-								ITimeFactory $timeFactory, $tokenProvider,
-								IConfig $config, IServiceLoader $serviceLoader) {
+								ITimeFactory $timeFactory, IProvider $tokenProvider,
+								IConfig $config, IServiceLoader $serviceLoader,
+								SyncService $userSyncService) {
 		$this->manager = $manager;
 		$this->session = $session;
 		$this->timeFactory = $timeFactory;
 		$this->tokenProvider = $tokenProvider;
 		$this->config = $config;
 		$this->serviceLoader = $serviceLoader;
+		$this->userSyncService = $userSyncService;
 	}
 
 	/**
@@ -555,6 +564,91 @@ class Session implements IUserSession, Emitter {
 		$this->session->set('app_password', $token);
 
 		return true;
+	}
+
+	/**
+	 * Try to login a user, assuming authentication
+	 * has already happened (e.g. via Single Sign On).
+	 *
+	 * Log in a user and regenerate a new session.
+	 *
+	 * @param \OCP\Authentication\IApacheBackend $apacheBackend
+	 * @return bool
+	 * @throws LoginException
+	 */
+	public function loginWithApache(IApacheBackend $apacheBackend) {
+
+		$uidAndBackend = $apacheBackend->getCurrentUserId();
+		if (is_array($uidAndBackend)
+			&& count($uidAndBackend) === 2
+			&& $uidAndBackend[0] !== ''
+			&& $uidAndBackend[0] !== null
+			&& $uidAndBackend[1] instanceof UserInterface
+		) {
+			list($uid, $backend) = $uidAndBackend;
+		} else if (is_string($uidAndBackend)) {
+			$uid = $uidAndBackend;
+			if ($apacheBackend instanceof UserInterface) {
+				$backend = $apacheBackend;
+			} else {
+				\OC::$server->getLogger()->error("Apache backend failed to provide a valid backend for the user");
+				return false;
+			}
+		} else {
+			\OC::$server->getLogger()->debug("No valid user detected from apache user backend");
+			return false;
+		}
+
+		if ($this->getUser() !== null && $uid === $this->getUser()->getUID()) {
+			return true; // nothing to do
+		}
+		$this->session->regenerateId();
+
+		$this->manager->emit('\OC\User', 'preLogin', [$uid, '']);
+
+		// Die here if not valid
+		if(!$apacheBackend->isSessionActive()) {
+			return false;
+		}
+
+		// Now we try to create the account or sync
+		$this->userSyncService->createOrSyncAccount($uid, $backend);
+
+		$user = $this->manager->get($uid);
+		if ($user === null) {
+			$this->manager->emit('\OC\User', 'failedLogin', [$uid]);
+			return false;
+		}
+
+		if ($user->isEnabled()) {
+			$this->setUser($user);
+			$this->setLoginName($uid);
+
+			$request = OC::$server->getRequest();
+			$this->createSessionToken($request, $uid, $uid);
+
+			// setup the filesystem
+			OC_Util::setupFS($uid);
+			// first call the post_login hooks, the login-process needs to be
+			// completed before we can safely create the users folder.
+			// For example encryption needs to initialize the users keys first
+			// before we can create the user folder with the skeleton files
+
+			$firstTimeLogin = $user->updateLastLoginTimestamp();
+			$this->manager->emit('\OC\User', 'postLogin', [$user, '']);
+			if ($this->isLoggedIn()) {
+				$this->prepareUserLogin($firstTimeLogin);
+				return true;
+			} else {
+				// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
+				$message = \OC::$server->getL10N('lib')->t('Login canceled by app');
+				throw new LoginException($message);
+			}
+		} else {
+			// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
+			$message = \OC::$server->getL10N('lib')->t('User disabled');
+			throw new LoginException($message);
+		}
 	}
 
 	/**

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -42,6 +42,7 @@ use OCP\IUser;
 use OCP\IConfig;
 use OCP\IUserBackend;
 use OCP\User\IChangePasswordBackend;
+use OCP\UserInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -151,6 +152,12 @@ class User implements IUser {
 		}
 		$this->account->setDisplayName($displayName);
 		$this->mapper->update($this->account);
+
+		$backend = $this->account->getBackendInstance();
+		if ($backend->implementsActions(Backend::SET_DISPLAYNAME)) {
+			$backend->setDisplayName($this->account->getUserId(), $displayName);
+		}
+
 		$this->triggerChange('displayName', $displayName);
 
 		return true;

--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -178,39 +178,7 @@ class OC_User {
 	 * @return bool
 	 */
 	public static function loginWithApache(\OCP\Authentication\IApacheBackend $backend) {
-
-		$uid = $backend->getCurrentUserId();
-		$run = true;
-		OC_Hook::emit("OC_User", "pre_login", ["run" => &$run, "uid" => $uid]);
-
-		if ($uid) {
-			if (self::getUser() !== $uid) {
-				self::setUserId($uid);
-				$userSession = self::getUserSession();
-				$userSession->getSession()->regenerateId();
-				$userSession->setLoginName($uid);
-				$request = OC::$server->getRequest();
-				$userSession->createSessionToken($request, $uid, $uid);
-				// setup the filesystem
-				OC_Util::setupFS($uid);
-				// first call the post_login hooks, the login-process needs to be
-				// completed before we can safely create the users folder.
-				// For example encryption needs to initialize the users keys first
-				// before we can create the user folder with the skeleton files
-				OC_Hook::emit("OC_User", "post_login", ["uid" => $uid, 'password' => '']);
-				$user = $userSession->getUser();
-				$firstTimeLogin = $user->updateLastLoginTimestamp();
-				if ($userSession->isLoggedIn()) {
-					$userSession->prepareUserLogin($firstTimeLogin);
-				} else {
-					// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
-					$message = \OC::$server->getL10N('lib')->t('Login canceled by app');
-					throw new \OC\User\LoginException($message);
-				}
-			}
-			return true;
-		}
-		return false;
+		return self::getUserSession()->loginWithApache($backend);
 	}
 
 	/**

--- a/lib/public/Authentication/IApacheBackend.php
+++ b/lib/public/Authentication/IApacheBackend.php
@@ -56,7 +56,7 @@ interface IApacheBackend {
 
 	/**
 	 * Return the id of the current user
-	 * @return string
+	 * @return string|array[] the uid, or an array with [uid, backend]
 	 * @since 6.0.0
 	 */
 	public function getCurrentUserId();

--- a/lib/public/User/IProvidesDisplayNameBackend.php
+++ b/lib/public/User/IProvidesDisplayNameBackend.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+// use OCP namespace for all classes that are considered public.
+// This means that they should be used by apps instead of the internal ownCloud classes
+namespace OCP\User;
+
+/**
+ * Interface IProvidesDisplayNameBackend
+ *
+ * @package OCP\User
+ * @since 10.0
+ */
+interface IProvidesDisplayNameBackend {
+
+	/**
+	 * get display name of the user
+	 * @param string $uid user ID of the user
+	 * @return string display name
+	 * @since 10.0.7
+	 */
+	public function getDisplayName($uid);
+}
+

--- a/lib/public/User/IProvidesHomeBackend.php
+++ b/lib/public/User/IProvidesHomeBackend.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+// use OCP namespace for all classes that are considered public.
+// This means that they should be used by apps instead of the internal ownCloud classes
+namespace OCP\User;
+
+/**
+ * Interface IProvidesHomeBackend
+ *
+ * @package OCP\User
+ * @since 10.0
+ */
+interface IProvidesHomeBackend {
+
+	/**
+	 * Get a users absolute home folder path
+	 *
+	 * @param string $uid The username
+	 * @return string|null
+	 * @since 10.0.7
+	 */
+	public function getHome($uid);
+}
+

--- a/tests/Core/Command/User/ListUsersTest.php
+++ b/tests/Core/Command/User/ListUsersTest.php
@@ -38,14 +38,14 @@ class ListUsersTest extends TestCase
     protected function setUp() {
         parent::setUp();
 
-        \OC::$server->getUserManager()->createUser('user1','password');
+        \OC::$server->getUserManager()->createUser('testlistuser','password');
         $command = new ListUsers(\OC::$server->getUserManager());
         $this->commandTester = new CommandTester($command);
     }
 
     protected function tearDown() {
         parent::tearDown();
-        \OC::$server->getUserManager()->get('user1')->delete();
+        \OC::$server->getUserManager()->get('testlistuser')->delete();
     }
 
 
@@ -62,8 +62,8 @@ class ListUsersTest extends TestCase
 
     public function inputProvider() {
         return [
-            [[], 'user1'],
-            [['search-pattern' => 'user'], 'user1']
+            [[], 'testlistuser'],
+            [['search-pattern' => 'testlist'], 'testlistuser']
         ];
     }
 

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -15,6 +15,7 @@ use OC\Log;
 use OC\User\Account;
 use OC\User\AccountMapper;
 use OC\User\Manager;
+use OC\User\SyncService;
 use OCP\Files\Config\ICachedMountInfo;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -67,7 +68,9 @@ class UserMountCacheTest extends TestCase {
 
 		/** @var Log $log */
 		$log = $this->createMock(Log::class);
-		$this->userManager = new Manager($config, $log, $accountMapper);
+		/** @var SyncService $syncService */
+		$syncService = $this->createMock(SyncService::class);
+		$this->userManager = new Manager($config, $log, $accountMapper, $syncService);
 		$this->cache = new UserMountCache($this->connection, $this->userManager, $log);
 
 		// hookup listener

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -293,7 +293,7 @@ class FilesystemTest extends TestCase {
 	}
 
 	/**
-	 * The parameter array can be redesigned if filesystem.php will get a constructor where it is possible to 
+	 * The parameter array can be redesigned if filesystem.php will get a constructor where it is possible to
 	 * define the excluded directories for unit tests
 	 * @dataProvider isExcludedData
 	 */

--- a/tests/lib/Traits/UserTrait.php
+++ b/tests/lib/Traits/UserTrait.php
@@ -9,8 +9,10 @@
 namespace Test\Traits;
 
 use OC\User\AccountTermMapper;
+use OC\User\SyncService;
 use OC\User\User;
 use OCP\IConfig;
+use OCP\ILogger;
 use Test\Util\User\Dummy;
 use Test\Util\User\MemoryAccountMapper;
 
@@ -38,13 +40,14 @@ trait UserTrait {
 	}
 
 	protected function setUpUserTrait() {
-
 		$db = \OC::$server->getDatabaseConnection();
-		$config = $this->createMock(IConfig::class);
+		$config =  \OC::$server->getConfig();
 		$accountMapper = new MemoryAccountMapper($config, $db, new AccountTermMapper($db));
+		$logger = $this->createMock(ILogger::class);
+		$syncService = new SyncService($config, $logger, $accountMapper);
 		$accountMapper->testCaseName = get_class($this);
 		$this->previousUserManagerInternals = \OC::$server->getUserManager()
-			->reset($accountMapper, [Dummy::class => new Dummy()]);
+			->reset($accountMapper, [Dummy::class => new Dummy()], $syncService);
 
 		if ($this->previousUserManagerInternals[0] instanceof MemoryAccountMapper) {
 			throw new \Exception("Missing tearDown call in " . $this->previousUserManagerInternals[0]->testCaseName);
@@ -56,6 +59,6 @@ trait UserTrait {
 			$user->delete();
 		}
 		\OC::$server->getUserManager()
-			->reset($this->previousUserManagerInternals[0], $this->previousUserManagerInternals[1]);
+			->reset($this->previousUserManagerInternals[0], $this->previousUserManagerInternals[1], $this->previousUserManagerInternals[2]);
 	}
 }

--- a/tests/lib/User/SyncServiceTest.php
+++ b/tests/lib/User/SyncServiceTest.php
@@ -1,13 +1,27 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: deepdiver
- * Date: 12.04.17
- * Time: 14:56
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Tom Needham <tom@owncloud.com>
+
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
  */
 
 namespace Test\User;
-
 
 use OC\User\Account;
 use OC\User\AccountMapper;
@@ -35,10 +49,32 @@ class SyncServiceTest extends TestCase {
 			['user1', 'settings', 'email', '', 'foo@bar.net'],
 		]);
 
-		$s = new SyncService($mapper, $backend, $config, $logger);
+		$s = new SyncService($config, $logger, $mapper);
 		$a = new Account();
-		$s->setupAccount($a, 'user1');
+		$a->setUserId('user1');
+		$s->syncAccount($a, $backend);
 
 		$this->assertEquals('foo@bar.net', $a->getEmail());
+	}
+
+	public function testSyncHomeLogsWhenBackendDiffersFromExisting() {
+		$mapper = $this->createMock(AccountMapper::class);
+		$backend = $this->createMock(UserInterface::class);
+		$config = $this->createMock(IConfig::class);
+		$logger = $this->createMock(ILogger::class);
+		$a = $this->createMock(Account::class);
+
+		// Accoutn returns existing home
+		$a->expects($this->once())->method('getHome')->willReturn('existing');
+
+		// Backend returns a new home
+		$backend->expects($this->exactly(2))->method('getHome')->willReturn('newwrongvalue');
+
+		// Should produce an error in the log if backend home different from stored account home
+		$logger->expects($this->once())->method('error');
+
+		$s = new SyncService($config, $logger, $mapper);
+
+		$this->invokePrivate($s, 'syncHome', [$a, $backend]);
 	}
 }

--- a/tests/lib/Util/User/MemoryAccountMapper.php
+++ b/tests/lib/Util/User/MemoryAccountMapper.php
@@ -37,7 +37,6 @@ class MemoryAccountMapper extends AccountMapper {
 	public function insert(Entity $entity) {
 		$entity->setId(self::$counter++);
 		self::$accounts[$entity->getId()] = $entity;
-
 		return $entity;
 	}
 


### PR DESCRIPTION
remove some code duplication and get the core to run a proper sync on the user metadata during a login

@DeepDiver1975 @PVince81 note that the account table introduced a change in behavior:
`setDisplayName()` was no longer called on the backend while `canChangeDisplayName()` would still check the backend if it implemented that function. With the account table we can always change display name, email, avatar ... but we may want to prevent that. `canChangeDisplayName()` already contains a check on the system value `allow_user_to_change_display_name`. `canChangeAvatar()` and `canChangePassword()` already exist, but email is missing.

Conceptually there are now two cases for setDisplayName:
1. End user triggered in the UI. Changeability may depend on the backend, eg LDAP is readonly.
2. Sync triggered.

The current User object code is intended only for the first case.

@tomneedham we need to add a codepath for the second case. AFAICT we should directly work on the accounts... the sync case bypasses any end user limitations.