### PR TITLE
[stable10] Add missing nodejs_deps in make dist rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ clean-docs:
 #
 # Build distribution
 #
-$(dist_dir)/owncloud: $(composer_deps) $(core_all_src)
+$(dist_dir)/owncloud: $(composer_deps) $(nodejs_deps) $(core_all_src)
 	rm -Rf $@; mkdir -p $@/config
 	cp -RL $(core_all_src) $@
 	cp -R config/config.sample.php $@/config
@@ -271,7 +271,7 @@ clean-dist:
 #
 # Build qa distribution
 #
-$(dist_dir)/qa/owncloud: $(composer_dev_deps) $(core_all_src) $(core_test_dirs)
+$(dist_dir)/qa/owncloud: $(composer_dev_deps) $(nodejs_deps) $(core_all_src) $(core_test_dirs)
 	rm -Rf $@; mkdir -p $@/config
 	cp -RL $(core_all_src) $@
 	cp -R $(core_test_dirs) $@


### PR DESCRIPTION
@DeepDiver1975 @davitol 

This broke the dist build and comes from the yarn changes.

TODO: forward port to master