### PR TITLE
Catch BadResponseException when trying to upload

### DIFF
--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -831,7 +831,7 @@ trait WebDav {
 		try {
 			$this->response = $this->makeDavRequest($user, "PUT", $destination, [], $file);
 			return $this->response->getHeader('oc-fileid');
-		} catch (\GuzzleHttp\Exception\ServerException $e) {
+		} catch (\GuzzleHttp\Exception\BadResponseException $e) {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
 		}


### PR DESCRIPTION
## Description
In integration tests, catch the correct ``BadResponseException`` when trying to upload a file and there is (expected to be) a problem (like a 4xx response).

## Related Issue

## Motivation and Context
I was debugging some integration tests in an app. They made use of this step to upload a file under conditions where a ``403 Forbidden`` was expected. But the ``403`` response was not getting back into the ``response`` object.

## How Has This Been Tested?
Makes ransomware tests work better.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
