### PR TITLE
UI-tests make waitForOutstandingAjaxCalls also wait for non-jQuery XHR

### DIFF
--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -267,22 +267,13 @@ class FilesPage extends FilesPageBasic {
 		$toMoveFileRow = $this->findFileRowByName($name, $session);
 		$destinationFileRow = $this->findFileRowByName($destination, $session);
 
-		$session->executeScript(
-			'
-			jQuery.countXHRRequests = 0;
-			(function(open) {
-				XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
-					jQuery.countXHRRequests++;
-					open.call(this, method, url, async, user, pass);
-				};
-			})(XMLHttpRequest.prototype.open);
-			'
-		);
-
+		$this->initAjaxCounters($session);
+		$this->resetSumStartedAjaxRequests($session);
+		
 		for ($retryCounter = 0; $retryCounter < $maxRetries; $retryCounter++) {
 			$toMoveFileRow->findFileLink()->dragTo($destinationFileRow->findFileLink());
 			$this->waitForAjaxCallsToStartAndFinish($session);
-			$countXHRRequests = $session->evaluateScript("jQuery.countXHRRequests");
+			$countXHRRequests = $this->getSumStartedAjaxRequests($session);
 			if ($countXHRRequests === 0) {
 				error_log("Error while moving file");
 			} else {

--- a/tests/ui/features/lib/FilesPageBasic.php
+++ b/tests/ui/features/lib/FilesPageBasic.php
@@ -360,6 +360,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 		Session $session,
 		$timeout_msec = LONGUIWAITTIMEOUTMILLISEC
 	) {
+		$this->initAjaxCounters($session);
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -314,7 +314,7 @@ class OwncloudPage extends Page {
 	}
 
 	/**
-	 * waits till all ajax calls are finished (jQuery.active === 0)
+	 * waits till all ajax calls are finished
 	 *
 	 * @param Session $session
 	 * @param int $timeout_msec
@@ -324,6 +324,7 @@ class OwncloudPage extends Page {
 		Session $session,
 		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
 	) {
+		$this->initAjaxCounters($session);
 		$timeout_msec = (int) $timeout_msec;
 		if ($timeout_msec <= 0) {
 			throw new \InvalidArgumentException("negative or zero timeout");
@@ -332,9 +333,20 @@ class OwncloudPage extends Page {
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
 			try {
+				//wait for jQuery.active and
+				//window.activeAjaxCount that is set by the testing code
+				//to catch non-jQuery XHR requests
+				//but if window.activeAjaxCount was not set, ignore it
 				$waitingResult = $session->wait(
 					STANDARDSLEEPTIMEMILLISEC,
-					"(typeof jQuery != 'undefined' && (0 === jQuery.active))"
+					"(
+						typeof jQuery != 'undefined' 
+						&& (0 === jQuery.active) 
+						&& (
+							typeof window.activeAjaxCount === 'undefined' 
+							|| 0 === window.activeAjaxCount
+							)
+					)"
 				);
 				if ($waitingResult === true) {
 					break;
@@ -361,7 +373,9 @@ class OwncloudPage extends Page {
 	 * @param int $timeout_msec
 	 * @return void
 	 */
-	public function waitForAjaxCallsToStart(Session $session, $timeout_msec = 1000) {
+	public function waitForAjaxCallsToStart(
+		Session $session, $timeout_msec = 1000
+	) {
 		$timeout_msec = (int) $timeout_msec;
 		if ($timeout_msec <= 0) {
 			throw new \InvalidArgumentException("negative or zero timeout");
@@ -369,7 +383,21 @@ class OwncloudPage extends Page {
 		$currentTime = microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
-			if ((int) $session->evaluateScript("jQuery.active") > 0) {
+			$activeAjax = $session->evaluateScript(
+				'(
+				function () {
+					var result = 0;
+					if (typeof window.activeAjaxCount === "number") {
+						result = result + window.activeAjaxCount;
+					}
+					if (typeof jQuery.active === "number") {
+						result = result + jQuery.active;
+					}
+					return result;
+				})()
+				'
+			);
+			if ((int) $activeAjax > 0) {
 				break;
 			}
 			usleep(STANDARDSLEEPTIMEMICROSEC);
@@ -395,6 +423,95 @@ class OwncloudPage extends Page {
 		$timeout_msec = $timeout_msec - (($end - $start) * 1000);
 		$timeout_msec = max($timeout_msec, MINIMUMUIWAITTIMEOUTMILLISEC);
 		$this->waitForOutstandingAjaxCalls($session, $timeout_msec);
+	}
+
+	/**
+	 * creates wrappers around XHR requests
+	 * counts active requests in "window.activeAjaxCount"
+	 * counts the sum of ajax requests in window.sumStartedAjaxRequests
+	 * 
+	 * @param Session $session
+	 * @see resetSumStartedAjaxRequests()
+	 * @see getSumStartedAjaxRequests()
+	 * @return void
+	 */
+	public function initAjaxCounters(
+		Session $session
+	) {
+		$activeAjaxCountIsUndefined = $session->evaluateScript(
+			"(typeof window.activeAjaxCount === 'undefined')"
+		);
+		
+		//only overwrite the send and open functions once
+		if ($activeAjaxCountIsUndefined === true) {
+			$session->executeScript(
+				'
+				window.sumStartedAjaxRequests = 0;
+				window.activeAjaxCount = 0;
+				function isAllXhrComplete(){
+					window.activeAjaxCount--;
+				}
+				
+				(function(open) {
+					XMLHttpRequest.prototype.open = function() {
+						this.addEventListener("load", isAllXhrComplete);
+						return open.apply(this, arguments);
+					};
+				})(XMLHttpRequest.prototype.open);
+				
+				(function(send) {
+					XMLHttpRequest.prototype.send = function () {
+						window.activeAjaxCount++;
+						window.sumStartedAjaxRequests++;
+						return send.apply(this, arguments);
+					};
+				})(XMLHttpRequest.prototype.send);
+				'
+			);
+		}
+	}
+
+	/**
+	 * reset the sum ajax counter so that every function can start counting from 0
+	 * 
+	 * @param Session $session
+	 * @see initAjaxCounters()
+	 * @return void
+	 */
+	public function resetSumStartedAjaxRequests(Session $session) {
+		$this->assertSumStartedAjaxRequestsIsDefined($session);
+		$session->executeScript('window.sumStartedAjaxRequests = 0;');
+	}
+
+	/**
+	 * gets the sum of all started Ajax requests
+	 * 
+	 * @param Session $session
+	 * @see initAjaxCounters()
+	 * @return int
+	 */
+	public function getSumStartedAjaxRequests(Session $session) {
+		$this->assertSumStartedAjaxRequestsIsDefined($session);
+		return (int) $session->evaluateScript("window.sumStartedAjaxRequests");
+	}
+
+	/**
+	 * 
+	 * @param Session $session
+	 * @see initAjaxCounters()
+	 * @throws \Exception
+	 * @return void
+	 */
+	private function assertSumStartedAjaxRequestsIsDefined(Session $session) {
+		$sumStartedAjaxRequestsIsUndefined = $session->evaluateScript(
+			"(typeof window.sumStartedAjaxRequests === 'undefined')"
+		);
+		if ($sumStartedAjaxRequestsIsUndefined === true) {
+			throw new \Exception(
+				"`window.sumStartedAjaxRequests` is undefined, " .
+				"call `initAjaxCounters()` first"
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
make sure we are waiting for all outstanding ajax calls not only those that are started by jQuery. This is achieved by overwriting the ajax methods and counting calls that were not finished yet.

## Motivation and Context
Generating a preview does lock the file, on systems with slow IO it takes a long time to generate previews so if we try to delete/rename etc. the file where the preview is just created the test code breaks because the file is locked.
As the preview requests are not send by jQuery the old code would not wait correctly till all requests come back.

## How Has This Been Tested?
run UI tests locally and on travis

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

