### PR TITLE
Handle case of first CORS whitelist entry

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1284,7 +1284,7 @@ class View {
 
 		try {
 			// if the file is not in the cache or needs to be updated, trigger the scanner and reload the data
-			if (!$data || $data['size'] === -1) {
+			if (!$data || (isset($data['size']) && ($data['size'] === -1))) {
 				$this->lockFile($relativePath, ILockingProvider::LOCK_SHARED);
 				if (!$storage->file_exists($internalPath)) {
 					$this->unlockFile($relativePath, ILockingProvider::LOCK_SHARED);

--- a/settings/Controller/CorsController.php
+++ b/settings/Controller/CorsController.php
@@ -112,14 +112,14 @@ class CorsController extends Controller {
 		}
 
 		$userId = $this->userId;
-		$domains = json_decode($this->config->getUserValue($userId, 'core', 'domains'));
+		$domains = json_decode($this->config->getUserValue($userId, 'core', 'domains', '[]'), true);
 		$domains = array_filter($domains);
 		array_push($domains, $domain);
 
 		// In case same domain is added
 		$domains = array_unique($domains);
 
-		// Store as comma seperated string
+		// Store as comma separated string
 		$domainsString = json_encode($domains);
 
 		$this->config->setUserValue($userId, 'core', 'domains', $domainsString);
@@ -136,11 +136,14 @@ class CorsController extends Controller {
 	 */
 	public function removeDomain($id) {
 		$userId = $this->userId;
-		$domains = json_decode($this->config->getUserValue($userId, 'core', 'domains'));
-
+		$domains = json_decode($this->config->getUserValue($userId, 'core', 'domains'), true);
 		if ($id >= 0 && $id < count($domains)) {
 			unset($domains[$id]);
-			$this->config->setUserValue($userId, 'core', 'domains', json_encode($domains));
+			if (count($domains)) {
+				$this->config->setUserValue($userId, 'core', 'domains', json_encode($domains));
+			} else {
+				$this->config->deleteUserValue($userId, 'core', 'domains');
+			}
 		}
 
 		return $this->getRedirectResponse();


### PR DESCRIPTION
When adding the first CORS whitelist entry it failed with:
```
array_filter() expects parameter 1 to be array, null given at \/home\/phil\/core\/settings\/Controller\/CorsController.php#116
```
after adding the code here I can add entries.