### PR TITLE
checkPassword should also check oc_authtokens 

### DIFF
--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -50,6 +50,8 @@
 
 namespace OC\User;
 
+use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Token\DefaultTokenProvider;
 use OC\Cache\CappedMemoryCache;
 use OCP\IUserBackend;
 use OCP\Util;
@@ -201,6 +203,21 @@ class Database extends Backend implements IUserBackend {
 	 * returns the user id or false
 	 */
 	public function checkPassword($uid, $password) {
+		// First check oc_auth_tokens (app password)
+		/** @var DefaultTokenProvider $tokenProvider */
+		$tokenProvider = \OC::$server->query('OC\Authentication\Token\DefaultTokenProvider');
+
+		try {
+			$token = $tokenProvider->getToken($password);
+			if ($token->getUID() === $uid) {
+				return $token->getUID();
+
+			}
+		} catch(InvalidTokenException $e) {
+			// Token login failed, continue...
+		}
+
+	    // Second check oc_users (normal password)
 		$query = \OC_DB::prepare('SELECT `uid`, `password` FROM `*PREFIX*users` WHERE LOWER(`uid`) = LOWER(?)');
 		$result = $query->execute([$uid]);
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
When authenticating via app password checkPassword is used which results in a failed login because it only checks oc_users. This change modifies checkPassword so that it also checks auth tokens.

## Related Issue
#30157

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

