### PR TITLE
Catch BadResponseException for integration test API requests

### DIFF
--- a/tests/integration/features/bootstrap/Auth.php
+++ b/tests/integration/features/bootstrap/Auth.php
@@ -1,7 +1,7 @@
 <?php
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\BadResponseException;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
@@ -38,7 +38,7 @@ trait Auth {
 			$request->setHeader('OCS_APIREQUEST', 'true');
 			$request->setHeader('requesttoken', $this->requestToken);
 			$this->response = $this->client->send($request);
-		} catch (ClientException $ex) {
+		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
 	}

--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -3,6 +3,7 @@
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\ResponseInterface;
 use TestHelpers\OcsApiHelper;
 
@@ -250,7 +251,7 @@ trait BasicStructure {
 				$request->addHeader('requesttoken', $this->requestToken);
 			}
 			$this->response = $client->send($request);
-		} catch (\GuzzleHttp\Exception\ClientException $ex) {
+		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
 	}
@@ -379,7 +380,7 @@ trait BasicStructure {
 		$request->addHeader('requesttoken', $this->requestToken);
 		try {
 			$this->response = $client->send($request);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
 	}
@@ -402,7 +403,7 @@ trait BasicStructure {
 		);
 		try {
 			$this->response = $client->send($request);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
 	}
@@ -485,7 +486,7 @@ trait BasicStructure {
 		$options['auth'] = $this->adminUser;
 		try {
 			$this->response = $client->send($client->createRequest('GET', $fullUrl, $options));
-		} catch (\GuzzleHttp\Exception\ClientException $ex) {
+		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
 	}

--- a/tests/integration/features/bootstrap/CalDavContext.php
+++ b/tests/integration/features/bootstrap/CalDavContext.php
@@ -22,6 +22,7 @@
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\ResponseInterface;
 
 class CalDavContext implements \Behat\Behat\Context\Context {
@@ -66,7 +67,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 					],
 				]
 			);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {}
+		} catch (BadResponseException $e) {}
 	}
 
 	/**
@@ -88,7 +89,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 					]
 				]
 			);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
 	}

--- a/tests/integration/features/bootstrap/CardDavContext.php
+++ b/tests/integration/features/bootstrap/CardDavContext.php
@@ -22,6 +22,7 @@
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\ResponseInterface;
 
 class CardDavContext implements \Behat\Behat\Context\Context {
@@ -66,7 +67,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 					],
 				]
 			);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {}
+		} catch (BadResponseException $e) {}
 	}
 
 	/**
@@ -90,7 +91,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 					],
 				]
 			);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
 

--- a/tests/integration/features/bootstrap/Comments.php
+++ b/tests/integration/features/bootstrap/Comments.php
@@ -83,7 +83,10 @@ trait Comments {
 			$elementList = $this->reportElementComments($user,$commentsPath,$properties);
 		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
-			return 1;
+			$statusCode = $this->response->getStatusCode();
+			PHPUnit_Framework_Assert::fail(
+				"checkComments failed to get comments for user $user path $path status $statusCode"
+			);
 		}
 
 		if ($expectedElements instanceof \Behat\Gherkin\Node\TableNode) {
@@ -118,6 +121,10 @@ trait Comments {
 			PHPUnit_Framework_Assert::assertCount((int) $numberOfComments, $elementList);
 		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
+			$statusCode = $this->response->getStatusCode();
+			PHPUnit_Framework_Assert::fail(
+				"checkNumberOfComments failed to get comments for user $user path $path status $statusCode"
+			);
 		}
 	}
 

--- a/tests/integration/features/bootstrap/Comments.php
+++ b/tests/integration/features/bootstrap/Comments.php
@@ -20,6 +20,8 @@
  *
  */
 
+use GuzzleHttp\Exception\BadResponseException;
+
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 //class CommentsContext implements \Behat\Behat\Context\Context {
@@ -61,7 +63,7 @@ trait Comments {
 			$responseHeaders =  $this->response->getHeaders();
 			$commentUrl = $responseHeaders['Content-Location'][0];
 			$this->lastCommentId = substr($commentUrl, strrpos($commentUrl,'/')+1);
-		} catch (\GuzzleHttp\Exception\ClientException $ex) {
+		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
 	}
