### PR TITLE
Put back Firefox IE Edge UI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,76 +57,135 @@ script:
 matrix:
   include:
     - php: 5.6
-      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="renameFiles" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="renameFolders" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="upload" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="renameFiles" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="renameFolders" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="upload" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
     - php: 5.6
       env: DB=pgsql TC=litmus-v1
     - php: 5.6
@@ -141,4 +200,214 @@ matrix:
       env: DB=sqlite TC=syntax TEST_DAV=0
     - php: 7.0
       env: DB=sqlite TC=syntax TEST_DAV=0
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="renameFiles" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="renameFolders" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="upload" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="renameFiles" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="renameFolders" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="upload" PLATFORM="Windows 10" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="other" PLATFORM="Windows 7" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 7" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="renameFiles" PLATFORM="Windows 7" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="renameFolders" PLATFORM="Windows 7" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="files" PLATFORM="Windows 7" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="trashbin" PLATFORM="Windows 7" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 7" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 7" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 7" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
+    - php: 5.6
+      if: type = cron
+      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="upload" PLATFORM="Windows 7" TEST_DAV=0
+      addons:
+        apt: *common_apt
+        hosts: *common_hosts
+        sauce_connect: true
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,60 +57,70 @@ script:
 matrix:
   include:
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="renameFiles" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="renameFolders" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
+      if: branch = stable10 OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="upload" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt


### PR DESCRIPTION
## Description
- revert the recent commit that temporarily removed almost all UI testing from Travis
- run chrome UI tests only for stable10 and/or the cron job (like done for Firefox, IE and Edge)

## Motivation and Context
It is good to run the UI tests on other browsers on some regular basis. This will run them again once a day. As discussed, also run chrome daily here, since it proves chrome on Windows (whereas drone is running chrome on Ubuntu). Keep running chrome in stable10 for backport PRs since UI tests are not yet running on drone in stable10.

## How Has This Been Tested?
We will know only after merging and observing a daily Travis cron job run.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

