### PR TITLE
Repair dav shares

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -28,4 +28,9 @@
 		<command>OCA\DAV\Command\SyncSystemAddressBook</command>
 		<command>OCA\DAV\Command\CleanupChunks</command>
 	</commands>
+	<repair-steps>
+		<post-migration>
+			<step>OCA\DAV\Repair\RemoveInvalidShares</step>
+		</post-migration>
+	</repair-steps>
 </info>

--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -162,7 +162,7 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IShareable {
 			/** @var CalDavBackend $calDavBackend */
 			$calDavBackend = $this->caldavBackend;
 			$calDavBackend->updateShares($this, [], [
-				'href' => $principal
+				$principal
 			]);
 			return;
 		}

--- a/apps/dav/lib/CardDAV/AddressBook.php
+++ b/apps/dav/lib/CardDAV/AddressBook.php
@@ -152,7 +152,7 @@ class AddressBook extends \Sabre\CardDAV\AddressBook implements IShareable {
 			/** @var CardDavBackend $cardDavBackend */
 			$cardDavBackend = $this->carddavBackend;
 			$cardDavBackend->updateShares($this, [], [
-				'href' => $principal
+				$principal
 			]);
 			return;
 		}

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -203,6 +203,13 @@ class Principal implements BackendInterface {
 				return $this->principalPrefix . '/' . $users[0]->getUID();
 			}
 		}
+		if (substr($uri, 0, 10) === 'principal:') {
+			$principal = substr($uri, 10);
+			$principal = $this->getPrincipalByPath($principal);
+			if ($principal !== null) {
+				return $principal['uri'];
+			}
+		}
 
 		return '';
 	}

