### PR TITLE
Do not auto-disable apps of certain types

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -245,8 +245,12 @@ class OC_App {
 			\OC::$server->getLogger()->logException($ex);
 			$blacklist = \OC::$server->getAppManager()->getAlwaysEnabledApps();
 			if (!in_array($app, $blacklist)) {
-				\OC::$server->getLogger()->warning('Could not load app "' . $app . '", it will be disabled', array('app' => 'core'));
-				self::disable($app);
+				if (!self::isType($app, ['authentication', 'filesystem'])) {
+					\OC::$server->getLogger()->warning('Could not load app "' . $app . '", it will be disabled', array('app' => 'core'));
+					self::disable($app);
+				} else {
+					\OC::$server->getLogger()->warning('Could not load app "' . $app . '", see exception above', array('app' => 'core'));
+				}
 			}
 			throw $ex;
 		}


### PR DESCRIPTION
## Description
Whenever the file appinfo/app.php throws an exception, the app manager
would disable the app automatically, believing it is broken. While this
might work fine for broken third party apps, it is crucial to keep
filesystem and authentication apps enabled in case of random errors
(like Redis being temporarily not available)

## Related Issue
Fixes https://github.com/owncloud/core/issues/29850

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Throw an exception randomly in user_ldap's appinfo/app.php and refresh the page until an error appears.

Before this fix: app would be disabled.
After this fix: error page and app stays enabled.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

