### PR TITLE
Allow group 0 to be created by provisioning API

### DIFF
--- a/apps/provisioning_api/lib/Groups.php
+++ b/apps/provisioning_api/lib/Groups.php
@@ -130,7 +130,7 @@ class Groups{
 	public function addGroup($parameters) {
 		// Validate name
 		$groupId = $this->request->getParam('groupid', '');
-		if(empty($groupId)){
+		if(($groupId === '') || is_null($groupId) || ($groupId === false)){
 			\OCP\Util::writeLog('provisioning_api', 'Group name not supplied', \OCP\Util::ERROR);
 			return new OC_OCS_Result(null, 101, 'Invalid group name');
 		}

--- a/tests/integration/features/provisioning-v1.feature
+++ b/tests/integration/features/provisioning-v1.feature
@@ -80,6 +80,16 @@ Feature: provisioning
 		And the HTTP status code should be "200"
 		And group "España" exists
 
+	Scenario: Create a group named "0"
+		Given as an "admin"
+		And group "0" does not exist
+		When sending "POST" to "/cloud/groups" with
+			| groupid | 0 |
+			| password | 123456 |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And group "0" exists
+
 	Scenario: adding user to a group without sending the group
 		Given as an "admin"
 		And user "brand-new-user" exists
@@ -140,13 +150,16 @@ Feature: provisioning
 
 	Scenario: Getting all groups
 		Given as an "admin"
+		And group "0" exists
 		And group "new-group" exists
 		And group "admin" exists
+		And group "España" exists
 		When sending "GET" to "/cloud/groups"
 		Then groups returned are
 			| España |
 			| admin |
 			| new-group |
+			| 0 |
 
 	Scenario: create a subadmin
 		Given as an "admin"


### PR DESCRIPTION
## Description
Only the empty string should be rejected as a group name (or things that ``==`` the empty string such as ``null`` and ``false``). This lets "0" be created as a group name.

## Related Issue
#29698 

## Motivation and Context
Zero and empty must not live in the same house.

## How Has This Been Tested?
The new integration test fails before and passes after this fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

