### PR TITLE
Allow user or group exists tests to fail

### DIFF
--- a/tests/integration/features/bootstrap/Provisioning.php
+++ b/tests/integration/features/bootstrap/Provisioning.php
@@ -39,6 +39,7 @@ trait Provisioning {
 	 */
 	public function userAlreadyExists($user) {
 		PHPUnit_Framework_Assert::assertTrue($this->userExists($user));
+		$this->rememberTheUser($user);
 	}
 
 	/**
@@ -55,6 +56,7 @@ trait Provisioning {
 	 */
 	public function groupAlreadyExists($group) {
 		PHPUnit_Framework_Assert::assertTrue($this->groupExists($group));
+		$this->rememberTheGroup($group);
 	}
 
 	/**
@@ -79,6 +81,14 @@ trait Provisioning {
 		PHPUnit_Framework_Assert::assertFalse($this->userExists($user));
 	}
 
+	public function rememberTheUser($user) {
+		if ($this->currentServer === 'LOCAL') {
+			$this->createdUsers[$user] = $user;
+		} elseif ($this->currentServer === 'REMOTE') {
+			$this->createdRemoteUsers[$user] = $user;
+		}
+	}
+
 	public function creatingTheUser($user) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users";
 		$client = new Client();
@@ -93,11 +103,7 @@ trait Provisioning {
 							];
 
 		$this->response = $client->send($client->createRequest("POST", $fullUrl, $options));
-		if ($this->currentServer === 'LOCAL') {
-			$this->createdUsers[$user] = $user;
-		} elseif ($this->currentServer === 'REMOTE') {
-			$this->createdRemoteUsers[$user] = $user;
-		}
+		$this->rememberTheUser($user);
 
 		//Quick hack to login once with the current user
 		$options2 = [
@@ -249,6 +255,17 @@ trait Provisioning {
 	}
 
 	/**
+	 * @param string $group
+	 */
+	public function rememberTheGroup($group) {
+		if ($this->currentServer === 'LOCAL') {
+			$this->createdGroups[$group] = $group;
+		} elseif ($this->currentServer === 'REMOTE') {
+			$this->createdRemoteGroups[$group] = $group;
+		}
+	}
+
+	/**
 	 * @When /^creating the group "([^"]*)"$/
 	 * @param string $group
 	 */
@@ -265,11 +282,7 @@ trait Provisioning {
 							];
 
 		$this->response = $client->send($client->createRequest("POST", $fullUrl, $options));
-		if ($this->currentServer === 'LOCAL') {
-			$this->createdGroups[$group] = $group;
-		} elseif ($this->currentServer === 'REMOTE') {
-			$this->createdRemoteGroups[$group] = $group;
-		}
+		$this->rememberTheGroup($group);
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/Provisioning.php
+++ b/tests/integration/features/bootstrap/Provisioning.php
@@ -210,7 +210,7 @@ trait Provisioning {
 		$this->response = $client->get($fullUrl, $options);
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
 
-		if (array_key_exists($group, $respondedArray)) {
+		if (in_array($group, $respondedArray)) {
 			return True;
 		} else {
 			return False;

--- a/tests/integration/features/provisioning-v1.feature
+++ b/tests/integration/features/provisioning-v1.feature
@@ -22,7 +22,7 @@ Feature: provisioning
 			| password | 123456 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "brand-new-user" exists
+		And user "brand-new-user" already exists
 
 	Scenario: Create an existing user
 		Given as an "admin"
@@ -35,6 +35,7 @@ Feature: provisioning
 
 	Scenario: Get an existing user
 		Given as an "admin"
+		And user "brand-new-user" exists
 		When sending "GET" to "/cloud/users/brand-new-user"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -58,7 +59,7 @@ Feature: provisioning
 			| value | brand-new-user@gmail.com |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "brand-new-user" exists
+		And user "brand-new-user" already exists
 
 	Scenario: Create a group
 		Given as an "admin"
@@ -68,7 +69,7 @@ Feature: provisioning
 			| password | 123456 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And group "new-group" exists
+		And group "new-group" already exists
 
 	Scenario: Create a group with special characters
 		Given as an "admin"
@@ -78,7 +79,7 @@ Feature: provisioning
 			| password | 123456 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And group "España" exists
+		And group "España" already exists
 
 	Scenario: Create a group named "0"
 		Given as an "admin"
@@ -88,7 +89,7 @@ Feature: provisioning
 			| password | 123456 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And group "0" exists
+		And group "0" already exists
 
 	Scenario: adding user to a group without sending the group
 		Given as an "admin"
@@ -281,7 +282,7 @@ Feature: provisioning
 		When sending "DELETE" to "/cloud/users/brand-new-user" 
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "brand-new-user" does not exist
+		And user "brand-new-user" does not already exist
 
 	Scenario: Delete a group
 		Given as an "admin"
@@ -289,7 +290,7 @@ Feature: provisioning
 		When sending "DELETE" to "/cloud/groups/new-group"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And group "new-group" does not exist
+		And group "new-group" does not already exist
 
 	Scenario: Delete a group with special characters
 	    Given as an "admin"
@@ -297,7 +298,7 @@ Feature: provisioning
 		When sending "DELETE" to "/cloud/groups/España"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And group "España" does not exist
+		And group "España" does not already exist
 
 	@no_encryption
 	Scenario: get enabled apps

--- a/tests/integration/features/provisioning-v1.feature
+++ b/tests/integration/features/provisioning-v1.feature
@@ -133,6 +133,8 @@ Feature: provisioning
 		And user "brand-new-user" exists
 		And group "new-group" exists
 		And group "0" exists
+		And user "brand-new-user" belongs to group "new-group"
+		And user "brand-new-user" belongs to group "0"
 		When sending "GET" to "/cloud/users/brand-new-user/groups"
 		Then groups returned are
 			| new-group |
@@ -182,7 +184,7 @@ Feature: provisioning
 		And user "brand-new-user" exists
 		And group "new-group" exists
 		And user "brand-new-user" belongs to group "new-group"
-		And user "brand-new-user" is subadmin of group "new-group"
+		And assure user "brand-new-user" is subadmin of group "new-group"
 		And as an "brand-new-user"
 		When sending "GET" to "/cloud/users"
 		Then users returned are
@@ -234,6 +236,7 @@ Feature: provisioning
 		Given as an "admin"
 		And user "brand-new-user" exists
 		And group "new-group" exists
+		And assure user "brand-new-user" is subadmin of group "new-group"
 		When sending "GET" to "/cloud/users/brand-new-user/subadmins"
 		Then subadmin groups returned are
 			| new-group |
@@ -252,6 +255,7 @@ Feature: provisioning
 		Given as an "admin"
 		And user "brand-new-user" exists
 		And group "new-group" exists
+		And assure user "brand-new-user" is subadmin of group "new-group"
 		When sending "GET" to "/cloud/groups/new-group/subadmins"
 		Then subadmin users returned are
 			| brand-new-user |
@@ -270,7 +274,7 @@ Feature: provisioning
 		Given as an "admin"
 		And user "brand-new-user" exists
 		And group "new-group" exists
-		And user "brand-new-user" is subadmin of group "new-group"
+		And assure user "brand-new-user" is subadmin of group "new-group"
 		When sending "DELETE" to "/cloud/users/brand-new-user/subadmins" with
 			| groupid | new-group |
 		Then the OCS status code should be "100"


### PR DESCRIPTION
## Description
1) Use existing step definitions that check if a user or group already exists (those steps do not first create the user or group). Do this in places where the step is a "then" test. That gives the chance that the test will fail.
2) Remember the user or group that was expected to exist, so that the ``AfterScenario`` will understand that the user or group needs to be removed at the end of the scenario.

## Related Issue

## Motivation and Context
Steps like ``And user "brand-new-user" exists`` work in the ``Given`` section - they create the user (or group). They do not fail if the user (or group) does not exist. In the ``Then`` section we want steps that actually fail if the user does not exist.

## How Has This Been Tested?
Run integration tests locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

