### PR TITLE
Integration tests delete remote groups between scenarios

### DIFF
--- a/tests/integration/features/bootstrap/Provisioning.php
+++ b/tests/integration/features/bootstrap/Provisioning.php
@@ -725,7 +725,7 @@ trait Provisioning {
 		}
 		$this->usingServer('REMOTE');
 		foreach ($this->createdRemoteGroups as $remoteGroup) {
-			$this->deleteUser($remoteGroup);
+			$this->deleteGroup($remoteGroup);
 		}
 		$this->usingServer($previousServer);
 	}


### PR DESCRIPTION

## Description
Fix an accidental call to ``deleteUser`` that should be ``deleteGroup``

## Related Issue

## Motivation and Context
Any remote groups created during a scenario are supposed to be cleaned up.
Noticed while doing refactoring examples for proposed gherkin step text changes.

## How Has This Been Tested?
CI knows

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

