### PR TITLE
[Stable10] Redisplay login page on CSRF error

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -260,4 +260,11 @@ class LoginController extends Controller {
 		return OC_Util::getDefaultPageUrl();
 	}
 
+	/**
+	 * @return ISession
+	 */
+	public function getSession() {
+		return $this->session;
+	}
+
 }

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -57,6 +57,11 @@ script('core', [
 			<input type="submit" id="submit" class="login primary icon-confirm" title="<?php p($l->t('Log in')); ?>" value="" disabled="disabled"/>
 		</p>
 
+		<?php if (!empty($_['csrf_error'])) { ?>
+		<p class="warning">
+			<?php p($l->t('You took too long to login, please try again now')); ?>
+		</p>
+		<?php } ?>
 		<?php if (!empty($_['invalidpassword']) && !empty($_['canResetPassword'])) { ?>
 		<a id="lost-password" class="warning" href="<?php p($_['resetPasswordLink']); ?>">
 			<?php p($l->t('Wrong password. Reset it?')); ?>

--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -33,6 +33,7 @@ use OC\AppFramework\Middleware\Security\Exceptions\CrossSiteRequestForgeryExcept
 use OC\AppFramework\Middleware\Security\Exceptions\NotAdminException;
 use OC\AppFramework\Middleware\Security\Exceptions\NotLoggedInException;
 use OC\AppFramework\Utility\ControllerMethodReflector;
+use OC\Core\Controller\LoginController;
 use OC\Security\CSP\ContentSecurityPolicyManager;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
@@ -201,6 +202,20 @@ class SecurityMiddleware extends Middleware {
 						]
 					);
 					$response = new RedirectResponse($url);
+				} elseif (
+					$methodName === 'tryLogin'
+					&& $exception instanceof CrossSiteRequestForgeryException
+					&& $controller instanceof LoginController
+				) {
+					$this->logger->debug($exception->getMessage());
+					$controller->getSession()->set(
+						'loginMessages',
+						[
+							['csrf_error'],
+							[]
+						]
+					);
+					return $controller->showLoginForm(null, null, null);
 				} else {
 					$response = new TemplateResponse('core', '403', ['file' => $exception->getMessage()], 'guest');
 					$response->setStatus($exception->getCode());

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -33,10 +33,12 @@ use OC\AppFramework\Middleware\Security\Exceptions\NotLoggedInException;
 use OC\AppFramework\Middleware\Security\Exceptions\SecurityException;
 use OC\AppFramework\Middleware\Security\SecurityMiddleware;
 use OC\AppFramework\Utility\ControllerMethodReflector;
+use OC\Core\Controller\LoginController;
 use OC\Security\CSP\ContentSecurityPolicy;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\ISession;
 
 
 class SecurityMiddlewareTest extends \Test\TestCase {
@@ -415,6 +417,50 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->assertEquals($expected , $response);
 	}
 
+	public function testAfterExceptionReturnsLoginPageForCsrfErrorOnLogin() {
+		$this->request = new Request(
+			[
+				'server' =>
+					[
+						'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+						'REQUEST_URI' => 'owncloud/index.php/apps/specialapp'
+					]
+			],
+			$this->createMock('\OCP\Security\ISecureRandom'),
+			$this->createMock('\OCP\IConfig')
+		);
+
+		$exception = new CrossSiteRequestForgeryException();
+		$sessionMock = $this->getMockBuilder(ISession::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->controller = $this->getMockBuilder(LoginController::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->middleware = $this->getMiddleware(false, false);
+
+		$this->logger
+			->expects($this->once())
+			->method('debug')
+			->with($exception->getMessage());
+		$this->controller
+			->expects($this->once())
+			->method('showLoginForm')
+			->with(null, null, null);
+		$this->controller
+			->expects($this->once())
+			->method('getSession')
+			->willReturn($sessionMock);
+
+		$response = $this->middleware->afterException(
+			$this->controller,
+			'tryLogin',
+			$exception
+		);
+
+	}
 
 	public function testAfterAjaxExceptionReturnsJSONError(){
 		$response = $this->middleware->afterException($this->controller, 'test',


### PR DESCRIPTION
Closes https://github.com/owncloud/core/issues/29462 for stable10
Backport of https://github.com/owncloud/core/pull/29950

## Description
Redisplay login page on CSRF error instead of deadend `CSRF error` page

## Related Issue
https://github.com/owncloud/core/issues/29462

## Motivation and Context
Better usability

## How Has This Been Tested?
By changing CSRF token on login page

## Screenshots (if appropriate):
![new-csrf](https://user-images.githubusercontent.com/991300/34363222-425f30c4-ea8b-11e7-8a5f-729a551010c3.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  