### PR TITLE
using LDAP users in UI tests

### DIFF
--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -190,7 +190,7 @@ trait BasicStructure {
 		if ($method === null && getenv("TEST_EXTERNAL_USER_BACKENDS") === "true") {
 			//guess yourself
 			$method = "ldap";
-		} else {
+		} elseif ($method === null) {
 			$method = "api";
 		}
 		$user = trim($user);
@@ -224,7 +224,7 @@ trait BasicStructure {
 				}
 				break;
 			case "ldap":
-				echo "creating LDAP users is not implemented, so assume they exists\n";
+				echo "creating LDAP users is not implemented, so assume they exist\n";
 				break;
 			default:
 				throw new InvalidArgumentException(
@@ -287,7 +287,7 @@ trait BasicStructure {
 		if ($method === null && getenv("TEST_EXTERNAL_USER_BACKENDS") === "true") {
 			//guess yourself
 			$method = "ldap";
-		} else {
+		} elseif ($method === null) {
 			$method = "api";
 		}
 		$group = trim($group);
@@ -315,7 +315,7 @@ trait BasicStructure {
 				}
 				break;
 			case "ldap":
-				echo "creating LDAP groups is not implemented, so assume they exists\n";
+				echo "creating LDAP groups is not implemented, so assume they exist\n";
 				break;
 			default:
 				throw new InvalidArgumentException(
@@ -349,7 +349,7 @@ trait BasicStructure {
 		if ($method === null && getenv("TEST_EXTERNAL_USER_BACKENDS") === "true") {
 			//guess yourself
 			$method = "ldap";
-		} else {
+		} elseif ($method === null) {
 			$method = "api";
 		}
 		$method = trim(strtolower($method));

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -499,6 +499,30 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @return array
+	 */
+	public function getCreatedUsers() {
+		return $this->createdUsers;
+	}
+
+	/**
+	 * returns an array of the real displayed names
+	 * if no "Display Name" is set the user-name is returned instead
+	 * @return array
+	 */
+	public function getCreatedUserDisplayNames() {
+		$result = array();
+		foreach ($this->getCreatedUsers() as $username=>$user) {
+			if (is_null($user['displayname'])) {
+				$result[] = $username;
+			} else {
+				$result[] = $user['displayname'];
+			}
+		}
+		return $result;
+	}
+
+	/**
 	 * @return string
 	 */
 	public function getRegularGroupName() {

--- a/tests/ui/features/bootstrap/SharingContext.php
+++ b/tests/ui/features/bootstrap/SharingContext.php
@@ -324,21 +324,22 @@ class SharingContext extends RawMinkContext implements Context {
 				= $this->sharingDialog->groupStringsToMatchAutoComplete($notToBeListed);
 		}
 		$autocompleteItems = $this->sharingDialog->getAutocompleteItemsList();
-		foreach (
-			array_merge(
-				$this->regularUserNames,
-				$this->sharingDialog->groupStringsToMatchAutoComplete(
-					$this->regularGroupNames
-				)
-			) as $regularUserOrGroup ) {
-
-			if (strpos($regularUserOrGroup, $requiredString) !== false
-				&& $regularUserOrGroup !== $notToBeListed
+		$createdGroups = $this->sharingDialog->groupStringsToMatchAutoComplete(
+			$this->featureContext->getCreatedGroupNames()
+		);
+		$usersAndGroups = array_merge(
+			$this->featureContext->getCreatedUserDisplayNames(),
+			$createdGroups
+		);
+		foreach ($usersAndGroups as $expectedUserOrGroup) {
+			if (strpos($expectedUserOrGroup, $requiredString) !== false
+				&& $expectedUserOrGroup !== $notToBeListed
+				&& $expectedUserOrGroup !== $this->featureContext->getCurrentUser()
 			) {
 				PHPUnit_Framework_Assert::assertContains(
-					$regularUserOrGroup,
+					$expectedUserOrGroup,
 					$autocompleteItems,
-					"'" . $regularUserOrGroup . "' not in autocomplete list"
+					"'" . $expectedUserOrGroup . "' not in autocomplete list"
 				);
 			}
 		}

--- a/tests/ui/features/other/login.feature
+++ b/tests/ui/features/other/login.feature
@@ -8,6 +8,7 @@ As an admin
 I want only authorised users to log in
 So that unauthorised access is impossible
 
+	@TestAlsoOnExternalUserBackend
 	Scenario: simple user login
 		Given a regular user exists but is not initialized
 		And I am on the login page

--- a/tests/ui/features/restrictSharing/disableSharing.feature
+++ b/tests/ui/features/restrictSharing/disableSharing.feature
@@ -9,7 +9,7 @@ So that users cannot share files
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
 		
-
+	@TestAlsoOnExternalUserBackend
 	Scenario: Users tries to share via WebUI when Sharing is disabled
 		When the setting "Allow apps to use the Share API" in the section "Sharing" is disabled
 		And I am on the login page

--- a/tests/ui/features/restrictSharing/restrictReSharing.feature
+++ b/tests/ui/features/restrictSharing/restrictReSharing.feature
@@ -19,7 +19,7 @@ I want to be able to forbid a user that received a share from me to share it fur
 		And I am on the login page
 		And I login with username "user2" and password "1234"
 
-	@skipOnMICROSOFTEDGE
+	@skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
 	Scenario: share a folder with another internal user and prohibit resharing
 		And the setting "Allow resharing" in the section "Sharing" is enabled
 		And I am on the files page
@@ -29,6 +29,7 @@ I want to be able to forbid a user that received a share from me to share it fur
 		And I relogin with username "user1" and password "1234"
 		Then it should not be possible to share the folder "simple-folder (2)"
 
+	@TestAlsoOnExternalUserBackend
 	Scenario: forbid resharing globally
 		When the setting "Allow resharing" in the section "Sharing" is disabled
 		And I am on the files page

--- a/tests/ui/features/restrictSharing/restrictSharing.feature
+++ b/tests/ui/features/restrictSharing/restrictSharing.feature
@@ -19,7 +19,8 @@ So that users can only share files with specific users and groups
 		And the user "user3" is in the group "grp2"
 		And I am on the login page
 		And I login with username "user2" and password "1234"
-		
+	
+	@TestAlsoOnExternalUserBackend
 	Scenario: Restrict users to only share with users in their groups
 		When the setting "Restrict users to only share with users in their groups" in the section "Sharing" is enabled
 		And I am on the files page
@@ -28,6 +29,7 @@ So that users can only share files with specific users and groups
 		And I relogin with username "user1" and password "1234"
 		Then the folder "simple-folder (2)" should be listed
 
+	@TestAlsoOnExternalUserBackend
 	Scenario: Restrict users to only share with groups they are member of
 		When the setting "Restrict users to only share with groups they are member of" in the section "Sharing" is enabled
 		And I am on the files page
@@ -36,6 +38,7 @@ So that users can only share files with specific users and groups
 		And I relogin with username "user1" and password "1234"
 		Then the folder "simple-folder (2)" should be listed
 
+	@TestAlsoOnExternalUserBackend
 	Scenario: Do not restrict users to only share with groups they are member of
 		When the setting "Restrict users to only share with groups they are member of" in the section "Sharing" is disabled
 		And I am on the files page
@@ -43,6 +46,7 @@ So that users can only share files with specific users and groups
 		And I relogin with username "user3" and password "1234"
 		Then the folder "simple-folder (2)" should be listed
 
+	@TestAlsoOnExternalUserBackend
 	Scenario: Forbid sharing with groups
 		When the setting "Allow sharing with groups" in the section "Sharing" is disabled
 		And I am on the files page

--- a/tests/ui/features/sharingExternalOther/federationSharing.feature
+++ b/tests/ui/features/sharingExternalOther/federationSharing.feature
@@ -1,4 +1,4 @@
-@insulated
+@insulated @TestAlsoOnExternalUserBackend
 Feature: Federation Sharing - sharing with users on other cloud storages
 As a user
 I want to share files with any users on other cloud storages

--- a/tests/ui/features/sharingExternalOther/shareAutocompletion.feature
+++ b/tests/ui/features/sharingExternalOther/shareAutocompletion.feature
@@ -1,4 +1,4 @@
-@insulated
+@insulated @TestAlsoOnExternalUserBackend
 Feature: Autocompletion of share-with names
 As a user
 I want to share files, with minimal typing, to the right people or groups
@@ -15,7 +15,7 @@ So that I can efficiently share my files with other users or groups
 		And regular groups exist
 		And I am logged in as a regular user
 		And I am on the files page
-		
+	@skipOnLDAP @user_ldap#175
 	Scenario: autocompletion of regular existing users
 		And the share dialog for the folder "simple-folder" is open
 		When I type "user" in the share-with-field

--- a/tests/ui/features/sharingExternalOther/shareAutocompletion.feature
+++ b/tests/ui/features/sharingExternalOther/shareAutocompletion.feature
@@ -5,7 +5,12 @@ I want to share files, with minimal typing, to the right people or groups
 So that I can efficiently share my files with other users or groups
 
 	Background:
-		Given regular users exist but are not initialized
+		Given these users exist but are not initialized:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+			|user2   |1234    |User Two   |u2@oc.com.np|
+			|user3   |1234    |User Three |u2@oc.com.np|
+			|usergrp |1234    |User Grp   |u@oc.com.np |
 		And a regular user exists
 		And regular groups exist
 		And I am logged in as a regular user
@@ -29,20 +34,22 @@ So that I can efficiently share my files with other users or groups
 		Then a tooltip with the text "No users or groups found for doesnotexist" should be shown near the share-with-field
 		And the autocomplete list should not be displayed
 		
+	@skipOnLDAP @user_ldap#175
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
-		And the folder "simple-folder" is shared with the user "user1"
+		And the folder "simple-folder" is shared with the user "User One"
 		And the share dialog for the folder "simple-folder" is open
 		When I type "user" in the share-with-field
-		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list except user "user1"
+		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list except user "User One"
 		And my own name should not be listed in the autocomplete list
 
+	@skipOnLDAP @user_ldap#175
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user whith whom the item is already shared (file)
-		And the file "data.zip" is shared with the user "usergrp"
+		And the file "data.zip" is shared with the user "User Grp"
 		And the share dialog for the file "data.zip" is open
 		When I type "user" in the share-with-field
-		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list except user "usergrp"
+		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list except user "User Grp"
 		And my own name should not be listed in the autocomplete list
-		
+	
 	Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
 		And the folder "simple-folder" is shared with the group "grp1"
 		And the share dialog for the folder "simple-folder" is open

--- a/tests/ui/features/sharingInternalGroupsUsers/shareWithGroups.feature
+++ b/tests/ui/features/sharingInternalGroupsUsers/shareWithGroups.feature
@@ -18,6 +18,7 @@ So that those groups can access the files and folders
 		And I am on the login page
 		And I login with username "user3" and password "1234"
 
+	@TestAlsoOnExternalUserBackend
 	Scenario: share a folder with an internal group
 		When the folder "simple-folder" is shared with the group "grp1"
 		And the file "testimage.jpg" is shared with the group "grp1"
@@ -32,6 +33,7 @@ So that those groups can access the files and folders
 		And the file "testimage (2).jpg" should be listed
 		And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three"
 
+	@TestAlsoOnExternalUserBackend
 	Scenario: share a file with an internal group a member overwrites and unshares the file
 		When I rename the file "lorem.txt" to "new-lorem.txt"
 		And the file "new-lorem.txt" is shared with the group "grp1"
@@ -51,6 +53,7 @@ So that those groups can access the files and folders
 		When I relogin with username "user2" and password "1234"
 		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
+	@TestAlsoOnExternalUserBackend
 	Scenario: share a folder with an internal group and a member uploads, overwrites and deletes files
 		When I rename the folder "simple-folder" to "new-simple-folder"
 		And the folder "new-simple-folder" is shared with the group "grp1"
@@ -80,6 +83,7 @@ So that those groups can access the files and folders
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		And the file "data.zip" should not be listed
 
+	@TestAlsoOnExternalUserBackend
 	Scenario: share a folder with an internal group and a member unshares the folder
 		When I rename the folder "simple-folder" to "new-simple-folder"
 		And the folder "new-simple-folder" is shared with the group "grp1"

--- a/tests/ui/features/sharingInternalGroupsUsers/shareWithUsers.feature
+++ b/tests/ui/features/sharingInternalGroupsUsers/shareWithUsers.feature
@@ -12,6 +12,7 @@ So that those users can access the files and folders
 		And I am on the login page
 		And I login with username "user2" and password "1234"
 
+	@TestAlsoOnExternalUserBackend
 	Scenario: share a file & folder with another internal user
 		When the folder "simple-folder" is shared with the user "User One"
 		And the file "testimage.jpg" is shared with the user "User One"
@@ -24,6 +25,7 @@ So that those users can access the files and folders
 		Then the file "lorem.txt" should be listed
 		But the folder "simple-folder (2)" should not be listed
 
+	@TestAlsoOnExternalUserBackend
 	Scenario: share a file with another internal user who overwrites and unshares the file
 		When I rename the file "lorem.txt" to "new-lorem.txt"
 		And the file "new-lorem.txt" is shared with the user "User One"
@@ -40,6 +42,7 @@ So that those users can access the files and folders
 		When I relogin with username "user2" and password "1234"
 		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
+	@TestAlsoOnExternalUserBackend
 	Scenario: share a folder with another internal user who uploads, overwrites and deletes files
 		When I rename the folder "simple-folder" to "new-simple-folder"
 		And the folder "new-simple-folder" is shared with the user "User One"
@@ -65,6 +68,7 @@ So that those users can access the files and folders
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		And the file "data.zip" should not be listed
 
+	@TestAlsoOnExternalUserBackend
 	Scenario: share a folder with another internal user who unshares the folder
 		When I rename the folder "simple-folder" to "new-simple-folder"
 		And the folder "new-simple-folder" is shared with the user "User One"
@@ -79,7 +83,7 @@ So that those users can access the files and folders
 		Then the file "lorem.txt" should be listed
 		Then the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 
-	@skipOnMICROSOFTEDGE
+	@skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
 	Scenario: share a folder with another internal user and prohibit deleting
 		When the folder "simple-folder" is shared with the user "User One"
 		And the sharing permissions of "User One" for "simple-folder" are set to


### PR DESCRIPTION
## Description
pseudo user creation in LDAP 

## Motivation and Context
we would like to run tests against a LDAP backend but not going throw the problems of creating the users/groups in PHP. So when running LDAP tests (TEST_LDAP env. variable set to "true") we assume the users/groups already exist in the LDAP server

So this would be a way to run at least some acceptance tests on LDAP with very minimal changes. See changes on the LDAP side https://github.com/owncloud/user_ldap/pull/173

## How Has This Been Tested?
run tests in drone https://github.com/owncloud/user_ldap/pull/173

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

