### PR TITLE
Validation for new storage key location

### DIFF
--- a/core/Command/Encryption/ChangeKeyStorageRoot.php
+++ b/core/Command/Encryption/ChangeKeyStorageRoot.php
@@ -136,7 +136,8 @@ class ChangeKeyStorageRoot extends Command {
 	 * @throws \Exception
 	 */
 	protected function prepareNewRoot($newRoot) {
-		if ($this->rootView->is_dir($newRoot) === false) {
+		$validateNewRootDir = $this->rootView->is_dir($newRoot);
+		if (($validateNewRootDir === false) or ($validateNewRootDir === null)) {
 			throw new \Exception("New root folder doesn't exist. Please create the folder or check the permissions and try again.");
 		}
 
@@ -150,7 +151,6 @@ class ChangeKeyStorageRoot extends Command {
 		}
 
 	}
-
 
 	/**
 	 * move system key folder

--- a/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
+++ b/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
@@ -200,6 +200,24 @@ class ChangeKeyStorageRootTest extends TestCase {
 		];
 	}
 
+	public function nulldir() {
+		return [
+			[null]
+		];
+	}
+
+	/**
+	 * @dataProvider nulldir
+	 * @expectedException \Exception
+	 * @expectedExceptionMessage New root folder doesn't exist. Please create the folder or check the permissions and try again.
+	 * @param $dirExists
+	 */
+	public function testPrepareNewRootExceptionForNullDir($dirExists) {
+		$this->view->expects($this->once())->method('is_dir')->with('../../newRoot')
+			->willReturn($dirExists);
+		$this->invokePrivate($this->changeKeyStorageRoot, 'prepareNewRoot', ['../../newRoot']);
+	}
+
 	/**
 	 * @dataProvider dataTestMoveSystemKeys
 	 *


### PR DESCRIPTION
Extra validation required if the new storage
key location is being provided to the command.
When is_dir returns null it wasn't captured by
the command. And hence the command was executed
successfully. This change would help to prevent
such scenario. If is_dir returns null throw exception.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
The new root directory wasn't checked for null. This change helps to validate against null

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/27660

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Validate new root against null.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Create dir `foo` outside the owncloud folder
- [x] Ran the command below:
```
sujith@sujith-Inspiron-5567 ~/test/owncloud $ ./occ encryption:change-key-storage-root ../foo
Cannot load Xdebug - it was already loaded
Change key storage root from tester to ../foo
Start to move keys:

In ChangeKeyStorageRoot.php line 141:
                                                                                                   
  New root folder doesn't exist. Please create the folder or check the permissions and try again.  
                                                                                                   

encryption:change-key-storage-root [<newRoot>]

sujith@sujith-Inspiron-5567 ~/test/owncloud $
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

