### PR TITLE
Default HTTPS for fed sharing & config option for allowing fallback

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1112,6 +1112,11 @@ $CONFIG = array(
  */
 'sharing.managerFactory' => '\OC\Share20\ProviderFactory',
 
+/**
+ * When talking with federated sharing server, allow falling back to HTTP
+ * instead of hard forcing HTTPS
+ */
+'sharing.federation.allowHttpFallback' => false,
 
 
 /**
@@ -1410,4 +1415,5 @@ $CONFIG = array(
  * Set this property to true if you want to enable debug logging for SMB access.
  */
 'smb.logging.enable' => false, 
+
 );


### PR DESCRIPTION

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Only uses HTTPS for federated share communication - unless admins explicitly allow HTTP (useful for testing as well)

## Related Issue
Potential for users to setup shares via HTTP with unsecure servers without the admin knowing.

## Motivation and Context
MITM

## How Has This Been Tested?
not yet

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

