### PR TITLE
run UI tests on FF57 and retire FF47

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,70 +118,70 @@ matrix:
         sauce_connect: true
     - php: 5.6
       if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
       if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
       if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
       if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="renameFiles" PLATFORM="Windows 10" TEST_DAV=0
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="renameFiles" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
       if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="renameFolders" PLATFORM="Windows 10" TEST_DAV=0
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="renameFolders" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
       if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
       if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 10" TEST_DAV=0
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
       if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 10" TEST_DAV=0
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
       if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 10" TEST_DAV=0
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
       if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="47.0" BEHAT_SUITE="upload" PLATFORM="Windows 10" TEST_DAV=0
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="upload" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts

--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -282,9 +282,10 @@ then
 	if verlte "$BROWSER_VERSION" "47.0"
 	then
 		EXTRA_CAPABILITIES='"seleniumVersion":"2.53.1",'$EXTRA_CAPABILITIES
+	else
+		EXTRA_CAPABILITIES='"seleniumVersion":"3.4.0",'$EXTRA_CAPABILITIES
 	fi
 fi
-
 
 if [ "$BROWSER" == "internet explorer" ]
 then


### PR DESCRIPTION
## Description
saucelabs can now run our tests with FF 57, so we should get rid of the ancient FF version

## Motivation and Context
run tests in a modern browser

## How Has This Been Tested?
run all tests https://github.com/individual-it/owncloud-core/pull/73

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

