### PR TITLE
[stable10] Dont reset dispalyname to uid on sso login

### DIFF
--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -186,7 +186,6 @@ class OC_User {
 		if ($uid) {
 			if (self::getUser() !== $uid) {
 				self::setUserId($uid);
-				self::setDisplayName($uid);
 				$userSession = self::getUserSession();
 				$userSession->getSession()->regenerateId();
 				$userSession->setLoginName($uid);


### PR DESCRIPTION
backport of #29981 