### PR TITLE
[stable10] Raise more useful message when constructor are not resolvable

### DIFF
--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -82,7 +82,13 @@ class App {
 		} catch(QueryException $e) {
 			$appNameSpace = self::buildAppNamespace($appName);
 			$controllerName = $appNameSpace . '\\Controller\\' . $controllerName;
-			$controller = $container->query($controllerName);
+			try {
+				$controller = $container->query($controllerName);
+			} catch (QueryException $e2) {
+				// the reason we got here could also be because of the first exception above,
+				// so combine the message from both
+				throw new QueryException($e2->getMessage() . ' or error resolving constructor arguments: ' . $e->getMessage());
+			}
 		}
 
 		// initialize the dispatcher and run all the middleware before the controller


### PR DESCRIPTION
Whenever resolved class C exists but one of its constructor arguments
cannot be resolved, the app framework would throw an exception that the
class C does not exist even though it does. This is misleading and leads
to confusion, anger and loss of time.

This fix expands the error message to include the message about the
constructor argument that wasn't properly forwarded.

backport of #29737 