### PR TITLE
Ensure that the basic auth module is the last module in the list

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -1013,7 +1013,6 @@ class Session implements IUserSession, Emitter {
 	private function getAuthModules($includeBuiltIn) {
 		if ($includeBuiltIn) {
 			yield new TokenAuthModule($this->session, $this->tokenProvider, $this->manager);
-			yield new BasicAuthModule($this->manager);
 		}
 
 		$modules = $this->serviceLoader->load(['auth-modules']);
@@ -1023,6 +1022,10 @@ class Session implements IUserSession, Emitter {
 			} else {
 				continue;
 			}
+		}
+
+		if ($includeBuiltIn) {
+			yield new BasicAuthModule($this->manager);
 		}
 	}
 }


### PR DESCRIPTION
## Description
We need to make sure that the BasicAuthModule is the last one to be checked.

Shall fix https://github.com/owncloud/core/pull/30364#issuecomment-363750684

https://github.com/owncloud/core/pull/30364#issuecomment-363750684

## How Has This Been Tested?
- needs manual test with oauth @SamuAlfageme  THX

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

