### PR TITLE
Fix add/delete user to group 0 via provisioning API

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -475,8 +475,8 @@ class Users {
 			return new Result(null, API::RESPOND_UNAUTHORISED);
 		}
 
-		$groupId = !empty($_POST['groupid']) ? $_POST['groupid'] : null;
-		if($groupId === null) {
+		$groupId = isset($_POST['groupid']) ? $_POST['groupid'] : null;
+		if (($groupId === '') || ($groupId === null) || ($groupId === false)) {
 			return new Result(null, 101);
 		}
 
@@ -511,8 +511,8 @@ class Users {
 			return new Result(null, API::RESPOND_UNAUTHORISED);
 		}
 
-		$group = !empty($parameters['_delete']['groupid']) ? $parameters['_delete']['groupid'] : null;
-		if($group === null) {
+		$group = isset($parameters['_delete']['groupid']) ? $parameters['_delete']['groupid'] : null;
+		if (($group === '') || ($group === null) || ($group === false)) {
 			return new Result(null, 101);
 		}
 

--- a/tests/integration/features/provisioning-v1.feature
+++ b/tests/integration/features/provisioning-v1.feature
@@ -114,14 +114,18 @@ Feature: provisioning
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 
-	Scenario: adding user to a group
+	Scenario Outline: adding a user to a group
 		Given as an "admin"
 		And user "brand-new-user" exists
-		And group "new-group" exists
+		And group "<group_id>" exists
 		When sending "POST" to "/cloud/users/brand-new-user/groups" with
-			| groupid | new-group |
+			| groupid | <group_id> |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
+		Examples:
+			| group_id  |
+			| new-group |
+			| 0         |
 
 	Scenario: getting groups of an user
 		Given as an "admin"
@@ -191,15 +195,19 @@ Feature: provisioning
 			| groupid | not-group |
 		Then the OCS status code should be "102"
 
-	Scenario: removing a user from a group
+	Scenario Outline: removing a user from a group
 		Given as an "admin"
 		And user "brand-new-user" exists
-		And group "new-group" exists
-		And user "brand-new-user" belongs to group "new-group"
+		And group "<group_id>" exists
+		And user "brand-new-user" belongs to group "<group_id>"
 		When sending "DELETE" to "/cloud/users/brand-new-user/groups" with
-			| groupid | new-group |
+			| groupid | <group_id> |
 		Then the OCS status code should be "100"
-		And user "brand-new-user" does not belong to group "new-group"
+		And user "brand-new-user" does not belong to group "<group_id>"
+		Examples:
+			| group_id  |
+			| new-group |
+			| 0         |
 
 	Scenario: create a subadmin using a user which does not exist
 		Given as an "admin"

--- a/tests/integration/features/provisioning-v1.feature
+++ b/tests/integration/features/provisioning-v1.feature
@@ -131,9 +131,11 @@ Feature: provisioning
 		Given as an "admin"
 		And user "brand-new-user" exists
 		And group "new-group" exists
+		And group "0" exists
 		When sending "GET" to "/cloud/users/brand-new-user/groups"
 		Then groups returned are
 			| new-group |
+			| 0 |
 		And the OCS status code should be "100"
 
 	Scenario: adding a user which doesn't exist to a group

--- a/tests/integration/features/provisioning-v2.feature
+++ b/tests/integration/features/provisioning-v2.feature
@@ -7,3 +7,29 @@ Feature: provisioning
     When sending "GET" to "/cloud/users/test"
     Then the HTTP status code should be "404"
 
+  Scenario Outline: adding a user to a group
+    Given as an "admin"
+    And user "brand-new-user" exists
+    And group "<group_id>" exists
+    When sending "POST" to "/cloud/users/brand-new-user/groups" with
+      | groupid | <group_id> |
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    Examples:
+      | group_id  |
+      | new-group |
+      | 0         |
+
+  Scenario Outline: removing a user from a group
+    Given as an "admin"
+    And user "brand-new-user" exists
+    And group "<group_id>" exists
+    And user "brand-new-user" belongs to group "<group_id>"
+    When sending "DELETE" to "/cloud/users/brand-new-user/groups" with
+      | groupid | <group_id> |
+    Then the OCS status code should be "200"
+    And user "brand-new-user" does not belong to group "<group_id>"
+    Examples:
+      | group_id  |
+      | new-group |
+      | 0         |


### PR DESCRIPTION
## Description
1) Add scenarios for adding users to group 0.
2) Add scenarios for deleting users from group 0.
Those scenarios fail, so fix the code:
3) When checking the group id, do not test with the ``empty()`` function - test explicitly for the things that are "empty" apart from ``0``.

## Related Issue
#29990 

## Motivation and Context
Remove more uses of ``empty()`` that cause problems for data that has the valid value "0".

## How Has This Been Tested?
Run the API tests locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

