### PR TITLE
make it possible to use the --remote option without additional argument

### DIFF
--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -70,7 +70,7 @@ fi
 BEHAT_TAGS_OPTION_FOUND=false
 REMOTE_ONLY=false
 
-while [[ $# -gt 1 ]]
+while [[ $# -gt 0 ]]
 do
 	key="$1"
 	case $key in
@@ -93,7 +93,6 @@ do
 			;;
 		--remote)
 			REMOTE_ONLY=true
-			shift
 			;;
 		*)
 			# ignore unknown options


### PR DESCRIPTION
## Description
the `--remote` option needed an additional argument e.g. `true` to become effective, with this change it can be used by its own.

## Motivation and Context
make the command line shorter

## How Has This Been Tested?
run UI tests locally
make travis run all UI tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

