### PR TITLE
Update Guzzle to 6.3

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -84,4 +84,3 @@ Options -Indexes
 <IfModule pagespeed_module>
   ModPagespeed Off
 </IfModule>
-

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "nikic/php-parser": "^4.0",
         "icewind/Streams": "0.5.2",
         "swiftmailer/swiftmailer": "^5.4",
-        "guzzlehttp/guzzle": "^5.3",
+        "guzzlehttp/guzzle": "^6.3",
         "league/flysystem": "^1.0",
         "pear/pear-core-minimal": "^v1.10",
         "interfasys/lognormalizer": "^v1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff18e9c01a4dc2372c06e5c666e39972",
+    "content-hash": "bb45575913bccf69899f83a13a631f91",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -605,29 +605,41 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "5.3.3",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "93bbdb30d59be6cd9839495306c65f2907370eb9"
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/93bbdb30d59be6cd9839495306c65f2907370eb9",
-                "reference": "93bbdb30d59be6cd9839495306c65f2907370eb9",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/ringphp": "^1.1",
-                "php": ">=5.4.0",
-                "react/promise": "^2.2"
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.4",
+                "php": ">=5.5"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.3-dev"
+                }
+            },
             "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
                 }
@@ -643,7 +655,7 @@
                     "homepage": "https://github.com/mtdowling"
                 }
             ],
-            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "description": "Guzzle is a PHP HTTP client library",
             "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "client",
@@ -654,44 +666,41 @@
                 "rest",
                 "web service"
             ],
-            "time": "2018-07-31T13:33:10+00:00"
+            "time": "2018-04-22T15:46:56+00:00"
         },
         {
-            "name": "guzzlehttp/ringphp",
-            "version": "1.1.1",
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/RingPHP.git",
-                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b"
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/5e2a174052995663dd68e6b5ad838afd47dd615b",
-                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/streams": "~3.0",
-                "php": ">=5.4.0",
-                "react/promise": "~2.0"
+                "php": ">=5.5.0"
             },
             "require-dev": {
-                "ext-curl": "*",
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+                "phpunit/phpunit": "^4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "GuzzleHttp\\Ring\\": "src/"
-                }
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -704,58 +713,76 @@
                     "homepage": "https://github.com/mtdowling"
                 }
             ],
-            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
-            "time": "2018-07-31T13:22:33+00:00"
-        },
-        {
-            "name": "guzzlehttp/streams",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/streams.git",
-                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
-                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Stream\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Provides a simple abstraction over streams of data",
-            "homepage": "http://guzzlephp.org/",
+            "description": "Guzzle promises library",
             "keywords": [
-                "Guzzle",
-                "stream"
+                "promise"
             ],
-            "time": "2014-10-12T19:18:40+00:00"
+            "time": "2016-12-20T10:07:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2017-03-20T17:10:46+00:00"
         },
         {
             "name": "icewind/streams",
@@ -1589,6 +1616,56 @@
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.0.2",
             "source": {
@@ -1760,52 +1837,6 @@
                 "swift"
             ],
             "time": "2014-02-06T20:53:21+00:00"
-        },
-        {
-            "name": "react/promise",
-            "version": "v2.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/promise.git",
-                "reference": "f4edc2581617431aea50430749db55cc3fc031b3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/f4edc2581617431aea50430749db55cc3fc031b3",
-                "reference": "f4edc2581617431aea50430749db55cc3fc031b3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.8"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "React\\Promise\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@gmail.com"
-                }
-            ],
-            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
-            "keywords": [
-                "promise",
-                "promises"
-            ],
-            "time": "2018-06-13T15:59:06+00:00"
         },
         {
             "name": "sabre/dav",
@@ -3874,35 +3905,41 @@
         },
         {
             "name": "fabpot/goutte",
-            "version": "v2.0.4",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/Goutte.git",
-                "reference": "0ad3ee6dc2d0aaa832a80041a1e09bf394e99802"
+                "reference": "3f0eaf0a40181359470651f1565b3e07e3dd31b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/Goutte/zipball/0ad3ee6dc2d0aaa832a80041a1e09bf394e99802",
-                "reference": "0ad3ee6dc2d0aaa832a80041a1e09bf394e99802",
+                "url": "https://api.github.com/repos/FriendsOfPHP/Goutte/zipball/3f0eaf0a40181359470651f1565b3e07e3dd31b8",
+                "reference": "3f0eaf0a40181359470651f1565b3e07e3dd31b8",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": ">=4,<6",
-                "php": ">=5.4.0",
-                "symfony/browser-kit": "~2.1",
-                "symfony/css-selector": "~2.1",
-                "symfony/dom-crawler": "~2.1"
+                "guzzlehttp/guzzle": "^6.0",
+                "php": ">=5.5.0",
+                "symfony/browser-kit": "~2.1|~3.0|~4.0",
+                "symfony/css-selector": "~2.1|~3.0|~4.0",
+                "symfony/dom-crawler": "~2.1|~3.0|~4.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3.3 || ^4"
             },
             "type": "application",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Goutte\\": "Goutte"
