### PR TITLE
Use codecov bash to upload coverage information

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -73,12 +73,13 @@ pipeline:
         TEST_SUITE: coverage
 
   codecov:
-    image: plugins/codecov:1
-    secrets: [codecov_token]
+    image: owncloudci/php:${PHP_VERSION}
     pull: true
-    files:
-     - tests/autotest-clover-${DB_TYPE}.xml
-     - tests/autotest-external-clover-${DB_TYPE}.xml
+    group: test
+    commands:
+      - curl -o codecov.sh https://codecov.io/bash
+      - sh -c "if [ '$DRONE_BUILD_EVENT' = 'pull_request' ]; then bash codecov.sh -B $DRONE_BRANCH -C $DRONE_COMMIT -P $DRONE_PULL_REQUEST -t f793afb1-3972-4979-9be0-998fb79ac605 -f tests/autotest-clover-external-${DB_TYPE}.xml -f tests/autotest-clover-${DB_TYPE}.xml; fi"
+      - sh -c "if [ '$DRONE_BUILD_EVENT' != 'pull_request' ]; then bash codecov.sh -B $DRONE_BRANCH -C $DRONE_COMMIT -t f793afb1-3972-4979-9be0-998fb79ac605 -f tests/autotest-clover-external-${DB_TYPE}.xml -f tests/autotest-clover-${DB_TYPE}.xml; fi"
     when:
       event: [push, pull_request]
       matrix:

--- a/tests/drone/test-coverage.sh
+++ b/tests/drone/test-coverage.sh
@@ -47,5 +47,5 @@ fi
 if [[ -z ${FILES_EXTERNAL_TYPE} ]]; then
   exec phpdbg -d memory_limit=4096M -rr ./lib/composer/bin/phpunit --configuration tests/phpunit-autotest.xml ${GROUP} --coverage-clover tests/autotest-clover-${DB_TYPE}.xml
 else
-  exec phpdbg -d memory_limit=4096M -rr ./lib/composer/bin/phpunit --configuration tests/phpunit-autotest-external.xml ${GROUP} --coverage-clover tests/autotest-external-clover-${DB_TYPE}.xml
+  exec phpdbg -d memory_limit=4096M -rr ./lib/composer/bin/phpunit --configuration tests/phpunit-autotest-external.xml ${GROUP} --coverage-clover tests/autotest-clover-external-${DB_TYPE}.xml
 fi


### PR DESCRIPTION
The drone plugin to upload clover reports to codecov.io misses one step and this is where paths are adjusted.

This PR now uses the official bash script as distributed by codecov.io

This is where the bash script adjusts the paths - https://github.com/codecov/codecov-bash/blob/15cdf48a5c270730a650f853b26869304b2cc379/codecov#L1283-L1433

This is missing in https://github.com/drone-plugins/drone-codecov - I have currently no intent to report a bug report there because this plugin is just plain wrong from my pov - no interest in fighting the devs ;-)