### PR TITLE
[stable10] UI tests - encode special char when using User Provisioning API

### DIFF
--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -147,6 +147,7 @@ class UserHelper {
 	public static function deleteGroup(
 		$baseUrl, $group, $adminUser, $adminPassword
 	) {
+		$group = rawurlencode($group);
 		return OcsApiHelper::sendRequest(
 			$baseUrl, $adminUser, $adminPassword,
 			"DELETE", "/cloud/groups/" . $group


### PR DESCRIPTION
backport of #30001 to stable10