### PR TITLE
Allow avatars to be visible publicly

### DIFF
--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -106,6 +106,7 @@ class AvatarController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @PublicPage
 	 *
 	 * @param string $userId
 	 * @param int $size


### PR DESCRIPTION
## Description
If a calendar is shared publicly the avatar cannot be loaded.
As a result we observe an automated reload every 5 secs

## Related Issue
fixes owncloud/calendar#869

## How Has This Been Tested?
- manually - see linked ticket for reproduction steps

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

