### PR TITLE
UI test to delete groups containing special URL chars

### DIFF
--- a/tests/ui/features/other/managingGroups.feature
+++ b/tests/ui/features/other/managingGroups.feature
@@ -38,7 +38,46 @@ So that access to resources can be controlled more effectively
 		|groupname|
 		|0        |
 		|false    |
-	
+
+	@skipOnOcV10.0.3 @skipOnOcV10.0.4 @skipOnOcV10.0.5
+	Scenario: delete groups with special characters that appear in URLs
+		And these groups exist:
+		|groupname     |
+		|do-not-delete |
+		|a/slash       |
+		|per%cent      |
+		|hash#char     |
+		|q?mark        |
+		|do-not-delete2|
+		And I am on the users page
+		When I delete these groups:
+		|groupname     |
+		|a/slash       |
+		|per%cent      |
+		|hash#char     |
+		|q?mark        |
+		And the users page is reloaded
+		Then these groups should be listed:
+		|groupname     |
+		|do-not-delete |
+		|do-not-delete2|
+		But these groups should not be listed:
+		|groupname     |
+		|a/slash       |
+		|per%cent      |
+		|hash#char     |
+		|q?mark        |
+		And these groups should exist:
+		|groupname     |
+		|do-not-delete |
+		|do-not-delete2|
+		But these groups should not exist:
+		|groupname     |
+		|a/slash       |
+		|per%cent      |
+		|hash#char     |
+		|q?mark        |
+
 	Scenario: delete groups with problematic names
 		And these groups exist:
 		|groupname     |


### PR DESCRIPTION
## Description
Test that group names containing characters that are common delimiters in URLs can be deleted.

## Related Issue
#29984

## Motivation and Context
Have a tes for the issue so that there is no future regression.

## How Has This Been Tested?
UI test has been run locally.
(note that the test is skipped on version up to 10.0.5 because the fix has missed being included in 10.0.5)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

