### PR TITLE
Proper template location order

### DIFF
--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -75,36 +75,62 @@ class Base {
 	}
 
 	/**
-	 * @param string $serverRoot
-	 * @param string|false $app_dir
 	 * @param ITheme $theme
 	 * @param string $app
+	 * @param string $serverRoot
+	 * @param string|false $appDir
 	 * @return string[]
 	 */
-	protected function getAppTemplateDirs($theme, $app, $serverRoot, $app_dir) {
-		// Check if the app is in the app folder or in the root
-		if( file_exists($app_dir.'/templates/' )) {
-			return [
-				$serverRoot.'/'.$theme->getDirectory().'/apps/'.$app.'/templates/',
-				$app_dir.'/templates/',
-			];
+	protected function getAppTemplateDirs(ITheme $theme, $app, $serverRoot, $appDir) {
+		$templateDirectories = [];
+		// Templates dir from the active theme first
+		if ($theme->getDirectory() !== '') {
+			$templateDirectories[] = $serverRoot . '/' . $theme->getDirectory() . '/apps/' . $app . '/templates/';
 		}
-		return [
-			$serverRoot.'/'.$theme->getDirectory().'/'.$app.'/templates/',
-			$serverRoot.'/'.$app.'/templates/',
-		];
+
+		// Templates dir from the app dir then
+		if ($appDir !== false) {
+			$templateDirectories[] = $appDir . '/templates/';
+		}
+
+		return $templateDirectories;
 	}
 
 	/**
-	 * @param string $serverRoot
 	 * @param ITheme $theme
+	 * @param string $serverRoot
 	 * @return string[]
 	 */
-	protected function getCoreTemplateDirs($theme, $serverRoot) {
-		return [
-			$serverRoot.'/'.$theme->getDirectory().'/core/templates/',
-			$serverRoot.'/core/templates/',
-		];
+	protected function getCoreTemplateDirs(ITheme $theme, $serverRoot) {
+		return $this->getTemplateDirs($theme, $serverRoot, '/core/templates/');
+	}
+
+	/**
+	 * @param ITheme $theme
+	 * @param string $serverRoot
+	 * @return string[]
+	 */
+	protected function getSettingsTemplateDirs(ITheme $theme, $serverRoot) {
+		return $this->getTemplateDirs($theme, $serverRoot, '/settings/templates/');
+	}
+
+	/**
+	 * Get path to templates directory in theme (if any) and then
+	 * in the requested ownCloud location
+	 *
+	 * @param ITheme $theme
+	 * @param string $basePath
+	 * @param string $relativePath
+	 * @return string[]
+	 */
+	protected function getTemplateDirs(ITheme $theme, $basePath, $relativePath) {
+		$directories = [];
+		if ($theme->getDirectory() !== '') {
+			$directories[] =  $basePath . '/' . $theme->getDirectory() . $relativePath;
+		}
+		$directories[] =  $basePath . $relativePath;
+
+		return $directories;
 	}
 
 	/**

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -189,10 +189,12 @@ class OC_Template extends \OC\Template\Base {
 	 */
 	protected function findTemplate($theme, $app, $name) {
 		// Check if it is a app template or not.
-		if( $app !== '' && $app !== 'core' ) {
-			$dirs = $this->getAppTemplateDirs($theme, $app, OC::$SERVERROOT, OC_App::getAppPath($app));
-		} else {
+		if($app === '' || $app === 'core') {
 			$dirs = $this->getCoreTemplateDirs($theme, OC::$SERVERROOT);
+		} elseif ($app === 'settings') {
+			$dirs = $this->getSettingsTemplateDirs($theme, OC::$SERVERROOT);
+		} else {
+			$dirs = $this->getAppTemplateDirs($theme, $app, OC::$SERVERROOT, OC_App::getAppPath($app));
 		}
 
 		$locator = new \OC\Template\TemplateFileLocator( $dirs );

--- a/tests/lib/Template/BaseTest.php
+++ b/tests/lib/Template/BaseTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright (c) 2017 Viktar Dubiniuk <dubiniuk@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Template;
+
+use OC\Template\Base;
+use OCP\Theme\ITheme;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamWrapper;
+
+
+class BaseTest extends \Test\TestCase {
+
+	/** @var ITheme|\PHPUnit_Framework_MockObject_MockObject */
+	protected $theme;
+
+	/** @var string */
+	protected $serverRoot;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->serverRoot = \OC::$SERVERROOT;
+		$this->theme = $this->getMockBuilder(ITheme::class)
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+
+	public function testTemplateIsLocatedWhenThemeIsActive() {
+		$base = $this->getMockBuilder(Base::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->theme->expects($this->any())
+			->method('getDirectory')
+			->willReturn('theme-test');
+
+		$app = 'anyapp';
+
+		$directories = self::invokePrivate(
+			$base,
+			'getAppTemplateDirs',
+			[$this->theme, $app, $this->serverRoot, $this->serverRoot . '/apps3/anyapp']
+		);
+		$this->assertEquals(
+			[
+				$this->serverRoot . '/' . $this->theme->getDirectory() . '/apps/' . $app . '/templates/',
+				$this->serverRoot . '/apps3/anyapp/templates/'
+			],
+			$directories
+		);
+	}
+
+	public function testTemplateIsLocatedWhenThemeIsNotActive() {
+		$base = $this->getMockBuilder(Base::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->theme->expects($this->any())
+			->method('getDirectory')
+			->willReturn('');
+
+		$app = 'anyapp';
+
+		$directories = self::invokePrivate(
+			$base,
+			'getAppTemplateDirs',
+			[$this->theme, $app, $this->serverRoot, $this->serverRoot . '/apps3/anyapp']
+		);
+		$this->assertEquals(
+			[
+				$this->serverRoot . '/apps3/anyapp/templates/'
+			],
+			$directories
+		);
+	}
+}


### PR DESCRIPTION
## Description
List a templates directory from the active theme as the first possible template dir and from  app/core/settings as the second


## Related Issue
Fixes https://github.com/owncloud/core/issues/29628

## Motivation and Context


## How Has This Been Tested?
By overriding core/settings/app templates from theme

A special test case was provided by @PVince81 in the related issue
### Steps
0. All kind of themes should be disabled.
1. Setup ownCloud with two apps folders "apps" and "apps2"
1. Install "customgroups" app version 0.3.1 into "apps"
1. Install "customgroups" app version 0.3.5 into "apps2"
1. `occ app:enable customgroups`
1.  run `make test-php` in `apps2/customgroups`


### Expected result
tests are passing

### Actual result
```
1) OCA\CustomGroups\Tests\unit\SettingsPanelTest::testGetPanel
Failed asserting that '
<div id="customgroups" class="section"></div>
' contains "<div id="customgroups" class="section" data-cancreategroups="true"></div>".

/srv/www/htdocs/owncloud/apps3/customgroups/tests/unit/SettingsPanelTest.php:50
/srv/www/htdocs/owncloud/apps3/customgroups/lib/composer/phpunit/phpunit/src/TextUI/Command.php:188
/srv/www/htdocs/owncloud/apps3/customgroups/lib/composer/phpunit/phpunit/src/TextUI/Command.php:118
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
