### PR TITLE
add uid parameter to validatePassword events

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -331,7 +331,7 @@ class Manager extends PublicEmitter implements IUserManager {
 			$this->emit('\OC\User', 'preCreateUser', [$uid, $password]);
 			\OC::$server->getEventDispatcher()->dispatch(
 				'OCP\User::validatePassword',
-				new GenericEvent(null, ['password' => $password])
+				new GenericEvent(null, ['uid' => $uid, 'password' => $password])
 			);
 
 			if (empty($this->backends)) {

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -251,7 +251,7 @@ class User implements IUser {
 				$this->emitter->emit('\OC\User', 'preSetPassword', [$this, $password, $recoveryPassword]);
 				\OC::$server->getEventDispatcher()->dispatch(
 					'OCP\User::validatePassword',
-					new GenericEvent(null, ['password' => $password])
+					new GenericEvent(null, ['uid'=> $this->getUID(), 'password' => $password])
 				);
 			}
 			if ($this->canChangePassword()) {
@@ -268,7 +268,10 @@ class User implements IUser {
 			} else {
 				return false;
 			}
-		}, ['before' => [], 'after' => ['user' => $this, 'password' => $password, 'recoveryPassword' => $recoveryPassword]], 'user', 'setpassword');
+		}, [
+			'before' => ['user' => $this, 'password' => $password, 'recoveryPassword' => $recoveryPassword],
+			'after' => ['user' => $this, 'password' => $password, 'recoveryPassword' => $recoveryPassword]
+		], 'user', 'setpassword');
 	}
 
 	/**


### PR DESCRIPTION
## Description
To use some features like password history validation rule, we need to add uid to validatePassword events. I added uid to validatePassword events. Moreover, since EventEmitterTrait does not accept event without argument and it does not emit such type of events, I also adjusted beforesetpassword event by adding necessary parameters.

## Related Issue
#30303 
https://github.com/owncloud/password_policy/pull/10


## How Has This Been Tested?
Tested locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.