### PR TITLE
use Provisioning API for user administration in UI tests

### DIFF
--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -137,7 +137,7 @@ class AppConfigHelper {
 	 * @param string $baseUrl
 	 * @param string $user
 	 * @param string $password
-	 * @return ResponseInterface|null
+	 * @return ResponseInterface
 	 */
 	public static function getCapabilities($baseUrl, $user, $password) {
 		$response = OcsApiHelper::sendRequest(

--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -23,7 +23,7 @@ namespace TestHelpers;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Message\ResponseInterface;
-
+use GuzzleHttp\Exception\ClientException;
 /**
  * Helper to make requests to the OCS API
  * 
@@ -39,7 +39,8 @@ class OcsApiHelper {
 	 * @param string $path
 	 * @param array $body array of key, value pairs e.g ['value' => 'yes']
 	 * @param int $apiVersion (1|2) default 2
-	 * @return ResponseInterface|null
+	 * @return ResponseInterface
+	 * @throws ClientException
 	 */
 	public static function sendRequest(
 		$baseUrl, $user, $password, $method, $path, $body = [], $apiVersion = 2
@@ -53,11 +54,17 @@ class OcsApiHelper {
 		$options['body'] = $body;
 		
 		try {
-			$response = $client->send($client->createRequest($method, $fullUrl, $options));
-		} catch (\GuzzleHttp\Exception\ClientException $ex) {
+			$response = $client->send(
+				$client->createRequest($method, $fullUrl, $options)
+			);
+		} catch (ClientException $ex) {
 			$response = $ex->getResponse();
+			
+			//if the response was null for some reason do not return it but re-throw
+			if ($response === null) {
+				throw $ex;
+			}
 		}
 		return $response;
 	}
-	
 }

--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace TestHelpers;
+
+use GuzzleHttp\Message\ResponseInterface;
+
+/**
+ * Helper to administrate users (and groups) through the provosioning API
+ * 
+ * @author Artur Neumann <artur@jankaritech.com>
+ *
+ */
+class UserHelper {
+	
+	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $adminUser
+	 * @param string $adminPassword
+	 * @param string $displayName
+	 * @param string $email
+	 * @return ResponseInterface[]
+	 *          we need multiple requests to set $displayName and $email
+	 *          this array will contain the responses from all requests
+	 */
+	public static function createUser(
+		$baseUrl, $user, $password, $adminUser, $adminPassword,
+		$displayName = null, $email = null
+	) {
+		$body = [
+			'userid' => $user,
+			'password' => $password
+		];
+		$return = [];
+		$return[] = OcsApiHelper::sendRequest(
+			$baseUrl, $adminUser, $adminPassword, "POST", "/cloud/users", $body
+		);
+		//if we couldn't successfully create the user, no need to keep on going
+		if ($return[0]->getStatusCode() !== 200) {
+			return $return;
+		}
+		if ($displayName !== null) {
+			$editReponse = self::editUser(
+				$baseUrl, $user, "display", $displayName, $adminUser, $adminPassword
+			);
+			$return[] = $editReponse;
+			if ($editReponse->getStatusCode() !== 200) {
+				return $return;
+			}
+		}
+		if ($email !== null) {
+			$return[] = self::editUser(
+				$baseUrl, $user, "email", $email, $adminUser, $adminPassword
+			);
+		}
+		return $return;
+	}
+
+	/**
+	 * 
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $key
+	 * @param string $value
+	 * @param string $adminUser
+	 * @param string $adminPassword
+	 * @return ResponseInterface
+	 */
+	public static function editUser(
+		$baseUrl, $user, $key, $value, $adminUser, $adminPassword
+	) {
+		return OcsApiHelper::sendRequest(
+			$baseUrl,
+			$adminUser,
+			$adminPassword,
+			"PUT",
+			"/cloud/users/" . $user,
+			["key" => $key, "value" => $value]
+		);
+	}
+
+	/**
+	 * 
+	 * @param string $baseUrl
+	 * @param string $userName
+	 * @param string $adminUser
+	 * @param string $adminPassword
+	 * @return ResponseInterface
+	 */
+	public static function deleteUser(
+		$baseUrl, $userName, $adminUser, $adminPassword
+	) {
+		return OcsApiHelper::sendRequest(
+			$baseUrl,
+			$adminUser,
+			$adminPassword,
+			"DELETE",
+			"/cloud/users/" . $userName
+		);
+	}
+
+	/**
+	 * 
+	 * @param string $baseUrl
+	 * @param string $group
+	 * @param string $adminUser
+	 * @param string $adminPassword
+	 * @return ResponseInterface
+	 */
+	public static function createGroup(
+		$baseUrl, $group, $adminUser, $adminPassword
+	) {
+		return OcsApiHelper::sendRequest(
+			$baseUrl, $adminUser, $adminPassword,
+			"POST", "/cloud/groups", ['groupid' => $group]
+		);
+	}
+
+	/**
+	 * 
+	 * @param string $baseUrl
+	 * @param string $group
+	 * @param string $adminUser
+	 * @param string $adminPassword
+	 * @return ResponseInterface
+	 */
+	public static function deleteGroup(
+		$baseUrl, $group, $adminUser, $adminPassword
+	) {
+		return OcsApiHelper::sendRequest(
+			$baseUrl, $adminUser, $adminPassword,
+			"DELETE", "/cloud/groups/" . $group
+		);
+	}
+
+	/**
+	 * 
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $group
+	 * @param string $adminUser
+	 * @param string $adminPassword
+	 * @return ResponseInterface
+	 */
+	public static function addUserToGroup(
+		$baseUrl, $user, $group, $adminUser, $adminPassword
+	) {
+		return OcsApiHelper::sendRequest(
+			$baseUrl, $adminUser, $adminPassword, "POST",
+			"/cloud/users/" . $user . "/groups", ['groupid' => $group]
+		);
+	}
+
+	/**
+	 * 
+	 * @param string $baseUrl
+	 * @param string $adminUser
+	 * @param string $adminPassword
+	 * @param string $search
+	 * @return ResponseInterface
+	 */
+	public static function getGroups(
+		$baseUrl, $adminUser, $adminPassword, $search =""
+	) {
+		return OcsApiHelper::sendRequest(
+			$baseUrl, $adminUser, $adminPassword, "GET",
+			"/cloud/groups?search=" . $search
+		);
+	}
+
+	/**
+	 * 
+	 * @param string $baseUrl
+	 * @param string $adminUser
+	 * @param string $adminPassword
+	 * @param string $search
+	 * @return string[]
+	 */
+	public static function getGroupsAsArray(
+		$baseUrl, $adminUser, $adminPassword, $search =""
+	) {
+		$result = self::getGroups($baseUrl, $adminUser, $adminPassword, $search);
+		$groups = $result->xml()->xpath(".//groups")[0];
+		$return = [];
+		foreach ($groups as $group) {
+			$return[] = $group->__toString();
+		}
+		return $return;
+	}
+}

--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -30,6 +30,7 @@ use Page\OwncloudPage;
 use TestHelpers\AppConfigHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\UploadHelper;
+use TestHelpers\UserHelper;
 
 require_once 'bootstrap.php';
 
@@ -283,7 +284,11 @@ class FeatureContext extends RawMinkContext implements Context {
 	 * @throws Exception
 	 */
 	public function theGroupNamedShouldNotExist($name) {
-		if (in_array($name, SetupHelper::getGroups(), true)) {
+		$groups = UserHelper::getGroupsAsArray(
+			$this->getMinkParameter("base_url"), "admin",
+			$this->getUserPassword("admin")
+		);
+		if (in_array($name, $groups, true)) {
 			throw new Exception("group '" . $name . "' exists but should not");
 		}
 	}


### PR DESCRIPTION
## Description
creating/deleting and modifying users in the UI tests is done through the provisioning API and not by `occ`

## Motivation and Context
the main goal is to make it possible to run UI tests against a remote instance, e.g. inside docker. See also https://github.com/owncloud/qa-enterprise/pull/115

One test fails because of https://github.com/owncloud/core/issues/29698

## How Has This Been Tested?
run tests in travis

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

