### PR TITLE
Fix failure of shares which are already moved with transfer-ownership

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -302,6 +302,18 @@ class TransferOwnership extends Command {
 					if ($share->getSharedBy() === $this->sourceUser) {
 						$share->setSharedBy($this->destinationUser);
 					}
+					/*
+					 * If the share is already moved then updateShare would cause exception
+					 * This can happen if the folder is shared and file(s) inside the folder
+					 * has shares, for example public link
+					 */
+					if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
+						$sharePath = ltrim($share->getNode()->getPath(), '/');
+						if (strpos($sharePath, $this->finalTarget) !== false) {
+							//The share is already moved
+							continue;
+						}
+					}
 
 					$this->shareManager->updateShare($share);
 				}

--- a/tests/integration/features/transfer-ownership.feature
+++ b/tests/integration/features/transfer-ownership.feature
@@ -165,6 +165,23 @@ Feature: transfer-ownership
 		Then downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
 
 	@no_default_encryption
+	Scenario: transferring ownership of folder shares which has public link
+		Given user "user0" exists
+		And user "user1" exists
+		And user "user2" exists
+		And user "user0" created a folder "/test"
+		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
+		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
+		And as an "user1"
+		And creating a share with
+			| path | /test/somefile.txt |
+			| shareType | 3 |
+		When transferring ownership of path "test" from "user0" to "user1"
+		And the command was successful
+		And as an "user2"
+		Then downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+
+	@no_default_encryption
 	Scenario: transferring ownership of folder shared with third user
 		Given user "user0" exists
 		And user "user1" exists


### PR DESCRIPTION
If the folder and files inside the folder are already moved
by the command, and if there is a public link inside the folder
then during the restore share operation the command throws
exception. This fix tries to check if the file/folder is already
moved. If so then there is no need to do call updateShare.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
When there are multiple shares during the transfer-ownership command, and if the share is already moved to the destination user, then the command would throw an exception if the share inside the folder is handled separately.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Lets say we have `user1` and `user2`. `user1` creates folder `foo` and shares with `user2`. Then `user2` tries to creates a public link of one of the files inside `foo`. Now run the transfer-ownership command with source user as `user1` and destination user as `user2`. An exception is thrown. The reason I found is if the folder is already moved, and in the restore share checks for the share of public share and run the updateShare causes exception. The file is not available. So this change checks if the file/folder is already there in the destination folder. If so then nothing to do.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

