### PR TITLE
Adding new Symfony events for zipfile download and public link share

### DIFF
--- a/apps/files_sharing/lib/API/OCSShareWrapper.php
+++ b/apps/files_sharing/lib/API/OCSShareWrapper.php
@@ -35,7 +35,8 @@ class OCSShareWrapper {
 			\OC::$server->getURLGenerator(),
 			\OC::$server->getUserSession()->getUser(),
 			\OC::$server->getL10N('files_sharing'),
-			\OC::$server->getConfig()
+			\OC::$server->getConfig(),
+			\OC::$server->getEventDispatcher()
 		);
 	}
 

--- a/apps/files_sharing/tests/API/Share20OCSTest.php
+++ b/apps/files_sharing/tests/API/Share20OCSTest.php
@@ -24,6 +24,7 @@
  */
 namespace OCA\Files_Sharing\Tests\API;
 
+use JMS\Serializer\EventDispatcher\EventDispatcher;
 use OCA\Files_Sharing\API\Share20OCS;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -36,6 +37,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Lock\LockedException;
 use OCP\Share;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Test\TestCase;
 
 /**
@@ -73,6 +75,9 @@ class Share20OCSTest extends TestCase {
 	/** @var IL10N */
 	private $l;
 
+	/** @var  EventDispatcher */
+	private $eventDispatcher;
+
 	protected function setUp() {
 		$this->shareManager = $this->getMockBuilder('OCP\Share\IManager')
 			->disableOriginalConstructor()
@@ -103,6 +108,8 @@ class Share20OCSTest extends TestCase {
 				['core', 'shareapi_default_permissions', \OCP\Constants::PERMISSION_ALL, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE]
 			]));
 
+		$this->eventDispatcher = \OC::$server->getEventDispatcher();
+
 		$this->ocs = new Share20OCS(
 			$this->shareManager,
 			$this->groupManager,
@@ -112,8 +119,16 @@ class Share20OCSTest extends TestCase {
 			$this->urlGenerator,
 			$this->currentUser,
 			$this->l,
-			$this->config
+			$this->config,
+			$this->eventDispatcher
 		);
+	}
+
+	protected function tearDown() {
+		\OC::$server->getEventDispatcher()->addListener('share.beforeCreate', function (GenericEvent $event) {
+			$event->setArgument('run', true);
+		});
+		return parent::tearDown();
 	}
 
 	private function mockFormatShare() {
@@ -128,6 +143,7 @@ class Share20OCSTest extends TestCase {
 				$this->currentUser,
 				$this->l,
 				$this->config,
+				$this->eventDispatcher,
 			])->setMethods(['formatShare'])
 			->getMock();
 	}
@@ -436,6 +452,7 @@ class Share20OCSTest extends TestCase {
 					$this->currentUser,
 					$this->l,
 					$this->config,
+					$this->eventDispatcher,
 				])->setMethods(['canAccessShare'])
 				->getMock();
 
@@ -763,6 +780,7 @@ class Share20OCSTest extends TestCase {
 				$this->currentUser,
 				$this->l,
 				$this->config,
+				$this->eventDispatcher,
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -815,11 +833,20 @@ class Share20OCSTest extends TestCase {
 			}))
 			->will($this->returnArgument(0));
 
+		$calledAfterCreate = [];
+		\OC::$server->getEventDispatcher()->addListener('share.afterCreate', function (GenericEvent $event) use (&$calledAfterCreate) {
+			$calledAfterCreate[] = 'share.afterCreate';
+			$calledAfterCreate[] = $event;
+		});
 		$expected = new \OC\OCS\Result();
 		$result = $ocs->createShare();
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
 		$this->assertEquals($expected->getData(), $result->getData());
+		$this->assertEquals('share.afterCreate', $calledAfterCreate[0]);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterCreate[1]);
+		$this->assertEquals('success', $calledAfterCreate[1]->getArgument('result'));
+		$this->assertArrayHasKey('output', $calledAfterCreate[1]);
 	}
 
 	public function testCreateShareGroupNoValidShareWith() {
@@ -880,6 +907,7 @@ class Share20OCSTest extends TestCase {
 				$this->currentUser,
 				$this->l,
 				$this->config,
+				$this->eventDispatcher,
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -1417,6 +1445,7 @@ class Share20OCSTest extends TestCase {
 				$this->currentUser,
 				$this->l,
 				$this->config,
+				$this->eventDispatcher,
 			])->setMethods(['formatShare'])
 			->getMock();
 
@@ -2699,7 +2728,8 @@ class Share20OCSTest extends TestCase {
 			$this->urlGenerator,
 			$this->currentUser,
 			$this->l,
-			$this->config
+			$this->config,
+			$this->eventDispatcher
 		);
 	}
 
@@ -2790,7 +2820,8 @@ class Share20OCSTest extends TestCase {
 			$this->urlGenerator,
 			$this->currentUser,
 			$this->l,
-			$config
+			$config,
+			$this->eventDispatcher
 		);
 
 		list($file,) = $this->getMockFileFolder();
