### PR TITLE
disable firstrunwizard and notifications apps for UI tests

### DIFF
--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -139,6 +139,29 @@ else
 	TESTING_ENABLED_BY_SCRIPT=false;
 fi
 
+#disable firstrunwizard and notifications apps
+remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:list ^firstrunwizard$"
+PREVIOUS_FIRSTRUNWIZARD_APP_STATUS=$REMOTE_OCC_STDOUT
+
+if [[ "$PREVIOUS_FIRSTRUNWIZARD_APP_STATUS" =~ ^Enabled: ]]
+then
+	FIRSTRUNWIZARD_APP_DISABLED_BY_SCRIPT=true;
+	remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:disable firstrunwizard"
+else
+	FIRSTRUNWIZARD_APP_DISABLED_BY_SCRIPT=false;
+fi
+
+remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:list ^notifications$"
+PREVIOUS_NOTIFICATIONS_APP_STATUS=$REMOTE_OCC_STDOUT
+
+if [[ "$PREVIOUS_NOTIFICATIONS_APP_STATUS" =~ ^Enabled: ]]
+then
+	NOTIFICATIONS_APP_DISABLED_BY_SCRIPT=true;
+	remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:disable notifications"
+else
+	NOTIFICATIONS_APP_DISABLED_BY_SCRIPT=false;
+fi
+
 #we need to skip some tests in certain browsers
 #and also skip tests if tags were given in the call of this script
 if [ "$BROWSER" == "internet explorer" ] || [ "$BROWSER" == "MicrosoftEdge" ] || ([ "$BROWSER" == "firefox" ] && verlt "47.0" "$BROWSER_VERSION")
@@ -335,6 +358,15 @@ fi
 # Put back state of the testing app
 if test "$TESTING_ENABLED_BY_SCRIPT" = true; then
 	$OCC app:disable testing
+fi
+
+# Put back state of the firstrunwizard and notifications app
+if test "$FIRSTRUNWIZARD_APP_DISABLED_BY_SCRIPT" = true; then
+	remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:enable firstrunwizard"
+fi
+
+if test "$NOTIFICATIONS_APP_DISABLED_BY_SCRIPT" = true; then
+	remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:enable notifications"
 fi
 
 #upload log file for later analysis


### PR DESCRIPTION
## Description
Disable the two apps for UI test runs

## Motivation and Context
currently we are not testing those apps and there hasn't been any problem so far because they live in separate repos from core. But when we try to run tests against finished builds, we find 'firstrunwizard' and 'notifications' enabled. Both apps change the 'workflow' of the WebUI, but we would like to user the same core tests when testing a git clone and a tarball. So better disable them before running tests.

## How Has This Been Tested?
run tests inside drone

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

