### PR TITLE
Don't try decrypting federated shares in decrypt-all command

### DIFF
--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -225,8 +225,8 @@ class DecryptAll {
 		while ($root = array_pop($directories)) {
 			$content = $this->rootView->getDirectoryContent($root);
 			foreach ($content as $file) {
-				// only decrypt files owned by the user
-				if($file->getStorage()->instanceOfStorage('OCA\Files_Sharing\SharedStorage')) {
+				// only decrypt files owned by the user, exclude incoming local shares, and incoming federated shares
+				if ($file->getStorage()->instanceOfStorage('\OCA\Files_Sharing\ISharedStorage')) {
 						continue;
 				}
 				$path = $root . '/' . $file['name'];

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -39,6 +39,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
+use OCP\Files\Storage\IStorage;
 
 /**
  * Class DecryptAllTest
@@ -261,16 +262,23 @@ class DecryptAllTest extends TestCase {
 
 	public function providesData() {
 		return[
-			[true],
-			[false]
+			['called', \OC\Files\Storage\Local::class],
+			['exception', \OC\Files\Storage\Local::class],
+			['skip', SharedStorage::class],
+			['skip', \OCA\Files_Sharing\External\Storage::class],
 		];
 	}
 	/**
 	 * @param $throwsExceptionInDecrypt
 	 * @dataProvider providesData
 	 */
-	public function testDecryptUsersFiles($throwsExceptionInDecrypt) {
-		$storage = $this->createMock(SharedStorage::class);
+	public function testDecryptUsersFiles($decryptBehavior, $storageClass) {
+		$storage = $this->createMock($storageClass);
+		$storage->expects($this->any())
+			->method('instanceOfStorage')
+			->will($this->returnCallback(function($className) use ($storage) {
+				return ($storage instanceof $className);
+			}));
 
 		/** @var DecryptAll | \PHPUnit_Framework_MockObject_MockObject  $instance */
 		$instance = $this->getMockBuilder(DecryptAll::class)
@@ -293,12 +301,14 @@ class DecryptAllTest extends TestCase {
 				]
 			);
 
-		$this->view->expects($this->at(3))->method('getDirectoryContent')
-			->with('/user1/files/foo')->willReturn(
-				[
-					new FileInfo('path', $storage, 'intPath', ['name' => 'subfile', 'type'=>'file', 'encrypted'=>true], null)
-				]
-			);
+		if ($decryptBehavior !== 'skip') {
+			$this->view->expects($this->at(3))->method('getDirectoryContent')
+				->with('/user1/files/foo')->willReturn(
+					[
+						new FileInfo('path', $storage, 'intPath', ['name' => 'subfile', 'type'=>'file', 'encrypted'=>true], null)
+					]
+				);
+		}
 
 		$this->view->expects($this->any())->method('is_dir')
 			->willReturnCallback(
@@ -310,11 +320,14 @@ class DecryptAllTest extends TestCase {
 				}
 			);
 
-		if ($throwsExceptionInDecrypt) {
+		if ($decryptBehavior === 'exception') {
 			$instance->expects($this->at(0))
 				->method('decryptFile')
 				->with('/user1/files/bar')
 				->willThrowException(new \Exception());
+		} else if ($decryptBehavior === 'skip') {
+			$instance->expects($this->never())
+				->method('decryptFile');
 		} else {
 			$instance->expects($this->at(0))
 				->method('decryptFile')


### PR DESCRIPTION
## Description
Fixes issue when attempting to explore federated shares during decrypt-all command. This could cause needless time wasting spent there, and also prevent errors when such storage is not available currently.

## Related Issue
Fixes https://github.com/owncloud/core/issues/29723

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual testing with the steps from ticket

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

