### PR TITLE
Use mysql:5.7 for coverage instead of mariadb until issues are solved

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -265,7 +265,7 @@ matrix:
       TEST_SUITE: coverage
 
     - PHP_VERSION: 7.1
-      DB_TYPE: mariadb
+      DB_TYPE: mysql
       TEST_SUITE: coverage
 
     - PHP_VERSION: 7.1


### PR DESCRIPTION
we are facing random failure on drone with mariadb - until sorted we switch over to mysql.