### PR TITLE
Scroll action menu on Files page and Public links page

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -2050,7 +2050,11 @@ OC.Util = {
 		var windowHeight = $(window).height();
 
 		if (scrollContainer === null) {
-			scrollContainer = $('#content-wrapper, #app-content');
+			if ($('#app-content').length) {
+				scrollContainer = $('#app-content');
+			} else {
+				scrollContainer = $('#content-wrapper');
+			}
 		}
 
 		if (toViewElBottomLocation > windowHeight) {

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1769,7 +1769,7 @@ function relative_modified_date(timestamp) {
 OC.Util = {
 	// TODO: remove original functions from global namespace
 	humanFileSize: humanFileSize,
-	
+
 	/**
 	* regular expression to parse size in bytes from a humanly readable string
 	* see computerFileSize(string)
@@ -1792,7 +1792,7 @@ OC.Util = {
 
 		var s = string.toLowerCase().trim();
 		var bytes = null;
-		
+
 		var bytesArray = {
 			'b': 1,
 			'k': 1024,
@@ -2036,21 +2036,21 @@ OC.Util = {
 		}
 		return false;
 	},
-	
+
 	/**
 	 * Checks if an element is completely visible and scrolls the screen if not
-	 * @param {jQuery} jQuery element that has to be displayed 
+	 * @param {jQuery} jQuery element that has to be displayed
 	 * @param {jQuery} scroll container if null scrollContainer will be set to $('#app-content')
 	 */
 	scrollIntoView: function (toViewEl, scrollContainer) {
-		
+
 		var toViewElTopLocation = toViewEl.offset().top;
 		var toViewElHeight = toViewEl.outerHeight();
 		var toViewElBottomLocation = toViewElTopLocation + toViewElHeight + 50;
 		var windowHeight = $(window).height();
-		
+
 		if (scrollContainer === null) {
-			scrollContainer = $('#app-content');
+			scrollContainer = $('#content-wrapper, #app-content');
 		}
 
 		if (toViewElBottomLocation > windowHeight) {


### PR DESCRIPTION
Modification to PR #30101 

``content-wrapper`` contains ``app-content`` on the ordinary files page. Putting both of them in the ``scrollContainer`` selection broke scroll into view on the ordinary files page.

The 2nd commit here uses ``app-content`` if it exists (e.g. on "ordinary" files pages), otherwise it uses ``content-wrapper`` which seems to be the thing to use on the public links page.

This stuff really needs basic scrolling actions tests for each of the variations of files page (e.g. is Trashbin or Favourites or... done with some other id(s) and breaks in some other way?)

We will see if Travis UI tests pass here (that shows that the ordinary files page is scrolling OK). 