### PR TITLE
[stable10] escape urlencode of strings to read messages properly

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1942,7 +1942,7 @@
 						if (status === 412) {
 							// TODO: some day here we should invoke the conflict dialog
 							OC.Notification.show(t('files', 'Could not move "{file}", target exists', 
-								{file: fileName}), {type: 'error'}
+								{file: fileName}, null, {escape: false}), {type: 'error'}
 							);
 						} else {
 							OC.Notification.show(t('files', 'Could not move "{file}"', 

--- a/apps/files_sharing/js/external.js
+++ b/apps/files_sharing/js/external.js
@@ -28,7 +28,7 @@
 				t(
 					'files_sharing',
 					'Do you want to add the remote share {name} from {owner}@{remote}?',
-					{name: name, owner: owner, remote: remoteClean}
+					{name: name, owner: owner, remote: remoteClean}, null, {escape: false}
 				),
 				t('files_sharing','Remote share'),
 				function (result) {
@@ -41,7 +41,7 @@
 				t(
 					'files_sharing',
 					'Do you want to add the remote share {name} from {owner}@{remote}?',
-					{name: name, owner: owner, remote: remoteClean}
+					{name: name, owner: owner, remote: remoteClean}, null, {escape: false}
 				),
 				t('files_sharing','Remote share'),
 				function (result, password) {


### PR DESCRIPTION
escaping urlencode of messages would help read messages properly
during notification

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
decodeuri would help read messages for humans. This would improve the messages shown in the notification.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/29556
https://github.com/owncloud/core/issues/29080

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
decodeuri would help read messages for humans. This would improve the messages shown in the notification.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
As per the instruction in https://github.com/owncloud/core/issues/29556
- [x] Tried to add multiple escape strings to the folder name and verified.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

