### PR TITLE
Validate system path data used in findBinaryPath

### DIFF
--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -540,13 +540,7 @@ class OC_Helper {
 			// Returns null if nothing is found
 			$result = $exeSniffer->find($program);
 			if (empty($result)) {
-				$paths = getenv('PATH');
-				if (empty($paths)) {
-					$paths = '/usr/local/bin /usr/bin /opt/bin /bin';
-				} else {
-					$paths = str_replace(':',' ',getenv('PATH'));
-				}
-				$command = 'find ' . $paths . ' -name ' . escapeshellarg($program) . ' 2> /dev/null';
+				$command = 'find ' . self::getCleanedPath(getenv('PATH')) . ' -name ' . escapeshellarg($program) . ' 2> /dev/null';
 				exec($command, $output, $returnCode);
 				if (count($output) > 0) {
 					$result = escapeshellcmd($output[0]);
@@ -556,6 +550,26 @@ class OC_Helper {
 		// store the value for 5 minutes
 		$memcache->set($program, $result, 300);
 		return $result;
+	}
+
+	/**
+	 * Return a validated (sanitised) version of the system path
+	 *
+	 * The system path needs to be validated/sanitised before being used, as identified in http://bit.ly/2CEUagp (HackerOne).
+	 * This method filters out of the retrieved system path, only valid path directories, if the path is defined. Otherwise
+	 * it returns a defined set of paths.
+	 *
+	 * @param string $path
+	 * @return string|null
+	 */
+	public static function getCleanedPath($path = '') {
+		$pattern = "((\/[\w\d]*)+)";
+
+		if (preg_match_all($pattern, $path, $matches) > 0) {
+			return implode(' ', $matches[0]);
+		}
+
+		return '/usr/local/bin /usr/bin /opt/bin /bin';
 	}
 
 	/**

--- a/tests/lib/legacy/HelperTest.php
+++ b/tests/lib/legacy/HelperTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Test\legacy;
+
+use Test\TestCase;
+
+class HelperTest extends TestCase {
+
+	/**
+	 * @dataProvider getCleanedPathProvider
+	 * @param string $original
+	 * @param string $expected
+	 */
+	public function testGetCleanedPath($original, $expected) {
+		$this->assertSame($expected, \OC_Helper::getCleanedPath($original), 'Returned system path is not what was expected.');
+	}
+
+	public function getCleanedPathProvider() {
+		return [
+			[
+				"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin:/usr/games:-exec:whoami:/usr/gaming;",
+				"/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /bin /usr/games /usr/gaming",
+			],
+			[
+				"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin:/usr/games:;rm -rvf;:/usr/gaming;",
+				"/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /bin /usr/games /usr/gaming",
+			],
+			[
+				"",
+				"/usr/local/bin /usr/bin /opt/bin /bin",
+			],
+			[
+				null,
+				"/usr/local/bin /usr/bin /opt/bin /bin",
+			],
+			[
+				FALSE,
+				"/usr/local/bin /usr/bin /opt/bin /bin",
+			],
+			[
+				false,
+				"/usr/local/bin /usr/bin /opt/bin /bin",
+			],
+			[
+				"-exec:whoami",
+				"/usr/local/bin /usr/bin /opt/bin /bin",
+			],
+			[
+				"-exec:whoami:",
+				"/usr/local/bin /usr/bin /opt/bin /bin",
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Description
This PR patches `findBinaryPath` in `lib/private/legacy/helper.php` to avoid a possible OS command injection vulnerability, as identified in http://bit.ly/2EF726S. 

## Motivation and Context
as above.

## How Has This Been Tested?
Covering tests have been added for the new method and existing tests were run.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Additional Notes

It was suggested that [is_dir](http://php.net/manual/en/function.is-dir.php) may be simpler and quicker, and after some preliminary testing, I found that it is. However, after researching the function's documentation and potential limitations, I believe that using a regex will end up requiring less code because it won't have to work around `is_dir`'s limitations — especially when working with remote filesystems.

  