### PR TITLE
accountMapper either returns an object or throws an exception

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -185,12 +185,9 @@ class Manager extends PublicEmitter implements IUserManager {
 		}
 		try {
 			$account = $this->accountMapper->getByUid($uid);
-			if (\is_null($account)) {
-				$this->cachedUsers->set($uid, null);
-				return null;
-			}
 			return $this->getUserObject($account);
 		} catch (DoesNotExistException $ex) {
+			$this->cachedUsers->set($uid, null);
 			return null;
 		}
 	}

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -77,18 +77,14 @@ class ManagerTest extends TestCase {
 	}
 
 
-	public function testUserExistsSingleBackendExists() {
+	public function testUserExistsAccountExists() {
 		$account = $this->createMock(Account::class);
 		$this->accountMapper->expects($this->once())->method('getByUid')->with('foo')->willReturn($account);
 		$this->assertTrue($this->manager->userExists('foo'));
 	}
 
-	public function testUserExistsSingleBackendNotExists() {
+	public function testUserExistsAccountNotExists() {
 		$this->accountMapper->expects($this->once())->method('getByUid')->with('foo')->willThrowException(new DoesNotExistException(''));
-		$this->assertFalse($this->manager->userExists('foo'));
-	}
-
-	public function testUserExistsNoBackends() {
 		$this->assertFalse($this->manager->userExists('foo'));
 	}
 
@@ -142,14 +138,15 @@ class ManagerTest extends TestCase {
 		$this->assertFalse($this->manager->checkPassword('foo', 'bar'));
 	}
 
-	public function testGetOneBackendExists() {
+	public function testGetAccountExists() {
 		$account = new Account();
 		$account->setUserId('foo');
 		$this->accountMapper->expects($this->once())->method('getByUid')->with('foo')->willReturn($account);
 		$this->assertEquals('foo', $this->manager->get('foo')->getUID());
 	}
 
-	public function testGetOneBackendNotExists() {
+	public function testGetAccountNotExists() {
+		$this->accountMapper->expects($this->once())->method('getByUid')->with('foo')->willThrowException(new DoesNotExistException(''));
 		$this->assertNull($this->manager->get('foo'));
 	}
 


### PR DESCRIPTION
the AccountManager getByUid cannot return null

thx @mrow4a for pointing this out
