### PR TITLE
Keep null in getMetaData in Checksum storage wrapper

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Checksum.php
+++ b/lib/private/Files/Storage/Wrapper/Checksum.php
@@ -188,6 +188,10 @@ class Checksum extends Wrapper {
 		$parentMetaData = [];
 		if(!self::isPartialFile($path)) {
 			$parentMetaData = $this->getWrapperStorage()->getMetaData($path);
+			// can be null if entry does not exist
+			if (is_null($parentMetaData)) {
+				return null;
+			}
 		}
 		$parentMetaData['checksum'] = self::getChecksumsInDbFormat($path);
 

--- a/tests/lib/Files/Storage/Wrapper/ChecksumTest.php
+++ b/tests/lib/Files/Storage/Wrapper/ChecksumTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @author Ilja Neumann <ineumann@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Files\Storage\Wrapper;
+
+
+use OC\Files\Storage\Wrapper\Checksum;
+
+/**
+ * @group DB
+ */
+class ChecksumTest extends \Test\TestCase
+{
+	/**
+	 * @var \OC\Files\Storage\Temporary
+	 */
+	private $sourceStorage;
+	/**
+	 * @var Checksum
+	 */
+	private $instance;
+
+	const TEST_DATA = 'somedata';
+	const EXPECTED_CHECKSUMS = 'SHA1:efaa311ae448a7374c122061bfed952d940e9e37 MD5:aefaf7502d52994c3b01957636a3cdd2 ADLER32:0f2c034f';
+
+	public function setUp() {
+		parent::setUp();
+		$this->sourceStorage = new \OC\Files\Storage\Temporary([]);
+		$this->instance = new \OC\Files\Storage\Wrapper\Checksum([
+			'storage' => $this->sourceStorage
+		]);
+	}
+
+
+	public function testFilePutContentsCalculatesChecksum() {
+		$this->instance->file_put_contents('/foo.txt', 'somedata');
+		$metaData = $this->instance->getMetaData('/foo.txt');
+
+		$this->assertArrayHasKey('checksum', $metaData);
+		$this->assertEquals(self::EXPECTED_CHECKSUMS, $metaData['checksum']);
+	}
+
+	public function testWriteToFileHandleCalculatesChecksum() {
+		$handle = $this->instance->fopen('/foo.txt','w+');
+
+		$this->assertInternalType('resource', $handle);
+		$this->assertNotFalse(fwrite($handle, self::TEST_DATA));
+		$this->assertNotFalse(fclose($handle));
+
+		$metaData = $this->instance->getMetaData('/foo.txt');
+
+
+		$this->assertArrayHasKey('checksum', $metaData);
+		$this->assertEquals(self::EXPECTED_CHECKSUMS, $metaData['checksum']);
+	}
+
+
+
+	public function testReadFromFileHandleOnNewFileCalculatesChecksum() {
+
+		$this->sourceStorage->file_put_contents('/foo.txt', self::TEST_DATA);
+
+		$handle = $this->instance->fopen('/foo.txt', "r");
+		$data = fread($handle, $this->sourceStorage->filesize('/foo.txt'));
+		fclose($handle);
+
+		$this->assertEquals(self::TEST_DATA, $data);
+
+		$metaData = $this->instance->getMetaData('/foo.txt');
+
+		$this->assertArrayHasKey('checksum', $metaData);
+		$this->assertEquals(self::EXPECTED_CHECKSUMS, $metaData['checksum']);
+	}
+
+	public function testNoChecksumForPartFile() {
+		$this->sourceStorage->file_put_contents('/foo.part', self::TEST_DATA);
+		$metaData = $this->instance->getMetaData('/foo.part');
+
+		$this->assertEquals(
+			$metaData,
+			['checksum' => '', 'mimetype' => 'application/octet-stream']
+		);
+	}
+
+	/**
+	 * @depends testFilePutContentsCalculatesChecksum
+	 */
+	public function testFileChangeChangesChecksum()
+	{
+		$this->instance->file_put_contents('/foo.txt', self::TEST_DATA);
+		$this->instance->file_put_contents('/foo.txt', 'otherdata');
+
+		$metaData = $this->instance->getMetaData('/foo.txt');
+
+		$this->assertEquals(
+			"SHA1:693301c930b242611c005b00c151cc216259f1bd MD5:e4de345997131e5fa4421c3b2a9edddb ADLER32:12fc03bd",
+			$metaData['checksum']
+		);
+	}
+}
+


### PR DESCRIPTION
## Description
Keep null in getMetaData in Checksum storage wrapper.

Not funny is that in PHP if you add an item into `null` as if it was an array, it suddenly becomes one...

related #28181 
fixes #28960 

## Related Issue
None raised. Discovered while debugging background scanner with size=-1 and I noticed that getMetaData() on a non-existing file returns not null but a partial array.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Not tested yet.
Why is there no unit test class for the Checksum storage wrapper ?!! @IljaN 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODO

- [x] write unit test (well, write the whole class as it's missing)
- [x] think about what was broken before this fix
- [x] think about what could break after this fix
