### PR TITLE
Separate Federation gherkin steps into trait

### DIFF
--- a/tests/integration/features/bootstrap/Federation.php
+++ b/tests/integration/features/bootstrap/Federation.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+require __DIR__ . '/../../../../lib/composer/autoload.php';
+
+trait Federation {
+
+	/**
+	 * @Given /^user "([^"]*)" from server "(LOCAL|REMOTE)" shares "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)"$/
+	 *
+	 * @param string $sharerUser
+	 * @param string $sharerServer "LOCAL" or "REMOTE"
+	 * @param string $sharerPath
+	 * @param string $shareeUser
+	 * @param string $shareeServer "LOCAL" or "REMOTE"
+	 * @return void
+	 */
+	public function federateSharing(
+		$sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer
+	) {
+		if ($shareeServer == "REMOTE") {
+			$shareWith = "$shareeUser@" . substr($this->remoteBaseUrl, 0, -4);
+		} else {
+			$shareWith = "$shareeUser@" . substr($this->localBaseUrl, 0, -4);
+		}
+		$previous = $this->usingServer($sharerServer);
+		$this->createShare(
+			$sharerUser, $sharerPath, 6, $shareWith, null, null, null
+		);
+		$this->usingServer($previous);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" accepts last pending share$/
+	 * @param string $user
+	 * @param string $server
+	 * @return void
+	 */
+	public function acceptLastPendingShare($user, $server) {
+		$previous = $this->usingServer($server);
+		$this->asAn($user);
+		$this->sendingToWith(
+			'GET',
+			"/apps/files_sharing/api/v1/remote_shares/pending",
+			null
+		);
+		$this->theHTTPStatusCodeShouldBe('200');
+		$this->theOCSStatusCodeShouldBe('100');
+		$share_id = $this->response->xml()->data[0]->element[0]->id;
+		$this->sendingToWith(
+			'POST',
+			"/apps/files_sharing/api/v1/remote_shares/pending/{$share_id}",
+			null
+		);
+		$this->theHTTPStatusCodeShouldBe('200');
+		$this->theOCSStatusCodeShouldBe('100');
+		$this->usingServer($previous);
+	}
+}

--- a/tests/integration/features/bootstrap/FederationContext.php
+++ b/tests/integration/features/bootstrap/FederationContext.php
@@ -34,58 +34,7 @@ require_once 'bootstrap.php';
 class FederationContext implements Context, SnippetAcceptingContext {
 
 	use BasicStructure;
-
-	/**
-	 * @Given /^user "([^"]*)" from server "(LOCAL|REMOTE)" shares "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)"$/
-	 *
-	 * @param string $sharerUser
-	 * @param string $sharerServer "LOCAL" or "REMOTE"
-	 * @param string $sharerPath
-	 * @param string $shareeUser
-	 * @param string $shareeServer "LOCAL" or "REMOTE"
-	 * @return void
-	 */
-	public function federateSharing(
-		$sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer
-	) {
-		if ($shareeServer == "REMOTE") {
-			$shareWith = "$shareeUser@" . substr($this->remoteBaseUrl, 0, -4);
-		} else {
-			$shareWith = "$shareeUser@" . substr($this->localBaseUrl, 0, -4);
-		}
-		$previous = $this->usingServer($sharerServer);
-		$this->createShare(
-			$sharerUser, $sharerPath, 6, $shareWith, null, null, null
-		);
-		$this->usingServer($previous);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" accepts last pending share$/
-	 * @param string $user
-	 * @param string $server
-	 * @return void
-	 */
-	public function acceptLastPendingShare($user, $server) {
-		$previous = $this->usingServer($server);
-		$this->asAn($user);
-		$this->sendingToWith(
-			'GET',
-			"/apps/files_sharing/api/v1/remote_shares/pending",
-			null
-		);
-		$this->theHTTPStatusCodeShouldBe('200');
-		$this->theOCSStatusCodeShouldBe('100');
-		$share_id = $this->response->xml()->data[0]->element[0]->id;
-		$this->sendingToWith(
-			'POST',
-			"/apps/files_sharing/api/v1/remote_shares/pending/{$share_id}",
-			null
-		);
-		$this->theHTTPStatusCodeShouldBe('200');
-		$this->theOCSStatusCodeShouldBe('100');
-		$this->usingServer($previous);
-	}
+	use Federation;
 
 	/**
 	 * @return void


### PR DESCRIPTION
## Description
Put the gherkin step definitions for creating and accepting a federated share into a separate trait file.

## Related Issue

## Motivation and Context
Let tests in other apps create and accept federated shares, so they can then test their app functionality in a federated sharing environment. (e.g. I want this for ransomware_protection)

## How Has This Been Tested?
Local use with ransomware_protection federated share recovery tests being developed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

