### PR TITLE
Picky Makefile being picky

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ SHELL=/bin/bash
 #
 YARN := $(shell command -v yarn 2> /dev/null)
 ifndef YARN
-	$(error yarn is not available on your system, please install yarn (npm install -g yarn))
+  $(error yarn is not available on your system, please install yarn (npm install -g yarn))
 endif
 
 KARMA=$(NODE_PREFIX)/node_modules/.bin/karma


### PR DESCRIPTION
without this PR:
```
Makefile:39: *** Rezept beginnt vor dem ersten Ziel.  Schluss.
```

with this PR:
```
Makefile:38: *** yarn is not available on your system, please install yarn (npm install -g yarn).  Schluss.
```
see https://stackoverflow.com/a/30775546