### PR TITLE
Correct theme documentation in config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1241,12 +1241,6 @@ $CONFIG = array(
 'share_folder' => '/',
 
 /**
- * If you are applying a theme to ownCloud, enter the name of the theme here.
- * The default location for themes is ``owncloud/themes/``.
- */
-'theme' => '',
-
-/**
  * The default cipher for encrypting files. Currently AES-128-CFB and
  * AES-256-CFB are supported.
  */


### PR DESCRIPTION
This is necessary, as https://doc.owncloud.org/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html, is generated from this file. So if this file is wrong, so is the documentation. This also fixes
https://github.com/owncloud/documentation/issues/3728.