### PR TITLE
Set version to 10.0.5 RC3

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 0, 4, 4];
+$OC_Version = [10, 0, 5, 2];
 
 // The human readable string
-$OC_VersionString = '10.0.4';
+$OC_VersionString = '10.0.5 RC3';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
Make the version match what is now in `stable10` to make life easy when switching branches back and forth in a dev environment.