### PR TITLE
throw ServerUnavailable exception with unexpected SMB errors

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -600,6 +600,10 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 		$path = $this->buildPath($path);
 		try {
 			$result = $this->share->mkdir($path);
+		} catch (ForbiddenException $e) {
+			$this->swallow(__FUNCTION__, $e);
+		} catch (AlreadyExistsException $e) {
+			$this->swallow(__FUNCTION__, $e);
 		} catch (Exception $e) {
 			if ($e->getCode() === 16) {
 				$this->swallow(__FUNCTION__, $e);

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -289,7 +289,7 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 				} else {
 					$result = false;
 				}
-			} else if ($e->getCode() === 16) {
+			} elseif ($e->getCode() === 16) {
 				$this->swallow(__FUNCTION__, $e);
 				$result = false;
 			} else {
@@ -543,7 +543,8 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 				$fh = $this->share->write($this->buildPath($path));
 				\fclose($fh);
 				$result = true;
-			}		} catch (Exception $e) {
+			}
+		} catch (Exception $e) {
 			if ($e->getCode() === 16) {
 				$this->swallow(__FUNCTION__, $e);
 			} else {

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -261,14 +261,18 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 
 		try {
 			$result = $this->share->rename($this->root . $source, $this->root . $target);
-			$this->removeFromCache($this->root . $source);
-			$this->removeFromCache($this->root . $target);
+			if ($result) {
+				$this->removeFromCache($this->root . $source);
+				$this->removeFromCache($this->root . $target);
+			}
 		} catch (AlreadyExistsException $e) {
 			$this->swallow(__FUNCTION__, $e);
 			if ($this->unlink($target)) {
 				$result = $this->share->rename($this->root . $source, $this->root . $target);
-				$this->removeFromCache($this->root . $source);
-				$this->removeFromCache($this->root . $target);
+				if ($result) {
+					$this->removeFromCache($this->root . $source);
+					$this->removeFromCache($this->root . $target);
+				}
 			} else {
 				$result = false;
 			}
@@ -278,8 +282,10 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			if ($e->getCode() === 22) {
 				if ($this->unlink($target)) {
 					$result = $this->share->rename($this->root . $source, $this->root . $target);
-					$this->removeFromCache($this->root . $source);
-					$this->removeFromCache($this->root . $target);
+					if ($result) {
+						$this->removeFromCache($this->root . $source);
+						$this->removeFromCache($this->root . $target);
+					}
 				} else {
 					$result = false;
 				}

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -265,18 +265,27 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			$this->removeFromCache($this->root . $target);
 		} catch (AlreadyExistsException $e) {
 			$this->swallow(__FUNCTION__, $e);
-			$this->unlink($target);
-			$result = $this->share->rename($this->root . $source, $this->root . $target);
-			$this->removeFromCache($this->root . $source);
-			$this->removeFromCache($this->root . $target);
+			if ($this->unlink($target)) {
+				$result = $this->share->rename($this->root . $source, $this->root . $target);
+				$this->removeFromCache($this->root . $source);
+				$this->removeFromCache($this->root . $target);
+			} else {
+				$result = false;
+			}
 		} catch (Exception $e) {
 			$this->swallow(__FUNCTION__, $e);
 			// Icewind\SMB\Exception\Exception, not a plain exception
 			if ($e->getCode() === 22) {
-				$this->unlink($target);
-				$result = $this->share->rename($this->root . $source, $this->root . $target);
-				$this->removeFromCache($this->root . $source);
-				$this->removeFromCache($this->root . $target);
+				if ($this->unlink($target)) {
+					$result = $this->share->rename($this->root . $source, $this->root . $target);
+					$this->removeFromCache($this->root . $source);
+					$this->removeFromCache($this->root . $target);
+				} else {
+					$result = false;
+				}
+			} else if ($e->getCode() === 16) {
+				$this->swallow(__FUNCTION__, $e);
+				$result = false;
 			} else {
 				$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 				$this->leave(__FUNCTION__, $ex);
@@ -373,8 +382,8 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 				$result = $this->rmdir($path);
 			} else {
 				$path = $this->buildPath($path);
-				unset($this->statCache[$path]);
 				$this->share->del($path);
+				unset($this->statCache[$path]);
 				$result = true;
 			}
 		} catch (NotFoundException $e) {
@@ -382,9 +391,13 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 		} catch (ForbiddenException $e) {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (Exception $e) {
-			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
-			$this->leave(__FUNCTION__, $ex);
-			throw $ex;
+			if ($e->getCode() === 16) {
+				$this->swallow(__FUNCTION__, $e);
+			} else {
+				$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+				$this->leave(__FUNCTION__, $ex);
+				throw $ex;
+			}
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -468,9 +481,13 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 		} catch (ForbiddenException $e) {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (Exception $e) {
-			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
-			$this->leave(__FUNCTION__, $ex);
-			throw $ex;
+			if ($e->getCode() === 16) {
+				$this->swallow(__FUNCTION__, $e);
+			} else {
+				$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+				$this->leave(__FUNCTION__, $ex);
+				throw $ex;
+			}
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -501,27 +518,33 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 		} catch (ForbiddenException $e) {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (Exception $e) {
-			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
-			$this->leave(__FUNCTION__, $ex);
-			throw $ex;
+			if ($e->getCode() === 16) {
+				$this->swallow(__FUNCTION__, $e);
+			} else {
+				$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+				$this->leave(__FUNCTION__, $ex);
+				throw $ex;
+			}
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
 
 	public function touch($path, $time = null) {
 		$this->log('enter: '.__FUNCTION__."($path, $time)");
+		$result = false;
 		try {
 			if (!$this->file_exists($path)) {
 				$fh = $this->share->write($this->buildPath($path));
 				\fclose($fh);
 				$result = true;
+			}		} catch (Exception $e) {
+			if ($e->getCode() === 16) {
+				$this->swallow(__FUNCTION__, $e);
 			} else {
-				$result = false;
+				$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+				$this->leave(__FUNCTION__, $ex);
+				throw $ex;
 			}
-		} catch (Exception $e) {
-			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
-			$this->leave(__FUNCTION__, $ex);
-			throw $ex;
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -572,9 +595,13 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 		try {
 			$result = $this->share->mkdir($path);
 		} catch (Exception $e) {
-			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
-			$this->leave(__FUNCTION__, $ex);
-			throw $ex;
+			if ($e->getCode() === 16) {
+				$this->swallow(__FUNCTION__, $e);
+			} else {
+				$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+				$this->leave(__FUNCTION__, $ex);
+				throw $ex;
+			}
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -278,7 +278,9 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 				$this->removeFromCache($this->root . $source);
 				$this->removeFromCache($this->root . $target);
 			} else {
-				$result = false;
+				$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+				$this->leave(__FUNCTION__, $ex);
+				throw $ex;
 			}
 		} catch (\Exception $e) {
 			$this->swallow(__FUNCTION__, $e);
@@ -305,6 +307,10 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 		} catch (NotFoundException $e) {
 			$this->swallow(__FUNCTION__, $e);
 			$result = false;
+		} catch (Exception $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+			$this->leave(__FUNCTION__, $ex);
+			throw $ex;
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -375,9 +381,8 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (ForbiddenException $e) {
 			$this->swallow(__FUNCTION__, $e);
-		} catch (ConnectException $e) {
-			$ex = new StorageNotAvailableException(
-				$e->getMessage(), $e->getCode(), $e);
+		} catch (Exception $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 			$this->leave(__FUNCTION__, $ex);
 			throw $ex;
 		}
@@ -462,9 +467,8 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (ForbiddenException $e) {
 			$this->swallow(__FUNCTION__, $e);
-		} catch (ConnectException $e) {
-			$ex = new StorageNotAvailableException(
-				$e->getMessage(), $e->getCode(), $e);
+		} catch (Exception $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 			$this->leave(__FUNCTION__, $ex);
 			throw $ex;
 		}
@@ -496,9 +500,8 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (ForbiddenException $e) {
 			$this->swallow(__FUNCTION__, $e);
-		} catch (ConnectException $e) {
-			$ex = new StorageNotAvailableException(
-				$e->getMessage(), $e->getCode(), $e);
+		} catch (Exception $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 			$this->leave(__FUNCTION__, $ex);
 			throw $ex;
 		}
@@ -515,9 +518,8 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			} else {
 				$result = false;
 			}
-		} catch (ConnectException $e) {
-			$ex = new StorageNotAvailableException(
-				$e->getMessage(), $e->getCode(), $e);
+		} catch (Exception $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 			$this->leave(__FUNCTION__, $ex);
 			throw $ex;
 		}
@@ -538,6 +540,10 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (ForbiddenException $e) {
 			$this->swallow(__FUNCTION__, $e);
+		} catch (Exception $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+			$this->leave(__FUNCTION__, $ex);
+			throw $ex;
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -551,6 +557,10 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (ForbiddenException $e) {
 			$this->swallow(__FUNCTION__, $e);
+		} catch (Exception $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+			$this->leave(__FUNCTION__, $ex);
+			throw $ex;
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -561,13 +571,10 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 		$path = $this->buildPath($path);
 		try {
 			$result = $this->share->mkdir($path);
-		} catch (ConnectException $e) {
-			$ex = new StorageNotAvailableException(
-				$e->getMessage(), $e->getCode(), $e);
+		} catch (Exception $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 			$this->leave(__FUNCTION__, $ex);
 			throw $ex;
-		} catch (Exception $e) {
-			$this->swallow(__FUNCTION__, $e);
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -582,9 +589,8 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (ForbiddenException $e) {
 			$this->swallow(__FUNCTION__, $e);
-		} catch (ConnectException $e) {
-			$ex = new StorageNotAvailableException(
-				$e->getMessage(), $e->getCode(), $e);
+		} catch (Exception $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
 			$this->leave(__FUNCTION__, $ex);
 			throw $ex;
 		}
@@ -601,6 +607,10 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (ForbiddenException $e) {
 			$this->swallow(__FUNCTION__, $e);
+		} catch (Exception $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+			$this->leave(__FUNCTION__, $ex);
+			throw $ex;
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -617,6 +627,10 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (ForbiddenException $e) {
 			$this->swallow(__FUNCTION__, $e);
+		} catch (Exception $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+			$this->leave(__FUNCTION__, $ex);
+			throw $ex;
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}
@@ -631,6 +645,10 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			$this->swallow(__FUNCTION__, $e);
 		} catch (ForbiddenException $e) {
 			$this->swallow(__FUNCTION__, $e);
+		} catch (Exception $e) {
+			$ex = new StorageNotAvailableException($e->getMessage(), $e->getCode(), $e);
+			$this->leave(__FUNCTION__, $ex);
+			throw $ex;
 		}
 		return $this->leave(__FUNCTION__, $result);
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
throw StorageNotAvailableException in case of unexpected errors in the public methods of the connector

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No public issue reported

## Motivation and Context
Unexpected errors might cause the storage to misbehave, for example getting empty results when accessing to a folder although it's in fact unable to connect or return a proper response.

## How Has This Been Tested?
**UNTESTED** for the moment

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@butonic @PVince81 