@@ -79,7 +81,7 @@ trait Comments {
 		$properties = '<oc:limit>200</oc:limit><oc:offset>0</oc:offset>';
 		try {
 			$elementList = $this->reportElementComments($user,$commentsPath,$properties);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 			return 1;
 		}
@@ -114,7 +116,7 @@ trait Comments {
 		try {
 			$elementList = $this->reportElementComments($user,$commentsPath,$properties);
 			PHPUnit_Framework_Assert::assertCount((int) $numberOfComments, $elementList);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
 	}
@@ -129,7 +131,7 @@ trait Comments {
 													null,
 													"uploads",
 													null);
-		} catch (\GuzzleHttp\Exception\ClientException $ex) {
+		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
 	}
@@ -192,7 +194,7 @@ trait Comments {
 											</d:prop>
 										</d:set>
 									</d:propertyupdate>');
-		} catch (\GuzzleHttp\Exception\ClientException $ex) {
+		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
 	}

--- a/tests/integration/features/bootstrap/MailTool.php
+++ b/tests/integration/features/bootstrap/MailTool.php
@@ -22,6 +22,7 @@
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
 
 trait MailTool {
 
@@ -38,7 +39,7 @@ trait MailTool {
 			$this->response = $client->send(
 				$client->createRequest('GET', $fullUrl, $options)
 			);
-		} catch (\GuzzleHttp\Exception\ClientException $ex) {
+		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
 		$json = json_decode($this->response->getBody()->getContents());

--- a/tests/integration/features/bootstrap/Provisioning.php
+++ b/tests/integration/features/bootstrap/Provisioning.php
@@ -1,6 +1,7 @@
 <?php
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\ResponseInterface;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
@@ -153,7 +154,7 @@ trait Provisioning {
 		try {
 			$this->response = $client->get($fullUrl, $options);
 			return True;
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 			return False;
 		}
@@ -368,7 +369,7 @@ trait Provisioning {
 		try {
 			$this->response = $client->get($fullUrl, $options);
 			return True;
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 			return False;
 		}

--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -23,7 +23,7 @@
  */
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\BadResponseException;
 use TestHelpers\SharingHelper;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
@@ -82,7 +82,7 @@ trait Sharing {
 			$this->response = $client->send(
 				$client->createRequest("POST", $fullUrl, $options)
 			);
-		} catch (\GuzzleHttp\Exception\ClientException $ex) {
+		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
 
@@ -184,7 +184,7 @@ trait Sharing {
 		try {
 			$this->response = $client->send($request);
 			PHPUnit_Framework_Assert::fail('download must fail');
-		} catch (ClientException $e) {
+		} catch (BadResponseException $e) {
 			// expected
 			PHPUnit_Framework_Assert::assertGreaterThanOrEqual(400, $e->getCode());
 			PHPUnit_Framework_Assert::assertLessThanOrEqual(499, $e->getCode());
@@ -306,7 +306,7 @@ trait Sharing {
 		try {
 			$this->publicUploadContent('whateverfilefortesting.txt', '', 'test');
 			PHPUnit_Framework_Assert::fail('Publicly uploading must fail');
-		} catch (ClientException $e) {
+		} catch (BadResponseException $e) {
 			// expected
 			PHPUnit_Framework_Assert::assertGreaterThanOrEqual(400, $e->getCode());
 			PHPUnit_Framework_Assert::assertLessThanOrEqual(499, $e->getCode());
@@ -405,7 +405,7 @@ trait Sharing {
 			$this->response = $client->send(
 				$client->createRequest("PUT", $fullUrl, $options)
 			);
-		} catch (\GuzzleHttp\Exception\ClientException $ex) {
+		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
 
@@ -453,7 +453,7 @@ trait Sharing {
 				$this->sharingApiVersion
 			);
 			$this->lastShareData = $this->response->xml();
-		} catch (\GuzzleHttp\Exception\ClientException $ex) {
+		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
 	}

--- a/tests/integration/features/bootstrap/Tags.php
+++ b/tests/integration/features/bootstrap/Tags.php
@@ -23,7 +23,7 @@
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 use Behat\Gherkin\Node\TableNode;
-use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\BadResponseException;
 use TestHelpers\TagsHelper;
 
 trait Tags {
@@ -49,7 +49,7 @@ trait Tags {
 			$lastTagId = $createdTag['lastTagId'];
 			$this->response = $createdTag['HTTPResponse'];
 			array_push($this->createdTags, $lastTagId);
-		} catch (ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
 	}
@@ -265,7 +265,7 @@ trait Tags {
 				$this->getPasswordForUser($user), $tagID,
 				$this->getDavPathVersion()
 			);
-		} catch (ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
 		
@@ -286,7 +286,7 @@ trait Tags {
 				$this->getPasswordForUser($taggingUser),
 				$tagName, $fileName, $fileOwner, $this->getDavPathVersion()
 				);
-		} catch ( ClientException $e ) {
+		} catch ( BadResponseException $e ) {
 			$this->response = $e->getResponse();
 		}
 	}
@@ -387,7 +387,7 @@ trait Tags {
 		$path = '/systemtags-relations/files/' . $fileID . '/' . $tagID;
 		try {
 			$this->response = $this->makeDavRequest($untaggingUser,"DELETE", $path, null, null, "uploads");
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
 	}
@@ -414,7 +414,7 @@ trait Tags {
 				$this->response = TagsHelper::deleteTag(
 					$this->baseUrlWithoutOCSAppendix(),
 					"admin", $this->getPasswordForUser("admin"), $tagID, 2);
-			} catch (ClientException  $e) {
+			} catch (BadResponseException  $e) {
 				$this->response = $e->getResponse();
 			}
 		}

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -1,7 +1,7 @@
 <?php
 
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Client as GClient;
-use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Message\ResponseInterface;
 use Sabre\DAV\Client as SClient;
 use Sabre\DAV\Xml\Property\ResourceType;
@@ -116,7 +116,7 @@ trait WebDav {
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		try {
 			$this->response = $this->makeDavRequest($user, "MOVE", $fileSource, $headers);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
 	}
@@ -132,7 +132,7 @@ trait WebDav {
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		try {
 			$this->response = $this->makeDavRequest($user, "COPY", $fileSource, $headers);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
 	}
@@ -209,7 +209,7 @@ trait WebDav {
 	public function downloadingFile($fileName) {
 		try {
 			$this->response = $this->makeDavRequest($this->currentUser, 'GET', $fileName, []);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
 	}
@@ -222,7 +222,7 @@ trait WebDav {
 	public function userDownloadsTheFile($user, $fileName) {
 		try {
 			$this->response = $this->makeDavRequest($user, 'GET', $fileName, []);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
 	}
@@ -647,7 +647,7 @@ trait WebDav {
 		$file = \GuzzleHttp\Stream\Stream::factory(fopen($source, 'r'));
 		try {
 			$this->response = $this->makeDavRequest($user, "PUT", $destination, [], $file);
-		} catch (\GuzzleHttp\Exception\BadResponseException $e) {
+		} catch (BadResponseException $e) {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
 		}
@@ -745,7 +745,7 @@ trait WebDav {
 				}
 				$this->userUploadsAFileTo($user, $source, $destination . $suffix);
 				$responses[] = $this->response;
-			} catch (ServerException $e) {
+			} catch (BadResponseException $e) {
 				$responses[] = $e->getResponse();
 			}
 
@@ -757,7 +757,7 @@ trait WebDav {
 				try {
 					$this->userUploadsAFileToWithChunks($user, $source, $destination . $suffix, 'old');
 					$responses[] = $this->response;
-				} catch (ServerException $e) {
+				} catch (BadResponseException $e) {
 					$responses[] = $e->getResponse();
 				}
 			}
@@ -768,7 +768,7 @@ trait WebDav {
 				try {
 					$this->userUploadsAFileToWithChunks($user, $source, $destination . $suffix, 'new');
 					$responses[] = $this->response;
-				} catch (ServerException $e) {
+				} catch (BadResponseException $e) {
 					$responses[] = $e->getResponse();
 				}
 			}
@@ -831,7 +831,7 @@ trait WebDav {
 		try {
 			$this->response = $this->makeDavRequest($user, "PUT", $destination, [], $file);
 			return $this->response->getHeader('oc-fileid');
-		} catch (\GuzzleHttp\Exception\BadResponseException $e) {
+		} catch (BadResponseException $e) {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
 		}
@@ -856,7 +856,7 @@ trait WebDav {
 				['OC-Checksum' => $checksum],
 				$file
 			);
-		} catch (\GuzzleHttp\Exception\BadResponseException $e) {
+		} catch (BadResponseException $e) {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
 		}
@@ -871,7 +871,7 @@ trait WebDav {
 	public function fileDoesNotExist($file, $user)  {
 		try {
 			$this->response = $this->makeDavRequest($user, 'DELETE', $file, []);
-		} catch (\GuzzleHttp\Exception\BadResponseException $e) {
+		} catch (BadResponseException $e) {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
 		}
@@ -886,7 +886,7 @@ trait WebDav {
 	public function userDeletesFile($user, $type, $file)  {
 		try {
 			$this->response = $this->makeDavRequest($user, 'DELETE', $file, []);
-		} catch (\GuzzleHttp\Exception\ServerException $e) {
+		} catch (BadResponseException $e) {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
 		}
@@ -901,11 +901,9 @@ trait WebDav {
 		try {
 			$destination = '/' . ltrim($destination, '/');
 			$this->response = $this->makeDavRequest($user, "MKCOL", $destination, []);
-		} catch (\GuzzleHttp\Exception\ServerException $e) {
+		} catch (BadResponseException $e) {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
-		} catch (\GuzzleHttp\Exception\ClientException $ex) {
-			$this->response = $ex->getResponse();
 		}
 	}
 
@@ -995,7 +993,7 @@ trait WebDav {
 
 		try {
 			$this->response = $this->makeDavRequest($user, 'MOVE', $source, $headers, null, "uploads");
-		} catch (\GuzzleHttp\Exception\BadResponseException $ex) {
+		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
 	}
@@ -1006,7 +1004,7 @@ trait WebDav {
 	public function downloadingFileAs($fileName, $user) {
 		try {
 			$this->response = $this->makeDavRequest($user, 'GET', $fileName, []);
-		} catch (\GuzzleHttp\Exception\ServerException $ex) {
+		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
 	}
@@ -1089,7 +1087,7 @@ trait WebDav {
 	public function connectingToDavEndpoint() {
 		try {
 			$this->response = $this->makeDavRequest(null, 'PROPFIND', '', []);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
+		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
 	}

--- a/tests/integration/features/comments.feature
+++ b/tests/integration/features/comments.feature
@@ -55,7 +55,8 @@ Feature: Comments
             | user0 | File owner comment |
             | user1 | Sharee comment |
     When user "user1" deletes the last created comment
-    Then user "user1" should have 1 comments on file "/myFileToComment.txt"
+    Then the HTTP status code should be "204"
+    And user "user1" should have 1 comments on file "/myFileToComment.txt"
 
   Scenario: Edit my own comments on a file belonging to myself
     Given user "user0" exists


### PR DESCRIPTION
## Description
Rather than catching ``ServerException`` or ``ClientException`` catch both of them by catching ``BadResponseException``

## Related Issue

## Motivation and Context
``ClientException`` is thrown by Guzzle when a 400-499 response is received.
``ServerException`` is thrown by Guzzle when a 500+ response is received.
for the integration tests we can catch both of these by catching ``BadResponseException`` and do something with it (e.g. put the details in the response object)

## How Has This Been Tested?
CI will tell

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

