### PR TITLE
[stable10] Use mysql in phpunit coverage run

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -326,7 +326,7 @@ matrix:
       TEST_SUITE: coverage
 
     - PHP_VERSION: 7.1
-      DB_TYPE: mariadb
+      DB_TYPE: mysql
       TEST_SUITE: coverage
 
     - PHP_VERSION: 7.1


### PR DESCRIPTION
# Motivation

Mariadb is failing during the codecoverage run - in `master` we already switched to mysql - so let's do this with mysql here as well
