### PR TITLE
switch to webcron for UI tests

### DIFF
--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -142,6 +142,16 @@ fi
 remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:list ^firstrunwizard$"
 PREVIOUS_FIRSTRUNWIZARD_APP_STATUS=$REMOTE_OCC_STDOUT
 
+#get the current backgroundjobs_mode 
+remote_occ $ADMIN_PASSWORD $OCC_URL "config:app:get core backgroundjobs_mode"
+PREVIOUS_BACKGROUNDJOBS_MODE=$REMOTE_OCC_STDOUT
+#switch to webcron
+remote_occ $ADMIN_PASSWORD $OCC_URL "config:app:set core backgroundjobs_mode --value webcron"
+if [ $? -ne 0 ]
+then
+	echo "WARNING: Could not set backgroundjobs mode to 'webcron'"
+fi
+
 if [[ "$PREVIOUS_FIRSTRUNWIZARD_APP_STATUS" =~ ^Enabled: ]]
 then
 	FIRSTRUNWIZARD_APP_DISABLED_BY_SCRIPT=true;
@@ -397,6 +407,9 @@ fi
 if test "$NOTIFICATIONS_APP_DISABLED_BY_SCRIPT" = true; then
 	remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:enable notifications"
 fi
+
+# put back the backgroundjobs_mode
+remote_occ $ADMIN_PASSWORD $OCC_URL "config:app:set core backgroundjobs_mode --value $PREVIOUS_BACKGROUNDJOBS_MODE"
 
 #upload log file for later analysis
 if [ "$PASSED" = false ] && [ ! -z "$REPORTING_WEBDAV_USER" ] && [ ! -z "$REPORTING_WEBDAV_PWD" ] && [ ! -z "$REPORTING_WEBDAV_URL" ]


### PR DESCRIPTION
## Description
change to webcron when running UI tests

## Related Issue
UI tests failing in https://github.com/owncloud/core/pull/29319

## Motivation and Context
cron jobs run on the php dev server blocking any other operation. If a cron job takes too long selenium times out and tests fail

## How Has This Been Tested?
run UI tests locally and in travis https://github.com/individual-it/owncloud-core/pull/55

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.