### PR TITLE
[stable10] Switch Webdav URL in field in nav bar

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -212,11 +212,14 @@ class ViewController extends Controller {
 			]
 		);
 
+		$user = $this->userSession->getUser()->getUID();
+
 		$navItems = \OCA\Files\App::getNavigationManager()->getAll();
 		usort($navItems, function($item1, $item2) {
 			return $item1['order'] - $item2['order'];
 		});
 		$nav->assign('navigationItems', $navItems);
+		$nav->assign('webdavUrl', $this->urlGenerator->getAbsoluteUrl($this->urlGenerator->linkTo('', 'remote.php') . '/dav/files/' . $user . '/'));
 
 		$contentItems = [];
 
@@ -243,7 +246,6 @@ class ViewController extends Controller {
 		$params['mailPublicNotificationEnabled'] = $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no');
 		$params['socialShareEnabled'] = $this->config->getAppValue('core', 'shareapi_allow_social_share', 'yes');
 		$params['allowShareWithLink'] = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes');
-		$user = $this->userSession->getUser()->getUID();
 		$params['defaultFileSorting'] = $this->config->getUserValue($user, 'files', 'file_sorting', 'name');
 		$params['defaultFileSortingDirection'] = $this->config->getUserValue($user, 'files', 'file_sorting_direction', 'asc');
 		$showHidden = (bool) $this->config->getUserValue($this->userSession->getUser()->getUID(), 'files', 'show_hidden', false);

--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -21,7 +21,7 @@
 				<label for="showhiddenfilesToggle"><?php p($l->t('Show hidden files')); ?></label>
 			</div>
 			<label for="webdavurl"><?php p($l->t('WebDAV'));?></label>
-			<input id="webdavurl" type="text" readonly="readonly" value="<?php p(\OCP\Util::linkToRemote('webdav')); ?>" />
+			<input id="webdavurl" type="text" readonly="readonly" value="<?php p($_['webdavUrl']); ?>" />
 			<em><?php print_unescaped($l->t('Use this address to <a href="%s" target="_blank" rel="noreferrer">access your Files via WebDAV</a>', [link_to_docs('user-webdav')]));?></em>
 		</div>
 	</div>

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -178,6 +178,13 @@ class ViewControllerTest extends TestCase {
 			->method('getAppValue')
 			->will($this->returnArgument(2));
 
+		$this->urlGenerator->method('linkTo')
+			->with('', 'remote.php')
+			->willReturn('/owncloud/remote.php');
+		$this->urlGenerator->method('getAbsoluteUrl')
+			->with('/owncloud/remote.php/dav/files/' . $this->user->getUID() . '/')
+			->willReturn('http://example.org/owncloud/remote.php/dav/files/' . $this->user->getUID() . '/');
+
 		$nav = new Template('files', 'appnavigation');
 		$nav->assign('navigationItems', [
 			[
@@ -244,6 +251,7 @@ class ViewControllerTest extends TestCase {
 				'icon' => '',
 			],
 		]);
+		$nav->assign('webdavUrl', 'http://example.org/owncloud/remote.php/dav/files/' . $this->user->getUID() . '/');
 
 		$expected = new Http\TemplateResponse(
 			'files',


### PR DESCRIPTION
For users to be able to copy the new DAV endpoint, switch it in the
navigation panel.

backport #29653 