### PR TITLE
Change remote to federated in autocomplete dialog.

### DIFF
--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -311,7 +311,7 @@
 						server: item.value.server
 					});
 				} else {
-					text = t('core', '{sharee} (remote)', {
+					text = t('core', '{sharee} (federated)', {
 						sharee: text
 					});
 				}

--- a/tests/ui/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/ui/features/lib/FilesPageElement/SharingDialog.php
@@ -47,7 +47,7 @@ class SharingDialog extends OwncloudPage {
 	protected $autocompleteItemsTextXpath = "//*[@class='autocomplete-item-text']";
 	protected $shareWithCloseXpath = "//div[@id='app-sidebar']//*[@class='close icon-close']";
 	protected $suffixToIdentifyGroups = " (group)";
-	protected $suffixToIdentifyRemoteUsers = " (remote)";
+	protected $suffixToIdentifyRemoteUsers = " (federated)";
 	protected $sharerInformationXpath = ".//*[@class='reshare']";
 	protected $sharedWithAndByRegEx = "^(?:[A-Z]\s)?Shared with you(?: and the group (.*))? by (.*)$";
 	protected $thumbnailContainerXpath = ".//*[contains(@class,'thumbnailContainer')]";


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Rename "Remote" for "Federated" in autocomplete dialog. I have only changed the string on the JS/PHP because I read there is a bot which replaces the other strings, is that correct?

## Related Issue
https://github.com/owncloud/core/issues/29015

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

