### PR TITLE
show warning if  no write permission for upload folder

### DIFF
--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -313,6 +313,11 @@ export IPV6_URL
 export REMOTE_FED_BASE_URL
 export FILES_FOR_UPLOAD="$(pwd)/tests/ui/filesForUpload/"
 
+if [ ! -w $FILES_FOR_UPLOAD ]
+then
+	echo "WARNING: cannot write to upload folder '$FILES_FOR_UPLOAD', some upload tests might fail"
+fi
+
 lib/composer/bin/behat -c $BEHAT_YML $BEHAT_SUITE_OPTION $BEHAT_TAG_OPTION $BEHAT_TAGS $BEHAT_FEATURE -v  2>&1 | tee -a $TEST_LOG_FILE
 
 BEHAT_EXIT_STATUS=${PIPESTATUS[0]}


### PR DESCRIPTION
## Description
Print a warning message in the case the user does not have permission to write into the folder that holds the files to upload.
This permission is needed to create upload files of arbitrary size. Some tests will fail if its missing.

## Motivation and Context
Let give more clues to the dev. why tests fail.

## How Has This Been Tested?
run UI tests locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

