### PR TITLE
proc_open needs  full path

### DIFF
--- a/apps/testing/lib/Occ.php
+++ b/apps/testing/lib/Occ.php
@@ -69,7 +69,7 @@ class Occ {
 			'php console.php ' . $args,
 			$descriptor,
 			$pipes,
-			"../"
+			realpath("../")
 		);
 		$lastStdOut = stream_get_contents($pipes[1]);
 		$lastStdErr = stream_get_contents($pipes[2]);


### PR DESCRIPTION
## Description
`proc_open` needs the full path as `$cwd`

## Motivation and Context
running the occ command through the testing app would fail sometime because of `../` as path

## How Has This Been Tested?
make UI test initialisations use the testing app and run them locally and on travis

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

