### PR TITLE
When executing the data-fingerprint command a log entry is written to…

### DIFF
--- a/core/Command/Maintenance/DataFingerprint.php
+++ b/core/Command/Maintenance/DataFingerprint.php
@@ -25,8 +25,11 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\ILogger;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 
 class DataFingerprint extends Command {
@@ -54,10 +57,23 @@ class DataFingerprint extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$osUser = get_current_user();
-		$server = gethostname();
-		$fingerprint = md5($this->timeFactory->getTime());
-		$this->config->setSystemValue('data-fingerprint', $fingerprint);
-		$this->logger->info("Data fingerprint was set by $osUser@$server to $fingerprint");
+		$io = new SymfonyStyle($input, $output);
+		$warning = <<<EOD
+Setting the data fingerprint will notify desktop and mobile clients that a server backup has been restored. 
+Users will be prompted to resolve any conflicts between newer and older file versions.
+
+Setting the data fingerprint has a large impact on all connected clients!
+
+Only perform this operation if you really know what you are doing.
+EOD;
+
+		$io->warning($warning);
+		if ($io->confirm('Do you want to set the data fingerprint?', false)) {
+			$osUser = get_current_user();
+			$server = gethostname();
+			$fingerprint = md5($this->timeFactory->getTime());
+			$this->config->setSystemValue('data-fingerprint', $fingerprint);
+			$this->logger->info("Data fingerprint was set by $osUser@$server to $fingerprint");
+		}
 	}
 }

--- a/core/Command/Maintenance/DataFingerprint.php
+++ b/core/Command/Maintenance/DataFingerprint.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @author Roeland Jago Douma <rullzer@owncloud.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
  * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0
@@ -22,6 +23,7 @@ namespace OC\Core\Command\Maintenance;
 
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
+use OCP\ILogger;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -30,14 +32,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DataFingerprint extends Command {
 
 	/** @var IConfig */
-	protected $config;
+	private $config;
 	/** @var ITimeFactory */
-	protected $timeFactory;
+	private $timeFactory;
+	/** @var ILogger */
+	private $logger;
 
 	public function __construct(IConfig $config,
-								ITimeFactory $timeFactory) {
+								ITimeFactory $timeFactory,
+								ILogger $logger ) {
 		$this->config = $config;
 		$this->timeFactory = $timeFactory;
+		$this->logger = $logger;
 		parent::__construct();
 	}
 
@@ -48,6 +54,10 @@ class DataFingerprint extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$this->config->setSystemValue('data-fingerprint', md5($this->timeFactory->getTime()));
+		$osUser = get_current_user();
+		$server = gethostname();
+		$fingerprint = md5($this->timeFactory->getTime());
+		$this->config->setSystemValue('data-fingerprint', $fingerprint);
+		$this->logger->info("Data fingerprint was set by $osUser@$server to $fingerprint");
 	}
 }

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -122,7 +122,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	);
 	$application->add(new OC\Core\Command\Encryption\ShowKeyStorageRoot($util));
 
-	$application->add(new OC\Core\Command\Maintenance\DataFingerprint(\OC::$server->getConfig(), new \OC\AppFramework\Utility\TimeFactory()));
+	$application->add(new OC\Core\Command\Maintenance\DataFingerprint(\OC::$server->getConfig(), new \OC\AppFramework\Utility\TimeFactory(), \OC::$server->getLogger()));
 	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateDB(\OC::$server->getMimeTypeDetector(), \OC::$server->getMimeTypeLoader()));
 	$application->add(new OC\Core\Command\Maintenance\Mimetype\UpdateJS(\OC::$server->getMimeTypeDetector()));
 	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));

--- a/tests/Core/Command/Maintenance/DataFingerprintTest.php
+++ b/tests/Core/Command/Maintenance/DataFingerprintTest.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @author Roeland Jago Douma <rullzer@owncloud.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
  * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0
@@ -24,31 +25,36 @@ namespace Tests\Core\Command\Maintenance;
 use OC\Core\Command\Maintenance\DataFingerprint;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
+use OCP\ILogger;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class DataFingerprintTest extends TestCase {
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
-	protected $config;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
-	protected $consoleInput;
-	/** @var \PHPUnit_Framework_MockObject_MockObject */
-	protected $consoleOutput;
-	/** @var ITimeFactory|\PHPUnit_Framework_MockObject_MockObject */
-	protected $timeFactory;
+	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+	/** @var InputInterface | \PHPUnit_Framework_MockObject_MockObject */
+	private $consoleInput;
+	/** @var OutputInterface | \PHPUnit_Framework_MockObject_MockObject */
+	private $consoleOutput;
+	/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject */
+	private $timeFactory;
+	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
 
 	/** @var \Symfony\Component\Console\Command\Command */
-	protected $command;
+	private $command;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->config = $this->createMock('OCP\IConfig');
-		$this->timeFactory = $this->createMock('OCP\AppFramework\Utility\ITimeFactory');
-		$this->consoleInput = $this->createMock('Symfony\Component\Console\Input\InputInterface');
-		$this->consoleOutput = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
+		$this->config = $this->createMock(IConfig::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->consoleInput = $this->createMock(InputInterface::class);
+		$this->consoleOutput = $this->createMock(OutputInterface::class);
+		$this->logger = $this->createMock(ILogger::class);
 
-		/** @var \OCP\IConfig $config */
-		$this->command = new DataFingerprint($this->config, $this->timeFactory);
+		$this->command = new DataFingerprint($this->config, $this->timeFactory, $this->logger);
 	}
 
 	public function testSetFingerPrint() {
@@ -58,6 +64,13 @@ class DataFingerprintTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('setSystemValue')
 			->with('data-fingerprint', md5(42));
+
+		$osUser = get_current_user();
+		$server = gethostname();
+
+		$this->logger->expects($this->once())
+			->method('info')
+			->with("Data fingerprint was set by $osUser@$server to a1d0c6e83f027327d8461063f4ac58a6");
 
 		self::invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}


### PR DESCRIPTION
… allow analysis who executed the command and when 

## Description
Executing the data fingerprint command has some large impact on the system.
The command should be logged for later analysis who executed the command.

In addition it is worth a second user confirmation before applying the data-fingerprint.

## Related Issue
refs #30154

## Motivation and Context
Make owncloud a bit more robust

## How Has This Been Tested?
- manual
- unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

