### PR TITLE
Fix recreate masterkey issue when decryptall command used

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -793,6 +793,7 @@ class Encryption extends Wrapper {
 				fclose($source);
 				fclose($target);
 			} catch (\Exception $e) {
+				Encryption::setDisableWriteEncryption(false);
 				fclose($source);
 				fclose($target);
 				throw $e;


### PR DESCRIPTION
When decrypt-all command is used the files get decrypted.
After this when user executes the recreate masterkey
command, the variable disableWriteEncryption is set to
true and never set to false. Though the decrypted files
when tried decrypt again in the copy operation, throws
exception, the value should be set to false. If not
set to false, user files would never be re-encrypted
with recreate masterkey.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
This tries to solve the problem caused when user tries to recreate masterkey after executing decrypt-all command.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/29726

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When user executes decrypt-all command the oC files are decrypted successfully. Now after this step if user tries to execute recreate masterkey command, then the user could see that decrypting already decrypted files throws exception and code flow reaches: https://github.com/owncloud/core/blob/master/lib/private/Files/Storage/Wrapper/Encryption.php#L795. As a result the value of the variable `disableWriteEncryption` still remains false. This causes problem with fopen during re-encryption phase. So this change helps to reset the value to false.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create user admin and login
2. Run decrypt-all command from the command line
3. Run recreate masterkey command from the command line the files should remain encrypted.
This has also been tested in the same way mentioned in the issue : https://github.com/owncloud/core/issues/29726

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

