### PR TITLE
Don't overwrite quota with null

### DIFF
--- a/lib/private/User/SyncService.php
+++ b/lib/private/User/SyncService.php
@@ -148,7 +148,10 @@ class SyncService {
 			}
 		}
 		if ($this->backend instanceof IProvidesQuotaBackend) {
-			$a->setQuota($this->backend->getQuota($uid));
+			$quota = $this->backend->getQuota($uid);
+			if ($quota !== null) {
+				$a->setQuota($quota);
+			}
 		} else {
 			list($hasKey, $value) = $this->readUserConfig($uid, 'files', 'quota');
 			if ($hasKey) {


### PR DESCRIPTION
user_ldap implements the IProvidesQuota interface but returns null if neither a default nor an individual quota has been set. In this case any manual quote configured by the admin gets overwritten.

This PR fixes that.