### PR TITLE
use skeleton dir from env. for UI tests

### DIFF
--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -239,7 +239,11 @@ EXTRA_CAPABILITIES=$EXTRA_CAPABILITIES'"maxDuration":"3600"'
 remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings config:system:get skeletondirectory"
 
 PREVIOUS_SKELETON_DIR=$REMOTE_OCC_STDOUT
-export SKELETON_DIR=$(pwd)/tests/ui/skeleton
+if [ -z "$SKELETON_DIR" ]
+then
+	export SKELETON_DIR=$(pwd)/tests/ui/skeleton
+fi
+
 remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set skeletondirectory --value=$SKELETON_DIR"
 if [ $? -ne 0 ]
 then


### PR DESCRIPTION
## Description
makes it possible to set the skeleton directory by an enviroment variable

## Motivation and Context
The main goal is to make it possible to run UI tests against a remote instance, e.g. inside docker. See also owncloud/qa-enterprise#115
For that we need to be able to pass the skeleton dir setting into the `start_ui_tests.sh` script

## How Has This Been Tested?
running UI tests against owncloud official docker container

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

