### PR TITLE
Fix potential security hole in license.php

### DIFF
--- a/build/license.php
+++ b/build/license.php
@@ -192,13 +192,20 @@ With help from many libraries and frameworks including:
 	 */
 	private function getAuthors($file, $gitRoot) {
 		// only add authors that changed code and not the license header
-		$licenseHeaderEndsAtLine = trim(shell_exec("grep -n '*/' $file | head -n 1 | cut -d ':' -f 1"));
+		$licenseHeaderEndsAtLine = trim(shell_exec(sprintf("grep -n '*/' %s | head -n 1 | cut -d ':' -f 1", escapeshellarg($file))));
+
 		$buildDir = getcwd();
 		if ($gitRoot) {
 			chdir($gitRoot);
 			$file = substr($file, strlen($gitRoot));
 		}
-		$out = shell_exec("git blame --line-porcelain -L $licenseHeaderEndsAtLine, $file | sed -n 's/^author //p;s/^author-mail //p' | sed 'N;s/\\n/ /' | sort -f | uniq");
+
+		$out = shell_exec(
+			sprintf("git blame --line-porcelain -L %d, %s | sed -n 's/^author //p;s/^author-mail //p' | sed 'N;s/\\n/ /' | sort -f | uniq"),
+			(int)$licenseHeaderEndsAtLine,
+			escapeshellarg($file)
+		);
+
 		if ($gitRoot) {
 			chdir($buildDir);
 		}


### PR DESCRIPTION
This PR sanitizes the arguments passed to `shell_exec` in `build/license.php`, which could potentially result in a remote code execution vulnerability, as the calls to `shell_exec` receive an unfiltered file path. This was raised in http://bit.ly/2AD9bhK. I've implemented the suggested fixes slightly changed for further sanity.

Also, would it be better to implement the scripts on https://github.com/owncloud/core/blob/fix-security-bug-in-license.php/build/license.php#L182 and https://github.com/owncloud/core/blob/fix-security-bug-in-license.php/build/license.php#L191 as bash and batch files?