### PR TITLE
[stable10] Add missing CorsController in settings's Application

### DIFF
--- a/settings/Application.php
+++ b/settings/Application.php
@@ -197,6 +197,16 @@ class Application extends App {
 				$c->query('Checker')
 			);
 		});
+		$container->registerService('CorsController', function(IContainer $c) {
+			return new CorsController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$c->query('UserSession'),
+				$c->query('Logger'),
+				$c->query('URLGenerator'),
+				$c->query('Config')
+			);
+		});
 
 		/**
 		 * Middleware


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/29736 to stable10