### PR TITLE
Makefile clean core vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,12 +234,14 @@ $(dist_dir)/owncloud: $(composer_deps) $(nodejs_deps) $(core_all_src)
 	find $@/{core/,l10n/} -iname \*.sh -delete
 	find $@/{apps/,lib/composer/,core/vendor/} \( \
 		-name bin -o \
+		-name build -o \
 		-name test -o \
 		-name tests -o \
 		-name examples -o \
 		-name demo -o \
 		-name demos -o \
 		-name doc -o \
+		-name docs -o \
 		-name travis -o \
 		-iname \*.sh \
 		\) -print | xargs rm -Rf
@@ -287,6 +289,7 @@ $(dist_dir)/qa/owncloud: $(composer_dev_deps) $(nodejs_deps) $(core_all_src) $(c
 		-name demo -o \
 		-name demos -o \
 		-name doc -o \
+		-name docs -o \
 		-name travis -o \
 		-iname \*.sh \
 		\) -print | xargs rm -Rf

--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,9 @@ $(dist_dir)/owncloud: $(composer_deps) $(nodejs_deps) $(core_all_src)
 		-name doc -o \
 		-name docs -o \
 		-name travis -o \
+		-name node_modules -o \
+		-name scripts -o \
+		-name grunt -o \
 		-iname \*.sh \
 		\) -print | xargs rm -Rf
 	find $@/{apps/,lib/composer/} -iname \*.exe -delete

--- a/build/package.json
+++ b/build/package.json
@@ -10,8 +10,6 @@
   "homepage": "https://github.com/owncloud/",
   "contributors": [],
   "dependencies": {
-    "@bower_components/Jcrop": "tapmodo/Jcrop#2.0.4",
-    "@bower_components/Snap.js": "jakiestfu/Snap.js#1.9.3",
     "@bower_components/backbone": "jashkenas/backbone#1.3.3",
     "@bower_components/base64": "davidchambers/Base64.js#1.0.1",
     "@bower_components/blueimp-md5": "blueimp/JavaScript-MD5#2.10.0",
@@ -22,7 +20,7 @@
     "@bower_components/davclient.js": "owncloud/davclient.js#0.1.2",
     "@bower_components/es6-promise": "components/es6-promise#4.1.1",
     "@bower_components/handlebars": "components/handlebars.js#4.0.11",
-    "@bower_components/jcrop": "tapmodo/Jcrop#0.9.12",
+    "@bower_components/Jcrop": "tapmodo/Jcrop#2.0.4",
     "@bower_components/jquery": "jquery/jquery-dist#2.1.4",
     "@bower_components/jquery-migrate": "appleboy/jquery-migrate#1.4.0",
     "@bower_components/jquery-ui": "components/jqueryui#1.10.0",

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -6,10 +6,6 @@
   version "2.0.4"
   resolved "https://codeload.github.com/tapmodo/Jcrop/tar.gz/80f645b69fc938b3823d92d74e5019036d04a9ca"
 
-"@bower_components/Snap.js@jakiestfu/Snap.js#1.9.3":
-  version "0.0.0"
-  resolved "https://codeload.github.com/jakiestfu/Snap.js/tar.gz/8538051df8e2c82a39d2603b6dfd8219ce8f04e6"
-
 "@bower_components/backbone@jashkenas/backbone#1.3.3":
   version "1.3.3"
   resolved "https://codeload.github.com/jashkenas/backbone/tar.gz/8ec88604732944f197b352a6be22c8216ea9d3a1"
@@ -55,10 +51,6 @@
 "@bower_components/handlebars@components/handlebars.js#4.0.11":
   version "4.0.11"
   resolved "https://codeload.github.com/components/handlebars.js/tar.gz/3494cd22feb926c5907237506243d358277dad71"
-
-"@bower_components/jcrop@tapmodo/Jcrop#0.9.12":
-  version "0.0.0"
-  resolved "https://codeload.github.com/tapmodo/Jcrop/tar.gz/1902fbc6afa14481dc019a17e0dcb7d62b808a98"
 
 "@bower_components/jquery-migrate@appleboy/jquery-migrate#1.4.0":
   version "0.0.0"

--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -3,8 +3,8 @@ script('settings', 'panels/profile');
 vendor_script('strengthify/jquery.strengthify');
 vendor_style('strengthify/strengthify');
 if ($_['enableAvatars']) {
-	vendor_script('jcrop/js/jquery.Jcrop');
-	vendor_style('jcrop/css/jquery.Jcrop');
+	vendor_script('Jcrop/js/Jcrop.min');
+	vendor_style('Jcrop/css/Jcrop.min');
 }
 ?>
 <?php if ($_['enableAvatars']): ?>


### PR DESCRIPTION
## Description
Since we updated some libs and switched to yarn, some new folders have sneaked into the build: "build" and "docs" folders. The Makefile now removes them.

Also, we had duplicate JCrop and SnapJS, these are removed too.

## Related Issue
None

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
I've retested:
- [x] snapjs (resize browser window until the left side panel disappears)
- [x] jcrop (avatar cropping)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

