### PR TITLE
Dont reset displayname to uid on sso login

### DIFF
--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -186,7 +186,6 @@ class OC_User {
 		if ($uid) {
 			if (self::getUser() !== $uid) {
 				self::setUserId($uid);
-				self::setDisplayName($uid);
 				$userSession = self::getUserSession();
 				$userSession->getSession()->regenerateId();
 				$userSession->setLoginName($uid);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
If you login with SSO your displayname is set to your uid. Metadata sync is handled at the moment via shibboleth but will eventually be handled by the sync service on login. This is not necessary.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Breaks sso dispalynames

## How Has This Been Tested?
 - setup ldap user backend with a server (use a custom internal user id)
 - use a custom displayname attribute
 - sync the users
 - displaynamse are correct
 - setup shibboleth login
 - login using sso 
 - see that dispalyname is still correct and is no longer converted to your uid

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

