### PR TITLE
Update the documentation comments to match the new directory structure

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -514,7 +514,7 @@ $CONFIG = array(
  *
  * * ``auto``
  *     default setting. Automatically expire versions according to expire
- *     rules. Please refer to :doc:`../configuration_files/file_versioning` for
+ *     rules. Please refer to :doc:`../configuration/files/file_versioning` for
  *     more information.
  * * ``D, auto``
  *     keep versions at least for D days, apply expire rules to all versions
@@ -829,7 +829,7 @@ $CONFIG = array(
  *  - OC\Preview\Font
  *
  * .. note:: Troubleshooting steps for the MS Word previews are available
- *    at the :doc:`../configuration_files/collaborative_documents_configuration`
+ *    at the :doc:`../configuration/files/collaborative_documents_configuration`
  *    section of the Administrators Manual.
  *
  * The following providers are not available in Microsoft Windows:


### PR DESCRIPTION
Without these changes, the documentation build is throwing errors, as it's trying to find files that no longer exist. For example:

```
/opt/documentation/admin_manual/configuration/server/config_sample_php_parameters.rst:592: WARNING: unknown document: ../configuration_files/file_versioning
/opt/documentation/admin_manual/configuration/server/config_sample_php_parameters.rst:936: WARNING: unknown document: ../configuration_files/collaborative_documents_configuration
```

This change will correct that.