### PR TITLE
Cors methods from dav plugins

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
@@ -26,6 +26,7 @@ use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Sabre\HTTP\Sapi;
 use OCP\IConfig;
+use Sabre\DAV\ServerPlugin;
 
 class CorsPluginTest extends \Test\TestCase {
 
@@ -59,6 +60,7 @@ class CorsPluginTest extends \Test\TestCase {
 		$this->server->sapi->expects($this->once())->method('sendResponse')->with($this->server->httpResponse);
 
 		$this->server->httpRequest->setMethod('OPTIONS');
+		$this->server->httpRequest->setUrl('/owncloud/remote.php/dav/files/user1/target/path');
 
 		$this->userSession = $this->createMock(IUserSession::class);
 
@@ -66,6 +68,14 @@ class CorsPluginTest extends \Test\TestCase {
 		$this->overwriteService('AllConfig', $this->config);
 
 		$this->plugin = new \OCA\DAV\Connector\Sabre\CorsPlugin($this->userSession);
+
+		$extraMethodPlugin = $this->createMock(ServerPlugin::class);
+		$extraMethodPlugin->method('getHTTPMethods')
+			->with('owncloud/remote.php/dav/files/user1/target/path')
+			->willReturn(['EXTRA']);
+		$extraMethodPlugin->method('getFeatures')->willReturn([]);
+
+		$this->server->addPlugin($extraMethodPlugin);
 	}
 
 	public function tearDown() {
@@ -100,8 +110,10 @@ class CorsPluginTest extends \Test\TestCase {
 			'PATCH',
 			'PROPPATCH',
 			'REPORT',
-			'MOVE',
+			'HEAD',
 			'COPY',
+			'MOVE',
+			'EXTRA',
 		];
 
 		return [

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -299,7 +299,7 @@ class OC_Response {
 
 			foreach ($headers as $key => $value) {
 				if (array_key_exists($key, $allHeaders)) {
-					$allHeaders[$key] = array_merge($allHeaders[$key], $value);
+					$allHeaders[$key] = array_unique(array_merge($allHeaders[$key], $value));
 				}
 			}
 
@@ -333,7 +333,7 @@ class OC_Response {
 
 		foreach ($headers as $key => $value) {
 			if (array_key_exists($key, $allHeaders)) {
-				$allHeaders[$key] = array_merge($allHeaders[$key], $value);
+				$allHeaders[$key] = array_unique(array_merge($allHeaders[$key], $value));
 			}
 		}
 


### PR DESCRIPTION
## Description
DAV plugins are able to provide a list of own methods through `getHTTPMethods()`.
This PR makes it use that list when buildling the access control headers for CORS.

## Related Issue
- [x] REQUIRES: https://github.com/owncloud/core/pull/29798

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

