### PR TITLE
use testing API to run occ commands in SetupHelper

### DIFF
--- a/tests/ui/config/behat.yml
+++ b/tests/ui/config/behat.yml
@@ -10,7 +10,7 @@ default:
         - %paths.base%/../features/files
       context: &common_suite_context
         parameters:
-          ocPath: ./
+          ocPath: apps/testing/api/v1/occ
           adminPassword: admin
           regularUserPassword: 123456
           regularUserName: regularuser

--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -410,9 +410,12 @@ class FeatureContext extends RawMinkContext implements Context {
 			//to include FilesContext
 		}
 
-		SetupHelper::setOcPath($scope);
 		$suiteParameters = SetupHelper::getSuiteParameters($scope);
 		$this->adminPassword = (string)$suiteParameters['adminPassword'];
+		SetupHelper::init(
+			"admin", $this->getUserPassword("admin"),
+			$this->getMinkParameter('base_url'), $suiteParameters['ocPath']
+		);
 		
 		$response = AppConfigHelper::getCapabilities(
 			$this->getMinkParameter('base_url'), "admin", $this->getUserPassword("admin")


### PR DESCRIPTION
## Description
make `TestHelpers\SetupHelper` use the testing app to run `occ` commands

## Motivation and Context
The main goal is to make it possible to run UI tests against a remote instance, e.g. inside docker. See also owncloud/qa-enterprise#115
For that to happen we need to reduce the use of the local occ command.

## How Has This Been Tested?
running UI tests locally and in travis
jenkins will run the integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

