### PR TITLE
run occ command through the testing app

### DIFF
--- a/apps/testing/appinfo/routes.php
+++ b/apps/testing/appinfo/routes.php
@@ -25,6 +25,7 @@ use OCA\Testing\Config;
 use OCA\Testing\BigFileID;
 use OCA\Testing\Locking\Provisioning;
 use OCP\API;
+use OCA\Testing\Occ;
 
 $config = new Config(
 	\OC::$server->getConfig(),
@@ -69,6 +70,16 @@ API::register(
 	'post',
 	'/apps/testing/api/v1/increasefileid',
 	[$bigFileID, 'increaseFileIDsBeyondMax32bits'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+$occ = new Occ(\OC::$server->getRequest());
+
+API::register(
+	'post',
+	'/apps/testing/api/v1/occ',
+	[$occ, 'execute'],
 	'testing',
 	API::ADMIN_AUTH
 );

--- a/apps/testing/lib/Occ.php
+++ b/apps/testing/lib/Occ.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * ownCloud
+ * 
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use \OCP\IRequest;
+use \OC\OCS\Result;
+
+/**
+ * run the occ command from an API call
+ * 
+ * @author Artur Neumann <artur@jankaritech.com>
+ *
+ */
+class Occ {
+
+	/**
+	 * 
+	 * @var IRequest
+	 */
+	private $request;
+	
+	/**
+	 * 
+	 * @param IRequest $request
+	 */
+	public function __construct(IRequest $request) {
+		$this->request = $request;
+	}
+
+	/**
+	 * 
+	 * @return Result
+	 */
+	public function execute() {
+		$command = $this->request->getParam("command", "");
+		$args = preg_split("/[\s,]+/", $command);
+		$args = array_map(
+			function ($arg) {
+				return escapeshellarg($arg);
+			}, $args
+		);
+
+		$args = implode(' ', $args);
+		$descriptor = [
+			0 => ['pipe', 'r'],
+			1 => ['pipe', 'w'],
+			2 => ['pipe', 'w'],
+		];
+		$process = proc_open(
+			'php console.php ' . $args,
+			$descriptor,
+			$pipes,
+			"../"
+		);
+		$lastStdOut = stream_get_contents($pipes[1]);
+		$lastStdErr = stream_get_contents($pipes[2]);
+		$lastCode = proc_close($process);
+		$result = [
+			"code" => $lastCode,
+			"stdOut" => $lastStdOut,
+			"stdErr" => $lastStdErr
+		];
+		
+		$resultCode = $lastCode + 100;
+		
+		return new Result($result, $resultCode);
+	}
+}

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -30,6 +30,7 @@
 				<directory suffix=".php">../apps/files_trashbin/tests</directory>
 				<directory suffix=".php">../apps/files_versions/tests</directory>
 				<directory suffix=".php">../apps/provisioning_api/tests</directory>
+				<directory suffix=".php">../apps/testing</directory>
 				<directory suffix=".php">../apps/updatenotification/tests</directory>
 				<directory suffix=".php">../tests</directory>
 				<directory suffix=".php">../build</directory>


### PR DESCRIPTION
## Description
make it possible to run arbitrary `occ` commands through the testing app API

## Related Issue
#29710

## Motivation and Context
for testing it would be handy to run occ commands remotely

## How Has This Been Tested?
manual tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

