### PR TITLE
UI test for unmarking a file/folder from favorites page

### DIFF
--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -166,7 +166,7 @@ class FilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the files page is reloaded
+	 * @When the files/favorites page is reloaded
 	 * @return void
 	 */
 	public function theFilesPageIsReloaded() {
@@ -931,6 +931,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I mark the file/folder :fileOrFolderName as favorite
+	 * @Given the file/folder :fileOrFolderName is marked as favorite 
 	 * @param string $fileOrFolderName
 	 * @return void
 	 */
@@ -951,6 +952,32 @@ class FilesContext extends RawMinkContext implements Context {
 			throw new Exception(
 				__METHOD__ .
 				" The file $fileOrFolderName is not marked as favorite but should be"
+			);
+		}
+	}
+	
+	/**
+	 * @When I unmark the file/folder :fileOrFolderName
+	 * @param string $fileOrFolderName
+	 * @return void
+	 */
+	public function iUnmarkTheFolder($fileOrFolderName) {
+		$fileRow = $this->getCurrentPageObject()->findFileRowByName($fileOrFolderName, $this->getSession());
+		$fileRow->unmarkFavorite();
+		$this->getCurrentPageObject()->waitTillFileRowsAreReady($this->getSession());
+	}
+	
+	/**
+	 * @Then the file/folder :fileOrFolderName should not be marked as favorite
+	 * @param string $fileOrFolderName
+	 * @return void
+	 */
+	public function theFolderShouldNotBeMarkedAsFavorite($fileOrFolderName) {
+		$fileRow = $this->filesPage->findFileRowByName($fileOrFolderName, $this->getSession());
+		if ($fileRow->isMarkedAsFavorite() === true) {
+			throw new Exception(
+				__METHOD__ .
+				" The file $fileOrFolderName is marked as favorite but should not be"
 			);
 		}
 	}

--- a/tests/ui/features/lib/FilesPageElement/FileRow.php
+++ b/tests/ui/features/lib/FilesPageElement/FileRow.php
@@ -316,7 +316,7 @@ class FileRow extends OwnCloudPage {
 	public function markAsFavorite() {
 		$element = $this->rowElement->find("xpath", $this->notMarkedFavoriteXpath);
 		if (is_null($element)) {
-			throw new Exception(
+			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->notMarkedFavoriteXpath not found"
 			);
@@ -337,5 +337,21 @@ class FileRow extends OwnCloudPage {
 		} else {
 			return true;
 		}
+	}
+	
+	/**
+	 * unmarks the current file or folder off favorite by clicking the star icon
+	 *
+	 * @return void
+	 */
+	public function unmarkFavorite() {
+		$element = $this->rowElement->find("xpath", $this->markedFavoriteXpath);
+		if (is_null($element)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->markedFavoriteXpath not found"
+			);
+		}
+		$element->click();
 	}
 }

--- a/tests/ui/features/other/unfavoriteFile.feature
+++ b/tests/ui/features/other/unfavoriteFile.feature
@@ -1,0 +1,44 @@
+@insulated
+Feature: Unmark file/folder as favorite
+
+As a user
+I would like to unmark any file/folder
+So that I can remove my favorite file/folder from favorite page
+
+	Background:
+		Given a regular user exists
+		And I am logged in as a regular user
+		And I am on the files page
+
+	Scenario: unmark a file as favorite from files page 
+		Given the file "data.zip" is marked as favorite 
+		When I unmark the file "data.zip"
+		Then the file "data.zip" should not be marked as favorite
+		And I am on the favorites page
+		Then the file "data.zip" should not be listed in the favorites page
+
+	Scenario: unmark a folder as favorite from files page 
+		Given the folder "simple-folder" is marked as favorite 
+		When I unmark the folder "simple-folder"
+		Then the folder "simple-folder" should not be marked as favorite
+		And I am on the favorites page
+		Then the folder "simple-folder" should not be listed in the favorites page
+	
+	Scenario: unmark a file as favorite from favorite page 
+		Given the file "data.zip" is marked as favorite 
+		And I am on the favorites page
+		When I unmark the file "data.zip"
+		And the favorites page is reloaded
+		Then the file "data.zip" should not be listed in the favorites page
+		And I am on the files page
+		Then the file "data.zip" should not be marked as favorite
+	
+
+	Scenario: unmark a folder as favorite from files page 
+		Given the folder "simple-folder" is marked as favorite 
+		And I am on the favorites page
+		When I unmark the folder "simple-folder"
+		And the favorites page is reloaded
+		Then the folder "simple-folder" should not be listed in the favorites page
+		And I am on the files page
+		Then the folder "simple-folder" should not be marked as favorite


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
UI tests for unmarking a file/folder which was previously marked as favorite.  

## Motivation and Context
UI tests to make sure that the favorite file/folder has been unmarked and removed from favorites page 

## How Has This Been Tested
Run tests locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