-                }
+                },
+                "exclude-from-classmap": [
+                    "Goutte/Tests"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3919,7 +3956,7 @@
             "keywords": [
                 "scraper"
             ],
-            "time": "2015-05-05T21:14:57+00:00"
+            "time": "2018-06-29T15:13:57+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
@@ -5989,25 +6026,25 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v2.8.44",
+            "version": "v3.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "fe44362c97307e7935996cb09d320fcc22619656"
+                "reference": "f6668d1a6182d5a8dec65a1c863a4c1d963816c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/fe44362c97307e7935996cb09d320fcc22619656",
-                "reference": "fe44362c97307e7935996cb09d320fcc22619656",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/f6668d1a6182d5a8dec65a1c863a4c1d963816c0",
+                "reference": "f6668d1a6182d5a8dec65a1c863a4c1d963816c0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9",
-                "symfony/dom-crawler": "~2.1|~3.0.0"
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/dom-crawler": "~2.8|~3.0|~4.0"
             },
             "require-dev": {
-                "symfony/css-selector": "^2.0.5|~3.0.0",
-                "symfony/process": "~2.3.34|^2.7.6|~3.0.0"
+                "symfony/css-selector": "~2.8|~3.0|~4.0",
+                "symfony/process": "~2.8|~3.0|~4.0"
             },
             "suggest": {
                 "symfony/process": ""
@@ -6015,7 +6052,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -6042,7 +6079,7 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T09:03:18+00:00"
+            "time": "2018-07-26T09:06:28+00:00"
         },
         {
             "name": "symfony/class-loader",
@@ -6166,25 +6203,25 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.8.44",
+            "version": "v3.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "294611f3a0d265bcf049e2da62cb4f712e3ed927"
+                "reference": "edda5a6155000ff8c3a3f85ee5c421af93cca416"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/294611f3a0d265bcf049e2da62cb4f712e3ed927",
-                "reference": "294611f3a0d265bcf049e2da62cb4f712e3ed927",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/edda5a6155000ff8c3a3f85ee5c421af93cca416",
+                "reference": "edda5a6155000ff8c3a3f85ee5c421af93cca416",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -6215,7 +6252,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T09:03:18+00:00"
+            "time": "2018-07-26T09:06:28+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -6290,25 +6327,25 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v2.8.44",
+            "version": "v3.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "2fd6513f2dd3b08446da420070084db376c0134c"
+                "reference": "452bfc854b60134438e3824b159b0d24a5892331"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/2fd6513f2dd3b08446da420070084db376c0134c",
-                "reference": "2fd6513f2dd3b08446da420070084db376c0134c",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/452bfc854b60134438e3824b159b0d24a5892331",
+                "reference": "452bfc854b60134438e3824b159b0d24a5892331",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9",
+                "php": "^5.5.9|>=7.0.8",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
-                "symfony/css-selector": "~2.8|~3.0.0"
+                "symfony/css-selector": "~2.8|~3.0|~4.0"
             },
             "suggest": {
                 "symfony/css-selector": ""
@@ -6316,7 +6353,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -6343,7 +6380,7 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-24T10:05:38+00:00"
+            "time": "2018-07-26T10:03:52+00:00"
         },
         {
             "name": "symfony/filesystem",

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -34,7 +34,6 @@ namespace OC\Files\Storage;
 
 use Exception;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Message\ResponseInterface;
 use OC\Files\Filesystem;
 use OC\Files\Stream\Close;
 use Icewind\Streams\IteratorDirectory;
@@ -50,6 +49,7 @@ use Sabre\HTTP\Client;
 use Sabre\HTTP\ClientHttpException;
 use Sabre\DAV\Exception\InsufficientStorage;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Class DAV

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -62,23 +62,24 @@ class Client implements IClient {
 			return;
 		}
 		$this->configured = true;
+		$config = $this->client->getConfig();
 		// Either use user bundle or the system bundle if nothing is specified
 		if ($this->certificateManager->listCertificates() !== []) {
-			$this->client->setDefaultOption('verify', $this->certificateManager->getAbsoluteBundlePath());
+			$config['verify'] = $this->certificateManager->getAbsoluteBundlePath();
 		} else {
 			// If the instance is not yet setup we need to use the static path as
 			// $this->certificateManager->getAbsoluteBundlePath() tries to instantiiate
 			// a view
 			if ($this->config->getSystemValue('installed', false) && !\OCP\Util::needUpgrade()) {
-				$this->client->setDefaultOption('verify', $this->certificateManager->getAbsoluteBundlePath(null));
+				$config['verify'] = $this->certificateManager->getAbsoluteBundlePath(null);
 			} else {
-				$this->client->setDefaultOption('verify', \OC::$SERVERROOT . '/resources/config/ca-bundle.crt');
+				$config['verify'] = \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
 			}
 		}
 
-		$this->client->setDefaultOption('headers/User-Agent', 'ownCloud Server Crawler');
+		$config['headers/User-Agent'] = 'ownCloud Server Crawler';
 		if ($this->getProxyUri() !== '') {
-			$this->client->setDefaultOption('proxy', $this->getProxyUri());
+			$config['proxy'] = $this->getProxyUri();
 		}
 	}
 
