### PR TITLE
UI tests - wait for folder to be created

### DIFF
--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -174,8 +174,9 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function createAFolder($name) {
-		$this->filesPage->createFolder($name);
-		$this->filesPage->waitTillPageIsLoaded($this->getSession());
+		$session = $this->getSession();
+		$this->filesPage->createFolder($session, $name);
+		$this->filesPage->waitTillPageIsLoaded($session);
 	}
 
 	/**
@@ -223,7 +224,7 @@ class FilesContext extends RawMinkContext implements Context {
 		}
 
 		while ($windowHeight > $lastItemCoordinates['top']) {
-			$this->filesPage->createFolder();
+			$this->filesPage->createFolder($this->getSession());
 			$itemsCount = $this->filesPage->getSizeOfFileFolderList();
 			$lastItemCoordinates = $this->filesPage->getCoordinatesOfElement(
 				$this->getSession(),


### PR DESCRIPTION
## Description
after creating a folder in the UI tests wait till its actually created

## Related Issue
#29926

## Motivation and Context
There is no nice way to wait till the folder is created, so this code basically waits till the input field for the new folder name is not visible any-more and then waits till the folder is displayed

## How Has This Been Tested?
run UI tests locally and in travis

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

