### PR TITLE
don't throw exception if usr/grp couldn't be deleted in AfterScenario

### DIFF
--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -396,8 +396,8 @@ trait BasicStructure {
 			);
 			
 			if ($result->getStatusCode() !== 200) {
-				throw new Exception(
-					"could not delete user. "
+				error_log(
+					"INFORMATION: could not delete user. '" . $user . "'"
 					. $result->getStatusCode() . " " . $result->getBody()
 				);
 			}
@@ -412,8 +412,8 @@ trait BasicStructure {
 			);
 			
 			if ($result->getStatusCode() !== 200) {
-				throw new Exception(
-					"could not delete group. "
+				error_log(
+					"INFORMATION: could not delete group. '" . $group . "'"
 					. $result->getStatusCode() . " " . $result->getBody()
 				);
 			}


### PR DESCRIPTION
## Description
if a user or group could not be deleted in the tear-down phase of a test, do not throw an exception (test fails) but only show an info message

## Motivation and Context
For situations where a test attempts to create a user but could not, e.g. testing invalid usernames, the tear-down cannot delete the user because it wasn't created.
If a test-case should have created a user but didn't the test itself should fail, not the tear down function

## How Has This Been Tested?
travis will test for me

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

