### PR TITLE
Add symfony events for file read and update

### DIFF
--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -45,6 +45,7 @@ use OCP\Lock\ILockingProvider;
  *
  */
 class OC_Files {
+	use \OCP\Events\EventEmitterTrait;
 	const FILE = 1;
 	const ZIP_FILES = 2;
 	const ZIP_DIR = 3;
@@ -259,63 +260,67 @@ class OC_Files {
 	 * @param array $params ; 'head' boolean to only send header of the request ; 'range' http range header
 	 */
 	private static function getSingleFile($view, $dir, $name, $params) {
-		$filename = $dir . '/' . $name;
-		OC_Util::obEnd();
-		$view->lockFile($filename, ILockingProvider::LOCK_SHARED);
-		
-		$rangeArray = [];
 
-		if (isset($params['range']) && substr($params['range'], 0, 6) === 'bytes=') {
-			$rangeArray = self::parseHttpRangeHeader(substr($params['range'], 6), 
-								 \OC\Files\Filesystem::filesize($filename));
-		}
-		
-		if (\OC\Files\Filesystem::isReadable($filename)) {
-			self::sendHeaders($filename, $name, $rangeArray);
-		} elseif (!\OC\Files\Filesystem::file_exists($filename)) {
-			header("HTTP/1.1 404 Not Found");
-			$tmpl = new OC_Template('', '404', 'guest');
-			$tmpl->printPage();
-			exit();
-		} else {
-			header("HTTP/1.1 403 Forbidden");
-			die('403 Forbidden');
-		}
-		if (isset($params['head']) && $params['head']) {
-			return;
-		}
-		if (!empty($rangeArray)) {
-			try {
-			    if (count($rangeArray) == 1) {
-				$view->readfilePart($filename, $rangeArray[0]['from'], $rangeArray[0]['to']);
-			    }
-			    else {
-				// check if file is seekable (if not throw UnseekableException)
-				// we have to check it before body contents
-				$view->readfilePart($filename, $rangeArray[0]['size'], $rangeArray[0]['size']);
+		$path = $view->getAbsolutePath($name);
+		return (new self())->emittingCall(function () use (&$view, &$dir, &$name, &$params) {
+			$filename = $dir . '/' . $name;
+			OC_Util::obEnd();
+			$view->lockFile($filename, ILockingProvider::LOCK_SHARED);
 
-				$type = \OC::$server->getMimeTypeDetector()->getSecureMimeType(\OC\Files\Filesystem::getMimeType($filename));
+			$rangeArray = [];
 
-				foreach ($rangeArray as $range) {
-				    echo "\r\n--".self::getBoundary()."\r\n".
-				         "Content-type: ".$type."\r\n".
-				         "Content-range: bytes ".$range['from']."-".$range['to']."/".$range['size']."\r\n\r\n";
-				    $view->readfilePart($filename, $range['from'], $range['to']);
-				}
-				echo "\r\n--".self::getBoundary()."--\r\n";
-			    }
-			} catch (\OCP\Files\UnseekableException $ex) {
-			    // file is unseekable
-			    header_remove('Accept-Ranges');
-			    header_remove('Content-Range');
-			    header("HTTP/1.1 200 OK");
-			    self::sendHeaders($filename, $name, []);
-			    $view->readfile($filename);
+			if (isset($params['range']) && substr($params['range'], 0, 6) === 'bytes=') {
+				$rangeArray = self::parseHttpRangeHeader(substr($params['range'], 6),
+					\OC\Files\Filesystem::filesize($filename));
 			}
-		}
-		else {
-		    $view->readfile($filename);
-		}
+
+			if (\OC\Files\Filesystem::isReadable($filename)) {
+				self::sendHeaders($filename, $name, $rangeArray);
+			} elseif (!\OC\Files\Filesystem::file_exists($filename)) {
+				header("HTTP/1.1 404 Not Found");
+				$tmpl = new OC_Template('', '404', 'guest');
+				$tmpl->printPage();
+				exit();
+			} else {
+				header("HTTP/1.1 403 Forbidden");
+				die('403 Forbidden');
+			}
+			if (isset($params['head']) && $params['head']) {
+				return;
+			}
+			if (!empty($rangeArray)) {
+				try {
+					if (count($rangeArray) == 1) {
+						$view->readfilePart($filename, $rangeArray[0]['from'], $rangeArray[0]['to']);
+					}
+					else {
+						// check if file is seekable (if not throw UnseekableException)
+						// we have to check it before body contents
+						$view->readfilePart($filename, $rangeArray[0]['size'], $rangeArray[0]['size']);
+
+						$type = \OC::$server->getMimeTypeDetector()->getSecureMimeType(\OC\Files\Filesystem::getMimeType($filename));
+
+						foreach ($rangeArray as $range) {
+							echo "\r\n--".self::getBoundary()."\r\n".
+								"Content-type: ".$type."\r\n".
+								"Content-range: bytes ".$range['from']."-".$range['to']."/".$range['size']."\r\n\r\n";
+							$view->readfilePart($filename, $range['from'], $range['to']);
+						}
+						echo "\r\n--".self::getBoundary()."--\r\n";
+					}
+				} catch (\OCP\Files\UnseekableException $ex) {
+					// file is unseekable
+					header_remove('Accept-Ranges');
+					header_remove('Content-Range');
+					header("HTTP/1.1 200 OK");
+					self::sendHeaders($filename, $name, []);
+					return $view->readfile($filename);
+				}
+			}
+			else {
+				return $view->readfile($filename);
+			}
+		}, ['before' => ['path' => $path], 'after' => ['path' => $path]], 'file', 'read');
 	}
 
 	/**

--- a/tests/lib/StreamTest.php
+++ b/tests/lib/StreamTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Files;
+
+use OC\Files\View;
+use OC\Streamer;
+use Test\TestCase;
+use Test\Traits\UserTrait;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Class StreamTest
+ *
+ * @group DB
+ * @package Test\Files
+ */
+class StreamTest extends TestCase {
+
+	use UserTrait;
+
+	/**
+	 * @var Streamer
+	 */
+	private $streamer;
+
+	protected function setUp() {
+		parent::setUp();
+	}
+
+	/**
+	 * Test the events for file read.
+	 */
+	public function testAddDirRecursive() {
+		$this->createUser('foo', 'foo');
+		$this->loginAsUser('foo');
+
+		$view = new View('/foo/files');
+		$view->mkdir('test');
+		$view->touch('test/foo.txt');
+		$view->touch('test/bar.txt');
+
+		$calledAfterEvent = [];
+		\OC::$server->getEventDispatcher()->addListener('file.afterread', function ($event) use (&$calledAfterEvent) {
+			$calledAfterEvent[] = 'file.afterread';
+			$calledAfterEvent[] = $event;
+		});
+		$this->streamer = new Streamer();
+		$this->streamer->addDirRecursive('test');
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterEvent[1]);
+		$this->assertArrayHasKey('path', $calledAfterEvent[1]);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterEvent[3]);
+		$this->assertArrayHasKey('path', $calledAfterEvent[3]);
+	}
+}


### PR DESCRIPTION
This event wouldbe generated and would
also be helpful when user tries to download
file or files from the UI.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Add symfony events for readfile method.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add symfony dispatcher event for `readfile` method.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

