### PR TITLE
[Stable10] Implement AppManager::getAppPath

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -494,7 +494,7 @@ class AppManager implements IAppManager {
 	}
 
 	/**
-	 * Get the directory for the given app.
+	 * Get the absolute path to the directory for the given app.
 	 * If the app exists in multiple directories, the most recent version is taken.
 	 * Returns false if not found
 	 *
@@ -513,7 +513,7 @@ class AppManager implements IAppManager {
 	}
 
 	/**
-	 * Get the web path for the given app.
+	 * Get the HTTP Web path to the app directory for the given app, relative to the ownCloud webroot.
 	 * If the app exists in multiple directories, web path to the most recent version is taken.
 	 * Returns false if not found
 	 *

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -543,10 +543,17 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			);
 		});
 		$this->registerService('AppManager', function (Server $c) {
+			if(\OC::$server->getSystemConfig()->getValue('installed', false)) {
+				$appConfig = $c->getAppConfig();
+				$groupManager = $c->getGroupManager();
+			} else {
+				$appConfig = null;
+				$groupManager = null;
+			}
 			return new \OC\App\AppManager(
 				$c->getUserSession(),
-				$c->getAppConfig(),
-				$c->getGroupManager(),
+				$appConfig,
+				$groupManager,
 				$c->getMemCacheFactory(),
 				$c->getEventDispatcher(),
 				$c->getConfig()

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -550,72 +550,29 @@ class OC_App {
 		return null;
 	}
 
-
-	/**
-	 * search for an app in all app-directories
-	 *
-	 * @param string $appId
-	 * @return false|string
-	 */
-	protected static function findAppInDirectories($appId) {
-		$sanitizedAppId = self::cleanAppId($appId);
-		if($sanitizedAppId !== $appId) {
-			return false;
-		}
-		static $app_dir = [];
-
-		if (isset($app_dir[$appId])) {
-			return $app_dir[$appId];
-		}
-
-		$possibleApps = [];
-		foreach (OC::$APPSROOTS as $dir) {
-			if (file_exists($dir['path'] . '/' . $appId)) {
-				$possibleApps[] = $dir;
-			}
-		}
-
-		if (empty($possibleApps)) {
-			return false;
-		} elseif (count($possibleApps) === 1) {
-			$dir = array_shift($possibleApps);
-			$app_dir[$appId] = $dir;
-			return $dir;
-		} else {
-			$versionToLoad = [];
-			foreach ($possibleApps as $possibleApp) {
-				$version = self::getAppVersionByPath($possibleApp['path'] . '/' . $appId);
-				if (empty($versionToLoad) || version_compare($version, $versionToLoad['version'], '>')) {
-					$versionToLoad = [
-						'dir' => $possibleApp,
-						'version' => $version,
-					];
-				}
-			}
-			$app_dir[$appId] = $versionToLoad['dir'];
-			return $versionToLoad['dir'];
-			//TODO - write test
-		}
-	}
-
 	/**
 	 * Get the directory for the given app.
-	 * If the app is defined in multiple directories, the first one is taken. (false if not found)
+	 * If the app exists in multiple directories, the most recent version is taken.
+	 * (false if not found)
 	 *
 	 * @param string $appId
 	 * @return string|false
 	 */
 	public static function getAppPath($appId) {
-		if ($appId === null || trim($appId) === '') {
-			return false;
-		}
-
-		if (($dir = self::findAppInDirectories($appId)) != false) {
-			return $dir['path'] . '/' . $appId;
-		}
-		return false;
+		return \OC::$server->getAppManager()->getAppPath($appId);
 	}
 
+	/**
+	 * Get the web path for the given app.
+	 * If the app exists in multiple directories, the most recent version is taken.
+	 * (false if not found)
+	 *
+	 * @param string $appId
+	 * @return string|false
+	 */
+	public static function getAppWebPath($appId) {
+		return \OC::$server->getAppManager()->getAppWebPath($appId);
+	}
 
 	/**
 	 * check if an app's directory is writable
@@ -626,20 +583,6 @@ class OC_App {
 	public static function isAppDirWritable($appId) {
 		$path = self::getAppPath($appId);
 		return ($path !== false) ? is_writable($path) : false;
-	}
-
-	/**
-	 * Get the path for the given app on the access
-	 * If the app is defined in multiple directories, the first one is taken. (false if not found)
-	 *
-	 * @param string $appId
-	 * @return string|false
-	 */
-	public static function getAppWebPath($appId) {
-		if (($dir = self::findAppInDirectories($appId)) != false) {
-			return OC::$WEBROOT . $dir['url'] . '/' . $appId;
-		}
-		return false;
 	}
 
 	/**

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -166,4 +166,26 @@ interface IAppManager {
 	 * @since 10.0.3
 	 */
 	public function canInstall();
+
+	/**
+	 * Get the directory for the given app.
+	 * If the app exists in multiple directories, the most recent version is taken.
+	 * Returns false if not found
+	 *
+	 * @param string $appId
+	 * @return string|false
+	 * @since 10.0.5
+	 */
+	public function getAppPath($appId);
+
+	/**
+	 * Get the web path for the given app.
+	 * If the app exists in multiple directories, web path to the most recent version is taken.
+	 * Returns false if not found
+	 *
+	 * @param string $appId
+	 * @return string|false
+	 * @since 10.0.5
+	 */
+	public function getAppWebPath($appId);
 }

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -168,7 +168,7 @@ interface IAppManager {
 	public function canInstall();
 
 	/**
-	 * Get the directory for the given app.
+	 * Get the absolute path to the directory for the given app.
 	 * If the app exists in multiple directories, the most recent version is taken.
 	 * Returns false if not found
 	 *
@@ -179,7 +179,7 @@ interface IAppManager {
 	public function getAppPath($appId);
 
 	/**
-	 * Get the web path for the given app.
+	 * Get the HTTP Web path to the app directory for the given app, relative to the ownCloud webroot.
 	 * If the app exists in multiple directories, web path to the most recent version is taken.
 	 * Returns false if not found
 	 *


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/29871
Closes https://github.com/owncloud/core/issues/25336

## Description
- Allows to get the app path and app web path
- Kill legacy code that does the same. `OC_App::getAppPath` and `OC_App::getAppWebPath` are cut down to work via AppManager implementation
- It is possible to use some AppManager methods without Db connection now (e.g. when OC is not installed)

## Related Issue
https://github.com/owncloud/core/issues/25336

## Motivation and Context
- public API enhancement
- unit testing is possible now
- killing old crap

## How Has This Been Tested?
`\OC::$server->getAppManager()->getAppPath('customgroups');`
`\OC::$server->getAppManager()->getAppWebPath('customgroups');`

where 'customgroups' is your favorite app. In a various configs including multiple app directories.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.