### PR TITLE
Add test for modifying a group shared file

### DIFF
--- a/tests/integration/features/sharing-v1.feature
+++ b/tests/integration/features/sharing-v1.feature
@@ -453,6 +453,20 @@ Feature: sharing
 		And the HTTP status code should be "200"
 		And last share_id is included in the answer
 
+	Scenario: Sharee can modify the group shared file
+		Given user "user0" exists
+		And user "user1" exists
+		And group "group0" exists
+		And user "user1" belongs to group "group0"
+		And file "textfile0.txt" of user "user0" is shared with group "group0"
+		When user "user1" uploads file with content "bartext" to "/textfile0.txt"
+		And as an "user1"
+		And downloading file "/textfile0.txt"
+		Then downloaded content should be "bartext"
+		And as an "user0"
+		And downloading file "/textfile0.txt"
+		Then downloaded content should be "bartext"
+
 	Scenario: User is not allowed to reshare file
 		Given user "user0" exists
 		And user "user1" exists


### PR DESCRIPTION
## Description
Share a single file with a group,
make a group member modify the file,
check if the group owner sees the modified content

## Related Issue

## Motivation and Context
This set of steps fails for me. I was using it to set up a scenario in another app ready for further testing of the app.
So I need to see if it really fails in core CI.
The steps work if done manually. So maybe there is some problem with one of the automated step definitions?

There seems to be no similar-enough scenario in the existing core integration tests, so I can't see straight away if there is a real application bug or an integration test implementation bug.

## How Has This Been Tested?
Fails locally - will it fail in CI?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

