### PR TITLE
Return 403 instead of 503 to resume syncing of desktop client

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -353,8 +353,8 @@ class File extends Node implements IFile {
 			}
 			return $res;
 		} catch (GenericEncryptionException $e) {
-			// returning 503 will allow retry of the operation at a later point in time
-			throw new ServiceUnavailable("Encryption not ready: " . $e->getMessage());
+			// returning 403 because some apps stops syncing if 503 is returned.
+			throw new Forbidden("Encryption not ready: " . $e->getMessage());
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable("Failed to open file: " . $e->getMessage());
 		} catch (ForbiddenException $ex) {

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -29,6 +29,7 @@ use OC\Files\Filesystem;
 use OC\Files\Storage\Local;
 use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
+use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\File;
 use OCP\Constants;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
@@ -1244,6 +1245,30 @@ class FileTest extends TestCase {
 		$view->expects($this->atLeastOnce())
 			->method('fopen')
 			->willThrowException(new ForbiddenException('', true));
+		$view->expects($this->atLeastOnce())
+			->method('file_exists')
+			->will($this->returnValue(true));
+
+		$info = new FileInfo('/test.txt', $this->getMockStorage(), null, [
+			'permissions' => Constants::PERMISSION_ALL
+		], null);
+
+		$file = new File($view, $info);
+
+		$file->get();
+	}
+
+	/**
+	 * @expectedException \Sabre\Dav\Exception\Forbidden
+	 * @expectedExceptionMessage Encryption not ready
+	 */
+	public function testFopenForbiddenExceptionEncryption() {
+		$view = $this->getMockBuilder(View::class)
+			->setMethods(['fopen', 'file_exists'])
+			->getMock();
+		$view->expects($this->atLeastOnce())
+			->method('fopen')
+			->willThrowException(new Exception\Forbidden('Encryption not ready', true));
 		$view->expects($this->atLeastOnce())
 			->method('file_exists')
 			->will($this->returnValue(true));


### PR DESCRIPTION
When 503 is returned the syncing is stopped
by desktop client. Hence its found better
to return 403.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Returning 503 was causing sync operation of desktop client to stop. Hence returning 403 makes sync operation not to stop.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/29794

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When 503 is returned the sync operation is stopped by the desktop client. Hence 403 is being returned.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Steps followed as mentioned in https://github.com/owncloud/core/issues/29794.
The result captured from desktop client after applying the patch:
```
01-09 14:16:21:873 [ warning sync.networkjob ]: QNetworkReply::NetworkError(ContentOperationNotPermittedError) "Server replied \"403 Forbidden\" to \"GET http://localhost/testing/remote.php/dav/files/admin/welcome.txt\"" QVariant(int, 403)
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

