### PR TITLE
Use LargeFileHelper to calculate log file size

### DIFF
--- a/settings/Panels/Admin/Logging.php
+++ b/settings/Panels/Admin/Logging.php
@@ -21,6 +21,7 @@
 
 namespace OC\Settings\Panels\Admin;
 
+use OC\LargeFileHelper;
 use OC\Settings\Panels\Helper;
 use OCP\Settings\ISettings;
 use OCP\Template;
@@ -54,7 +55,8 @@ class Logging implements ISettings {
 		$doesLogFileExist = file_exists($logFilePath);
 		$logFileSize = 0;
 		if($doesLogFileExist) {
-			$logFileSize = filesize($logFilePath);
+			$h = new LargeFileHelper();
+			$logFileSize = $h->getFileSize($logFilePath);
 		}
 		$tmpl->assign('loglevel', $this->config->getSystemValue("loglevel", 2));
 		$tmpl->assign('doesLogFileExist', $doesLogFileExist);


### PR DESCRIPTION
## Description
On a 32 bit system the log file size can be displayed wrong

## Related Issue
fixes #30227

## Motivation and Context
Make users of 32 bit systems happy

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

