### PR TITLE
Check trashbin perms before moving to trash

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -141,11 +141,23 @@ class Trashbin {
 		}
 	}
 
+	/**
+	 * Sets up the trashbin for the given user
+	 *
+	 * @param string $user user id
+	 * @return bool true if trashbin is setup and usable, false otherwise
+	 */
 	private static function setUpTrash($user) {
 		$view = new View('/' . $user);
 		if (!$view->is_dir('files_trashbin')) {
 			$view->mkdir('files_trashbin');
 		}
+
+		if (!$view->isUpdatable('files_trashbin')) {
+			// no trashbin access or denied
+			return false;
+		}
+
 		if (!$view->is_dir('files_trashbin/files')) {
 			$view->mkdir('files_trashbin/files');
 		}
@@ -155,6 +167,8 @@ class Trashbin {
 		if (!$view->is_dir('files_trashbin/keys')) {
 			$view->mkdir('files_trashbin/keys');
 		}
+
+		return true;
 	}
 
 
@@ -249,7 +263,14 @@ class Trashbin {
 			return true;
 		}
 
-		self::setUpTrash($user);
+		if (!self::setUpTrash($user)) {
+			// trashbin not usable for user (ex: guest), switch to owner only
+			$user = $owner;
+			if (!self::setUpTrash($owner)) {
+				// nothing to do as no trash is available anywheree
+				return true;
+			}
+		}
 		if ($owner !== $user) {
 			// also setup for owner
 			self::setUpTrash($owner);

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -151,6 +151,13 @@ class Cache implements ICache {
 				$data['storage_mtime'] = $data['mtime'];
 			}
 			$data['permissions'] = (int)$data['permissions'];
+			// Oracle stores empty strings as null...
+			if (is_null($data['name'])) {
+				$data['name'] = '';
+			}
+			if (is_null($data['path'])) {
+				$data['path'] = '';
+			}
 			return new CacheEntry($data);
 		} else if (!$data and is_string($file)) {
 			if (isset($this->partial[$file])) {


### PR DESCRIPTION
## Description
Check whether the target trashbin is writable (ex: guests).
In the case where a guest deletes a file as recipient, the owner would
get a copy in their trash. The logic here will detect that the guests'
trashbin is not writeable so it will fall back to simply moving directly
to the owner's trashbin.

## Related Issue
https://github.com/owncloud/guests/issues/31 approach 1

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## TODOs:

- [ ] add unit tests if we agree on the approach
