### PR TITLE
Return status as string in getOCSResponseStatusCode

### DIFF
--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -142,8 +142,8 @@ trait BasicStructure {
 	 * @param ResponseInterface $response
 	 * @return string
 	 */
-	public function getOCSResponse($response) {
-		return $response->xml()->meta[0]->statuscode;
+	public function getOCSResponseStatusCode($response) {
+		return (string) $response->xml()->meta[0]->statuscode;
 	}
 
 	/**
@@ -275,7 +275,7 @@ trait BasicStructure {
 	 * @param int $statusCode
 	 */
 	public function theOCSStatusCodeShouldBe($statusCode) {
-		PHPUnit_Framework_Assert::assertEquals($statusCode, $this->getOCSResponse($this->response));
+		PHPUnit_Framework_Assert::assertEquals($statusCode, $this->getOCSResponseStatusCode($this->response));
 	}
 
 	/**


### PR DESCRIPTION
## Description
Actually return the status code as a string in ``getOCSResponseStatusCode``

## Related Issue

## Motivation and Context
``getOCSResponseStatusCode`` says it returns a string. But actually it returns a simple XML object.
That can cause problems with the check in ``theOCSStatusCodeShouldBe``. If you pass it a string as the expected value ``"100"`` all is well, and ``assertEquals`` understands to cast the simple XML object to string and compare to ``"100"``. But if you pass it just ``100`` (looks like an ``int``) then ``assertEquals`` does not cope with comparing ``int`` with ``simpleXMLObject``.

This is a latent issue that I noticed while doing other integration test refactoring. Rather than burying this little gem in another huge refactoring PR, I have separated it.

## How Has This Been Tested?
Run some integration tests locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

