### PR TITLE
Fix error when querying non present "log_secret" parameter

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -284,7 +284,7 @@ class Log implements ILogger {
 						$request = \OC::$server->getRequest();
 
 						// if token is found in the request change set the log condition to satisfied
-						if ($request && hash_equals($logCondition['shared_secret'], $request->getParam('log_secret'))) {
+						if ($request && hash_equals($logCondition['shared_secret'], $request->getParam('log_secret', ''))) {
 							$this->logConditionSatisfied = true;
 							break;
 						}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Query ``$request->getParam('log_secret', '')`` returns now an empty string instead of NULL.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/30388 (Error PHP hash_equals() function in Log.php line 288)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
``hash_equals`` requires a string as user parameter.
NULL as before when the request parameter ``log_secret`` was not found results in an PHP error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Shall I create a backport to stable10? 

@PVince81  fyi