### PR TITLE
Add Webdav-Location header in private link redirect

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -41,6 +41,7 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use OCP\AppFramework\Http;
 
 /**
  * Class ViewController
@@ -282,12 +283,14 @@ class ViewController extends Controller {
 		$files = $baseFolder->getById($fileId);
 		$params = [];
 
+		$isFilesView = true;
 		if (empty($files) && $this->appManager->isEnabledForUser('files_trashbin')) {
 			// Access files_trashbin if it exists
 			if ( $this->rootFolder->nodeExists($uid . '/files_trashbin/files/')) {
 				$baseFolder = $this->rootFolder->get($uid . '/files_trashbin/files/');
 				$files = $baseFolder->getById($fileId);
 				$params['view'] = 'trashbin';
+				$isFilesView = false;
 			}
 		}
 
@@ -302,14 +305,23 @@ class ViewController extends Controller {
 				// and scroll to the entry
 				$params['scrollto'] = $file->getName();
 			}
-			return new RedirectResponse($this->urlGenerator->linkToRoute('files.view.index', $params));
+			$response = new RedirectResponse($this->urlGenerator->linkToRoute('files.view.index', $params));
+			if ($isFilesView) {
+				$webdavUrl = $this->urlGenerator->linkTo('', 'remote.php') . '/dav/files/' . $uid . '/';
+				$webdavUrl .= ltrim($baseFolder->getRelativePath($file->getPath()), '/');
+				$response->addHeader('Webdav-Location', $webdavUrl);
+			}
+			return $response;
 		}
 
-		if ( $this->userSession->isLoggedIn() and empty($files)) {
+		if ($this->userSession->isLoggedIn() and empty($files)) {
 			$param["error"] = $this->l10n->t("You don't have permissions to access this file/folder - Please contact the owner to share it with you.");
-			return new TemplateResponse("core", 'error', ["errors" => [$param]], 'guest');
+			$response = new TemplateResponse("core", 'error', ["errors" => [$param]], 'guest');
+			$response->setStatus(Http::STATUS_NOT_FOUND);
+			return $response;
 		}
 
+		// FIXME: potentially dead code as the user is normally always logged in non-public routes
 		throw new \OCP\Files\NotFoundException();
 	}
 }


### PR DESCRIPTION
## Description
Added Webdav-Location header in response when opening private links.
Added 404 status code for error page when requesting inaccessible/invalid private links.

## Related Issue
Similar to https://github.com/owncloud/core/issues/28615

## Motivation and Context
Useful for clients to resolve private links to Webdav URLs without having to extract the file id from the URL. Please note that there are at least two permalink formats, one with "/f/$fileId" and another one is the link when copied directly from the browser which has "fileid=$fileId". This removes the need for clients to know about this format and simply query whatever link they got and get it resolved.

## How Has This Been Tested?
Manual test with curl (with `-I` to only request headers with the "HEAD" method) and unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

cc @michaelstingl @nasli 