### PR TITLE
UI tests - wait for scrolling to be finished when opening filesaction menu

### DIFF
--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -201,7 +201,7 @@ class FilesPage extends FilesPageBasic {
 		for ($counter = 0; $counter < $maxRetries; $counter++) {
 			try {
 				$fileRow = $this->findFileRowByName($fromFileName, $session);
-				$fileRow->rename($toFileName);
+				$fileRow->rename($toFileName, $session);
 				break;
 			} catch (\Exception $e) {
 				error_log(

--- a/tests/ui/features/lib/FilesPageBasic.php
+++ b/tests/ui/features/lib/FilesPageBasic.php
@@ -263,7 +263,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	 */
 	public function deleteFile($name, Session $session) {
 		$row = $this->findFileRowByName($name, $session);
-		$row->delete();
+		$row->delete($session);
 		$this->waitForOutstandingAjaxCalls($session);
 	}
 

--- a/tests/ui/features/lib/FilesPageElement/FileRow.php
+++ b/tests/ui/features/lib/FilesPageElement/FileRow.php
@@ -23,6 +23,7 @@
 
 namespace Page\FilesPageElement;
 
+use Behat\Mink\Session;
 use Behat\Mink\Element\NodeElement;
 use Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
@@ -115,15 +116,17 @@ class FileRow extends OwnCloudPage {
 	/**
 	 * opens the file action menu
 	 *
+	 * @param Session $session
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 * @return FileActionsMenu
 	 */
-	public function openFileActionsMenu() {
+	public function openFileActionsMenu(Session $session) {
 		$this->clickFileActionButton();
 		$filesPage = $this->getPage('FilesPage');
 		$actionMenuElement = $filesPage->findFileActionMenuElement();
 		$actionMenu = $this->getPage('FilesPageElement\\FileActionsMenu');
 		$actionMenu->setElement($actionMenuElement);
+		$this->waitForScrollingToFinish($session, '#app-content');
 		return $actionMenu;
 	}
 
@@ -179,10 +182,11 @@ class FileRow extends OwnCloudPage {
 	 * renames the file
 	 *
 	 * @param string $toName
+	 * @param Session $session
 	 * @return void
 	 */
-	public function rename($toName) {
-		$actionMenu = $this->openFileActionsMenu();
+	public function rename($toName, Session $session) {
+		$actionMenu = $this->openFileActionsMenu($session);
 		$actionMenu->rename();
 		$this->waitTillElementIsNotNull($this->fileRenameInputXpath);
 		$inputField = $this->findRenameInputField();
@@ -194,10 +198,11 @@ class FileRow extends OwnCloudPage {
 	/**
 	 * deletes the file
 	 *
+	 * @param Session $session
 	 * @return void
 	 */
-	public function delete() {
-		$actionMenu = $this->openFileActionsMenu();
+	public function delete(Session $session) {
+		$actionMenu = $this->openFileActionsMenu($session);
 		$actionMenu->delete();
 		$this->waitTillElementIsNull($this->fileBusyIndicatorXpath);
 	}

--- a/tests/ui/features/renameFiles/renameFiles.feature
+++ b/tests/ui/features/renameFiles/renameFiles.feature
@@ -43,6 +43,9 @@ So that I can organise my data structure
 		When I rename the file 'no-double-quotes.txt' to "hash#And&QuestionMark?At@Filename.txt"
 		And the files page is reloaded
 		Then the file "hash#And&QuestionMark?At@Filename.txt" should be listed
+		When I rename the file 'zzzz-must-be-last-file-in-folder.txt' to "aaaaaa.txt"
+		And the files page is reloaded
+		Then the file "aaaaaa.txt" should be listed
 
 	Scenario: Rename a file using spaces at front and/or back of file name and type
 		When I rename the file "lorem.txt" to " space at start"


### PR DESCRIPTION
## Description
when the filesaction menu is opened of a file that is at the bottom of the screen, the page get scrolled. UI tests need to wait till the scrolling is finished.

## Motivation and Context
In some circumstances (in my case running tests in selemium docker) the wrong menu item received the click in cases when the scrolling was still going on.

## How Has This Been Tested?
run all tests in docker env.
now lets run all tests in travis

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

