### PR TITLE
Refactor integration tests to remove hardcoded password 123456

### DIFF
--- a/tests/integration/features/auth.feature
+++ b/tests/integration/features/auth.feature
@@ -2,7 +2,7 @@ Feature: auth
 
 	Background:
 		Given user "user0" exists
-		And a new client token is used
+		And a new client token is used for user "user0"
 
 
 	# FILES APP
@@ -12,7 +12,7 @@ Feature: auth
 		Then the HTTP status code should be "401"
 
 	Scenario: access files app with basic auth
-		When requesting "/index.php/apps/files" with "GET" using basic auth
+		When requesting "/index.php/apps/files" with "GET" using basic auth for user "user0"
 		Then the HTTP status code should be "200"
 
 	Scenario: access files app with basic token auth
@@ -24,7 +24,7 @@ Feature: auth
 		Then the HTTP status code should be "200"
 
 	Scenario: access files app with browser session
-		Given a new browser session is started
+		Given a new browser session is started for user "user0"
 		When requesting "/index.php/apps/files" with "GET" using browser session
 		Then the HTTP status code should be "200"
 
@@ -36,7 +36,7 @@ Feature: auth
 		Then the HTTP status code should be "401"
 
 	Scenario: using WebDAV with basic auth
-		When requesting "/remote.php/webdav" with "PROPFIND" using basic auth
+		When requesting "/remote.php/webdav" with "PROPFIND" using basic auth for user "user0"
 		Then the HTTP status code should be "207"
 
 	Scenario: using WebDAV with token auth
@@ -49,7 +49,7 @@ Feature: auth
 	#	Then the HTTP status code should be "207"
 
 	Scenario: using WebDAV with browser session
-		Given a new browser session is started
+		Given a new browser session is started for user "user0"
 		When requesting "/remote.php/webdav" with "PROPFIND" using browser session
 		Then the HTTP status code should be "207"
 
@@ -61,7 +61,7 @@ Feature: auth
 		Then the OCS status code should be "997"
 
 	Scenario: using OCS with basic auth
-		When requesting "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic auth
+		When requesting "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic auth for user "user0"
 		Then the OCS status code should be "100"
 
 	Scenario: using OCS with token auth
@@ -73,6 +73,6 @@ Feature: auth
 		Then the OCS status code should be "100"
 
 	Scenario: using OCS with browser session
-		Given a new browser session is started
+		Given a new browser session is started for user "user0"
 		When requesting "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using browser session
 		Then the OCS status code should be "100"

--- a/tests/integration/features/bootstrap/Auth.php
+++ b/tests/integration/features/bootstrap/Auth.php
@@ -44,24 +44,26 @@ trait Auth {
 	}
 
 	/**
-	 * @Given a new client token is used
+	 * @Given a new client token is used for user :user
+	 * @param string $user
 	 */
