### PR TITLE
move UI tests to drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -120,6 +120,54 @@ pipeline:
       matrix:
         TEST_SUITE: files_external
 
+  install-server:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - cd /drone/src/
+      - php occ maintenance:install -vvv --database=mysql --database-host=${DB_TYPE} --database-user=owncloud --database-pass=owncloud --database-name=owncloud --database-table-prefix=oc_ --admin-user=admin --admin-pass=admin --data-dir=/drone/src/data
+      - php occ a:l
+      - php occ a:e testing
+      - php occ a:l
+      - php occ config:system:set trusted_domains 1 --value=server
+      - php occ config:system:set trusted_domains 2 --value=federated
+      - php occ log:manage --level 0
+      - php occ config:list
+    when:
+      matrix:
+        TEST_SUITE: selenium
+
+  owncloud-log:
+    image: owncloud/ubuntu:16.04
+    detach: true
+    pull: true
+    commands:
+      - tail -f /drone/src/data/owncloud.log
+    when:
+      matrix:
+        TEST_SUITE: selenium
+
+  acceptance-tests:
+    image: owncloudci/php:latest
+    pull: true
+    environment:
+      - BROWSER=chrome
+      - SELENIUM_HOST=selenium
+      - SRV_HOST_NAME=server
+      - SRV_HOST_PORT=80
+      - REMOTE_FED_SRV_HOST_NAME=federated
+      - REMOTE_FED_SRV_HOST_PORT=80
+      - SKELETON_DIR=/drone/src/tests/ui/skeleton
+      - SELENIUM_PORT=4444
+      - PLATFORM=Linux
+    commands:
+      - cd /drone/src/
+      - chown www-data * -R
+      - bash tests/travis/start_ui_tests.sh --remote 
+    when:
+      matrix:
+        TEST_SUITE: selenium
+
 services:
   mariadb:
     image: mariadb:10.2
@@ -180,6 +228,32 @@ services:
       matrix:
         DB_TYPE: oracle
 
+  selenium:
+    image: selenium/standalone-chrome-debug:latest
+    pull: true
+    when:
+      matrix:
+        TEST_SUITE: selenium
+
+  server:
+    image: owncloudci/php:latest
+    pull: true
+    environment:
+      - APACHE_WEBROOT=/drone/src/
+    command: [ "/usr/local/bin/apachectl", "-e debug" , "-DFOREGROUND" ]
+    when:
+      matrix:
+        USE_SERVER: true
+
+  federated:
+    image: owncloudci/php:latest
+    pull: true
+    environment:
+      - APACHE_WEBROOT=/drone/src/
+    command: [ "/usr/local/bin/apachectl", "-e debug" , "-DFOREGROUND" ]
+    when:
+      matrix:
+        USE_FEDERATED_SERVER: true
 matrix:
   include:
     # PHP 5.6
@@ -272,3 +346,64 @@ matrix:
       DB_TYPE: sqlite
       TEST_SUITE: coverage
       FILES_EXTERNAL_TYPE: webdav
+      
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BEHAT_SUITE: other
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BEHAT_SUITE: files
+      DB_TYPE: mariadb
+      USE_SERVER: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BEHAT_SUITE: moveFilesFolders
+      DB_TYPE: mariadb
+      USE_SERVER: true
+    
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BEHAT_SUITE: renameFiles
+      DB_TYPE: mariadb
+      USE_SERVER: true
+    
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BEHAT_SUITE: renameFolders
+      DB_TYPE: mariadb
+      USE_SERVER: true
+    
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BEHAT_SUITE: trashbin
+      DB_TYPE: mariadb
+      USE_SERVER: true
+    
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BEHAT_SUITE: sharingInternalGroupsUsers
+      DB_TYPE: mariadb
+      USE_SERVER: true
+    
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BEHAT_SUITE: sharingExternalOther
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      USE_FEDERATED_SERVER: true
+    
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BEHAT_SUITE: restrictSharing
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BEHAT_SUITE: upload
+      DB_TYPE: mariadb
+      USE_SERVER: true

