### PR TITLE
[stable10] User should be able to set the email address

### DIFF
--- a/settings/js/panels/profile.js
+++ b/settings/js/panels/profile.js
@@ -154,7 +154,7 @@ $(document).ready(function () {
 		if (query.changestatus === 'error') {
 			OC.Notification.showTemporary(t('settings', 'Failed to change the email address.'));
 		} else if (query.changestatus === 'success') {
-			OC.Notification.showTemporary(t('settings', 'Email changed successfully.'));
+			OC.Notification.showTemporary(t('settings', 'Email changed successfully for {user}.', {user: query.user}));
 		}
 		OC.Util.History.replaceState({});
 	}

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -11,9 +11,27 @@
 namespace Tests\Settings\Controller;
 
 use OC\Settings\Application;
+use OC\Settings\Controller\UsersController;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\RedirectResponse;
+use OCP\IRequest;
+use OCP\IUserManager;
+use OCP\IGroupManager;
+use OCP\IUserSession;
+use OCP\IConfig;
+use OCP\Security\ISecureRandom;
+use OCP\IL10N;
+use OCP\ILogger;
+use OCP\Mail\IMailer;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IURLGenerator;
+use OCP\App\IAppManager;
+use OCP\IAvatarManager;
+use OC\SubAdmin;
+use OC\Mail\Message;
+use OCP\IUser;
+use OC\Group\Manager;
 
 /**
  * @group DB
@@ -1788,6 +1806,145 @@ class UsersControllerTest extends \Test\TestCase {
 
 		$result = self::invokePrivate($this->container['UsersController'], 'formatUserForIndex', [$user]);
 		$this->assertEquals($expectedResult, $result);
+	}
+
+	public function dataforemailaddress() {
+		return [
+			['foo', 'foo', 'foo', 'foo' , 'foo@localhost'],
+			['bar', 'bar', 'bar', 'foo', 'foo@localhoster']
+		];
+	}
+
+	/**
+	 * Test to verify setting email address by user who had logged in
+	 * for itself.
+	 *
+	 * @dataProvider dataforemailaddress
+	 * @param $userName
+	 * @param $userPassword
+	 * @param $loginUser
+	 * @param $setUser
+	 * @param $emailAddress
+	 */
+	public function testSetSelfEmailAddress($userName, $userPassword, $loginUser, $setUser, $emailAddress) {
+		\OC::$server->getUserManager()->createUser($userName, $userPassword);
+
+		$appName = "settings";
+		$irequest = $this->createMock(IRequest::class);
+		$userManager = $this->createMock(IUserManager::class);
+		$groupManager = $this->createMock(Manager::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$iConfig = $this->createMock(IConfig::class);
+		$iSecureRandom = $this->createMock(ISecureRandom::class);
+		$iL10 = $this->createMock(IL10N::class);
+		$iLogger = $this->createMock(ILogger::class);
+		$ocDefault = $this->getMockBuilder('\OC_Defaults')
+			->disableOriginalConstructor()->getMock();
+		$iMailer = $this->createMock(IMailer::class);
+		$iTimeFactory = $this->createMock(ITimeFactory::class);
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$appManager = $this->createMock(IAppManager::class);
+		$iAvatarManager = $this->createMock(IAvatarManager::class);
+		$userController = new UsersController($appName, $irequest, $userManager, $groupManager,
+			$userSession, $iConfig, $iSecureRandom, false, $iL10, $iLogger, $ocDefault, $iMailer,
+			$iTimeFactory, "", $urlGenerator, $appManager, $iAvatarManager);
+
+		$this->loginAsUser($loginUser);
+
+
+		$iUser = $this->createMock(IUser::class);
+		$userManager->method('get')->willReturn($iUser);
+		$iUser->method('getUID')->willReturn($loginUser);
+		$userSession->expects($this->any())
+			->method('getUser')
+			->willReturn($iUser);
+		$subAdmin = $this->createMock(SubAdmin::class);
+		$subAdmin->method('isSubAdmin')->with($iUser)->willReturn(false);
+		$groupManager->expects($this->any())
+			->method('getSubAdmin')
+			->willReturn($subAdmin);
+		$response = $userController->setEmailAddress($setUser, $emailAddress);
+		if ($loginUser !== $setUser) {
+			$this->assertEquals( new Http\JSONResponse([
+				'error' => 'cannotSetEmailAddress',
+				'message' => 'Cannot set email address for user'
+			], HTTP::STATUS_NOT_FOUND), $response);
+		} else {
+			$this->assertEquals(new Http\JSONResponse(), $response);
+		}
+	}
+
+	public function setDataForSendMail() {
+		return [
+			['foo', 'foo@localhost'],
+			['bar', 'bar@localhost']
+		];
+	}
+
+	/**
+	 * A test to verify if the email is send and verify data response for
+	 * the success
+	 *
+	 * @dataProvider setDataForSendMail
+	 * @param $id
+	 * @param $mailaddress
+	 */
+	public function testSetEmailAddressSendEmail($id, $mailaddress) {
+
+		$appName = "settings";
+		$irequest = $this->createMock(IRequest::class);
+		$userManager = $this->createMock(IUserManager::class);
+		$groupManager = $this->createMock(IGroupManager::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$iConfig = $this->createMock(IConfig::class);
+		$iSecureRandom = $this->createMock(ISecureRandom::class);
+		$iL10 = $this->createMock(IL10N::class);
+		$iLogger = $this->createMock(ILogger::class);
+		$ocDefault = $this->getMockBuilder('\OC_Defaults')
+			->disableOriginalConstructor()->getMock();
+		$iMailer = $this->createMock(IMailer::class);
+		$iTimeFactory = $this->createMock(ITimeFactory::class);
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$appManager = $this->createMock(IAppManager::class);
+		$iAvatarManager = $this->createMock(IAvatarManager::class);
+		$userController = new UsersController($appName, $irequest, $userManager, $groupManager,
+			$userSession, $iConfig, $iSecureRandom, false, $iL10, $iLogger, $ocDefault, $iMailer,
+			$iTimeFactory, "", $urlGenerator, $appManager, $iAvatarManager);
+
+		$this->loginAsUser($id);
+
+		$iUser = $this->createMock(IUser::class);
+		$iUser->expects($this->once())
+			->method('canChangeDisplayName')
+			->willReturn(true);
+		$userManager->method('get')->willReturn($iUser);
+		$iUser->method('getUID')->willReturn($id);
+		$userSession->expects($this->any())
+			->method('getUser')
+			->willReturn($iUser);
+
+		$iMailer->expects($this->once())->method('validateMailAddress')
+			->willReturn(true);
+		$mailMessage = $this->createMock(Message::class);
+		$iMailer->expects($this->once())
+			->method('createMessage')
+			->willReturn($mailMessage);
+		$iL10->expects($this->atLeastOnce())
+			->method('t')
+			->willReturn('An email has been sent to this address for confirmation. Until the email is verified this address will not be set.');
+		$expectedResponse = new DataResponse(
+			[
+				'status' => 'success',
+				'data' => [
+					'username' => $id,
+					'mailAddress' => $mailaddress,
+					'message' => 'An email has been sent to this address for confirmation. Until the email is verified this address will not be set.'
+				]
+			],
+			Http::STATUS_OK
+		);
+		$response = $userController->setMailAddress($id, $mailaddress);
+		$this->assertEquals($expectedResponse, $response);
 	}
 
 	/**


### PR DESCRIPTION
User should be able to set his/her
email address after the email address is validated.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Users were not able to set the email address due to the regression caused at the commit: https://github.com/owncloud/core/commit/b73b488cc91803d2236a9f1ff7ac7d78b6b1b1fa

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/27667

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Added an extra condition to check if the user logged in is trying to set the email. And it should be possible for the user to set the email address.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Created user `user1`
- [x] Logged in as `user1`
- [x] And then set the email address
- [x] Verified the confirmaition email has arrived
- [x] Use the confirmation link got in the email to verify the email address.
- [x] Refresh the `user1` settings page to see if the email is shown in the email text box.
- [x] Verified that email is updated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

