### PR TITLE
[stable10] bump phpunit and symfony/translation to match master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,6 @@
         "deepdiver/zipstreamer": "^1.1",
         "zendframework/zend-inputfilter": "^2.8",
         "zendframework/zend-servicemanager": "^3.3",
-        "symfony/translation": "3.3.16"
+        "symfony/translation": "^3.4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "jakub-onderka/php-parallel-lint": "^0.9.2",
         "jakub-onderka/php-console-highlighter": "^0.3.2",
-        "phpunit/phpunit": "^5.5",
+        "phpunit/phpunit": "^5.7",
         "mikey179/vfsStream": "^1.6",
         "behat/mink-extension": "^2.2",
         "behat/mink-goutte-driver": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "248e15b7646bf315581760418dd0f6d3",
+    "content-hash": "039f610db6d91f7ae09985093786fa96",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "039f610db6d91f7ae09985093786fa96",
+    "content-hash": "afe01a9162d2444fecf937c68bec7db2",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -2975,16 +2975,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v3.3.16",
+            "version": "v3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "90cb5ca3eb84b3053fef876e11e405fd819487fc"
+                "reference": "10b32cf0eae28b9b39fe26c456c42b19854c4b84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/90cb5ca3eb84b3053fef876e11e405fd819487fc",
-                "reference": "90cb5ca3eb84b3053fef876e11e405fd819487fc",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/10b32cf0eae28b9b39fe26c456c42b19854c4b84",
+                "reference": "10b32cf0eae28b9b39fe26c456c42b19854c4b84",
                 "shasum": ""
             },
             "require": {
@@ -2993,13 +2993,16 @@
             },
             "conflict": {
                 "symfony/config": "<2.8",
-                "symfony/yaml": "<3.3"
+                "symfony/dependency-injection": "<3.4",
+                "symfony/yaml": "<3.4"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0",
-                "symfony/intl": "^2.8.18|^3.2.5",
-                "symfony/yaml": "~3.3"
+                "symfony/config": "~2.8|~3.0|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/finder": "~2.8|~3.0|~4.0",
+                "symfony/intl": "^2.8.18|^3.2.5|~4.0",
+                "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
                 "psr/log": "To use logging capability in translator",
@@ -3009,7 +3012,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -3036,7 +3039,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-18T14:19:00+00:00"
+            "time": "2018-01-18T22:16:57+00:00"
         },
         {
             "name": "zendframework/zend-filter",


### PR DESCRIPTION
## Description
Bump ``phpunit/phpunit`` in ``composer.json`` to min ``5.7`` as it is in ``master``
Bump ``symfony/translation`` in ``composer.json`` to min ``3.4`` as it is in ``master``

## Related Issue
Implements PR #29904 (``phpunit/phpunit``) in ``stable10``
Fully implements PR #30258 (``symfony/translation``) in ``stable10``

## Motivation and Context
Make ``stable10`` as close as possible to ``master`` for ``composer.json`` dependencies.

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
