### PR TITLE
Exclude DAV CORS handling for non-browsers

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CorsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CorsPlugin.php
@@ -49,6 +49,7 @@ class CorsPlugin extends \Sabre\DAV\ServerPlugin {
 	public function __construct(\OCP\IUserSession $userSession) {
 		$this->userSession = $userSession;
 		$this->extraHeaders['Access-Control-Allow-Headers'] = ["X-OC-Mtime", "OC-Checksum", "OC-Total-Length", "Depth", "Destination", "Overwrite"];
+		// TODO: use $this->server->getAllowedMethods($request->getPath()) in the right location
 		$this->extraHeaders['Access-Control-Allow-Methods'] = ["MOVE", "COPY"];
 	}
 
@@ -65,6 +66,11 @@ class CorsPlugin extends \Sabre\DAV\ServerPlugin {
 	 */
 	public function initialize(\Sabre\DAV\Server $server) {
 		$this->server = $server;
+
+		$request = $this->server->httpRequest;
+		if (!$request->hasHeader('Origin') || \OCP\Util::isSameDomain($request->getHeader('Origin'), $request->getAbsoluteUrl())) {
+			return false;
+		}
 
 		$this->server->on('beforeMethod', [$this, 'setCorsHeaders']);
 		$this->server->on('beforeMethod:OPTIONS', [$this, 'setOptionsRequestHeaders']);

--- a/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\Tests\unit\Connector\Sabre;
+
+use OCP\IUserSession;
+use OCP\IUser;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\HTTP\Sapi;
+use OCP\IConfig;
+
+class CorsPluginTest extends \Test\TestCase {
+
+	/**
+	 * @var \Sabre\DAV\Server
+	 */
+	private $server;
+
+	/**
+	 * @var \OCA\DAV\Connector\Sabre\CorsPlugin
+	 */
+	private $plugin;
+
+	/**
+	 * @var IUserSession | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $userSession;
+
+	/**
+	 * @var IConfig | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $config;
+
+	public function setUp() {
+		parent::setUp();
+		$this->server = new \Sabre\DAV\Server();
+
+		$this->server->sapi = $this->getMockBuilder(\stdclass::class)
+			->setMethods(['sendResponse'])
+			->getMock();
+		$this->server->sapi->expects($this->once())->method('sendResponse')->with($this->server->httpResponse);
+
+		$this->server->httpRequest->setMethod('OPTIONS');
+
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->overwriteService('AllConfig', $this->config);
+
+		$this->plugin = new \OCA\DAV\Connector\Sabre\CorsPlugin($this->userSession);
+	}
+
+	public function tearDown() {
+		$this->restoreService('AllConfig');
+	}
+
+	public function optionsCases() {
+		$allowedDomains = '["https://requesterdomain.tld", "http://anotherdomain.tld"]';
+
+		$allowedHeaders = [
+			'authorization',
+			'OCS-APIREQUEST',
+			'Origin',
+			'X-Requested-With',
+			'Content-Type',
+			'Access-Control-Allow-Origin',
+			'X-OC-Mtime',
+			'OC-Checksum',
+			'OC-Total-Length',
+			'Depth',
+			'Destination',
+			'Overwrite',
+		];
+		$allowedMethods = [
+			'GET',
+			'OPTIONS',
+			'POST',
+			'PUT',
+			'DELETE',
+			'MKCOL',
+			'PROPFIND',
+			'PATCH',
+			'PROPPATCH',
+			'REPORT',
+			'MOVE',
+			'COPY',
+		];
+
+		return [
+			// OPTIONS headers
+			[
+				$allowedDomains,
+				false,
+				[
+					'Origin' => 'https://requesterdomain.tld',
+				],
+				200,
+				[
+					'Access-Control-Allow-Headers' => implode(',', $allowedHeaders),
+					'Access-Control-Allow-Origin' => '*',
+					'Access-Control-Allow-Methods' => implode(',', $allowedMethods),
+				],
+				false
+			],
+			// OPTIONS headers with user
+			[
+				$allowedDomains,
+				true,
+				[
+					'Origin' => 'https://requesterdomain.tld',
+					'Authorization' => 'abc',
+				],
+				200,
+				[
+					'Access-Control-Allow-Headers' => implode(',', $allowedHeaders),
+					'Access-Control-Allow-Origin' => 'https://requesterdomain.tld',
+					'Access-Control-Allow-Methods' => implode(',', $allowedMethods),
+				],
+				true
+			],
+			// OPTIONS headers no user
+			[
+				$allowedDomains,
+				false,
+				[
+					'Origin' => 'https://requesterdomain.tld',
+					'Authorization' => 'abc',
+				],
+				200,
+				[
+					'Access-Control-Allow-Headers' => null,
+					'Access-Control-Allow-Origin' => null,
+					'Access-Control-Allow-Methods' => null,
+				],
+				true
+			],
+			// OPTIONS headers domain not allowed
+			[
+				'[]',
+				true,
+				[
+					'Origin' => 'https://requesterdomain.tld',
+					'Authorization' => 'abc',
+				],
+				200,
+				[
+					'Access-Control-Allow-Headers' => null,
+					'Access-Control-Allow-Origin' => null,
+					'Access-Control-Allow-Methods' => null,
+				],
+				true
+			],
+			// OPTIONS headers not allowed but no cross-domain
+			[
+				'[]',
+				true,
+				[
+					'Origin' => 'https://requesterdomain.tld',
+					'Authorization' => 'abc',
+				],
+				200,
+				[
+					'Access-Control-Allow-Headers' => null,
+					'Access-Control-Allow-Origin' => null,
+					'Access-Control-Allow-Methods' => null,
+				],
+				true
+			],
+			// OPTIONS headers allowed but no cross-domain
+			[
+				'["currentdomain.tld:8080"]',
+				true,
+				[
+					'Origin' => 'https://currentdomain.tld:8080',
+					'Authorization' => 'abc',
+				],
+				200,
+				[
+					'Access-Control-Allow-Headers' => null,
+					'Access-Control-Allow-Origin' => null,
+					'Access-Control-Allow-Methods' => null,
+				],
+				true
+			],
+			// OPTIONS headers allowed, cross-domain through different port
+			[
+				'["https://currentdomain.tld:8443"]',
+				true,
+				[
+					'Origin' => 'https://currentdomain.tld:8443',
+					'Authorization' => 'abc',
+				],
+				200,
+				[
+					'Access-Control-Allow-Headers' => implode(',', $allowedHeaders),
+					'Access-Control-Allow-Origin' => 'https://currentdomain.tld:8443',
+					'Access-Control-Allow-Methods' => implode(',', $allowedMethods),
+				],
+				true
+			],
+			// no Origin header
+			[
+				$allowedDomains,
+				true,
+				[
+				],
+				200,
+				[
+					'Access-Control-Allow-Headers' => null,
+					'Access-Control-Allow-Origin' => null,
+					'Access-Control-Allow-Methods' => null,
+				],
+				true
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider optionsCases
+	 */
+	public function testOptionsHeaders($allowedDomains, $hasUser, $requestHeaders, $expectedStatus, $expectedHeaders, $expectDavHeaders = false) {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('someuser');
+
+		if ($hasUser) {
+			$this->userSession->method('getUser')->willReturn($user);
+		} else {
+			$this->userSession->method('getUser')->willReturn(null);
+		}
+
+		$this->config->method('getUserValue')
+			->with('someuser', 'core', 'domains')
+			->willReturn($allowedDomains);
+
+		$this->server->httpRequest->setHeaders($requestHeaders);
+		$this->server->httpRequest->setAbsoluteUrl('https://currentdomain.tld:8080/owncloud/remote.php/dav/files/user1/target/path');
+		$this->server->httpRequest->setUrl('/owncloud/remote.php/dav/files/user1/target/path');
+
+		$this->server->addPlugin($this->plugin);
+		$this->server->exec();
+
+		$this->assertEquals($expectedStatus, $this->server->httpResponse->getStatus());
+
+		foreach ($expectedHeaders as $headerKey => $headerValue) {
+			if ($headerValue !== null) {
+				$this->assertTrue($this->server->httpResponse->hasHeader($headerKey), "Response header \"$headerKey\" exists");
+			} else {
+				$this->assertFalse($this->server->httpResponse->hasHeader($headerKey), "Response header \"$headerKey\" does not exist");
+			}
+			$this->assertEquals($headerValue, $this->server->httpResponse->getHeader($headerKey));
+		}
+
+		// if it has DAV headers, it means we did not bypass further processing
+		$this->assertEquals($expectDavHeaders, $this->server->httpResponse->hasHeader('DAV'));
+	}
+
+}

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -749,4 +749,60 @@ class Util {
 
 		return $values;
 	}
+
+	/**
+	 * Returns the protocol, domain and port as string in a normalized
+	 * format for easier comparison.
+	 * Example: "HTTPS://HOST.tld:8080" is returned as "https://host.tld:8080"
+	 *
+	 * If no port was specified, it will add the default port
+	 * of the specified protocol (80 for http or 443 for https)
+	 *
+	 * @param string $url full url
+	 * @return string protocol, domain and port as string
+	 * @since 10.0.5
+	 */
+	public static function getFullDomain($url) {
+		$parts = parse_url($url);
+		if ($parts === false) {
+			throw new \InvalidArgumentException('Invalid url "' . $url . '"');
+		}
+		if (!isset($parts['scheme']) || !isset($parts['host'])) {
+			throw new \InvalidArgumentException('Invalid url "' . $url . '"');
+		}
+		$protocol = strtolower($parts['scheme']);
+		$host = strtolower($parts['host']);
+		$port = null;
+		if ($protocol === 'http') {
+			$port = 80;
+		} else if ($protocol === 'https') {
+			$port = 443;
+		} else {
+			throw new \InvalidArgumentException('Only http based URLs supported');
+		}
+
+		if (isset($parts['port']) && $port !== '') {
+			$port = $parts['port'];
+		}
+
+		return $protocol . '://' . strtolower($host) . ':' . $port;
+	}
+
+	/**
+	 * Check whether the given URLs have the same protocol, domain and port.
+	 * This is useful to check a browser's cross-domain situation.
+	 * If this method returns false, a browser would consider both URLs to be
+	 * a cross-domain situation and would require a CORS setup.
+	 *
+	 * @param string $url1
+	 * @param string $url2
+	 *
+	 * @return bool true if both URLs have the same protocol, domain and port
+	 *
+	 * @since 10.0.5
+	 */
+	public static function isSameDomain($url1, $url2) {
+		return self::getFullDomain($url1) === self::getFullDomain($url2);
+	}
+
 }


### PR DESCRIPTION
## Description
CORS only makes sense for browsers and davfs has trouble with the OPTIONS logic from CORS.

## Related Issue
Fixes https://github.com/owncloud/core/issues/29793

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] TEST: Manual local test with davfs.
- [x] TEST: rerun sample app tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

