### PR TITLE
Fix code checker "class not found"

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -39,6 +39,9 @@
 namespace OC;
 
 use Doctrine\DBAL\Exception\TableExistsException;
+use OC\App\CodeChecker\CodeChecker;
+use OC\App\CodeChecker\EmptyCheck;
+use OC\App\CodeChecker\PrivateCheck;
 use OC\DB\MigrationService;
 use OC_App;
 use OC_DB;


### PR DESCRIPTION
## Description
This prevents `[Symfony\Component\Debug\Exception\FatalThrowableError] Class 'OC\CodeChecker' not found`

## Related Issue
https://github.com/owncloud/core/issues/30129

## Motivation and Context
See description.

## How Has This Been Tested?
Tested via `occ upgrade`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

