### PR TITLE
Refactor use of admin username

### DIFF
--- a/tests/integration/features/bootstrap/AppConfiguration.php
+++ b/tests/integration/features/bootstrap/AppConfiguration.php
@@ -77,7 +77,7 @@ trait AppConfiguration {
 	 */
 	public function serverParameterIsSetTo($parameter, $app, $value) {
 		$user = $this->currentUser;
-		$this->currentUser = 'admin';
+		$this->currentUser = $this->getAdminUserName();
 
 		$this->modifyServerConfig($app, $parameter, $value);
 
@@ -251,7 +251,7 @@ trait AppConfiguration {
 	 */
 	public function prepareParametersBeforeScenario() {
 		$user = $this->currentUser;
-		$this->currentUser = 'admin';
+		$this->currentUser = $this->getAdminUserName();
 		$this->resetAppConfigs();
 		$this->currentUser = $user;
 	}
@@ -262,7 +262,7 @@ trait AppConfiguration {
 	 */
 	public function restoreParametersAfterScenario() {
 		$user = $this->currentUser;
-		$this->currentUser = 'admin';
+		$this->currentUser = $this->getAdminUserName();
 
 		foreach ($this->savedCapabilitiesChanges as $capabilitiesChange) {
 			$this->modifyServerConfig(

--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -353,7 +353,7 @@ trait BasicStructure {
 		$this->extracRequestTokenFromResponse($response);
 
 		// Login and extract new token
-		$password = ($user === 'admin') ? 'admin' : '123456';
+		$password = $this->getPasswordForUser($user);
 		$client = new Client();
 		$response = $client->post(
 			$loginUrl,
@@ -475,14 +475,14 @@ trait BasicStructure {
 	/**
 	 * @return string
 	 */
-	private function getAdminUserName() {
+	public function getAdminUserName() {
 		return (string) $this->adminUser[0];
 	}
 
 	/**
 	 * @return string
 	 */
-	private function getAdminPassword() {
+	public function getAdminPassword() {
 		return (string) $this->adminUser[1];
 	}
 
@@ -490,8 +490,8 @@ trait BasicStructure {
 	 * @param string $userName
 	 * @return string
 	 */
-	private function getPasswordForUser($userName) {
-		if ($userName === 'admin') {
+	public function getPasswordForUser($userName) {
+		if ($userName === $this->getAdminUserName()) {
 			return (string) $this->getAdminPassword();
 		} else {
 			return (string) $this->regularUserPassword;
@@ -502,12 +502,15 @@ trait BasicStructure {
 	 * @param string $userName
 	 * @return array
 	 */
-	private function getAuthOptionForUser($userName) {
-		if ($userName === 'admin') {
-			return $this->adminUser;
-		} else {
-			return [$userName, $this->getPasswordForUser($userName)];
-		}
+	public function getAuthOptionForUser($userName) {
+		return [$userName, $this->getPasswordForUser($userName)];
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getAuthOptionForAdmin() {
+		return $this->getAuthOptionForUser($this->getAdminUserName());
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/Provisioning.php
+++ b/tests/integration/features/bootstrap/Provisioning.php
@@ -27,7 +27,7 @@ trait Provisioning {
 	public function assureUserExists($user) {
 		if ( !$this->userExists($user) ) {
 			$previous_user = $this->currentUser;
-			$this->currentUser = "admin";
+			$this->currentUser = $this->getAdminUserName();
 			$this->creatingTheUser($user);
 			$this->currentUser = $previous_user;
 		}
@@ -75,7 +75,7 @@ trait Provisioning {
 	public function assureUserDoesNotExist($user) {
 		if ($this->userExists($user)) {
 			$previous_user = $this->currentUser;
-			$this->currentUser = "admin";
+			$this->currentUser = $this->getAdminUserName();
 			$this->deletingTheUser($user);
 			$this->currentUser = $previous_user;
 		}
@@ -94,8 +94,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$options['body'] = [
@@ -116,7 +116,7 @@ trait Provisioning {
 
 	public function createUser($user) {
 		$previous_user = $this->currentUser;
-		$this->currentUser = "admin";
+		$this->currentUser = $this->getAdminUserName();
 		$this->creatingTheUser($user);
 		PHPUnit_Framework_Assert::assertTrue($this->userExists($user));
 		$this->currentUser = $previous_user;
@@ -124,7 +124,7 @@ trait Provisioning {
 
 	public function deleteUser($user) {
 		$previous_user = $this->currentUser;
-		$this->currentUser = "admin";
+		$this->currentUser = $this->getAdminUserName();
 		$this->deletingTheUser($user);
 		PHPUnit_Framework_Assert::assertFalse($this->userExists($user));
 		$this->currentUser = $previous_user;
@@ -132,7 +132,7 @@ trait Provisioning {
 
 	public function createGroup($group) {
 		$previous_user = $this->currentUser;
-		$this->currentUser = "admin";
+		$this->currentUser = $this->getAdminUserName();
 		$this->creatingTheGroup($group);
 		PHPUnit_Framework_Assert::assertTrue($this->groupExists($group));
 		$this->currentUser = $previous_user;
@@ -140,7 +140,7 @@ trait Provisioning {
 
 	public function deleteGroup($group) {
 		$previous_user = $this->currentUser;
-		$this->currentUser = "admin";
+		$this->currentUser = $this->getAdminUserName();
 		$this->deletingTheGroup($group);
 		PHPUnit_Framework_Assert::assertFalse($this->groupExists($group));
 		$this->currentUser = $previous_user;
@@ -150,7 +150,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
-		$options['auth'] = $this->getAuthOptionForUser('admin');
+		$options['auth'] = $this->getAuthOptionForAdmin();
 		try {
 			$this->response = $client->get($fullUrl, $options);
 			return True;
@@ -169,8 +169,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -189,8 +189,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -204,8 +204,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -225,7 +225,7 @@ trait Provisioning {
 	 */
 	public function assureUserBelongsToGroup($user, $group) {
 		$previous_user = $this->currentUser;
-		$this->currentUser = "admin";
+		$this->currentUser = $this->getAdminUserName();
 
 		if (!$this->userBelongsToGroup($user, $group)) {
 			$this->addingUserToGroup($user, $group);
@@ -244,8 +244,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -274,8 +274,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/groups";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$options['body'] = [
@@ -293,8 +293,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/disable";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$this->response = $client->send($client->createRequest("PUT", $fullUrl, $options));
@@ -308,8 +308,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$this->response = $client->send($client->createRequest("DELETE", $fullUrl, $options));
@@ -323,8 +323,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/groups/$group";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$this->response = $client->send($client->createRequest("DELETE", $fullUrl, $options));
@@ -350,8 +350,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/groups";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$options['body'] = [
@@ -365,7 +365,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group";
 		$client = new Client();
 		$options = [];
-		$options['auth'] = $this->getAuthOptionForUser('admin');
+		$options['auth'] = $this->getAuthOptionForAdmin();
 		try {
 			$this->response = $client->get($fullUrl, $options);
 			return True;
@@ -382,7 +382,7 @@ trait Provisioning {
 	public function assureGroupExists($group) {
 		if (!$this->groupExists($group)) {
 			$previous_user = $this->currentUser;
-			$this->currentUser = "admin";
+			$this->currentUser = $this->getAdminUserName();
 			$this->creatingTheGroup($group);
 			$this->currentUser = $previous_user;
 		}
@@ -396,7 +396,7 @@ trait Provisioning {
 	public function assureGroupDoesNotExist($group) {
 		if ($this->groupExists($group)) {
 			$previous_user = $this->currentUser;
-			$this->currentUser = "admin";
+			$this->currentUser = $this->getAdminUserName();
 			$this->deletingTheGroup($group);
 			$this->currentUser = $previous_user;
 		}
@@ -412,8 +412,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group/subadmins";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -432,8 +432,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/subadmins";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 		$options['body'] = [
 							'groupid' => $group
@@ -451,8 +451,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group/subadmins";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -580,8 +580,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/apps?filter=disabled";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -598,8 +598,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/apps?filter=enabled";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -616,8 +616,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -632,8 +632,8 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === 'admin') {
-			$options['auth'] = $this->getAuthOptionForUser('admin');
+		if ($this->currentUser === $this->getAdminUserName()) {
+			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
 		$this->response = $client->get($fullUrl, $options);
@@ -674,7 +674,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
-		$options['auth'] = $this->getAuthOptionForUser('admin');
+		$options['auth'] = $this->getAuthOptionForAdmin();
 		$this->response = $client->get($fullUrl, $options);
 		return $this->response->xml()->data[0]->home;
 	}

--- a/tests/integration/features/bootstrap/Tags.php
+++ b/tests/integration/features/bootstrap/Tags.php
@@ -173,7 +173,7 @@ trait Tags {
 	 * @Then the :type tag with name :tagName has the groups :groups
 	 */
 	public function theTagHasGroup($type, $tagName, $groups) {
-		$tagData = $this->requestTagByDisplayName('admin', $tagName, true);
+		$tagData = $this->requestTagByDisplayName($this->getAdminUserName(), $tagName, true);
 		PHPUnit_Framework_Assert::assertNotNull($tagData, "Tag $tagName wasn't found for admin user");
 		$this->assertTypeOfTag($tagData, $type);
 		PHPUnit_Framework_Assert::assertEquals($tagData['{http://owncloud.org/ns}groups'], $groups,
@@ -197,7 +197,7 @@ trait Tags {
 	 * @return int
 	 */
 	private function findTagIdByName($name) {
-		$tagData = $this->requestTagByDisplayName('admin', $name);
+		$tagData = $this->requestTagByDisplayName($this->getAdminUserName(), $name);
 		return (int)$tagData['{http://owncloud.org/ns}id'];
 	}
 
@@ -414,7 +414,10 @@ trait Tags {
 			try {
 				$this->response = TagsHelper::deleteTag(
 					$this->baseUrlWithoutOCSAppendix(),
-					"admin", $this->getPasswordForUser("admin"), $tagID, 2);
+					$this->getAdminUserName(),
+					$this->getAdminPassword(),
+					$tagID,
+					2);
 			} catch (BadResponseException  $e) {
 				$this->response = $e->getResponse();
 			}


### PR DESCRIPTION
## Description
In integration tests:
- Create more methods for getting data related to admin and user credentials.
- Use those methods rather than having 'admin' and '123456' literally.

## Related Issue

## Motivation and Context
In integration tests, the user name for the administrator and the password to be used for a regular user are being passed in through ``behat.yml`` but are also quoted literally in places. Try harder to use the passed in values.

## How Has This Been Tested?
Running selected integration tests locally. CI will do a full run.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

