### PR TITLE
Notify user while adding an existing group again

### DIFF
--- a/core/js/multiselect.js
+++ b/core/js/multiselect.js
@@ -231,6 +231,7 @@
 							$.each(options,function(index, item) {
 								if ($(item).val() == value || $(item).text() == value) {
 									exists = true;
+									OC.Notification.showTemporary(t('settings', "Error adding {addItem}: {addItem} already exists", {addItem: value}));
 									return false;
 								}
 							});


### PR DESCRIPTION
When user tries to add group from UI which already
exists, then a notification in the UI will help user
understand the cause for not adding.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Provide error notification if the group already exist when user tries to add group in the UI.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/18972

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Provide error notification when user tries to add group already available

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![errormessage](https://user-images.githubusercontent.com/3600427/34952915-511659ec-fa41-11e7-8988-266912c112cf.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

