### PR TITLE
[stable10] Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/apps/dav/tests/unit/CalDAV/Publishing/PublisherTest.php
+++ b/apps/dav/tests/unit/CalDAV/Publishing/PublisherTest.php
@@ -22,8 +22,9 @@ namespace OCA\DAV\Tests\unit\CalDAV\Publishing;
 
 use OCA\DAV\CalDAV\Publishing\Xml\Publisher;
 use Sabre\Xml\Writer;
+use PHPUnit\Framework\TestCase;
 
-class PublisherTest extends \PHPUnit_Framework_TestCase {
+class PublisherTest extends TestCase {
 
 	const NS_CALENDARSERVER = 'http://calendarserver.org/ns/';
 

--- a/apps/dav/tests/unit/bootstrap.php
+++ b/apps/dav/tests/unit/bootstrap.php
@@ -25,7 +25,7 @@ if (!defined('PHPUNIT_RUN')) {
 
 require_once __DIR__.'/../../../../lib/base.php';
 
-if(!class_exists('PHPUnit_Framework_TestCase')) {
+if(!class_exists('PHPUnit\Framework\TestCase')) {
 	require_once('PHPUnit/Autoload.php');
 }
 

--- a/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/ApcUniversalClassLoaderTest.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/ApcUniversalClassLoaderTest.php
@@ -12,8 +12,9 @@
 namespace Symfony\Component\ClassLoader\Tests;
 
 use Symfony\Component\ClassLoader\ApcUniversalClassLoader;
+use PHPUnit\Framework\TestCase;
 
-class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
+class ApcUniversalClassLoaderTest extends TestCase
 {
     protected function setUp()
     {

--- a/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
@@ -12,13 +12,14 @@
 namespace Symfony\Component\ClassLoader\Tests;
 
 use Symfony\Component\ClassLoader\ClassCollectionLoader;
+use PHPUnit\Framework\TestCase;
 
 require_once __DIR__.'/Fixtures/ClassesWithParents/GInterface.php';
 require_once __DIR__.'/Fixtures/ClassesWithParents/CInterface.php';
 require_once __DIR__.'/Fixtures/ClassesWithParents/B.php';
 require_once __DIR__.'/Fixtures/ClassesWithParents/A.php';
 
-class ClassCollectionLoaderTest extends \PHPUnit_Framework_TestCase
+class ClassCollectionLoaderTest extends TestCase
 {
     public function testTraitDependencies()
     {

--- a/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/ClassLoaderTest.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/ClassLoaderTest.php
@@ -12,8 +12,9 @@
 namespace Symfony\Component\ClassLoader\Tests;
 
 use Symfony\Component\ClassLoader\ClassLoader;
+use PHPUnit\Framework\TestCase;
 
-class ClassLoaderTest extends \PHPUnit_Framework_TestCase
+class ClassLoaderTest extends TestCase
 {
     public function testGetPrefixes()
     {

--- a/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
@@ -12,8 +12,9 @@
 namespace Symfony\Component\ClassLoader\Tests;
 
 use Symfony\Component\ClassLoader\ClassMapGenerator;
+use PHPUnit\Framework\TestCase;
 
-class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
+class ClassMapGeneratorTest extends TestCase
 {
     /**
      * @var string $workspace

--- a/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/Psr4ClassLoaderTest.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/Psr4ClassLoaderTest.php
@@ -12,8 +12,9 @@
 namespace Symfony\Component\ClassLoader\Tests;
 
 use Symfony\Component\ClassLoader\Psr4ClassLoader;
+use PHPUnit\Framework\TestCase;
 
-class Psr4ClassLoaderTest extends \PHPUnit_Framework_TestCase
+class Psr4ClassLoaderTest extends TestCase
 {
     /**
      * @param string $className

--- a/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/UniversalClassLoaderTest.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/UniversalClassLoaderTest.php
@@ -12,8 +12,9 @@
 namespace Symfony\Component\ClassLoader\Tests;
 
 use Symfony\Component\ClassLoader\UniversalClassLoader;
+use PHPUnit\Framework\TestCase;
 
-class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
+class UniversalClassLoaderTest extends TestCase
 {
     /**
      * @dataProvider getLoadClassTests

--- a/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
@@ -16,8 +16,9 @@ use Symfony\Component\DependencyInjection\Scope;
 use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use PHPUnit\Framework\TestCase;
 
-class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
+class ContainerAwareEventDispatcherTest extends TestCase
 {
     public function testAddAListenerService()
     {

--- a/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -16,8 +16,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\Stopwatch\Stopwatch;
+use PHPUnit\Framework\TestCase;
 
-class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
+class TraceableEventDispatcherTest extends TestCase
 {
     public function testAddRemoveListener()
     {

--- a/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -13,8 +13,9 @@ namespace Symfony\Component\EventDispatcher\Tests\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
+use PHPUnit\Framework\TestCase;
 
-class RegisterListenersPassTest extends \PHPUnit_Framework_TestCase
+class RegisterListenersPassTest extends TestCase
 {
     /**
      * Tests that event subscribers not implementing EventSubscriberInterface

--- a/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -14,8 +14,9 @@ namespace Symfony\Component\EventDispatcher\Tests;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use PHPUnit\Framework\TestCase;
 
-class EventDispatcherTest extends \PHPUnit_Framework_TestCase
+class EventDispatcherTest extends TestCase
 {
     /* Some pseudo events */
     const preFoo = 'pre.foo';

--- a/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/EventTest.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/EventTest.php
@@ -13,11 +13,12 @@ namespace Symfony\Component\EventDispatcher\Tests;
 
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Event.
  */
-class EventTest extends \PHPUnit_Framework_TestCase
+class EventTest extends TestCase
 {
     /**
      * @var \Symfony\Component\EventDispatcher\Event

--- a/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
@@ -12,11 +12,12 @@
 namespace Symfony\Component\EventDispatcher\Tests;
 
 use Symfony\Component\EventDispatcher\GenericEvent;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for Event.
  */
-class GenericEventTest extends \PHPUnit_Framework_TestCase
+class GenericEventTest extends TestCase
 {
     /**
      * @var GenericEvent

--- a/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
+++ b/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
@@ -13,11 +13,12 @@ namespace Symfony\Component\EventDispatcher\Tests;
 
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\ImmutableEventDispatcher;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class ImmutableEventDispatcherTest extends \PHPUnit_Framework_TestCase
+class ImmutableEventDispatcherTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -35,13 +35,14 @@ use OCP\IUserManager;
 use OCP\Mail\IMailer;
 use OCP\Security\ISecureRandom;
 use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class LostControllerTest
  *
  * @package OC\Core\Controller
  */
-class LostControllerTest extends \PHPUnit_Framework_TestCase {
+class LostControllerTest extends TestCase {
 
 	/** @var LostController */
 	private $lostController;

--- a/tests/lib/Files/Storage/Wrapper/DirMaskTest.php
+++ b/tests/lib/Files/Storage/Wrapper/DirMaskTest.php
@@ -7,9 +7,10 @@ namespace Test\Files\Storage\Wrapper;
 use OC\Files\Storage\Temporary;
 use OC\Files\Storage\Wrapper\DirMask;
 use OCP\Constants;
+use PHPUnit\Framework\TestCase;
 
 
-class DirMaskTest extends \PHPUnit_Framework_TestCase {
+class DirMaskTest extends TestCase {
 
 	/** @var  Temporary */
 	private $sourceStorage;

--- a/tests/lib/Files/Storage/Wrapper/ReadOnlyJailTest.php
+++ b/tests/lib/Files/Storage/Wrapper/ReadOnlyJailTest.php
@@ -6,9 +6,10 @@ namespace Test\Files\Storage\Wrapper;
 use OC\Files\Storage\Temporary;
 use OC\Files\Storage\Wrapper\ReadOnlyJail;
 use OCP\Constants;
+use PHPUnit\Framework\TestCase;
 
 
-class ReadOnlyJailTest extends \PHPUnit_Framework_TestCase {
+class ReadOnlyJailTest extends TestCase {
 
 	/** @var  ReadOnlyJail */
 	private $sut;

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -32,8 +32,9 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase {
+abstract class TestCase extends BaseTestCase {
 	/** @var \OC\Command\QueueBus */
 	private $commandBus;
 


### PR DESCRIPTION
Backport #29969 