### PR TITLE
[stable10] Don't break event chain in GDrive storage oauth2 handler

### DIFF
--- a/apps/files_external/js/gdrive.js
+++ b/apps/files_external/js/gdrive.js
@@ -36,7 +36,7 @@ $(document).ready(function() {
 	 */
 	$('.configuration').on('oauth_step1', function (event, data) {
 		if (data['backend_id'] !== backendId) {
-			return false;	// means the trigger is not for this storage adapter
+			return;	// means the trigger is not for this storage adapter
 		}
 
 		// Redirects the User on success else displays an alert (with error message sent by backend)
@@ -45,7 +45,7 @@ $(document).ready(function() {
 
 	$('.configuration').on('oauth_step2', function (event, data) {
 		if (data['backend_id'] !== backendId || data['code'] === undefined) {
-			return false;		// means the trigger is not for this OAuth2 grant
+			return;		// means the trigger is not for this OAuth2 grant
 		}
 
 		OCA.External.Settings.OAuth2.verifyCode(backendUrl, data)


### PR DESCRIPTION
## Description
Returning false would cancel the chain of events, preventing other
handlers to be executed for example when setting up a Dropbox storage...

## Related Issue
https://github.com/owncloud/files_external_dropbox/issues/23

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
See https://github.com/owncloud/files_external_dropbox/issues/23#issuecomment-356284960.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@Hemant-Mann can you review ?
