### PR TITLE
Bump master version to 10.0.6

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 0, 5, 4];
+$OC_Version = [10, 0, 6, 1];
 
 // The human readable string
-$OC_VersionString = '10.0.5';
+$OC_VersionString = '10.0.6';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
forward "port" to match ``stable10``

Might as well get this the same as ``stable10`` before again bumping it for 10.1 or whatever. 