### PR TITLE
Bump PHP to 5.6.33 in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "optimize-autoloader": true,
         "classmap-authoritative": false,
         "platform": {
-            "php": "5.6.32"
+            "php": "5.6.33"
         }
     },
     "autoload" : {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d768a1aeafaab4070c48a0b41eb8de9",
+    "content-hash": "225f33588968102e080c32fd5a128164",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -6153,6 +6153,6 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.32"
+        "php": "5.6.33"
     }
 }


### PR DESCRIPTION
## Description
Bump PHP to 5.6.33 in ``composer.json``

## Related Issue

## Motivation and Context
Before taking the plunge to PHP 7.1, might as well get ``master`` right up-to-date with the current PHP 5.6.33

## How Has This Been Tested?
CI will tell

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
