### PR TITLE
Improve search query for adressbooks

### DIFF
--- a/apps/dav/appinfo/Migrations/Version20200114181454.php
+++ b/apps/dav/appinfo/Migrations/Version20200114181454.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\dav\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Add index to oc_cards_properties to assist with searching with large numbers of rows
+ */
+class Version20200114181454 implements ISchemaMigration {
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+		$table = $schema->getTable("${prefix}cards_properties");
+		// Check for existing index spanning these columns
+		foreach ($table->getIndexes() as $index) {
+			// Check if we have a matching index already
+			if (empty(\array_diff($index->getColumns(), ['addressbookid', 'name', 'value']))) {
+				return;
+			}
+		}
+		// Add the index if we dont have one spanning this column already
+		$table->addIndex(['addressbookid', 'name', 'value'], 'carddata_aid_n_v_idx');
+	}
+}


### PR DESCRIPTION
The current search query for addressbook entries is problematic:
```sql
MariaDB [core]> EXPLAIN
SELECT c.`carddata`, c.`uri`
FROM `oc_cards` c
WHERE c.`id` IN (
    SELECT DISTINCT cp.`cardid`
    FROM `oc_cards_properties` cp
    WHERE (
        ( (cp.`name` = 'CLOUD') AND (cp.`value`  COLLATE utf8_general_ci LIKE '%foo%') )
        OR ( (cp.`name` = 'FN') AND (cp.`value`  COLLATE utf8_general_ci LIKE '%foo%') )
    )
    AND (cp.`addressbookid` = 10)
) ORDER BY c.`uri` ASC LIMIT 200 OFFSET 0;
+------+--------------+-------------+--------+--------------------------------------+-----------------+---------+------+--------+------------------------------------+
| id   | select_type  | table       | type   | possible_keys                        | key             | key_len | ref  | rows   | Extra                              |
+------+--------------+-------------+--------+--------------------------------------+-----------------+---------+------+--------+------------------------------------+
|    1 | PRIMARY      | c           | index  | PRIMARY,id_uri_index                 | uri_index       | 768     | NULL |      1 |                                    |
|    1 | PRIMARY      | <subquery2> | eq_ref | distinct_key                         | distinct_key    | 8       | func |      1 |                                    |
|    2 | MATERIALIZED | cp          | range  | card_name_index,card_contactid_index | card_name_index | 195     | NULL | 372808 | Using index condition; Using where |
+------+--------------+-------------+--------+--------------------------------------+-----------------+---------+------+--------+------------------------------------+
3 rows in set (0.00 sec)

SELECT c.`carddata`, c.`uri` FROM `oc_cards` c WHERE c.`id` IN (     SELECT DISTINCT cp.`cardid`     FROM `oc_cards_properties` cp     WHERE cp.`addressbookid` = 10     AND cp.`name` IN ('CLOUD','FN')     AND cp.`value`  COLLATE utf8_general_ci LIKE '%filler%' ) ORDER BY c.`uri` ASC LIMIT 200 OFFSET 0;
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------+
...
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------+
200 rows in set (0.29 sec)
```
0.29 sec. ouch. on large addressbooks (>100k cards) tables this query takes more than a second ... per addressbook. 20 addressbooks => 20 seconds until the user sees a result.

