### PR TITLE
[stable10] Fix federated share import

### DIFF
--- a/apps/files_sharing/ajax/external.php
+++ b/apps/files_sharing/ajax/external.php
@@ -69,9 +69,8 @@ $externalManager = new \OCA\Files_Sharing\External\Manager(
 		\OC::$server->getDatabaseConnection(),
 		\OC\Files\Filesystem::getMountManager(),
 		\OC\Files\Filesystem::getLoader(),
-		\OC::$server->getHTTPHelper(),
 		\OC::$server->getNotificationManager(),
-		$discoveryManager,
+		\OC::$server->getEventDispatcher(),
 		\OC::$server->getUserSession()->getUser()->getUID()
 );
 


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/29676 to stable10.

Tested by adding a share and it appearing correctly in the file list, no error log.