@@ -2821,5 +2852,49 @@ class Share20OCSTest extends TestCase {
 		$result = $this->invokePrivate($ocs, 'formatShare', [$share]);
 
 		$this->assertEquals($expectedInfo, $result['share_with_additional_info']);
+	}
+
+	public function testCreateShareNotAllowed() {
+
+		$share = $this->newShare();
+		$this->shareManager->method('newShare')->willReturn($share);
+
+		$this->request
+			->method('getParam')
+			->will($this->returnValueMap([
+				['path', null, 'valid-path'],
+				['permissions', null, \OCP\Constants::PERMISSION_ALL],
+				['shareType', $this->any(), Share::SHARE_TYPE_USER],
+				['shareWith', $this->any(), 'invalidUser'],
+			]));
+
+		$userFolder = $this->createMock('\OCP\Files\Folder');
+		$this->rootFolder->expects($this->once())
+			->method('getUserFolder')
+			->with('currentUser')
+			->willReturn($userFolder);
+
+		$path = $this->createMock('\OCP\Files\File');
+		$storage = $this->createMock('OCP\Files\Storage');
+		$storage->method('instanceOfStorage')
+			->with('OCA\Files_Sharing\External\Storage')
+			->willReturn(false);
+		$path->method('getStorage')->willReturn($storage);
+
+		$expected = new \OC\OCS\Result(null, 403, 'No permission to create share');
+
+		$calledCreateEvent = [];
+		\OC::$server->getEventDispatcher()->addListener('share.beforeCreate', function (GenericEvent $event) use (&$calledCreateEvent) {
+			$calledCreateEvent[] = "share.beforeCreate";
+			$event->setArgument('run', false);
+			$calledCreateEvent[] = $event;
+		});
+		$result = $this->ocs->createShare();
+
+		$this->assertEquals($expected->getMeta(), $result->getMeta());
+		$this->assertEquals($expected->getData(), $result->getData());
+		$this->assertEquals('share.beforeCreate', $calledCreateEvent[0]);
+		$this->assertInstanceOf(GenericEvent::class, $calledCreateEvent[1]);
+		$this->assertArrayHasKey('run', $calledCreateEvent[1]);
 	}
 }

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -32,6 +32,7 @@ use OCP\Constants;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\Share;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Class ApiTest
@@ -124,7 +125,8 @@ class ApiTest extends TestCase {
 			\OC::$server->getURLGenerator(),
 			$currentUser,
 			$l,
-			\OC::$server->getConfig()
+			\OC::$server->getConfig(),
+			\OC::$server->getEventDispatcher()
 		);
 	}
 
@@ -137,10 +139,18 @@ class ApiTest extends TestCase {
 		$data['shareWith'] = self::TEST_FILES_SHARING_API_USER2;
 		$data['shareType'] = Share::SHARE_TYPE_USER;
 
+		$calledBeforeCreate = [];
+		\OC::$server->getEventDispatcher()->addListener('share.beforeCreate', function (GenericEvent $event) use (&$calledBeforeCreate) {
+			$calledBeforeCreate[] = 'share.beforeCreate';
+			$calledBeforeCreate[] = $event;
+		});
 		$request = $this->createRequest($data);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->createShare();
 
+		$this->assertEquals('share.beforeCreate', $calledBeforeCreate[0]);
+		$this->assertInstanceOf(GenericEvent::class, $calledBeforeCreate[1]);
+		$this->assertTrue($calledBeforeCreate[1]->getArgument('run'));
 		$this->assertTrue($result->succeeded());
 		$data = $result->getData();
 		$this->assertEquals(19, $data['permissions']);

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -139,6 +139,13 @@ class OC_Files {
 				}
 			}
 
+			//Dispatch an event to see if any apps have problem with download
+			$event = new \Symfony\Component\EventDispatcher\GenericEvent(null, ['dir' => $dir, 'files' => $files, 'run' => true]);
+			OC::$server->getEventDispatcher()->dispatch('file.beforeCreateZip', $event);
+			if (($event->getArgument('run') === false) or ($event->hasArgument('errorMessage'))) {
+				throw new \OC\ForbiddenException("Access denied: " . $event->getArgument('errorMessage'));
+			}
+
 			$streamer = new Streamer();
 			OC_Util::obEnd();
 
@@ -167,6 +174,9 @@ class OC_Files {
 			$streamer->finalize();
 			set_time_limit($executionTime);
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
+			$event = new \Symfony\Component\EventDispatcher\GenericEvent(null, ['result' => 'success', 'dir' => $dir, 'files' => $files]);
+			OC::$server->getEventDispatcher()->dispatch('file.afterCreateZip', $event);
+
 		} catch (\OCP\Lock\LockedException $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);
@@ -183,6 +193,9 @@ class OC_Files {
 			OC::$server->getLogger()->logException($ex);
 			$l = \OC::$server->getL10N('core');
 			$hint = method_exists($ex, 'getHint') ? $ex->getHint() : '';
+			if ($event->hasArgument('message')) {
+				$hint .= ' ' . $event->getArgument('message');
+			}
 			\OC_Template::printErrorPage($l->t('File cannot be read'), $hint);
 		}
 	}


### PR DESCRIPTION
Adding new Symfony events, to check, if creating
shares or downloading zips are blocked by any
apps or not.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Adding new Symfony events to check if any apps revoked the premission to download zip files or creating public links.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/29877
https://github.com/owncloud/core/issues/29876

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding new symfony events which can be used by the apps to see if creating public links for files/folders are allowed or not. And also see if downloading zip files are allowed or not.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