@@ -199,6 +200,10 @@ class Client implements IClient {
 	 */
 	public function post($uri, array $options = []) {
 		$this->setDefaultOptions();
+		if (isset($options['body']) && is_array($options['body'])) {
+			$options['form_params'] = $options['body'];
+			unset($options['body']);
+		}
 		$response = $this->client->post($uri, $options);
 		return new Response($response);
 	}

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -200,7 +200,7 @@ class Client implements IClient {
 	 */
 	public function post($uri, array $options = []) {
 		$this->setDefaultOptions();
-		if (isset($options['body']) && is_array($options['body'])) {
+		if (isset($options['body']) && \is_array($options['body'])) {
 			$options['form_params'] = $options['body'];
 			unset($options['body']);
 		}

--- a/lib/private/Http/Client/Response.php
+++ b/lib/private/Http/Client/Response.php
@@ -23,7 +23,7 @@
 namespace OC\Http\Client;
 
 use OCP\Http\Client\IResponse;
-use GuzzleHttp\Message\Response as GuzzleResponse;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Class Response
@@ -43,7 +43,7 @@ class Response implements IResponse {
 	 * @param GuzzleResponse $response
 	 * @param bool $stream
 	 */
-	public function __construct(GuzzleResponse $response, $stream = false) {
+	public function __construct(ResponseInterface $response, $stream = false) {
 		$this->response = $response;
 		$this->stream = $stream;
 	}

--- a/lib/private/Http/Client/Response.php
+++ b/lib/private/Http/Client/Response.php
@@ -31,7 +31,7 @@ use Psr\Http\Message\ResponseInterface;
  * @package OC\Http
  */
 class Response implements IResponse {
-	/** @var GuzzleResponse */
+	/** @var ResponseInterface */
 	private $response;
 
 	/**
@@ -40,7 +40,7 @@ class Response implements IResponse {
 	private $stream;
 
 	/**
-	 * @param GuzzleResponse $response
+	 * @param ResponseInterface $response
 	 * @param bool $stream
 	 */
 	public function __construct(ResponseInterface $response, $stream = false) {

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -454,7 +454,7 @@ class CheckSetupControllerTest extends TestCase {
 		/** @var ClientException | \PHPUnit_Framework_MockObject_MockObject $exception */
 		$exception = $this->getMockBuilder('\GuzzleHttp\Exception\ClientException')
 			->disableOriginalConstructor()->getMock();
-		$response = $this->getMockBuilder('\GuzzleHttp\Message\ResponseInterface')
+		$response = $this->getMockBuilder('\Psr\Http\Message\ResponseInterface')
 			->disableOriginalConstructor()->getMock();
 		$response->expects($this->once())
 			->method('getStatusCode')
@@ -488,7 +488,7 @@ class CheckSetupControllerTest extends TestCase {
 		/** @var ClientException | \PHPUnit_Framework_MockObject_MockObject $exception */
 		$exception = $this->getMockBuilder('\GuzzleHttp\Exception\ClientException')
 			->disableOriginalConstructor()->getMock();
-		$response = $this->getMockBuilder('\GuzzleHttp\Message\ResponseInterface')
+		$response = $this->getMockBuilder('\Psr\Http\Message\ResponseInterface')
 			->disableOriginalConstructor()->getMock();
 		$response->expects($this->once())
 			->method('getStatusCode')

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -29,11 +29,13 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\RedirectResponse;
+use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use Psr\Http\Message\ResponseInterface;
 use Test\TestCase;
 
 /**
@@ -63,28 +65,28 @@ class CheckSetupControllerTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->request = $this->getMockBuilder('\OCP\IRequest')
+		$this->request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()->getMock();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()->getMock();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()->getMock();
-		$this->clientService = $this->getMockBuilder('\OCP\Http\Client\IClientService')
+		$this->clientService = $this->getMockBuilder(IClientService::class)
 			->disableOriginalConstructor()->getMock();
-		$this->util = $this->getMockBuilder('\OC_Util')
+		$this->util = $this->getMockBuilder(\OC_Util::class)
 			->disableOriginalConstructor()->getMock();
-		$this->urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()->getMock();
-		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
+		$this->l10n = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
 		$this->l10n->expects($this->any())
 			->method('t')
 			->will($this->returnCallback(function ($message, array $replace) {
 				return \vsprintf($message, $replace);
 			}));
-		$this->checker = $this->getMockBuilder('\OC\IntegrityCheck\Checker')
+		$this->checker = $this->getMockBuilder(Checker::class)
 				->disableOriginalConstructor()->getMock();
-		$this->checkSetupController = $this->getMockBuilder('\OC\Settings\Controller\CheckSetupController')
+		$this->checkSetupController = $this->getMockBuilder(CheckSetupController::class)
 			->setConstructorArgs([
 				'settings',
 				$this->request,
@@ -118,7 +120,7 @@ class CheckSetupControllerTest extends TestCase {
 			->with('has_internet_connection', true)
 			->will($this->returnValue(true));
 
-		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
+		$client = $this->getMockBuilder(IClient::class)
 			->disableOriginalConstructor()->getMock();
 		$client->expects($this->at(0))
 			->method('get')
@@ -145,7 +147,7 @@ class CheckSetupControllerTest extends TestCase {
 			->with('has_internet_connection', true)
 			->will($this->returnValue(true));
 
-		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
+		$client = $this->getMockBuilder(IClient::class)
 			->disableOriginalConstructor()->getMock();
 		$client->expects($this->at(0))
 			->method('get')
@@ -170,7 +172,7 @@ class CheckSetupControllerTest extends TestCase {
 			->with('has_internet_connection', true)
 			->will($this->returnValue(true));
 
-		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
+		$client = $this->getMockBuilder(IClient::class)
 			->disableOriginalConstructor()->getMock();
 		$client->expects($this->at(0))
 			->method('get')
@@ -305,7 +307,7 @@ class CheckSetupControllerTest extends TestCase {
 			->method('getRemoteAddress')
 			->willReturn('4.3.2.1');
 
-		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
+		$client = $this->getMockBuilder(IClient::class)
 			->disableOriginalConstructor()->getMock();
 		$client->expects($this->at(0))
 			->method('get')
@@ -359,7 +361,7 @@ class CheckSetupControllerTest extends TestCase {
 	}
 
 	public function testGetCurlVersion() {
-		$checkSetupController = $this->getMockBuilder('\OC\Settings\Controller\CheckSetupController')
+		$checkSetupController = $this->getMockBuilder(CheckSetupController::class)
 			->setConstructorArgs([
 				'settings',
 				$this->request,
@@ -449,12 +451,12 @@ class CheckSetupControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getCurlVersion')
 			->will($this->returnValue(['ssl_version' => 'NSS/1.0.2b']));
-		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
+		$client = $this->getMockBuilder(IClient::class)
 			->disableOriginalConstructor()->getMock();
 		/** @var ClientException | \PHPUnit_Framework_MockObject_MockObject $exception */
-		$exception = $this->getMockBuilder('\GuzzleHttp\Exception\ClientException')
+		$exception = $this->getMockBuilder(ClientException::class)
 			->disableOriginalConstructor()->getMock();
-		$response = $this->getMockBuilder('\Psr\Http\Message\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()->getMock();
 		$response->expects($this->once())
 			->method('getStatusCode')
@@ -483,12 +485,12 @@ class CheckSetupControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getCurlVersion')
 			->will($this->returnValue(['ssl_version' => 'NSS/1.0.2b']));
-		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
+		$client = $this->getMockBuilder(IClient::class)
 			->disableOriginalConstructor()->getMock();
 		/** @var ClientException | \PHPUnit_Framework_MockObject_MockObject $exception */
-		$exception = $this->getMockBuilder('\GuzzleHttp\Exception\ClientException')
+		$exception = $this->getMockBuilder(ClientException::class)
 			->disableOriginalConstructor()->getMock();
-		$response = $this->getMockBuilder('\Psr\Http\Message\ResponseInterface')
+		$response = $this->getMockBuilder(ResponseInterface::class)
 			->disableOriginalConstructor()->getMock();
 		$response->expects($this->once())
 			->method('getStatusCode')

--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -21,9 +21,9 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\ResponseInterface;
-use GuzzleHttp\Exception\ServerException;
+use Psr\Http\Message\ResponseInterface;
 use PHPUnit_Framework_Assert;
+use SimpleXMLElement;
 
 /**
  * Helper to set various configurations through the testing app
@@ -206,7 +206,19 @@ class AppConfigHelper {
 	 * @return string
 	 */
 	public static function getOCSResponse($response) {
-		return $response->xml()->meta[0]->statuscode;
+		return self::getResponseXml($response)->meta[0]->statuscode;
+	}
+
+	/**
+	 * Parses the response as XML
+	 *
+	 * @param ResponseInterface $response
+	 * @return SimpleXMLElement
+	 */
+	public static function getResponseXml($response) {
+		// rewind just to make sure we can re-parse it in case it was parsed already...
+		$response->getBody()->rewind();
+		return new SimpleXMLElement($response->getBody()->getContents());
 	}
 
 	/**
@@ -237,7 +249,7 @@ class AppConfigHelper {
 	 * @return string retrieved capabilities in XML format
 	 */
 	public static function getCapabilitiesXml($response) {
-		return $response->xml()->data->capabilities;
+		return self::getResponseXml($response)->data->capabilities;
 	}
 
 	/**

--- a/tests/TestHelpers/DownloadHelper.php
+++ b/tests/TestHelpers/DownloadHelper.php
@@ -21,8 +21,7 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\FutureResponse;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Helper for Downloads
@@ -45,7 +44,7 @@ class DownloadHelper {
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
 	 *
-	 * @return FutureResponse|ResponseInterface|NULL
+	 * @return ResponseInterface|NULL
 	 */
 	public static function download(
 		$baseUrl,

--- a/tests/TestHelpers/EmailHelper.php
+++ b/tests/TestHelpers/EmailHelper.php
@@ -23,6 +23,7 @@ namespace TestHelpers;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Message\ResponseInterface;
+use GuzzleHttp\Psr7\Request;
 
 /**
  * Helper to test email sending, using mailhog
@@ -39,9 +40,10 @@ class EmailHelper {
 	 */
 	public static function getEmails($mailhogUrl) {
 		$client = new Client();
-		$options = ['headers' => ['Content-Type' => 'application/json']];
-		$request = $client->createRequest(
-			'GET', $mailhogUrl . "/api/v2/messages", $options
+		$request = new Request(
+			'GET',
+			$mailhogUrl . "/api/v2/messages",
+			['Content-Type' => 'application/json']
 		);
 		$response = $client->send($request);
 
@@ -80,8 +82,9 @@ class EmailHelper {
 	 */
 	public static function deleteAllMessages($mailhogUrl) {
 		$client = new Client();
-		$request = $client->createRequest(
-			'DELETE', $mailhogUrl . "/api/v1/messages"
+		$request = new Request(
+			'DELETE',
+			$mailhogUrl . "/api/v1/messages"
 		);
 		$response = $client->send($request);
 		return $response;

--- a/tests/TestHelpers/MoveCopyHelper.php
+++ b/tests/TestHelpers/MoveCopyHelper.php
@@ -21,6 +21,8 @@
  */
 namespace TestHelpers;
 
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * Helper for move and copy files
  *
@@ -44,7 +46,7 @@ class MoveCopyHelper {
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
 	 *
-	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @return ResponseInterface|NULL
 	 */
 	public static function copy(
 		$baseUrl,
@@ -77,7 +79,7 @@ class MoveCopyHelper {
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
 	 *
-	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @return ResponseInterface|NULL
 	 */
 	public static function move(
 		$baseUrl,
@@ -111,7 +113,7 @@ class MoveCopyHelper {
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
 	 *
-	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @return ResponseInterface|NULL
 	 */
 	private static function copyOrMove(
 		$baseUrl,

--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -22,8 +22,9 @@
 namespace TestHelpers;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Helper to make requests to the OCS API
@@ -57,12 +58,10 @@ class OcsApiHelper {
 		if ($user !== null) {
 			$options['auth'] = [$user, $password];
 		}
-		$options['body'] = $body;
+		$options['form_params'] = $body;
 		
 		try {
-			$response = $client->send(
-				$client->createRequest($method, $fullUrl, $options)
-			);
+			$response = $client->send(new Request($method, $fullUrl), $options);
 		} catch (ClientException $ex) {
 			$response = $ex->getResponse();
 			

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -337,9 +337,10 @@ class SetupHelper {
 		}
 
 		$return = [];
-		$return['code'] = $result->xml()->xpath("//ocs/data/code");
-		$return['stdOut'] = $result->xml()->xpath("//ocs/data/stdOut");
-		$return['stdErr'] = $result->xml()->xpath("//ocs/data/stdErr");
+		$resultXml = \simplexml_load_string($result->getBody()->getContents());
+		$return['code'] = $resultXml->xpath("//ocs/data/code");
+		$return['stdOut'] = $resultXml->xpath("//ocs/data/stdOut");
+		$return['stdErr'] = $resultXml->xpath("//ocs/data/stdErr");
 
 		if (!\is_a($return['code'][0], "SimpleXMLElement")
 			|| !\is_a($return['stdOut'][0], "SimpleXMLElement")

--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -22,6 +22,8 @@
 namespace TestHelpers;
 
 use GuzzleHttp\Client as GClient;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * manage Shares via OCS API
@@ -63,7 +65,7 @@ class SharingHelper {
 	 * @param int $ocsApiVersion
 	 * @param int $sharingApiVersion
 	 *
-	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @return ResponseInterface|NULL
 	 */
 	public static function createShare(
 		$baseUrl,
@@ -173,8 +175,8 @@ class SharingHelper {
 			$fd['name'] = $linkName;
 		}
 
-		$options['body'] = $fd;
+		$options['form_params'] = $fd;
 
-		return $client->send($client->createRequest("POST", $fullUrl, $options));
+		return $client->send(new Request("POST", $fullUrl), $options);
 	}
 }

--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -21,6 +21,9 @@
  */
 namespace TestHelpers;
 
+use GuzzleHttp\Exception\ClientException;
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * Helper to administer Tags
  *
@@ -39,7 +42,7 @@ class TagsHelper {
 	 * @param string $fileOwner
 	 * @param int $davPathVersionToUse (1|2)
 	 *
-	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @return ResponseInterface|NULL
 	 */
 	public static function tag(
 		$baseUrl,
@@ -142,7 +145,7 @@ class TagsHelper {
 	 * @param int $davPathVersionToUse (1|2)
 	 *
 	 * @return array ['lastTagId', 'HTTPResponse']
-	 * @throws \GuzzleHttp\Exception\ClientException
+	 * @throws ClientException
 	 * @link self::makeDavRequest()
 	 */
 	public static function createTag(
@@ -192,8 +195,8 @@ class TagsHelper {
 	 * @param int $tagID
 	 * @param int $davPathVersionToUse (1|2)
 	 *
-	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
-	 * @throws \GuzzleHttp\Exception\ClientException
+	 * @return ResponseInterface|NULL
+	 * @throws ClientException
 	 */
 	public static function deleteTag(
 		$baseUrl,

--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -21,9 +21,7 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\FutureResponse;
-use GuzzleHttp\Message\ResponseInterface;
-use GuzzleHttp\Stream\Stream;
+use Psr\Http\Message\ResponseInterface;
 use PHPUnit_Framework_Assert;
 
 /**
@@ -50,7 +48,7 @@ class UploadHelper {
 	 *                                    if set to null chunking will not be used
 	 * @param int    $noOfChunks          how many chunks do we want to upload
 	 *
-	 * @return FutureResponse|ResponseInterface|NULL
+	 * @return ResponseInterface|NULL
 	 */
 	public static function upload(
 		$baseUrl,
@@ -66,7 +64,7 @@ class UploadHelper {
 
 		//simple upload with no chunking
 		if ($chunkingVersion === null) {
-			$data = Stream::factory(\fopen($source, 'r'));
+			$data = \file_get_contents($source);
 			return WebDavHelper::makeDavRequest(
 				$baseUrl,
 				$user,
@@ -103,7 +101,6 @@ class UploadHelper {
 
 		//upload chunks
 		foreach ($chunks as $index => $chunk) {
-			$data = Stream::factory($chunk);
 			if ($chunkingVersion === 1) {
 				$filename = $destination . "-" . $chunkingId . "-" .
 					\count($chunks) . '-' . ( string ) $index;
@@ -119,7 +116,7 @@ class UploadHelper {
 				"PUT",
 				$filename,
 				$headers,
-				$data,
+				$chunk,
 				null,
 				$davPathVersionToUse,
 				$davRequestType

--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -167,7 +167,7 @@ trait AppConfiguration {
 	 * @return string latest retrieved capabilities in XML format
 	 */
 	public function getCapabilitiesXml() {
-		return $this->response->xml()->data->capabilities;
+		return $this->getResponseXml()->data->capabilities;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -24,7 +24,8 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Psr7\Request;
 
 /**
  * CalDav functions
@@ -191,16 +192,17 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 		$davUrl = $this->featureContext->getBaseUrl()
 			. '/remote.php/dav/calendars/' . $user . '/' . $name;
 
-		$request = $this->client->createRequest(
+		$options = [
+			'auth' => $this->featureContext->getAuthOptionForUser($user)
+		];
+		$request = new Request(
 			'MKCALENDAR',
 			$davUrl,
-			[
-				'body' => '<c:mkcalendar xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:d="DAV:" xmlns:a="http://apple.com/ns/ical/" xmlns:o="http://owncloud.org/ns"><d:set><d:prop><d:displayname>test</d:displayname><o:calendar-enabled>1</o:calendar-enabled><a:calendar-color>#21213D</a:calendar-color><c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set></d:prop></d:set></c:mkcalendar>',
-				'auth' => $this->featureContext->getAuthOptionForUser($user)
-			]
+			[],
+			'<c:mkcalendar xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:d="DAV:" xmlns:a="http://apple.com/ns/ical/" xmlns:o="http://owncloud.org/ns"><d:set><d:prop><d:displayname>test</d:displayname><o:calendar-enabled>1</o:calendar-enabled><a:calendar-color>#21213D</a:calendar-color><c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set></d:prop></d:set></c:mkcalendar>'
 		);
 
-		$this->response = $this->client->send($request);
+		$this->response = $this->client->send($request, $options);
 		$this->theCalDavHttpStatusCodeShouldBe(201);
 	}
 }

--- a/tests/acceptance/features/bootstrap/CardDavContext.php
+++ b/tests/acceptance/features/bootstrap/CardDavContext.php
@@ -24,7 +24,8 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Psr7\Request;
 
 /**
  * CardDav functions
@@ -121,11 +122,14 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 		$davUrl = $this->featureContext->getBaseUrl()
 			. '/remote.php/dav/addressbooks/users/' . $user . '/' . $addressBook;
 
-		$request = $this->client->createRequest(
+		$options = [
+			'auth' => $this->featureContext->getAuthOptionForUser($user)
+		];
+		$request = new Request(
 			'MKCOL',
 			$davUrl,
-			[
-				'body' => '<d:mkcol xmlns:card="urn:ietf:params:xml:ns:carddav"
+			['Content-Type' => 'application/xml;charset=UTF-8'],
+			'<d:mkcol xmlns:card="urn:ietf:params:xml:ns:carddav"
               xmlns:d="DAV:">
     <d:set>
       <d:prop>
@@ -134,15 +138,10 @@ class CardDavContext implements \Behat\Behat\Context\Context {
           </d:resourcetype>,<d:displayname>' . $addressBook . '</d:displayname>
       </d:prop>
     </d:set>
-  </d:mkcol>',
-				'auth' => $this->featureContext->getAuthOptionForUser($user),
-				'headers' => [
-					'Content-Type' => 'application/xml;charset=UTF-8',
-				],
-			]
+  </d:mkcol>'
 		);
 
-		$this->response = $this->client->send($request);
+		$this->response = $this->client->send($request, $options);
 		$this->theCardDavHttpStatusCodeShouldBe(201);
 	}
 

--- a/tests/acceptance/features/bootstrap/Checksums.php
+++ b/tests/acceptance/features/bootstrap/Checksums.php
@@ -22,6 +22,7 @@
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
 
 /**
  * Checksum functions
@@ -42,7 +43,7 @@ trait Checksums {
 	public function userUploadsFileToWithChecksumUsingTheAPI(
 		$user, $source, $destination, $checksum
 	) {
-		$file = \GuzzleHttp\Stream\Stream::factory(\fopen($source, 'r'));
+		$file = \file_get_contents($source);
 		$this->response = $this->makeDavRequest(
 			$user,
 			'PUT',
@@ -79,20 +80,21 @@ trait Checksums {
 	 */
 	public function userRequestsTheChecksumOfViaPropfind($user, $path) {
 		$client = new Client();
-		$request = $client->createRequest(
+		$options = [
+			'auth' => $this->getAuthOptionForUser($user)
+		];
+		$request = new Request(
 			'PROPFIND',
 			$this->getBaseUrl() . '/' . $this->getDavFilesPath($user) . $path,
-			[
-				'body' => '<?xml version="1.0"?>
+			[],
+			'<?xml version="1.0"?>
 <d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
   <d:prop>
     <oc:checksums />
   </d:prop>
-</d:propfind>',
-				'auth' => $this->getAuthOptionForUser($user)
-			]
+</d:propfind>'
 		);
-		$this->response = $client->send($request);
+		$this->response = $client->send($request, $options);
 	}
 
 	/**
@@ -129,7 +131,7 @@ trait Checksums {
 	 * @throws \Exception
 	 */
 	public function theHeaderChecksumShouldMatch($checksum) {
-		if ($this->response->getHeader('OC-Checksum') !== $checksum) {
+		if ($this->response->getHeader('OC-Checksum')[0] !== $checksum) {
 			throw new \Exception(
 				"Expected $checksum, got "
 				. $this->response->getHeader('OC-Checksum')
@@ -193,7 +195,6 @@ trait Checksums {
 	) {
 		try {
 			$num -= 1;
-			$data = \GuzzleHttp\Stream\Stream::factory($data);
 			$file = $destination . '-chunking-42-' . $total . '-' . $num;
 			$this->response = $this->makeDavRequest(
 				$user,

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -94,12 +94,7 @@ class FederationContext implements Context {
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe('200');
 		$this->featureContext->theOCSStatusCodeShouldBe('100');
-		/**
-		 *
-		 * @var ResponseInterface $response
-		 */
-		$response = $this->featureContext->getResponse();
-		$share_id = $response->xml()->data[0]->element[0]->id;
+		$share_id = $this->featureContext->getResponseXml()->data[0]->element[0]->id;
 		$this->featureContext->theUserSendsToOcsApiEndpointWithBody(
 			'POST',
 			"/apps/files_sharing/api/v1/remote_shares/pending/{$share_id}",

--- a/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
@@ -22,7 +22,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use TestHelpers\OcsApiHelper;
 
 require_once 'bootstrap.php';

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1492,7 +1492,8 @@ trait Provisioning {
 	 * @return array
 	 */
 	public function getArrayOfAppInfoResponded($resp) {
-		$listCheckedElements = $resp->xml()->data[0];
+		$listCheckedElements
+			= $this->getResponseXml($resp)->data[0];
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -22,7 +22,8 @@
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Message\ResponseInterface;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\ResponseInterface;
 use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\UserHelper;
@@ -549,7 +550,7 @@ trait Provisioning {
 		$options = [
 			'auth' => [$user, $password],
 		];
-		$client->send($client->createRequest('GET', $url, $options));
+		$client->send(new Request('GET', $url), $options);
 	}
 
 	/**
@@ -1043,9 +1044,7 @@ trait Provisioning {
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
 
-		$this->response = $client->send(
-			$client->createRequest("PUT", $fullUrl, $options)
-		);
+		$this->response = $client->send(new Request("PUT", $fullUrl), $options);
 	}
 
 	/**
@@ -1212,12 +1211,10 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
-		$options['body'] = [
-							'groupid' => $group
-							];
-		$this->response = $client->send(
-			$client->createRequest("POST", $fullUrl, $options)
-		);
+		$options['form_params'] = [
+			'groupid' => $group
+		];
+		$this->response = $client->send(new Request("POST", $fullUrl), $options);
 		PHPUnit_Framework_Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
@@ -1423,7 +1420,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theDisplayNameReturnedByTheApiShouldBe($displayname) {
-		$responseName = $this->response->xml()->data[0]->displayname;
+		$responseName = $this->getResponseXml()->data[0]->displayname;
 		PHPUnit_Framework_Assert::assertEquals($displayname, $responseName);
 	}
 
@@ -1435,7 +1432,8 @@ trait Provisioning {
 	 * @return array
 	 */
 	public function getArrayOfUsersResponded($resp) {
-		$listCheckedElements = $resp->xml()->data[0]->users[0]->element;
+		$listCheckedElements
+			= $this->getResponseXml($resp)->data[0]->users[0]->element;
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -1449,7 +1447,8 @@ trait Provisioning {
 	 * @return array
 	 */
 	public function getArrayOfGroupsResponded($resp) {
-		$listCheckedElements = $resp->xml()->data[0]->groups[0]->element;
+		$listCheckedElements
+			= $this->getResponseXml($resp)->data[0]->groups[0]->element;
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -1463,7 +1462,8 @@ trait Provisioning {
 	 * @return array
 	 */
 	public function getArrayOfAppsResponded($resp) {
-		$listCheckedElements = $resp->xml()->data[0]->apps[0]->element;
+		$listCheckedElements
+			= $this->getResponseXml($resp)->data[0]->apps[0]->element;
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -1477,7 +1477,8 @@ trait Provisioning {
 	 * @return array
 	 */
 	public function getArrayOfSubadminsResponded($resp) {
-		$listCheckedElements = $resp->xml()->data[0]->element;
+		$listCheckedElements
+			= $this->getResponseXml($resp)->data[0]->element;
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -1585,7 +1586,7 @@ trait Provisioning {
 
 		$this->response = $client->get($fullUrl, $options);
 		PHPUnit_Framework_Assert::assertEquals(
-			"false", $this->response->xml()->data[0]->enabled
+			"false", $this->getResponseXml()->data[0]->enabled
 		);
 	}
 
@@ -1605,7 +1606,7 @@ trait Provisioning {
 
 		$this->response = $client->get($fullUrl, $options);
 		PHPUnit_Framework_Assert::assertEquals(
-			"true", $this->response->xml()->data[0]->enabled
+			"true", $this->getResponseXml()->data[0]->enabled
 		);
 	}
 
@@ -1666,7 +1667,7 @@ trait Provisioning {
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
 		$this->response = $client->get($fullUrl, $options);
-		return $this->response->xml()->data[0]->home;
+		return $this->getResponseXml()->data[0]->home;
 	}
 
 	/**
@@ -1679,7 +1680,7 @@ trait Provisioning {
 	public function checkUserAttributes($body) {
 		$fd = $body->getRowsHash();
 		foreach ($fd as $field => $value) {
-			$data = $this->response->xml()->data[0];
+			$data = $this->getResponseXml()->data[0];
 			$field_array = \explode(' ', $field);
 			foreach ($field_array as $field_name) {
 				$data = $data->$field_name;
@@ -1714,7 +1715,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theApiShouldNotReturnAnyData() {
-		$responseData = $this->response->xml()->data[0];
+		$responseData = $this->getResponseXml()->data[0];
 		PHPUnit_Framework_Assert::assertEmpty(
 			$responseData,
 			"Response data is not empty but it should be empty"
@@ -1727,7 +1728,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theListOfUsersReturnedByTheApiShouldBeEmpty() {
-		$usersList = $this->response->xml()->data[0]->users[0];
+		$usersList = $this->getResponseXml()->data[0]->users[0];
 		PHPUnit_Framework_Assert::assertEmpty(
 			$usersList,
 			"Users list is not empty but it should be empty"
@@ -1740,7 +1741,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theListOfGroupsReturnedByTheApiShouldBeEmpty() {
-		$groupsList = $this->response->xml()->data[0]->groups[0];
+		$groupsList = $this->getResponseXml()->data[0]->groups[0];
 		PHPUnit_Framework_Assert::assertEmpty(
 			$groupsList,
 			"Groups list is not empty but it should be empty"

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -25,7 +25,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 require_once 'bootstrap.php';
 
@@ -117,7 +117,7 @@ class ShareesContext implements Context {
 	public function getArrayOfShareesResponded(
 		ResponseInterface $response, $shareeType
 	) {
-		$elements = $response->xml()->data;
+		$elements = $this->featureContext->getResponseXml($response)->data;
 		$elements = \json_decode(\json_encode($elements), 1);
 		if (\strpos($shareeType, 'exact ') === 0) {
 			$elements = $elements['exact'];

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -25,6 +25,7 @@ use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\FutureResponse;
 use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Stream\StreamInterface;
+use GuzzleHttp\Psr7\Request;
 use Sabre\DAV\Client as SClient;
 use Sabre\DAV\Xml\Property\ResourceType;
 use TestHelpers\WebDavHelper;
@@ -45,7 +46,8 @@ trait WebDav {
 	 */
 	private $usingOldDavPath = true;
 	/**
-	 * @var ResponseInterface[]
+	 * @var array ResponseInterface with keys 'response' and
+	 *                              'upload_type' string text describing the type of upload
 	 */
 	private $uploadResponses;
 	/**
@@ -373,12 +375,12 @@ trait WebDav {
 		$client = new GClient();
 		$options = [];
 		$options['auth'] = [$token, ""];
-		$options['headers']['X-Requested-With'] = 'XMLHttpRequest';
+		$headers['Range'] = $range;
+		$headers['X-Requested-With'] = 'XMLHttpRequest';
 
-		$request = $client->createRequest("GET", $fullUrl, $options);
-		$request->addHeader('Range', $range);
+		$request = new Request("GET", $fullUrl, $headers);
 
-		$this->response = $client->send($request);
+		$this->response = $client->send($request, $options);
 	}
 
 	/**
@@ -395,12 +397,12 @@ trait WebDav {
 		$client = new GClient();
 		$options = [];
 		$options['auth'] = [$token, ""];
-		$options['headers']['X-Requested-With'] = 'XMLHttpRequest';
+		$headers['Range'] = $range;
+		$headers['X-Requested-With'] = 'XMLHttpRequest';
 
-		$request = $client->createRequest("GET", $fullUrl, $options);
-		$request->addHeader('Range', $range);
+		$request = new Request("GET", $fullUrl, $headers);
 
-		$this->response = $client->send($request);
+		$this->response = $client->send($request, $options);
 	}
 
 	/**
@@ -418,14 +420,18 @@ trait WebDav {
 		$token = $this->lastShareData->data->token;
 		$fullUrl = $this->getBaseUrl() . "/public.php/webdav" . "$path";
 		$client = new GClient();
+
 		$options = [];
 		$options['auth'] = [$token, $password];
-		$options['headers']['X-Requested-With'] = 'XMLHttpRequest';
-		
-		$request = $client->createRequest("GET", $fullUrl, $options);
-		$request->addHeader('Range', $range);
-		
-		$this->response = $client->send($request);
+
+		$headers = [];
+		$headers['X-Requested-With'] = 'XMLHttpRequest';
+		$headers['Range'] = $range;
+
+		$this->response = $client->send(
+			new Request('GET', $fullUrl, $headers),
+			$options
+		);
 	}
 
 	/**
@@ -586,7 +592,20 @@ trait WebDav {
 			$headerName = $header[0];
 			$expectedHeaderValue = $header[1];
 			$returnedHeader = $this->response->getHeader($headerName);
-			if ($returnedHeader !== $expectedHeaderValue) {
+			if (\is_array($returnedHeader)) {
+				if (empty($returnedHeader)) {
+					throw new \Exception(
+						\sprintf(
+							"Missing expected header '%s'",
+							$headerName
+						)
+					);
+				}
+				$headerValue = $returnedHeader[0];
+			} else {
+				$headerValue = $returnedHeader;
+			}
+			if ($headerValue !== $expectedHeaderValue) {
 				throw new \Exception(
 					\sprintf(
 						"Expected value '%s' for header '%s', got '%s'",
@@ -1100,7 +1119,7 @@ trait WebDav {
 					</oc:filter-files>';
 
 		$response = $client->request(
-			'REPORT', $this->makeSabrePath($user, $path), $body
+			'REPORT', $this->makeSabrePath($user, $path), $body, []
 		);
 		$parsedResponse = $client->parseMultistatus($response['body']);
 		return $parsedResponse;
@@ -1124,7 +1143,7 @@ trait WebDav {
 							 </oc:filter-comments>';
 
 		$response = $client->request(
-			'REPORT', $this->makeSabrePathNotForFiles($path), $body
+			'REPORT', $this->makeSabrePathNotForFiles($path), $body, []
 		);
 
 		$parsedResponse = $client->parseMultistatus($response['body']);
@@ -1226,7 +1245,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function userUploadsAFileTo($user, $source, $destination) {
-		$file = \GuzzleHttp\Stream\Stream::factory(\fopen($source, 'r'));
+		$file = \fopen($source, 'r');
 		try {
 			$this->response = $this->makeDavRequest(
 				$user, "PUT", $destination, [], $file
@@ -1380,10 +1399,15 @@ trait WebDav {
 				$this->userUploadsAFileTo(
 					$user, $source, $destination . $suffix
 				);
-				$responses[] = $this->response;
+				$response = $this->response;
 			} catch (BadResponseException $e) {
-				$responses[] = $e->getResponse();
+				$response = $e->getResponse();
 			}
+
+			$responses[] = [
+				'response' => $response,
+				'upload_type' => $dav . ' regular'
+			];
 
 			// old chunking upload
 			if ($dav === 'old') {
@@ -1394,11 +1418,18 @@ trait WebDav {
 					$this->userUploadsAFileToWithChunks(
 						$user, $source, $destination . $suffix, 'old'
 					);
-					$responses[] = $this->response;
+					$response = $this->response;
 				} catch (BadResponseException $e) {
-					$responses[] = $e->getResponse();
+					$response = $e->getResponse();
 				}
+
+				$responses[] = [
+					'response' => $response,
+					'upload_type' => $dav . ' chunking'
+				];
 			}
+
+			// new chunking upload
 			if ($dav === 'new') {
 				if (!$overwriteMode) {
 					$suffix = '-' . $dav . 'dav-newchunking';
@@ -1407,10 +1438,15 @@ trait WebDav {
 					$this->userUploadsAFileToWithChunks(
 						$user, $source, $destination . $suffix, 'new'
 					);
-					$responses[] = $this->response;
+					$response = $this->response;
 				} catch (BadResponseException $e) {
-					$responses[] = $e->getResponse();
+					$response = $e->getResponse();
 				}
+
+				$responses[] = [
+					'response' => $response,
+					'upload_type' => $dav . ' chunking'
+				];
 			}
 		}
 
@@ -1428,8 +1464,8 @@ trait WebDav {
 		foreach ($this->uploadResponses as $response) {
 			PHPUnit_Framework_Assert::assertEquals(
 				$statusCode,
-				$response->getStatusCode(),
-				'Response for ' . $response->getEffectiveUrl() . ' did not return expected status code'
+				$response['response']->getStatusCode(),
+				'Response for dav upload ' . $response['upload_type'] . ' did not return expected status code'
 			);
 		}
 	}
@@ -1489,7 +1525,6 @@ trait WebDav {
 	public function userUploadsAFileWithContentTo(
 		$user, $content, $destination
 	) {
-		$file = \GuzzleHttp\Stream\Stream::factory($content);
 		try {
 			$time = \time();
 			if ($this->lastUploadTime !== null && $time - $this->lastUploadTime < 1) {
@@ -1498,7 +1533,7 @@ trait WebDav {
 				\sleep(1);
 			}
 			$this->response = $this->makeDavRequest(
-				$user, "PUT", $destination, [], $file
+				$user, "PUT", $destination, [], $content
 			);
 			$this->lastUploadTime = \time();
 			return $this->response->getHeader('oc-fileid');
@@ -1526,14 +1561,13 @@ trait WebDav {
 	public function userUploadsAFileWithChecksumAndContentTo(
 		$user, $checksum, $content, $destination
 	) {
-		$file = \GuzzleHttp\Stream\Stream::factory($content);
 		try {
 			$this->response = $this->makeDavRequest(
 				$user,
 				"PUT",
 				$destination,
 				['OC-Checksum' => $checksum],
-				$file
+				$content
 			);
 		} catch (BadResponseException $e) {
 			// 4xx and 5xx responses cause an exception
@@ -1700,7 +1734,6 @@ trait WebDav {
 	) {
 		try {
 			$num -= 1;
-			$data = \GuzzleHttp\Stream\Stream::factory($data);
 			$file = $destination . '-chunking-42-' . $total . '-' . $num;
 			$this->makeDavRequest(
 				$user, 'PUT', $file, ['OC-Chunked' => '1'], $data, "uploads"
@@ -1789,7 +1822,6 @@ trait WebDav {
 	 */
 	public function userUploadsNewChunkFileOfWithToId($user, $num, $data, $id) {
 		try {
-			$data = \GuzzleHttp\Stream\Stream::factory($data);
 			$destination = '/uploads/' . $user . '/' . $id . '/' . $num;
 			$this->makeDavRequest(
 				$user, 'PUT', $destination, [], $data, "uploads"

--- a/tests/lib/Files/Storage/DavTest.php
+++ b/tests/lib/Files/Storage/DavTest.php
@@ -104,7 +104,7 @@ class DavTest extends TestCase {
 		$this->davClient = $this->createMock(Client::class);
 		$this->webDavClientService->method('newClient')->willReturn($this->davClient);
 
-		$this->instance = $this->getMockBuilder(\OC\Files\Storage\DAV::class)
+		$this->instance = $this->getMockBuilder(DAV::class)
 			->setConstructorArgs([[
 				'user' => 'davuser',
 				'password' => 'davpassword',
@@ -154,7 +154,7 @@ class DavTest extends TestCase {
 			])
 			->willReturn($this->davClient);
 
-		$this->instance = new \OC\Files\Storage\DAV([
+		$this->instance = new DAV([
 			'user' => 'davuser',
 			'password' => 'davpassword',
 			'host' => 'davhost',
@@ -190,7 +190,7 @@ class DavTest extends TestCase {
 	 * @expectedException \InvalidArgumentException
 	 */
 	public function testInstantiateWebDavClientInvalidConfig($params) {
-		new \OC\Files\Storage\DAV($params);
+		new DAV($params);
 	}
 
 	private function createClientHttpException($statusCode) {
@@ -224,7 +224,7 @@ class DavTest extends TestCase {
 		];
 
 		$testCases = [
-			[new \Sabre\DAV\Exception\Forbidden('Forbidden'), \Sabre\DAV\Exception\Forbidden::class],
+			[new Forbidden('Forbidden'), Forbidden::class],
 			[new \InvalidArgumentException(), StorageNotAvailableException::class],
 			[new StorageNotAvailableException(), StorageNotAvailableException::class],
 			[new StorageInvalidException(), StorageInvalidException::class],

--- a/tests/lib/Files/Storage/DavTest.php
+++ b/tests/lib/Files/Storage/DavTest.php
@@ -34,6 +34,8 @@ use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IWebDavClientService;
 use OCP\Lock\LockedException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Sabre\DAV\Client;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\InsufficientStorage;
@@ -199,15 +201,15 @@ class DavTest extends TestCase {
 	}
 
 	private function createGuzzleClientException($statusCode) {
-		$request = $this->createMock(\GuzzleHttp\Message\RequestInterface::class);
-		$response = $this->createMock(\GuzzleHttp\Message\ResponseInterface::class);
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
 		$response->method('getStatusCode')->willReturn($statusCode);
 		return new ClientException('ClientException', $request, $response);
 	}
 
 	private function createGuzzleServerException($statusCode) {
-		$request = $this->createMock(\GuzzleHttp\Message\RequestInterface::class);
-		$response = $this->createMock(\GuzzleHttp\Message\ResponseInterface::class);
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
 		$response->method('getStatusCode')->willReturn($statusCode);
 		return new ServerException('ServerException', $request, $response);
 	}
@@ -239,7 +241,7 @@ class DavTest extends TestCase {
 		$testCases[] = [
 			new ServerException(
 				'ServerException with no response',
-				$this->createMock(\GuzzleHttp\Message\RequestInterface::class),
+				$this->createMock(RequestInterface::class),
 				null
 			),
 			StorageNotAvailableException::class
@@ -517,7 +519,7 @@ class DavTest extends TestCase {
 	}
 
 	public function testFopenRead() {
-		$response = $this->createMock(\GuzzleHttp\Message\ResponseInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
 		$response->method('getStatusCode')->willReturn(Http::STATUS_OK);
 		$response->method('getBody')->willReturn(\fopen('data://text/plain,response body', 'r'));
 
@@ -573,7 +575,7 @@ class DavTest extends TestCase {
 	 * @expectedException \OCP\Lock\LockedException
 	 */
 	public function testFopenReadLockedException() {
-		$response = $this->createMock(\GuzzleHttp\Message\ResponseInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
 		$response->method('getStatusCode')->willReturn(Http::STATUS_LOCKED);
 		$response->method('getBody')->willReturn(\fopen('data://text/plain,response body', 'r'));
 

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -10,6 +10,7 @@ namespace Test\Http\Client;
 
 use GuzzleHttp\Client as GuzzleClient;
 use OC\Http\Client\Client;
+use OCP\ICertificateManager;
 use OCP\IConfig;
 use Psr\Http\Message\ResponseInterface;
 
@@ -28,15 +29,15 @@ class ClientTest extends \Test\TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->config = $this->createMock('\OCP\IConfig');
-		$this->response = $this->createMock('\Psr\Http\Message\ResponseInterface');
+		$this->config = $this->createMock(IConfig::class);
+		$this->response = $this->createMock(ResponseInterface::class);
 		$this->response->method('getStatusCode')
 			->willReturn(1337);
-		$this->guzzleClient = $this->getMockBuilder('\GuzzleHttp\Client')
+		$this->guzzleClient = $this->getMockBuilder(GuzzleClient::class)
 			->disableOriginalConstructor()
 			->setMethods(['get', 'post', 'put', 'delete', 'options'])
 			->getMock();
-		$certificateManager = $this->createMock('\OCP\ICertificateManager');
+		$certificateManager = $this->createMock(ICertificateManager::class);
 		$this->client = new Client(
 			$this->config,
 			$certificateManager,

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -8,15 +8,18 @@
 
 namespace Test\Http\Client;
 
-use GuzzleHttp\Message\Response;
+use GuzzleHttp\Client as GuzzleClient;
 use OC\Http\Client\Client;
 use OCP\IConfig;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Class ClientTest
  */
 class ClientTest extends \Test\TestCase {
-	/** @var \GuzzleHttp\Client */
+	/** @var ResponseInterface */
+	private $response;
+	/** @var GuzzleClient */
 	private $guzzleClient;
 	/** @var Client */
 	private $client;
@@ -26,8 +29,12 @@ class ClientTest extends \Test\TestCase {
 	public function setUp() {
 		parent::setUp();
 		$this->config = $this->createMock('\OCP\IConfig');
+		$this->response = $this->createMock('\Psr\Http\Message\ResponseInterface');
+		$this->response->method('getStatusCode')
+			->willReturn(1337);
 		$this->guzzleClient = $this->getMockBuilder('\GuzzleHttp\Client')
 			->disableOriginalConstructor()
+			->setMethods(['get', 'post', 'put', 'delete', 'options'])
 			->getMock();
 		$certificateManager = $this->createMock('\OCP\ICertificateManager');
 		$this->client = new Client(
@@ -81,31 +88,31 @@ class ClientTest extends \Test\TestCase {
 
 	public function testGet() {
 		$this->guzzleClient->method('get')
-			->willReturn(new Response(1337));
+			->willReturn($this->response);
 		$this->assertEquals(1337, $this->client->get('http://localhost/', [])->getStatusCode());
 	}
 
 	public function testPost() {
 		$this->guzzleClient->method('post')
-			->willReturn(new Response(1337));
+			->willReturn($this->response);
 		$this->assertEquals(1337, $this->client->post('http://localhost/', [])->getStatusCode());
 	}
 
 	public function testPut() {
 		$this->guzzleClient->method('put')
-			->willReturn(new Response(1337));
+			->willReturn($this->response);
 		$this->assertEquals(1337, $this->client->put('http://localhost/', [])->getStatusCode());
 	}
 
 	public function testDelete() {
 		$this->guzzleClient->method('delete')
-			->willReturn(new Response(1337));
+			->willReturn($this->response);
 		$this->assertEquals(1337, $this->client->delete('http://localhost/', [])->getStatusCode());
 	}
 
 	public function testOptions() {
 		$this->guzzleClient->method('options')
-			->willReturn(new Response(1337));
+			->willReturn($this->response);
 		$this->assertEquals(1337, $this->client->options('http://localhost/', [])->getStatusCode());
 	}
 }

--- a/tests/lib/Http/Client/ResponseTest.php
+++ b/tests/lib/Http/Client/ResponseTest.php
@@ -8,8 +8,8 @@
 
 namespace Test\Http\Client;
 
-use GuzzleHttp\Message\Response as GuzzleResponse;
 use OC\Http\Client\Response;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Class ResponseTest
@@ -17,21 +17,27 @@ use OC\Http\Client\Response;
 class ResponseTest extends \Test\TestCase {
 	/** @var Response */
 	private $response;
-	/** @var GuzzleResponse */
+	/** @var ResponseInterface */
 	private $guzzleResponse;
 
 	public function setUp() {
 		parent::setUp();
-		$this->guzzleResponse = new GuzzleResponse(1337);
+		$this->guzzleResponse = $this->createMock(ResponseInterface::class);
 		$this->response = new Response($this->guzzleResponse);
 	}
 
 	public function testGetStatusCode() {
+		$this->guzzleResponse->expects($this->once())
+			->method('getStatusCode')
+			->willReturn(1337);
 		$this->assertEquals(1337, $this->response->getStatusCode());
 	}
 
 	public function testGetHeader() {
-		$this->guzzleResponse->setHeader('bar', 'foo');
+		$this->guzzleResponse->expects($this->once())
+			->method('getHeader')
+			->with('bar')
+			->willReturn('foo');
 		$this->assertEquals('foo', $this->response->getHeader('bar'));
 	}
 }


### PR DESCRIPTION
## Description
Update Guzzle to 6.3, and also other libraries (deleted and regenerated composer.lock)

## Related Issue

## Motivation and Context
Guzzle 5.3 is outdated, needs update.
Also some libs used by apps will need Guzzle > 6.

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

This is a newer version of #29211 made by cherry-pick and reorganize of the commits from there, to massage it all into these "logical" commits.