We can do better. Let us have a look at the query. Maybe we can simplify it? What about:
```sql
MariaDB [core]> EXPLAIN
SELECT c.`carddata`, c.`uri`
FROM `oc_cards` c
WHERE c.`id` IN (
    SELECT DISTINCT cp.`cardid`
    FROM `oc_cards_properties` cp
    WHERE cp.`addressbookid` = 11
    AND cp.`name` IN ('CLOUD','FN')
    AND cp.`value`  COLLATE utf8_general_ci LIKE '%filler%'
)
ORDER BY c.`uri` ASC LIMIT 200 OFFSET 0;
+------+--------------+-------------+--------+--------------------------------------+-----------------+---------+------+--------+------------------------------------+
| id   | select_type  | table       | type   | possible_keys                        | key             | key_len | ref  | rows   | Extra                              |
+------+--------------+-------------+--------+--------------------------------------+-----------------+---------+------+--------+------------------------------------+
|    1 | PRIMARY      | c           | index  | PRIMARY,id_uri_index                 | uri_index       | 768     | NULL |      1 |                                    |
|    1 | PRIMARY      | <subquery2> | eq_ref | distinct_key                         | distinct_key    | 8       | func |      1 |                                    |
|    2 | MATERIALIZED | cp          | range  | card_name_index,card_contactid_index | card_name_index | 195     | NULL | 372808 | Using index condition; Using where |
+------+--------------+-------------+--------+--------------------------------------+-----------------+---------+------+--------+------------------------------------+
3 rows in set (0.00 sec)

SELECT c.`carddata`, c.`uri` FROM `oc_cards` c WHERE c.`id` IN (     SELECT DISTINCT cp.`cardid`     FROM `oc_cards_properties` cp     WHERE cp.`addressbookid` = 11     AND cp.`name` IN ('CLOUD','FN')     AND cp.`value`  COLLATE utf8_general_ci LIKE '%filler%' ) ORDER BY c.`uri` ASC LIMIT 200 OFFSET 0;
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------+
...
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------+
200 rows in set (0.29 sec)
```

Well, nothing changed. But at least it is more readable ... so what about the indexes. Adding one for the materialized subquery became clearer:
```sql
MariaDB [core]> CREATE INDEX carddata_aid_n_v_idx ON oc_cards_properties (addressbookid, name, value);
Query OK, 0 rows affected (1.81 sec)
Records: 0  Duplicates: 0  Warnings: 0

MariaDB [core]> EXPLAIN SELECT c.`carddata`, c.`uri` FROM `oc_cards` c WHERE c.`id` IN (     SELECT DISTINCT cp.`cardid`     FROM `oc_cards_properties` cp     WHERE cp.`addressbookid` = 12     AND cp.`name` IN ('CLOUD','FN')     AND cp.`value`  COLLATE utf8_general_ci LIKE '%filler%' ) ORDER BY c.`uri` ASC LIMIT 200 OFFSET 0;
+------+--------------+-------------+--------+-----------------------------------------------------------+----------------------+---------+----------------+------+---------------------------------+
| id   | select_type  | table       | type   | possible_keys                                             | key                  | key_len | ref            | rows | Extra                           |
+------+--------------+-------------+--------+-----------------------------------------------------------+----------------------+---------+----------------+------+---------------------------------+
|    1 | PRIMARY      | <subquery2> | ALL    | distinct_key                                              | NULL                 | NULL    | NULL           | 3962 | Using temporary; Using filesort |
|    1 | PRIMARY      | c           | eq_ref | PRIMARY,id_uri_index                                      | PRIMARY              | 8       | core.cp.cardid |    1 |                                 |
|    2 | MATERIALIZED | cp          | range  | card_name_index,card_contactid_index,carddata_aid_n_v_idx | carddata_aid_n_v_idx | 203     | NULL           | 3962 | Using index condition           |
+------+--------------+-------------+--------+-----------------------------------------------------------+----------------------+---------+----------------+------+---------------------------------+
3 rows in set (0.00 sec)

MariaDB [core]> SELECT c.`carddata`, c.`uri` FROM `oc_cards` c WHERE c.`id` IN (     SELECT DISTINCT cp.`cardid`     FROM `oc_cards_properties` cp     WHERE cp.`addressbookid` = 12     AND cp.`name` IN ('CLOUD','FN')     AND cp.`value`  COLLATE utf8_general_ci LIKE '%filler%' ) ORDER BY c.`uri` ASC LIMIT 200 OFFSET 0;
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------+
...
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------+
200 rows in set (0.03 sec)
```

Much better. We now have an index that correctly partitions the table.

