### PR TITLE
only run javascript tests once in a matrix build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -84,15 +84,14 @@ pipeline:
       matrix:
         TEST_SUITE: coverage
 
-  javascript:
+  test-javascript:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
-    group: test
     commands:
       - ./tests/drone/test-javascript.sh
     when:
       matrix:
-        TEST_SUITE: phpunit
+        TEST_SUITE: javascript
 
   phpunit:
     image: owncloudci/php:${PHP_VERSION}
@@ -182,6 +181,8 @@ services:
 
 matrix:
   include:
+    - TEST_SUITE: javascript
+      PHP_VERSION: 7.1
     # PHP 5.6
     #- PHP_VERSION: 5.6
     #  DB_TYPE: sqlite


### PR DESCRIPTION
# Motivation

Currently all phpunit steps would execute the javascript test step. 
This is unnecessary - thus I propose to run the javascript tests as a separate matrix step

