### PR TITLE
Streamline the app installer's archive mimetype check

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -50,6 +50,12 @@ use OCP\App\AppAlreadyInstalledException;
  */
 class Installer {
 
+	private static $allowedArchiveMimetypes = array (
+		'application/zip',
+		'application/x-gzip',
+		'application/x-bzip2',
+	);
+
 	/**
 	 *
 	 * This function installs an app. All information needed are passed in the
@@ -276,9 +282,9 @@ class Installer {
 		}
 
 		//detect the archive type
-		$mime = \OC::$server->getMimeTypeDetector()->detect($path);
-		if ($mime !=='application/zip' && $mime !== 'application/x-gzip' && $mime !== 'application/x-bzip2') {
-			throw new \Exception($l->t("Archives of type %s are not supported", [$mime]));
+		$mimeType = \OC::$server->getMimeTypeDetector()->detect($path);
+		if (!in_array($mimeType, self::$allowedArchiveMimetypes)) {
+			throw new \Exception($l->t("Archives of type %s are not supported", [$mimeType]));
 		}
 
 		//extract the archive in a temporary folder


### PR DESCRIPTION
## Description

Streamline the app installer's archive mimetype check.

## Motivation and Context

This change isn't strictly necessary. [The existing code](https://github.com/owncloud/core/blob/master/lib/private/Installer.php#L280) operates correctly, as-is. However, on reading through it, I felt that that the logic could be:

- Shortened, leading to less potential for error.
- More verbose, so that it's easier to understand what's happening.
- Easier to maintain, as a list is easier to change than a set of comparative code conditions.

This PR attempts to achieve these three points.

## How Has This Been Tested?

- Ran the existing tests and no failures were attributable to this code change.
- The code is successfully validated by PHP's linter.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Code refresh/simplification/optimisation

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.