### PR TITLE
disable php cache control

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -43,6 +43,7 @@
     php_value mbstring.func_overload 0
     php_value default_charset 'UTF-8'
     php_value output_buffering 0
+    php_value session.cache_limiter 0
     <IfModule mod_env.c>
       SetEnv htaccessWorking true
     </IfModule>
@@ -55,6 +56,7 @@
     php_value mbstring.func_overload 0
     php_value default_charset 'UTF-8'
     php_value output_buffering 0
+    php_value session.cache_limiter 0
     <IfModule mod_env.c>
       SetEnv htaccessWorking true
     </IfModule>


### PR DESCRIPTION
Had to prevent PHP from sending cache control headers. Otherwise the dav previews from https://github.com/owncloud/core/pull/29319 always had to reload the previews because Chrome respects the Pragma:nocache header that is sent by default.

Related: https://github.com/owncloud/core/issues/26922#issuecomment-272392100
