### PR TITLE
use testing app API to run occ commands in UI tests start script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ addons:
     packages:
     - realpath
     - net-tools
+    - libxml2-utils
   hosts: &common_hosts
     - owncloud
 

--- a/apps/testing/lib/Occ.php
+++ b/apps/testing/lib/Occ.php
@@ -69,7 +69,7 @@ class Occ {
 			'php console.php ' . $args,
 			$descriptor,
 			$pipes,
-			"../"
+			realpath("../")
 		);
 		$lastStdOut = stream_get_contents($pipes[1]);
 		$lastStdErr = stream_get_contents($pipes[2]);


### PR DESCRIPTION
## Description
As it's now possible to run `occ` through the testing app we want to use that possibility in the UI tests start script.
The script still needs the local `occ` command to enable the testing app. When testing a remote instance (e.g. inside docker) the testing app needs to be installed and enabled by other means and the ui test script has to be started with the  `--remote` switch

## Motivation and Context
The main goal is to make it possible to run UI tests against a remote instance, e.g. inside docker. See also owncloud/qa-enterprise#115
For that to happen we need to reduce the use of the local `occ` command.

## How Has This Been Tested?
running UI tests locally and in travis

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

