### PR TITLE
[stable10] make it possible to use the --remote option without additional argument

### DIFF
--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -70,7 +70,7 @@ fi
 BEHAT_TAGS_OPTION_FOUND=false
 REMOTE_ONLY=false
 
-while [[ $# -gt 1 ]]
+while [[ $# -gt 0 ]]
 do
 	key="$1"
 	case $key in
@@ -93,7 +93,6 @@ do
 			;;
 		--remote)
 			REMOTE_ONLY=true
-			shift
 			;;
 		*)
 			# ignore unknown options


### PR DESCRIPTION
backport of #29776 to stable10