### PR TITLE
additional skeleton directory setting for UI tests

### DIFF
--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -238,9 +238,15 @@ EXTRA_CAPABILITIES=$EXTRA_CAPABILITIES'"maxDuration":"3600"'
 remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings config:system:get skeletondirectory"
 
 PREVIOUS_SKELETON_DIR=$REMOTE_OCC_STDOUT
+
+#$SRC_SKELETON_DIR is the path to the skeleton folder on the machine where the tests are executed
+#it is used for file comparisons in various tests
+export SRC_SKELETON_DIR=$(pwd)/tests/ui/skeleton
+#$SKELETON_DIR is the path to the skeleton folder on the machine where oC runs (system under test)
+#it is used to give users a defined set of files and folders for the tests
 if [ -z "$SKELETON_DIR" ]
 then
-	export SKELETON_DIR=$(pwd)/tests/ui/skeleton
+	export SKELETON_DIR="$SRC_SKELETON_DIR"
 fi
 
 remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set skeletondirectory --value=$SKELETON_DIR"

--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -788,7 +788,7 @@ class FilesContext extends RawMinkContext implements Context {
 		// The capturing group of the regex always includes the quotes at each
 		// end of the captured string, so trim them.
 		$remoteFile = $this->currentFolder . "/" . trim($remoteFile, $remoteFile[0]);
-		$originalFile = getenv("SKELETON_DIR") . "/" . trim($originalFile, $originalFile[0]);
+		$originalFile = getenv("SRC_SKELETON_DIR") . "/" . trim($originalFile, $originalFile[0]);
 		$shouldBeSame = ($shouldOrNot !== "not");
 		$this->assertContentOfRemoteAndLocalFileIsSame($remoteFile, $originalFile, $shouldBeSame);
 	}
@@ -826,7 +826,7 @@ class FilesContext extends RawMinkContext implements Context {
 		} else {
 			$subFolderPath = "";
 		}
-		$localFile = getenv("SKELETON_DIR") . "/" . $subFolderPath . $fileName;
+		$localFile = getenv("SRC_SKELETON_DIR") . "/" . $subFolderPath . $fileName;
 		$this->assertContentOfRemoteAndLocalFileIsSame($remoteFile, $localFile);
 	}
 


### PR DESCRIPTION
## Description
This change makes it possible to have different paths to the skeleton directory on the SUT and the machine where the tests are executed

## Motivation and Context
The main goal is to make it possible to run UI tests against a remote instance, e.g. inside docker. In that case the test executing machine is different to the SUT but both need to have access to their own copy of the skeleton directory. The SUT to give new users the correct files and the test-executor to check the content of uploaded/modified files
See also owncloud/qa-enterprise#115

## How Has This Been Tested?
run tests locally, travis will run them again

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

