### PR TITLE
Single active app theme with no magic fallbacks to inactive app themes

### DIFF
--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -70,14 +70,20 @@ class Enable extends Command {
 			return 1;
 		}
 
-		$groups = $input->getOption('groups');
-		if (empty($groups)) {
-			\OC_App::enable($appId);
-			$output->writeln($appId . ' enabled');
-		} else {
-			\OC_App::enable($appId, $groups);
-			$output->writeln($appId . ' enabled for groups: ' . implode(', ', $groups));
+		try {
+			$groups = $input->getOption('groups');
+			if (empty($groups)) {
+				\OC_App::enable($appId);
+				$output->writeln($appId . ' enabled');
+			} else {
+				\OC_App::enable($appId, $groups);
+				$output->writeln($appId . ' enabled for groups: ' . implode(', ', $groups));
+			}
+		} catch (\Exception $e) {
+			$output->writeln($e->getMessage());
+			return 2;
 		}
+
 		return 0;
 	}
 }

--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -25,6 +25,7 @@
 namespace OC\Core\Command\App;
 
 use OCP\App\IAppManager;
+use OCP\ILogger;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -70,18 +71,13 @@ class Enable extends Command {
 			return 1;
 		}
 
-		try {
-			$groups = $input->getOption('groups');
-			if (empty($groups)) {
-				\OC_App::enable($appId);
-				$output->writeln($appId . ' enabled');
-			} else {
-				\OC_App::enable($appId, $groups);
-				$output->writeln($appId . ' enabled for groups: ' . implode(', ', $groups));
-			}
-		} catch (\Exception $e) {
-			$output->writeln($e->getMessage());
-			return 2;
+		$groups = $input->getOption('groups');
+		if (empty($groups)) {
+			\OC_App::enable($appId);
+			$output->writeln($appId . ' enabled');
+		} else {
+			\OC_App::enable($appId, $groups);
+			$output->writeln($appId . ' enabled for groups: ' . implode(', ', $groups));
 		}
 
 		return 0;

--- a/index.php
+++ b/index.php
@@ -52,30 +52,24 @@ if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 try {
 
 	require_once __DIR__ . '/lib/base.php';
-
 	OC::handleRequest();
 
 } catch(\OC\ServiceUnavailableException $ex) {
-	\OC::loadDefaultEnabledAppTheme();
 	\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 
 	//show the user a detailed error page
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 	OC_Template::printExceptionErrorPage($ex);
 } catch (\OC\HintException $ex) {
-	\OC::loadDefaultEnabledAppTheme();
 	OC_Response::setStatus(OC_Response::STATUS_SERVICE_UNAVAILABLE);
 	OC_Template::printErrorPage($ex->getMessage(), $ex->getHint());
 } catch (\OC\User\LoginException $ex) {
-	\OC::loadDefaultEnabledAppTheme();
 	OC_Response::setStatus(OC_Response::STATUS_FORBIDDEN);
 	OC_Template::printErrorPage($ex->getMessage());
 } catch (\OCP\Files\ForbiddenException $ex) {
-	\OC::loadDefaultEnabledAppTheme();
 	OC_Response::setStatus(OC_Response::STATUS_FORBIDDEN);
 	OC_Template::printErrorPage($ex->getMessage());
 } catch (Exception $ex) {
-	\OC::loadDefaultEnabledAppTheme();
 	try {
 		\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 
@@ -91,7 +85,6 @@ try {
 		echo('</body></html>');
 	}
 } catch (Error $ex) {
-	\OC::loadDefaultEnabledAppTheme();
 	\OC::$server->getLogger()->logException($ex, array('app' => 'index'));
 	OC_Response::setStatus(OC_Response::STATUS_INTERNAL_SERVER_ERROR);
 	OC_Template::printExceptionErrorPage($ex);

--- a/lib/base.php
+++ b/lib/base.php
@@ -580,6 +580,7 @@ class OC {
 		\OC::$server->getEventLogger()->start('init_session', 'Initialize session');
 		OC_App::loadApps(['session']);
 		if (!self::$CLI) {
+			\OC_App::loadApps(['theme']);
 			self::initSession();
 		}
 		\OC::$server->getEventLogger()->end('init_session');

--- a/lib/base.php
+++ b/lib/base.php
@@ -583,6 +583,7 @@ class OC {
 			\OC_App::loadApps(['theme']);
 			self::initSession();
 		}
+
 		\OC::$server->getEventLogger()->end('init_session');
 
 		// incognito mode for now
@@ -829,22 +830,6 @@ class OC {
 	}
 
 	/**
-	 * Enables the defaultEnabled app theme
-	 * __do not__ call this for every request, as this parses all apps info.xml
-	 * files in order to determine which app is a default enabled theme while
-	 * not accessing the database which might not be available.
-	 */
-	public static function loadDefaultEnabledAppTheme() {
-		$defaultEnabledAppTheme = \OC_App::getDefaultEnabledAppTheme();
-
-		if ($defaultEnabledAppTheme !== false) {
-			/** @var \OC\Theme\ThemeService $themeService */
-			$themeService = \OC::$server->query('ThemeService');
-			$themeService->setAppTheme($defaultEnabledAppTheme);
-		}
-	}
-
-	/**
 	 * Handle the request
 	 */
 	public static function handleRequest() {
@@ -861,8 +846,6 @@ class OC {
 			$setupHelper = new OC\Setup(\OC::$server->getConfig(), \OC::$server->getIniWrapper(),
 				\OC::$server->getL10N('lib'), new \OC_Defaults(), \OC::$server->getLogger(),
 				\OC::$server->getSecureRandom());
-
-			self::loadDefaultEnabledAppTheme();
 
 			$controller = new OC\Core\Controller\SetupController($setupHelper);
 			$controller->run($_POST);

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -217,12 +217,46 @@ class AppManager implements IAppManager {
 		if(OC_App::getAppPath($appId) === false) {
 			throw new \Exception("$appId can't be enabled since it is not installed.");
 		}
+		$this->canEnableTheme($appId);
+
 		$this->installedAppsCache[$appId] = 'yes';
 		$this->appConfig->setValue($appId, 'enabled', 'yes');
 		$this->dispatcher->dispatch(ManagerEvent::EVENT_APP_ENABLE, new ManagerEvent(
 			ManagerEvent::EVENT_APP_ENABLE, $appId
 		));
 		$this->clearAppsCache();
+	}
+
+	/**
+	 * Do not allow more than one active app-theme
+	 *
+	 * @param $appId
+	 * @throws \Exception
+	 */
+	protected function canEnableTheme($appId) {
+		$info = $this->getAppInfo($appId);
+		if (
+			isset($info['types'])
+			&& is_array($info['types'])
+			&& in_array('theme', $info['types'])
+		) {
+			$apps = $this->getInstalledApps();
+			foreach ($apps as $installedAppId) {
+				if ($this->isTheme($installedAppId)) {
+					throw new \Exception("$appId can't be enabled until $installedAppId is disabled.");
+				}
+			}
+		}
+	}
+
+	/**
+	 *  Wrapper for OC_App for easy mocking
+	 *
+	 * @param string $appId
+	 * @return bool
+	 */
+	protected function isTheme($appId) {
+		return \OC_App::isType($appId,'theme');
 	}
 
 	/**

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -33,6 +33,7 @@ namespace OC\App;
 use OC_App;
 use OC\Installer;
 use OCP\App\IAppManager;
+use OCP\App\AppManagerException;
 use OCP\App\ManagerEvent;
 use OCP\Files;
 use OCP\IAppConfig;
@@ -231,7 +232,7 @@ class AppManager implements IAppManager {
 	 * Do not allow more than one active app-theme
 	 *
 	 * @param $appId
-	 * @throws \Exception
+	 * @throws AppManagerException
 	 */
 	protected function canEnableTheme($appId) {
 		$info = $this->getAppInfo($appId);
@@ -243,7 +244,7 @@ class AppManager implements IAppManager {
 			$apps = $this->getInstalledApps();
 			foreach ($apps as $installedAppId) {
 				if ($this->isTheme($installedAppId)) {
-					throw new \Exception("$appId can't be enabled until $installedAppId is disabled.");
+					throw new AppManagerException("$appId can't be enabled until $installedAppId is disabled.");
 				}
 			}
 		}

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -193,18 +193,9 @@ class Factory implements IFactory {
 
 		// merge with translations from themes
 		$relativePath = substr($dir, strlen($this->serverRoot));
-
-		// legacy themes
-		$themeDir = $this->getActiveLegacyThemeDirectory();
+		$themeDir = $this->getActiveThemeDirectory();
 		if ($themeDir !== '') {
 			$themeDir .= $relativePath;
-			$available = array_merge($available, $this->findAvailableLanguageFiles($themeDir));
-		}
-
-		// merge with translations from app-theme
-		$appThemeDir = $this->getActiveAppThemeDirectory();
-		if ($appThemeDir !== '' ) {
-			$themeDir .= $this->serverRoot . '/' . $appThemeDir . $relativePath;
 			$available = array_merge($available, $this->findAvailableLanguageFiles($themeDir));
 		}
 
@@ -297,20 +288,9 @@ class Factory implements IFactory {
 
 		// merge with translations from themes
 		$relativePath = substr($transFile, strlen($this->serverRoot));
-
-		// legacy themes
-		$themeDir = $this->getActiveLegacyThemeDirectory();
+		$themeDir = $this->getActiveThemeDirectory();
 		if ($themeDir !== '') {
-			$legacyThemeTransFile = $this->serverRoot . '/themes/' . $themeDir . $relativePath;
-			if (file_exists($legacyThemeTransFile)) {
-				$languageFiles[] = $legacyThemeTransFile;
-			}
-		}
-
-		// app-themes
-		$appThemeDir = $this->getActiveAppThemeDirectory();
-		if ($appThemeDir !== '' ) {
-			$themeTransFile = $this->serverRoot . '/' . $appThemeDir . $relativePath;
+			$themeTransFile = $themeDir . $relativePath;
 			if (file_exists($themeTransFile)) {
 				$languageFiles[] = $themeTransFile;
 			}
@@ -357,6 +337,20 @@ class Factory implements IFactory {
 	}
 
 	/**
+	 * Get the currently active theme
+	 *
+	 * @return string
+	 */
+	protected function getActiveThemeDirectory() {
+		$themeDir = $this->getActiveAppThemeDirectory();
+		if ($themeDir === '') {
+			// fallback to legacy theme
+			$themeDir = $this->getActiveLegacyThemeDirectory();
+		}
+		return $themeDir;
+	}
+
+	/**
 	 * Get the currently active legacy theme
 	 *
 	 * @return string
@@ -378,7 +372,7 @@ class Factory implements IFactory {
 	protected function getActiveAppThemeDirectory() {
 		$theme = $this->themeService->getTheme();
 		if ($theme instanceof ITheme && $theme->getDirectory() !== '' ) {
-			return $theme->getDirectory();
+			return $this->serverRoot . '/' . $theme->getDirectory();
 		}
 		return '';
 	}

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -31,6 +31,9 @@ use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
+use OCP\Theme\ITheme;
+use OCP\Theme\IThemeService;
+
 
 /**
  * A factory that generates language instances
@@ -65,22 +68,28 @@ class Factory implements IFactory {
 	/** @var IUserSession */
 	protected $userSession;
 
+	/** @var IThemeService */
+	protected $themeService;
+
 	/** @var string */
 	protected $serverRoot;
 
 	/**
 	 * @param IConfig $config
 	 * @param IRequest $request
+	 * @param IThemeService $themeService
 	 * @param IUserSession $userSession
 	 * @param string $serverRoot
 	 */
 	public function __construct(IConfig $config,
 								IRequest $request,
+								IThemeService $themeService,
 								IUserSession $userSession = null,
 								$serverRoot) {
 		$this->config = $config;
 		$this->request = $request;
 		$this->userSession = $userSession;
+		$this->themeService = $themeService;
 		$this->serverRoot = $serverRoot;
 	}
 
@@ -180,32 +189,23 @@ class Factory implements IFactory {
 
 		$available = ['en']; //english is always available
 		$dir = $this->findL10nDir($app);
-		if (is_dir($dir)) {
-			$files = scandir($dir);
-			if ($files !== false) {
-				foreach ($files as $file) {
-					if (substr($file, -5) === '.json' && substr($file, 0, 4) !== 'l10n') {
-						$available[] = substr($file, 0, -5);
-					}
-				}
-			}
+		$available = array_merge($available, $this->findAvailableLanguageFiles($dir));
+
+		// merge with translations from themes
+		$relativePath = substr($dir, strlen($this->serverRoot));
+
+		// legacy themes
+		$themeDir = $this->getActiveLegacyThemeDirectory();
+		if ($themeDir !== '') {
+			$themeDir .= $relativePath;
+			$available = array_merge($available, $this->findAvailableLanguageFiles($themeDir));
 		}
 
-		// merge with translations from theme
-		$theme = $this->config->getSystemValue('theme');
-		if (!empty($theme)) {
-			$themeDir = $this->serverRoot . '/themes/' . $theme . substr($dir, strlen($this->serverRoot));
-
-			if (is_dir($themeDir)) {
-				$files = scandir($themeDir);
-				if ($files !== false) {
-					foreach ($files as $file) {
-						if (substr($file, -5) === '.json' && substr($file, 0, 4) !== 'l10n') {
-							$available[] = substr($file, 0, -5);
-						}
-					}
-				}
-			}
+		// merge with translations from app-theme
+		$appThemeDir = $this->getActiveAppThemeDirectory();
+		if ($appThemeDir !== '' ) {
+			$themeDir .= $this->serverRoot . '/' . $appThemeDir . $relativePath;
+			$available = array_merge($available, $this->findAvailableLanguageFiles($themeDir));
 		}
 
 		$this->availableLanguages[$key] = $available;
@@ -295,12 +295,24 @@ class Factory implements IFactory {
 			$languageFiles[] = $transFile;
 		}
 
-		// merge with translations from theme
-		$theme = $this->config->getSystemValue('theme');
-		if (!empty($theme)) {
-			$transFile = $this->serverRoot . '/themes/' . $theme . substr($transFile, strlen($this->serverRoot));
-			if (file_exists($transFile)) {
-				$languageFiles[] = $transFile;
+		// merge with translations from themes
+		$relativePath = substr($transFile, strlen($this->serverRoot));
+
+		// legacy themes
+		$themeDir = $this->getActiveLegacyThemeDirectory();
+		if ($themeDir !== '') {
+			$legacyThemeTransFile = $this->serverRoot . '/themes/' . $themeDir . $relativePath;
+			if (file_exists($legacyThemeTransFile)) {
+				$languageFiles[] = $legacyThemeTransFile;
+			}
+		}
+
+		// app-themes
+		$appThemeDir = $this->getActiveAppThemeDirectory();
+		if ($appThemeDir !== '' ) {
+			$themeTransFile = $this->serverRoot . '/' . $appThemeDir . $relativePath;
+			if (file_exists($themeTransFile)) {
+				$languageFiles[] = $themeTransFile;
 			}
 		}
 
@@ -323,6 +335,52 @@ class Factory implements IFactory {
 			return \OC_App::getAppPath($app) . '/l10n/';
 		}
 		return $this->serverRoot . '/core/l10n/';
+	}
+
+	/**
+	 * @param string $dir
+	 * @return array
+	 */
+	protected function findAvailableLanguageFiles($dir) {
+		$availableLanguageFiles = [];
+		if (is_dir($dir)) {
+			$files = scandir($dir);
+			if ($files !== false) {
+				foreach ($files as $file) {
+					if (substr($file, -5) === '.json' && substr($file, 0, 4) !== 'l10n') {
+						$availableLanguageFiles[] = substr($file, 0, -5);
+					}
+				}
+			}
+		}
+		return $availableLanguageFiles;
+	}
+
+	/**
+	 * Get the currently active legacy theme
+	 *
+	 * @return string
+	 */
+	protected function getActiveLegacyThemeDirectory() {
+		$themeDir = '';
+		$activeLegacyTheme = $this->config->getSystemValue('theme', '');
+		if ($activeLegacyTheme !== '') {
+			$themeDir = $this->serverRoot . '/themes/' . $activeLegacyTheme;
+		}
+		return $themeDir;
+	}
+
+	/**
+	 * Get the currently active app-theme
+	 *
+	 * @return string
+	 */
+	protected function getActiveAppThemeDirectory() {
+		$theme = $this->themeService->getTheme();
+		if ($theme instanceof ITheme && $theme->getDirectory() !== '' ) {
+			return $theme->getDirectory();
+		}
+		return '';
 	}
 
 	/**

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -32,6 +32,7 @@ namespace OC;
 use OC\Repair\Apps;
 use OC\Repair\CleanTags;
 use OC\Repair\Collation;
+use OC\Repair\DisableExtraThemes;
 use OC\Repair\DropOldJobs;
 use OC\Repair\OldGroupMembershipShares;
 use OC\Repair\RemoveGetETagEntries;
@@ -150,6 +151,11 @@ class Repair implements IOutput{
 				\OC::$server->getDatabaseConnection(),
 				\OC::$server->getUserManager(),
 				\OC::$server->getGroupManager()
+			),
+			new DisableExtraThemes(
+				\OC::$server->getAppManager(),
+				\OC::$server->getConfig(),
+				\OC::$server->getAppConfig()
 			),
 		];
 	}

--- a/lib/private/Repair/DisableExtraThemes.php
+++ b/lib/private/Repair/DisableExtraThemes.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Repair;
+
+
+use OCP\App\IAppManager;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * Leave only one app-theme active to prevent the mess
+ */
+class DisableExtraThemes implements IRepairStep {
+
+	/** @var IAppManager */
+	protected $appManager;
+
+	/** @var IConfig */
+	protected $config;
+
+	/** @var IAppConfig */
+	protected $appConfig;
+
+	/**
+	 * @param IAppManager $appManager
+	 * @param IConfig $config
+	 * @param IAppConfig $appConfig
+	 */
+	public function __construct($appManager, $config, $appConfig) {
+		$this->appManager = $appManager;
+		$this->config = $config;
+		$this->appConfig = $appConfig;
+	}
+
+	public function getName() {
+		return 'Disable extra themes';
+	}
+
+	/**
+	 * @param IOutput $out
+	 */
+	public function run(IOutput $out) {
+		$enabledThemes = $this->getEnabledAppThemes();
+
+		$activeTheme = '';
+		if (count($enabledThemes) >= 2) {
+			$activeTheme = array_pop($enabledThemes);
+			foreach ($enabledThemes as $appId) {
+				$this->appManager->disableApp($appId);
+				$out->info("Theme $appId disabled");
+			}
+		}
+
+		$activeLegacyTheme = $this->config->getSystemValue('theme', '');
+		if ($activeLegacyTheme !== '' && count($enabledThemes) > 0) {
+			$this->config->setSystemValue('theme', '');
+			$out->info("Legacy theme $activeLegacyTheme disabled");
+		}
+
+		if ($activeTheme !== '') {
+			$out->info("Theme $activeTheme left active");
+		}
+	}
+
+	/**
+	 * @return string[]
+	 */
+	protected function getEnabledAppThemes() {
+		// get enabled apps as index => appId
+		$enabledApps = $this->appManager->getInstalledApps();
+
+		// get themes as appId => appType
+		$appTypes = $this->appConfig->getValues(false, 'types');
+		$allThemes = array_filter(
+			$appTypes,
+			function ($appTypes){
+				return in_array('theme', explode(',', $appTypes));
+			}
+		);
+
+		// calculate an intersection to get enabled themes
+		$enabledThemes = array_intersect(array_keys($allThemes), $enabledApps);
+
+		return $enabledThemes;
+	}
+}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -368,6 +368,7 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			return new \OC\L10N\Factory(
 				$c->getConfig(),
 				$c->getRequest(),
+				$c->getThemeService(),
 				$c->getUserSession(),
 				\OC::$SERVERROOT
 			);

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -23,6 +23,8 @@ use OCP\Theme\IThemeService;
 
 class ThemeService implements IThemeService {
 
+	const DEFAULT_THEME_PATH = '/themes/default';
+
 	/**
 	 * @var Theme
 	 */
@@ -35,10 +37,9 @@ class ThemeService implements IThemeService {
 	 * ThemeService constructor.
 	 *
 	 * @param string $themeName
-	 * @param string $defaultThemeDirectory
 	 */
-	public function __construct($themeName = '', $defaultThemeDirectory = '') {
-		$this->setDefaultThemeDirectory($defaultThemeDirectory);
+	public function __construct($themeName = '') {
+		$this->defaultThemeDirectory = \OC::$SERVERROOT . self::DEFAULT_THEME_PATH;
 
 		if ($themeName === '' && $this->defaultThemeExists()) {
 			$themeName = 'default';
@@ -48,25 +49,10 @@ class ThemeService implements IThemeService {
 	}
 
 	/**
-	 * @param string $defaultThemeDirectory
-	 */
-	private function setDefaultThemeDirectory($defaultThemeDirectory = '') {
-		if ($defaultThemeDirectory === '') {
-			$this->defaultThemeDirectory = \OC::$SERVERROOT . '/themes/default';
-		} else {
-			$this->defaultThemeDirectory = $defaultThemeDirectory;
-		}
-	}
-
-	/**
 	 * @return bool
 	 */
-	private function defaultThemeExists() {
-		if (is_dir($this->defaultThemeDirectory)) {
-			return true;
-		}
-
-		return false;
+	public function defaultThemeExists() {
+		return is_dir($this->defaultThemeDirectory);
 	}
 
 	/**

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -671,24 +671,6 @@ class OC_App {
 	}
 
 	/**
-	 * @return false|string
-	 */
-	public static function getDefaultEnabledAppTheme() {
-		$apps = self::getAllApps();
-		$parser = new InfoParser();
-		foreach ($apps as $app) {
-			$info = $parser->parse(self::getAppPath($app) . '/appinfo/info.xml');
-			if (is_array($info)) {
-				$info = OC_App::parseAppInfo($info);
-			}
-			if (isset($info['default_enable']) && in_array('theme', $info['types'])) {
-				return $app;
-			}
-		}
-		return false;
-	}
-
-	/**
 	 * Read all app metadata from the info.xml file
 	 *
 	 * @param string $appId id of the app or the path of the info.xml file

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -722,7 +722,6 @@ class Util {
 
 		$installed = (bool) $systemConfig->getValue('installed', false);
 		$maintenance = (bool) $systemConfig->getValue('maintenance', false);
-		\OC_App::loadApps(['theme']);
 
 		// see core/lib/private/legacy/defaults.php and core/themes/example/defaults.php
 		// for description and defaults

--- a/tests/data/apptheme/apps/files/l10n/zz.json
+++ b/tests/data/apptheme/apps/files/l10n/zz.json
@@ -1,0 +1,4 @@
+{ "translations": {
+  "Menu" : "Dish"
+},"pluralForm" :"nplurals=2; plural=(n != 1);"
+}

--- a/tests/lib/App/ManagerTest.php
+++ b/tests/lib/App/ManagerTest.php
@@ -124,7 +124,7 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
-	 * @expectedException \Exception
+	 * @expectedException \OCP\App\AppManagerException
 	 */
 	public function testEnableSecondAppTheme() {
 		$manager = $this->getMockBuilder(AppManager::class)
@@ -134,16 +134,15 @@ class ManagerTest extends TestCase {
 				$this->config])
 			->getMock();
 
-		$manager->expects($this->any())
+		$manager->expects($this->once())
 			->method('getAppInfo')
-			->with('files')
 			->willReturn(['types'=>['theme']]);
 
-		$manager->expects($this->any())
+		$manager->expects($this->once())
 			->method('isTheme')
 			->willReturn(true);
 
-		$manager->enableApp('files');
+		$manager->enableApp('dav');
 	}
 
 	public function testDisableApp() {

--- a/tests/lib/App/ManagerTest.php
+++ b/tests/lib/App/ManagerTest.php
@@ -123,11 +123,35 @@ class ManagerTest extends TestCase {
 		$this->assertEquals('yes', $this->appConfig->getValue('files_trashbin', 'enabled', 'no'));
 	}
 
+	/**
+	 * @expectedException \Exception
+	 */
+	public function testEnableSecondAppTheme() {
+		$manager = $this->getMockBuilder(AppManager::class)
+			->setMethods(['isTheme', 'getAppInfo'])
+			->setConstructorArgs([$this->userSession, $this->appConfig,
+				$this->groupManager, $this->cacheFactory, $this->eventDispatcher,
+				$this->config])
+			->getMock();
+
+		$manager->expects($this->any())
+			->method('getAppInfo')
+			->with('files')
+			->willReturn(['types'=>['theme']]);
+
+		$manager->expects($this->any())
+			->method('isTheme')
+			->willReturn(true);
+
+		$manager->enableApp('files');
+	}
+
 	public function testDisableApp() {
 		$this->expectClearCache();
 		$this->manager->disableApp('files_trashbin');
 		$this->assertEquals('no', $this->appConfig->getValue('files_trashbin', 'enabled', 'no'));
 	}
+
 	/**
 	 * @expectedException \Exception
 	 */

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -9,6 +9,7 @@
 namespace Test\L10N;
 
 use OC\L10N\Factory;
+use OCP\Theme\IThemeService;
 use Test\TestCase;
 
 /**
@@ -28,6 +29,9 @@ class FactoryTest extends TestCase {
 	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
 	protected $userSession;
 
+	/** @var IThemeService|\PHPUnit_Framework_MockObject_MockObject */
+	protected $themeService;
+
 	/** @var string */
 	protected $serverRoot;
 
@@ -41,6 +45,11 @@ class FactoryTest extends TestCase {
 
 		/** @var \OCP\IRequest $request */
 		$this->request = $this->getMockBuilder('OCP\IRequest')
+			->disableOriginalConstructor()
+			->getMock();
+
+		/** @var IThemeService $themeService */
+		$this->themeService = $this->getMockBuilder(IThemeService::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -59,13 +68,14 @@ class FactoryTest extends TestCase {
 				->setConstructorArgs([
 					$this->config,
 					$this->request,
+					$this->themeService,
 					$this->userSession,
 					$this->serverRoot,
 				])
 				->setMethods($methods)
 				->getMock();
 		} else {
-			return new Factory($this->config, $this->request, $this->userSession, $this->serverRoot);
+			return new Factory($this->config, $this->request, $this->themeService, $this->userSession, $this->serverRoot);
 		}
 	}
 
@@ -309,6 +319,47 @@ class FactoryTest extends TestCase {
 			->willReturn('abc');
 
 		$this->assertEquals(['en', 'zz'], $factory->findAvailableLanguages($app), '', 0.0, 10, true);
+	}
+
+	public function testFindAvailableLanguagesWithAppThemes() {
+		$app = 'files';
+		$factory = $this->getFactory(['getActiveAppThemeDirectory']);
+
+		$this->config
+			->expects($this->any())
+			->method('getSystemValue')
+			->with('theme')
+			->willReturn('');
+
+		$factory->expects($this->any())
+			->method('getActiveAppThemeDirectory')
+			->with()
+			->willReturn('tests/data/apptheme');
+
+		$availableLanguages = $factory->findAvailableLanguages($app);
+		$this->assertContains('en', $availableLanguages);
+		$this->assertContains('zz', $availableLanguages);
+	}
+
+	public function testAppThemeTranslation() {
+		$app = 'files';
+		$lang = 'zz';
+		$factory = $this->getFactory(['getActiveAppThemeDirectory']);
+
+		$this->config
+			->expects($this->any())
+			->method('getSystemValue')
+			->with('theme')
+			->willReturn('');
+
+		$factory->expects($this->any())
+			->method('getActiveAppThemeDirectory')
+			->with()
+			->willReturn('tests/data/apptheme');
+
+		$themeTranslations = $factory->getL10nFilesForApp($app, $lang);
+		$this->assertCount(1, $themeTranslations);
+		$this->assertContains('zz.json', $themeTranslations[0]);
 	}
 
 	/**

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -334,7 +334,7 @@ class FactoryTest extends TestCase {
 		$factory->expects($this->any())
 			->method('getActiveAppThemeDirectory')
 			->with()
-			->willReturn('tests/data/apptheme');
+			->willReturn($this->serverRoot . '/tests/data/apptheme');
 
 		$availableLanguages = $factory->findAvailableLanguages($app);
 		$this->assertContains('en', $availableLanguages);
@@ -355,7 +355,7 @@ class FactoryTest extends TestCase {
 		$factory->expects($this->any())
 			->method('getActiveAppThemeDirectory')
 			->with()
-			->willReturn('tests/data/apptheme');
+			->willReturn($this->serverRoot . '/tests/data/apptheme');
 
 		$themeTranslations = $factory->getL10nFilesForApp($app, $lang);
 		$this->assertCount(1, $themeTranslations);

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -13,6 +13,7 @@ use DateTime;
 use OC\L10N\Factory;
 use OC\L10N\L10N;
 use OCP\IUserSession;
+use OCP\Theme\IThemeService;
 use Test\TestCase;
 
 /**
@@ -29,9 +30,13 @@ class L10nTest extends TestCase {
 		$config = $this->createMock('OCP\IConfig');
 		/** @var \OCP\IRequest $request */
 		$request = $this->createMock('OCP\IRequest');
+		/** @var IThemeService $themeService */
+		$themeService = $this->getMockBuilder(IThemeService::class)
+			->disableOriginalConstructor()
+			->getMock();
 		/** @var IUserSession $userSession */
 		$userSession = $this->createMock('OCP\IUserSession');
-		return new Factory($config, $request, $userSession, \OC::$SERVERROOT);
+		return new Factory($config, $request, $themeService, $userSession, \OC::$SERVERROOT);
 	}
 
 	public function testGermanPluralTranslations() {

--- a/tests/lib/Repair/DisableExtraThemesTest.php
+++ b/tests/lib/Repair/DisableExtraThemesTest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Copyright (c) 2017 Viktar Dubiniuk <dubiniuk@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Repair;
+
+use OC\Repair\DisableExtraThemes;
+use OCP\App\IAppManager;
+use OCP\IAppConfig;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use Test\TestCase;
+
+/**
+ * Tests for leaving only one theme active
+ */
+class DisableExtraThemesTest extends TestCase {
+
+	/** @var IAppManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $appManager;
+
+	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	protected $config;
+
+	/** @var IAppConfig|\PHPUnit_Framework_MockObject_MockObject */
+	protected $appConfig;
+
+	/** @var IOutput|\PHPUnit_Framework_MockObject_MockObject */
+	protected $output;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->output = $this->createMock(IOutput::class);
+	}
+
+	public function testExtraThemeAppsDisabled() {
+		$this->appManager->expects($this->any())
+			->method('getInstalledApps')
+			->willReturn(['theme-one', 'customapp', 'someotherapp', 'theme-two', 'theme-three']);
+
+		$this->appConfig->expects($this->any())
+			->method('getValues')
+			->willReturn([
+				'theme-one' => 'theme',
+				'theme-two' => 'theme',
+				'customapp' => 'filesystem',
+				'theme-three'  => 'theme'
+			]);
+
+		$this->appManager->expects($this->exactly(2))
+			->method('disableApp')
+			->withConsecutive(['theme-one'],['theme-two']);
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('theme', '')
+			->willReturn('veryoldtheme');
+
+		$this->config->expects($this->once())
+			->method('setSystemValue')
+			->with('theme', '');
+
+		$repairStep = new DisableExtraThemes($this->appManager, $this->config, $this->appConfig);
+		$repairStep->run($this->output);
+	}
+
+	public function testSingleThemeAppStillEnabled() {
+		$this->appManager->expects($this->any())
+			->method('getInstalledApps')
+			->willReturn(['one', 'customapp', 'someotherapp', 'two', 'theme-three']);
+
+		$this->appConfig->expects($this->any())
+			->method('getValues')
+			->willReturn([
+				'one' => 'filesystem',
+				'two' => 'filesystem',
+				'customapp' => 'filesystem',
+				'theme-three'  => 'theme'
+			]);
+
+		$this->appManager->expects($this->never())
+			->method('disableApp');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('theme', '')
+			->willReturn('');
+
+		$this->config->expects($this->never())
+			->method('setSystemValue')
+			->with('theme', '');
+
+		$repairStep = new DisableExtraThemes($this->appManager, $this->config, $this->appConfig);
+		$repairStep->run($this->output);
+	}
+
+	public function testSingleThemeAppDisablesLegacyTheme() {
+		$this->appManager->expects($this->any())
+			->method('getInstalledApps')
+			->willReturn(['one', 'customapp', 'someotherapp', 'two', 'theme-three']);
+
+		$this->appConfig->expects($this->any())
+			->method('getValues')
+			->willReturn([
+				'one' => 'filesystem',
+				'two' => 'filesystem',
+				'customapp' => 'filesystem',
+				'theme-three'  => 'theme'
+			]);
+
+		$this->appManager->expects($this->never())
+			->method('disableApp');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('theme', '')
+			->willReturn('veryoldtheme');
+
+		$this->config->expects($this->once())
+			->method('setSystemValue')
+			->with('theme', '');
+
+		$repairStep = new DisableExtraThemes($this->appManager, $this->config, $this->appConfig);
+		$repairStep->run($this->output);
+	}
+
+	public function testNoThemeAppsKeepsLegacyTheme() {
+		$this->appManager->expects($this->any())
+			->method('getInstalledApps')
+			->willReturn(['one', 'customapp', 'someotherapp', 'two', 'three']);
+
+		$this->appConfig->expects($this->any())
+			->method('getValues')
+			->willReturn([
+				'one' => 'filesystem',
+				'two' => 'filesystem',
+				'customapp' => 'filesystem',
+				'three'  => 'authentication'
+			]);
+
+		$this->appManager->expects($this->never())
+			->method('disableApp');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('theme', '')
+			->willReturn('veryoldtheme');
+
+		$this->config->expects($this->never())
+			->method('setSystemValue')
+			->with('theme', '');
+
+		$repairStep = new DisableExtraThemes($this->appManager, $this->config, $this->appConfig);
+		$repairStep->run($this->output);
+	}
+}

--- a/tests/lib/Theme/ThemeServiceTest.php
+++ b/tests/lib/Theme/ThemeServiceTest.php
@@ -3,20 +3,8 @@
 namespace Test\Theme;
 
 use OC\Theme\ThemeService;
-use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamDirectory;
 
 class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
-
-	/**
-	 * @var vfsStreamDirectory
-	 */
-	private $root;
-
-	protected function setUp() {
-		$this->root = vfsStream::setup();
-		parent::setUp();
-	}
 
 	public function testCreatesThemeByGivenName() {
 		$themeService = new ThemeService('theme-name');
@@ -26,10 +14,16 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testCreatesEmptyThemeIfDefaultDoesNotExist() {
-		$structure = [];
-		$this->root = vfsStream::setup('root', null, $structure);
+		$themeService = $this->getMockBuilder(ThemeService::class)
+			->disableOriginalConstructor()
+			->setMethods(['defaultThemeExists'])
+			->getMock();
 
-		$themeService = new ThemeService('', $this->root->url() . '/themes/default');
+		$themeService->expects($this->any())
+			->method('defaultThemeExists')
+			->willReturn(false);
+
+		$themeService->__construct('');
 		$theme = $themeService->getTheme();
 
 		$this->assertEquals('', $theme->getName());
@@ -37,15 +31,16 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testCreatesDefaultThemeIfItExists() {
-		$structure = [
-			'themes' => [
-				'default' => []
-			]
-		];
+		$themeService = $this->getMockBuilder(ThemeService::class)
+			->disableOriginalConstructor()
+			->setMethods(['defaultThemeExists'])
+			->getMock();
 
-		$this->root = vfsStream::setup('root', null, $structure);
+		$themeService->expects($this->any())
+			->method('defaultThemeExists')
+			->willReturn(true);
 
-		$themeService = new ThemeService('', $this->root->url() . '/themes/default');
+		$themeService->__construct('');
 		$theme = $themeService->getTheme();
 
 		$this->assertEquals('default', $theme->getName());


### PR DESCRIPTION
## Description
Fixes custom translations inside app-themes.

TODO: 
- [x] Remove undocumented fallback to the app-theme with `default_enabled` attribute
- [x] Fallback to the legacy theme only in case there is no app-theme active
- [x] Allow only one app-theme to be active (CLI/Web)


 A migration step that
- [x]  resets legacy theme if app-theme is enabled `->setSystemValue('theme', '')`
- [x]  disables extra app-themes in case there is more than one active app-theme
currently the last (alphabetically) app-theme wins. So the latest theme should stay active.

## Related Issue
Fixes 
https://github.com/owncloud/core/issues/28167 
https://github.com/owncloud/theme-enterprise/issues/16


## Motivation and Context


## How Has This Been Tested?

### Test 1
1. Activate app-theme. e.g. theme-example
2. Switch to British English
3. `mkdir -p apps/theme-example/core/l10n`
4. `cp core/l10n/en_GB.json apps/theme-example/core/l10n/en_GB.json`
5. Change 
`    "Log out" : "Log out",`
to
`    "Log out" : "Go away!",`

### Expected 
Log out is renamed in menu

### Actual 
it is not

#### Tested as a guest 
Please note that guest user uses a language based on browser locale settings. 
You'll need to override another file (es.json, de.json, whatever...) instead of en_GB.json if your browser is not in en_GB
- [x]     "File not found" changed to "File not found and never will be"
Accessing an unexisting share - translation works
- [x]     "Password" changed to "Password 123"
Accessing a login page - translation works

### Test 2
1. Activate another app-theme

### Expected 
It can't be enabled until  the current theme is active

### Actual
Both themes are enabled, theme that is the last according to the alphabet is loaded.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