-	public function aNewClientTokenIsUsed() {
+	public function aNewClientTokenIsUsed($user) {
 		$client = new Client();
 		$resp = $client->post(substr($this->baseUrl, 0, -5) . '/token/generate', [
-		    'json' => [
-			'user' => 'user0',
-			'password' => '123456',
-		    ]
+			'json' => [
+				'user' => $user,
+				'password' => $this->getPasswordForUser($user),
+			]
 		]);
 		$this->clientToken = json_decode($resp->getBody()->getContents())->token;
 	}
 
 	/**
-	 * @When requesting :url with :method using basic auth
+	 * @When requesting :url with :method using basic auth for user :user
 	 */
-	public function requestingWithBasicAuth($url, $method) {
-		$this->sendRequest($url, $method, 'basic ' . base64_encode('user0:123456'));
+	public function requestingWithBasicAuth($url, $method, $user) {
+		$authString = $user . ':' . $this->getPasswordForUser($user);
+		$this->sendRequest($url, $method, 'basic ' . base64_encode($authString));
 	}
 
 	/**
@@ -86,9 +88,10 @@ trait Auth {
 	}
 
 	/**
-	 * @Given a new browser session is started
+	 * @Given a new browser session is started for user :user
+	 * @param string $user
 	 */
-	public function aNewBrowserSessionIsStarted() {
+	public function aNewBrowserSessionIsStarted($user) {
 		$loginUrl = substr($this->baseUrl, 0, -5) . '/login';
 		// Request a new session and extract CSRF token
 		$client = new Client();
@@ -103,12 +106,12 @@ trait Auth {
 		$client = new Client();
 		$response = $client->post(
 			$loginUrl, [
-		    'body' => [
-			'user' => 'user0',
-			'password' => '123456',
-			'requesttoken' => $this->requestToken,
-		    ],
-		    'cookies' => $this->cookieJar,
+				'body' => [
+					'user' => $user,
+					'password' => $this->getPasswordForUser($user),
+					'requesttoken' => $this->requestToken,
+				],
+				'cookies' => $this->cookieJar,
 			]
 		);
 		$this->extracRequestTokenFromResponse($response);

--- a/tests/integration/features/bootstrap/Provisioning.php
+++ b/tests/integration/features/bootstrap/Provisioning.php
@@ -98,9 +98,10 @@ trait Provisioning {
 			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
+		$password = $this->getPasswordForUser($user);
 		$options['body'] = [
 							'userid' => $user,
-							'password' => '123456'
+							'password' => $password
 							];
 
 		$this->response = $client->send($client->createRequest("POST", $fullUrl, $options));
@@ -108,7 +109,7 @@ trait Provisioning {
 
 		//Quick hack to login once with the current user
 		$options2 = [
-			'auth' => [$user, '123456'],
+			'auth' => [$user, $password],
 		];
 		$url = $fullUrl.'/'.$user;
 		$client->send($client->createRequest('GET', $url, $options2));

--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -771,10 +771,7 @@ trait Sharing {
 		$res = $client->get(
 			$url,
 			[
-				'auth' => [
-					$user,
-					'123456',
-				],
+				'auth' => $this->getAuthOptionForUser($user),
 				'headers' => [
 					'Content-Type' => 'application/json',
 				],
@@ -788,10 +785,7 @@ trait Sharing {
 				$client->delete(
 					$this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/{$id}",
 					[
-						'auth' => [
-							$user,
-							'123456',
-						],
+						'auth' => $this->getAuthOptionForUser($user),
 						'headers' => [
 							'Content-Type' => 'application/json',
 						],

--- a/tests/integration/features/dav-versions.feature
+++ b/tests/integration/features/dav-versions.feature
@@ -43,7 +43,7 @@ Feature: dav-versions
   Scenario: User can access meta folder of a file which is owned by somebody else but shared with that user
     Given user "user1" exists
     And user "user0" uploads file with content "123" to "/davtest.txt"
-    And user "user0" uploads file with content "123456" to "/davtest.txt"
+    And user "user0" uploads file with content "456789" to "/davtest.txt"
     And we save it into "FILEID"
     And as an "user0"
     And creating a share with

--- a/tests/integration/features/provisioning-v1.feature
+++ b/tests/integration/features/provisioning-v1.feature
@@ -18,8 +18,8 @@ Feature: provisioning
 		Given as an "admin"
 		And user "brand-new-user" does not exist
 		When sending "POST" to "/cloud/users" with
-			| userid | brand-new-user |
-			| password | 123456 |
+			| userid   | brand-new-user |
+			| password | 456firstpwd    |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "brand-new-user" already exists
@@ -28,8 +28,8 @@ Feature: provisioning
 		Given as an "admin"
 		And user "brand-new-user" exists
 		When sending "POST" to "/cloud/users" with
-			| userid | brand-new-user |
-			| password | 123456 |
+			| userid   | brand-new-user |
+			| password | 456newpwd      |
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
 
@@ -66,7 +66,6 @@ Feature: provisioning
 		And group "new-group" does not exist
 		When sending "POST" to "/cloud/groups" with
 			| groupid | new-group |
-			| password | 123456 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And group "new-group" already exists
@@ -76,7 +75,6 @@ Feature: provisioning
 		And group "España" does not exist
 		When sending "POST" to "/cloud/groups" with
 			| groupid | España |
-			| password | 123456 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And group "España" already exists
@@ -86,7 +84,6 @@ Feature: provisioning
 		And group "0" does not exist
 		When sending "POST" to "/cloud/groups" with
 			| groupid | 0 |
-			| password | 123456 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And group "0" already exists


### PR DESCRIPTION
## Description
- Replace literal "123456" uses in integration tests with a call to get the password that is passed in from ``behat.yml``
- Change other accidental uses of "123456" to something else so they do not cause confusion in the future (since people might think they are a password when they are actually just a "random" string)
- do not bother passing a password when creating a group, the password attribute is not relevant/needed in those tests

## Related Issue

## Motivation and Context
There are various hard-coded uses of the "regular user password" "123456" sprinkled in the integration test code. Those will make life difficult if someone wants to change that default password some day.

## How Has This Been Tested?
Run relevant tests locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

