### PR TITLE
UI tests - encode special char when using User Provisioning API

### DIFF
--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -147,6 +147,7 @@ class UserHelper {
 	public static function deleteGroup(
 		$baseUrl, $group, $adminUser, $adminPassword
 	) {
+		$group = rawurlencode($group);
 		return OcsApiHelper::sendRequest(
 			$baseUrl, $adminUser, $adminPassword,
 			"DELETE", "/cloud/groups/" . $group


### PR DESCRIPTION
## Description
sending data in the path to the User Provisioning API requires some char to be encoded

## Motivation and Context
we want be able to create/delete etc. groups with char like "&/#" in the name from UI tests

## How Has This Been Tested?
travis will tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

