### PR TITLE
Change the styling of the active settings navigation menu item

### DIFF
--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -83,6 +83,11 @@
 	opacity: 1;
 }
 
+#app-navigation .active {
+	background-color: rgba(240, 240, 240, .9);
+	font-weight: bold;
+}
+
 #app-navigation li.divider {
 	display: block;
 	width: 100%;

--- a/settings/templates/settingsPage.php
+++ b/settings/templates/settingsPage.php
@@ -20,9 +20,10 @@ style('settings', 'settings');
 
 <div id="app-navigation">
 	<ul class="with-icon">
+		<!-- Personal Navigation Settings -->
 		<li class="divider"><?php p($l->t('Personal')); ?></li>
 		<?php foreach ($_['personalNav'] as $item): ?>
-		<li>
+		<li class="<?php $item['active'] ? p(' active ') : p('') ?>">
 			<?php if (\strpos($item['icon'], '/', 1) !== false): ?>
 				<a class="svg <?php $item['active'] ? p(' active ') : p('') ?>" style="background-image: url(<?php p($item['icon']) ?>)" href='<?php p($item['link']); ?>'><?php p($item['name']) ?></a>
 			<?php else: ?>
@@ -31,10 +32,11 @@ style('settings', 'settings');
 		</li>
 		<?php endforeach; ?>
 
+		<!-- Admin Navigation Settings -->
 		<?php if (!empty($_['adminNav'])): ?>
 			<li class="divider"><?php p($l->t('Admin')); ?></li>
 			<?php foreach ($_['adminNav'] as $item): ?>
-				<li>
+				<li class="<?php $item['active'] ? p(' active ') : p('') ?>">
 					<?php if (\strpos($item['icon'], '/', 1) !== false): ?>
 						<a class="svg <?php $item['active'] ? p(' active ') : p('') ?>" style="background-image: url(<?php p($item['icon']) ?>)" href='<?php p($item['link']); ?>'><?php p($item['name']) ?></a>
 					<?php else: ?>


### PR DESCRIPTION
## Description

In the ownCloud UI, when a navigation menu is active, it's not always obvious that it is. There is a subtle difference in how it's rendered, but I don't feel that it's that clear, nor distinct. This commit updates it so that it's that much clear to the user as to which element is currently active.

## Motivation and Context

It makes it easier to quickly see which navigation menu is the active one.

## How Has This Been Tested?

This was visually tested.

## Screenshots (if appropriate):

<img width="258" alt="active menu item is highlighted" src="https://user-images.githubusercontent.com/196801/34298001-b63cc010-e71b-11e7-913b-aab65f06268d.png">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
