### PR TITLE
Handle case of first CORS whitelist add-delete

### DIFF
--- a/settings/Controller/CorsController.php
+++ b/settings/Controller/CorsController.php
@@ -90,13 +90,7 @@ class CorsController extends Controller {
 	 */
 	public function getDomains() {
 		$userId = $this->userId;
-
-		if (empty($this->config->getUserValue($userId, 'core', 'domains'))) {
-			$domains = [];
-		} else {
-			$domains = json_decode($this->config->getUserValue($userId, 'core', 'domains'));
-		}
-
+		$domains = json_decode($this->config->getUserValue($userId, 'core', 'domains', '[]'), true);
 		return new JSONResponse($domains);
 	}
 
@@ -112,14 +106,14 @@ class CorsController extends Controller {
 		}
 
 		$userId = $this->userId;
-		$domains = json_decode($this->config->getUserValue($userId, 'core', 'domains'));
+		$domains = json_decode($this->config->getUserValue($userId, 'core', 'domains', '[]'), true);
 		$domains = array_filter($domains);
 		array_push($domains, $domain);
 
 		// In case same domain is added
 		$domains = array_unique($domains);
 
-		// Store as comma seperated string
+		// Store as comma separated string
 		$domainsString = json_encode($domains);
 
 		$this->config->setUserValue($userId, 'core', 'domains', $domainsString);
@@ -136,11 +130,14 @@ class CorsController extends Controller {
 	 */
 	public function removeDomain($id) {
 		$userId = $this->userId;
-		$domains = json_decode($this->config->getUserValue($userId, 'core', 'domains'));
-
-		if ($id >= 0 && $id < count($domains)) {
+		$domains = json_decode($this->config->getUserValue($userId, 'core', 'domains', '[]'), true);
+		if (isset($domains[$id])) {
 			unset($domains[$id]);
-			$this->config->setUserValue($userId, 'core', 'domains', json_encode($domains));
+			if (count($domains)) {
+				$this->config->setUserValue($userId, 'core', 'domains', json_encode($domains));
+			} else {
+				$this->config->deleteUserValue($userId, 'core', 'domains');
+			}
 		}
 
 		return $this->getRedirectResponse();

--- a/settings/Panels/Personal/Cors.php
+++ b/settings/Panels/Personal/Cors.php
@@ -58,7 +58,7 @@ class Cors implements ISettings {
 	 */
 	public function getPanel() {
 		$userId = $this->userSession->getUser()->getUID();
-		$domains = json_decode($this->config->getUserValue($userId, 'core', 'domains'));
+		$domains = json_decode($this->config->getUserValue($userId, 'core', 'domains', '[]'), true);
 
 		$t = new Template('settings', 'panels/personal/cors');
 		$t->assign('user_id', $userId);

--- a/tests/Settings/Controller/CorsControllerTest.php
+++ b/tests/Settings/Controller/CorsControllerTest.php
@@ -72,6 +72,7 @@ class CorsControllerTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->config->method('getUserValue')->willReturn('["http:\/\/www.test.com"]');
 		$this->config->method('setUserValue')->willReturn(true);
+		$this->config->method('deleteUserValue')->willReturn(true);
 
 		$this->corsController = new CorsController(
 			'core',
@@ -155,7 +156,7 @@ class CorsControllerTest extends TestCase {
 		// the error message that invalid domain ID passed, would never be triggered
 		$this->config
 			->expects($this->once())
-			->method("setUserValue");
+			->method("deleteUserValue");
 
 		// The argument for removing domain is the ID of the white-listed domain
 		// and not the domain itself


### PR DESCRIPTION
## Description
Handle a default array the first time when there are no CORS whitelist entries.
When removing the last entry, delete the value completely.

## Related Issue

## Motivation and Context
Be able to add and delete CORS whitelist entries.

## How Has This Been Tested?
Add and delete various entries manually in the webUI, refreshing to confirm the changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

