### PR TITLE
UI-tests focus() on button before clicking it

### DIFF
--- a/tests/ui/features/lib/FilesPageElement/FileRow.php
+++ b/tests/ui/features/lib/FilesPageElement/FileRow.php
@@ -100,6 +100,7 @@ class FileRow extends OwnCloudPage {
 				" xpath $this->fileActionMenuBtnXpath could not find actionButton in fileRow"
 			);
 		}
+		$actionButton->focus();
 		return $actionButton;
 	}
 
@@ -144,6 +145,7 @@ class FileRow extends OwnCloudPage {
 				" xpath $this->shareBtnXpath could not find sharing button in fileRow"
 			);
 		}
+		$shareBtn->focus();
 		return $shareBtn;
 	}
 


### PR DESCRIPTION
## Description
focus the found button before returning it to the outer function

## Related Issue
making UI tests run in docker https://github.com/owncloud/qa-enterprise/pull/115

## Motivation and Context
when running tests in docker on FF57 some would fail if the found line was just at the bottom of the screen with: ` WebDriver\Exception\MoveTargetOutOfBounds: (1016.5, 1606.7666015625) is out of bounds of viewport width (1360) and height (897)`
I cannot totally explain why that happens because the line was visible and it got a `focus()` before in `findFileRowByName()`, but focusing here fixes the problem and should not hurt.

## How Has This Been Tested?
run UI tests in docker with FF and chrome
travis will run them all in saucelabs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

