### PR TITLE
[master] fix drone depth

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ branches: [master, stable10, stable9.1, stable9]
 clone:
   git:
     image: plugins/git
-    depth: 1
+    depth: 50
 
 pipeline:
   restore:


### PR DESCRIPTION
## Context

If we only fetch with a shallow history of 1 - drone will fail, if another commit is pushed on the branch, before the job started running

I propose to have a depth of 50 - that should be a good trade-off between amount of data to fetch and allow for even larger commits to be merged 

Example:
https://drone.owncloud.com/owncloud/core/3561/203