### PR TITLE
Refactor integration tests regular and admin user password

### DIFF
--- a/tests/integration/features/bootstrap/AppConfiguration.php
+++ b/tests/integration/features/bootstrap/AppConfiguration.php
@@ -177,8 +177,8 @@ trait AppConfiguration {
 	) {
 		$savedCapabilitiesChanges = AppConfigHelper::setCapability(
 			$this->baseUrlWithoutOCSAppendix(),
-			$this->adminUser[0],
-			$this->adminUser[1],
+			$this->getAdminUserName(),
+			$this->getAdminPassword(),
 			$capabilitiesApp,
 			$capabilitiesParameter,
 			$testingApp,
@@ -201,8 +201,8 @@ trait AppConfiguration {
 	protected function modifyServerConfig($app, $parameter, $value) {
 		AppConfigHelper::modifyServerConfig(
 			$this->baseUrlWithoutOCSAppendix(),
-			$this->adminUser[0],
-			$this->adminUser[1],
+			$this->getAdminUserName(),
+			$this->getAdminPassword(),
 			$app,
 			$parameter,
 			$value,

--- a/tests/integration/features/bootstrap/Checksums.php
+++ b/tests/integration/features/bootstrap/Checksums.php
@@ -51,10 +51,7 @@ trait Checksums {
     <oc:checksums />
   </d:prop>
 </d:propfind>',
-				'auth' => [
-					$user,
-					$this->getPasswordForUser($user),
-				]
+				'auth' => $this->getAuthOptionForUser($user)
 			]
 		);
 		$this->response = $client->send($request);
@@ -105,10 +102,7 @@ trait Checksums {
 			'COPY',
 			substr($this->baseUrl, 0, -4) . $this->davPath . $source,
 			[
-				'auth' => [
-					$user,
-					$this->getPasswordForUser($user),
-				],
+				'auth' => $this->getAuthOptionForUser($user),
 				'headers' => [
 					'Destination' => substr($this->baseUrl, 0, -4) . $this->davPath . $destination,
 				],

--- a/tests/integration/features/bootstrap/Provisioning.php
+++ b/tests/integration/features/bootstrap/Provisioning.php
@@ -94,7 +94,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$options['body'] = [
@@ -149,7 +149,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
-		$options['auth'] = $this->adminUser;
+		$options['auth'] = $this->getAuthOptionForUser('admin');
 		try {
 			$this->response = $client->get($fullUrl, $options);
 			return True;
@@ -169,7 +169,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -189,7 +189,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -204,7 +204,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -244,7 +244,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -274,7 +274,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$options['body'] = [
@@ -293,7 +293,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$this->response = $client->send($client->createRequest("PUT", $fullUrl, $options));
@@ -308,7 +308,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$this->response = $client->send($client->createRequest("DELETE", $fullUrl, $options));
@@ -323,7 +323,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$this->response = $client->send($client->createRequest("DELETE", $fullUrl, $options));
@@ -350,7 +350,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$options['body'] = [
@@ -364,7 +364,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group";
 		$client = new Client();
 		$options = [];
-		$options['auth'] = $this->adminUser;
+		$options['auth'] = $this->getAuthOptionForUser('admin');
 		try {
 			$this->response = $client->get($fullUrl, $options);
 			return True;
@@ -412,7 +412,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -432,7 +432,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 		$options['body'] = [
 							'groupid' => $group
@@ -451,7 +451,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -580,7 +580,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -598,7 +598,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -616,7 +616,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -632,7 +632,7 @@ trait Provisioning {
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
+			$options['auth'] = $this->getAuthOptionForUser('admin');
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -673,7 +673,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
-		$options['auth'] = $this->adminUser;
+		$options['auth'] = $this->getAuthOptionForUser('admin');
 		$this->response = $client->get($fullUrl, $options);
 		return $this->response->xml()->data[0]->home;
 	}

--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -63,11 +63,7 @@ trait Sharing {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
 		$client = new Client();
 		$options = [];
-		if ($user === 'admin') {
-			$options['auth'] = $this->adminUser;
-		} else {
-			$options['auth'] = [$user, $this->regularUser];
-		}
+		$options['auth'] = $this->getAuthOptionForUser($user);
 
 		if ($body instanceof \Behat\Gherkin\Node\TableNode) {
 			$fd = $body->getRowsHash();
@@ -360,11 +356,7 @@ trait Sharing {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
-		} else {
-			$options['auth'] = [$this->currentUser, $this->regularUser];
-		}
+		$options['auth'] = $this->getAuthOptionForUser($this->currentUser);
 		$date = date('Y-m-d', strtotime("+3 days"));
 		$options['body'] = ['expireDate' => $date];
 		$this->response = $client->send(
@@ -386,11 +378,7 @@ trait Sharing {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->adminUser;
-		} else {
-			$options['auth'] = [$this->currentUser, $this->regularUser];
-		}
+		$options['auth'] = $this->getAuthOptionForUser($this->currentUser);
 
 		if ($body instanceof \Behat\Gherkin\Node\TableNode) {
 			$fd = $body->getRowsHash();
@@ -615,11 +603,7 @@ trait Sharing {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
 		$client = new Client();
 		$options = [];
-		if ($user1 === 'admin') {
-			$options['auth'] = $this->adminUser;
-		} else {
-			$options['auth'] = [$user1, $this->regularUser];
-		}
+		$options['auth'] = $this->getAuthOptionForUser($user1);
 		$this->response = $client->get($fullUrl, $options);
 		if ($this->isUserOrGroupInSharedData($user2, $permissions)) {
 			return;
@@ -660,11 +644,7 @@ trait Sharing {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
 		$client = new Client();
 		$options = [];
-		if ($user === 'admin') {
-			$options['auth'] = $this->adminUser;
-		} else {
-			$options['auth'] = [$user, $this->regularUser];
-		}
+		$options['auth'] = $this->getAuthOptionForUser($user);
 		$this->response = $client->get($fullUrl, $options);
 		if ($this->isUserOrGroupInSharedData($group, $permissions)) {
 			return;
@@ -857,12 +837,7 @@ trait Sharing {
 
 		$client = new Client();
 		$options = [];
-
-		if ($user === 'admin') {
-			$options['auth'] = $this->adminUser;
-		} else {
-			$options['auth'] = [$user, $this->regularUser];
-		}
+		$options['auth'] = $this->getAuthOptionForUser($user);
 
 		$this->response = $client->send(
 			$client->createRequest("GET", $fullUrl, $options)

--- a/tests/integration/features/bootstrap/Tags.php
+++ b/tests/integration/features/bootstrap/Tags.php
@@ -262,7 +262,8 @@ trait Tags {
 			$this->response = TagsHelper::deleteTag(
 				$this->baseUrlWithoutOCSAppendix(),
 				$user,
-				$this->getPasswordForUser($user), $tagID,
+				$this->getPasswordForUser($user),
+				$tagID,
 				$this->getDavPathVersion()
 			);
 		} catch (ClientException $e) {


### PR DESCRIPTION

## Description
Provide new methods to get admin/user passwords..., make use of them.

## Related Issue

## Motivation and Context
While doing other integration test refactoring I got tired of seeing ``$regularUser`` var which actually contains the regular user **password** - and also references to ``$adminUser[0]`` and ``$adminUser[1]`` which are the user name and password of the admin user.
Tidy this up so it is easier to read and understand when used elsewhere in the integration test code.

## How Has This Been Tested?
Running bits of CI locally - a full automated run will tell.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