--- a/apps/dav/lib/Connector/Sabre/Server.php
+++ b/apps/dav/lib/Connector/Sabre/Server.php
@@ -37,6 +37,7 @@ class Server extends \Sabre\DAV\Server {
 
 	/**
 	 * @see \Sabre\DAV\Server
+	 * @throws \Sabre\DAV\Exception
 	 */
 	public function __construct($treeOrNode = null) {
 		parent::__construct($treeOrNode);

--- a/apps/dav/lib/DAV/Sharing/Backend.php
+++ b/apps/dav/lib/DAV/Sharing/Backend.php
@@ -58,10 +58,17 @@ class Backend {
 	 */
 	public function updateShares($shareable, $add, $remove) {
 		foreach($add as $element) {
-			$this->shareWith($shareable, $element);
+			$principal = $this->principalBackend->findByUri($element['href'], '');
+			if ($principal !== '') {
+				$this->shareWith($shareable, $element);
+			}
+
 		}
 		foreach($remove as $element) {
-			$this->unshare($shareable, $element);
+			$principal = $this->principalBackend->findByUri($element, '');
+			if ($principal !== '') {
+				$this->unshare($shareable, $element);
+			}
 		}
 	}
 
@@ -213,4 +220,5 @@ class Backend {
 		}
 		return $acl;
 	}
+
 }

--- a/apps/dav/lib/Repair/RemoveInvalidShares.php
+++ b/apps/dav/lib/Repair/RemoveInvalidShares.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Repair;
+
+use OCA\DAV\Connector\Sabre\Principal;
+use OCP\IDBConnection;
+use OCP\ILogger;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+/**
+ * Class RemoveInvalidShares - removes shared calendars and addressbook which
+ * have no matching principal. Happened because of a bug in the calendar app.
+ *
+ * @package OCA\DAV\Repair
+ */
+class RemoveInvalidShares implements IRepairStep {
+
+	/** @var IDBConnection */
+	private $connection;
+	/** @var Principal */
+	private $principalBackend;
+
+	/**
+	 * RemoveInvalidShares constructor.
+	 *
+	 * @param IDBConnection $connection
+	 * @param Principal $principalBackend
+	 */
+	public function __construct(IDBConnection $connection,
+								Principal $principalBackend) {
+		$this->connection = $connection;
+		$this->principalBackend = $principalBackend;
+	}
+
+	/**
+	 * Returns the step's name
+	 *
+	 * @return string
+	 * @since 9.1.0
+	 */
+	public function getName() {
+		return 'Remove invalid calendar and addressbook shares';
+	}
+
+	/**
+	 * Run repair step.
+	 * Must throw exception on error.
+	 *
+	 * @param IOutput $output
+	 * @throws \Exception in case of failure
+	 * @since 9.1.0
+	 */
+	public function run(IOutput $output) {
+		$query = $this->connection->getQueryBuilder();
+		$result = $query->selectDistinct('principaluri')
+			->from('dav_shares')
+			->execute();
+
+		while($row = $result->fetch()) {
+			$principaluri = $row['principaluri'];
+			$p = $this->principalBackend->getPrincipalByPath($principaluri);
+			if ($p === null) {
+				$output->info(" ... for principal '$principaluri'");
+				$this->deleteSharesForPrincipal($principaluri);
+			}
+		}
+
+		$result->closeCursor();
+	}
+
+	/**
+	 * @param string $principaluri
+	 */
+	private function deleteSharesForPrincipal($principaluri) {
+		$delete = $this->connection->getQueryBuilder();
+		$delete->delete('dav_shares')
+			->where($delete->expr()->eq('principaluri', $delete->createNamedParameter($principaluri)));
+		$delete->execute();
+	}
+}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -126,7 +126,7 @@ class Server {
 		// with performance and locking issues because it will query
 		// every parent node which might trigger an implicit rescan in the
 		// case of external storages with update detection
-		if (!$this->isRequestForSubtree('files')) {
+		if (!$this->isRequestForSubtree(['files'])) {
 			// acl
 			$acl = new DavAclPlugin();
 			$acl->principalCollectionSet = [
@@ -137,7 +137,7 @@ class Server {
 		}
 
 		// calendar plugins
-		if ($this->isRequestForSubtree('calendars')) {
+		if ($this->isRequestForSubtree(['calendars', 'principals'])) {
 			$mailer = \OC::$server->getMailer();
 			$this->server->addPlugin(new \OCA\DAV\CalDAV\Plugin());
 			$this->server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
@@ -153,7 +153,7 @@ class Server {
 		}
 
 		// addressbook plugins
-		if ($this->isRequestForSubtree('addressbooks')) {
+		if ($this->isRequestForSubtree(['addressbooks', 'principals'])) {
 			$this->server->addPlugin(new DAV\Sharing\Plugin($authBackend, \OC::$server->getRequest()));
 			$this->server->addPlugin(new \OCA\DAV\CardDAV\Plugin());
 			$this->server->addPlugin(new VCFExportPlugin());
@@ -280,11 +280,16 @@ class Server {
 	}
 
 	/**
-	 * @param string $subTree
+	 * @param string[] $subTree
 	 * @return bool
 	 */
-	private function isRequestForSubtree($subTree) {
+	private function isRequestForSubtree(array $subTrees) {
+		foreach ($subTrees as $subTree) {
 		$subTree = trim($subTree, " /");
-		return strpos($this->server->getRequestUri(), "$subTree/") === 0;
+			if (strpos($this->server->getRequestUri(), "$subTree/") === 0) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/apps/dav/tests/unit/Repair/RemoveInvalidSharesTest.php
+++ b/apps/dav/tests/unit/Repair/RemoveInvalidSharesTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\DAV\Tests\Unit\Repair;
+
+
+use OCA\DAV\Connector\Sabre\Principal;
+use OCA\DAV\Repair\RemoveInvalidShares;
+use OCP\Migration\IOutput;
+use Test\TestCase;
+
+/**
+ * Class RemoveInvalidSharesTest
+ *
+ * @package OCA\DAV\Tests\Unit\Repair
+ * @group DB
+ */
+class RemoveInvalidSharesTest extends TestCase {
+
+	public function setUp() {
+		parent::setUp();
+		$db = \OC::$server->getDatabaseConnection();
+
+		$db->upsert('dav_shares', [
+			'principaluri' => 'principal:unknown',
+			'type' => 'calendar',
+			'access' => 2,
+			'resourceid' => 666,
+		]);
+	}
+
+	public function test() {
+		$db = \OC::$server->getDatabaseConnection();
+		/** @var Principal | \PHPUnit_Framework_MockObject_MockObject $principal */
+		$principal = $this->createMock(Principal::class);
+
+		/** @var IOutput | \PHPUnit_Framework_MockObject_MockObject $output */
+		$output = $this->createMock(IOutput::class);
+
+		$repair = new RemoveInvalidShares($db, $principal);
+		$this->assertEquals("Remove invalid calendar and addressbook shares", $repair->getName());
+		$repair->run($output);
+
+		$query = $db->getQueryBuilder();
+		$result = $query->select('*')->from('dav_shares')
+			->where($query->expr()->eq('principaluri', $query->createNamedParameter('principal:unknown')))->execute();
+		$data = $result->fetchAll();
+		$result->closeCursor();
+		$this->assertEquals(0, count($data));
+	}
+}

--- a/apps/dav/tests/unit/ServerTest.php
+++ b/apps/dav/tests/unit/ServerTest.php
@@ -35,10 +35,26 @@ use OCP\IRequest;
  */
 class ServerTest extends \Test\TestCase {
 
-	public function test() {
-		/** @var IRequest $r */
+	/**
+	 * @dataProvider providesUris
+	 */
+	public function test($uri, array $plugins) {
+		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $r */
 		$r = $this->createMock(IRequest::class);
+		$r->expects($this->any())->method('getRequestUri')->willReturn($uri);
 		$s = new Server($r, '/');
 		$this->assertNotNull($s->server);
+
+		foreach ($plugins as $plugin) {
+			$this->assertNotNull($s->server->getPlugin($plugin));
+		}
+	}
+
+	public function providesUris() {
+		return [
+			'principals' => ['principals/users/admin', ['caldav', 'oc-resource-sharing', 'carddav']],
+			'calendars' => ['calendars/admin', ['caldav', 'oc-resource-sharing']],
+			'addressbooks' => ['addressbooks/admin', ['carddav', 'oc-resource-sharing']],
+		];
 	}
 }


### PR DESCRIPTION
## Description
This fixes multiple issues which belong together:

1. CalDAV and CardDAV plugins need to be registered for the principal collection as well.
Without this change neither calendar nor addressbook home is set. No calendar or carddav client will work with out. Regression as introduced in #30113 

2. Principal uri is now verified when sharing a calendar or addressbook.
Due to a bug in calendar https://github.com/owncloud/calendar/issues/836 invalid principal uris have been used when sharing. In order to prevent insertion of bad data additional check have been added

3. Now that bad data has been entered a repair step is cleaning up the dav shares table

## Related Issue
refs https://github.com/owncloud/calendar/issues/836

## Motivation and Context
- fix calendar
- ensure data integrity

## How Has This Been Tested?
- manually with calendar app 1.5.4 and master branch

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

