### PR TITLE
Adjust error message to say PHP X.X

### DIFF
--- a/index.php
+++ b/index.php
@@ -31,14 +31,14 @@
 // because base.php will already use 5.6 syntax.
 if (version_compare(PHP_VERSION, '5.6.0') === -1) {
 	echo 'This version of ownCloud requires at least PHP 5.6.0<br/>';
-	echo 'You are currently running ' . PHP_VERSION . '. Please update your PHP version.';
+	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.';
 	return;
 }
 
 // Show warning if PHP 7.2 is used as ownCloud is not compatible with PHP 7.2
 if (version_compare(PHP_VERSION, '7.2.0alpha1') !== -1) {
 	echo 'This version of ownCloud is not compatible with PHP 7.2<br/>';
-	echo 'You are currently running ' . PHP_VERSION . '.';
+	echo 'You are currently running PHP ' . PHP_VERSION . '.';
 	return;
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change the message shown when PHP version installed is not compatible with ownCloud.

## Related Issue
https://github.com/owncloud/core/issues/27570

## Motivation and Context
This change is required to avoid the confusion of the previous message. The previous message led to the confusion of the user that is the version of ownCloud instead of the PHP version.

## How Has This Been Tested?
I just did a fresh install of ownCloud 10 with PHP7.2 and PHP 5.5 to display this messages.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

