### PR TITLE
Sort allowed storages checkbox list

### DIFF
--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -143,6 +143,9 @@
 				$userBackends = array_filter($_['backends'], function($backend) {
 					return $backend->isAllowedVisibleFor(IStoragesBackendService::VISIBILITY_PERSONAL);
 				});
+				uasort($userBackends, function($a, $b) {
+					return strcasecmp($a->getText(), $b->getText());
+				});
 			?>
 			<?php $i = 0; foreach ($userBackends as $backend): ?>
 				<?php if ($deprecateTo = $backend->getDeprecateTo()): ?>


### PR DESCRIPTION
## Description
Sort the array of possible allowed storages before displaying the checkbox list.

## Related Issue
#29732 

## Motivation and Context
Nicer UI

## How Has This Been Tested?
Observe checkbox list on UI, Check/clear various checkboxes, confirm that the personal storages drop-down corresponds to the selected storages.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Documentation at https://doc.owncloud.org/server/10.0/admin_manual/configuration/files/external_storage_configuration_gui.html already shows the checkbox list sorted.