### PR TITLE
skip tests tagged with the current oC version

### DIFF
--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -196,6 +196,21 @@ else
 	fi
 fi
 
+#skip tests tagged with the current oC version
+#one, two or three parts of the version can be used
+#e.g.
+#@skipOnOcV10.0.4
+#@skipOnOcV10.0
+#@skipOnOcV10
+
+remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:get version"
+OWNCLOUD_VERSION=`echo $REMOTE_OCC_STDOUT | cut -d"." -f1-3`
+BEHAT_TAGS='~@skipOnOcV'$OWNCLOUD_VERSION'&&'$BEHAT_TAGS
+OWNCLOUD_VERSION=`echo $OWNCLOUD_VERSION | cut -d"." -f1-2`
+BEHAT_TAGS='~@skipOnOcV'$OWNCLOUD_VERSION'&&'$BEHAT_TAGS
+OWNCLOUD_VERSION=`echo $OWNCLOUD_VERSION | cut -d"." -f1`
+BEHAT_TAGS='~@skipOnOcV'$OWNCLOUD_VERSION'&&'$BEHAT_TAGS
+
 REMOTE_FED_BASE_URL=$REMOTE_FED_SRV_HOST_NAME
 
 if [ ! -z "$REMOTE_FED_SRV_HOST_PORT" ] && [ "$REMOTE_FED_SRV_HOST_PORT" != "80" ]


### PR DESCRIPTION
## Description
make it possible to tag UI tests with an oC version to skip them when running against this particular version
one, two or three parts of the version can be used
e.g.
```
@skipOnOcV10.0.4
@skipOnOcV10.0
@skipOnOcV10
```

## Related Issue
#29802

## Motivation and Context
When testing a specific tarball a bug might be still exist in that particular version while fixed in others

## How Has This Been Tested?
run UI tests locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

