### PR TITLE
Fix translations in app-themes

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -580,6 +580,7 @@ class OC {
 		\OC::$server->getEventLogger()->start('init_session', 'Initialize session');
 		OC_App::loadApps(['session']);
 		if (!self::$CLI) {
+			\OC_App::loadApps(['theme']);
 			self::initSession();
 		}
 		\OC::$server->getEventLogger()->end('init_session');

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -27,6 +27,7 @@
 
 namespace OC\L10N;
 
+use OC\Theme\Theme;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -295,12 +296,24 @@ class Factory implements IFactory {
 			$languageFiles[] = $transFile;
 		}
 
-		// merge with translations from theme
+		// merge with translations from themes
+		$relativePath = substr($transFile, strlen($this->serverRoot));
+
+		// legacy themes
 		$theme = $this->config->getSystemValue('theme');
 		if (!empty($theme)) {
-			$transFile = $this->serverRoot . '/themes/' . $theme . substr($transFile, strlen($this->serverRoot));
-			if (file_exists($transFile)) {
-				$languageFiles[] = $transFile;
+			$legacyThemeTransFile = $this->serverRoot . '/themes/' . $theme . $relativePath;
+			if (file_exists($legacyThemeTransFile)) {
+				$languageFiles[] = $legacyThemeTransFile;
+			}
+		}
+
+		// merge translations from app-themes
+		$theme = \OC::$server->getThemeService()->getTheme();
+		if ($theme instanceof Theme && $theme->getDirectory() !== '' ) {
+			$themeTransFile = $this->serverRoot . '/' . $theme->getDirectory() . $relativePath;
+			if (file_exists($themeTransFile)) {
+				$languageFiles[] = $themeTransFile;
 			}
 		}
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -368,6 +368,7 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			return new \OC\L10N\Factory(
 				$c->getConfig(),
 				$c->getRequest(),
+				$c->getThemeService(),
 				$c->getUserSession(),
 				\OC::$SERVERROOT
 			);

--- a/tests/data/apptheme/apps/files/l10n/zz.json
+++ b/tests/data/apptheme/apps/files/l10n/zz.json
@@ -1,0 +1,4 @@
+{ "translations": {
+  "Menu" : "Dish"
+},"pluralForm" :"nplurals=2; plural=(n != 1);"
+}

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -9,6 +9,7 @@
 namespace Test\L10N;
 
 use OC\L10N\Factory;
+use OCP\Theme\IThemeService;
 use Test\TestCase;
 
 /**
@@ -28,6 +29,9 @@ class FactoryTest extends TestCase {
 	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
 	protected $userSession;
 
+	/** @var IThemeService|\PHPUnit_Framework_MockObject_MockObject */
+	protected $themeService;
+
 	/** @var string */
 	protected $serverRoot;
 
@@ -41,6 +45,11 @@ class FactoryTest extends TestCase {
 
 		/** @var \OCP\IRequest $request */
 		$this->request = $this->getMockBuilder('OCP\IRequest')
+			->disableOriginalConstructor()
+			->getMock();
+
+		/** @var IThemeService $themeService */
+		$this->themeService = $this->getMockBuilder(IThemeService::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -59,13 +68,14 @@ class FactoryTest extends TestCase {
 				->setConstructorArgs([
 					$this->config,
 					$this->request,
+					$this->themeService,
 					$this->userSession,
 					$this->serverRoot,
 				])
 				->setMethods($methods)
 				->getMock();
 		} else {
-			return new Factory($this->config, $this->request, $this->userSession, $this->serverRoot);
+			return new Factory($this->config, $this->request, $this->themeService, $this->userSession, $this->serverRoot);
 		}
 	}
 
@@ -309,6 +319,47 @@ class FactoryTest extends TestCase {
 			->willReturn('abc');
 
 		$this->assertEquals(['en', 'zz'], $factory->findAvailableLanguages($app), '', 0.0, 10, true);
+	}
+
+	public function testFindAvailableLanguagesWithAppThemes() {
+		$app = 'files';
+		$factory = $this->getFactory(['getActiveAppThemeDirectory']);
+
+		$this->config
+			->expects($this->any())
+			->method('getSystemValue')
+			->with('theme')
+			->willReturn('');
+
+		$factory->expects($this->any())
+			->method('getActiveAppThemeDirectory')
+			->with()
+			->willReturn('tests/data/apptheme');
+
+		$availableLanguages = $factory->findAvailableLanguages($app);
+		$this->assertContains('en', $availableLanguages);
+		$this->assertContains('zz', $availableLanguages);
+	}
+
+	public function testAppThemeTranslation() {
+		$app = 'files';
+		$lang = 'zz';
+		$factory = $this->getFactory(['getActiveAppThemeDirectory']);
+
+		$this->config
+			->expects($this->any())
+			->method('getSystemValue')
+			->with('theme')
+			->willReturn('');
+
+		$factory->expects($this->any())
+			->method('getActiveAppThemeDirectory')
+			->with()
+			->willReturn('tests/data/apptheme');
+
+		$themeTranslations = $factory->getL10nFilesForApp($app, $lang);
+		$this->assertCount(1, $themeTranslations);
+		$this->assertContains('zz.json', $themeTranslations[0]);
 	}
 
 	/**

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -13,6 +13,7 @@ use DateTime;
 use OC\L10N\Factory;
 use OC\L10N\L10N;
 use OCP\IUserSession;
+use OCP\Theme\IThemeService;
 use Test\TestCase;
 
 /**
@@ -29,9 +30,13 @@ class L10nTest extends TestCase {
 		$config = $this->createMock('OCP\IConfig');
 		/** @var \OCP\IRequest $request */
 		$request = $this->createMock('OCP\IRequest');
+		/** @var IThemeService $themeService */
+		$themeService = $this->getMockBuilder(IThemeService::class)
+			->disableOriginalConstructor()
+			->getMock();
 		/** @var IUserSession $userSession */
 		$userSession = $this->createMock('OCP\IUserSession');
-		return new Factory($config, $request, $userSession, \OC::$SERVERROOT);
+		return new Factory($config, $request, $themeService, $userSession, \OC::$SERVERROOT);
 	}
 
 	public function testGermanPluralTranslations() {


### PR DESCRIPTION
## Related Issue
https://github.com/owncloud/core/issues/28167

## Motivation and Context
Fixes custom translations inside app-themes.

## How Has This Been Tested?
1. Activate app-theme. e.g. theme-example
2. Switch to British English
3. `mkdir -p apps/theme-example/core/l10n`
4. `cp core/l10n/en_GB.json apps/theme-example/core/l10n/en_GB.json`
5. Change 
`    "Log out" : "Log out",`
to
`    "Log out" : "Go away!",`

### Expected 
Log out is renamed in menu

### Actual 
it is not

#### Tested as a guest 
Please note that guest user uses a language based on browser locale settings. 
You'll need to override another file (es.json, de.json, whatever...) instead of en_GB.json if your browser is not in en_GB
- [x]     "File not found" changed to "File not found and never will be"
Accessing an unexisting share - translation works
- [x]     "Password" changed to "Password 123"
Accessing a login page - translation works

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
