### PR TITLE
always set the behat option extra_capabilities/browserVersion

### DIFF
--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -240,7 +240,7 @@ if [ "$BROWSER" == "firefox" ]
 then
 	#set screen resolution so that hopefully dragable elements will be visible
 	#FF gives problems if the destination element is not visible
-	EXTRA_CAPABILITIES='"browserVersion":"'$BROWSER_VERSION'","screenResolution":"1920x1080",'
+	EXTRA_CAPABILITIES='"screenResolution":"1920x1080",'
 	
 	#FF 47 needs a specific selenium version
 	if verlte "$BROWSER_VERSION" "47.0"
@@ -255,7 +255,7 @@ then
 	EXTRA_CAPABILITIES='"iedriverVersion": "3.4.0","requiresWindowFocus":true,"screenResolution":"1920x1080",'
 fi
 
-EXTRA_CAPABILITIES=$EXTRA_CAPABILITIES'"maxDuration":"3600"'
+EXTRA_CAPABILITIES=$EXTRA_CAPABILITIES'"browserVersion":"'$BROWSER_VERSION'","maxDuration":"3600"'
 
 #Set up personalized skeleton
 remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings config:system:get skeletondirectory"


### PR DESCRIPTION
## Description
set the  extra_capabilities/browserVersion not only for FF tests but always

## Motivation and Context
running the UI tests on [zalenium](https://github.com/zalando/zalenium) does not work otherwise `org.openqa.grid.common.exception.CapabilityNotPresentOnTheGridException`

## How Has This Been Tested?
running UI tests with zalenium env.
travis will test if they still work with our normal setup

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

