### PR TITLE
Ensure backend is verified on sync. 

### DIFF
--- a/apps/testing/lib/Application.php
+++ b/apps/testing/lib/Application.php
@@ -36,6 +36,12 @@ class Application extends App {
 			// replace all user backends with this one
 			$userManager->clearBackends();
 			$userManager->registerBackend($c->query(AlternativeHomeUserBackend::class));
+
+			// Make existing accounts use the new alternative home backed
+			$q = $c->getServer()->getDatabaseConnection()->getQueryBuilder();
+			$q->update('*PREFIX*accounts')
+				->set('backend', AlternativeHomeUserBackend::class)
+				->execute();
 		}
 	}
 }

--- a/apps/testing/lib/Application.php
+++ b/apps/testing/lib/Application.php
@@ -22,6 +22,7 @@
 namespace OCA\Testing;
 
 use OCP\AppFramework\App;
+use OCP\App\ManagerEvent;
 
 class Application extends App {
 	public function __construct (array $urlParams = array()) {
@@ -37,11 +38,36 @@ class Application extends App {
 			$userManager->clearBackends();
 			$userManager->registerBackend($c->query(AlternativeHomeUserBackend::class));
 
-			// Make existing accounts use the new alternative home backed
-			$q = $c->getServer()->getDatabaseConnection()->getQueryBuilder();
-			$q->update('*PREFIX*accounts')
-				->set('backend', AlternativeHomeUserBackend::class)
-				->execute();
+			$userManager->listen('\OC\User', 'postCreateUser', function ($user, $password) use ($c) {
+				$q = $c->getServer()->getDatabaseConnection()->getQueryBuilder();
+				$q->update('*PREFIX*accounts')
+					->set('backend', $q->expr()->literal(AlternativeHomeUserBackend::class))
+					->where($q->expr()->eq('user_id', $q->createNamedParameter($user->getUID())))
+					->execute();
+			});
+
+			// first call must adjust all existing backends
+			if ($config->getAppValue($appName, 'updated_all', 'no') === 'no') {
+				$q = $c->getServer()->getDatabaseConnection()->getQueryBuilder();
+				$q->update('*PREFIX*accounts')
+					->set('backend', $q->expr()->literal(AlternativeHomeUserBackend::class))
+					->where($q->expr()->eq('backend', $q->createNamedParameter(\OC\User\Database::class)))
+					->execute();
+
+				// set this value to only do it once, the value is cleared when disabling the app
+				$config->setAppValue($appName, 'updated_all', 'yes');
+			};
 		}
+
+		$eventDispatcher = $c->getServer()->getEventDispatcher();
+		$eventDispatcher->addListener(
+			ManagerEvent::EVENT_APP_DISABLE,
+			function($event) use ($appName, $config) {
+				// clear the "already updated" flag when disabling this app
+				if ($event->getAppID() === $appName) {
+					$config->deleteAppValue($appName, 'updated_all');
+				}
+			}
+		);
 	}
 }

--- a/lib/private/User/SyncService.php
+++ b/lib/private/User/SyncService.php
@@ -227,7 +227,9 @@ class SyncService {
 			$existing = $a->getHome();
 			$backendHome = $backend->getHome($uid);
 			$class = get_class($backend);
-			$this->logger->error("User backend $class is returning home: $backendHome for user: $uid which differs from existing value: $existing");
+			if ($existing !== '') {
+				$this->logger->error("User backend $class is returning home: $backendHome for user: $uid which differs from existing value: $existing");
+			}
 		}
 		// Home is handled differently, it should only be set on account creation, when there is no home already set
 		// Otherwise it could change on a sync and result in a new user folder being created

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -20,7 +20,7 @@ function env_alt_home_enable {
 }
 
 function env_alt_home_clear {
-	$OCC app:disable testing
+	$OCC app:disable testing || { echo "Unable to disable testing app" >&2; exit 1; }
 }
 
 function env_encryption_enable {
@@ -29,12 +29,12 @@ function env_encryption_enable {
 }
 
 function env_encryption_enable_master_key {
-	env_encryption_enable
+	env_encryption_enable || { echo "Unable to enable user-keys encryption" >&2; exit 1; }
 	$OCC encryption:select-encryption-type masterkey --yes
 }
 
 function env_encryption_enable_user_keys {
-	env_encryption_enable
+	env_encryption_enable || { echo "Unable to enable user-keys encryption" >&2; exit 1; }
 	$OCC encryption:select-encryption-type user-keys --yes
 }
 
@@ -44,12 +44,12 @@ function env_encryption_disable {
 }
 
 function env_encryption_disable_master_key {
-	env_encryption_disable
+	env_encryption_disable || { echo "Unable to disable encryption" >&2; exit 1; }
 	$OCC config:app:delete encryption useMasterKey
 }
 
 function env_encryption_disable_users_key {
-	env_encryption_disable
+	env_encryption_disable || { echo "Unable to disable encryption" >&2; exit 1; }
 	$OCC config:app:delete encryption userSpecificKey
 }
 
@@ -83,7 +83,7 @@ $OCC config:system:set files_external_allow_create_new_local --value=true
 PREVIOUS_TESTING_APP_STATUS=$($OCC --no-warnings app:list "^testing$")
 if [[ "$PREVIOUS_TESTING_APP_STATUS" =~ ^Disabled: ]]
 then
-	$OCC app:enable testing
+	$OCC app:enable testing || { echo "Unable to enable testing app" >&2; exit 1; }
 	TESTING_ENABLED_BY_SCRIPT=true;
 else
 	TESTING_ENABLED_BY_SCRIPT=false;


### PR DESCRIPTION
## Description
When we sync with an existing account entity, we must always check that we are syncing against the same backend as when the account was created.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

