### PR TITLE
disallow closing php tag

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -46,7 +46,7 @@
 		<exclude name="PEAR.Functions.FunctionDeclaration.BraceOnSameLine" />
 		<exclude name="PEAR.Classes.ClassDeclaration.OpenBraceNewLine" />
 	</rule>
-
+	<rule ref="Zend.Files.ClosingTag"/>
 	<rule ref="Squiz.WhiteSpace.OperatorSpacing.NoSpaceBefore" />
 	<rule ref="Squiz.WhiteSpace.OperatorSpacing.NoSpaceAfter" />
 	<rule ref="Squiz.Commenting.DocCommentAlignment" />


### PR DESCRIPTION
## Description
make phpcs complain about closing php tag 

## Motivation and Context
this tags are not allowed according to the code style https://doc.owncloud.org/server/10.0/developer_manual/general/codingguidelines.html#start-closing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

