### PR TITLE
Fix deleted items auto expiration for users with no quota

### DIFF
--- a/apps/files_trashbin/lib/AppInfo/Application.php
+++ b/apps/files_trashbin/lib/AppInfo/Application.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author Roeland Jago Douma <rullzer@owncloud.com>
- * @author Victor Dubiniuk <dubiniuk@owncloud.com>
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
  *
  * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0
@@ -23,6 +23,7 @@
 namespace OCA\Files_Trashbin\AppInfo;
 
 use OCA\Files_Trashbin\Expiration;
+use OCA\Files_Trashbin\Quota;
 use OCP\AppFramework\App;
 
 class Application extends App {
@@ -39,9 +40,19 @@ class Application extends App {
 		 * Register expiration
 		 */
 		$container->registerService('Expiration', function($c) {
-			return  new Expiration(
+			return new Expiration(
 				$c->query('ServerContainer')->getConfig(),
 				$c->query('OCP\AppFramework\Utility\ITimeFactory')
+			);
+		});
+
+		/*
+		 * Register quota
+		 */
+		$container->registerService('Quota', function($c) {
+			return new Quota(
+				$c->getServer()->getUserManager(),
+				$c->query('ServerContainer')->getConfig()
 			);
 		});
 	}

--- a/apps/files_trashbin/lib/Quota.php
+++ b/apps/files_trashbin/lib/Quota.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Trashbin;
+
+use OC\Files\Filesystem;
+use OCP\Files\FileInfo;
+use OCP\IConfig;
+use OCP\IUserManager;
+use OCP\IUser;
+
+class Quota  {
+
+	// percent of free disk space/quota that triggers trashbin cleanup by default
+	const DEFAULTMAXSIZE = 50;
+
+	/** @var IUserManager */
+	protected $userManager;
+
+	/** @var IConfig */
+	protected $config;
+
+	public function __construct(IUserManager $userManager, IConfig $config){
+		$this->userManager = $userManager;
+		$this->config = $config;
+	}
+
+	/**
+	 * Calculate remaining free space for trash bin
+	 *
+	 * @param integer $trashbinSize current size of the trash bin
+	 * @param string $user
+	 * @return int available free space for trash bin
+	 */
+	public function calculateFreeSpace($trashbinSize, $user) {
+		$userObject = $this->userManager->get($user);
+		if(is_null($userObject)) {
+			return 0;
+		}
+		$quota = $this->getUserQuota($userObject);
+
+		$userFolder = \OC::$server->getUserFolder($user);
+		if(is_null($userFolder)) {
+			return 0;
+		}
+
+		$free = $quota - $userFolder->getSize(); // remaining free space for user
+		if ($free > 0) {
+			// does trashbin size hit purge limit with the current free space
+			$availableSpace = ($free * $this->getPurgeLimit() / 100) - $trashbinSize;
+		} else {
+			$availableSpace = $free - $trashbinSize;
+		}
+
+		return $availableSpace;
+	}
+
+	/**
+	 * Get a percentage of free space that should trigger
+	 * cleanup for outdated files in trashbin
+	 *
+	 * @return int
+	 */
+	public function getPurgeLimit(){
+		return $this->config->getSystemValue('trashbin_purge_limit', self::DEFAULTMAXSIZE);
+	}
+
+
+	/**
+	 * Get user quota or free space when there is no quota set
+	 *
+	 * @param IUser $user
+	 * @return int|mixed
+	 */
+	protected function getUserQuota(IUser $user) {
+		$quota = \OC_Util::getUserQuota($user);
+		if ($quota === FileInfo::SPACE_UNLIMITED) {
+			$quota = Filesystem::free_space('/');
+			// inf or unknown free space
+			if ($quota < 0) {
+				$quota = PHP_INT_MAX;
+			}
+		}
+
+		return $quota;
+	}
+}

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -15,7 +15,7 @@
  * @author Sjors van der Pluijm <sjors@desjors.nl>
  * @author Steven Bühner <buehner@me.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
- * @author Victor Dubiniuk <dubiniuk@owncloud.com>
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
  * @author Vincent Petry <pvince81@owncloud.com>
  *
  * @copyright Copyright (c) 2018, ownCloud GmbH
@@ -45,9 +45,6 @@ use OCP\Files\NotFoundException;
 use OCP\User;
 
 class Trashbin {
-
-	// unit: percentage; 50% of available disk space/quota
-	const DEFAULTMAXSIZE = 50;
 
 	/**
 	 * Whether versions have already be rescanned during this PHP request
@@ -664,8 +661,6 @@ class Trashbin {
 
 		if ($timestamp) {
 			$filename = $filename . '.d' . $timestamp;
-		} else {
-			$filename = $filename;
 		}
 
 		$target = Filesystem::normalizePath('files_trashbin/files/' . $filename);
@@ -684,60 +679,13 @@ class Trashbin {
 	}
 
 	/**
-	 * calculate remaining free space for trash bin
-	 *
-	 * @param integer $trashbinSize current size of the trash bin
-	 * @param string $user
-	 * @return int available free space for trash bin
-	 */
-	private static function calculateFreeSpace($trashbinSize, $user) {
-		$softQuota = true;
-		$userObject = \OC::$server->getUserManager()->get($user);
-		if(is_null($userObject)) {
-			return 0;
-		}
-		$quota = \OC_Util::getUserQuota($userObject);
-		if ($quota === \OCP\Files\FileInfo::SPACE_UNLIMITED) {
-			$quota = Filesystem::free_space('/');
-			$softQuota = false;
-			// inf or unknown free space
-			if ($quota < 0) {
-				$quota = PHP_INT_MAX;
-			}
-		} else {
-			$quota = \OCP\Util::computerFileSize($quota);
-		}
-
-		// calculate available space for trash bin
-		// subtract size of files and current trash bin size from quota
-		if ($softQuota) {
-			$userFolder = \OC::$server->getUserFolder($user);
-			if(is_null($userFolder)) {
-				return 0;
-			}
-			$free = $quota - $userFolder->getSize(); // remaining free space for user
-			if ($free > 0) {
-				$availableSpace = ($free * self::DEFAULTMAXSIZE / 100) - $trashbinSize; // how much space can be used for versions
-			} else {
-				$availableSpace = $free - $trashbinSize;
-			}
-		} else {
-			$availableSpace = $quota;
-		}
-
-		return $availableSpace;
-	}
-
-	/**
 	 * resize trash bin if necessary after a new file was added to ownCloud
 	 *
 	 * @param string $user user id
 	 */
 	public static function resizeTrash($user) {
-
 		$size = self::getTrashbinSize($user);
-
-		$freeSpace = self::calculateFreeSpace($size, $user);
+		$freeSpace = self::getQuota()->calculateFreeSpace($size, $user);
 
 		if ($freeSpace < 0) {
 			self::scheduleExpire($user);
@@ -751,7 +699,7 @@ class Trashbin {
 	 */
 	public static function expire($user) {
 		$trashBinSize = self::getTrashbinSize($user);
-		$availableSpace = self::calculateFreeSpace($trashBinSize, $user);
+		$availableSpace = self::getQuota()->calculateFreeSpace($trashBinSize, $user);
 
 		$dirContent = Helper::getTrashFiles('/', $user, 'mtime');
 
@@ -762,6 +710,14 @@ class Trashbin {
 
 		// delete files from trash until we meet the trash bin size limit again
 		self::deleteFiles(array_slice($dirContent, $count), $user, $availableSpace);
+	}
+
+	/**
+	 * @return Quota
+	 */
+	protected static function getQuota() {
+		$application = new Application();
+		return $application->getContainer()->query('Quota');
 	}
 
 	/**
@@ -794,7 +750,13 @@ class Trashbin {
 			foreach ($files as $file) {
 				if ($availableSpace < 0 && $expiration->isExpired($file['mtime'], true)) {
 					$tmp = self::delete($file['name'], $user, $file['mtime']);
-					\OCP\Util::writeLog('files_trashbin', 'remove "' . $file['name'] . '" (' . $tmp . 'B) to meet the limit of trash bin size (50% of available quota)', \OCP\Util::INFO);
+					$message = sprintf(
+						'remove "%s" (%dB) to meet the limit of trash bin size (%d%% of available quota)',
+						$file['name'],
+						$tmp,
+						self::getQuota()->getPurgeLimit()
+					);
+					\OCP\Util::writeLog('files_trashbin', $message, \OCP\Util::INFO);
 					$availableSpace += $tmp;
 					$size += $tmp;
 				} else {

--- a/apps/files_trashbin/tests/QuotaTest.php
+++ b/apps/files_trashbin/tests/QuotaTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+use OCA\Files_Trashbin\Quota;
+use OCP\IConfig;
+use OCP\IUserManager;
+
+class QuotaTest extends \Test\TestCase {
+
+	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject  */
+	private $userManager;
+
+	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject  */
+	protected $config;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->userManager = $this->getMockBuilder(IUserManager::class)
+			->getMock();
+		$this->config =  $this->getMockBuilder(IConfig::class)
+			->getMock();
+	}
+
+	public function testNonExistingUserNoNeedPurge() {
+		$this->userManager->expects($this->any())
+			->method('get')
+			->willReturn(null);
+
+		$quota = new Quota($this->userManager, $this->config);
+		$neededSpace = $quota->calculateFreeSpace(100, 'anyuser');
+		$this->assertEquals(0, $neededSpace);
+	}
+
+}

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -485,6 +485,11 @@ $CONFIG = array(
  */
 'trashbin_retention_obligation' => 'auto',
 
+/**
+ * This setting defines percentage of free space occupied by deleted files
+ * that triggers auto purging of deleted files for this user
+ */
+'trashbin_purge_limit' => 50,
 
 /**
  * File versions


### PR DESCRIPTION
## Description
Fix regression introduced a long time ago in https://github.com/owncloud/core/commit/a3999036f720e73727dac07a337578f3e25f92aa#diff-0dc914768208fc24b2aa2f2a369bb684
It is based on a wrong assumption that FS free space could be negative. 

## Related Issue
https://github.com/owncloud/core/issues/27412
obsoletes https://github.com/owncloud/core/pull/29951
## Motivation and Context
Trashbin auto clean up doesn't work when a user has no quota

## How Has This Been Tested?
1. Set `trashbin_retention_obligation` to `auto`
2. Create a user with no quota
3. Upload some files and delete uploaded files for that user
4. Keep uploading until all partition for `datadir` is occupied

### Expected 
Deleted files are purged to save space

### Actual
They are not


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

To document: 
New config.php `'trashbin_purge_limit'` that was just a constant before.
Introduced to fine tune purging in cases like https://github.com/owncloud/core/issues/2936