### PR TITLE
Add missing CorsController in settings's Application

### DIFF
--- a/settings/Application.php
+++ b/settings/Application.php
@@ -174,6 +174,16 @@ class Application extends App {
 				$c->query('Checker')
 			);
 		});
+		$container->registerService('CorsController', function(IContainer $c) {
+			return new CorsController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$c->query('UserSession'),
+				$c->query('Logger'),
+				$c->query('URLGenerator'),
+				$c->query('Config')
+			);
+		});
 
 		/**
 		 * Middleware


### PR DESCRIPTION
## Description
Since "settings" is not an application but the app framework thinks it
is, it tries to resolve the namespaces to OCA. However we used OC for
all the controllers, so we need to register these explicitly into the
settings Application container.

## Related Issue
None raised. Found by @phil-davis during QA of 10.0.4 RC1.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Go to settings page, "Security" section. Add a whitelist domain for CORS.

Before fix: full page internal server error with exception about CorsController missing.
After fix: domain can be added.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

