### PR TITLE
Show new basename and extension while waiting for AJAX rename

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2045,10 +2045,16 @@
 						self.showFileBusyState(tr, true);
 						tr.attr('data-file', newName);
 						var basename = newName;
-						if (newName.indexOf('.') > 0 && tr.data('type') !== 'dir') {
-							basename = newName.substr(0, newName.lastIndexOf('.'));
+						if (tr.data('type') !== 'dir') {
+							var extension = '';
+							if (newName.indexOf('.') > 0) {
+								var lastDotIndex = newName.lastIndexOf('.');
+								basename = newName.substr(0, lastDotIndex);
+								extension = newName.substr(lastDotIndex);
+							}
+							td.find('a.name span.nametext span.extension').text(extension);
 						}
-						td.find('a.name span.nametext').text(basename);
+						td.find('a.name span.nametext span.innernametext').text(basename);
 						td.children('a.name').show();
 
 						var path = tr.attr('data-path') || self.getCurrentDirectory();

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -700,6 +700,8 @@ describe('OCA.Files.FileList tests', function() {
 			expect(fileList.findFileEl('One.txt').length).toEqual(0);
 			// file actions are hidden
 			expect($tr.hasClass('busy')).toEqual(true);
+			expect($tr.find('a .nametext').text().trim()).toEqual('Tu_after_three.txt');
+			expect($tr.find('a.name').is(':visible')).toEqual(true);
 
 			// input and form are gone
 			expect(fileList.$fileList.find('input.filename').length).toEqual(0);


### PR DESCRIPTION
## Description
Show the file name and extension after the file name input has been accepted and while waiting for the AJAX to do the actual rename on the server.

## Related Issue
#29600 

## Motivation and Context
Showing just the file name without file extension looks odd (for half a second). I made me wonder what was really going on.

## How Has This Been Tested?
Manually watching while doing renames.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

