### PR TITLE
Add further function docblock comments in build/license.php

### DIFF
--- a/build/license.php
+++ b/build/license.php
@@ -111,6 +111,12 @@ With help from many libraries and frameworks including:
 		file_put_contents(__DIR__.'/../AUTHORS', $template);
 	}
 
+	/**
+	 * Update the license file
+	 *
+	 * @param string $path
+	 * @param string|bool $gitRoot
+	 */
 	function handleFile($path, $gitRoot) {
 		$source = file_get_contents($path);
 		if ($this->isMITLicensed($source)) {
@@ -177,6 +183,13 @@ With help from many libraries and frameworks including:
 		return implode(PHP_EOL, $lines);
 	}
 
+	/**
+	 * Retrieve a list of code contributors
+	 *
+	 * @param string $file
+	 * @param string|bool $gitRoot
+	 * @return string
+	 */
 	private function getAuthors($file, $gitRoot) {
 		// only add authors that changed code and not the license header
 		$licenseHeaderEndsAtLine = trim(shell_exec("grep -n '*/' $file | head -n 1 | cut -d ':' -f 1"));


### PR DESCRIPTION
This PR adds function-level docblock comments to `handleFile` and `getAuthors` in `build/license.php`.