### PR TITLE
Raise more useful message when constructor are not resolvable

### DIFF
--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -82,7 +82,13 @@ class App {
 		} catch(QueryException $e) {
 			$appNameSpace = self::buildAppNamespace($appName);
 			$controllerName = $appNameSpace . '\\Controller\\' . $controllerName;
-			$controller = $container->query($controllerName);
+			try {
+				$controller = $container->query($controllerName);
+			} catch (QueryException $e2) {
+				// the reason we got here could also be because of the first exception above,
+				// so combine the message from both
+				throw new QueryException($e2->getMessage() . ' or error resolving constructor arguments: ' . $e->getMessage());
+			}
 		}
 
 		// initialize the dispatcher and run all the middleware before the controller


### PR DESCRIPTION
## Description
Whenever resolved class C exists but one of its constructor arguments
cannot be resolved, the app framework would throw an exception that the
class C does not exist even though it does. This is misleading and leads
to confusion, anger and loss of time.

This fix expands the error message to include the message about the
constructor argument that wasn't properly forwarded.

## Related Issue
None raised.

## Motivation and Context
Happened to me several times

## How Has This Been Tested?
Open settings/Application, go to the CheckSetupController and modify one letter of one of the constructor arg services. Ex replace "Config" with "Xonfig". Then go to settings page and check owncloud.log.

Before the fix: it would say that CheckSetupController does not exist at all.
After the fix. it says the above, but also adds that constructor arg "Xonfig" could not be resolved.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

