### PR TITLE
Dispatch share.beforeCreate after share object is fully populated

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -145,7 +145,7 @@ class Share20OCS {
 			'uid_owner' => $share->getSharedBy(),
 			'displayname_owner' => $sharedBy !== null ? $sharedBy->getDisplayName() : $share->getSharedBy(),
 			'permissions' => $share->getPermissions(),
-			'stime' => $share->getShareTime()->getTimestamp(),
+			'stime' => $share->getShareTime() ? $share->getShareTime()->getTimestamp() : null,
 			'parent' => null,
 			'expiration' => null,
 			'token' => null,
@@ -194,7 +194,9 @@ class Share20OCS {
 			$result['name'] = $share->getName();
 
 			$result['token'] = $share->getToken();
-			$result['url'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', ['token' => $share->getToken()]);
+			if ($share->getToken() !== null) {
+				$result['url'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', ['token' => $share->getToken()]);
+			}
 
 			$expiration = $share->getExpirationDate();
 			if ($expiration !== null) {
@@ -280,7 +282,7 @@ class Share20OCS {
 	 * @return \OC\OCS\Result
 	 */
 	public function createShare() {
-		$event = new GenericEvent(null);
+		$beforeEvent = new GenericEvent(null);
 		$share = $this->shareManager->newShare();
 
 		if (!$this->shareManager->shareApiEnabled()) {
@@ -296,15 +298,13 @@ class Share20OCS {
 		}
 
 		$userFolder = $this->rootFolder->getUserFolder($this->currentUser->getUID());
-		$event->setArgument('userFolder', $userFolder);
-		$event->setArgument('path', $path);
-		$event->setArgument('name', $name);
-		$event->setArgument('run', true);
-		//Dispatch an event to see if creating shares is blocked by any app
-		$this->eventDispatcher->dispatch('share.beforeCreate', $event);
-		if ($event->getArgument('run') === false) {
+		$beforeEvent->setArgument('userFolder', $userFolder);
+		$beforeEvent->setArgument('run', true);
+
+		if ($beforeEvent->getArgument('run') === false) {
 			return new \OC\OCS\Result(null, 403, $this->l->t('No permission to create share'));
 		}
+
 		try {
 			$path = $userFolder->get($path);
 		} catch (NotFoundException $e) {
@@ -469,6 +469,13 @@ class Share20OCS {
 		$share->setShareType($shareType);
 		$share->setSharedBy($this->currentUser->getUID());
 
+
+
+
+		$beforeEvent->setArgument('share', $this->formatShare($share));
+
+		$this->eventDispatcher->dispatch('share.beforeCreate', $beforeEvent);
+
 		try {
 			$share = $this->shareManager->createShare($share);
 		} catch (GenericShareException $e) {
@@ -480,15 +487,16 @@ class Share20OCS {
 			return new \OC\OCS\Result(null, 403, $e->getMessage());
 		}
 
-		$output = $this->formatShare($share);
+
 
 		$share->getNode()->unlock(\OCP\Lock\ILockingProvider::LOCK_SHARED);
 
-		$event = new GenericEvent(null, []);
-		$event->setArgument('output', $output);
-		$event->setArgument('result', 'success');
-		$this->eventDispatcher->dispatch('share.afterCreate', $event);
-		return new \OC\OCS\Result($output);
+		$formattedShareAfterCreate = $this->formatShare($share);
+		$afterEvent = new GenericEvent(null, []);
+		$afterEvent->setArgument('share', $formattedShareAfterCreate);
+		$afterEvent->setArgument('result', 'success');
+		$this->eventDispatcher->dispatch('share.afterCreate', $afterEvent);
+		return new \OC\OCS\Result($formattedShareAfterCreate);
 	}
 
 	/**


### PR DESCRIPTION


<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Motivation and Context
share.beforeCreate event is dispatched to early thus almost having no info to pass to the subscriber. This PR moves the event dispatch to a later point where all share info is available thus providing richer information to the subscriber

## How Has This Been Tested?
- UnitTests pass
- Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

