### PR TITLE
strip down travis work to minimum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,135 +57,76 @@ script:
 matrix:
   include:
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="renameFiles" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="renameFolders" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="upload" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="renameFiles" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="renameFolders" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="upload" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
+
     - php: 5.6
       env: DB=pgsql TC=litmus-v1
     - php: 5.6
@@ -200,214 +141,4 @@ matrix:
       env: DB=sqlite TC=syntax TEST_DAV=0
     - php: 7.0
       env: DB=sqlite TC=syntax TEST_DAV=0
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="renameFiles" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="renameFolders" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="upload" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="renameFiles" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="renameFolders" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="upload" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="other" PLATFORM="Windows 7" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 7" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="renameFiles" PLATFORM="Windows 7" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="renameFolders" PLATFORM="Windows 7" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="files" PLATFORM="Windows 7" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="trashbin" PLATFORM="Windows 7" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 7" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 7" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 7" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 5.6
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="upload" PLATFORM="Windows 7" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
   fast_finish: true


### PR DESCRIPTION
ease the workload of travis
1. only run UI tests on stable10 PRs and on cron
2. only run UI tests in latest chrome