### PR TITLE
Handle no read access to skeleton

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -48,6 +48,7 @@ use OCP\App\IServiceLoader;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\IAuthModule;
 use OCP\Events\EventEmitterTrait;
+use OCP\Files\NoReadAccessException;
 use OCP\Files\NotPermittedException;
 use OCP\IConfig;
 use OCP\IRequest;
@@ -416,6 +417,11 @@ class Session implements IUserSession, Emitter {
 				// possible if files directory is in an readonly jail
 				\OC::$server->getLogger()->warning(
 					'Skeleton not created due to missing write permission'
+				);
+			} catch (NoReadAccessException $ex) {
+				// possible if the skeleton directory does not have read access
+				\OC::$server->getLogger()->warning(
+					'Skeleton not created due to missing read permission in skeleton directory'
 				);
 			} catch(\OC\HintException $hintEx) {
 				// only if Skeleton no existing Dir

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -420,7 +420,7 @@ class OC_Util {
 	 * @throws NoReadAccessException
 	 */
 	public static function copyr($source, \OCP\Files\Folder $target) {
-		$dir = opendir($source);
+		$dir = @opendir($source);
 		if (false === $dir) {
 			throw new NoReadAccessException('No read permission for folder ' . $source);
 		}
@@ -430,7 +430,7 @@ class OC_Util {
 					$child = $target->newFolder($file);
 					self::copyr($source . '/' . $file, $child);
 				} else {
-					$sourceFileHandle = fopen($source . '/' . $file,'r');
+					$sourceFileHandle = @fopen($source . '/' . $file,'r');
 					if (false === $sourceFileHandle) {
 						throw new NoReadAccessException('No read permission for file ' . $file);
 					}

--- a/lib/public/Files/NoReadAccessException.php
+++ b/lib/public/Files/NoReadAccessException.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+/**
+ * Public interface of ownCloud for apps to use.
+ * Files/NoReadAccessException class
+ */
+
+// use OCP namespace for all classes that are considered public.
+// This means that they should be used by apps instead of the internal ownCloud classes
+namespace OCP\Files;
+
+/**
+ * Exception for no read access to a file/folder/resource
+ * @since 10.0.5
+ */
+class NoReadAccessException extends \Exception {}

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -417,11 +417,55 @@ class UtilTest extends \Test\TestCase {
 	 * @expectedException \OC\HintException
 	 * @expectedExceptionMessage The skeleton folder /not/existing/Directory is not accessible
 	 */
-	public function testCopySkeletonDirectory() {
+	public function testCopySkeletonDirectoryDoesNotExist() {
 		$config = \OC::$server->getConfig();
 		$config->setSystemValue('skeletondirectory', '/not/existing/Directory');
 		$userFolder = $this->createMock('\OCP\Files\Folder');
-		\OC_Util::copySkeleton($config, $userFolder);
+		\OC_Util::copySkeleton('testuser', $userFolder);
+
+		$config->deleteSystemValue('skeletondirectory');
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NoReadAccessException
+	 * @expectedExceptionMessage No read permission for folder
+	 */
+	public function testCopySkeletonDirectoryNoReadAccess() {
+		if ($this->getCurrentUser() === 'root') {
+			// root can still read folders with protection mask 0
+			$this->markTestSkipped(
+				'You are running tests as root - testCopySkeletonDirectoryNoReadAccess will not work in this case.'
+			);
+		}
+		$skeletonDir = \OCP\Files::tmpFolder();
+		touch($skeletonDir . '/a-file');
+		chmod($skeletonDir, 0);
+		$config = \OC::$server->getConfig();
+		$config->setSystemValue('skeletondirectory', $skeletonDir);
+		$userFolder = $this->createMock('\OCP\Files\Folder');
+		\OC_Util::copySkeleton('testuser', $userFolder);
+
+		$config->deleteSystemValue('skeletondirectory');
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NoReadAccessException
+	 * @expectedExceptionMessage No read permission for file
+	 */
+	public function testCopySkeletonDirectoryNoReadAccessToFile() {
+		if ($this->getCurrentUser() === 'root') {
+			// root can still read files with protection mask 0
+			$this->markTestSkipped(
+				'You are running tests as root - testCopySkeletonDirectoryNoReadAccessToFile will not work in this case.'
+			);
+		}
+		$skeletonDir = \OCP\Files::tmpFolder();
+		touch($skeletonDir . '/a-file');
+		chmod($skeletonDir . '/a-file', 0);
+		$config = \OC::$server->getConfig();
+		$config->setSystemValue('skeletondirectory', $skeletonDir);
+		$userFolder = $this->createMock('\OCP\Files\Folder');
+		\OC_Util::copySkeleton('testuser', $userFolder);
 
 		$config->deleteSystemValue('skeletondirectory');
 	}


### PR DESCRIPTION
## Description

## Related Issue
#30017 

## Motivation and Context

## How Has This Been Tested?
Manually make the skeleton top-level folder have no read access.
Manually make a file in the skeleton folder have no read access.
Check that in each case a new user can login, and ``owncloud.log`` has a message:
``Skeleton not created due to missing read permission in skeleton directory``

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

