### PR TITLE
[Stable10] Do not cache app path if app is not found

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -561,9 +561,22 @@ class AppManager implements IAppManager {
 					$versionToLoad['url'] .= '/' . $appId;
 				}
 			}
-			$this->appDirs[$appId] = empty($versionToLoad) ? false : $versionToLoad;
+
+			if (empty($versionToLoad)) {
+				return false;
+			}
+			$this->saveAppPath($appId, $versionToLoad);
 		}
 		return $this->appDirs[$appId];
+	}
+
+	/**
+	 * Save app path and webPath to internal cache
+	 * @param string $appId
+	 * @param string[] $appData
+	 */
+	protected function saveAppPath($appId, $appData) {
+		$this->appDirs[$appId] = $appData;
 	}
 
 	/**

--- a/tests/lib/App/ManagerTest.php
+++ b/tests/lib/App/ManagerTest.php
@@ -510,4 +510,23 @@ class ManagerTest extends TestCase {
 			[ '2.2.3', '2.2.1', true ]
 		];
 	}
+
+	public function testPathIsNotCachedForNotFoundApp() {
+		$appId = 'notexistingapp';
+
+		$appManager = $this->getMockBuilder(AppManager::class)
+			->setMethods(['getAppVersionByPath', 'getAppRoots', 'saveAppPath'])
+			->disableOriginalConstructor()
+			->getMock();
+
+		$appManager->expects($this->any())
+			->method('getAppRoots')
+			->willReturn([]);
+
+		$appManager->expects($this->never())
+			->method('saveAppPath');
+
+		$appPath = $appManager->getAppPath($appId);
+		$this->assertFalse($appPath);
+	}
 }


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/30144

## Description
- Do not cache app path if an app hasn't found 
Introduced in https://github.com/owncloud/core/pull/29871 where I made app path cache a bit more 
 agressive 

## Related Issue
Fixes #30112 https://github.com/owncloud/core/issues/30126

## Motivation and Context
Fixes <image src="https://user-images.githubusercontent.com/10596560/34866220-1ae719aa-f77c-11e7-98f4-7e625bc9b9f0.png" >

## How Has This Been Tested?
- Unit-test 
- `php occ market:install -l ../xmas-0.0.4.tar.gz`

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