--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -812,17 +812,28 @@ class FilesContext extends RawMinkContext implements Context {
 	public function theFilesactionmenuShouldBeCompletelyVisibleAfterClickingOnIt() {
 		for ($i = 1; $i <= $this->filesPage->getSizeOfFileFolderList(); $i++) {
 			$actionMenu = $this->filesPage->openFileActionsMenuByNo($i);
-
-			$windowHeight = $this->filesPage->getWindowHeight(
-				$this->getSession()
-			);
-
-			$deleteBtn = $actionMenu->findButton(
-				$actionMenu->getDeleteActionLabel()
-			);
-			$deleteBtnCoordinates = $this->filesPage->getCoordinatesOfElement(
-				$this->getSession(), $deleteBtn
-			);
+			
+			$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC;
+			$currentTime = microtime(true);
+			$end = $currentTime + ($timeout_msec / 1000);
+			while ($currentTime <= $end) {
+				$windowHeight = $this->filesPage->getWindowHeight(
+					$this->getSession()
+				);
+				
+				$deleteBtn = $actionMenu->findButton(
+					$actionMenu->getDeleteActionLabel()
+				);
+				$deleteBtnCoordinates = $this->filesPage->getCoordinatesOfElement(
+					$this->getSession(), $deleteBtn
+				);
+				if ($windowHeight >= $deleteBtnCoordinates ["top"]) {
+					break;
+				}
+				usleep(STANDARDSLEEPTIMEMICROSEC);
+				$currentTime = microtime(true);
+			}
+			
 			PHPUnit_Framework_Assert::assertLessThan(
 				$windowHeight, $deleteBtnCoordinates ["top"]
 			);

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -253,6 +253,7 @@ class FilesPage extends FilesPageBasic {
 				$fileRow->rename($toFileName, $session);
 				break;
 			} catch (\Exception $e) {
+				$this->closeFileActionsMenu();
 				error_log(
 					"Error while renaming file"
 					. "\n-------------------------\n"

--- a/tests/ui/features/lib/FilesPageBasic.php
+++ b/tests/ui/features/lib/FilesPageBasic.php
@@ -44,6 +44,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	protected $controlsId = "controls";
 	protected $loadingIndicatorXpath = ".//*[@class='loading']";
 	protected $deleteAllSelectedBtnXpath = ".//*[@id='app-content-files']//*[@class='delete-selected']";
+	protected $fileRowXpathFromActionMenu = "/../..";
 
 	/**
 	 * @return string
@@ -259,12 +260,65 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	 *
 	 * @param string|array $name
 	 * @param Session $session
+	 * @param int $maxRetries
 	 * @return void
 	 */
-	public function deleteFile($name, Session $session) {
-		$row = $this->findFileRowByName($name, $session);
-		$row->delete($session);
-		$this->waitForOutstandingAjaxCalls($session);
+	public function deleteFile($name, Session $session, $maxRetries = 5) {
+		$this->initAjaxCounters($session);
+		$this->resetSumStartedAjaxRequests($session);
+		
+		for ($counter = 0; $counter < $maxRetries; $counter++) {
+			$row = $this->findFileRowByName($name, $session);
+			try {
+				$row->delete($session);
+				$this->waitForAjaxCallsToStartAndFinish($session);
+				$countXHRRequests = $this->getSumStartedAjaxRequests($session);
+				//if no XHR Request were fired we assume the delete action
+				//did not work and we retry
+				if ($countXHRRequests === 0) {
+					error_log("Error while deleting file");
+				} else {
+					break;
+				}
+			} catch (\Exception $e) {
+				$this->closeFileActionsMenu();
+				error_log(
+					"Error while deleting file"
+					. "\n-------------------------\n"
+					. $e->getMessage()
+					. "\n-------------------------\n"
+				);
+				usleep(STANDARDSLEEPTIMEMICROSEC);
+			}
+		}
+		if ($counter > 0) {
+			$message = "INFORMATION: retried to delete file '" . $name . "' " .
+					   $counter . " times";
+			echo $message;
+			error_log($message);
+		}
+	}
+
+	/**
+	 * closes the fileactionsmenu is any is open
+	 * 
+	 * @return void
+	 */
+	public function closeFileActionsMenu() {
+		try {
+			$actionMenu = $this->findFileActionMenuElement();
+			$fileRowElement = $actionMenu->find(
+				"xpath", $this->fileRowXpathFromActionMenu
+			);
+			/**
+			 * 
+			 * @var FileRow $fileRow
+			 */
+			$fileRow = $this->getPage('FilesPageElement\\FileRow');
+			$fileRow->setElement($fileRowElement);
+			$fileRow->clickFileActionButton();
+		} catch (\Exception $e) {
+		}
 	}
 
 	/**

--- a/tests/ui/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/ui/features/lib/FilesPageElement/FileActionsMenu.php
@@ -91,6 +91,7 @@ class FileActionsMenu extends OwnCloudPage {
 				" could not find action button with label " . $this->deleteActionLabel
 			);
 		}
+		$deleteBtn->focus();
 		$deleteBtn->click();
 	}
 	
@@ -114,6 +115,9 @@ class FileActionsMenu extends OwnCloudPage {
 				" xpath $xpathLocator could not find button '$action' in action Menu"
 			);
 		} else {
+			$this->waitFor(
+				STANDARDUIWAITTIMEOUTMILLISEC / 1000, array($button, 'isVisible')
+			);
 			return $button;
 		}
 	}


### PR DESCRIPTION
1. some improvements on the UI tests infrastructure (was needed because we run on different timing issues in drone - drone is just sooo fast)
2. run the UI tests in drone

ToDo:

- [x] change from `arturneumann/owncloud-ci-php` to `owncloudci/php` as soon as its build the version after https://github.com/owncloud-ci/php/pull/13