### PR TITLE
Add support heic

### DIFF
--- a/lib/private/Preview/Heic.php
+++ b/lib/private/Preview/Heic.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Preview;
+
+//.psd
+class Heic extends Bitmap {
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getMimeType() {
+		return '/image\/hei(f|c)/';
+	}
+}

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -243,6 +243,7 @@ class PreviewManager implements IPreview {
 			'OC\Preview\JPEG',
 			'OC\Preview\GIF',
 			'OC\Preview\BMP',
+			'OC\Preview\Heic',
 			'OC\Preview\XBitmap'
 		];
 
@@ -303,6 +304,7 @@ class PreviewManager implements IPreview {
 				'PSD'	=> ['mimetype' => '/application\/x-photoshop/', 'class' => '\OC\Preview\Photoshop'],
 				'EPS'	=> ['mimetype' => '/application\/postscript/', 'class' => '\OC\Preview\Postscript'],
 				'TTF'	=> ['mimetype' => '/application\/(?:font-sfnt|x-font$)/', 'class' => '\OC\Preview\Font'],
+				'HEIC'	=> ['mimetype' => '/image\/hei(f|c)/', 'class' => '\OC\Preview\Heic'],
 			];
 
 			foreach ($imagickProviders as $queryFormat => $provider) {

--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -51,6 +51,8 @@
 	"gz": ["application/x-gzip"],
 	"gzip": ["application/x-gzip"],
 	"h": ["text/x-h"],
+	"heic": ["image/heic"],
+	"heif": ["image/heif"],
 	"hh": ["text/x-h"],
 	"hpp": ["text/x-h"],
 	"html": ["text/html", "text/plain"],


### PR DESCRIPTION
## Description
HEIF and HEIC formats are added to iOS and will pop up in the cloud sooner or later.

## Related Issue
https://github.com/owncloud/gallery/issues/737


## How Has This Been Tested?
- upload a heic file and see at least it being marked as an image

get test images from here https://nokiatech.github.io/heif/examples.html

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

