### PR TITLE
Bring back NFD encoding warning when scanning

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -129,7 +129,7 @@ class Scan extends Base {
 		$path = basename($fullPath);
 
 		if ($normalizedPath !== $path) {
-			$output->writeln("\t<error>Entry \"" . $fullPath . '" will not be accessible due to incompatible encoding</error>');
+			$output->writeln("\t<error>Entry \"" . $fullPath . '" will not be accessible due to incompatible encoding. Please try enabling encoding compatibility mode for this storage.</error>');
 		}
 	}
 
@@ -210,10 +210,7 @@ class Scan extends Base {
 				}
 			});
 		}
-		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function($path) use ($output) {
-			$this->checkScanWarning($path, $output);
-		});
-		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function($path) use ($output) {
+		$scanner->listen('\OC\Files\Utils\Scanner', 'scanError', function($path) use ($output) {
 			$this->checkScanWarning($path, $output);
 		});
 

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -350,7 +350,11 @@ class Scanner extends BasicEmitter implements IScanner {
 			if (is_resource($dh)) {
 				while (($file = readdir($dh)) !== false) {
 					if (!Filesystem::isIgnoredDir($file) && !Filesystem::isForbiddenFileOrDir($file)) {
-						$children[] = trim(\OC\Files\Filesystem::normalizePath($file), '/');
+						$normalizedName = trim(\OC\Files\Filesystem::normalizePath($file), '/');
+						if ($normalizedName !== trim($file, '/')) {
+							$this->emit('\OC\Files\Cache\Scanner', 'scanError', [$file, $this->storageId]);
+						}
+						$children[] = $normalizedName;
 					}
 				}
 			}

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -116,6 +116,9 @@ class Scanner extends PublicEmitter {
 	protected function attachListener($mount) {
 		$scanner = $mount->getStorage()->getScanner();
 		$emitter = $this;
+		$scanner->listen('\OC\Files\Cache\Scanner', 'scanError', function ($path) use ($mount, $emitter) {
+			$emitter->emit('\OC\Files\Utils\Scanner', 'scanError', [$mount->getMountPoint() . $path]);
+		});
 		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFile', function ($path) use ($mount, $emitter) {
 			$emitter->emit('\OC\Files\Utils\Scanner', 'scanFile', [$mount->getMountPoint() . $path]);
 		});

--- a/tests/lib/Files/Cache/ScannerTest.php
+++ b/tests/lib/Files/Cache/ScannerTest.php
@@ -393,4 +393,25 @@ class ScannerTest extends \Test\TestCase {
 		$this->assertEquals($expectedThrown, $thrown);
 	}
 
+	public function testScanErrorFromEncoding() {
+		$data = "dummy file data\n";
+		// it might not look like it but these two accents have different encoding!
+		$nfcName = 'féchier.txt';
+		$nfdName = 'féchier.txt';
+
+		$eventPath = null;
+
+		$this->scanner->listen('\OC\Files\Cache\Scanner', 'scanError', function ($path) use (&$eventPath) {
+			$eventPath = $path;
+		});
+
+		$this->storage->file_put_contents($nfdName, $data);
+		$this->scanner->scan('');
+
+		$this->assertFalse($this->cache->inCache($nfcName));
+		$this->assertFalse($this->cache->inCache($nfdName));
+
+		$this->assertEquals($nfdName, $eventPath);
+	}
+
 }


### PR DESCRIPTION
## Description
Bring back NFD encoding warning when scanning.
Not sure what broke it, it seems the name is normalized too early so we couldn't detect this properly.

Note: to fully work without aborting, it will also need https://github.com/owncloud/core/pull/29739 to be merged.

## Related Issue
Fixes https://github.com/owncloud/core/issues/28181

## Motivation and Context
When people have NFD file names on external storage, it is best to provide a hint in the scanner output to explain why the file was not scanned.

## How Has This Been Tested?
Unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


