### PR TITLE
Disable enforce password upload only

### DIFF
--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -302,7 +302,7 @@ class ApiTest extends TestCase {
 	function testEnfoceLinkPassword() {
 
 		$appConfig = \OC::$server->getAppConfig();
-		$appConfig->setValue('core', 'shareapi_enforce_links_password', 'yes');
+		$appConfig->setValue('core', 'shareapi_enforce_links_password_read_only', 'yes');
 
 		// don't allow to share link without a password
 		$data['path'] = $this->folder;
@@ -361,7 +361,7 @@ class ApiTest extends TestCase {
 		$result = $ocs->deleteShare($data['id']);
 		$this->assertTrue($result->succeeded());
 
-		$appConfig->setValue('core', 'shareapi_enforce_links_password', 'no');
+		$appConfig->setValue('core', 'shareapi_enforce_links_password_read_only', 'no');
 	}
 
 	/**

--- a/core/Migrations/Version20180123131835.php
+++ b/core/Migrations/Version20180123131835.php
@@ -1,0 +1,26 @@
+<?php
+namespace OC\Migrations;
+
+use OCP\Migration\ISimpleMigration;
+use OCP\Migration\IOutput;
+
+/**
+ * Split shareapi_enforce_links_password config key into 3 different keys for read-only,
+ * read & write and write-only links
+ */
+class Version20180123131835 implements ISimpleMigration {
+
+	/**
+	 * @param IOutput $out
+	 */
+	public function run(IOutput $out) {
+		$config = \OC::$server->getConfig();
+		$enforceLinks = $config->getAppValue('core', 'shareapi_enforce_links_password', null);
+		if ($enforceLinks !== null) {
+			$config->setAppValue('core', 'shareapi_enforce_links_password_read_only', $enforceLinks);
+			$config->setAppValue('core', 'shareapi_enforce_links_password_read_write', $enforceLinks);
+			$config->setAppValue('core', 'shareapi_enforce_links_password_write_only', $enforceLinks);
+		}
+		$config->deleteAppValue('core', 'shareapi_enforce_links_password');
+	}
+}

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -66,6 +66,7 @@ if ($defaultExpireDateEnabled) {
 	$value = $config->getAppValue('core', 'shareapi_enforce_expire_date', 'no');
 	$enforceDefaultExpireDate = ($value === 'yes') ? true : false;
 }
+$disableEnforceLinkPasswordForUploadOnly = $config->getAppValue('core', 'shareapi_disable_enforce_links_password_for_upload_only', 'no') === 'yes';
 $outgoingServer2serverShareEnabled = $config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes') === 'yes';
 
 $countOfDataLocation = 0;
@@ -164,6 +165,7 @@ $array = [
 				'defaultExpireDate' => $defaultExpireDate,
 				'defaultExpireDateEnforced' => $enforceDefaultExpireDate,
 				'enforcePasswordForPublicLink' => \OCP\Util::isPublicLinkPasswordRequired(),
+				'disableEnforceLinkPasswordForUploadOnly' => $disableEnforceLinkPasswordForUploadOnly,
 				'sharingDisabledForUser' => \OCP\Util::isSharingDisabledForUser(),
 				'resharingAllowed' => \OCP\Share::isResharingAllowed(),
 				'remoteShareAllowed' => $outgoingServer2serverShareEnabled,

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -166,7 +166,6 @@ $array = [
 				'defaultExpireDateEnabled' => $defaultExpireDateEnabled,
 				'defaultExpireDate' => $defaultExpireDate,
 				'defaultExpireDateEnforced' => $enforceDefaultExpireDate,
-				'enforcePasswordForPublicLink' => \OCP\Util::isPublicLinkPasswordRequired(),
 				'enforceLinkPasswordReadOnly' => $enforceLinkPasswordReadOnly,
 				'enforceLinkPasswordReadWrite' => $enforceLinkPasswordReadWrite,
 				'enforceLinkPasswordWriteOnly' => $enforceLinkPasswordWriteOnly,

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -66,7 +66,9 @@ if ($defaultExpireDateEnabled) {
 	$value = $config->getAppValue('core', 'shareapi_enforce_expire_date', 'no');
 	$enforceDefaultExpireDate = ($value === 'yes') ? true : false;
 }
-$disableEnforceLinkPasswordForUploadOnly = $config->getAppValue('core', 'shareapi_disable_enforce_links_password_for_upload_only', 'no') === 'yes';
+$enforceLinkPasswordReadOnly = $config->getAppValue('core', 'shareapi_enforce_links_password_read_only', 'no') === 'yes';
+$enforceLinkPasswordReadWrite = $config->getAppValue('core', 'shareapi_enforce_links_password_read_write', 'no') === 'yes';
+$enforceLinkPasswordWriteOnly = $config->getAppValue('core', 'shareapi_enforce_links_password_write_only', 'no') === 'yes';
 $outgoingServer2serverShareEnabled = $config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes') === 'yes';
 
 $countOfDataLocation = 0;
@@ -165,7 +167,9 @@ $array = [
 				'defaultExpireDate' => $defaultExpireDate,
 				'defaultExpireDateEnforced' => $enforceDefaultExpireDate,
 				'enforcePasswordForPublicLink' => \OCP\Util::isPublicLinkPasswordRequired(),
-				'disableEnforceLinkPasswordForUploadOnly' => $disableEnforceLinkPasswordForUploadOnly,
+				'enforceLinkPasswordReadOnly' => $enforceLinkPasswordReadOnly,
+				'enforceLinkPasswordReadWrite' => $enforceLinkPasswordReadWrite,
+				'enforceLinkPasswordWriteOnly' => $enforceLinkPasswordWriteOnly,
 				'sharingDisabledForUser' => \OCP\Util::isSharingDisabledForUser(),
 				'resharingAllowed' => \OCP\Share::isResharingAllowed(),
 				'remoteShareAllowed' => $outgoingServer2serverShareEnabled,

--- a/core/js/shareconfigmodel.js
+++ b/core/js/shareconfigmodel.js
@@ -21,7 +21,6 @@
 	var ShareConfigModel = OC.Backbone.Model.extend({
 		defaults: {
 			publicUploadEnabled: false,
-			enforcePasswordForPublicLink: oc_appconfig.core.enforcePasswordForPublicLink,
 			enforceLinkPasswordReadOnly: oc_appconfig.core.enforceLinkPasswordReadOnly,
 			enforceLinkPasswordReadWrite: oc_appconfig.core.enforceLinkPasswordReadWrite,
 			enforceLinkPasswordWriteOnly: oc_appconfig.core.enforceLinkPasswordWriteOnly,

--- a/core/js/shareconfigmodel.js
+++ b/core/js/shareconfigmodel.js
@@ -22,7 +22,9 @@
 		defaults: {
 			publicUploadEnabled: false,
 			enforcePasswordForPublicLink: oc_appconfig.core.enforcePasswordForPublicLink,
-			disableEnforceLinkPasswordForUploadOnly: oc_appconfig.core.disableEnforceLinkPasswordForUploadOnly,
+			enforceLinkPasswordReadOnly: oc_appconfig.core.enforceLinkPasswordReadOnly,
+			enforceLinkPasswordReadWrite: oc_appconfig.core.enforceLinkPasswordReadWrite,
+			enforceLinkPasswordWriteOnly: oc_appconfig.core.enforceLinkPasswordWriteOnly,
 			isDefaultExpireDateEnforced: oc_appconfig.core.defaultExpireDateEnforced === true,
 			isDefaultExpireDateEnabled: oc_appconfig.core.defaultExpireDateEnabled === true,
 			isRemoteShareAllowed: oc_appconfig.core.remoteShareAllowed,

--- a/core/js/shareconfigmodel.js
+++ b/core/js/shareconfigmodel.js
@@ -22,6 +22,7 @@
 		defaults: {
 			publicUploadEnabled: false,
 			enforcePasswordForPublicLink: oc_appconfig.core.enforcePasswordForPublicLink,
+			disableEnforceLinkPasswordForUploadOnly: oc_appconfig.core.disableEnforceLinkPasswordForUploadOnly,
 			isDefaultExpireDateEnforced: oc_appconfig.core.defaultExpireDateEnforced === true,
 			isDefaultExpireDateEnabled: oc_appconfig.core.defaultExpireDateEnabled === true,
 			isRemoteShareAllowed: oc_appconfig.core.remoteShareAllowed,

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -40,7 +40,7 @@
 			'</div>' +
 			'{{/if}}' +
 			'<div id="linkPass-{{cid}}" class="public-link-modal--item linkPass">' +
-				'<label class="public-link-modal--label" for="linkPassText-{{cid}}">{{passwordLabel}}{{#if isPasswordRequired}}<span class="required-indicator">*</span>{{/if}}</label>' +
+				'<label class="public-link-modal--label" for="linkPassText-{{cid}}">{{passwordLabel}}</label>' +
 				'<input class="public-link-modal--input linkPassText" id="linkPassText-{{cid}}" type="password" placeholder="{{passwordPlaceholder}}" />' +
 				'<span class="error-message hidden"></span>' +
 			'</div>' +
@@ -101,7 +101,7 @@
 		_getPermissions: function() {
 			var permissions = this.$('input[name="publicPermissions"]:checked').val();
 
-			return (permissions) ? permissions : OC.PERMISSION_READ;
+			return (permissions) ? parseInt(permissions, 10) : OC.PERMISSION_READ;
 		},
 
 		_save: function () {
@@ -146,7 +146,7 @@
 
 			if (this.configModel.get('enforcePasswordForPublicLink')
 				&& !password
-				&& (this.model.get('permissions') !== OC.PERMISSION_CREATE || !this.configModel.get('disableEnforceLinkPasswordForUploadOnly'))
+				&& (this._getPermissions() !== OC.PERMISSION_CREATE || !this.configModel.get('disableEnforceLinkPasswordForUploadOnly'))
 				&& (this.model.isNew() || !this.model.get('encryptedPassword'))
 			) {
 				$password.addClass('error');
@@ -222,7 +222,6 @@
 			this.$el.html(this.template({
 				cid: this.cid,
 				passwordPlaceholder: isPasswordSet ? PASSWORD_PLACEHOLDER_STARS : PASSWORD_PLACEHOLDER_MESSAGE,
-				isPasswordRequired: this.configModel.get('enforcePasswordForPublicLink') && (this.model.get('permissions') !== OC.PERMISSION_CREATE || !this.configModel.get('disableEnforceLinkPasswordForUploadOnly')),
 				namePlaceholder: t('core', 'Name'),
 				name: this.model.get('name'),
 				isPasswordSet: isPasswordSet,

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -146,6 +146,7 @@
 
 			if (this.configModel.get('enforcePasswordForPublicLink')
 				&& !password
+				&& (this.model.get('permissions') !== OC.PERMISSION_CREATE || !this.configModel.get('disableEnforceLinkPasswordForUploadOnly'))
 				&& (this.model.isNew() || !this.model.get('encryptedPassword'))
 			) {
 				$password.addClass('error');
@@ -221,7 +222,7 @@
 			this.$el.html(this.template({
 				cid: this.cid,
 				passwordPlaceholder: isPasswordSet ? PASSWORD_PLACEHOLDER_STARS : PASSWORD_PLACEHOLDER_MESSAGE,
-				isPasswordRequired: this.configModel.get('enforcePasswordForPublicLink'),
+				isPasswordRequired: this.configModel.get('enforcePasswordForPublicLink') && (this.model.get('permissions') !== OC.PERMISSION_CREATE || !this.configModel.get('disableEnforceLinkPasswordForUploadOnly')),
 				namePlaceholder: t('core', 'Name'),
 				name: this.model.get('name'),
 				isPasswordSet: isPasswordSet,

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -104,6 +104,19 @@
 			return (permissions) ? parseInt(permissions, 10) : OC.PERMISSION_READ;
 		},
 
+		_shouldRequirePassword: function() {
+			// matching passwordMustBeEnforced from server side
+			var permissions = this._getPermissions();
+			var roEnforcement = permissions === OC.PERMISSION_READ && this.configModel.get('enforceLinkPasswordReadOnly');
+			var woEnforcement = permissions === OC.PERMISSION_CREATE && this.configModel.get('enforceLinkPasswordWriteOnly');
+			var rwEnforcement = (permissions !== OC.PERMISSION_READ && permissions !== OC.PERMISSION_CREATE) && this.configModel.get('enforceLinkPasswordReadWrite');
+			if (roEnforcement || woEnforcement || rwEnforcement) {
+				return true;
+			} else {
+				return false;
+			}
+		},
+
 		_save: function () {
 			var deferred = $.Deferred();
 			var $el = this.$el;
@@ -144,9 +157,8 @@
 			var validates = true;
 			validates &= this.expirationView.validate();
 
-			if (this.configModel.get('enforcePasswordForPublicLink')
-				&& !password
-				&& (this._getPermissions() !== OC.PERMISSION_CREATE || !this.configModel.get('disableEnforceLinkPasswordForUploadOnly'))
+			if (!password
+				&& this._shouldRequirePassword()
 				&& (this.model.isNew() || !this.model.get('encryptedPassword'))
 			) {
 				$password.addClass('error');

--- a/core/js/tests/specs/sharedialogexpirationviewSpec.js
+++ b/core/js/tests/specs/sharedialogexpirationviewSpec.js
@@ -67,8 +67,8 @@ describe('OC.Share.ShareDialogExpirationView', function() {
 		});
 		view.render();
 	});
-	afterEach(function() { 
-		tooltipStub.restore(); 
+	afterEach(function() {
+		tooltipStub.restore();
 		view.remove();
 	});
 
@@ -128,7 +128,6 @@ describe('OC.Share.ShareDialogExpirationView', function() {
 				setDefaultsStub = sinon.stub($.datepicker, 'setDefaults');
 
 				configModel.set({
-					enforcePasswordForPublicLink: false,
 					isDefaultExpireDateEnabled: false,
 					isDefaultExpireDateEnforced: false,
 					defaultExpireDate: 7

--- a/core/js/tests/specs/sharedialoglinkshareviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinkshareviewSpec.js
@@ -230,16 +230,6 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 				expect(view.$('.linkPassText').val()).toEqual('');
 				expect(view.$('.linkPassText').attr('placeholder')).toEqual(PASSWORD_PLACEHOLDER_STARS);
 			});
-			it('renders required indicator when password is enforced', function() {
-				configModel.set('enforcePasswordForPublicLink', true);
-				view.render();
-				expect(view.$('.linkPass .required-indicator').length).toEqual(1);
-			});
-			it('does not render required indicator when password not enforced', function() {
-				configModel.set('enforcePasswordForPublicLink', false);
-				view.render();
-				expect(view.$('.linkPass .required-indicator').length).toEqual(0);
-			});
 		});
 	});
 
@@ -271,7 +261,7 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 				name: 'first link',
 				expireDate: '',
 				password: 'newpassword',
-				permissions: OC.PERMISSION_READ.toString(),
+				permissions: OC.PERMISSION_READ,
 				shareType: OC.Share.SHARE_TYPE_LINK
 			});
 		});
@@ -284,7 +274,7 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 			expect(saveStub.getCall(0).args[0]).toEqual({
 				name: 'first link',
 				expireDate: '',
-				permissions: OC.PERMISSION_READ.toString(),
+				permissions: OC.PERMISSION_READ,
 				shareType: OC.Share.SHARE_TYPE_LINK
 			});
 		});
@@ -367,8 +357,8 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 			beforeEach(function() {
 				publicUploadConfigStub = sinon.stub(configModel, 'isPublicUploadEnabled');
 			});
-			afterEach(function() { 
-				publicUploadConfigStub.restore(); 
+			afterEach(function() {
+				publicUploadConfigStub.restore();
 			});
 
 			var dataProvider = [
@@ -379,7 +369,7 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 			];
 
 			function testPermissions(globalEnabled, expectedPerms) {
-				expectedPerms = expectedPerms.toString();
+				expectedPerms = expectedPerms;
 				it('sets permissions to ' + expectedPerms +
 					' if global enabled is ' + globalEnabled +
 					' and corresponding radiobutton is checked', function() {

--- a/core/js/tests/specs/sharedialoglinkshareviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinkshareviewSpec.js
@@ -238,6 +238,7 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 		var sendMailStub;
 		var sendMailDeferred;
 		var isMailEnabledStub;
+		var isPublicUploadEnabledStub;
 
 		beforeEach(function() {
 			saveStub = sinon.stub(OC.Share.ShareModel.prototype, 'save');
@@ -251,6 +252,9 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 			sendMailStub.restore();
 			isMailEnabledStub.restore();
 			sendMailDeferred = null;
+			if (isPublicUploadEnabledStub) {
+				isPublicUploadEnabledStub.restore();
+			}
 		});
 
 		it('reads values from the fields and saves', function() {
@@ -342,8 +346,35 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 			expect(view.$('.error-message-global').hasClass('hidden')).toEqual(false);
 			expect(view.$('.error-message-global').text()).toEqual('Some error');
 		});
-		it('displays inline error when password enforced but missing', function() {
-			configModel.set('enforcePasswordForPublicLink', true);
+		it('displays inline error when password enforced for read-only but missing', function() {
+			isPublicUploadEnabledStub = sinon.stub(configModel, 'isPublicUploadEnabled').returns(true);
+			configModel.set('enforceLinkPasswordReadOnly', true);
+			view.render();
+			view.$('#sharingDialogAllowPublicRead-' + view.cid).prop('checked', true)
+			var handler = sinon.stub();
+			view.on('saved', handler);
+			view._save();
+			expect(handler.notCalled).toEqual(true);
+
+			expect(view.$('.linkPassText').next('.error-message').hasClass('hidden')).toEqual(false);
+		});
+		it('displays inline error when password enforced for read & write but missing', function() {
+			isPublicUploadEnabledStub = sinon.stub(configModel, 'isPublicUploadEnabled').returns(true);
+			configModel.set('enforceLinkPasswordReadWrite', true);
+			view.render();
+			view.$('#sharingDialogAllowPublicReadWrite-' + view.cid).prop('checked', true)
+			var handler = sinon.stub();
+			view.on('saved', handler);
+			view._save();
+			expect(handler.notCalled).toEqual(true);
+
+			expect(view.$('.linkPassText').next('.error-message').hasClass('hidden')).toEqual(false);
+		});
+		it('displays inline error when password enforced for write-only but missing', function() {
+			isPublicUploadEnabledStub = sinon.stub(configModel, 'isPublicUploadEnabled').returns(true);
+			configModel.set('enforceLinkPasswordWriteOnly', true);
+			view.render();
+			view.$('#sharingDialogAllowPublicUpload-' + view.cid).prop('checked', true)
 			var handler = sinon.stub();
 			view.on('saved', handler);
 			view._save();

--- a/core/js/tests/specs/sharedialogshareelistview.js
+++ b/core/js/tests/specs/sharedialogshareelistview.js
@@ -32,7 +32,6 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 	beforeEach(function () {
 		/* jshint camelcase:false */
 		oldAppConfig = _.extend({}, oc_appconfig.core);
-		oc_appconfig.core.enforcePasswordForPublicLink = false;
 
 		$('#testArea').append('<input id="mailNotificationEnabled" name="mailNotificationEnabled" type="hidden" value="yes">');
 
@@ -59,9 +58,7 @@ describe('OC.Share.ShareDialogShareeListView', function () {
 		});
 
 		configModel = new OC.Share.ShareConfigModel({
-			enforcePasswordForPublicLink: false,
 			isResharingAllowed: true,
-			enforcePasswordForPublicLink: false,
 			isDefaultExpireDateEnabled: false,
 			isDefaultExpireDateEnforced: false,
 			defaultExpireDate: 7

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -44,7 +44,6 @@ describe('OC.Share.ShareDialogView', function() {
 		$container = $('#shareContainer');
 		/* jshint camelcase:false */
 		oldAppConfig = _.extend({}, oc_appconfig.core);
-		oc_appconfig.core.enforcePasswordForPublicLink = false;
 
 		fetchStub = sinon.stub(OC.Share.ShareItemModel.prototype, 'fetch');
 
@@ -65,9 +64,7 @@ describe('OC.Share.ShareDialogView', function() {
 			permissions: 31
 		};
 		configModel = new OC.Share.ShareConfigModel({
-			enforcePasswordForPublicLink: false,
 			isResharingAllowed: true,
-			enforcePasswordForPublicLink: false,
 			isDefaultExpireDateEnabled: false,
 			isDefaultExpireDateEnforced: false,
 			defaultExpireDate: 7

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -147,10 +147,10 @@ class Manager implements IManager {
 	 * @param string $password
 	 * @throws \Exception
 	 */
-	protected function verifyPassword($password) {
+	protected function verifyPassword($password, $permissions) {
 		if ($password === null) {
 			// No password is set, check if this is allowed.
-			if ($this->shareApiLinkEnforcePassword()) {
+			if ($this->shareApiLinkEnforcePassword() && ($permissions !== \OCP\CONSTANTS::PERMISSION_CREATE || !$this->shareApiLinkEnforcePasswordDisabledForUploads())) {
 				throw new \InvalidArgumentException('Passwords are enforced for link shares');
 			}
 
@@ -585,7 +585,7 @@ class Manager implements IManager {
 			$this->validateExpirationDate($share);
 
 			//Verify the password
-			$this->verifyPassword($share->getPassword());
+			$this->verifyPassword($share->getPassword(), $share->getPermissions());
 
 			// If a password is set. Hash it!
 			if ($share->getPassword() !== null) {
@@ -699,7 +699,7 @@ class Manager implements IManager {
 			// Password updated.
 			if ($share->getPassword() !== $originalShare->getPassword()) {
 				//Verify the password
-				$this->verifyPassword($share->getPassword());
+				$this->verifyPassword($share->getPassword(), $share->getPermissions());
 
 				// If a password is set. Hash it!
 				if ($share->getPassword() !== null) {
@@ -1257,6 +1257,15 @@ class Manager implements IManager {
 	 */
 	public function shareApiLinkEnforcePassword() {
 		return $this->config->getAppValue('core', 'shareapi_enforce_links_password', 'no') === 'yes';
+	}
+
+	/**
+	 * Is password enforced for upload-only shares?
+	 *
+	 * @return bool
+	 */
+	public function shareApiLinkEnforcePasswordDisabledForUploads() {
+		return $this->config->getAppValue('core', 'shareapi_disable_enforce_links_password_for_upload_only', 'no') === 'yes';
 	}
 
 	/**

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -697,7 +697,8 @@ class Manager implements IManager {
 			$this->linkCreateChecks($share);
 
 			// Password updated.
-			if ($share->getPassword() !== $originalShare->getPassword()) {
+			if ($share->getPassword() !== $originalShare->getPassword() ||
+					$share->getPermissions() !== $originalShare->getPermissions()) {
 				//Verify the password
 				$this->verifyPassword($share->getPassword(), $share->getPermissions());
 

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -304,13 +304,17 @@ class OC_Util {
 	}
 
 	/**
-	 * check if a password is required for each public link
+	 * check if a password is required for each public link.
+	 * This is deprecated due to not reflecting all the possibilities now. Falling back to
+	 * enforce password for read-only links. Note that read & write or write-only options won't
+	 * be considered here
 	 *
 	 * @return boolean
+	 * @deprecated
 	 */
 	public static function isPublicLinkPasswordRequired() {
 		$appConfig = \OC::$server->getAppConfig();
-		$enforcePassword = $appConfig->getValue('core', 'shareapi_enforce_links_password', 'no');
+		$enforcePassword = $appConfig->getValue('core', 'shareapi_enforce_links_password_read_only', 'no');
 		return ($enforcePassword === 'yes') ? true : false;
 	}
 

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -116,7 +116,7 @@ interface IManager {
 	/**
 	 * Get shares shared with $userId for specified share types.
 	 * Filter by $node if provided
-	 * 
+	 *
 	 * @param string $userId
 	 * @param int[] $shareTypes - ref \OC\Share\Constants[]
 	 * @param Node|null $node
@@ -235,6 +235,14 @@ interface IManager {
 	 * @since 9.0.0
 	 */
 	public function shareApiLinkEnforcePassword();
+
+	/**
+	 * Is password enforced for upload-only shares?
+	 *
+	 * @return bool true -> password isn't enforce for upload-only share, false otherwise
+	 * @since 10.0.6
+	 */
+	public function shareApiLinkEnforcePasswordDisabledForUploads();
 
 	/**
 	 * Is default expire date enabled

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -230,19 +230,38 @@ interface IManager {
 
 	/**
 	 * Is password on public link requires
+	 * NOTE: This method is deprecated and will fallback to the "shareApiLinkEnforcePasswordReadOnly"
 	 *
 	 * @return bool
 	 * @since 9.0.0
+	 * @see IManager::shareApiLinkEnforcePasswordReadOnly()
+	 * @deprecated
 	 */
 	public function shareApiLinkEnforcePassword();
 
 	/**
-	 * Is password enforced for upload-only shares?
+	 * Is password enforced for read-only shares?
 	 *
-	 * @return bool true -> password isn't enforce for upload-only share, false otherwise
+	 * @return bool true if password is enforced, false otherwise
 	 * @since 10.0.6
 	 */
-	public function shareApiLinkEnforcePasswordDisabledForUploads();
+	public function shareApiLinkEnforcePasswordReadOnly();
+
+	/**
+	 * Is password enforced for read & write shares?
+	 *
+	 * @return bool true if password is enforced, false otherwise
+	 * @since 10.0.6
+	 */
+	public function shareApiLinkEnforcePasswordReadWrite();
+
+	/**
+	 * Is password enforced for write-only shares?
+	 *
+	 * @return bool true if password is enforced, false otherwise
+	 * @since 10.0.6
+	 */
+	public function shareApiLinkEnforcePasswordWriteOnly();
 
 	/**
 	 * Is default expire date enabled

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -243,7 +243,7 @@ interface IManager {
 	 * Is password enforced for read-only shares?
 	 *
 	 * @return bool true if password is enforced, false otherwise
-	 * @since 10.0.6
+	 * @since 10.0.8
 	 */
 	public function shareApiLinkEnforcePasswordReadOnly();
 
@@ -251,7 +251,7 @@ interface IManager {
 	 * Is password enforced for read & write shares?
 	 *
 	 * @return bool true if password is enforced, false otherwise
-	 * @since 10.0.6
+	 * @since 10.0.8
 	 */
 	public function shareApiLinkEnforcePasswordReadWrite();
 
@@ -259,7 +259,7 @@ interface IManager {
 	 * Is password enforced for write-only shares?
 	 *
 	 * @return bool true if password is enforced, false otherwise
-	 * @since 10.0.6
+	 * @since 10.0.8
 	 */
 	public function shareApiLinkEnforcePasswordWriteOnly();
 

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -679,8 +679,12 @@ class Util {
 
 	/**
 	 * check if a password is required for each public link
+	 * This is deprecated due to not reflecting all the possibilities now. Falling back to
+	 * enforce password for read-only links. Note that read & write or write-only options won't
+	 * be considered here
 	 * @return boolean
 	 * @since 7.0.0
+	 * @deprecated
 	 */
 	public static function isPublicLinkPasswordRequired() {
 		return \OC_Util::isPublicLinkPasswordRequired();

--- a/settings/Panels/Admin/FileSharing.php
+++ b/settings/Panels/Admin/FileSharing.php
@@ -53,6 +53,7 @@ class FileSharing implements ISettings {
 		$template->assign('allowLinks', $this->config->getAppValue('core', 'shareapi_allow_links', 'yes'));
 		$template->assign('allowPublicUpload', $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes'));
 		$template->assign('enforceLinkPassword', $this->helper->isPublicLinkPasswordRequired());
+		$template->assign('disableEnforceLinkPasswordForUploadOnly', $this->config->getAppValue('core', 'shareapi_disable_enforce_links_password_for_upload_only', 'no'));
 		$template->assign('shareDefaultExpireDateSet', $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no'));
 		$template->assign('allowPublicMailNotification', $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no'));
 		$template->assign('allowSocialShare', $this->config->getAppValue('core', 'shareapi_allow_social_share', 'yes'));

--- a/settings/Panels/Admin/FileSharing.php
+++ b/settings/Panels/Admin/FileSharing.php
@@ -52,8 +52,9 @@ class FileSharing implements ISettings {
 		$template->assign('shareAPIEnabled', $this->config->getAppValue('core', 'shareapi_enabled', 'yes'));
 		$template->assign('allowLinks', $this->config->getAppValue('core', 'shareapi_allow_links', 'yes'));
 		$template->assign('allowPublicUpload', $this->config->getAppValue('core', 'shareapi_allow_public_upload', 'yes'));
-		$template->assign('enforceLinkPassword', $this->helper->isPublicLinkPasswordRequired());
-		$template->assign('disableEnforceLinkPasswordForUploadOnly', $this->config->getAppValue('core', 'shareapi_disable_enforce_links_password_for_upload_only', 'no'));
+		$template->assign('enforceLinkPasswordReadOnly', $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_only', 'no'));
+		$template->assign('enforceLinkPasswordReadWrite', $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write', 'no'));
+		$template->assign('enforceLinkPasswordWriteOnly', $this->config->getAppValue('core', 'shareapi_enforce_links_password_write_only', 'no'));
 		$template->assign('shareDefaultExpireDateSet', $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no'));
 		$template->assign('allowPublicMailNotification', $this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no'));
 		$template->assign('allowSocialShare', $this->config->getAppValue('core', 'shareapi_allow_social_share', 'yes'));

--- a/settings/Panels/Helper.php
+++ b/settings/Panels/Helper.php
@@ -35,10 +35,6 @@ class Helper  {
 		return \OC_App::getForms('admin');
 	}
 
-	public function isPublicLinkPasswordRequired() {
-		return \OCP\Util::isPublicLinkPasswordRequired();
-	}
-
 	public function shareWithGroupMembersOnly() {
 		return \OC\Share\Share::shareWithGroupMembersOnly();
 	}

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -23,13 +23,17 @@
 			   value="1" <?php if ($_['allowPublicUpload'] == 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="allowPublicUpload"><?php p($l->t('Allow public uploads'));?></label><br/>
 
-		<input type="checkbox" name="shareapi_enforce_links_password" id="enforceLinkPassword" class="checkbox"
-			   value="1" <?php if ($_['enforceLinkPassword']) print_unescaped('checked="checked"'); ?> />
-		<label for="enforceLinkPassword"><?php p($l->t('Enforce password protection'));?></label><br/>
+		<input type="checkbox" name="shareapi_enforce_links_password_read_only" id="enforceLinkPasswordReadOnly" class="checkbox"
+			value="1" <?php if ($_['enforceLinkPasswordReadOnly']) print_unescaped('checked="checked"'); ?> />
+		<label for="enforceLinkPasswordReadOnly"><?php p($l->t('Enforce password protection for read-only shares'));?></label><br/>
 
-		<input type="checkbox" name="shareapi_disable_enforce_links_password_for_upload_only" id="disableEnforceLinkPasswordForUploadOnly" class="checkbox"
-			value="1" <?php if ($_['disableEnforceLinkPasswordForUploadOnly'] === 'yes') print_unescaped('checked="checked"'); ?> />
-		<label for="disableEnforceLinkPasswordForUploadOnly"><?php p($l->t('Disable enforce password protection for upload-only shares'));?></label><br/>
+		<input type="checkbox" name="shareapi_enforce_links_password_read_write" id="enforceLinkPasswordReadWrite" class="checkbox"
+			value="1" <?php if ($_['enforceLinkPasswordReadWrite'] === 'yes') print_unescaped('checked="checked"'); ?> />
+		<label for="enforceLinkPasswordReadWrite"><?php p($l->t('Enforce password protection for read & write shares'));?></label><br/>
+
+		<input type="checkbox" name="shareapi_enforce_links_password_write_only" id="enforceLinkPasswordWriteOnly" class="checkbox"
+			value="1" <?php if ($_['enforceLinkPasswordWriteOnly'] === 'yes') print_unescaped('checked="checked"'); ?> />
+		<label for="enforceLinkPasswordWriteOnly"><?php p($l->t('Enforce password protection for write-only shares'));?></label><br/>
 
 		<input type="checkbox" name="shareapi_default_expire_date" id="shareapiDefaultExpireDate" class="checkbox"
 			   value="1" <?php if ($_['shareDefaultExpireDateSet'] === 'yes') print_unescaped('checked="checked"'); ?> />

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -27,6 +27,10 @@
 			   value="1" <?php if ($_['enforceLinkPassword']) print_unescaped('checked="checked"'); ?> />
 		<label for="enforceLinkPassword"><?php p($l->t('Enforce password protection'));?></label><br/>
 
+		<input type="checkbox" name="shareapi_disable_enforce_links_password_for_upload_only" id="disableEnforceLinkPasswordForUploadOnly" class="checkbox"
+			value="1" <?php if ($_['disableEnforceLinkPasswordForUploadOnly'] === 'yes') print_unescaped('checked="checked"'); ?> />
+		<label for="disableEnforceLinkPasswordForUploadOnly"><?php p($l->t('Disable enforce password protection for upload-only shares'));?></label><br/>
+
 		<input type="checkbox" name="shareapi_default_expire_date" id="shareapiDefaultExpireDate" class="checkbox"
 			   value="1" <?php if ($_['shareDefaultExpireDateSet'] === 'yes') print_unescaped('checked="checked"'); ?> />
 		<label for="shareapiDefaultExpireDate"><?php p($l->t('Set default expiration date'));?></label><br/>

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -555,7 +555,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertFalse($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_READ]));
 	}
 
-	public function testPasswordMustBeEnforcedForReadWrite() {
+	public function testPasswordMustBeEnforcedForReadWriteNotEnforced() {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'no'],
@@ -565,7 +565,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertFalse($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_ALL]));
 	}
 
-	public function testPasswordMustBeEnforcedForWriteOnly() {
+	public function testPasswordMustBeEnforcedForWriteOnlyNotEnforced() {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Add option to disable password enforcement for write-only shares

## Related Issue
https://github.com/owncloud/core/issues/29526

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested

Known problems (Jan, 17th):
* Adding these changes to share 1.0 isn't straightforward. We'll likely need to create another function to get the share data (such function doesn't exists now) in order to get the share permissions.
* Share dialog has a problem when the share mode (read-only, read & write, write-only) is switched. Although the password isn't enforced for write-only links, the dialog will show an error when create the share. The share is properly created anyway, so this is a visual problem. The password requirement seems to be determined when the template is loaded, not dinamically. I think other scenarios work fine due to the exception coming from the server.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

@felixheidecke for both checking the styling in the settings page (being a dependent option of the enforce password one doesn't seem a good idea to be on the same level, but I'd prefer not to touch css if possible) and also for the sharing dialog fix, or whatever we want to do with it (check the known issues above).