### PR TITLE
[stable10] Enable SMB logging for the Community Edition 

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -663,14 +663,14 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 	 * @param int $level
 	 * @param string $from
 	 */
-	private function log($message, $level = Util::DEBUG, $from = 'wnd') {
-		if (\OC::$server->getConfig()->getSystemValue('wnd.logging.enable', false) === true) {
+	private function log($message, $level = Util::DEBUG, $from = 'smb') {
+		if (\OC::$server->getConfig()->getSystemValue('smb.logging.enable', false) === true) {
 			Util::writeLog($from, $message, $level);
 		}
 	}
 
 	/**
-	 * if wnd.logging.enable is set to true in the config will log a leave line
+	 * if smb.logging.enable is set to true in the config will log a leave line
 	 * with the given function, the return value or the exception
 	 *
 	 * @param $function
@@ -678,31 +678,31 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 	 * @return mixed
 	 */
 	private function leave($function, $result) {
-		if (\OC::$server->getConfig()->getSystemValue('wnd.logging.enable', false) === false) {
+		if (\OC::$server->getConfig()->getSystemValue('smb.logging.enable', false) === false) {
 			//don't bother building log strings
 			return $result;
 		} else if ($result === true) {
-			Util::writeLog('wnd', "leave: $function, return true", Util::DEBUG);
+			Util::writeLog('smb', "leave: $function, return true", Util::DEBUG);
 		} else if ($result === false) {
-			Util::writeLog('wnd', "leave: $function, return false", Util::DEBUG);
+			Util::writeLog('smb', "leave: $function, return false", Util::DEBUG);
 		} else if (is_string($result)) {
-			Util::writeLog('wnd', "leave: $function, return '$result'", Util::DEBUG);
+			Util::writeLog('smb', "leave: $function, return '$result'", Util::DEBUG);
 		} else if (is_resource($result)) {
-			Util::writeLog('wnd', "leave: $function, return resource", Util::DEBUG);
+			Util::writeLog('smb', "leave: $function, return resource", Util::DEBUG);
 		} else if ($result instanceof \Exception) {
-			Util::writeLog('wnd', "leave: $function, throw ".get_class($result)
+			Util::writeLog('smb', "leave: $function, throw ".get_class($result)
 				.' - code: '.$result->getCode()
 				.' message: '.$result->getMessage()
 				.' trace: '.$result->getTraceAsString(), Util::DEBUG);
 		} else {
-			Util::writeLog('wnd', "leave: $function, return ".json_encode($result, true), Util::DEBUG);
+			Util::writeLog('smb', "leave: $function, return ".json_encode($result, true), Util::DEBUG);
 		}
 		return $result;
 	}
 
 	private function swallow($function, \Exception $exception) {
-		if (\OC::$server->getConfig()->getSystemValue('wnd.logging.enable', false) === true) {
-			Util::writeLog('wnd', "$function swallowing ".get_class($exception)
+		if (\OC::$server->getConfig()->getSystemValue('smb.logging.enable', false) === true) {
+			Util::writeLog('smb', "$function swallowing ".get_class($exception)
 				.' - code: '.$exception->getCode()
 				.' message: '.$exception->getMessage()
 				.' trace: '.$exception->getTraceAsString(), Util::DEBUG);

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1438,4 +1438,8 @@ $CONFIG = array(
  */
 'files_external_allow_create_new_local' => false,
 
+/**
+ * Set this property to true if you want to enable debug logging for SMB access.
+ */
+'smb.logging.enable' => false, 
 );


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Backport of #30185 (Enable SMB logging for the Community Edition) 14b6937

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@PVince81 @jvillafanez 