### PR TITLE
Sort out skipped trashbin integration tests

### DIFF
--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -965,6 +965,25 @@ trait WebDav {
 	}
 
 	/**
+	 * Wait for 1 second then delete a file/folder to avoid creating trashbin
+	 * entries with the same timestamp. Only use this step to avoid the problem
+	 * in core issue 23151 when wanting to demonstrate other correct behavior
+	 *
+	 * @When /^user "([^"]*)" waits and deletes (file|folder) "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has waited and deleted (file|folder) "([^"]*)"$/
+	 * @param string $user
+	 * @param string $type unused
+	 * @param string $file
+	 */
+	public function userWaitsAndDeletesFile($user, $type, $file) {
+		// prevent creating two files in the trashbin with the same timestamp
+		// which is based on seconds. e.g. deleting a/file.txt and b/file.txt
+		// might result in a name clash file.txt.d1456657282 in the trashbin
+		sleep(1);
+		$this->userDeletesFile($user, $type, $file);
+	}
+
+	/**
 	 * @When /^user "([^"]*)" deletes (file|folder) "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has deleted (file|folder) "([^"]*)"$/
 	 * @param string $user

--- a/tests/integration/features/trashbin-new-endpoint.feature
+++ b/tests/integration/features/trashbin-new-endpoint.feature
@@ -151,8 +151,8 @@ Feature: trashbin-new-endpoint
 		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
 		And as "user0" the file "/new-folder/new-file.txt" should exist
 
-	@skip
-	Scenario: trashbin can store two files with same name but different origins
+	@skip @issue-23151
+	Scenario: trashbin can store two files with the same name but different origins when the files are deleted close together in time
 		Given user "user0" has been created
 		And user "user0" has created a folder "/folderA"
 		And user "user0" has created a folder "/folderB"
@@ -161,6 +161,19 @@ Feature: trashbin-new-endpoint
 		When user "user0" deletes file "/folderA/textfile0.txt" using the API
 		And user "user0" deletes file "/folderB/textfile0.txt" using the API
 		And user "user0" deletes file "/textfile0.txt" using the API
+		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
+		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
+		And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+
+	Scenario: trashbin can store two files with the same name but different origins when the deletes are separated by at least 1 second
+		Given user "user0" has been created
+		And user "user0" has created a folder "/folderA"
+		And user "user0" has created a folder "/folderB"
+		And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
+		And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
+		When user "user0" waits and deletes file "/folderA/textfile0.txt" using the API
+		And user "user0" waits and deletes file "/folderB/textfile0.txt" using the API
+		And user "user0" waits and deletes file "/textfile0.txt" using the API
 		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
 		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
 		And as "user0" the folder with original path "/textfile0.txt" should exist in trash

--- a/tests/integration/features/trashbin-old-endpoint.feature
+++ b/tests/integration/features/trashbin-old-endpoint.feature
@@ -151,8 +151,8 @@ Feature: trashbin-new-endpoint
 		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
 		And as "user0" the file "/new-folder/new-file.txt" should exist
 
-	@skip
-	Scenario: trashbin can store two files with same name but different origins
+	@skip @issue-23151
+	Scenario: trashbin can store two files with the same name but different origins when the files are deleted close together in time
 		Given user "user0" has been created
 		And user "user0" has created a folder "/folderA"
 		And user "user0" has created a folder "/folderB"
@@ -161,6 +161,19 @@ Feature: trashbin-new-endpoint
 		When user "user0" deletes file "/folderA/textfile0.txt" using the API
 		And user "user0" deletes file "/folderB/textfile0.txt" using the API
 		And user "user0" deletes file "/textfile0.txt" using the API
+		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
+		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
+		And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+
+	Scenario: trashbin can store two files with the same name but different origins when the deletes are separated by at least 1 second
+		Given user "user0" has been created
+		And user "user0" has created a folder "/folderA"
+		And user "user0" has created a folder "/folderB"
+		And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
+		And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
+		When user "user0" waits and deletes file "/folderA/textfile0.txt" using the API
+		And user "user0" waits and deletes file "/folderB/textfile0.txt" using the API
+		And user "user0" waits and deletes file "/textfile0.txt" using the API
 		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
 		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
 		And as "user0" the folder with original path "/textfile0.txt" should exist in trash


### PR DESCRIPTION
## Description
1) tag the existing skipped tests with issue-23151
2) add a new step definition that will wait and delete, to work around the timing issue
3) use that step definition in new scenarios that demonstrate the good working behaviour

## Related Issue
#23151 

## Motivation and Context
I noticed 2 trashbin tests that were skipped, while refactoring integration tests. 

I tried the tests, and they pass locally for me, they look decent and I tried combinations of what they do to make sure they would really fail if things are not right. But they fail when run in CI. It turns out they fail when run quickly - if multiple files with the same name are deleted in the same second then there is a naming conflict in the trashbin.

The automated tests can have 1 scenario that work around the timing bug/issue and tests/demonstrates the other correct behaviour of putting files with the same name from different folders into the trashbin. Then the existing scenario with the timing bug/issue can remain skipped, but also be tagged with the issue number so people can easily follow it up in future.

## How Has This Been Tested?
Run the skipped tests locally - they pass
Unskip the tests to run them in CI - they fail there, so we know they are "good" example failing cases

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

