### PR TITLE
Implement AppManager::getAppPath

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -494,7 +494,7 @@ class AppManager implements IAppManager {
 	}
 
 	/**
-	 * Get the directory for the given app.
+	 * Get the absolute path to the directory for the given app.
 	 * If the app exists in multiple directories, the most recent version is taken.
 	 * Returns false if not found
 	 *
@@ -513,7 +513,7 @@ class AppManager implements IAppManager {
 	}
 
 	/**
-	 * Get the web path for the given app.
+	 * Get the HTTP Web path to the app directory for the given app, relative to the ownCloud webroot.
 	 * If the app exists in multiple directories, web path to the most recent version is taken.
 	 * Returns false if not found
 	 *

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -543,10 +543,17 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			);
 		});
 		$this->registerService('AppManager', function (Server $c) {
+			if(\OC::$server->getSystemConfig()->getValue('installed', false)) {
+				$appConfig = $c->getAppConfig();
+				$groupManager = $c->getGroupManager();
+			} else {
+				$appConfig = null;
+				$groupManager = null;
+			}
 			return new \OC\App\AppManager(
 				$c->getUserSession(),
-				$c->getAppConfig(),
-				$c->getGroupManager(),
+				$appConfig,
+				$groupManager,
 				$c->getMemCacheFactory(),
 				$c->getEventDispatcher(),
 				$c->getConfig()

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -166,4 +166,26 @@ interface IAppManager {
 	 * @since 10.0.3
 	 */
 	public function canInstall();
+
+	/**
+	 * Get the directory for the given app.
+	 * If the app exists in multiple directories, the most recent version is taken.
+	 * Returns false if not found
+	 *
+	 * @param string $appId
+	 * @return string|false
+	 * @since 10.0.5
+	 */
+	public function getAppPath($appId);
+
+	/**
+	 * Get the web path for the given app.
+	 * If the app exists in multiple directories, web path to the most recent version is taken.
+	 * Returns false if not found
+	 *
+	 * @param string $appId
+	 * @return string|false
+	 * @since 10.0.5
+	 */
+	public function getAppWebPath($appId);
 }

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -168,7 +168,7 @@ interface IAppManager {
 	public function canInstall();
 
 	/**
-	 * Get the directory for the given app.
+	 * Get the absolute path to the directory for the given app.
 	 * If the app exists in multiple directories, the most recent version is taken.
 	 * Returns false if not found
 	 *
@@ -179,7 +179,7 @@ interface IAppManager {
 	public function getAppPath($appId);
 
 	/**
-	 * Get the web path for the given app.
+	 * Get the HTTP Web path to the app directory for the given app, relative to the ownCloud webroot.
 	 * If the app exists in multiple directories, web path to the most recent version is taken.
 	 * Returns false if not found
 	 *


### PR DESCRIPTION
## Description
- Allows to get the app path and app web path
- Kill legacy code that does the same. `OC_App::getAppPath` and `OC_App::getAppWebPath` are cut down to work via AppManager implementation
- It is possible to use some AppManager methods without Db connection now (e.g. when OC is not installed)

## Related Issue
https://github.com/owncloud/core/issues/25336

## Motivation and Context
- public API enhancement
- unit testing is possible now
- killing old crap

## How Has This Been Tested?
`\OC::$server->getAppManager()->getAppPath('customgroups');`
`\OC::$server->getAppManager()->getAppWebPath('customgroups');`

where 'customgroups' is your favorite app. In a various configs including multiple app directories.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

