### PR TITLE
New formats for integration test given-when-then step text

### DIFF
--- a/tests/integration/capabilities_features/capabilities.feature
+++ b/tests/integration/capabilities_features/capabilities.feature
@@ -22,362 +22,362 @@ Feature: capabilities
 	Scenario: getting capabilities with admin user
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | 1 |
-			| files_sharing | public@@@send_mail | EMPTY |
-			| files_sharing | public@@@social_share | 1 |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | 1                 |
+			| files_sharing | public@@@upload                       | 1                 |
+			| files_sharing | public@@@send_mail                    | EMPTY             |
+			| files_sharing | public@@@social_share                 | 1                 |
+			| files_sharing | resharing                             | 1                 |
+			| files_sharing | federation@@@outgoing                 | 1                 |
+			| files_sharing | federation@@@incoming                 | 1                 |
+			| files_sharing | group_sharing                         | 1                 |
+			| files_sharing | share_with_group_members_only         | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |
 
 	Scenario: Changing public upload
 		Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | EMPTY |
-			| files_sharing | public@@@send_mail | EMPTY |
-			| files_sharing | public@@@social_share | 1 |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | 1                 |
+			| files_sharing | public@@@upload                       | EMPTY             |
+			| files_sharing | public@@@send_mail                    | EMPTY             |
+			| files_sharing | public@@@social_share                 | 1                 |
+			| files_sharing | resharing                             | 1                 |
+			| files_sharing | federation@@@outgoing                 | 1                 |
+			| files_sharing | federation@@@incoming                 | 1                 |
+			| files_sharing | group_sharing                         | 1                 |
+			| files_sharing | share_with_group_members_only         | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |
 
 	Scenario: Disabling share api
 		Given parameter "shareapi_enabled" of app "core" has been set to "no"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | EMPTY |
-			| files_sharing | public@@@enabled | EMPTY |
-			| files_sharing | public@@@upload | EMPTY |
-			| files_sharing | resharing | EMPTY |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element       | value             |
+			| core          | pollinterval          | 60                |
+			| core          | webdav-root           | remote.php/webdav |
+			| files_sharing | api_enabled           | EMPTY             |
+			| files_sharing | public@@@enabled      | EMPTY             |
+			| files_sharing | public@@@upload       | EMPTY             |
+			| files_sharing | resharing             | EMPTY             |
+			| files_sharing | federation@@@outgoing | 1                 |
+			| files_sharing | federation@@@incoming | 1                 |
+			| files         | bigfilechunking       | 1                 |
+			| files         | undelete              | 1                 |
+			| files         | versioning            | 1                 |
 
 	Scenario: Disabling public links
 		Given parameter "shareapi_allow_links" of app "core" has been set to "no"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | EMPTY |
-			| files_sharing | public@@@upload | EMPTY |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | EMPTY             |
+			| files_sharing | public@@@upload                       | EMPTY             |
+			| files_sharing | resharing                             | 1                 |
+			| files_sharing | federation@@@outgoing                 | 1                 |
+			| files_sharing | federation@@@incoming                 | 1                 |
+			| files_sharing | group_sharing                         | 1                 |
+			| files_sharing | share_with_group_members_only         | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |
 
 	Scenario: Changing resharing
 		Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | 1 |
-			| files_sharing | public@@@send_mail | EMPTY |
-			| files_sharing | public@@@social_share | 1 |
-			| files_sharing | resharing | EMPTY |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | 1                 |
+			| files_sharing | public@@@upload                       | 1                 |
+			| files_sharing | public@@@send_mail                    | EMPTY             |
+			| files_sharing | public@@@social_share                 | 1                 |
+			| files_sharing | resharing                             | EMPTY             |
+			| files_sharing | federation@@@outgoing                 | 1                 |
+			| files_sharing | federation@@@incoming                 | 1                 |
+			| files_sharing | group_sharing                         | 1                 |
+			| files_sharing | share_with_group_members_only         | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |
 
 	Scenario: Changing federation outgoing
 		Given parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | 1 |
-			| files_sharing | public@@@send_mail | EMPTY |
-			| files_sharing | public@@@social_share | 1 |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | EMPTY |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | 1                 |
+			| files_sharing | public@@@upload                       | 1                 |
+			| files_sharing | public@@@send_mail                    | EMPTY             |
+			| files_sharing | public@@@social_share                 | 1                 |
+			| files_sharing | resharing                             | 1                 |
+			| files_sharing | federation@@@outgoing                 | EMPTY             |
+			| files_sharing | federation@@@incoming                 | 1                 |
+			| files_sharing | group_sharing                         | 1                 |
+			| files_sharing | share_with_group_members_only         | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |
 
 	Scenario: Changing federation incoming
 		Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | 1 |
-			| files_sharing | public@@@send_mail | EMPTY |
-			| files_sharing | public@@@social_share | 1 |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | EMPTY |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | 1                 |
+			| files_sharing | public@@@upload                       | 1                 |
+			| files_sharing | public@@@send_mail                    | EMPTY             |
+			| files_sharing | public@@@social_share                 | 1                 |
+			| files_sharing | resharing                             | 1                 |
+			| files_sharing | federation@@@outgoing                 | 1                 |
+			| files_sharing | federation@@@incoming                 | EMPTY             |
+			| files_sharing | group_sharing                         | 1                 |
+			| files_sharing | share_with_group_members_only         | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |
 
 	Scenario: Changing password enforce
 		Given parameter "shareapi_enforce_links_password" of app "core" has been set to "yes"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | 1 |
-			| files_sharing | public@@@send_mail | EMPTY |
-			| files_sharing | public@@@social_share | 1 |
-			| files_sharing | public@@@password@@@enforced | 1 |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | 1                 |
+			| files_sharing | public@@@upload                       | 1                 |
+			| files_sharing | public@@@send_mail                    | EMPTY             |
+			| files_sharing | public@@@social_share                 | 1                 |
+			| files_sharing | public@@@password@@@enforced          | 1                 |
+			| files_sharing | resharing                             | 1                 |
+			| files_sharing | federation@@@outgoing                 | 1                 |
+			| files_sharing | federation@@@incoming                 | 1                 |
+			| files_sharing | group_sharing                         | 1                 |
+			| files_sharing | share_with_group_members_only         | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |
 
 	Scenario: Changing public notifications
 		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | 1 |
-			| files_sharing | public@@@send_mail | 1 |
-			| files_sharing | public@@@social_share | 1 |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | 1                 |
+			| files_sharing | public@@@upload                       | 1                 |
+			| files_sharing | public@@@send_mail                    | 1                 |
+			| files_sharing | public@@@social_share                 | 1                 |
+			| files_sharing | resharing                             | 1                 |
+			| files_sharing | federation@@@outgoing                 | 1                 |
+			| files_sharing | federation@@@incoming                 | 1                 |
+			| files_sharing | group_sharing                         | 1                 |
+			| files_sharing | share_with_group_members_only         | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |
 
 	Scenario: Changing public social share
 		Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | 1 |
-			| files_sharing | public@@@send_mail | EMPTY |
-			| files_sharing | public@@@social_share | EMPTY |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | 1                 |
+			| files_sharing | public@@@upload                       | 1                 |
+			| files_sharing | public@@@send_mail                    | EMPTY             |
+			| files_sharing | public@@@social_share                 | EMPTY             |
+			| files_sharing | resharing                             | 1                 |
+			| files_sharing | federation@@@outgoing                 | 1                 |
+			| files_sharing | federation@@@incoming                 | 1                 |
+			| files_sharing | group_sharing                         | 1                 |
+			| files_sharing | share_with_group_members_only         | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |
 
 	Scenario: Changing expire date
 		Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | 1 |
-			| files_sharing | public@@@send_mail | EMPTY |
-			| files_sharing | public@@@social_share | 1 |
-			| files_sharing | public@@@expire_date@@@enabled | 1 |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | 1                 |
+			| files_sharing | public@@@upload                       | 1                 |
+			| files_sharing | public@@@send_mail                    | EMPTY             |
+			| files_sharing | public@@@social_share                 | 1                 |
+			| files_sharing | public@@@expire_date@@@enabled        | 1                 |
+			| files_sharing | resharing                             | 1                 |
+			| files_sharing | federation@@@outgoing                 | 1                 |
+			| files_sharing | federation@@@incoming                 | 1                 |
+			| files_sharing | group_sharing                         | 1                 |
+			| files_sharing | share_with_group_members_only         | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |
 
 	Scenario: Changing expire date enforcing
 		Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
 		And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | 1 |
-			| files_sharing | public@@@send_mail | EMPTY |
-			| files_sharing | public@@@social_share | 1 |
-			| files_sharing | public@@@expire_date@@@enabled | 1 |
-			| files_sharing | public@@@expire_date@@@enforced | 1 |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | 1                 |
+			| files_sharing | public@@@upload                       | 1                 |
+			| files_sharing | public@@@send_mail                    | EMPTY             |
+			| files_sharing | public@@@social_share                 | 1                 |
+			| files_sharing | public@@@expire_date@@@enabled        | 1                 |
+			| files_sharing | public@@@expire_date@@@enforced       | 1                 |
+			| files_sharing | resharing                             | 1                 |
+			| files_sharing | federation@@@outgoing                 | 1                 |
+			| files_sharing | federation@@@incoming                 | 1                 |
+			| files_sharing | group_sharing                         | 1                 |
+			| files_sharing | share_with_group_members_only         | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |
 
 	Scenario: Changing group sharing allowed
 		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | 1 |
-			| files_sharing | public@@@send_mail | EMPTY |
-			| files_sharing | public@@@social_share | 1 |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | EMPTY |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | 1                 |
+			| files_sharing | public@@@upload                       | 1                 |
+			| files_sharing | public@@@send_mail                    | EMPTY             |
+			| files_sharing | public@@@social_share                 | 1                 |
+			| files_sharing | resharing                             | 1                 |
+			| files_sharing | federation@@@outgoing                 | 1                 |
+			| files_sharing | federation@@@incoming                 | 1                 |
+			| files_sharing | group_sharing                         | EMPTY             |
+			| files_sharing | share_with_group_members_only         | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |
 
 	Scenario: Changing only share with group member
 		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | 1 |
-			| files_sharing | public@@@send_mail | EMPTY |
-			| files_sharing | public@@@social_share | 1 |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | 1 |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | 1                 |
+			| files_sharing | public@@@upload                       | 1                 |
+			| files_sharing | public@@@send_mail                    | EMPTY             |
+			| files_sharing | public@@@social_share                 | 1                 |
+			| files_sharing | resharing                             | 1                 |
+			| files_sharing | federation@@@outgoing                 | 1                 |
+			| files_sharing | federation@@@incoming                 | 1                 |
+			| files_sharing | group_sharing                         | 1                 |
+			| files_sharing | share_with_group_members_only         | 1                 |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |
 
 	Scenario: Changing allow share dialog user enumeration
 		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | 1 |
-			| files_sharing | public@@@send_mail | EMPTY |
-			| files_sharing | public@@@social_share | 1 |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | EMPTY |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element               | value             |
+			| core          | pollinterval                  | 60                |
+			| core          | webdav-root                   | remote.php/webdav |
+			| files_sharing | api_enabled                   | 1                 |
+			| files_sharing | public@@@enabled              | 1                 |
+			| files_sharing | public@@@upload               | 1                 |
+			| files_sharing | public@@@send_mail            | EMPTY             |
+			| files_sharing | public@@@social_share         | 1                 |
+			| files_sharing | resharing                     | 1                 |
+			| files_sharing | federation@@@outgoing         | 1                 |
+			| files_sharing | federation@@@incoming         | 1                 |
+			| files_sharing | group_sharing                 | 1                 |
+			| files_sharing | share_with_group_members_only | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled    | EMPTY             |
+			| files         | bigfilechunking               | 1                 |
+			| files         | undelete                      | 1                 |
+			| files         | versioning                    | 1                 |
 
 	Scenario: Changing allow share dialog user enumeration for group members only
 		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability | path_to_element | value |
-			| core | pollinterval | 60 |
-			| core | webdav-root | remote.php/webdav |
-			| files_sharing | api_enabled | 1 |
-			| files_sharing | public@@@enabled | 1 |
-			| files_sharing | public@@@upload | 1 |
-			| files_sharing | public@@@send_mail | EMPTY |
-			| files_sharing | public@@@social_share | 1 |
-			| files_sharing | resharing | 1 |
-			| files_sharing | federation@@@outgoing | 1 |
-			| files_sharing | federation@@@incoming | 1 |
-			| files_sharing | group_sharing         | 1 |
-			| files_sharing | share_with_group_members_only | EMPTY |
-			| files_sharing | user_enumeration@@@enabled | 1 |
-			| files_sharing | user_enumeration@@@group_members_only | 1 |
-			| files | bigfilechunking | 1 |
-			| files | undelete | 1 |
-			| files | versioning | 1 |
+			| capability    | path_to_element                       | value             |
+			| core          | pollinterval                          | 60                |
+			| core          | webdav-root                           | remote.php/webdav |
+			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | public@@@enabled                      | 1                 |
+			| files_sharing | public@@@upload                       | 1                 |
+			| files_sharing | public@@@send_mail                    | EMPTY             |
+			| files_sharing | public@@@social_share                 | 1                 |
+			| files_sharing | resharing                             | 1                 |
+			| files_sharing | federation@@@outgoing                 | 1                 |
+			| files_sharing | federation@@@incoming                 | 1                 |
+			| files_sharing | group_sharing                         | 1                 |
+			| files_sharing | share_with_group_members_only         | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled            | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only | 1                 |
+			| files         | bigfilechunking                       | 1                 |
+			| files         | undelete                              | 1                 |
+			| files         | versioning                            | 1                 |

--- a/tests/integration/capabilities_features/capabilities.feature
+++ b/tests/integration/capabilities_features/capabilities.feature
@@ -1,27 +1,27 @@
 Feature: capabilities
 	Background:
-		Given using api version "1"
-		And as an "admin"
+		Given using API version "1"
+		And as user "admin"
 
 	Scenario: Check that the sharing API can be enabled
-		When parameter "shareapi_enabled" of app "core" is set to "yes"
-		Then the capabilities setting of "files_sharing" path "api_enabled" is "1"
+		When the administrator sets parameter "shareapi_enabled" of app "core" to "yes" using the API
+		Then the capabilities setting of "files_sharing" path "api_enabled" should be "1"
 
 	Scenario: Check that the sharing API can be disabled
-		When parameter "shareapi_enabled" of app "core" is set to "no"
-		Then the capabilities setting of "files_sharing" path "api_enabled" is ""
+		When the administrator sets parameter "shareapi_enabled" of app "core" to "no" using the API
+		Then the capabilities setting of "files_sharing" path "api_enabled" should be ""
 
 	Scenario: Check that group sharing can be enabled
-		When parameter "shareapi_allow_group_sharing" of app "core" is set to "yes"
-		Then the capabilities setting of "files_sharing" path "group_sharing" is "1"
+		When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "yes" using the API
+		Then the capabilities setting of "files_sharing" path "group_sharing" should be "1"
 
 	Scenario: Check that group sharing can be disabled
-		When parameter "shareapi_allow_group_sharing" of app "core" is set to "no"
-		Then the capabilities setting of "files_sharing" path "group_sharing" is ""
+		When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "no" using the API
+		Then the capabilities setting of "files_sharing" path "group_sharing" should be ""
 
 	Scenario: getting capabilities with admin user
-		When the capabilities are retrieved
-		Then fields of capabilities match with
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -42,9 +42,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing public upload
-		Given parameter "shareapi_allow_public_upload" of app "core" is set to "no"
-		When the capabilities are retrieved
-		Then fields of capabilities match with
+		Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -65,9 +65,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Disabling share api
-		Given parameter "shareapi_enabled" of app "core" is set to "no"
-		When the capabilities are retrieved
-		Then fields of capabilities match with
+		Given parameter "shareapi_enabled" of app "core" has been set to "no"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -82,9 +82,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Disabling public links
-		Given parameter "shareapi_allow_links" of app "core" is set to "no"
-		When the capabilities are retrieved
-		Then fields of capabilities match with
+		Given parameter "shareapi_allow_links" of app "core" has been set to "no"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -103,9 +103,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing resharing
-		Given parameter "shareapi_allow_resharing" of app "core" is set to "no"
-		When the capabilities are retrieved
-		Then fields of capabilities match with
+		Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -126,9 +126,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing federation outgoing
-		Given parameter "outgoing_server2server_share_enabled" of app "files_sharing" is set to "no"
-		When the capabilities are retrieved
-		Then fields of capabilities match with
+		Given parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -149,9 +149,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing federation incoming
-		Given parameter "incoming_server2server_share_enabled" of app "files_sharing" is set to "no"
-		When the capabilities are retrieved
-		Then fields of capabilities match with
+		Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -172,9 +172,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing password enforce
-		Given parameter "shareapi_enforce_links_password" of app "core" is set to "yes"
-		When the capabilities are retrieved
-		Then fields of capabilities match with
+		Given parameter "shareapi_enforce_links_password" of app "core" has been set to "yes"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -196,9 +196,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing public notifications
-		Given parameter "shareapi_allow_public_notification" of app "core" is set to "yes"
-		When the capabilities are retrieved
-		Then fields of capabilities match with
+		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -219,10 +219,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing public social share
-		Given parameter "shareapi_allow_social_share" of app "core" is set to "no"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -243,9 +242,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing expire date
-		Given parameter "shareapi_default_expire_date" of app "core" is set to "yes"
-		When the capabilities are retrieved
-		Then fields of capabilities match with
+		Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -267,10 +266,10 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing expire date enforcing
-		Given parameter "shareapi_default_expire_date" of app "core" is set to "yes"
-		And parameter "shareapi_enforce_expire_date" of app "core" is set to "yes"
-		When the capabilities are retrieved
-		Then fields of capabilities match with
+		Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
+		And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -293,9 +292,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing group sharing allowed
-		Given parameter "shareapi_allow_group_sharing" of app "core" is set to "no"
-		When the capabilities are retrieved
-		Then fields of capabilities match with
+		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -316,10 +315,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing only share with group member
-		Given parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -340,10 +338,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing allow share dialog user enumeration
-		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |
@@ -363,10 +360,9 @@ Feature: capabilities
 			| files | versioning | 1 |
 
 	Scenario: Changing allow share dialog user enumeration for group members only
-		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" is set to "yes"
-		When sending "GET" to "/cloud/capabilities"
-		Then the HTTP status code should be "200"
-		And fields of capabilities match with
+		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
 			| capability | path_to_element | value |
 			| core | pollinterval | 60 |
 			| core | webdav-root | remote.php/webdav |

--- a/tests/integration/features/appmanagement.feature
+++ b/tests/integration/features/appmanagement.feature
@@ -1,16 +1,16 @@
 Feature: AppManagement
 
   Background:
-    Given apps are in two directories "apps" and "apps2"
+    Given apps have been put in two directories "apps" and "apps2"
 
   Scenario: Two app instances exist the first is more recent
-    Given app "multidirtest" with version "1.0.1" exists in dir "apps"
-    And app "multidirtest" with version "1.0.0" exists in dir "apps2"
-    When app "multidirtest" is loaded
-    Then path to "multidirtest" should be "apps"
+    Given app "multidirtest" with version "1.0.1" has been put in dir "apps"
+    And app "multidirtest" with version "1.0.0" has been put in dir "apps2"
+    When the administrator loads app "multidirtest" using the console
+    Then the path to "multidirtest" should be "apps"
 
   Scenario: Two app instances exist the second is more recent
-    Given app "multidirtest" with version "1.0.0" exists in dir "apps"
-    And app "multidirtest" with version "1.0.5" exists in dir "apps2"
-    When app "multidirtest" is loaded
-    Then path to "multidirtest" should be "apps2"
+    Given app "multidirtest" with version "1.0.0" has been put in dir "apps"
+    And app "multidirtest" with version "1.0.5" has been put in dir "apps2"
+    When the administrator loads app "multidirtest" using the console
+    Then the path to "multidirtest" should be "apps2"

--- a/tests/integration/features/auth.feature
+++ b/tests/integration/features/auth.feature
@@ -1,46 +1,45 @@
 Feature: auth
 
 	Background:
-		Given user "user0" exists
-		And a new client token is used for user "user0"
-
+		Given user "user0" has been created
+		And a new client token for "user0" has been generated
 
 	# FILES APP
 
 	Scenario: access files app anonymously
-		When requesting "/index.php/apps/files" with "GET"
+		When a user requests "/index.php/apps/files" with "GET" and no authentication
 		Then the HTTP status code should be "401"
 
 	Scenario: access files app with basic auth
-		When requesting "/index.php/apps/files" with "GET" using basic auth for user "user0"
+		When user "user0" requests "/index.php/apps/files" with "GET" using basic auth
 		Then the HTTP status code should be "200"
 
 	Scenario: access files app with basic token auth
-		When requesting "/index.php/apps/files" with "GET" using basic token auth
+		When user "user0" requests "/index.php/apps/files" with "GET" using basic token auth
 		Then the HTTP status code should be "200"
 
 	Scenario: access files app with a client token
-		When requesting "/index.php/apps/files" with "GET" using a client token
+		When the user requests "/index.php/apps/files" with "GET" using the generated client token
 		Then the HTTP status code should be "200"
 
 	Scenario: access files app with browser session
-		Given a new browser session is started for user "user0"
-		When requesting "/index.php/apps/files" with "GET" using browser session
+		Given a new browser session for "user0" has been started
+		When the user requests "/index.php/apps/files" with "GET" using the browser session
 		Then the HTTP status code should be "200"
 
 
 	# WebDAV
 
 	Scenario: using WebDAV anonymously
-		When requesting "/remote.php/webdav" with "PROPFIND"
+		When a user requests "/remote.php/webdav" with "PROPFIND" and no authentication
 		Then the HTTP status code should be "401"
 
 	Scenario: using WebDAV with basic auth
-		When requesting "/remote.php/webdav" with "PROPFIND" using basic auth for user "user0"
+		When user "user0" requests "/remote.php/webdav" with "PROPFIND" using basic auth
 		Then the HTTP status code should be "207"
 
 	Scenario: using WebDAV with token auth
-		When requesting "/remote.php/webdav" with "PROPFIND" using basic token auth
+		When user "user0" requests "/remote.php/webdav" with "PROPFIND" using basic token auth
 		Then the HTTP status code should be "207"
 
 	# DAV token auth is not possible yet
@@ -49,30 +48,30 @@ Feature: auth
 	#	Then the HTTP status code should be "207"
 
 	Scenario: using WebDAV with browser session
-		Given a new browser session is started for user "user0"
-		When requesting "/remote.php/webdav" with "PROPFIND" using browser session
+		Given a new browser session for "user0" has been started
+		When the user requests "/remote.php/webdav" with "PROPFIND" using the browser session
 		Then the HTTP status code should be "207"
 
 
 	# OCS
 
 	Scenario: using OCS anonymously
-		When requesting "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET"
+		When a user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" and no authentication
 		Then the OCS status code should be "997"
 
 	Scenario: using OCS with basic auth
-		When requesting "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic auth for user "user0"
+		When user "user0" requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic auth
 		Then the OCS status code should be "100"
 
 	Scenario: using OCS with token auth
-		When requesting "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic token auth
+		When user "user0" requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic token auth
 		Then the OCS status code should be "100"
 
 	Scenario: using OCS with client token
-		When requesting "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using a client token
+		When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using the generated client token
 		Then the OCS status code should be "100"
 
 	Scenario: using OCS with browser session
-		Given a new browser session is started for user "user0"
-		When requesting "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using browser session
+		Given a new browser session for "user0" has been started
+		When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using the browser session
 		Then the OCS status code should be "100"

--- a/tests/integration/features/bootstrap/AppConfiguration.php
+++ b/tests/integration/features/bootstrap/AppConfiguration.php
@@ -69,13 +69,13 @@ trait AppConfiguration {
 	abstract public function theHTTPStatusCodeShouldBe($statusCode);
 
 	/**
-	 * @Given /^parameter "([^"]*)" of app "([^"]*)" is set to "([^"]*)"$/
+	 * @When /^the administrator sets parameter "([^"]*)" of app "([^"]*)" to "([^"]*)" using the API$/
 	 * @param string $parameter
 	 * @param string $app
 	 * @param string $value
 	 * @return void
 	 */
-	public function serverParameterIsSetTo($parameter, $app, $value) {
+	public function adminSetsServerParameterToUsingAPI($parameter, $app, $value) {
 		$user = $this->currentUser;
 		$this->currentUser = $this->getAdminUserName();
 
@@ -85,13 +85,24 @@ trait AppConfiguration {
 	}
 
 	/**
-	 * @Then the capabilities setting of :capabilitiesApp path :capabilitiesPath is :expectedValue
+	 * @Given /^parameter "([^"]*)" of app "([^"]*)" has been set to "([^"]*)"$/
+	 * @param string $parameter
+	 * @param string $app
+	 * @param string $value
+	 * @return void
+	 */
+	public function serverParameterHasBeenSetTo($parameter, $app, $value) {
+		$this->adminSetsServerParameterToUsingAPI($parameter, $app, $value);
+	}
+
+	/**
+	 * @Then the capabilities setting of :capabilitiesApp path :capabilitiesPath should be :expectedValue
 	 * @param string $capabilitiesApp the "app" name in the capabilities response
 	 * @param string $capabilitiesPath the path to the element
 	 * @param string $expectedValue
 	 * @return void
 	 */
-	public function theCapabilitiesSettingOfAppParameterIs($capabilitiesApp, $capabilitiesPath, $expectedValue) {
+	public function theCapabilitiesSettingOfAppParameterShouldBe($capabilitiesApp, $capabilitiesPath, $expectedValue) {
 		$this->getCapabilitiesCheckResponse();
 
 		PHPUnit_Framework_Assert::assertEquals(
@@ -116,7 +127,7 @@ trait AppConfiguration {
 	}
 
 	/**
-	 * @When the capabilities are retrieved
+	 * @When the user retrieves the capabilities using the API
 	 * @return void
 	 */
 	public function getCapabilitiesCheckResponse() {

--- a/tests/integration/features/bootstrap/AppManagementContext.php
+++ b/tests/integration/features/bootstrap/AppManagementContext.php
@@ -36,8 +36,7 @@ class AppManagementContext implements  Context {
 	/**
 	 * @BeforeScenario
 	 *
-	 * Enable the testing app before the first scenario of the feature and
-	 * reset the configs before each scenario
+	 * Remember the config values before each scenario
 	 */
 	public function prepareParameters() {
 		include_once __DIR__ . '/../../../../lib/base.php';
@@ -47,7 +46,7 @@ class AppManagementContext implements  Context {
 	/**
 	 * @AfterScenario
 	 *
-	 * Reset the values after the last scenario of the feature and disable the testing app
+	 * Reset the config values after each scenario
 	 */
 	public function undoChangingParameters() {
 		if (!is_null($this->oldAppPath)) {
@@ -58,7 +57,7 @@ class AppManagementContext implements  Context {
 	}
 	
 	/**
-	 * @Given apps are in two directories :dir1 and :dir2
+	 * @Given apps have been put in two directories :dir1 and :dir2
 	 * @param string $dir1
 	 * @param string $dir2
 	 */
@@ -75,12 +74,12 @@ class AppManagementContext implements  Context {
 	}
 	
 	/**
-	 * @Given app :appId with version :version exists in dir :dir
+	 * @Given app :appId with version :version has been put in dir :dir
 	 * @param string $appId app id
 	 * @param string $version app version
 	 * @param string $dir app directory
 	 */
-	public function appExistsInDir($appId, $version, $dir) {
+	public function appHasBeenPutInDir($appId, $version, $dir) {
 		$ocVersion = \OC::$server->getConfig()->getSystemValue('version', '0.0.0');
 		$appInfo = sprintf('<?xml version="1.0"?>
 			<info>
@@ -123,7 +122,7 @@ class AppManagementContext implements  Context {
 	}
 	
 	/**
-	 * @When app :appId is loaded
+	 * @When the administrator loads app :appId using the console
 	 * @param string $appId app id
 	 */
 	public function loadApp($appId) {
@@ -145,7 +144,7 @@ class AppManagementContext implements  Context {
 	}
 	
 	/**
-	 * @Then path to :appId should be :dir
+	 * @Then the path to :appId should be :dir
 	 * @param string $appId
 	 * @param string $dir
 	 */

--- a/tests/integration/features/bootstrap/Auth.php
+++ b/tests/integration/features/bootstrap/Auth.php
@@ -16,12 +16,20 @@ trait Auth {
 	}
 
 	/**
-	 * @When requesting :url with :method
+	 * @When a user requests :url with :method and no authentication
+	 * @param string $url
+	 * @param string $method
 	 */
-	public function requestingWith($url, $method) {
+	public function userRequestsURLWith($url, $method) {
 		$this->sendRequest($url, $method);
 	}
 
+	/**
+	 * @param string $url
+	 * @param string $method
+	 * @param string|null $authHeader
+	 * @param bool $useCookies
+	 */
 	private function sendRequest($url, $method, $authHeader = null, $useCookies = false) {
 		$fullUrl = substr($this->baseUrl, 0, -5) . $url;
 		try {
@@ -44,54 +52,64 @@ trait Auth {
 	}
 
 	/**
-	 * @Given a new client token is used for user :user
+	 * @Given a new client token for :user has been generated
 	 * @param string $user
 	 */
-	public function aNewClientTokenIsUsed($user) {
+	public function aNewClientTokenHasBeenGenerated($user) {
 		$client = new Client();
 		$resp = $client->post(substr($this->baseUrl, 0, -5) . '/token/generate', [
 			'json' => [
-				'user' => $user,
-				'password' => $this->getPasswordForUser($user),
+					'user' => $user,
+					'password' => $this->getPasswordForUser($user),
 			]
 		]);
 		$this->clientToken = json_decode($resp->getBody()->getContents())->token;
 	}
 
 	/**
-	 * @When requesting :url with :method using basic auth for user :user
+	 * @When user :user requests :url with :method using basic auth
+	 * @param string $user
+	 * @param string $url
+	 * @param string $method
 	 */
-	public function requestingWithBasicAuth($url, $method, $user) {
+	public function userRequestsURLWithUsingBasicAuth($user, $url, $method) {
 		$authString = $user . ':' . $this->getPasswordForUser($user);
 		$this->sendRequest($url, $method, 'basic ' . base64_encode($authString));
 	}
 
 	/**
-	 * @When requesting :url with :method using basic token auth
+	 * @When user :user requests :url with :method using basic token auth
+	 * @param string $user
+	 * @param string $url
+	 * @param string $method
 	 */
-	public function requestingWithBasicTokenAuth($url, $method) {
-		$this->sendRequest($url, $method, 'basic ' . base64_encode('user0:' . $this->clientToken));
+	public function userRequestsURLWithUsingBasicTokenAuth($user, $url, $method) {
+		$this->sendRequest($url, $method, 'basic ' . base64_encode($user . ':' . $this->clientToken));
 	}
 
 	/**
-	 * @When requesting :url with :method using a client token
+	 * @When the user requests :url with :method using the generated client token
+	 * @param string $url
+	 * @param string $method
 	 */
-	public function requestingWithUsingAClientToken($url, $method) {
+	public function userRequestsURLWithUsingAClientToken($url, $method) {
 		$this->sendRequest($url, $method, 'token ' . $this->clientToken);
 	}
 
 	/**
-	 * @When requesting :url with :method using browser session
+	 * @When the user requests :url with :method using the browser session
+	 * @param string $url
+	 * @param string $method
 	 */
-	public function requestingWithBrowserSession($url, $method) {
+	public function userRequestsURLWithBrowserSession($url, $method) {
 		$this->sendRequest($url, $method, null, true);
 	}
 
 	/**
-	 * @Given a new browser session is started for user :user
+	 * @Given a new browser session for :user has been started
 	 * @param string $user
 	 */
-	public function aNewBrowserSessionIsStarted($user) {
+	public function aNewBrowserSessionForHasBeenStarted($user) {
 		$loginUrl = substr($this->baseUrl, 0, -5) . '/login';
 		// Request a new session and extract CSRF token
 		$client = new Client();

--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -31,12 +31,6 @@ trait BasicStructure {
 	 */
 	private $regularUserPassword = '';
 
-	/**
-	 * @var string
-	 * @deprecated this var actually store[s|d] the password - better to use method getPasswordForUser()
-	 */
-	private $regularUser = '';
-
 	/** @var string */
 	private $currentUser = '';
 
@@ -64,8 +58,6 @@ trait BasicStructure {
 		$this->baseUrl = $baseUrl;
 		$this->adminUser = $admin;
 		$this->regularUserPassword = $regular_user_password;
-		// Set regularUser for backward-compatibility with old app tests that use BasicStructure
-		$this->regularUser = $regular_user_password;
 		$this->mailhogUrl = $mailhog_url;
 		$this->localBaseUrl = $this->baseUrl;
 		$this->remoteBaseUrl = $this->baseUrl;
@@ -107,15 +99,6 @@ trait BasicStructure {
 	 * @param string $user
 	 */
 	public function asUser($user) {
-		$this->currentUser = $user;
-	}
-
-	/**
-	 * @Given /^as an "([^"]*)"$/
-	 * @param string $user
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function asAn($user) {
 		$this->currentUser = $user;
 	}
 

--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -95,7 +95,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @Given /^using api version "([^"]*)"$/
+	 * @Given /^using (?:api|API) version "([^"]*)"$/
 	 * @param string $version
 	 */
 	public function usingApiVersion($version) {
@@ -103,8 +103,17 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @Given /^as user "([^"]*)"$/
+	 * @param string $user
+	 */
+	public function asUser($user) {
+		$this->currentUser = $user;
+	}
+
+	/**
 	 * @Given /^as an "([^"]*)"$/
 	 * @param string $user
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
 	 */
 	public function asAn($user) {
 		$this->currentUser = $user;
@@ -128,12 +137,27 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When /^sending "([^"]*)" to "([^"]*)"$/
+	 * @When /^the user sends HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
 	 * @param string $verb
 	 * @param string $url
 	 */
 	public function sendingTo($verb, $url) {
 		$this->sendingToWith($verb, $url, null);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
+	 * @param string $user
+	 * @param string $verb
+	 * @param string $url
+	 */
+	public function userSendingTo($user, $verb, $url) {
+		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+			$user,
+			$verb,
+			$url,
+			null
+		);
 	}
 
 	/**
@@ -196,17 +220,35 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When /^sending "([^"]*)" to "([^"]*)" with$/
+	 * @When /^the user sends HTTP method "([^"]*)" to API endpoint "([^"]*)" with body$/
+	 * @Given /^the user has sent HTTP method "([^"]*)" to API endpoint "([^"]*)" with body$/
 	 * @param string $verb
 	 * @param string $url
 	 * @param \Behat\Gherkin\Node\TableNode $body
 	 */
 	public function sendingToWith($verb, $url, $body) {
-		
+		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+			$this->currentUser,
+			$verb,
+			$url,
+			$body
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to API endpoint "([^"]*)" with body$/
+	 * @Given /^user "([^"]*)" has sent HTTP method "([^"]*)" to API endpoint "([^"]*)" with body$/
+	 * @param string $user
+	 * @param string $verb
+	 * @param string $url
+	 * @param \Behat\Gherkin\Node\TableNode $body
+	 */
+	public function userSendsHTTPMethodToAPIEndpointWithBody($user, $verb, $url, $body) {
+
 		/**
 		 * array of the data to be sent in the body.
-		 * contains $body data converted to an array 
-		 * 
+		 * contains $body data converted to an array
+		 *
 		 * @var array $bodyArray
 		 */
 		$bodyArray = [];
@@ -214,8 +256,7 @@ trait BasicStructure {
 			$bodyArray = $body->getRowsHash();
 		}
 
-		if ($this->currentUser !== 'UNAUTHORIZED_USER') {
-			$user = $this->currentUser;
+		if ($user !== 'UNAUTHORIZED_USER') {
 			$password = $this->getPasswordForUser($user);
 		} else {
 			$user = null;
@@ -230,19 +271,26 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When /^sending "([^"]*)" with exact url to "([^"]*)"$/
+	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to URL "([^"]*)"$/
+	 * @param string $user
 	 * @param string $verb
 	 * @param string $url
 	 */
-	public function sendingToDirectUrl($verb, $url) {
-		$this->sendingToWithDirectUrl($verb, $url, null);
+	public function userSendsHTTPMethodToUrl($user, $verb, $url) {
+		$this->sendingToWithDirectUrl($user, $verb, $url, null);
 	}
 
-	public function sendingToWithDirectUrl($verb, $url, $body) {
+	/**
+	 * @param string $user
+	 * @param string $verb
+	 * @param string $url
+	 * @param \Behat\Gherkin\Node\TableNode $body
+	 */
+	public function sendingToWithDirectUrl($user, $verb, $url, $body) {
 		$fullUrl = substr($this->baseUrl, 0, -5) . $url;
 		$client = new Client();
 		$options = [];
-		$options['auth'] = $this->getAuthOptionForUser($this->currentUser);
+		$options['auth'] = $this->getAuthOptionForUser($user);
 
 		if (!empty($this->cookieJar->toArray())) {
 			$options['cookies'] = $this->cookieJar;
@@ -264,6 +312,11 @@ trait BasicStructure {
 		}
 	}
 
+	/**
+	 * @param string $possibleUrl
+	 * @param string $finalPart
+	 * @return bool
+	 */
 	public function isExpectedUrl($possibleUrl, $finalPart) {
 		$baseUrlChopped = $this->baseUrlWithoutOCSAppendix();
 		$endCharacter = strlen($baseUrlChopped) + strlen($finalPart);
@@ -319,7 +372,6 @@ trait BasicStructure {
 	 * @param string $key2
 	 * @param string $key3
 	 * @param string $attribute
-	 * @param string $idText
 	 */
 	public function theXMLKey1Key2AttributeValueShouldBe($key1, $key2, $key3, $attribute) {
 		$value = $this->getXMLKey1Key2Key3AttributeValue($this->response, $key1, $key2, $key3, $attribute);
@@ -337,10 +389,11 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @Given logging in using web as :user
+	 * @When /^user "([^"]*)" logs in to a web-style session using the API$/
+	 * @Given /^user "([^"]*)" has logged in to a web-style session using the API$/
 	 * @param string $user
 	 */
-	public function loggingInUsingWebAs($user) {
+	public function userHasLoggedInToAWebStyleSessionUsingTheAPI($user) {
 		$loginUrl = substr($this->baseUrl, 0, -5) . '/login';
 		// Request a new session and extract CSRF token
 		$client = new Client();
@@ -370,7 +423,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When sending a :method to :url with requesttoken
+	 * @When the client sends a :method to :url with requesttoken using the API
 	 * @param string $method
 	 * @param string $url
 	 */
@@ -394,7 +447,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When sending a :method to :url without requesttoken
+	 * @When the client sends a :method to :url without requesttoken using the API
 	 * @param string $method
 	 * @param string $url
 	 */
@@ -416,6 +469,10 @@ trait BasicStructure {
 		}
 	}
 
+	/**
+	 * @param string $path
+	 * @param string $filename
+	 */
 	public static function removeFile($path, $filename) {
 		if (file_exists("$path" . "$filename")) {
 			unlink("$path" . "$filename");
@@ -423,7 +480,8 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @Given user :user modifies text of :filename with text :text
+	 * @When user :user modifies text of :filename with text :text using the API
+	 * @Given user :user has modified text of :filename with text :text
 	 * @param string $user
 	 * @param string $filename
 	 * @param string $text
@@ -433,6 +491,10 @@ trait BasicStructure {
 		file_put_contents($this->getUserHome($user) . "/files" . "$filename", "$text");
 	}
 
+	/**
+	 * @param string $name
+	 * @param string $size
+	 */
 	public function createFileSpecificSize($name, $size) {
 		$file = fopen("work/" . "$name", 'w');
 		fseek($file, $size - 1 ,SEEK_CUR);
@@ -440,6 +502,10 @@ trait BasicStructure {
 		fclose($file);
 	}
 
+	/**
+	 * @param string $name
+	 * @param string $text
+	 */
 	public function createFileWithText($name, $text) {
 		$file = fopen("work/" . "$name", 'w');
 		fwrite($file, $text);
@@ -447,28 +513,28 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @Given file :filename of size :size is created in local storage
+	 * @Given file :filename of size :size has been created in local storage
 	 * @param string $filename
 	 * @param string $size
 	 */
-	public function fileIsCreatedInLocalStorageWithSize($filename, $size) {
+	public function fileHasBeenCreatedInLocalStorageWithSize($filename, $size) {
 		$this->createFileSpecificSize("local_storage/$filename", $size);
 	}
 
 	/**
-	 * @Given file :filename with text :text is created in local storage
+	 * @Given file :filename with text :text has been created in local storage
 	 * @param string $filename
 	 * @param string $text
 	 */
-	public function fileIsCreatedInLocalStorageWithText($filename, $text) {
+	public function fileHasBeenCreatedInLocalStorageWithText($filename, $text) {
 		$this->createFileWithText("local_storage/$filename", $text);
 	}
 
 	/**
-	 * @Given file :filename is deleted in local storage
+	 * @Given file :filename has been deleted in local storage
 	 * @param string $filename
 	 */
-	public function fileIsDeletedInLocalStorage($filename) {
+	public function fileHasBeenDeletedInLocalStorage($filename) {
 		unlink("work/local_storage/$filename");
 	}
 
@@ -514,7 +580,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When requesting status.php
+	 * @When the admin requests status.php using the API
 	 */
 	public function getStatusPhp(){
 		$fullUrl = $this->baseUrlWithoutOCSAppendix() . "status.php";
@@ -530,6 +596,7 @@ trait BasicStructure {
 
 	/**
 	 * @Then the json responded should match with
+	 * @param PyStringNode $jsonExpected
 	 */
 	public function jsonRespondedShouldMatch(PyStringNode $jsonExpected) {
 		$jsonExpectedEncoded = json_encode($jsonExpected->getRaw());
@@ -538,7 +605,8 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @Then the status.php with versions fixed responded should match with
+	 * @Then the status.php response should match with
+	 * @param PyStringNode $jsonExpected
 	 */
 	public function statusPhpRespondedShouldMatch(PyStringNode $jsonExpected) {
 		$jsonExpectedDecoded = json_decode($jsonExpected->getRaw(), true);
@@ -584,6 +652,7 @@ trait BasicStructure {
 
 	/**
 	 * @BeforeSuite
+	 * @param BeforeSuiteScope $scope
 	 */
 	public static function useBigFileIDs(BeforeSuiteScope $scope) {
 		$fullUrl = getenv('TEST_SERVER_URL') . "/v1.php/apps/testing/api/v1/increasefileid";

--- a/tests/integration/features/bootstrap/CalDavContext.php
+++ b/tests/integration/features/bootstrap/CalDavContext.php
@@ -83,11 +83,11 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @When :user requests calendar :calendar
+	 * @When user :user requests calendar :calendar using the API
 	 * @param string $user
 	 * @param string $calendar
 	 */
-	public function requestsCalendar($user, $calendar)  {
+	public function userRequestsCalendarUsingTheAPI($user, $calendar) {
 		$davUrl = $this->baseUrl . '/remote.php/dav/calendars/'.$calendar;
 
 		try {
@@ -107,7 +107,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 * @param int $code
 	 * @throws \Exception
 	 */
-	public function theCaldavHttpStatusCodeShouldBe($code) {
+	public function theCalDavHttpStatusCodeShouldBe($code) {
 		if ((int)$code !== $this->response->getStatusCode()) {
 			throw new \Exception(
 				sprintf(
@@ -127,11 +127,11 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @Then the exception is :message
+	 * @Then the CalDAV exception should be :message
 	 * @param string $message
 	 * @throws \Exception
 	 */
-	public function theExceptionIs($message) {
+	public function theCalDavExceptionShouldBe($message) {
 		$result = $this->responseXml['value'][0]['value'];
 
 		if ($message !== $result) {
@@ -146,11 +146,11 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @Then the error message is :message
+	 * @Then the CalDAV error message should be :message
 	 * @param string $message
 	 * @throws \Exception
 	 */
-	public function theErrorMessageIs($message) {
+	public function theCalDavErrorMessageShouldBe($message) {
 		$result = $this->responseXml['value'][1]['value'];
 
 		if ($message !== $result) {
@@ -165,11 +165,11 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @Given :user creates a calendar named :name
+	 * @Given user :user has successfully created a calendar named :name
 	 * @param string $user
 	 * @param string $name
 	 */
-	public function createsACalendarNamed($user, $name) {
+	public function userHasCreatedACalendarNamed($user, $name) {
 		$davUrl = $this->baseUrl . '/remote.php/dav/calendars/'.$user.'/'.$name;
 
 		$request = $this->client->createRequest(
@@ -182,6 +182,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 		);
 
 		$this->response = $this->client->send($request);
+		$this->theCalDavHttpStatusCodeShouldBe(201);
 	}
 
 }

--- a/tests/integration/features/bootstrap/CapabilitiesContext.php
+++ b/tests/integration/features/bootstrap/CapabilitiesContext.php
@@ -35,7 +35,7 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 	use BasicStructure;
 
 	/**
-	 * @Then /^fields of capabilities match with$/
+	 * @Then the capabilities should contain
 	 * @param \Behat\Gherkin\Node\TableNode|null $formData
 	 * @return void
 	 */

--- a/tests/integration/features/bootstrap/CardDavContext.php
+++ b/tests/integration/features/bootstrap/CardDavContext.php
@@ -83,13 +83,12 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @When :user requests addressbook :addressBook with statuscode :statusCode
+	 * @When user :user requests addressbook :addressBook using the API
 	 * @param string $user
 	 * @param string $addressBook
-	 * @param int $statusCode
 	 * @throws \Exception
 	 */
-	public function requestsAddressbookWithStatuscode($user, $addressBook, $statusCode) {
+	public function userRequestsAddressbookUsingTheAPI($user, $addressBook) {
 		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/'.$addressBook;
 
 		try {
@@ -102,33 +101,15 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
-
-		if((int)$statusCode !== $this->response->getStatusCode()) {
-			throw new \Exception(
-				sprintf(
-					'Expected %s got %s',
-					(int)$statusCode,
-					$this->response->getStatusCode()
-				)
-			);
-		}
-
-		$body = $this->response->getBody()->getContents();
-		if(substr($body, 0, 1) === '<') {
-			$reader = new Sabre\Xml\Reader();
-			$reader->xml($body);
-			$this->responseXml = $reader->parse();
-		}
 	}
 
 	/**
-	 * @Given :user creates an addressbook named :addressBook with statuscode :statusCode
+	 * @Given user :user has successfully created an addressbook named :addressBook
 	 * @param string $user
 	 * @param string $addressBook
-	 * @param int $statusCode
 	 * @throws \Exception
 	 */
-	public function createsAnAddressbookNamedWithStatuscode($user, $addressBook, $statusCode) {
+	public function userHasCreatedAnAddressbookNamed($user, $addressBook) {
 		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/'.$user.'/'.$addressBook;
 
 		$request = $this->client->createRequest(
@@ -153,24 +134,39 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 		);
 
 		$this->response = $this->client->send($request);
+		$this->theCardDavHttpStatusCodeShouldBe(201);
+	}
 
-		if($this->response->getStatusCode() !== (int)$statusCode) {
+	/**
+	 * @Then the CardDAV HTTP status code should be :code
+	 * @param int $code
+	 * @throws \Exception
+	 */
+	public function theCardDavHttpStatusCodeShouldBe($code) {
+		if ((int)$code !== $this->response->getStatusCode()) {
 			throw new \Exception(
 				sprintf(
 					'Expected %s got %s',
-					(int)$statusCode,
+					(int)$code,
 					$this->response->getStatusCode()
 				)
 			);
 		}
+
+		$body = $this->response->getBody()->getContents();
+		if ($body && substr($body, 0, 1) === '<') {
+			$reader = new Sabre\Xml\Reader();
+			$reader->xml($body);
+			$this->responseXml = $reader->parse();
+		}
 	}
 
 	/**
-	 * @When the CardDAV exception is :message
+	 * @Then the CardDAV exception should be :message
 	 * @param string $message
 	 * @throws \Exception
 	 */
-	public function theCarddavExceptionIs($message) {
+	public function theCardDavExceptionShouldBe($message) {
 		$result = $this->responseXml['value'][0]['value'];
 
 		if ($message !== $result) {
@@ -185,11 +181,11 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @When the CardDAV error message is :arg1
+	 * @Then the CardDAV error message should be :arg1
 	 * @param string $message
 	 * @throws \Exception
 	 */
-	public function theCarddavErrorMessageIs($message) {
+	public function theCardDavErrorMessageShouldBe($message) {
 		$result = $this->responseXml['value'][1]['value'];
 
 		if ($message !== $result) {

--- a/tests/integration/features/bootstrap/Checksums.php
+++ b/tests/integration/features/bootstrap/Checksums.php
@@ -7,13 +7,14 @@ use GuzzleHttp\Client;
 trait Checksums {
 
 	/**
-	 * @When user :user uploads file :source to :destination with checksum :checksum
+	 * @When user :user uploads file :source to :destination with checksum :checksum using the API
+	 * @Given user :user has uploaded file :source to :destination with checksum :checksum
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
 	 * @param string $checksum
 	 */
-	public function userUploadsFileToWithChecksum($user, $source, $destination, $checksum) {
+	public function userUploadsFileToWithChecksumUsingTheAPI($user, $source, $destination, $checksum) {
 		$file = \GuzzleHttp\Stream\Stream::factory(fopen($source, 'r'));
 		$this->response = $this->makeDavRequest($user,
 							  'PUT',
@@ -91,27 +92,6 @@ trait Checksums {
 	}
 
 	/**
-	 * @Given user :user copied file :source to :destination
-	 * @param string $user
-	 * @param string $source
-	 * @param string $destination
-	 */
-	public function userCopiedFileTo($user, $source, $destination) {
-		$client = new Client();
-		$request = $client->createRequest(
-			'COPY',
-			substr($this->baseUrl, 0, -4) . $this->davPath . $source,
-			[
-				'auth' => $this->getAuthOptionForUser($user),
-				'headers' => [
-					'Destination' => substr($this->baseUrl, 0, -4) . $this->davPath . $destination,
-				],
-			]
-		);
-		$this->response = $client->send($request);
-	}
-
-	/**
 	 * @Then the webdav checksum should be empty
 	 */
 	public function theWebdavChecksumShouldBeEmpty()
@@ -141,7 +121,8 @@ trait Checksums {
 	}
 
 	/**
-	 * @Given user :user uploads chunk file :num of :total with :data to :destination with checksum :checksum
+	 * @When user :user uploads chunk file :num of :total with :data to :destination with checksum :checksum using the API
+	 * @Given user :user has uploaded chunk file :num of :total with :data to :destination with checksum :checksum
 	 * @param string $user
 	 * @param int $num
 	 * @param int $total

--- a/tests/integration/features/bootstrap/CommandLine.php
+++ b/tests/integration/features/bootstrap/CommandLine.php
@@ -58,7 +58,8 @@ trait CommandLine {
 	}
 
 	/**
-	 * @Given /^invoking occ with "([^"]*)"$/
+	 * @Given /^the administrator has invoked occ command "([^"]*)"$/
+	 * @param string $cmd
 	 */
 	public function invokingTheCommand($cmd) {
 		$args = explode(' ', $cmd);
@@ -105,9 +106,9 @@ trait CommandLine {
 	}
 
 	/**
-	 * @Then /^the command was successful$/
+	 * @Then /^the command should have been successful$/
 	 */
-	public function theCommandWasSuccessful() {
+	public function theCommandShouldHaveBeenSuccessful() {
 		$exceptions = $this->findExceptions();
 		if ($this->lastCode !== 0) {
 			$msg = 'The command was not successful, exit code was ' . $this->lastCode . '.';
@@ -122,7 +123,9 @@ trait CommandLine {
 	}
 
 	/**
-	 * @Then /^the command failed with exit code ([0-9]+)$/
+	 * @Then /^the command should have failed with exit code ([0-9]+)$/
+	 * @param int $exitCode
+	 * @throws Exception
 	 */
 	public function theCommandFailedWithExitCode($exitCode) {
 		if ($this->lastCode !== (int)$exitCode) {
@@ -131,9 +134,11 @@ trait CommandLine {
 	}
 
 	/**
-	 * @Then /^the command failed with exception text "([^"]*)"$/
+	 * @Then /^the command should have failed with exception text "([^"]*)"$/
+	 * @param string $exceptionText
+	 * @throws Exception
 	 */
-	public function theCommandFailedWithException($exceptionText) {
+	public function theCommandFailedWithExceptionText($exceptionText) {
 		$exceptions = $this->findExceptions();
 		if (empty($exceptions)) {
 			throw new \Exception('The command did not throw any exceptions');
@@ -145,7 +150,9 @@ trait CommandLine {
 	}
 
 	/**
-	 * @Then /^the command output contains the text "([^"]*)"$/
+	 * @Then /^the command output should contain the text "([^"]*)"$/
+	 * @param string $text
+	 * @throws Exception
 	 */
 	public function theCommandOutputContainsTheText($text) {
 		$lines = $this->findLines($this->lastStdOut, $text);
@@ -155,7 +162,9 @@ trait CommandLine {
 	}
 
 	/**
-	 * @Then /^the command error output contains the text "([^"]*)"$/
+	 * @Then /^the command error output should contain the text "([^"]*)"$/
+	 * @param string $text
+	 * @throws Exception
 	 */
 	public function theCommandErrorOutputContainsTheText($text) {
 		$lines = $this->findLines($this->lastStdErr, $text);
@@ -166,6 +175,11 @@ trait CommandLine {
 
 	private $lastTransferPath;
 
+	/**
+	 * @param string $sourceUser
+	 * @param string $targetUser
+	 * @return string|null
+	 */
 	private function findLastTransferFolderForUser($sourceUser, $targetUser) {
 		$foundPaths = [];
 		$results = $this->listFolder($targetUser, '', 1);
@@ -200,7 +214,10 @@ trait CommandLine {
 	}
 
 	/**
-	 * @When /^transferring ownership from "([^"]+)" to "([^"]+)"/
+	 * @When /^the administrator transfers ownership from "([^"]+)" to "([^"]+)" using the occ command$/
+	 * @Given /^the administrator has transferred ownership from "([^"]+)" to "([^"]+)"$/
+	 * @param string $user1
+	 * @param string $user2
 	 */
 	public function transferringOwnership($user1, $user2) {
 		if ($this->runOcc(['files:transfer-ownership', $user1, $user2]) === 0) {
@@ -212,16 +229,20 @@ trait CommandLine {
 	}
 
 	/**
-	 * @When /^recreating masterkey by deleting old one and encrypting the filesystem/
+	 * @When /^the administrator successfully recreates the encryption masterkey using the occ command$/
+	 * @Given /^the administrator has successfully recreated the encryption masterkey$/
 	 */
-	public function recreateMasterKey() {
-		if ($this->runOcc(['encryption:recreate-master-key', '-y']) === 0) {
-			return $this->lastCode;
-		}
+	public function recreateMasterKeyUsingOccCommand() {
+		$this->runOcc(['encryption:recreate-master-key', '-y']);
+		$this->theCommandShouldHaveBeenSuccessful();
 	}
 
 	/**
-	 * @When /^transferring ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)"/
+	 * @When /^the administrator transfers ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)" using the occ command$/
+	 * @Given /^the administrator has transferred ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)"$/
+	 * @param string $path
+	 * @param string $user1
+	 * @param string $user2
 	 */
 	public function transferringOwnershipPath($path, $user1, $user2) {
 		$path = '--path=' . $path;
@@ -235,6 +256,7 @@ trait CommandLine {
 
 	/**
 	 * @When /^using received transfer folder of "([^"]+)" as dav path$/
+	 * @param string $user
 	 */
 	public function usingTransferFolderAsDavPath($user) {
 		$davPath = $this->getDavFilesPath($user);

--- a/tests/integration/features/bootstrap/Comments.php
+++ b/tests/integration/features/bootstrap/Comments.php
@@ -34,14 +34,15 @@ trait Comments {
 	private $lastFileId;
 
 	/**
-	 * @When /^user "([^"]*)" comments with content "([^"]*)" on (file|folder) "([^"]*)"$/
+	 * @When /^user "([^"]*)" comments with content "([^"]*)" on (file|folder) "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has commented with content "([^"]*)" on (file|folder) "([^"]*)"$/
 	 * @param string $user
 	 * @param string $content
 	 * @param string $type
 	 * @param string $path
 	 * @throws \Exception
 	 */
-	public function postsAComment($user, $content, $type, $path) {
+	public function userCommentsWithContentOnEntry($user, $content, $type, $path) {
 		$fileId = $this->getFileIdForPath($user, $path);
 		$this->lastFileId = $fileId;
 		$commentsPath = '/comments/files/' . $fileId . '/';
@@ -128,6 +129,11 @@ trait Comments {
 		}
 	}
 
+	/**
+	 * @param string $user
+	 * @param string $fileId
+	 * @param string $commentId
+	 */
 	public function deleteComment($user, $fileId, $commentId) {
 		$commentsPath = '/comments/files/' . $fileId . '/' . $commentId;
 		try {
@@ -144,7 +150,8 @@ trait Comments {
 	}
 
 	/**
-	 * @Then user :user deletes the last created comment
+	 * @When user :user deletes the last created comment using the API
+	 * @Given user :user has deleted the last created comment
 	 * @param string $user
 	 * @throws \Exception
 	 */
@@ -184,6 +191,12 @@ trait Comments {
 		}
 	}
 
+	/**
+	 * @param string $user
+	 * @param string $content
+	 * @param string $fileId
+	 * @param string $commentId
+	 */
 	public function editAComment($user, $content, $fileId, $commentId) {
 		$commentsPath = '/comments/files/' . $fileId . '/' . $commentId;
 		try {
@@ -207,11 +220,10 @@ trait Comments {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" edits last comment with content "([^"]*)"$/
+	 * @When /^user "([^"]*)" edits the last created comment with content "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has edited the last created comment with content "([^"]*)"$/
 	 * @param string $user
 	 * @param string $content
-	 * @param string $type
-	 * @param string $path
 	 * @throws \Exception
 	 */
 	public function userEditsLastCreatedComment($user, $content) {

--- a/tests/integration/features/bootstrap/Federation.php
+++ b/tests/integration/features/bootstrap/Federation.php
@@ -24,7 +24,8 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 trait Federation {
 
 	/**
-	 * @Given /^user "([^"]*)" from server "(LOCAL|REMOTE)" shares "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)"$/
+	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" shares "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)" using the API$/
+	 * @Given /^user "([^"]*)" from server "(LOCAL|REMOTE)" has shared "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)"$/
 	 *
 	 * @param string $sharerUser
 	 * @param string $sharerServer "LOCAL" or "REMOTE"
@@ -49,14 +50,15 @@ trait Federation {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" accepts last pending share$/
+	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" accepts the last pending share using the API$/
+	 * @Given /^user "([^"]*)" from server "(LOCAL|REMOTE)" has accepted the last pending share$/
 	 * @param string $user
 	 * @param string $server
 	 * @return void
 	 */
 	public function acceptLastPendingShare($user, $server) {
 		$previous = $this->usingServer($server);
-		$this->asAn($user);
+		$this->asUser($user);
 		$this->sendingToWith(
 			'GET',
 			"/apps/files_sharing/api/v1/remote_shares/pending",

--- a/tests/integration/features/bootstrap/Provisioning.php
+++ b/tests/integration/features/bootstrap/Provisioning.php
@@ -21,67 +21,126 @@ trait Provisioning {
 	private $createdGroups = [];
 
 	/**
-	 * @Given /^user "([^"]*)" exists$/
+	 * @When /^the administrator creates the user "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has been created$/
 	 * @param string $user
 	 */
-	public function assureUserExists($user) {
+	public function adminCreatesUserUsingTheAPI($user) {
 		if ( !$this->userExists($user) ) {
 			$previous_user = $this->currentUser;
 			$this->currentUser = $this->getAdminUserName();
-			$this->creatingTheUser($user);
+			$this->createTheUserUsingTheAPI($user);
 			$this->currentUser = $previous_user;
 		}
 		PHPUnit_Framework_Assert::assertTrue($this->userExists($user));
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" already exists$/
+	 * @Given /^user "([^"]*)" exists$/
+	 * @param string $user
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
+	 */
+	public function assureUserExists($user) {
+		$this->adminCreatesUserUsingTheAPI($user);
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" should exist$/
 	 * @param string $user
 	 */
-	public function userAlreadyExists($user) {
+	public function userShouldExist($user) {
 		PHPUnit_Framework_Assert::assertTrue($this->userExists($user));
 		$this->rememberTheUser($user);
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" does not already exist$/
+	 * @Then /^user "([^"]*)" already exists$/
+	 * @param string $user
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
+	 */
+	public function userAlreadyExists($user) {
+		$this->userShouldExist($user);
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" should not exist$/
 	 * @param string $user
 	 */
-	public function userDoesNotAlreadyExist($user) {
+	public function userShouldNotExist($user) {
 		PHPUnit_Framework_Assert::assertFalse($this->userExists($user));
 	}
 
 	/**
-	 * @Then /^group "([^"]*)" already exists$/
+	 * @Then /^user "([^"]*)" does not already exist$/
+	 * @param string $user
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
+	 */
+	public function userDoesNotAlreadyExist($user) {
+		$this->userShouldNotExist($user);
+	}
+
+	/**
+	 * @Then /^group "([^"]*)" should exist$/
 	 * @param string $group
 	 */
-	public function groupAlreadyExists($group) {
+	public function groupShouldExist($group) {
 		PHPUnit_Framework_Assert::assertTrue($this->groupExists($group));
 		$this->rememberTheGroup($group);
 	}
 
 	/**
-	 * @Then /^group "([^"]*)" does not already exist$/
+	 * @Then /^group "([^"]*)" already exists$/
+	 * @param string $group
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
+	 */
+	public function groupAlreadyExists($group) {
+		$this->groupShouldExist($group);
+	}
+
+	/**
+	 * @Then /^group "([^"]*)" should not exist$/
 	 * @param string $group
 	 */
-	public function groupDoesNotAlreadyExist($group) {
+	public function groupShouldNotExist($group) {
 		PHPUnit_Framework_Assert::assertFalse($this->groupExists($group));
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" does not exist$/
+	 * @Then /^group "([^"]*)" does not already exist$/
+	 * @param string $group
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
+	 */
+	public function groupDoesNotAlreadyExist($group) {
+		$this->groupShouldNotExist($group);
+	}
+
+	/**
+	 * @When /^the administrator deletes user "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has been deleted$/
 	 * @param string $user
 	 */
-	public function assureUserDoesNotExist($user) {
+	public function adminDeletesUserUsingTheAPI($user) {
 		if ($this->userExists($user)) {
 			$previous_user = $this->currentUser;
 			$this->currentUser = $this->getAdminUserName();
-			$this->deletingTheUser($user);
+			$this->deleteTheUserUsingTheAPI($user);
 			$this->currentUser = $previous_user;
 		}
 		PHPUnit_Framework_Assert::assertFalse($this->userExists($user));
 	}
 
+	/**
+	 * @Given /^user "([^"]*)" does not exist$/
+	 * @param string $user
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
+	 */
+	public function assureUserDoesNotExist($user) {
+		$this->adminDeletesUserUsingTheAPI($user);
+	}
+
+	/**
+	 * @param string $user
+	 */
 	public function rememberTheUser($user) {
 		if ($this->currentServer === 'LOCAL') {
 			$this->createdUsers[$user] = $user;
@@ -90,7 +149,10 @@ trait Provisioning {
 		}
 	}
 
-	public function creatingTheUser($user) {
+	/**
+	 * @param string $user
+	 */
+	public function createTheUserUsingTheAPI($user) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users";
 		$client = new Client();
 		$options = [];
@@ -115,38 +177,54 @@ trait Provisioning {
 		$client->send($client->createRequest('GET', $url, $options2));
 	}
 
+	/**
+	 * @param string $user
+	 */
 	public function createUser($user) {
 		$previous_user = $this->currentUser;
 		$this->currentUser = $this->getAdminUserName();
-		$this->creatingTheUser($user);
+		$this->createTheUserUsingTheAPI($user);
 		PHPUnit_Framework_Assert::assertTrue($this->userExists($user));
 		$this->currentUser = $previous_user;
 	}
 
+	/**
+	 * @param string $user
+	 */
 	public function deleteUser($user) {
 		$previous_user = $this->currentUser;
 		$this->currentUser = $this->getAdminUserName();
-		$this->deletingTheUser($user);
+		$this->deleteTheUserUsingTheAPI($user);
 		PHPUnit_Framework_Assert::assertFalse($this->userExists($user));
 		$this->currentUser = $previous_user;
 	}
 
+	/**
+	 * @param string $group
+	 */
 	public function createGroup($group) {
 		$previous_user = $this->currentUser;
 		$this->currentUser = $this->getAdminUserName();
-		$this->creatingTheGroup($group);
+		$this->createTheGroup($group);
 		PHPUnit_Framework_Assert::assertTrue($this->groupExists($group));
 		$this->currentUser = $previous_user;
 	}
 
+	/**
+	 * @param string $group
+	 */
 	public function deleteGroup($group) {
 		$previous_user = $this->currentUser;
 		$this->currentUser = $this->getAdminUserName();
-		$this->deletingTheGroup($group);
+		$this->deleteTheGroupUsingTheAPI($group);
 		PHPUnit_Framework_Assert::assertFalse($this->groupExists($group));
 		$this->currentUser = $previous_user;
 	}
 
+	/**
+	 * @param string $user
+	 * @return bool
+	 */
 	public function userExists($user) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user";
 		$client = new Client();
@@ -162,17 +240,15 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^check that user "([^"]*)" belongs to group "([^"]*)"$/
+	 * @Then /^user "([^"]*)" should belong to group "([^"]*)"$/
 	 * @param string $user
 	 * @param string $group
 	 */
-	public function checkThatUserBelongsToGroup($user, $group) {
+	public function userShouldBelongToGroup($user, $group) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
-			$options['auth'] = $this->getAuthOptionForAdmin();
-		}
+		$options['auth'] = $this->getAuthOptionForAdmin();
 
 		$this->response = $client->get($fullUrl, $options);
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
@@ -182,17 +258,25 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^check that user "([^"]*)" does not belong to group "([^"]*)"$/
+	 * @Then /^check that user "([^"]*)" belongs to group "([^"]*)"$/
+	 * @param string $user
+	 * @param string $group
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
+	 */
+	public function checkThatUserBelongsToGroup($user, $group) {
+		$this->userShouldBelongToGroup($user, $group);
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" should not belong to group "([^"]*)"$/
 	 * @param string $user
 	 * @param string $group
 	 */
-	public function checkThatUserDoesNotBelongToGroup($user, $group) {
+	public function userShouldNotBelongToGroup($user, $group) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
-			$options['auth'] = $this->getAuthOptionForAdmin();
-		}
+		$options['auth'] = $this->getAuthOptionForAdmin();
 
 		$this->response = $client->get($fullUrl, $options);
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
@@ -201,6 +285,21 @@ trait Provisioning {
 		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
 	}
 
+	/**
+	 * @Then /^check that user "([^"]*)" does not belong to group "([^"]*)"$/
+	 * @param string $user
+	 * @param string $group
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
+	 */
+	public function checkThatUserDoesNotBelongToGroup($user, $group) {
+		$this->userShouldNotBelongToGroup($user, $group);
+	}
+
+	/**
+	 * @param string $user
+	 * @param string $group
+	 * @return bool
+	 */
 	public function userBelongsToGroup($user, $group) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
 		$client = new Client();
@@ -220,40 +319,31 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" belongs to group "([^"]*)"$/
+	 * @When /^the administrator adds user "([^"]*)" to group "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has been added to group "([^"]*)"$/
 	 * @param string $user
 	 * @param string $group
 	 */
-	public function assureUserBelongsToGroup($user, $group) {
+	public function adminAddsUserToGroupUsingTheAPI($user, $group) {
 		$previous_user = $this->currentUser;
 		$this->currentUser = $this->getAdminUserName();
 
 		if (!$this->userBelongsToGroup($user, $group)) {
-			$this->addingUserToGroup($user, $group);
+			$this->addUserToGroupUsingTheAPI($user, $group);
 		}
 
-		$this->checkThatUserBelongsToGroup($user, $group);
+		$this->userShouldBelongToGroup($user, $group);
 		$this->currentUser = $previous_user;
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" does not belong to group "([^"]*)"$/
+	 * @Given /^user "([^"]*)" belongs to group "([^"]*)"$/
 	 * @param string $user
 	 * @param string $group
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
 	 */
-	public function userDoesNotBelongToGroup($user, $group) {
-		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
-		$client = new Client();
-		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
-			$options['auth'] = $this->getAuthOptionForAdmin();
-		}
-
-		$this->response = $client->get($fullUrl, $options);
-		$groups = [$group];
-		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
-		PHPUnit_Framework_Assert::assertNotEquals($groups, $respondedArray, "", 0.0, 10, true);
-		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+	public function assureUserBelongsToGroup($user, $group) {
+		$this->adminAddsUserToGroupUsingTheAPI($user, $group);
 	}
 
 	/**
@@ -268,10 +358,24 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^creating the group "([^"]*)"$/
+	 * @When /^the administrator creates group "([^"]*)" using the API$/
+	 * @Given /^group "([^"]*)" has been created$/
 	 * @param string $group
 	 */
-	public function creatingTheGroup($group) {
+	public function adminCreatesGroupUsingTheAPI($group) {
+		if (!$this->groupExists($group)) {
+			$previous_user = $this->currentUser;
+			$this->currentUser = $this->getAdminUserName();
+			$this->createTheGroup($group);
+			$this->currentUser = $previous_user;
+		}
+		PHPUnit_Framework_Assert::assertTrue($this->groupExists($group));
+	}
+
+	/**
+	 * @param string $group
+	 */
+	public function createTheGroup($group) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/groups";
 		$client = new Client();
 		$options = [];
@@ -280,32 +384,40 @@ trait Provisioning {
 		}
 
 		$options['body'] = [
-							'groupid' => $group,
-							];
+			'groupid' => $group,
+		];
 
 		$this->response = $client->send($client->createRequest("POST", $fullUrl, $options));
 		$this->rememberTheGroup($group);
 	}
 
 	/**
-	 * @When /^assure user "([^"]*)" is disabled$/
+	 * @When /^the administrator disables user "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has been disabled$/
+	 * @param string $user
 	 */
-	public function assureUserIsDisabled($user) {
+	public function adminDisablesUserUsingTheAPI($user) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/disable";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
-			$options['auth'] = $this->getAuthOptionForAdmin();
-		}
+		$options['auth'] = $this->getAuthOptionForAdmin();
 
 		$this->response = $client->send($client->createRequest("PUT", $fullUrl, $options));
 	}
 
 	/**
-	 * @When /^deleting the user "([^"]*)"$/
+	 * @When /^assure user "([^"]*)" is disabled$/
+	 * @param string $user
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
+	 */
+	public function assureUserIsDisabled($user) {
+		$this->adminDisablesUserUsingTheAPI($user);
+	}
+
+	/**
 	 * @param string $user
 	 */
-	public function deletingTheUser($user) {
+	public function deleteTheUserUsingTheAPI($user) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
@@ -317,10 +429,24 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^deleting the group "([^"]*)"$/
+	 * @When /^the administrator deletes group "([^"]*)" using the API$/
+	 * @Given /^group "([^"]*)" has been deleted$/
 	 * @param string $group
 	 */
-	public function deletingTheGroup($group) {
+	public function adminDeletesGroupUsingTheAPI($group) {
+		if ($this->groupExists($group)) {
+			$previous_user = $this->currentUser;
+			$this->currentUser = $this->getAdminUserName();
+			$this->deleteTheGroupUsingTheAPI($group);
+			$this->currentUser = $previous_user;
+		}
+		PHPUnit_Framework_Assert::assertFalse($this->groupExists($group));
+	}
+
+	/**
+	 * @param string $group
+	 */
+	public function deleteTheGroupUsingTheAPI($group) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/groups/$group";
 		$client = new Client();
 		$options = [];
@@ -332,22 +458,10 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^add user "([^"]*)" to the group "([^"]*)"$/
 	 * @param string $user
 	 * @param string $group
 	 */
-	public function addUserToGroup($user, $group) {
-		PHPUnit_Framework_Assert::assertTrue($this->userExists($user));
-		PHPUnit_Framework_Assert::assertTrue($this->groupExists($group));
-		$this->addingUserToGroup($user, $group);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" is added to the group "([^"]*)"$/
-	 * @param string $user
-	 * @param string $group
-	 */
-	public function addingUserToGroup($user, $group) {
+	public function addUserToGroupUsingTheAPI($user, $group) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/groups";
 		$client = new Client();
 		$options = [];
@@ -362,6 +476,10 @@ trait Provisioning {
 		$this->response = $client->send($client->createRequest("POST", $fullUrl, $options));
 	}
 
+	/**
+	 * @param string $group
+	 * @return bool
+	 */
 	public function groupExists($group) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group";
 		$client = new Client();
@@ -379,37 +497,27 @@ trait Provisioning {
 	/**
 	 * @Given /^group "([^"]*)" exists$/
 	 * @param string $group
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
 	 */
 	public function assureGroupExists($group) {
-		if (!$this->groupExists($group)) {
-			$previous_user = $this->currentUser;
-			$this->currentUser = $this->getAdminUserName();
-			$this->creatingTheGroup($group);
-			$this->currentUser = $previous_user;
-		}
-		PHPUnit_Framework_Assert::assertTrue($this->groupExists($group));
+		$this->adminCreatesGroupUsingTheAPI($group);
 	}
 
 	/**
 	 * @Given /^group "([^"]*)" does not exist$/
 	 * @param string $group
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
 	 */
 	public function assureGroupDoesNotExist($group) {
-		if ($this->groupExists($group)) {
-			$previous_user = $this->currentUser;
-			$this->currentUser = $this->getAdminUserName();
-			$this->deletingTheGroup($group);
-			$this->currentUser = $previous_user;
-		}
-		PHPUnit_Framework_Assert::assertFalse($this->groupExists($group));
+		$this->adminDeletesGroupUsingTheAPI($group);
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" is subadmin of group "([^"]*)"$/
+	 * @Then /^user "([^"]*)" should be a subadmin of group "([^"]*)"$/
 	 * @param string $user
 	 * @param string $group
 	 */
-	public function userIsSubadminOfGroup($user, $group) {
+	public function userShouldBeSubadminOfGroup($user, $group) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group/subadmins";
 		$client = new Client();
 		$options = [];
@@ -425,17 +533,16 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^assure user "([^"]*)" is subadmin of group "([^"]*)"$/
+	 * @When /^the administrator makes user "([^"]*)" a subadmin of group "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has been made a subadmin of group "([^"]*)"$/
 	 * @param string $user
 	 * @param string $group
 	 */
-	public function assureUserIsSubadminOfGroup($user, $group) {
+	public function adminMakesUserSubadminOfGroupUsingTheAPI($user, $group) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/subadmins";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
-			$options['auth'] = $this->getAuthOptionForAdmin();
-		}
+		$options['auth'] = $this->getAuthOptionForAdmin();
 		$options['body'] = [
 							'groupid' => $group
 							];
@@ -444,11 +551,22 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" is not a subadmin of group "([^"]*)"$/
+	 * @Given /^assure user "([^"]*)" is subadmin of group "([^"]*)"$/
+	 * @param string $user
+	 * @param string $group
+	 * @deprecated This step is not according to the latest standard - core usages have been changed
+	 */
+	public function assureUserIsSubadminOfGroup($user, $group) {
+		$this->adminMakesUserSubadminOfGroupUsingTheAPI($user, $group);
+	}
+
+	/**
+	 * @When /^the administrator makes user "([^"]*)" not a subadmin of group "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has been made not a subadmin of group "([^"]*)"$/
 	 * @param string $user
 	 * @param string $group
 	 */
-	public function userIsNotSubadminOfGroup($user, $group) {
+	public function adminMakesUserNotSubadminOfGroupUsingTheAPI($user, $group) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group/subadmins";
 		$client = new Client();
 		$options = [];
@@ -464,7 +582,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^users returned are$/
+	 * @Then /^the users returned by the API should be$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $usersList
 	 */
 	public function theUsersShouldBe($usersList) {
@@ -478,7 +596,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^groups returned are$/
+	 * @Then /^the groups returned by the API should be$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $groupsList
 	 */
 	public function theGroupsShouldBe($groupsList) {
@@ -492,40 +610,42 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^subadmin groups returned are$/
+	 * @param \Behat\Gherkin\Node\TableNode|null $groupsOrUsersList
+	 */
+	public function checkSubadminGroupsOrUsersTable($groupsOrUsersList) {
+		$tableRows = $groupsOrUsersList->getRows();
+		$simplifiedTableRows = $this->simplifyArray($tableRows);
+		$respondedArray = $this->getArrayOfSubadminsResponded($this->response);
+		PHPUnit_Framework_Assert::assertEquals($simplifiedTableRows, $respondedArray, "", 0.0, 10, true);
+	}
+
+	/**
+	 * @Then /^the subadmin groups returned by the API should be$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $groupsList
 	 */
 	public function theSubadminGroupsShouldBe($groupsList) {
-		if ($groupsList instanceof \Behat\Gherkin\Node\TableNode) {
-			$groups = $groupsList->getRows();
-			$groupsSimplified = $this->simplifyArray($groups);
-			$respondedArray = $this->getArrayOfSubadminsResponded($this->response);
-			PHPUnit_Framework_Assert::assertEquals($groupsSimplified, $respondedArray, "", 0.0, 10, true);
-		}
-
+		$this->checkSubadminGroupsOrUsersTable($groupsList);
 	}
 
 	/**
-	 * @Then /^apps returned are$/
+	 * @Then /^the subadmin users returned by the API should be$/
+	 * @param \Behat\Gherkin\Node\TableNode|null $usersList
+	 */
+	public function theSubadminUsersShouldBe($usersList) {
+		$this->checkSubadminGroupsOrUsersTable($usersList);
+	}
+
+	/**
+	 * @Then /^the apps returned by the API should include$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $appList
 	 */
-	public function theAppsShouldBe($appList) {
-		if ($appList instanceof \Behat\Gherkin\Node\TableNode) {
-			$apps = $appList->getRows();
-			$appsSimplified = $this->simplifyArray($apps);
-			$respondedArray = $this->getArrayOfAppsResponded($this->response);
-			foreach ($appsSimplified as $app) {
-				PHPUnit_Framework_Assert::assertContains($app, $respondedArray);
-			}
+	public function theAppsShouldInclude($appList) {
+		$apps = $appList->getRows();
+		$appsSimplified = $this->simplifyArray($apps);
+		$respondedArray = $this->getArrayOfAppsResponded($this->response);
+		foreach ($appsSimplified as $app) {
+			PHPUnit_Framework_Assert::assertContains($app, $respondedArray);
 		}
-	}
-
-	/**
-	 * @Then /^subadmin users returned are$/
-	 * @param \Behat\Gherkin\Node\TableNode|null $groupsList
-	 */
-	public function theSubadminUsersShouldBe($groupsList) {
-		$this->theSubadminGroupsShouldBe($groupsList);
 	}
 
 	/**
@@ -572,12 +692,11 @@ trait Provisioning {
 		return $extractedElementsArray;
 	}
 
-
 	/**
-	 * @Given /^app "([^"]*)" is disabled$/
+	 * @Then /^app "([^"]*)" should be disabled$/
 	 * @param string $app
 	 */
-	public function appIsDisabled($app) {
+	public function appShouldBeDisabled($app) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/apps?filter=disabled";
 		$client = new Client();
 		$options = [];
@@ -592,10 +711,10 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^app "([^"]*)" is enabled$/
+	 * @Then /^app "([^"]*)" should be enabled$/
 	 * @param string $app
 	 */
-	public function appIsEnabled($app) {
+	public function appShouldBeEnabled($app) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/apps?filter=enabled";
 		$client = new Client();
 		$options = [];
@@ -610,61 +729,62 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" is disabled$/
+	 * @Then /^user "([^"]*)" should be disabled$/
 	 * @param string $user
 	 */
-	public function userIsDisabled($user) {
+	public function userShouldBeDisabled($user) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
-			$options['auth'] = $this->getAuthOptionForAdmin();
-		}
+		$options['auth'] = $this->getAuthOptionForAdmin();
 
 		$this->response = $client->get($fullUrl, $options);
 		PHPUnit_Framework_Assert::assertEquals("false", $this->response->xml()->data[0]->enabled);
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" is enabled$/
+	 * @Then /^user "([^"]*)" should be enabled$/
 	 * @param string $user
 	 */
-	public function userIsEnabled($user) {
+	public function useShouldBeEnabled($user) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
-			$options['auth'] = $this->getAuthOptionForAdmin();
-		}
+		$options['auth'] = $this->getAuthOptionForAdmin();
 
 		$this->response = $client->get($fullUrl, $options);
 		PHPUnit_Framework_Assert::assertEquals("true", $this->response->xml()->data[0]->enabled);
 	}
 
 	/**
-	 * @Given user :user has a quota of :quota
+	 * @When the administrator sets the quota of user :user to :quota using the API
+	 * @Given the quota of user :user has been set to :quota
 	 * @param string $user
 	 * @param string $quota
 	 */
-	public function userHasAQuotaOf($user, $quota)
+	public function adminSetsUserQuotaToUsingTheAPI($user, $quota)
 	{
 		$body = new \Behat\Gherkin\Node\TableNode([
 			0 => ['key', 'quota'],
 			1 => ['value', $quota],
 		]);
 
+		$previous_user = $this->currentUser;
+		$this->currentUser = "admin";
 		// method used from BasicStructure trait
 		$this->sendingToWith("PUT", "/cloud/users/" . $user, $body);
+		$this->currentUser = $previous_user;
 		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
 	}
 
 	/**
-	 * @Given user :user has unlimited quota
+	 * @When the administrator gives unlimited quota to user :user using the API
+	 * @Given user :user has been given unlimited quota
 	 * @param string $user
 	 */
-	public function userHasUnlimitedQuota($user)
+	public function adminGivesUnlimitedQuotaToUserUsingTheAPI($user)
 	{
-		$this->userHasAQuotaOf($user, 'none');
+		$this->adminSetsUserQuotaToUsingTheAPI($user, 'none');
 	}
 
 	/**
@@ -681,17 +801,15 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^user attributes match with$/
+	 * @Then /^the user attributes returned by the API should include$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
 	 */
 	public function checkUserAttributes($body) {
 		$data = $this->response->xml()->data[0];
-		if ($body instanceof \Behat\Gherkin\Node\TableNode) {
-			$fd = $body->getRowsHash();
-			foreach ($fd as $field => $value) {
-				if ($data->$field != $value) {
-					PHPUnit_Framework_Assert::fail("$field" . " has value " . "$data->$field");
-				}
+		$fd = $body->getRowsHash();
+		foreach ($fd as $field => $value) {
+			if ($data->$field != $value) {
+				PHPUnit_Framework_Assert::fail("$field" . " has value " . "$data->$field");
 			}
 		}
 	}

--- a/tests/integration/features/bootstrap/Provisioning.php
+++ b/tests/integration/features/bootstrap/Provisioning.php
@@ -36,15 +36,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" exists$/
-	 * @param string $user
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function assureUserExists($user) {
-		$this->adminCreatesUserUsingTheAPI($user);
-	}
-
-	/**
 	 * @Then /^user "([^"]*)" should exist$/
 	 * @param string $user
 	 */
@@ -54,29 +45,11 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" already exists$/
-	 * @param string $user
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function userAlreadyExists($user) {
-		$this->userShouldExist($user);
-	}
-
-	/**
 	 * @Then /^user "([^"]*)" should not exist$/
 	 * @param string $user
 	 */
 	public function userShouldNotExist($user) {
 		PHPUnit_Framework_Assert::assertFalse($this->userExists($user));
-	}
-
-	/**
-	 * @Then /^user "([^"]*)" does not already exist$/
-	 * @param string $user
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function userDoesNotAlreadyExist($user) {
-		$this->userShouldNotExist($user);
 	}
 
 	/**
@@ -89,29 +62,11 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^group "([^"]*)" already exists$/
-	 * @param string $group
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function groupAlreadyExists($group) {
-		$this->groupShouldExist($group);
-	}
-
-	/**
 	 * @Then /^group "([^"]*)" should not exist$/
 	 * @param string $group
 	 */
 	public function groupShouldNotExist($group) {
 		PHPUnit_Framework_Assert::assertFalse($this->groupExists($group));
-	}
-
-	/**
-	 * @Then /^group "([^"]*)" does not already exist$/
-	 * @param string $group
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function groupDoesNotAlreadyExist($group) {
-		$this->groupShouldNotExist($group);
 	}
 
 	/**
@@ -127,15 +82,6 @@ trait Provisioning {
 			$this->currentUser = $previous_user;
 		}
 		PHPUnit_Framework_Assert::assertFalse($this->userExists($user));
-	}
-
-	/**
-	 * @Given /^user "([^"]*)" does not exist$/
-	 * @param string $user
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function assureUserDoesNotExist($user) {
-		$this->adminDeletesUserUsingTheAPI($user);
 	}
 
 	/**
@@ -258,16 +204,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Then /^check that user "([^"]*)" belongs to group "([^"]*)"$/
-	 * @param string $user
-	 * @param string $group
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function checkThatUserBelongsToGroup($user, $group) {
-		$this->userShouldBelongToGroup($user, $group);
-	}
-
-	/**
 	 * @Then /^user "([^"]*)" should not belong to group "([^"]*)"$/
 	 * @param string $user
 	 * @param string $group
@@ -283,16 +219,6 @@ trait Provisioning {
 		sort($respondedArray);
 		PHPUnit_Framework_Assert::assertNotContains($group, $respondedArray);
 		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
-	}
-
-	/**
-	 * @Then /^check that user "([^"]*)" does not belong to group "([^"]*)"$/
-	 * @param string $user
-	 * @param string $group
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function checkThatUserDoesNotBelongToGroup($user, $group) {
-		$this->userShouldNotBelongToGroup($user, $group);
 	}
 
 	/**
@@ -334,16 +260,6 @@ trait Provisioning {
 
 		$this->userShouldBelongToGroup($user, $group);
 		$this->currentUser = $previous_user;
-	}
-
-	/**
-	 * @Given /^user "([^"]*)" belongs to group "([^"]*)"$/
-	 * @param string $user
-	 * @param string $group
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function assureUserBelongsToGroup($user, $group) {
-		$this->adminAddsUserToGroupUsingTheAPI($user, $group);
 	}
 
 	/**
@@ -403,15 +319,6 @@ trait Provisioning {
 		$options['auth'] = $this->getAuthOptionForAdmin();
 
 		$this->response = $client->send($client->createRequest("PUT", $fullUrl, $options));
-	}
-
-	/**
-	 * @When /^assure user "([^"]*)" is disabled$/
-	 * @param string $user
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function assureUserIsDisabled($user) {
-		$this->adminDisablesUserUsingTheAPI($user);
 	}
 
 	/**
@@ -495,24 +402,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^group "([^"]*)" exists$/
-	 * @param string $group
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function assureGroupExists($group) {
-		$this->adminCreatesGroupUsingTheAPI($group);
-	}
-
-	/**
-	 * @Given /^group "([^"]*)" does not exist$/
-	 * @param string $group
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function assureGroupDoesNotExist($group) {
-		$this->adminDeletesGroupUsingTheAPI($group);
-	}
-
-	/**
 	 * @Then /^user "([^"]*)" should be a subadmin of group "([^"]*)"$/
 	 * @param string $user
 	 * @param string $group
@@ -548,16 +437,6 @@ trait Provisioning {
 							];
 		$this->response = $client->send($client->createRequest("POST", $fullUrl, $options));
 		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
-	}
-
-	/**
-	 * @Given /^assure user "([^"]*)" is subadmin of group "([^"]*)"$/
-	 * @param string $user
-	 * @param string $group
-	 * @deprecated This step is not according to the latest standard - core usages have been changed
-	 */
-	public function assureUserIsSubadminOfGroup($user, $group) {
-		$this->adminMakesUserSubadminOfGroupUsingTheAPI($user, $group);
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/ShareesContext.php
+++ b/tests/integration/features/bootstrap/ShareesContext.php
@@ -35,11 +35,21 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 	use BasicStructure;
 
 	/**
-	 * @When /^getting sharees for$/
+	 * @When /^the user gets the sharees using the API with parameters$/
 	 * @param \Behat\Gherkin\Node\TableNode $body
 	 * @return void
 	 */
-	public function whenGettingShareesFor($body) {
+	public function theUserGetsTheShareesWithParameters($body) {
+		$this->userGetsTheShareesWithParameters($this->currentUser, $body);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" gets the sharees using the API with parameters$/
+	 * @param string $user
+	 * @param \Behat\Gherkin\Node\TableNode $body
+	 * @return void
+	 */
+	public function userGetsTheShareesWithParameters($user, $body) {
 		$url = '/apps/files_sharing/api/v1/sharees';
 		if ($body instanceof \Behat\Gherkin\Node\TableNode) {
 			$parameters = [];
@@ -51,29 +61,35 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 			}
 		}
 
-		$this->sendingTo('GET', $url);
+		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+			$user, 'GET', $url, null
+		);
 	}
 
 	/**
-	 * @Then /^"([^"]*)" sharees returned (are|is empty)$/
+	 * @Then /^the "([^"]*)" sharees returned should be$/
 	 * @param string $shareeType
-	 * @param string $isEmpty
-	 * @param \Behat\Gherkin\Node\TableNode|null $shareesList
+	 * @param \Behat\Gherkin\Node\TableNode $shareesList
 	 * @return void
 	 */
-	public function thenListOfSharees($shareeType, $isEmpty, $shareesList = null) {
-		if ($isEmpty !== 'is empty') {
-			$sharees = $shareesList->getRows();
-			$respondedArray = $this->getArrayOfShareesResponded(
-				$this->response, $shareeType
-			);
-			PHPUnit_Framework_Assert::assertEquals($sharees, $respondedArray);
-		} else {
-			$respondedArray = $this->getArrayOfShareesResponded(
-				$this->response, $shareeType
-			);
-			PHPUnit_Framework_Assert::assertEmpty($respondedArray);
-		}
+	public function theShareesReturnedShouldBe($shareeType, $shareesList) {
+		$sharees = $shareesList->getRows();
+		$respondedArray = $this->getArrayOfShareesResponded(
+			$this->response, $shareeType
+		);
+		PHPUnit_Framework_Assert::assertEquals($sharees, $respondedArray);
+	}
+
+	/**
+	 * @Then /^the "([^"]*)" sharees returned should be empty$/
+	 * @param string $shareeType
+	 * @return void
+	 */
+	public function theShareesReturnedShouldBeEmpty($shareeType) {
+		$respondedArray = $this->getArrayOfShareesResponded(
+			$this->response, $shareeType
+		);
+		PHPUnit_Framework_Assert::assertEmpty($respondedArray);
 	}
 
 	/**

--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -630,26 +630,6 @@ trait Sharing {
 	public function userSharesFileWithUserUsingTheAPI(
 		$user1, $entry, $filepath, $user2, $withPerms = null, $permissions = null
 	) {
-		$this->fileOfUserHasBeenSharedWithUser(
-			$entry, $filepath, $user1, $user2, $withPerms, $permissions
-		);
-	}
-
-	/**
-	 * @Given /^(file|folder|entry) "([^"]*)" of user "([^"]*)" has been shared with user "([^"]*)"( with permissions ([\d]*))?$/
-	 *
-	 * @param string $entry unused
-	 * @param string $filepath
-	 * @param string $user1
-	 * @param string $user2
-	 * @param null $withPerms unused
-	 * @param int $permissions
-	 * @deprecated prefer using the gherkin forms for userSharesFileWithUserUsingTheAPI()
-	 * @return void
-	 */
-	public function fileOfUserHasBeenSharedWithUser(
-		$entry, $filepath, $user1, $user2, $withPerms = null, $permissions = null
-	) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
 		$client = new Client();
 		$options = [];
@@ -700,7 +680,7 @@ trait Sharing {
 	 * @When /^user "([^"]*)" shares (file|folder|entry) "([^"]*)" with group "([^"]*)"( with permissions ([\d]*))? using the API$/
 	 * @Given /^user "([^"]*)" has shared (file|folder|entry) "([^"]*)" with group "([^"]*)"( with permissions ([\d]*))?$/
 	 *
-	 * @param string $user1
+	 * @param string $user
 	 * @param string $entry unused
 	 * @param string $filepath
 	 * @param string $group
@@ -709,27 +689,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function userSharesFileWithGroupUsingTheAPI(
-		$user1, $entry, $filepath, $group, $withPerms = null, $permissions = null
-	) {
-		$this->fileOfUserHasBeenSharedWithGroup(
-			$entry, $filepath, $user1, $group, $withPerms, $permissions
-		);
-	}
-
-	/**
-	 * @Given /^(file|folder|entry) "([^"]*)" of user "([^"]*)" has been shared with group "([^"]*)"( with permissions ([\d]*))?$/
-	 *
-	 * @param string $entry unused
-	 * @param string $filepath
-	 * @param string $user
-	 * @param string $group
-	 * @param null $withPerms unused
-	 * @param int $permissions
-	 * @deprecated prefer using the gherkin forms for userSharesFileWithGroupUsingTheAPI()
-	 * @return void
-	 */
-	public function fileOfUserHasBeenSharedWithGroup(
-		$entry, $filepath, $user, $group, $withPerms = null, $permissions = null
+		$user, $entry, $filepath, $group, $withPerms = null, $permissions = null
 	) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
 		$client = new Client();

--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -54,12 +54,13 @@ trait Sharing {
 	private $lastShareTime = null;
 
 	/**
-	 * @Given /^as "([^"]*)" creating a share with$/
+	 * @When /^user "([^"]*)" creates a share using the API with settings$/
+	 * @Given /^user "([^"]*)" has created a share with settings$/
 	 * @param string $user
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
 	 * @return void
 	 */
-	public function asCreatingAShareWith($user, $body) {
+	public function userCreatesAShareWithSettings($user, $body) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
 		$client = new Client();
 		$options = [];
@@ -86,12 +87,23 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^creating a share with$/
+	 * @When /^the user creates a share using the API with settings$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
 	 * @return void
 	 */
-	public function creatingShare($body) {
-		$this->asCreatingAShareWith($this->currentUser, $body);
+	public function theUserCreatesAShareWithSettings($body) {
+		$this->userCreatesAShareWithSettings($this->currentUser, $body);
+	}
+
+	/**
+	 * @Given /^the user has created a share with settings$/
+	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 * @return void
+	 */
+	public function theUserHasCreatedAShareWithSettings($body) {
+		$this->userCreatesAShareWithSettings($this->currentUser, $body);
+		$this->theOCSStatusCodeShouldBe(100);
+		$this->theHTTPStatusCodeShouldBe(200);
 	}
 
 	/**
@@ -125,7 +137,8 @@ trait Sharing {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)"$/
+	 * @When /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has created a public share of (?:file|folder) "([^"]*)"$/
 	 * @param string $user
 	 * @param string $path
 	 * @return void
@@ -135,7 +148,8 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^a public share of (?:file|folder) "([^"]*)" is created/
+	 * @When /^the user creates a public share of (?:file|folder) "([^"]*)" using the API$/
+	 * @Given /^the user has created a public share of (?:file|folder) "([^"]*)"$/
 	 * @param string $path
 	 * @return void
 	 */
@@ -144,9 +158,11 @@ trait Sharing {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 * @When /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)" using the API with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 * @Given /^user "([^"]*)" has created a public share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|share|all) permission(?:s|)$/
 	 * @param string $user
 	 * @param string $path
+	 * @param string|int|string[]|int[]|null $permissions
 	 * @return void
 	 */
 	public function userCreatesAPublicShareOfWithPermission($user, $path, $permissions) {
@@ -154,8 +170,10 @@ trait Sharing {
 	}
 
 	/**
-	 * @Given /^a public share of (?:file|folder) "([^"]*)" is created with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 * @When /^the user creates a public share of (?:file|folder) "([^"]*)" using the API with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 * @Given /^the user has created a public share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|share|all) permission(?:s|)$/
 	 * @param string $path
+	 * @param string|int|string[]|int[]|null $permissions
 	 * @return void
 	 */
 	public function aPublicShareOfIsCreatedWithPermission($path, $permissions) {
@@ -163,11 +181,11 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^public shared file "([^"]*)" cannot be downloaded$/
+	 * @Then /^the public shared file "([^"]*)" should not be able to be downloaded$/
 	 * @param string $path
 	 * @return void
 	 */
-	public function publicSharedFileCannotDownload($path) {
+	public function publicSharedFileCannotBeDownloaded($path) {
 		$token = $this->getLastShareToken();
 		$fullUrl = substr($this->baseUrl, 0, -4) . "public.php/webdav/" . rawurlencode(ltrim($path, '/'));
 
@@ -189,11 +207,10 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^public shared file "([^"]*)" can be downloaded$/
-	 * @param string $filename unused
+	 * @Then /^the last public shared file should be able to be downloaded without a password$/
 	 * @return void
 	 */
-	public function checkPublicSharedFile($filename) {
+	public function checkLastPublicSharedFileDownload() {
 		if (count($this->lastShareData->data->element) > 0) {
 			$url = $this->lastShareData->data[0]->url;
 		} else {
@@ -204,12 +221,12 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^public shared file "([^"]*)" with password "([^"]*)" can be downloaded$/
+	 * @Then /^the last public shared file should be able to be downloaded with password "([^"]*)"$/
 	 * @param string $filename unused
 	 * @param string $password
 	 * @return void
 	 */
-	public function checkPublicSharedFileWithPassword($filename, $password) {
+	public function checkLastPublicSharedFileWithPasswordDownload($password) {
 		$token = $this->getLastShareToken();
 		$fullUrl = substr($this->baseUrl, 0, -4) . "public.php/webdav";
 		$this->checkDownload($fullUrl, [$token, $password], 'text/plain');
@@ -252,7 +269,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When publicly uploading file ":filename" with content ":body"
+	 * @Given the public has uploaded file ":filename" with content ":body"
 	 * @param string $filename target file name
 	 * @param string $body content to upload
 	 * @return void
@@ -262,7 +279,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When publicly overwriting file ":filename" with content ":body"
+	 * @When the public overwrites file ":filename" with content ":body" using the API
 	 * @param string $filename target file name
 	 * @param string $body content to upload
 	 * @return void
@@ -272,7 +289,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When publicly uploading file ":filename" with password ":password" and content ":body"
+	 * @Given the public has uploaded file ":filename" with password ":password" and content ":body"
 	 * @param string $filename target file name
 	 * @param string $password
 	 * @param string $body content to upload
@@ -285,7 +302,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When publicly uploading file ":filename" with content ":body" with autorename mode
+	 * @Given the public has uploaded file ":filename" with content ":body" with autorename mode
 	 * @param string $filename target file name
 	 * @param string $body content to upload
 	 * @return void
@@ -295,10 +312,10 @@ trait Sharing {
 	}
 
 	/**
-	 * @When publicly uploading a file does not work
+	 * @Then publicly uploading a file should not work
 	 * @return void
 	 */
-	public function publiclyUploadingDoesNotWork() {
+	public function publiclyUploadingShouldNotWork() {
 		try {
 			$this->publicUploadContent('whateverfilefortesting.txt', '', 'test');
 			PHPUnit_Framework_Assert::fail('Publicly uploading must fail');
@@ -348,10 +365,10 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^adding expiration date to last share$/
+	 * @When /^the user adds an expiration date to the last share using the API$/
 	 * @return void
 	 */
-	public function addingExpirationDate() {
+	public function theUserAddsExpirationDateToLastShare() {
 		$share_id = (string) $this->lastShareData->data[0]->id;
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
 		$client = new Client();
@@ -369,16 +386,28 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^updating last share with$/
+	 * @When /^the user updates the last share using the API with$/
+	 * @Given /^the user has updated the last share with$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
 	 * @return void
 	 */
-	public function updatingLastShare($body) {
+	public function theUserUpdatesTheLastShareWith($body) {
+		$this->userUpdatesTheLastShareWith($this->currentUser, $body);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" updates the last share using the API with$/
+	 * @Given /^user "([^"]*)" has updated the last share with$/
+	 * @param string $user
+	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 * @return void
+	 */
+	public function userUpdatesTheLastShareWith($user, $body) {
 		$share_id = (string) $this->lastShareData->data[0]->id;
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
 		$client = new Client();
 		$options = [];
-		$options['auth'] = $this->getAuthOptionForUser($this->currentUser);
+		$options['auth'] = $this->getAuthOptionForUser($user);
 
 		if ($body instanceof \Behat\Gherkin\Node\TableNode) {
 			$fd = $body->getRowsHash();
@@ -587,7 +616,27 @@ trait Sharing {
 	}
 
 	/**
-	 * @Given /^(file|folder|entry) "([^"]*)" of user "([^"]*)" is shared with user "([^"]*)"( with permissions ([\d]*))?$/
+	 * @When /^user "([^"]*)" shares (file|folder|entry) "([^"]*)" with user "([^"]*)"( with permissions ([\d]*))? using the API$/
+	 * @Given /^user "([^"]*)" has shared (file|folder|entry) "([^"]*)" with user "([^"]*)"( with permissions ([\d]*))?$/
+	 *
+	 * @param string $user1
+	 * @param string $entry unused
+	 * @param string $filepath
+	 * @param string $user2
+	 * @param null $withPerms unused
+	 * @param int $permissions
+	 * @return void
+	 */
+	public function userSharesFileWithUserUsingTheAPI(
+		$user1, $entry, $filepath, $user2, $withPerms = null, $permissions = null
+	) {
+		$this->fileOfUserHasBeenSharedWithUser(
+			$entry, $filepath, $user1, $user2, $withPerms, $permissions
+		);
+	}
+
+	/**
+	 * @Given /^(file|folder|entry) "([^"]*)" of user "([^"]*)" has been shared with user "([^"]*)"( with permissions ([\d]*))?$/
 	 *
 	 * @param string $entry unused
 	 * @param string $filepath
@@ -595,9 +644,10 @@ trait Sharing {
 	 * @param string $user2
 	 * @param null $withPerms unused
 	 * @param int $permissions
+	 * @deprecated prefer using the gherkin forms for userSharesFileWithUserUsingTheAPI()
 	 * @return void
 	 */
-	public function assureFileIsShared(
+	public function fileOfUserHasBeenSharedWithUser(
 		$entry, $filepath, $user1, $user2, $withPerms = null, $permissions = null
 	) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
@@ -621,14 +671,53 @@ trait Sharing {
 			);
 		}
 		$this->response = $client->get($fullUrl, $options);
-		PHPUnit_Framework_Assert::assertEquals(
-			true,
-			$this->isUserOrGroupInSharedData($user2, $permissions)
+		PHPUnit_Framework_Assert::assertTrue(
+			$this->isUserOrGroupInSharedData($user2, $permissions),
+			"User $user1 failed to share $filepath with user $user2"
 		);
 	}
 
 	/**
-	 * @Given /^(file|folder|entry) "([^"]*)" of user "([^"]*)" is shared with group "([^"]*)"( with permissions ([\d]*))?$/
+	 * @When /^the user shares (file|folder|entry) "([^"]*)" with group "([^"]*)"( with permissions ([\d]*))? using the API$/
+	 * @Given /^the user has shared (file|folder|entry) "([^"]*)" with group "([^"]*)"( with permissions ([\d]*))?$/
+	 *
+	 * @param string $entry unused
+	 * @param string $filepath
+	 * @param string $group
+	 * @param null $withPerms unused
+	 * @param int $permissions
+	 * @return void
+	 */
+	public function theUserSharesFileWithGroupUsingTheAPI(
+		$entry, $filepath, $group, $withPerms = null, $permissions = null
+	) {
+		$this->userSharesFileWithGroupUsingTheAPI(
+			$this->currentUser, $entry, $filepath, $group, $withPerms, $permissions
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" shares (file|folder|entry) "([^"]*)" with group "([^"]*)"( with permissions ([\d]*))? using the API$/
+	 * @Given /^user "([^"]*)" has shared (file|folder|entry) "([^"]*)" with group "([^"]*)"( with permissions ([\d]*))?$/
+	 *
+	 * @param string $user1
+	 * @param string $entry unused
+	 * @param string $filepath
+	 * @param string $group
+	 * @param null $withPerms unused
+	 * @param int $permissions
+	 * @return void
+	 */
+	public function userSharesFileWithGroupUsingTheAPI(
+		$user1, $entry, $filepath, $group, $withPerms = null, $permissions = null
+	) {
+		$this->fileOfUserHasBeenSharedWithGroup(
+			$entry, $filepath, $user1, $group, $withPerms, $permissions
+		);
+	}
+
+	/**
+	 * @Given /^(file|folder|entry) "([^"]*)" of user "([^"]*)" has been shared with group "([^"]*)"( with permissions ([\d]*))?$/
 	 *
 	 * @param string $entry unused
 	 * @param string $filepath
@@ -636,9 +725,10 @@ trait Sharing {
 	 * @param string $group
 	 * @param null $withPerms unused
 	 * @param int $permissions
+	 * @deprecated prefer using the gherkin forms for userSharesFileWithGroupUsingTheAPI()
 	 * @return void
 	 */
-	public function assureFileIsSharedWithGroup(
+	public function fileOfUserHasBeenSharedWithGroup(
 		$entry, $filepath, $user, $group, $withPerms = null, $permissions = null
 	) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
@@ -661,27 +751,46 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^deleting last share$/
+	 * @When /^the user deletes the last share using the API$/
 	 * @return void
 	 */
-	public function deletingLastShare() {
-		$share_id = $this->lastShareData->data[0]->id;
-		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
-		$this->sendingToWith("DELETE", $url, null);
+	public function theUserDeletesLastShareUsingTheAPI() {
+		$this->userDeletesLastShareUsingTheAPI($this->currentUser);
 	}
 
 	/**
-	 * @When /^getting info of last share$/
+	 * @When /^user "([^"]*)" deletes the last share using the API$/
+	 * @Given /^user "([^"]*)" has deleted the last share$/
+	 * @param string $user
 	 * @return void
 	 */
-	public function gettingInfoOfLastShare() {
+	public function userDeletesLastShareUsingTheAPI($user) {
 		$share_id = $this->lastShareData->data[0]->id;
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
-		$this->sendingToWith("GET", $url, null);
+		$this->userSendsHTTPMethodToAPIEndpointWithBody($user, "DELETE", $url, null);
 	}
 
 	/**
-	 * @Then /^last share_id is included in the answer$/
+	 * @When /^the user gets the info of the last share using the API$/
+	 * @return void
+	 */
+	public function theUserGetsInfoOfLastShareUsingTheAPI() {
+		$this->userGetsInfoOfLastShareUsingTheAPI($this->currentUser);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" gets the info of the last share using the API$/
+	 * @param string $user
+	 * @return void
+	 */
+	public function userGetsInfoOfLastShareUsingTheAPI($user) {
+		$share_id = $this->lastShareData->data[0]->id;
+		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
+		$this->userSendsHTTPMethodToAPIEndpointWithBody($user, "GET", $url, null);
+	}
+
+	/**
+	 * @Then /^the last share_id should be included in the response/
 	 * @return void
 	 */
 	public function checkingLastShareIDIsIncluded() {
@@ -694,7 +803,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^last share_id is not included in the answer$/
+	 * @Then /^the last share_id should not be included in the response/
 	 * @return void
 	 */
 	public function checkingLastShareIDIsNotIncluded() {
@@ -707,7 +816,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^the response contains ([0-9]+) entries$/
+	 * @Then /^the response should contain ([0-9]+) entries$/
 	 * @param int $count
 	 * @return void
 	 */
@@ -717,7 +826,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^share fields of last share match with$/
+	 * @Then /^the share fields of the last share should include$/
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
 	 * @return void
 	 */
@@ -759,13 +868,14 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then as :user remove all shares from the file named :fileName
+	 * @When user :user removes all shares from the file named :fileName using the API
+	 * @Given user :user has removed all shares from the file named :fileName
 	 * @param string $user
 	 * @param string $fileName
 	 * @throws Exception
 	 * @return void
 	 */
-	public function asRemoveAllSharesFromTheFileNamed($user, $fileName) {
+	public function userRemovesAllSharesFromTheFileNamed($user, $fileName) {
 		$url = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares?format=json";
 		$client = new \GuzzleHttp\Client();
 		$res = $client->get(
@@ -796,20 +906,20 @@ trait Sharing {
 		}
 
 		if ($deleted === false) {
-			throw new \Exception("Could not delete file $fileName");
+			throw new \Exception("Could not delete shares for user $user file $fileName");
 		}
 	}
 
 	/**
-	 * @When save last share id
+	 * @Given the last share id has been remembered
 	 * @return void
 	 */
-	public function saveLastShareId() {
+	public function rememberLastShareId() {
 		$this->savedShareId = $this->lastShareData['data']['id'];
 	}
 
 	/**
-	 * @Then share ids should match
+	 * @Then the share ids should match
 	 * @return void
 	 */
 	public function shareIdsShouldMatch() {
@@ -840,7 +950,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" checks public shares of (file|folder) "([^"]*)"$/
+	 * @Then /^as user "([^"]*)" the public shares of (file|folder) "([^"]*)" should be$/
 	 * @param string $user
 	 * @param string $type
 	 * @param string $path
@@ -901,14 +1011,14 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes public share named "([^"]*)" in (file|folder) "([^"]*)"$/
+	 * @When /^user "([^"]*)" deletes public share named "([^"]*)" in (file|folder) "([^"]*)" using the API$/
 	 * @param string $user
 	 * @param string $name
-	 * @param string $type
+	 * @param string $type unused
 	 * @param string $path
 	 * @return void
 	 */
-	public function deletingPublicShareNamed($user, $name, $type, $path) {
+	public function userDeletesPublicShareNamedUsingTheAPI($user, $name, $type, $path) {
 		$share_id = $this->getPublicShareIDByName($user, $path, $name);
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
 		$this->sendingToWith("DELETE", $url, null);

--- a/tests/integration/features/bootstrap/Tags.php
+++ b/tests/integration/features/bootstrap/Tags.php
@@ -33,7 +33,8 @@ trait Tags {
 
 	/**
 	 * @param string $user
-	 * @param string $type
+	 * @param bool $userVisible
+	 * @param bool $userAssignable
 	 * @param string $name
 	 * @param string $groups
 	 */
@@ -70,7 +71,8 @@ trait Tags {
 	}
 
 	/**
-	 * @When :user creates a :type tag with name :name
+	 * @When user :user creates a :type tag with name :name using the API
+	 * @Given user :user has created a :type tag with name :name
 	 * @param string $user
 	 * @param string $type
 	 * @param string $name
@@ -81,7 +83,8 @@ trait Tags {
 	}
 
 	/**
-	 * @When :user creates a :type tag with name :name and groups :groups
+	 * @When user :user creates a :type tag with name :name and groups :groups using the API
+	 * @Given user :user has created a :type tag with name :name and groups :groups
 	 * @param string $user
 	 * @param string $type
 	 * @param string $name
@@ -142,9 +145,8 @@ trait Tags {
 
 	/**
 	 * @Then tag :tagDisplayName should not exist for :user
+	 * @param string $tagDisplayName
 	 * @param string $user
-	 * @param TableNode $table
-	 * @throws \Exception
 	 */
 	public function tagShouldNotExistForUser($tagDisplayName, $user) {
 		$tagData = $this->requestTagByDisplayName($user, $tagDisplayName);
@@ -152,17 +154,22 @@ trait Tags {
 	}
 
 	/**
-	 * @Then the user :user :can assign the :type tag with name :tagDisplayName
+	 * @Then /^the user "([^"]*)" (should|should not) be able to assign the "([^"]*)" tag with name "([^"]*)"$/
+	 * @param string $user
+	 * @param string $shouldOrNot should or should not
+	 * @param string $type
+	 * @param string $tagDisplayName
+	 * @throws Exception
 	 */
-	public function theUserCanAssignTheTag($user, $can, $type, $tagDisplayName) {
+	public function theUserCanAssignTheTag($user, $shouldOrNot, $type, $tagDisplayName) {
 		$tagData = $this->requestTagByDisplayName($user, $tagDisplayName);
 		$this->assertTypeOfTag($tagData, $type);
-		if ($can === 'can') {
+		if ($shouldOrNot === 'should') {
 			$expected = 'true';
-		} else if ($can === 'cannot') {
+		} else if ($shouldOrNot === 'should not') {
 			$expected = 'false';
 		} else {
-			throw new \Exception('Invalid condition, must be "can" or "cannot"');
+			throw new \Exception('Invalid condition, must be "should" or "should not"');
 		}
 		if ($tagData['{http://owncloud.org/ns}can-assign'] !== $expected) {
 			throw new \Exception('Tag cannot be assigned by user');
@@ -170,7 +177,10 @@ trait Tags {
 	}
 
 	/**
-	 * @Then the :type tag with name :tagName has the groups :groups
+	 * @Then the :type tag with name :tagName should have the groups :groups
+	 * @param string $type
+	 * @param string $tagName
+	 * @param string $groups list of groups separated by "|"
 	 */
 	public function theTagHasGroup($type, $tagName, $groups) {
 		$tagData = $this->requestTagByDisplayName($this->getAdminUserName(), $tagName, true);
@@ -186,7 +196,7 @@ trait Tags {
 	 * @param string $user
 	 * @throws \Exception
 	 */
-	public function tagsShouldExistFor($count, $user)  {
+	public function tagsShouldExistFor($count, $user) {
 		if ((int)$count !== count($this->requestTagsForUser($user))) {
 			throw new \Exception("Expected $count tags, got ".count($this->requestTagsForUser($user)));
 		}
@@ -224,7 +234,8 @@ trait Tags {
 	}
 
 	/**
-	 * @When :user edits the tag with name :oldName and sets its name to :newName
+	 * @When user :user edits the tag with name :oldName and sets its name to :newName using the API
+	 * @Given user :user has edited the tag with name :oldName and set its name to :newName
 	 * @param string $user
 	 * @param string $oldName
 	 * @param string $newName
@@ -238,7 +249,8 @@ trait Tags {
 	}
 
 	/**
-	 * @When :user edits the tag with name :oldName and sets its groups to :groups
+	 * @When user :user edits the tag with name :oldName and sets its groups to :groups using the API
+	 * @Given user :user has edited the tag with name :oldName and set its groups to :groups
 	 * @param string $user
 	 * @param string $oldName
 	 * @param string $groups
@@ -252,9 +264,10 @@ trait Tags {
 	}
 
 	/**
-	 * @Given :user deletes the tag with name :name
+	 * @When user :user deletes the tag with name :name using the API
+	 * @Given user :user has deleted the tag with name :name
 	 * @param string $user
-	 * @param string $groupName
+	 * @param string $name
 	 */
 	public function userDeletesTag($user, $name) {
 		$tagID = $this->findTagIdByName($name);
@@ -324,10 +337,12 @@ trait Tags {
 	}
 
 	/**
-	 * @When /^"([^"]*)" adds the tag "([^"]*)" to "([^"]*)" (shared|owned) by "([^"]*)"$/
+	 * @When /^user "([^"]*)" adds the tag "([^"]*)" to "([^"]*)" (shared|owned) by "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has added the tag "([^"]*)" to "([^"]*)" (shared|owned) by "([^"]*)"$/
 	 * @param string $taggingUser
 	 * @param string $tagName
 	 * @param string $fileName
+	 * @param string $sharedOrOwnedBy unused
 	 * @param string $sharingUser
 	 */
 	public function addsTheTagToSharedBy($taggingUser, $tagName, $fileName, $sharedOrOwnedBy, $sharingUser) {
@@ -335,11 +350,12 @@ trait Tags {
 	}
 
 	/**
-	 * @Then /^"([^"]*)" (shared|owned) by "([^"]*)" has the following tags$/
+	 * @Then /^(?:file|folder|entry) "([^"]*)" (shared|owned) by "([^"]*)" should have the following tags$/
 	 * @param string $fileName
+	 * @param string $sharedOrOwnedBy unused
 	 * @param string $sharingUser
 	 * @param TableNode $table
-	 * @throws \Exception
+	 * @return bool
 	 */
 	public function sharedByHasTheFollowingTags($fileName, $sharedOrOwnedBy, $sharingUser, TableNode $table) {
 		$tagList = $this->requestTagsForFile($sharingUser, $fileName);
@@ -365,9 +381,9 @@ trait Tags {
 	}
 
 	/**
-	 * @Then :fileName shared by :sharingUser has the following tags for :user
+	 * @Then file :fileName shared by :sharingUser should have the following tags for :user
 	 * @param string $fileName
-	 * @param string $sharingUser
+	 * @param string $sharingUser unused
 	 * @param string $user
 	 * @param TableNode $table
 	 * @throws \Exception
@@ -394,7 +410,8 @@ trait Tags {
 	}
 
 	/**
-	 * @When :user removes the tag :tagName from :fileName shared by :shareUser
+	 * @When user :user removes the tag :tagName from :fileName shared by :shareUser using the API
+	 * @Given user :user has removed the tag :tagName from :fileName shared by :shareUser
 	 * @param string $user
 	 * @param string $tagName
 	 * @param string $fileName

--- a/tests/integration/features/bootstrap/Trashbin.php
+++ b/tests/integration/features/bootstrap/Trashbin.php
@@ -27,13 +27,13 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 trait Trashbin {
 
 	/**
-	 * @When user :user empties the trashbin
+	 * @When user :user empties the trashbin using the API
+	 * @Given user :user has emptied the trashbin
 	 * @param string $user user
 	 */
 	public function emptyTrashbin($user) {
-		$this->asAn($user);
 		$body = new \Behat\Gherkin\Node\TableNode([['allfiles', 'true'], ['dir', '%2F']]);
-		$this->sendingToWithDirectUrl('POST', "/index.php/apps/files_trashbin/ajax/delete.php", $body);
+		$this->sendingToWithDirectUrl($user, 'POST', "/index.php/apps/files_trashbin/ajax/delete.php", $body);
 		$this->theHTTPStatusCodeShouldBe('200');
 	}
 
@@ -45,9 +45,8 @@ trait Trashbin {
 	 * @return array response
 	 */
 	public function listTrashbinFolder($user, $path) {
-		$this->asAn($user);
 		$params = '?dir=' . rawurlencode('/' . trim($path, '/'));
-		$this->sendingToWithDirectUrl('GET', '/index.php/apps/files_trashbin/ajax/list.php' . $params, null);
+		$this->sendingToWithDirectUrl($user, 'GET', '/index.php/apps/files_trashbin/ajax/list.php' . $params, null);
 		$this->theHTTPStatusCodeShouldBe('200');
 
 
@@ -57,9 +56,9 @@ trait Trashbin {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (file|folder|entry) "([^"]*)" exists in trash$/
+	 * @Then /^as "([^"]*)" the (file|folder|entry) "([^"]*)" should exist in trash$/
 	 * @param string $user
-	 * @param string $entryText
+	 * @param string $entryText unused
 	 * @param string $path
 	 */
 	public function asTheFileOrFolderExistsInTrash($user, $entryText, $path) {
@@ -97,7 +96,12 @@ trait Trashbin {
 		PHPUnit_Framework_Assert::assertTrue($found);
 	}
 
-	/*Function to check if an element is in trashbin*/
+	/**
+	 * Function to check if an element is in trashbin
+	 * @param string $user
+	 * @param string $originalPath
+	 * @return bool
+	 */
 	private function isInTrash($user, $originalPath) {
 		$listing = $this->listTrashbinFolder($user, null);
 		$originalPath = trim($originalPath, '/');
@@ -115,13 +119,20 @@ trait Trashbin {
 		return $found;
 	}
 
+	/**
+	 * @param string $user
+	 * @param string $elementTrashID
+	 */
 	private function sendUndeleteRequest($user, $elementTrashID) {
-		$this->asAn($user);
 		$body = new \Behat\Gherkin\Node\TableNode([['files',  "[\"$elementTrashID\"]"], ['dir', '/']]);
-		$this->sendingToWithDirectUrl('POST', "/index.php/apps/files_trashbin/ajax/undelete.php", $body);
+		$this->sendingToWithDirectUrl($user, 'POST', "/index.php/apps/files_trashbin/ajax/undelete.php", $body);
 		$this->theHTTPStatusCodeShouldBe('200');
 	}
 
+	/**
+	 * @param string $user
+	 * @param string $originalPath
+	 */
 	private function restoreElement($user, $originalPath) {
 		$listing = $this->listTrashbinFolder($user, null);
 		$originalPath = trim($originalPath, '/');
@@ -138,9 +149,10 @@ trait Trashbin {
 	}
 
 	/**
-	 * @Given /^as "([^"]*)" the (file|folder|entry) with original path "([^"]*)" is restored$/
+	 * @When /^user "([^"]*)" restores the (file|folder|entry) with original path "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has restored the (file|folder|entry) with original path "([^"]*)"$/
 	 * @param string $user
-	 * @param string $entryText
+	 * @param string $entryText unused
 	 * @param string $originalPath
 	 */
 	public function elementInTrashIsRestored($user, $entryText, $originalPath) {
@@ -150,9 +162,9 @@ trait Trashbin {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (file|folder|entry) with original path "([^"]*)" exists in trash$/
+	 * @Then /^as "([^"]*)" the (file|folder|entry) with original path "([^"]*)" should exist in trash$/
 	 * @param string $user
-	 * @param string $entryText
+	 * @param string $entryText unused
 	 * @param string $originalPath
 	 */
 	public function elementIsInTrashCheckingOriginalPath($user, $entryText, $originalPath) {
@@ -161,7 +173,7 @@ trait Trashbin {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (file|folder|entry) with original path "([^"]*)" does not exist in trash$/
+	 * @Then /^as "([^"]*)" the (file|folder|entry) with original path "([^"]*)" should not exist in trash$/
 	 * @param string $user
 	 * @param string $entryText
 	 * @param string $originalPath
@@ -174,6 +186,7 @@ trait Trashbin {
 	/**
 	 * Finds the first trashed entry matching the given name
 	 *
+	 * @param string $user
 	 * @param string $name
 	 * @return string|null real entry name with timestamp suffix or null if not found
 	 */
@@ -189,4 +202,3 @@ trait Trashbin {
 		return null;
 	}
 }
-

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -31,6 +31,7 @@ trait WebDav {
 
 	/**
 	 * @Given /^using dav path "([^"]*)"$/
+	 * @param string $davPath
 	 */
 	public function usingDavPath($davPath) {
 		$this->davPath = $davPath;
@@ -38,7 +39,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^using old dav path$/
+	 * @Given /^using old (?:dav|DAV) path$/
 	 */
 	public function usingOldDavPath() {
 		$this->davPath = "remote.php/webdav";
@@ -47,7 +48,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^using new dav path$/
+	 * @Given /^using new (?:dav|DAV) path$/
 	 */
 	public function usingNewDavPath() {
 		$this->davPath = "remote.php/dav";
@@ -55,6 +56,10 @@ trait WebDav {
 		$this->customDavPath = null;
 	}
 
+	/**
+	 * @param string $user
+	 * @return string
+	 */
 	public function getDavFilesPath($user) {
 		if ($this->usingOldDavPath === true) {
 			return $this->davPath;
@@ -71,6 +76,17 @@ trait WebDav {
 			return 2;
 		}
 	}
+
+	/**
+	 * @param string $user
+	 * @param string $method
+	 * @param string $path
+	 * @param array $headers
+	 * @param StreamInterface $body
+	 * @param string $type
+	 * @param string|null $requestBody
+	 * @return \GuzzleHttp\Message\FutureResponse|ResponseInterface|NULL
+	 */
 	public function makeDavRequest($user,
 								   $method,
 								   $path,
@@ -93,12 +109,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" moved (file|folder|entry) "([^"]*)" to "([^"]*)"$/
+	 * @Given /^user "([^"]*)" has moved (file|folder|entry) "([^"]*)" to "([^"]*)"$/
 	 * @param string $user
+	 * @param string $entry unused
 	 * @param string $fileSource
 	 * @param string $fileDestination
 	 */
-	public function userMovedFile($user, $entry, $fileSource, $fileDestination) {
+	public function userHasMovedFile($user, $entry, $fileSource, $fileDestination) {
 		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		$this->response = $this->makeDavRequest($user, "MOVE", $fileSource, $headers);
@@ -106,12 +123,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" moves (file|folder|entry) "([^"]*)" to "([^"]*)"$/
+	 * @When /^user "([^"]*)" moves (file|folder|entry) "([^"]*)" to "([^"]*)" using the API$/
 	 * @param string $user
+	 * @param string $entry unused
 	 * @param string $fileSource
 	 * @param string $fileDestination
 	 */
-	public function userMovesFile($user, $entry, $fileSource, $fileDestination) {
+	public function userMovesFileUsingTheAPI($user, $entry, $fileSource, $fileDestination) {
 		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		try {
@@ -122,12 +140,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" copies file "([^"]*)" to "([^"]*)"$/
+	 * @When /^user "([^"]*)" copies file "([^"]*)" to "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has copied file "([^"]*)" to "([^"]*)"$/
 	 * @param string $user
 	 * @param string $fileSource
 	 * @param string $fileDestination
 	 */
-	public function userCopiesFile($user, $fileSource, $fileDestination) {
+	public function userCopiesFileUsingTheAPI($user, $fileSource, $fileDestination) {
 		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		try {
@@ -138,17 +157,27 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^downloading file "([^"]*)" with range "([^"]*)"$/
+	 * @When /^the user downloads file "([^"]*)" with range "([^"]*)" using the API$/
 	 * @param string $fileSource
 	 * @param string $range
 	 */
 	public function downloadFileWithRange($fileSource, $range) {
-		$headers['Range'] = $range;
-		$this->response = $this->makeDavRequest($this->currentUser, "GET", $fileSource, $headers);
+		$this->userDownloadsFileWithRange($this->currentUser, $fileSource, $range);
 	}
 
 	/**
-	 * @When /^downloading last public shared file with range "([^"]*)"$/
+	 * @When /^user "([^"]*)" downloads file "([^"]*)" with range "([^"]*)" using the API$/
+	 * @param string $user
+	 * @param string $fileSource
+	 * @param string $range
+	 */
+	public function userDownloadsFileWithRange($user, $fileSource, $range) {
+		$headers['Range'] = $range;
+		$this->response = $this->makeDavRequest($user, "GET", $fileSource, $headers);
+	}
+
+	/**
+	 * @When /^the public downloads the last public shared file with range "([^"]*)" using the API$/
 	 * @param string $range
 	 */
 	public function downloadPublicFileWithRange($range) {
@@ -166,7 +195,8 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^downloading last public shared file inside a folder "([^"]*)" with range "([^"]*)"$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with range "([^"]*)" using the API$/
+	 * @param string $path
 	 * @param string $range
 	 */
 	public function downloadPublicFileInsideAFolderWithRange($path, $range) {
@@ -184,7 +214,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^downloaded content should be "([^"]*)"$/
+	 * @Then /^the downloaded content should be "([^"]*)"$/
 	 * @param string $content
 	 */
 	public function downloadedContentShouldBe($content) {
@@ -192,38 +222,46 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^downloaded content when downloading file "([^"]*)" with range "([^"]*)" should be "([^"]*)"$/
+	 * @Then /^the downloaded content when downloading file "([^"]*)" with range "([^"]*)" should be "([^"]*)"$/
 	 * @param string $fileSource
 	 * @param string $range
 	 * @param string $content
 	 */
-	public function downloadedContentWhenDownloadindShouldBe($fileSource, $range, $content) {
+	public function downloadedContentWhenDownloadingShouldBe($fileSource, $range, $content) {
 		$this->downloadFileWithRange($fileSource, $range);
 		$this->downloadedContentShouldBe($content);
 	}
 
 	/**
-	 * @When downloading file :fileName
-	 * @param string $fileName
+	 * @Then /^the downloaded content when downloading file "([^"]*)" for user "([^"]*)" with range "([^"]*)" should be "([^"]*)"$/
+	 * @param string $fileSource
+	 * @param string $user
+	 * @param string $range
+	 * @param string $content
 	 */
-	public function downloadingFile($fileName) {
-		try {
-			$this->response = $this->makeDavRequest($this->currentUser, 'GET', $fileName, []);
-		} catch (BadResponseException $e) {
-			$this->response = $e->getResponse();
-		}
+	public function downloadedContentWhenDownloadingForUserShouldBe($fileSource, $user, $range, $content) {
+		$this->userDownloadsFileWithRange($user, $fileSource, $range);
+		$this->downloadedContentShouldBe($content);
 	}
 
 	/**
-	 * @When user :user downloads the file :fileName
-	 * @param string $user
+	 * @When the user downloads the file :fileName using the API
 	 * @param string $fileName
 	 */
-	public function userDownloadsTheFile($user, $fileName) {
+	public function theUserDownloadsTheFileUsingTheAPI($fileName) {
+		$this->userDownloadsTheFileUsingTheAPI($this->currentUser, $fileName);
+	}
+
+	/**
+	 * @When user :user downloads the file :fileName using the API
+	 * @param string $fileName
+	 * @param string $user
+	 */
+	public function userDownloadsTheFileUsingTheAPI($user, $fileName) {
 		try {
 			$this->response = $this->makeDavRequest($user, 'GET', $fileName, []);
-		} catch (BadResponseException $e) {
-			$this->response = $e->getResponse();
+		} catch (BadResponseException $ex) {
+			$this->response = $ex->getResponse();
 		}
 	}
 
@@ -251,8 +289,8 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then downloaded content should start with :start
-	 * @param int $start
+	 * @Then the downloaded content should start with :start
+	 * @param string $start
 	 * @throws \Exception
 	 */
 	public function downloadedContentShouldStartWith($start) {
@@ -268,12 +306,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" gets properties of (file|folder|entry) "([^"]*)" with$/
+	 * @When /^user "([^"]*)" gets the following properties of (file|folder|entry) "([^"]*)" using the API$/
 	 * @param string $user
+	 * @param string $elementType unused
 	 * @param string $path
 	 * @param \Behat\Gherkin\Node\TableNode|null $propertiesTable
 	 */
-	public function asGetsPropertiesOfFolderWith($user, $elementType, $path, $propertiesTable) {
+	public function userGetsPropertiesOfFolder($user, $elementType, $path, $propertiesTable) {
 		$properties = null;
 		if ($propertiesTable instanceof \Behat\Gherkin\Node\TableNode) {
 			foreach ($propertiesTable->getRows() as $row) {
@@ -284,12 +323,12 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given as :arg1 gets a custom property :arg2 of file :arg3
+	 * @When user :user gets a custom property :propertyName of file :path
 	 * @param string $user
 	 * @param string $propertyName
 	 * @param string $path
 	 */
-	 public function asGetsPropertiesOfFile($user, $propertyName, $path) {
+	 public function userGetsPropertiesOfFile($user, $propertyName, $path) {
 		$client = $this->getSabreClient($user);
 		 $properties = [
 				$propertyName
@@ -299,14 +338,15 @@ trait WebDav {
 	 }
 
 	/**
-	 * @Given /^"([^"]*)" sets property "([^"]*)" of (file|folder|entry) "([^"]*)" to "([^"]*)"$/
+	 * @When /^user "([^"]*)" sets property "([^"]*)" of (file|folder|entry) "([^"]*)" to "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has set property "([^"]*)" of (file|folder|entry) "([^"]*)" to "([^"]*)"$/
 	 * @param string $user
 	 * @param string $propertyName
-	 * @param string $elementType
+	 * @param string $elementType unused
 	 * @param string $path
 	 * @param string $propertyValue
 	 */
-	public function asSetsPropertiesOfFolderWith($user, $propertyName, $elementType, $path, $propertyValue) {
+	public function userHasSetPropertyOfEntryTo($user, $propertyName, $elementType, $path, $propertyValue) {
 		$client = $this->getSabreClient($user);
 		$properties = [
 				$propertyName => $propertyValue
@@ -318,6 +358,8 @@ trait WebDav {
 	 * @Then /^the response should contain a custom "([^"]*)" property with "([^"]*)"$/
 	 * @param string $propertyName
 	 * @param string $propertyValue
+	 * @param null $table unused
+	 * @throws Exception
 	 */
 	public function theResponseShouldContainACustomPropertyWithValue($propertyName, $propertyValue, $table=null)
 	{
@@ -331,12 +373,14 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (file|folder|entry) "([^"]*)" does not exist$/
+	 * @Then /^as "([^"]*)" the (file|folder|entry) "([^"]*)" should not exist$/
 	 * @param string $user
+	 * @param string $entry
 	 * @param string $path
-	 * @param \Behat\Gherkin\Node\TableNode|null $propertiesTable
+	 * @return array
+	 * @throws Exception
 	 */
-	public function asTheFileOrFolderDoesNotExist($user, $entry, $path) {
+	public function asTheFileOrFolderShouldNotExist($user, $entry, $path) {
 		$client = $this->getSabreClient($user);
 		$response = $client->request('HEAD', $this->makeSabrePath($user, '/' . ltrim($path, '/')));
 		if ($response['statusCode'] !== 404) {
@@ -347,12 +391,13 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (file|folder|entry) "([^"]*)" exists$/
+	 * @Then /^as "([^"]*)" the (file|folder|entry) "([^"]*)" should exist$/
 	 * @param string $user
+	 * @param string $entry
 	 * @param string $path
-	 * @param \Behat\Gherkin\Node\TableNode|null $propertiesTable
+	 * @throws Exception
 	 */
-	public function asTheFileOrFolderExists($user, $entry, $path) {
+	public function asTheFileOrFolderShouldExist($user, $entry, $path) {
 		$this->response = $this->listFolder($user, $path, 0);
 		if (!is_array($this->response) || !isset($this->response['{DAV:}getetag'])) {
 			throw new \Exception($entry . ' "' . $path . '" expected to exist but not found');
@@ -426,6 +471,8 @@ trait WebDav {
 
 	/**
 	 * @Then the response should contain a share-types property with
+	 * @param \Behat\Gherkin\Node\TableNode $table
+	 * @throws Exception
 	 */
 	public function theResponseShouldContainAShareTypesPropertyWith($table)
 	{
@@ -474,7 +521,14 @@ trait WebDav {
 		}
 	}
 
-	/*Returns the elements of a propfind, $folderDepth requires 1 to see elements without children*/
+	/**
+	 * Returns the elements of a propfind
+	 * @param string $user
+	 * @param string $path
+	 * @param int $folderDepth requires 1 to see elements without children
+	 * @param array|null $properties
+	 * @return array|\Sabre\HTTP\ResponseInterface
+	 */
 	public function listFolder($user, $path, $folderDepth, $properties = null) {
 		$client = $this->getSabreClient($user);
 		if (!$properties) {
@@ -491,6 +545,13 @@ trait WebDav {
 		return $response;
 	}
 
+	/**
+	 * @param string $user
+	 * @param string $path
+	 * @param int $folderDepth
+	 * @param array|null $properties
+	 * @return array|\Sabre\HTTP\ResponseInterface
+	 */
 	public function listVersionFolder($user, $path, $folderDepth, $properties = null) {
 		$client = $this->getSabreClient($user);
 		if (!$properties) {
@@ -508,33 +569,34 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then the version folder of file :path for user :user contains :count elements
-	 * @param $path
-	 * @param $count
-	 * @param $user
+	 * @Then the version folder of file :path for user :user should contain :count element(s)
+	 * @param string $path
+	 * @param string $user
+	 * @param int $count
 	 */
-	public function theVersionFolderOfFileContainsElements($path, $user, $count) {
+	public function theVersionFolderOfFilehouldContainElements($path, $user, $count) {
 		$fileId = $this->getFileIdForPath($user, $path);
 		$elements = $this->listVersionFolder($user, '/meta/'.$fileId.'/v', 1);
 		PHPUnit_Framework_Assert::assertEquals($count, count($elements)-1);
 	}
 
 	/**
-	 * @Then the version folder of fileId :fileId contains :count elements
-	 * @param int $count
+	 * @Then the version folder of fileId :fileId for user :user should contain :count element(s)
 	 * @param int $fileId
+	 * @param string $user
+	 * @param int $count
 	 */
-	public function theVersionFolderOfFileIdContainsElements($fileId, $count) {
-		$elements = $this->listVersionFolder($this->currentUser, '/meta/'.$fileId.'/v', 1);
+	public function theVersionFolderOfFileIdShouldContainElements($fileId, $user, $count) {
+		$elements = $this->listVersionFolder($user, '/meta/'.$fileId.'/v', 1);
 		PHPUnit_Framework_Assert::assertEquals($count, count($elements)-1);
 	}
 
 	/**
-	 * @Then the content length of file :path with version index :index for user :user in versions folder is :length
-	 * @param $path
-	 * @param $index
-	 * @param $user
-	 * @param $length
+	 * @Then the content length of file :path with version index :index for user :user in versions folder should be :length
+	 * @param string $path
+	 * @param int $index
+	 * @param string $user
+	 * @param int $length
 	 */
 	public function theContentLengthOfFileForUserInVersionsFolderIs($path, $index, $user, $length) {
 		$fileId = $this->getFileIdForPath($user, $path);
@@ -543,11 +605,16 @@ trait WebDav {
 		PHPUnit_Framework_Assert::assertEquals($length, $elements[$index]['{DAV:}getcontentlength']);
 	}
 
-	/* Returns the elements of a report command
+	/**
+	 * Returns the elements of a report command
+	 *
 	 * @param string $user
 	 * @param string $path
 	 * @param string $properties properties which needs to be included in the report
 	 * @param string $filterRules filter-rules to choose what needs to appear in the report
+	 * @param int|null $offset
+	 * @param int|null $limit
+	 * @return array
 	 */
 	public function reportFolder($user, $path, $properties, $filterRules, $offset = null, $limit = null) {
 		$client = $this->getSabreClient($user);
@@ -586,7 +653,6 @@ trait WebDav {
 	 * @param string $user
 	 * @param string $path
 	 * @param string $properties properties which needs to be included in the report
-	 * @param string $filterRules filter-rules to choose what needs to appear in the report
 	 */
 	public function reportElementComments($user, $path, $properties) {
 		$client = $this->getSabreClient($user);
@@ -603,14 +669,27 @@ trait WebDav {
 		return $parsedResponse;
 	}
 
+	/**
+	 * @param string $user
+	 * @param string $path
+	 * @return string
+	 */
 	public function makeSabrePath($user, $path) {
 		return $this->encodePath($this->getDavFilesPath($user) . $path);
 	}
 
+	/**
+	 * @param string $path
+	 * @return string
+	 */
 	public function makeSabrePathNotForFiles($path) {
 		return $this->encodePath($this->davPath . $path);
 	}
 
+	/**
+	 * @param string $user
+	 * @return SClient
+	 */
 	public function getSabreClient($user) {
 		return WebDavHelper::getSabreClient(
 			$this->baseUrlWithoutOCSAppendix(),
@@ -619,7 +698,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should see following elements$/
+	 * @Then /^user "([^"]*)" should see the following elements$/
 	 * @param string $user
 	 * @param \Behat\Gherkin\Node\TableNode|null $expectedElements
 	 */
@@ -638,7 +717,8 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads file :source to :destination
+	 * @When user :user uploads file :source to :destination using the API
+	 * @Given user :user has uploaded file :source to :destination
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
@@ -654,7 +734,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads file :source to :destination with chunks
+	 * @When user :user uploads file :source to :destination with chunks using the API
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
@@ -672,6 +752,12 @@ trait WebDav {
 		$this->uploadChunks($user, $chunks, $destination, $chunkingVersion);
 	}
 
+	/**
+	 * @param string $user
+	 * @param array $chunks
+	 * @param string $destination
+	 * @param string|null $chunkingVersion null for autodetect, "old" with old style, "new" for new style
+	 */
 	public function uploadChunks($user, $chunks, $destination, $chunkingVersion = null) {
 		if ($chunkingVersion === null) {
 			if ($this->usingOldDavPath) {
@@ -697,7 +783,7 @@ trait WebDav {
 	/**
 	 * Uploading with old/new dav and chunked/non-chunked.
 	 *
-	 * @When user :user uploads file :source to :destination with all mechanisms
+	 * @When user :user uploads file :source to :destination with all mechanisms using the API
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
@@ -709,7 +795,7 @@ trait WebDav {
 	/**
 	 * Overwriting with old/new dav and chunked/non-chunked.
 	 *
-	 * @When user :user overwrites file :source to :destination with all mechanisms
+	 * @When user :user overwrites file :source to :destination with all mechanisms using the API
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
@@ -794,25 +880,25 @@ trait WebDav {
 	/**
 	 * Check that all the files uploaded with old/new dav and chunked/non-chunked exist.
 	 *
-	 * @Then as :user the files uploaded to :destination with all mechanisms exist
+	 * @Then as :user the files uploaded to :destination with all mechanisms should exist
 	 * @param string $user
 	 * @param string $destination
 	 */
-	public function filesUploadedToWithAllMechanismsExist($user, $destination) {
+	public function filesUploadedToWithAllMechanismsShouldExist($user, $destination) {
 		foreach (['old', 'new'] as $davVersion) {
 			foreach ([$davVersion . 'dav-regular', $davVersion . 'dav-' . $davVersion . 'chunking'] as $suffix) {
-				$this->asTheFileOrFolderExists($user, 'file', $destination . '-' . $suffix);
+				$this->asTheFileOrFolderShouldExist($user, 'file', $destination . '-' . $suffix);
 			}
 		}
 	}
 
 	/**
-	 * @When User :user adds a file of :bytes bytes to :destination
+	 * @Given user :user has added file :destination of :bytes bytes
 	 * @param string $user
 	 * @param string $bytes
 	 * @param string $destination
 	 */
-	public function userAddsAFileTo($user, $bytes, $destination) {
+	public function userAddsAFileTo($user, $destination, $bytes) {
 		$filename = "filespecificSize.txt";
 		$this->createFileSpecificSize($filename, $bytes);
 		PHPUnit_Framework_Assert::assertFileExists("work/$filename");
@@ -823,7 +909,12 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads file with content :content to :destination
+	 * @When user :user uploads file with content :content to :destination using the API
+	 * @Given user :user has uploaded file with content :content to :destination
+	 * @param string $user
+	 * @param string $content
+	 * @param string $destination
+	 * @return string
 	 */
 	public function userUploadsAFileWithContentTo($user, $content, $destination)
 	{
@@ -839,11 +930,12 @@ trait WebDav {
 
 
 	/**
-	 * @When user :user uploads file with checksum :checksum and content :content to :destination
-	 * @param $user
-	 * @param $checksum
-	 * @param $content
-	 * @param $destination
+	 * @When user :user uploads file with checksum :checksum and content :content to :destination using the API
+	 * @Given user :user has uploaded file with checksum :checksum and content :content to :destination
+	 * @param string $user
+	 * @param string $checksum
+	 * @param string $content
+	 * @param string $destination
 	 */
 	public function userUploadsAFileWithChecksumAndContentTo($user, $checksum, $content, $destination)
 	{
@@ -864,26 +956,22 @@ trait WebDav {
 
 
 	/**
-	 * @Given file :file  does not exist for user :user
+	 * @Given file :file has been deleted for user :user
 	 * @param string $file
-	 * @param $user
-	 */
-	public function fileDoesNotExist($file, $user)  {
-		try {
-			$this->response = $this->makeDavRequest($user, 'DELETE', $file, []);
-		} catch (BadResponseException $e) {
-			// 4xx and 5xx responses cause an exception
-			$this->response = $e->getResponse();
-		}
-	}
-
-	/**
-	 * @When /^user "([^"]*)" deletes (file|folder) "([^"]*)"$/
 	 * @param string $user
-	 * @param string $type
+	 */
+	public function fileHasBeenDeleted($file, $user) {
+		$this->userDeletesFile($user, 'file', $file);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" deletes (file|folder) "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has deleted (file|folder) "([^"]*)"$/
+	 * @param string $user
+	 * @param string $type unused
 	 * @param string $file
 	 */
-	public function userDeletesFile($user, $type, $file)  {
+	public function userDeletesFile($user, $type, $file) {
 		try {
 			$this->response = $this->makeDavRequest($user, 'DELETE', $file, []);
 		} catch (BadResponseException $e) {
@@ -893,11 +981,12 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user created a folder :destination
+	 * @When user :user creates a folder :destination using the API
+	 * @Given user :user has created a folder :destination
 	 * @param string $user
 	 * @param string $destination
 	 */
-	public function userCreatedAFolder($user, $destination) {
+	public function userCreatesAFolder($user, $destination) {
 		try {
 			$destination = '/' . ltrim($destination, '/');
 			$this->response = $this->makeDavRequest($user, "MKCOL", $destination, []);
@@ -910,7 +999,8 @@ trait WebDav {
 	/**
 	 * Old style chunking upload
 	 *
-	 * @Given user :user uploads chunk file :num of :total with :data to :destination
+	 * @When user :user uploads chunk file :num of :total with :data to :destination using the API
+	 * @Given user :user has uploaded chunk file :num of :total with :data to :destination
 	 * @param string $user
 	 * @param int $num
 	 * @param int $total
@@ -930,7 +1020,10 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user creates a new chunking upload with id :id
+	 * @When user :user creates a new chunking upload with id :id using the API
+	 * @Given user :user has created a new chunking upload with id :id
+	 * @param string $user
+	 * @param string $id
 	 */
 	public function userCreatesANewChunkingUploadWithId($user, $id)
 	{
@@ -943,7 +1036,12 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user uploads new chunk file :num with :data to id :id
+	 * @When user :user uploads new chunk file :num with :data to id :id using the API
+	 * @Given user :user has uploaded new chunk file :num with :data to id :id
+	 * @param string $user
+	 * @param int $num
+	 * @param string $data
+	 * @param string $id
 	 */
 	public function userUploadsNewChunkFileOfWithToId($user, $num, $data, $id)
 	{
@@ -957,21 +1055,33 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user moves new chunk file with id :id to :dest
+	 * @When user :user moves new chunk file with id :id to :dest using the API
+	 * @Given user :user has moved new chunk file with id :id to :dest
+	 * @param string $user
+	 * @param string $id
+	 * @param string $dest
 	 */
 	public function userMovesNewChunkFileWithIdToMychunkedfile($user, $id, $dest) {
 		$this->moveNewDavChunkToFinalFile($user, $id, $dest, []);
 	}
 
 	/**
-	 * @Then user :user moves new chunk file with id :id to :dest with size :size
+	 * @When user :user moves new chunk file with id :id to :dest with size :size using the API
+	 * @param string $user
+	 * @param string $id
+	 * @param string $dest
+	 * @param int $size
 	 */
 	public function userMovesNewChunkFileWithIdToMychunkedfileWithSize($user, $id, $dest, $size) {
 		$this->moveNewDavChunkToFinalFile($user, $id, $dest, ['OC-Total-Length' => $size]);
 	}
 
 	/**
-	 * @Then user :user moves new chunk file with id :id to :dest with checksum :checksum
+	 * @When user :user moves new chunk file with id :id to :dest with checksum :checksum using the API
+	 * @param string $user
+	 * @param string $id
+	 * @param string $dest
+	 * @param string $checksum
 	 */
 	public function userMovesNewChunkFileWithIdToMychunkedfileWithChecksum($user, $id, $dest, $checksum) {
 		$this->moveNewDavChunkToFinalFile($user, $id, $dest, ['OC-Checksum' => $checksum]);
@@ -999,17 +1109,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^downloading file "([^"]*)" as "([^"]*)"$/
-	 */
-	public function downloadingFileAs($fileName, $user) {
-		try {
-			$this->response = $this->makeDavRequest($user, 'GET', $fileName, []);
-		} catch (BadResponseException $ex) {
-			$this->response = $ex->getResponse();
-		}
-	}
-
-	/**
 	 * URL encodes the given path but keeps the slashes
 	 *
 	 * @param string $path to encode
@@ -1021,20 +1120,34 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user favorites element :path
+	 * @When user :user favorites element :path using the API
+	 * @Given user :user has favorited element :path
+	 * @param string $user
+	 * @param string $path
 	 */
 	public function userFavoritesElement($user, $path) {
 		$this->response = $this->changeFavStateOfAnElement($user, $path, 1, 0, null);
 	}
 
 	/**
-	 * @When user :user unfavorites element :path
+	 * @When user :user unfavorites element :path using the API
+	 * @Given user :user has unfavorited element :path
+	 * @param string $user
+	 * @param string $path
 	 */
 	public function userUnfavoritesElement($user, $path) {
 		$this->response = $this->changeFavStateOfAnElement($user, $path, 0, 0, null);
 	}
 
-	/*Set the elements of a proppatch, $folderDepth requires 1 to see elements without children*/
+	/**
+	 * Set the elements of a proppatch
+	 * @param string $user
+	 * @param string $path
+	 * @param int $favOrUnfav 1 = favorite, 0 = unfavorite
+	 * @param int $folderDepth requires 1 to see elements without children
+	 * @param array|null $properties
+	 * @return bool
+	 */
 	public function changeFavStateOfAnElement($user, $path, $favOrUnfav, $folderDepth, $properties = null) {
 		$settings = [
 			'baseUri' => $this->baseUrlWithoutOCSAppendix(),
@@ -1054,35 +1167,42 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given user :user stores etag of element :path
+	 * @When user :user stores etag of element :path using the API
+	 * @Given user :user has stored etag of element :path
+	 * @param string $user
+	 * @param string $path
 	 */
 	public function userStoresEtagOfElement($user, $path) {
 		$propertiesTable = new \Behat\Gherkin\Node\TableNode([['{DAV:}getetag']]);
-		$this->asGetsPropertiesOfFolderWith($user, NULL, $path, $propertiesTable);
+		$this->userGetsPropertiesOfFolder($user, NULL, $path, $propertiesTable);
 		$pathETAG[$path] = $this->response['{DAV:}getetag'];
-		$this->storedETAG[$user]= $pathETAG;
+		$this->storedETAG[$user] = $pathETAG;
 	}
 
 	/**
-	 * @Then etag of element :path of user :user has not changed
+	 * @Then the etag of element :path of user :user should not have changed
+	 * @param string $path
+	 * @param string $user
 	 */
-	public function checkIfETAGHasNotChanged($path, $user) {
+	public function etagOfElementOfUserShouldNotHaveChanged($path, $user) {
 		$propertiesTable = new \Behat\Gherkin\Node\TableNode([['{DAV:}getetag']]);
-		$this->asGetsPropertiesOfFolderWith($user, NULL, $path, $propertiesTable);
+		$this->userGetsPropertiesOfFolder($user, NULL, $path, $propertiesTable);
 		PHPUnit_Framework_Assert::assertEquals($this->response['{DAV:}getetag'], $this->storedETAG[$user][$path]);
 	}
 
 	/**
-	 * @Then etag of element :path of user :user has changed
+	 * @Then the etag of element :path of user :user should have changed
+	 * @param string $path
+	 * @param string $user
 	 */
-	public function checkIfETAGHasChanged($path, $user) {
+	public function etagOfElementOfUserShouldHaveChanged($path, $user) {
 		$propertiesTable = new \Behat\Gherkin\Node\TableNode([['{DAV:}getetag']]);
-		$this->asGetsPropertiesOfFolderWith($user, NULL, $path, $propertiesTable);
+		$this->userGetsPropertiesOfFolder($user, NULL, $path, $propertiesTable);
 		PHPUnit_Framework_Assert::assertNotEquals($this->response['{DAV:}getetag'], $this->storedETAG[$user][$path]);
 	}
 
 	/**
-	 * @When connecting to dav endpoint
+	 * @When an unauthenticated client connects to the dav endpoint using the API
 	 */
 	public function connectingToDavEndpoint() {
 		try {
@@ -1093,7 +1213,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then there are no duplicate headers
+	 * @Then there should be no duplicate headers
 	 */
 	public function thereAreNoDuplicateHeaders() {
 		$headers = $this->response->getHeaders();
@@ -1120,8 +1240,8 @@ trait WebDav {
 	 * @param string $user
 	 * @param string $folder
 	 * @param \Behat\Gherkin\Node\TableNode|null $expectedElements
-	 * @param int $offset
-	 * @param int $limit
+	 * @param int $offset unused
+	 * @param int $limit unused
 	 */
 	public function checkFavoritedElementsPaginated($user, $folder, $expectedElements, $offset, $limit) {
 		$elementList = $this->reportFolder($user,
@@ -1141,11 +1261,11 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes everything from folder "([^"]*)"$/
+	 * @When /^user "([^"]*)" deletes everything from folder "([^"]*)" using the API$/
 	 * @param string $user
 	 * @param string $folder
 	 */
-	public function userDeletesEverythingInFolder($user, $folder)  {
+	public function userDeletesEverythingInFolder($user, $folder) {
 		$elementList = $this->listFolder($user, $folder, 1);
 		if (is_array($elementList) && count($elementList)) {
 			$elementListKeys = array_keys($elementList);
@@ -1176,7 +1296,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" stores id of file "([^"]*)"$/
+	 * @Given /^user "([^"]*)" has stored id of file "([^"]*)"$/
 	 * @param string $user
 	 * @param string $path
 	 * @return void
@@ -1186,18 +1306,18 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" checks id of file "([^"]*)"$/
+	 * @Then /^user "([^"]*)" file "([^"]*)" should have the previously stored id$/
 	 * @param string $user
 	 * @param string $path
 	 * @return void
 	 */
-	public function userChecksFileIdForPath($user, $path) {
+	public function userFileShouldHaveStoredId($user, $path) {
 		$currentFileID = $this->getFileIdForPath($user, $path);
 		PHPUnit_Framework_Assert::assertEquals($currentFileID, $this->storedFileID);
 	}
 
 	/**
-	 * @When user :user restores version index :versionIndex of file :path
+	 * @When user :user restores version index :versionIndex of file :path using the API
 	 * @param string $user
 	 * @param int $versionIndex
 	 * @param string $path

--- a/tests/integration/features/caldav.feature
+++ b/tests/integration/features/caldav.feature
@@ -1,34 +1,32 @@
 Feature: caldav
 
+	Background:
+		Given user "user0" has been created
+
 	@caldav
 	Scenario: Accessing a not existing calendar of another user
-		Given user "user0" exists
-		When "admin" requests calendar "user0/MyCalendar"
+		When user "admin" requests calendar "user0/MyCalendar" using the API
 		Then the CalDAV HTTP status code should be "404"
-		And the exception is "Sabre\DAV\Exception\NotFound"
-		And the error message is "Node with name 'MyCalendar' could not be found"
+		And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
+		And the CalDAV error message should be "Node with name 'MyCalendar' could not be found"
 
 	@caldav
 	Scenario: Accessing a not shared calendar of another user
-		Given user "user0" exists
-		And "admin" creates a calendar named "MyCalendar"
-		And the CalDAV HTTP status code should be "201"
-		When "user0" requests calendar "admin/MyCalendar"
+		And user "admin" has successfully created a calendar named "MyCalendar"
+		When user "user0" requests calendar "admin/MyCalendar" using the API
 		Then the CalDAV HTTP status code should be "404"
-		And the exception is "Sabre\DAV\Exception\NotFound"
-		And the error message is "Node with name 'MyCalendar' could not be found"
+		And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
+		And the CalDAV error message should be "Node with name 'MyCalendar' could not be found"
 
 	@caldav
 	Scenario: Accessing a not existing calendar of myself
-		Given user "user0" exists
-		When "user0" requests calendar "admin/MyCalendar"
+		When user "user0" requests calendar "admin/MyCalendar" using the API
 		Then the CalDAV HTTP status code should be "404"
-		And the exception is "Sabre\DAV\Exception\NotFound"
-		And the error message is "Node with name 'MyCalendar' could not be found"
+		And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
+		And the CalDAV error message should be "Node with name 'MyCalendar' could not be found"
 
 	@caldav
 	Scenario: Creating a new calendar
-		When "admin" creates a calendar named "MyCalendar"
-		Then the CalDAV HTTP status code should be "201"
-		And "admin" requests calendar "admin/MyCalendar"
+		Given user "user0" has successfully created a calendar named "MyCalendar"
+		When user "user0" requests calendar "user0/MyCalendar" using the API
 		Then the CalDAV HTTP status code should be "200"

--- a/tests/integration/features/carddav.feature
+++ b/tests/integration/features/carddav.feature
@@ -1,27 +1,32 @@
 Feature: carddav
+
+  Background:
+    Given user "user0" has been created
+
   @carddav
   Scenario: Accessing a not existing addressbook of another user
-    Given user "user0" exists
-    When "admin" requests addressbook "user0/MyAddressbook" with statuscode "404"
-    And the CardDAV exception is "Sabre\DAV\Exception\NotFound"
-    And the CardDAV error message is "Addressbook with name 'MyAddressbook' could not be found"
+    When user "admin" requests addressbook "user0/MyAddressbook" using the API
+    Then the CardDAV HTTP status code should be "404"
+    And the CardDAV exception should be "Sabre\DAV\Exception\NotFound"
+    And the CardDAV error message should be "Addressbook with name 'MyAddressbook' could not be found"
 
   @carddav
   Scenario: Accessing a not shared addressbook of another user
-    Given user "user0" exists
-    And "admin" creates an addressbook named "MyAddressbook" with statuscode "201"
-    When "user0" requests addressbook "admin/MyAddressbook" with statuscode "404"
-    And the CardDAV exception is "Sabre\DAV\Exception\NotFound"
-    And the CardDAV error message is "Addressbook with name 'MyAddressbook' could not be found"
+    And user "admin" has successfully created an addressbook named "MyAddressbook"
+    When user "user0" requests addressbook "admin/MyAddressbook" using the API
+    Then the CardDAV HTTP status code should be "404"
+    And the CardDAV exception should be "Sabre\DAV\Exception\NotFound"
+    And the CardDAV error message should be "Addressbook with name 'MyAddressbook' could not be found"
 
   @carddav
   Scenario: Accessing a not existing addressbook of myself
-    Given user "user0" exists
-    When "user0" requests addressbook "admin/MyAddressbook" with statuscode "404"
-    And the CardDAV exception is "Sabre\DAV\Exception\NotFound"
-    And the CardDAV error message is "Addressbook with name 'MyAddressbook' could not be found"
+    When user "user0" requests addressbook "admin/MyAddressbook" using the API
+    Then the CardDAV HTTP status code should be "404"
+    And the CardDAV exception should be "Sabre\DAV\Exception\NotFound"
+    And the CardDAV error message should be "Addressbook with name 'MyAddressbook' could not be found"
 
   @carddav
   Scenario: Creating a new addressbook
-    When "admin" creates an addressbook named "MyAddressbook" with statuscode "201"
-    Then "admin" requests addressbook "admin/MyAddressbook" with statuscode "200"
+    Given user "user0" has successfully created an addressbook named "MyAddressbook"
+    When user "user0" requests addressbook "user0/MyAddressbook" using the API
+    Then the CardDAV HTTP status code should be "200"

--- a/tests/integration/features/checksums.feature
+++ b/tests/integration/features/checksums.feature
@@ -151,7 +151,7 @@ Feature: checksums
     And user "user0" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt"
     When user "user0" downloads the file "/chksumtst.txt" using the API
     Then the following headers should be set
-            | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
+      | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
 
   @local_storage
   Scenario: Uploaded file to external storage should have the same checksum when downloaded
@@ -160,7 +160,7 @@ Feature: checksums
     And user "user0" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/local_storage/chksumtst.txt"
     When user "user0" downloads the file "/local_storage/chksumtst.txt" using the API
     Then the following headers should be set
-            | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
+      | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
 
   ## Validation Plugin or Old Endpoint Specific
 

--- a/tests/integration/features/checksums.feature
+++ b/tests/integration/features/checksums.feature
@@ -1,184 +1,170 @@
 Feature: checksums
 
+  Background:
+    Given user "user0" has been created
+
   Scenario: Uploading a file with checksum should work
-    Given using old dav path
-    And user "user0" exists
-    When user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    Given using old DAV path
+    When user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the API
     Then the webdav response should have a status code "201"
 
   Scenario: Uploading a file with checksum should return the checksum in the propfind
-    Given using old dav path
-    And user "user0" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    Given using old DAV path
+    And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "user0" requests the checksum of "/myChecksumFile.txt" via propfind
     Then the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
 
   Scenario: Uploading a file with checksum should return the checksum in the download header
-    Given using old dav path
-    And user "user0" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" downloads the file "/myChecksumFile.txt"
+    Given using old DAV path
+    And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    When user "user0" downloads the file "/myChecksumFile.txt" using the API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
 
   Scenario: Moving a file with checksum should return the checksum in the propfind
-    Given using old dav path
-    And user "user0" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt"
+    Given using old DAV path
+    And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the API
     And user "user0" requests the checksum of "/myMovedChecksumFile.txt" via propfind
     Then the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
 
   Scenario: Downloading a file with checksum should return the checksum in the download header
-    Given using old dav path
-    And user "user0" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt"
-    And user "user0" downloads the file "/myMovedChecksumFile.txt"
+    Given using old DAV path
+    And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the API
+    And user "user0" downloads the file "/myMovedChecksumFile.txt" using the API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
 
   Scenario: Uploading a chunked file with checksum should return the checksum in the propfind
-    Given using old dav path
-    And user "user0" exists
-    And user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
-    And user "user0" uploads chunk file "2" of "3" with "BBBBB" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
-    And user "user0" uploads chunk file "3" of "3" with "CCCCC" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
+    Given using old DAV path
+    And user "user0" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
+    And user "user0" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
+    And user "user0" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
     When user "user0" requests the checksum of "/myChecksumFile.txt" via propfind
     Then the webdav checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8 MD5:45a72715acdd5019c5be30bdbb75233e ADLER32:1ecd03df"
 
   Scenario: Uploading a chunked file with checksum should return the checksum in the download header
-    Given using old dav path
-    And user "user0" exists
-    And user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
-    And user "user0" uploads chunk file "2" of "3" with "BBBBB" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
-    And user "user0" uploads chunk file "3" of "3" with "CCCCC" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
-    When user "user0" downloads the file "/myChecksumFile.txt"
+    Given using old DAV path
+    And user "user0" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
+    And user "user0" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
+    And user "user0" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
+    When user "user0" downloads the file "/myChecksumFile.txt" using the API
     Then the header checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8"
 
   @local_storage
   Scenario: Downloading a file from local storage has correct checksum
-    Given using old dav path
-    And user "user0" exists
-    And file "prueba_cksum.txt" with text "Test file for checksums" is created in local storage
-    When user "user0" downloads the file "/local_storage/prueba_cksum.txt"
-    And user "user0" downloads the file "/local_storage/prueba_cksum.txt"
+    Given using old DAV path
+    # Create the file directly in local storage, bypassing ownCloud
+    And file "prueba_cksum.txt" with text "Test file for checksums" has been created in local storage
+    # Do a first download, which will trigger ownCloud to calculate a checksum for the file
+    And user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the API
+    # Now do a download that is expected to have a checksum with it
+    When user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the API
     Then the header checksum should match "SHA1:a35b7605c8f586d735435535c337adc066c2ccb6"
 
-  Scenario: Uploading a file with checksum should work using new dav path
-    Given using new dav path
-    And user "user0" exists
-    When user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+  Scenario: Uploading a file with checksum should work using new DAV path
+    Given using new DAV path
+    When user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the API
     Then the webdav response should have a status code "201"
 
-  Scenario: Uploading a file with checksum should return the checksum in the propfind using new dav path
-    Given using new dav path
-    And user "user0" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+  Scenario: Uploading a file with checksum should return the checksum in the propfind using new DAV path
+    Given using new DAV path
+    And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "user0" requests the checksum of "/myChecksumFile.txt" via propfind
     Then the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
 
-  Scenario: Uploading a file with checksum should return the checksum in the download header using new dav path
-    Given using new dav path
-    And user "user0" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" downloads the file "/myChecksumFile.txt"
+  Scenario: Uploading a file with checksum should return the checksum in the download header using new DAV path
+    Given using new DAV path
+    And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    When user "user0" downloads the file "/myChecksumFile.txt" using the API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
 
-  Scenario: Moving a file with checksum should return the checksum in the propfind using new dav path
-    Given using new dav path
-    And user "user0" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" moved file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt"
+  Scenario: Moving a file with checksum should return the checksum in the propfind using new DAV path
+    Given using new DAV path
+    And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the API
     And user "user0" requests the checksum of "/myMovedChecksumFile.txt" via propfind
     Then the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
 
-  Scenario: Moving file with checksum should return the checksum in the download header using new dav path
-    Given using new dav path
-    And user "user0" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" moved file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt"
-    And user "user0" downloads the file "/myMovedChecksumFile.txt"
+  Scenario: Moving file with checksum should return the checksum in the download header using new DAV path
+    Given using new DAV path
+    And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the API
+    And user "user0" downloads the file "/myMovedChecksumFile.txt" using the API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
 
-  Scenario: Copying a file with checksum should return the checksum in the propfind using new dav path
-    Given using new dav path
-    And user "user0" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt"
+  Scenario: Copying a file with checksum should return the checksum in the propfind using new DAV path
+    Given using new DAV path
+    And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    When user "user0" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt" using the API
     And user "user0" requests the checksum of "/myChecksumFileCopy.txt" via propfind
     Then the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
 
-  Scenario: Copying file with checksum should return the checksum in the download header using new dav path
-    Given using new dav path
-    And user "user0" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt"
-    And user "user0" downloads the file "/myChecksumFileCopy.txt"
+  Scenario: Copying file with checksum should return the checksum in the download header using new DAV path
+    Given using new DAV path
+    And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    When user "user0" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt" using the API
+    And user "user0" downloads the file "/myChecksumFileCopy.txt" using the API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
 
   @local_storage
-  Scenario: Downloading a file from local storage has correct checksum using new dav path
-    Given using new dav path
-    And user "user0" exists
-    And file "prueba_cksum.txt" with text "Test file for checksums" is created in local storage
-    When user "user0" downloads the file "/local_storage/prueba_cksum.txt"
-    And user "user0" downloads the file "/local_storage/prueba_cksum.txt"
+  Scenario: Downloading a file from local storage has correct checksum using new DAV path
+    Given using new DAV path
+    # Create the file directly in local storage, bypassing ownCloud
+    And file "prueba_cksum.txt" with text "Test file for checksums" has been created in local storage
+    # Do a first download, which will trigger ownCloud to calculate a checksum for the file
+    And user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the API
+    # Now do a download that is expected to have a checksum with it
+    When user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the API
     Then the header checksum should match "SHA1:a35b7605c8f586d735435535c337adc066c2ccb6"
 
   Scenario: Upload new dav chunked file where checksum matches
-    Given using new dav path
-    And user "user0" exists
-    When user "user0" creates a new chunking upload with id "chunking-42"
-    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
-    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
-    And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1"
+    Given using new DAV path
+    When user "user0" creates a new chunking upload with id "chunking-42" using the API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the API
+    And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the API
     Then the HTTP status code should be "201"
 
   Scenario: Upload new dav chunked file where checksum does not match
-    Given using new dav path
-    And user "user0" exists
-    When user "user0" creates a new chunking upload with id "chunking-42"
-    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
-    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
-    And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:f005ba11"
+    Given using new DAV path
+    When user "user0" creates a new chunking upload with id "chunking-42" using the API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the API
+    And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:f005ba11" using the API
     Then the HTTP status code should be "400"
 
   Scenario: Upload a file where checksum does not match
-    Given using old dav path
-    And user "user0" exists
-    And file "/chksumtst.txt"  does not exist for user "user0"
-    When user "user0" uploads file with checksum "SHA1:f005ba11" and content "Some Text" to "/chksumtst.txt"
+    Given using old DAV path
+    And file "/chksumtst.txt" has been deleted for user "user0"
+    When user "user0" uploads file with checksum "SHA1:f005ba11" and content "Some Text" to "/chksumtst.txt" using the API
     Then the HTTP status code should be "400"
 
   Scenario: Upload a file where checksum does match
-    Given using old dav path
-    And user "user0" exists
-    And file "/chksumtst.txt"  does not exist for user "user0"
-    When user "user0" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt"
+    Given using old DAV path
+    And file "/chksumtst.txt" has been deleted for user "user0"
+    When user "user0" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt" using the API
     Then the HTTP status code should be "201"
 
   Scenario: Uploaded file should have the same checksum when downloaded
-    Given using old dav path
-    And user "user0" exists
-    And file "/chksumtst.txt"  does not exist for user "user0"
-    And user "user0" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt"
-    When downloading file "/chksumtst.txt" as "user0"
+    Given using old DAV path
+    And file "/chksumtst.txt" has been deleted for user "user0"
+    And user "user0" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt"
+    When user "user0" downloads the file "/chksumtst.txt" using the API
     Then the following headers should be set
             | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
 
   @local_storage
   Scenario: Uploaded file to external storage should have the same checksum when downloaded
-    Given using old dav path
-    And user "user0" exists
-    And file "/local_storage/chksumtst.txt"  does not exist for user "user0"
-    And user "user0" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/local_storage/chksumtst.txt"
-    When downloading file "/local_storage/chksumtst.txt" as "user0"
+    Given using old DAV path
+    And file "/local_storage/chksumtst.txt" has been deleted for user "user0"
+    And user "user0" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/local_storage/chksumtst.txt"
+    When user "user0" downloads the file "/local_storage/chksumtst.txt" using the API
     Then the following headers should be set
             | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
 
   ## Validation Plugin or Old Endpoint Specific
 
-  Scenario: Uploading an old method chunked file with checksum should fail using new dav path
-    Given using new dav path
-    And user "user0" exists
-    When user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
+  Scenario: Uploading an old method chunked file with checksum should fail using new DAV path
+    Given using new DAV path
+    When user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e" using the API
     Then the HTTP status code should be "503"

--- a/tests/integration/features/comments.feature
+++ b/tests/integration/features/comments.feature
@@ -1,104 +1,99 @@
 Feature: Comments
   Background:
-    Given using new dav path
+    Given using new DAV path
 
   Scenario: Creating a comment on a file belonging to myself
-    Given user "user0" exists
-    And as an "user0"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    When user "user0" comments with content "My first comment" on file "/myFileToComment.txt"
+    Given user "user0" has been created
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
+    When user "user0" comments with content "My first comment" on file "/myFileToComment.txt" using the API
     Then user "user0" should have the following comments on file "/myFileToComment.txt"
             | user0 | My first comment |
 
   Scenario: Creating a comment on a shared file belonging to another user
-    Given user "user0" exists
-    And user "user1" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    And file "/myFileToComment.txt" of user "user0" is shared with user "user1"
-    When user "user1" comments with content "A comment from sharee" on file "/myFileToComment.txt"
-    And user "user0" comments with content "A comment from sharer" on file "/myFileToComment.txt"
-    And the HTTP status code should be "201"
-    Then user "user1" should have the following comments on file "/myFileToComment.txt"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
+    And user "user0" has shared file "/myFileToComment.txt" with user "user1"
+    When user "user1" comments with content "A comment from sharee" on file "/myFileToComment.txt" using the API
+    And user "user0" comments with content "A comment from sharer" on file "/myFileToComment.txt" using the API
+    Then the HTTP status code should be "201"
+    And user "user1" should have the following comments on file "/myFileToComment.txt"
             | user1 | A comment from sharee |
             | user0 | A comment from sharer |
 
   Scenario: Deleting my own comments on a file belonging to myself
-    Given user "user0" exists
-    And as an "user0"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    And user "user0" comments with content "My first comment" on file "/myFileToComment.txt"
-    When user "user0" deletes the last created comment
+    Given user "user0" has been created
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
+    And user "user0" has commented with content "My first comment" on file "/myFileToComment.txt"
+    When user "user0" deletes the last created comment using the API
     Then the HTTP status code should be "204"
     And user "user0" should have 0 comments on file "/myFileToComment.txt"
 
   Scenario: Deleting a comment on a file belonging to myself having several comments
-    Given user "user0" exists
-    And as an "user0"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    And user "user0" comments with content "My first comment" on file "/myFileToComment.txt"
-    And user "user0" comments with content "My second comment" on file "/myFileToComment.txt"
-    And user "user0" comments with content "My third comment" on file "/myFileToComment.txt"
-    And user "user0" comments with content "My fourth comment" on file "/myFileToComment.txt"
-    When user "user0" deletes the last created comment
+    Given user "user0" has been created
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
+    And user "user0" has commented with content "My first comment" on file "/myFileToComment.txt"
+    And user "user0" has commented with content "My second comment" on file "/myFileToComment.txt"
+    And user "user0" has commented with content "My third comment" on file "/myFileToComment.txt"
+    And user "user0" has commented with content "My fourth comment" on file "/myFileToComment.txt"
+    When user "user0" deletes the last created comment using the API
     Then the HTTP status code should be "204"
     And user "user0" should have 3 comments on file "/myFileToComment.txt"
 
   Scenario: Deleting my own comments on a file shared by somebody else
-    Given user "user0" exists
-    And user "user1" exists
-    And as an "user0"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    And file "/myFileToComment.txt" of user "user0" is shared with user "user1"
-    And user "user0" comments with content "File owner comment" on file "/myFileToComment.txt"
-    And user "user1" comments with content "Sharee comment" on file "/myFileToComment.txt"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
+    And user "user0" has shared file "/myFileToComment.txt" with user "user1"
+    And user "user0" has commented with content "File owner comment" on file "/myFileToComment.txt"
+    And user "user1" has commented with content "Sharee comment" on file "/myFileToComment.txt"
     And user "user1" should have the following comments on file "/myFileToComment.txt"
             | user0 | File owner comment |
             | user1 | Sharee comment |
-    When user "user1" deletes the last created comment
+    When user "user1" deletes the last created comment using the API
     Then the HTTP status code should be "204"
     And user "user1" should have 1 comments on file "/myFileToComment.txt"
 
   Scenario: Edit my own comments on a file belonging to myself
-    Given user "user0" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    And user "user0" comments with content "File owner comment" on file "/myFileToComment.txt"
-    When user "user0" edits last comment with content "My edited comment"
+    Given user "user0" has been created
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
+    And user "user0" has commented with content "File owner comment" on file "/myFileToComment.txt"
+    When user "user0" edits the last created comment with content "My edited comment" using the API
     Then the HTTP status code should be "207"
     And user "user0" should have the following comments on file "/myFileToComment.txt"
             | user0 | My edited comment |
 
   Scenario: Edit my own comments on a file shared by someone with me
-    Given user "user0" exists
-    And user "user1" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    And file "/myFileToComment.txt" of user "user0" is shared with user "user1"
-    And user "user1" comments with content "Sharee comment" on file "/myFileToComment.txt"
-    When user "user1" edits last comment with content "My edited comment"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
+    And user "user0" has shared file "/myFileToComment.txt" with user "user1"
+    And user "user1" has commented with content "Sharee comment" on file "/myFileToComment.txt"
+    When user "user1" edits the last created comment with content "My edited comment" using the API
     Then the HTTP status code should be "207"
     And user "user1" should have the following comments on file "/myFileToComment.txt"
             | user1 | My edited comment |
 
-  Scenario: Edit comments of other users should not be possible
-    Given user "user0" exists
-    And user "user1" exists
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    And file "/myFileToComment.txt" of user "user0" is shared with user "user1"
-    And user "user1" comments with content "Sharee comment" on file "/myFileToComment.txt"
+  Scenario: Editing comments of other users should not be possible
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
+    And user "user0" has shared file "/myFileToComment.txt" with user "user1"
+    And user "user1" has commented with content "Sharee comment" on file "/myFileToComment.txt"
     And user "user0" should have the following comments on file "/myFileToComment.txt"
             | user1 | Sharee comment |
-    When user "user0" edits last comment with content "User1 edited comment"
+    When user "user0" edits the last created comment with content "User1 edited comment" using the API
     Then the HTTP status code should be "403"
     And user "user0" should have the following comments on file "/myFileToComment.txt"
             | user1 | Sharee comment |
 
   Scenario: Getting info of comments using files endpoint
-    Given user "user0" exists
-    And as an "user0"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToComment.txt"
-    And user "user0" comments with content "My first comment" on file "/myFileToComment.txt"
+    Given user "user0" has been created
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
+    And user "user0" has commented with content "My first comment" on file "/myFileToComment.txt"
     And user "user0" should have the following comments on file "/myFileToComment.txt"
             | user0 | My first comment |
-    When as "user0" gets properties of folder "/myFileToComment.txt" with
+    When user "user0" gets the following properties of folder "/myFileToComment.txt" using the API
           | {http://owncloud.org/ns}comments-href |
           | {http://owncloud.org/ns}comments-count |
           | {http://owncloud.org/ns}comments-unread |
@@ -107,20 +102,19 @@ Feature: Comments
     And the single response should contain a property "{http://owncloud.org/ns}comments-href" with value "a_comment_url"
 
   Scenario: Creating a comment on a folder belonging to myself
-    Given user "user0" exists
-    And as an "user0"
-    When user "user0" comments with content "My first comment" on folder "/FOLDER"
+    Given user "user0" has been created
+    When user "user0" comments with content "My first comment" on folder "/FOLDER" using the API
     Then user "user0" should have the following comments on folder "/FOLDER"
             | user0 | My first comment |
 
   Scenario: Creating a comment on a shared folder belonging to another user
-    Given user "user0" exists
-    And user "user1" exists
-    And user "user0" created a folder "/FOLDER_TO_SHARE"
-    And folder "/FOLDER_TO_SHARE" of user "user0" is shared with user "user1"
-    And user "user1" comments with content "A comment from sharee" on folder "/FOLDER_TO_SHARE"
-    And user "user0" comments with content "A comment from sharer" on folder "/FOLDER_TO_SHARE"
-    And the HTTP status code should be "201"
-    Then user "user1" should have the following comments on file "/FOLDER_TO_SHARE"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/FOLDER_TO_SHARE"
+    And user "user0" has shared folder "/FOLDER_TO_SHARE" with user "user1"
+    When user "user1" comments with content "A comment from sharee" on folder "/FOLDER_TO_SHARE" using the API
+    And user "user0" comments with content "A comment from sharer" on folder "/FOLDER_TO_SHARE" using the API
+    Then the HTTP status code should be "201"
+    And user "user1" should have the following comments on file "/FOLDER_TO_SHARE"
             | user1 | A comment from sharee |
             | user0 | A comment from sharer |

--- a/tests/integration/features/comments.feature
+++ b/tests/integration/features/comments.feature
@@ -7,7 +7,7 @@ Feature: Comments
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
     When user "user0" comments with content "My first comment" on file "/myFileToComment.txt" using the API
     Then user "user0" should have the following comments on file "/myFileToComment.txt"
-            | user0 | My first comment |
+      | user0 | My first comment |
 
   Scenario: Creating a comment on a shared file belonging to another user
     Given user "user0" has been created
@@ -18,8 +18,8 @@ Feature: Comments
     And user "user0" comments with content "A comment from sharer" on file "/myFileToComment.txt" using the API
     Then the HTTP status code should be "201"
     And user "user1" should have the following comments on file "/myFileToComment.txt"
-            | user1 | A comment from sharee |
-            | user0 | A comment from sharer |
+      | user1 | A comment from sharee |
+      | user0 | A comment from sharer |
 
   Scenario: Deleting my own comments on a file belonging to myself
     Given user "user0" has been created
@@ -48,8 +48,8 @@ Feature: Comments
     And user "user0" has commented with content "File owner comment" on file "/myFileToComment.txt"
     And user "user1" has commented with content "Sharee comment" on file "/myFileToComment.txt"
     And user "user1" should have the following comments on file "/myFileToComment.txt"
-            | user0 | File owner comment |
-            | user1 | Sharee comment |
+      | user0 | File owner comment |
+      | user1 | Sharee comment     |
     When user "user1" deletes the last created comment using the API
     Then the HTTP status code should be "204"
     And user "user1" should have 1 comments on file "/myFileToComment.txt"
@@ -61,7 +61,7 @@ Feature: Comments
     When user "user0" edits the last created comment with content "My edited comment" using the API
     Then the HTTP status code should be "207"
     And user "user0" should have the following comments on file "/myFileToComment.txt"
-            | user0 | My edited comment |
+      | user0 | My edited comment |
 
   Scenario: Edit my own comments on a file shared by someone with me
     Given user "user0" has been created
@@ -72,7 +72,7 @@ Feature: Comments
     When user "user1" edits the last created comment with content "My edited comment" using the API
     Then the HTTP status code should be "207"
     And user "user1" should have the following comments on file "/myFileToComment.txt"
-            | user1 | My edited comment |
+      | user1 | My edited comment |
 
   Scenario: Editing comments of other users should not be possible
     Given user "user0" has been created
@@ -81,22 +81,22 @@ Feature: Comments
     And user "user0" has shared file "/myFileToComment.txt" with user "user1"
     And user "user1" has commented with content "Sharee comment" on file "/myFileToComment.txt"
     And user "user0" should have the following comments on file "/myFileToComment.txt"
-            | user1 | Sharee comment |
+      | user1 | Sharee comment |
     When user "user0" edits the last created comment with content "User1 edited comment" using the API
     Then the HTTP status code should be "403"
     And user "user0" should have the following comments on file "/myFileToComment.txt"
-            | user1 | Sharee comment |
+      | user1 | Sharee comment |
 
   Scenario: Getting info of comments using files endpoint
     Given user "user0" has been created
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
     And user "user0" has commented with content "My first comment" on file "/myFileToComment.txt"
     And user "user0" should have the following comments on file "/myFileToComment.txt"
-            | user0 | My first comment |
+      | user0 | My first comment |
     When user "user0" gets the following properties of folder "/myFileToComment.txt" using the API
-          | {http://owncloud.org/ns}comments-href |
-          | {http://owncloud.org/ns}comments-count |
-          | {http://owncloud.org/ns}comments-unread |
+      | {http://owncloud.org/ns}comments-href   |
+      | {http://owncloud.org/ns}comments-count  |
+      | {http://owncloud.org/ns}comments-unread |
     #Then the single response should contain a property "{http://owncloud.org/ns}comments-count" with value "1"
     And the single response should contain a property "{http://owncloud.org/ns}comments-unread" with value "0"
     And the single response should contain a property "{http://owncloud.org/ns}comments-href" with value "a_comment_url"
@@ -105,7 +105,7 @@ Feature: Comments
     Given user "user0" has been created
     When user "user0" comments with content "My first comment" on folder "/FOLDER" using the API
     Then user "user0" should have the following comments on folder "/FOLDER"
-            | user0 | My first comment |
+      | user0 | My first comment |
 
   Scenario: Creating a comment on a shared folder belonging to another user
     Given user "user0" has been created
@@ -116,5 +116,5 @@ Feature: Comments
     And user "user0" comments with content "A comment from sharer" on folder "/FOLDER_TO_SHARE" using the API
     Then the HTTP status code should be "201"
     And user "user1" should have the following comments on file "/FOLDER_TO_SHARE"
-            | user1 | A comment from sharee |
-            | user0 | A comment from sharer |
+      | user1 | A comment from sharee |
+      | user0 | A comment from sharer |

--- a/tests/integration/features/dav-versions.feature
+++ b/tests/integration/features/dav-versions.feature
@@ -44,8 +44,8 @@ Feature: dav-versions
     And user "user0" has uploaded file with content "456789" to "/davtest.txt"
     And we save it into "FILEID"
     When user "user0" creates a share using the API with settings
-      | path | /davtest.txt |
-      | shareType | 0 |
-      | shareWith | user1 |
-      | permissions | 8 |
+      | path        | /davtest.txt |
+      | shareType   | 0            |
+      | shareWith   | user1        |
+      | permissions | 8            |
     Then the version folder of fileId "<<FILEID>>" for user "user1" should contain "1" element

--- a/tests/integration/features/dav-versions.feature
+++ b/tests/integration/features/dav-versions.feature
@@ -1,55 +1,51 @@
 Feature: dav-versions
   Background:
-    Given using api version "2"
-    And using new dav path
-    And user "user0" exists
-    And file "/davtest.txt"  does not exist for user "user0"
-    And as an "user0"
+    Given using API version "2"
+    And using new DAV path
+    And user "user0" has been created
+    And file "/davtest.txt" has been deleted for user "user0"
 
   Scenario: Upload file and no version is available
-    When user "user0" uploads file "data/davtest.txt" to "/davtest.txt"
-    Then the version folder of file "/davtest.txt" for user "user0" contains "0" elements
+    When user "user0" uploads file "data/davtest.txt" to "/davtest.txt" using the API
+    Then the version folder of file "/davtest.txt" for user "user0" should contain "0" elements
 
   Scenario: Upload a file twice and versions are available
-    When user "user0" uploads file "data/davtest.txt" to "/davtest.txt"
-    Then user "user0" uploads file "data/davtest.txt" to "/davtest.txt"
-    And the version folder of file "/davtest.txt" for user "user0" contains "1" elements
-    And the content length of file "/davtest.txt" with version index "1" for user "user0" in versions folder is "8"
+    When user "user0" uploads file "data/davtest.txt" to "/davtest.txt" using the API
+    And user "user0" uploads file "data/davtest.txt" to "/davtest.txt" using the API
+    Then the version folder of file "/davtest.txt" for user "user0" should contain "1" element
+    And the content length of file "/davtest.txt" with version index "1" for user "user0" in versions folder should be "8"
 
   Scenario: Remove a file
-    Given user "user0" uploads file "data/davtest.txt" to "/davtest.txt"
-    And user "user0" uploads file "data/davtest.txt" to "/davtest.txt"
-    And the version folder of file "/davtest.txt" for user "user0" contains "1" elements
-    And user "user0" deletes file "/davtest.txt"
-    When user "user0" uploads file "data/davtest.txt" to "/davtest.txt"
-    Then the version folder of file "/davtest.txt" for user "user0" contains "0" elements
+    Given user "user0" has uploaded file "data/davtest.txt" to "/davtest.txt"
+    And user "user0" has uploaded file "data/davtest.txt" to "/davtest.txt"
+    And the version folder of file "/davtest.txt" for user "user0" should contain "1" element
+    And user "user0" has deleted file "/davtest.txt"
+    When user "user0" uploads file "data/davtest.txt" to "/davtest.txt" using the API
+    Then the version folder of file "/davtest.txt" for user "user0" should contain "0" elements
 
   Scenario: Restore a file and check, if the content is now in the current file
-    Given user "user0" uploads file with content "123" to "/davtest.txt"
-    And user "user0" uploads file with content "12345" to "/davtest.txt"
-    And the version folder of file "/davtest.txt" for user "user0" contains "1" elements
-    When user "user0" restores version index "1" of file "/davtest.txt"
-    Then downloading file "davtest.txt"
-    And downloaded content should be "123"
+    Given user "user0" has uploaded file with content "123" to "/davtest.txt"
+    And user "user0" has uploaded file with content "12345" to "/davtest.txt"
+    And the version folder of file "/davtest.txt" for user "user0" should contain "1" element
+    When user "user0" restores version index "1" of file "/davtest.txt" using the API
+    And user "user0" downloads the file "davtest.txt" using the API
+    Then the downloaded content should be "123"
 
   Scenario: User cannot access meta folder of a file which is owned by somebody else
-    Given user "user1" exists
-    And user "user0" uploads file with content "123" to "/davtest.txt"
+    Given user "user1" has been created
+    And user "user0" has uploaded file with content "123" to "/davtest.txt"
     And we save it into "FILEID"
-    And as an "user1"
-    When sending "PROPFIND" with exact url to "/remote.php/dav/meta/<<FILEID>>"
+    When user "user1" sends HTTP method "PROPFIND" to URL "/remote.php/dav/meta/<<FILEID>>"
     Then the HTTP status code should be "404"
 
   Scenario: User can access meta folder of a file which is owned by somebody else but shared with that user
-    Given user "user1" exists
-    And user "user0" uploads file with content "123" to "/davtest.txt"
-    And user "user0" uploads file with content "456789" to "/davtest.txt"
+    Given user "user1" has been created
+    And user "user0" has uploaded file with content "123" to "/davtest.txt"
+    And user "user0" has uploaded file with content "456789" to "/davtest.txt"
     And we save it into "FILEID"
-    And as an "user0"
-    And creating a share with
+    When user "user0" creates a share using the API with settings
       | path | /davtest.txt |
       | shareType | 0 |
       | shareWith | user1 |
       | permissions | 8 |
-    When as an "user1"
-    Then the version folder of fileId "<<FILEID>>" contains "1" elements
+    Then the version folder of fileId "<<FILEID>>" for user "user1" should contain "1" element

--- a/tests/integration/features/external-storage.feature
+++ b/tests/integration/features/external-storage.feature
@@ -1,25 +1,23 @@
 Feature: external-storage
   Background:
-    Given using api version "1"
-    And using old dav path
+    Given using API version "1"
+    And using old DAV path
 
   # TODO: change to @no_default_encryption once all this works with master key
   @local_storage
   @no_encryption
   Scenario: Share by link a file inside a local external storage
-    Given user "user0" exists
-    And user "user1" exists
-    And as an "user0"
-    And user "user0" created a folder "/local_storage/foo"
-    And user "user0" moved file "/textfile0.txt" to "/local_storage/foo/textfile0.txt"
-    And folder "/local_storage/foo" of user "user0" is shared with user "user1"
-    And as an "user1"
-    When creating a share with
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/local_storage/foo"
+    And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo/textfile0.txt"
+    And user "user0" has shared folder "/local_storage/foo" with user "user1"
+    When user "user1" creates a share using the API with settings
       | path | foo |
       | shareType | 3 |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And share fields of last share match with
+    And the share fields of the last share should include
       | id | A_NUMBER |
       | url | AN_URL |
       | token | A_TOKEN |
@@ -27,44 +25,39 @@ Feature: external-storage
 
   @local_storage
   @no_encryption
-  Scenario: Move a file into storage works
-    Given user "user0" exists
-    And user "user1" exists
-    And as an "user0"
-    And user "user0" created a folder "/local_storage/foo1"
-    When user "user0" moved file "/textfile0.txt" to "/local_storage/foo1/textfile0.txt"
-    Then as "user1" the file "/local_storage/foo1/textfile0.txt" exists
-    And as "user0" the file "/local_storage/foo1/textfile0.txt" exists
+  Scenario: Move a file into storage
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/local_storage/foo1"
+    When user "user0" moves file "/textfile0.txt" to "/local_storage/foo1/textfile0.txt" using the API
+    Then as "user1" the file "/local_storage/foo1/textfile0.txt" should exist
+    And as "user0" the file "/local_storage/foo1/textfile0.txt" should exist
 
   @local_storage
   @no_encryption
-  Scenario: Move a file out of the storage works
-    Given user "user0" exists
-    And user "user1" exists
-    And as an "user0"
-    And user "user0" created a folder "/local_storage/foo2"
-    And user "user0" moved file "/textfile0.txt" to "/local_storage/foo2/textfile0.txt"
-    When user "user1" moved file "/local_storage/foo2/textfile0.txt" to "/local.txt"
-    Then as "user1" the file "/local_storage/foo2/textfile0.txt" does not exist
-    And as "user0" the file "/local_storage/foo2/textfile0.txt" does not exist
-    And as "user1" the file "/local.txt" exists
+  Scenario: Move a file out of storage
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "user0" has created a folder "/local_storage/foo2"
+    And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo2/textfile0.txt"
+    When user "user1" moves file "/local_storage/foo2/textfile0.txt" to "/local.txt" using the API
+    Then as "user1" the file "/local_storage/foo2/textfile0.txt" should not exist
+    And as "user0" the file "/local_storage/foo2/textfile0.txt" should not exist
+    And as "user1" the file "/local.txt" should exist
 
   Scenario: Download a file that exists in filecache but not storage fails with 404
-    Given user "user0" exists
-    And as an "user0"
-    And user "user0" created a folder "/local_storage/foo3"
-    And user "user0" moved file "/textfile0.txt" to "/local_storage/foo3/textfile0.txt"
-    And file "foo3/textfile0.txt" is deleted in local storage
-    When downloading file "local_storage/foo3/textfile0.txt"
+    Given user "user0" has been created
+    And user "user0" has created a folder "/local_storage/foo3"
+    And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo3/textfile0.txt"
+    And file "foo3/textfile0.txt" has been deleted in local storage
+    When user "user0" downloads the file "local_storage/foo3/textfile0.txt" using the API
     Then the HTTP status code should be "404"
-    And as "user0" the file "local_storage/foo3/textfile0.txt" does not exist
+    And as "user0" the file "local_storage/foo3/textfile0.txt" should not exist
 
   @local_storage
   Scenario: Upload a file to external storage while quota is set on home storage
-    Given user "user0" exists
-    And as an "admin"
-    And user "user0" has a quota of "1 B"
-    And as an "user0"
-    When user "user0" uploads file "data/textfile.txt" to "/local_storage/testquota.txt" with all mechanisms
+    Given user "user0" has been created
+    And the quota of user "user0" has been set to "1 B"
+    When user "user0" uploads file "data/textfile.txt" to "/local_storage/testquota.txt" with all mechanisms using the API
     Then the HTTP status code of all upload responses should be "201"
-    And as "user0" the files uploaded to "/local_storage/testquota.txt" with all mechanisms exist
+    And as "user0" the files uploaded to "/local_storage/testquota.txt" with all mechanisms should exist

--- a/tests/integration/features/external-storage.feature
+++ b/tests/integration/features/external-storage.feature
@@ -13,14 +13,14 @@ Feature: external-storage
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo/textfile0.txt"
     And user "user0" has shared folder "/local_storage/foo" with user "user1"
     When user "user1" creates a share using the API with settings
-      | path | foo |
-      | shareType | 3 |
+      | path      | foo |
+      | shareType | 3   |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the share fields of the last share should include
-      | id | A_NUMBER |
-      | url | AN_URL |
-      | token | A_TOKEN |
+      | id       | A_NUMBER             |
+      | url      | AN_URL               |
+      | token    | A_TOKEN              |
       | mimetype | httpd/unix-directory |
 
   @local_storage

--- a/tests/integration/features/favorites.feature
+++ b/tests/integration/features/favorites.feature
@@ -1,155 +1,155 @@
 Feature: favorite
     Background:
-        Given using api version "1"
+        Given using API version "1"
 
     Scenario: Favorite a folder
-        Given using old dav path
-        And user "user0" exists
-        When user "user0" favorites element "/FOLDER"
-        Then as "user0" gets properties of folder "/FOLDER" with
+        Given using old DAV path
+        And user "user0" has been created
+        When user "user0" favorites element "/FOLDER" using the API
+        And user "user0" gets the following properties of folder "/FOLDER" using the API
             |{http://owncloud.org/ns}favorite|
-        And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
+        Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
 
     Scenario: Favorite and unfavorite a folder
-        Given using old dav path
-        And user "user0" exists
-        When user "user0" favorites element "/FOLDER"
-        And user "user0" unfavorites element "/FOLDER"
-        Then as "user0" gets properties of folder "/FOLDER" with
+        Given using old DAV path
+        And user "user0" has been created
+        When user "user0" favorites element "/FOLDER" using the API
+        And user "user0" unfavorites element "/FOLDER" using the API
+        And user "user0" gets the following properties of folder "/FOLDER" using the API
             |{http://owncloud.org/ns}favorite|
-        And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
+        Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
 
     Scenario: Favorite a file
-        Given using old dav path
-        And user "user0" exists
-        When user "user0" favorites element "/textfile0.txt"
-        Then as "user0" gets properties of file "/textfile0.txt" with
+        Given using old DAV path
+        And user "user0" has been created
+        When user "user0" favorites element "/textfile0.txt" using the API
+        And user "user0" gets the following properties of file "/textfile0.txt" using the API
             |{http://owncloud.org/ns}favorite|
-        And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
+        Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
 
     Scenario: Favorite and unfavorite a file
-        Given using old dav path
-        And user "user0" exists
-        When user "user0" favorites element "/textfile0.txt"
-        And user "user0" unfavorites element "/textfile0.txt"
-        Then as "user0" gets properties of file "/textfile0.txt" with
+        Given using old DAV path
+        And user "user0" has been created
+        When user "user0" favorites element "/textfile0.txt" using the API
+        And user "user0" unfavorites element "/textfile0.txt" using the API
+        And user "user0" gets the following properties of file "/textfile0.txt" using the API
             |{http://owncloud.org/ns}favorite|
-        And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
+        Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
 
     Scenario: Favorite a folder new endpoint
-        Given using new dav path
-        And user "user0" exists
-        When user "user0" favorites element "/FOLDER"
-        Then as "user0" gets properties of folder "/FOLDER" with
+        Given using new DAV path
+        And user "user0" has been created
+        When user "user0" favorites element "/FOLDER" using the API
+        And user "user0" gets the following properties of folder "/FOLDER" using the API
             |{http://owncloud.org/ns}favorite|
-        And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
+        Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
 
     Scenario: Favorite and unfavorite a folder new endpoint
-        Given using new dav path
-        And user "user0" exists
-        When user "user0" favorites element "/FOLDER"
-        And user "user0" unfavorites element "/FOLDER"
-        Then as "user0" gets properties of folder "/FOLDER" with
+        Given using new DAV path
+        And user "user0" has been created
+        When user "user0" favorites element "/FOLDER" using the API
+        And user "user0" unfavorites element "/FOLDER" using the API
+        And user "user0" gets the following properties of folder "/FOLDER" using the API
             |{http://owncloud.org/ns}favorite|
-        And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
+        Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
 
     Scenario: Favorite a file new endpoint
-        Given using new dav path
-        And user "user0" exists
-        When user "user0" favorites element "/textfile0.txt"
-        Then as "user0" gets properties of file "/textfile0.txt" with
+        Given using new DAV path
+        And user "user0" has been created
+        When user "user0" favorites element "/textfile0.txt" using the API
+        And user "user0" gets the following properties of file "/textfile0.txt" using the API
             |{http://owncloud.org/ns}favorite|
-        And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
+        Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
 
     Scenario: Favorite and unfavorite a file new endpoint
-        Given using new dav path
-        And user "user0" exists
-        When user "user0" favorites element "/textfile0.txt"
-        And user "user0" unfavorites element "/textfile0.txt"
-        Then as "user0" gets properties of file "/textfile0.txt" with
+        Given using new DAV path
+        And user "user0" has been created
+        When user "user0" favorites element "/textfile0.txt" using the API
+        And user "user0" unfavorites element "/textfile0.txt" using the API
+        And user "user0" gets the following properties of file "/textfile0.txt" using the API
             |{http://owncloud.org/ns}favorite|
-        And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
+        Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
 
     Scenario: Get favorited elements of a folder
-        Given using old dav path
-        And user "user0" exists
-        When user "user0" favorites element "/FOLDER"
-        And user "user0" favorites element "/textfile0.txt"
-        And user "user0" favorites element "/textfile1.txt"
+        Given using old DAV path
+        And user "user0" has been created
+        When user "user0" favorites element "/FOLDER" using the API
+        And user "user0" favorites element "/textfile0.txt" using the API
+        And user "user0" favorites element "/textfile1.txt" using the API
         Then user "user0" in folder "/" should have favorited the following elements
             | /FOLDER |
             | /textfile0.txt |
             | /textfile1.txt |
 
     Scenario: Get favorited elements of a folder using new path
-        Given using new dav path
-        And user "user0" exists
-        When user "user0" favorites element "/FOLDER"
-        And user "user0" favorites element "/textfile0.txt"
-        And user "user0" favorites element "/textfile1.txt"
+        Given using new DAV path
+        And user "user0" has been created
+        When user "user0" favorites element "/FOLDER" using the API
+        And user "user0" favorites element "/textfile0.txt" using the API
+        And user "user0" favorites element "/textfile1.txt" using the API
         Then user "user0" in folder "/" should have favorited the following elements
             | /FOLDER |
             | /textfile0.txt |
             | /textfile1.txt |
 
     Scenario: Get favorited elements of a subfolder
-        Given using old dav path
-        And user "user0" exists
-        And user "user0" created a folder "/subfolder"
-        And user "user0" moves file "/textfile0.txt" to "/subfolder/textfile0.txt"
-        And user "user0" moves file "/textfile1.txt" to "/subfolder/textfile1.txt"
-        And user "user0" moves file "/textfile2.txt" to "/subfolder/textfile2.txt"
-        When user "user0" favorites element "/subfolder/textfile0.txt"
-        And user "user0" favorites element "/subfolder/textfile1.txt"
-        And user "user0" favorites element "/subfolder/textfile2.txt"
-        And user "user0" unfavorites element "/subfolder/textfile1.txt"
+        Given using old DAV path
+        And user "user0" has been created
+        And user "user0" has created a folder "/subfolder"
+        And user "user0" has moved file "/textfile0.txt" to "/subfolder/textfile0.txt"
+        And user "user0" has moved file "/textfile1.txt" to "/subfolder/textfile1.txt"
+        And user "user0" has moved file "/textfile2.txt" to "/subfolder/textfile2.txt"
+        When user "user0" favorites element "/subfolder/textfile0.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile1.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile2.txt" using the API
+        And user "user0" unfavorites element "/subfolder/textfile1.txt" using the API
         Then user "user0" in folder "/subfolder" should have favorited the following elements
             | /subfolder/textfile0.txt |
             | /subfolder/textfile2.txt |
 
     Scenario: Get favorited elements of a subfolder using new path
-        Given using old dav path
-        And user "user0" exists
-        And user "user0" created a folder "/subfolder"
-        And user "user0" moves file "/textfile0.txt" to "/subfolder/textfile0.txt"
-        And user "user0" moves file "/textfile1.txt" to "/subfolder/textfile1.txt"
-        And user "user0" moves file "/textfile2.txt" to "/subfolder/textfile2.txt"
-        When user "user0" favorites element "/subfolder/textfile0.txt"
-        And user "user0" favorites element "/subfolder/textfile1.txt"
-        And user "user0" favorites element "/subfolder/textfile2.txt"
-        And user "user0" unfavorites element "/subfolder/textfile1.txt"
+        Given using old DAV path
+        And user "user0" has been created
+        And user "user0" has created a folder "/subfolder"
+        And user "user0" has moved file "/textfile0.txt" to "/subfolder/textfile0.txt"
+        And user "user0" has moved file "/textfile1.txt" to "/subfolder/textfile1.txt"
+        And user "user0" has moved file "/textfile2.txt" to "/subfolder/textfile2.txt"
+        When user "user0" favorites element "/subfolder/textfile0.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile1.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile2.txt" using the API
+        And user "user0" unfavorites element "/subfolder/textfile1.txt" using the API
         Then user "user0" in folder "/subfolder" should have favorited the following elements
             | /subfolder/textfile0.txt |
             | /subfolder/textfile2.txt |
 
     Scenario: moving a favorite file out of a share keeps favorite state
-        Given using old dav path
-        And user "user0" exists
-        And user "user1" exists
-        And user "user0" created a folder "/shared"
-        And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-        And folder "/shared" of user "user0" is shared with user "user1"
-        And user "user1" favorites element "/shared/shared_file.txt"
-        When user "user1" moved file "/shared/shared_file.txt" to "/taken_out.txt"
+        Given using old DAV path
+        And user "user0" has been created
+        And user "user1" has been created
+        And user "user0" has created a folder "/shared"
+        And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+        And user "user0" has shared folder "/shared" with user "user1"
+        And user "user1" has favorited element "/shared/shared_file.txt"
+        When user "user1" moves file "/shared/shared_file.txt" to "/taken_out.txt" using the API
         Then user "user1" in folder "/" should have favorited the following elements
             | /taken_out.txt |
 
     Scenario: Get favorited elements paginated
-        Given using old dav path
-        And user "user0" exists
-        And user "user0" created a folder "/subfolder"
-        And user "user0" copies file "/textfile0.txt" to "/subfolder/textfile0.txt"
-        And user "user0" copies file "/textfile0.txt" to "/subfolder/textfile1.txt"
-        And user "user0" copies file "/textfile0.txt" to "/subfolder/textfile2.txt"
-        And user "user0" copies file "/textfile0.txt" to "/subfolder/textfile3.txt"
-        And user "user0" copies file "/textfile0.txt" to "/subfolder/textfile4.txt"
-        And user "user0" copies file "/textfile0.txt" to "/subfolder/textfile5.txt"
-        When user "user0" favorites element "/subfolder/textfile0.txt"
-        And user "user0" favorites element "/subfolder/textfile1.txt"
-        And user "user0" favorites element "/subfolder/textfile2.txt"
-        And user "user0" favorites element "/subfolder/textfile3.txt"
-        And user "user0" favorites element "/subfolder/textfile4.txt"
-        And user "user0" favorites element "/subfolder/textfile5.txt"
+        Given using old DAV path
+        And user "user0" has been created
+        And user "user0" has created a folder "/subfolder"
+        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile0.txt"
+        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile1.txt"
+        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile2.txt"
+        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile3.txt"
+        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile4.txt"
+        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile5.txt"
+        When user "user0" favorites element "/subfolder/textfile0.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile1.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile2.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile3.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile4.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile5.txt" using the API
         Then user "user0" in folder "/subfolder" should have favorited the following elements from offset 3 and limit 2
             | /subfolder/textfile2.txt |
             | /subfolder/textfile3.txt |

--- a/tests/integration/features/favorites.feature
+++ b/tests/integration/features/favorites.feature
@@ -77,7 +77,7 @@ Feature: favorite
         And user "user0" favorites element "/textfile0.txt" using the API
         And user "user0" favorites element "/textfile1.txt" using the API
         Then user "user0" in folder "/" should have favorited the following elements
-            | /FOLDER |
+            | /FOLDER        |
             | /textfile0.txt |
             | /textfile1.txt |
 
@@ -88,7 +88,7 @@ Feature: favorite
         And user "user0" favorites element "/textfile0.txt" using the API
         And user "user0" favorites element "/textfile1.txt" using the API
         Then user "user0" in folder "/" should have favorited the following elements
-            | /FOLDER |
+            | /FOLDER        |
             | /textfile0.txt |
             | /textfile1.txt |
 

--- a/tests/integration/features/multilinksharing.feature
+++ b/tests/integration/features/multilinksharing.feature
@@ -8,29 +8,29 @@ Feature: multilinksharing
 
 	Scenario: Creating three public shares of a folder
 		Given the user has created a share with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| publicUpload | true |
-			| permissions | 15 |
-			| name | sharedlink1 |
+			| path         | FOLDER      |
+			| shareType    | 3           |
+			| password     | publicpw    |
+			| expireDate   | +3 days     |
+			| publicUpload | true        |
+			| permissions  | 15          |
+			| name         | sharedlink1 |
 		And the user has created a share with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| publicUpload | true |
-			| permissions | 15 |
-			| name | sharedlink2 |
+			| path         | FOLDER      |
+			| shareType    | 3           |
+			| password     | publicpw    |
+			| expireDate   | +3 days     |
+			| publicUpload | true        |
+			| permissions  | 15          |
+			| name         | sharedlink2 |
 		And the user has created a share with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| publicUpload | true |
-			| permissions | 15 |
-			| name | sharedlink3 |
+			| path         | FOLDER      |
+			| shareType    | 3           |
+			| password     | publicpw    |
+			| expireDate   | +3 days     |
+			| publicUpload | true        |
+			| permissions  | 15          |
+			| name         | sharedlink3 |
 		When the user updates the last share using the API with
 			| permissions | 1 |
 		Then the OCS status code should be "100"
@@ -38,30 +38,30 @@ Feature: multilinksharing
 		And as user "user0" the public shares of folder "/FOLDER" should be
 			| /FOLDER | 15 | sharedlink2 |
 			| /FOLDER | 15 | sharedlink1 |
-			| /FOLDER | 1 | sharedlink3 |
+			| /FOLDER | 1  | sharedlink3 |
 
 	Scenario: Creating three public shares of a file
 		Given the user has created a share with settings
-			| path | textfile0.txt |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| permissions | 1 |
-			| name | sharedlink1 |
+			| path        | textfile0.txt |
+			| shareType   | 3             |
+			| password    | publicpw      |
+			| expireDate  | +3 days       |
+			| permissions | 1             |
+			| name        | sharedlink1   |
 		And the user has created a share with settings
-			| path | textfile0.txt |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| permissions | 1 |
-			| name | sharedlink2 |
+			| path        | textfile0.txt |
+			| shareType   | 3             |
+			| password    | publicpw      |
+			| expireDate  | +3 days       |
+			| permissions | 1             |
+			| name        | sharedlink2   |
 		And the user has created a share with settings
-			| path | textfile0.txt |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| permissions | 1 |
-			| name | sharedlink3 |
+			| path        | textfile0.txt |
+			| shareType   | 3             |
+			| password    | publicpw      |
+			| expireDate  | +3 days       |
+			| permissions | 1             |
+			| name        | sharedlink3   |
 		When the user updates the last share using the API with
 			| permissions | 1 |
 		Then the OCS status code should be "100"
@@ -73,21 +73,21 @@ Feature: multilinksharing
 
 	Scenario: Check that updating password doesn't remove name of links
 		Given the user has created a share with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| publicUpload | true |
-			| permissions | 15 |
-			| name | sharedlink1 |
+			| path         | FOLDER      |
+			| shareType    | 3           |
+			| password     | publicpw    |
+			| expireDate   | +3 days     |
+			| publicUpload | true        |
+			| permissions  | 15          |
+			| name         | sharedlink1 |
 		And the user has created a share with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| publicUpload | true |
-			| permissions | 15 |
-			| name | sharedlink2 |
+			| path         | FOLDER      |
+			| shareType    | 3           |
+			| password     | publicpw    |
+			| expireDate   | +3 days     |
+			| publicUpload | true        |
+			| permissions  | 15          |
+			| name         | sharedlink2 |
 		When the user updates the last share using the API with
 			| password | newpassword |
 		Then the OCS status code should be "100"
@@ -98,19 +98,19 @@ Feature: multilinksharing
 
 	Scenario: Deleting a file deletes also its public links
 		Given the user has created a share with settings
-			| path | textfile0.txt |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| permissions | 1 |
-			| name | sharedlink1 |
+			| path        | textfile0.txt |
+			| shareType   | 3             |
+			| password    | publicpw      |
+			| expireDate  | +3 days       |
+			| permissions | 1             |
+			| name        | sharedlink1   |
 		And the user has created a share with settings
-			| path | textfile0.txt |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| permissions | 1 |
-			| name | sharedlink2 |
+			| path        | textfile0.txt |
+			| shareType   | 3             |
+			| password    | publicpw      |
+			| expireDate  | +3 days       |
+			| permissions | 1             |
+			| name        | sharedlink2   |
 		And user "user0" has deleted file "/textfile0.txt"
 		And the HTTP status code should be "204"
 		When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt" using the API
@@ -120,26 +120,26 @@ Feature: multilinksharing
 
 	Scenario: Deleting one public share of a file doesn't affect the rest
 		Given the user has created a share with settings
-			| path | textfile0.txt |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| permissions | 1 |
-			| name | sharedlink1 |
+			| path        | textfile0.txt |
+			| shareType   | 3             |
+			| password    | publicpw      |
+			| expireDate  | +3 days       |
+			| permissions | 1             |
+			| name        | sharedlink1   |
 		And the user has created a share with settings
-			| path | textfile0.txt |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| permissions | 1 |
-			| name | sharedlink2 |
+			| path        | textfile0.txt |
+			| shareType   | 3             |
+			| password    | publicpw      |
+			| expireDate  | +3 days       |
+			| permissions | 1             |
+			| name        | sharedlink2   |
 		And the user has created a share with settings
-			| path | textfile0.txt |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| permissions | 1 |
-			| name | sharedlink3 |
+			| path        | textfile0.txt |
+			| shareType   | 3             |
+			| password    | publicpw      |
+			| expireDate  | +3 days       |
+			| permissions | 1             |
+			| name        | sharedlink3   |
 		When user "user0" deletes public share named "sharedlink2" in file "/textfile0.txt" using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -149,19 +149,19 @@ Feature: multilinksharing
 
 	Scenario: Overwriting a file doesn't remove its public shares
 		Given the user has created a share with settings
-			| path | textfile0.txt |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| permissions | 1 |
-			| name | sharedlink1 |
+			| path        | textfile0.txt |
+			| shareType   | 3             |
+			| password    | publicpw      |
+			| expireDate  | +3 days       |
+			| permissions | 1             |
+			| name        | sharedlink1   |
 		And the user has created a share with settings
-			| path | textfile0.txt |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| permissions | 1 |
-			| name | sharedlink2 |
+			| path        | textfile0.txt |
+			| shareType   | 3             |
+			| password    | publicpw      |
+			| expireDate  | +3 days       |
+			| permissions | 1             |
+			| name        | sharedlink2   |
 		When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt" using the API
 		Then as user "user0" the public shares of file "/textfile0.txt" should be
 			| /textfile0.txt | 1 | sharedlink1 |
@@ -169,21 +169,21 @@ Feature: multilinksharing
 
 	Scenario: Renaming a folder doesn't remove its public shares
 		Given the user has created a share with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| publicUpload | true |
-			| permissions | 15 |
-			| name | sharedlink1 |
+			| path         | FOLDER      |
+			| shareType    | 3           |
+			| password     | publicpw    |
+			| expireDate   | +3 days     |
+			| publicUpload | true        |
+			| permissions  | 15          |
+			| name         | sharedlink1 |
 		And the user has created a share with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| publicUpload | true |
-			| permissions | 15 |
-			| name | sharedlink2 |
+			| path         | FOLDER      |
+			| shareType    | 3           |
+			| password     | publicpw    |
+			| expireDate   | +3 days     |
+			| publicUpload | true        |
+			| permissions  | 15          |
+			| name         | sharedlink2 |
 		When user "user0" moves folder "/FOLDER" to "/FOLDER_RENAMED" using the API
 		Then as user "user0" the public shares of file "/FOLDER_RENAMED" should be
 			| /FOLDER_RENAMED | 15 | sharedlink1 |

--- a/tests/integration/features/multilinksharing.feature
+++ b/tests/integration/features/multilinksharing.feature
@@ -1,13 +1,13 @@
 Feature: multilinksharing
 
 	Background:
-		Given using api version "1"
-		And using old dav path
+		Given using API version "1"
+		And using old DAV path
+		And user "user0" has been created
+		And as user "user0"
 
 	Scenario: Creating three public shares of a folder
-		Given user "user0" exists
-		And as an "user0"
-		And creating a share with
+		Given the user has created a share with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| password | publicpw |
@@ -15,9 +15,7 @@ Feature: multilinksharing
 			| publicUpload | true |
 			| permissions | 15 |
 			| name | sharedlink1 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And creating a share with
+		And the user has created a share with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| password | publicpw |
@@ -25,9 +23,7 @@ Feature: multilinksharing
 			| publicUpload | true |
 			| permissions | 15 |
 			| name | sharedlink2 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And creating a share with
+		And the user has created a share with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| password | publicpw |
@@ -35,60 +31,48 @@ Feature: multilinksharing
 			| publicUpload | true |
 			| permissions | 15 |
 			| name | sharedlink3 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		When updating last share with
+		When the user updates the last share using the API with
 			| permissions | 1 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "user0" checks public shares of folder "/FOLDER"
+		And as user "user0" the public shares of folder "/FOLDER" should be
 			| /FOLDER | 15 | sharedlink2 |
 			| /FOLDER | 15 | sharedlink1 |
 			| /FOLDER | 1 | sharedlink3 |
 
 	Scenario: Creating three public shares of a file
-		Given user "user0" exists
-		And as an "user0"
-		And creating a share with
+		Given the user has created a share with settings
 			| path | textfile0.txt |
 			| shareType | 3 |
 			| password | publicpw |
 			| expireDate | +3 days |
 			| permissions | 1 |
 			| name | sharedlink1 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And creating a share with
+		And the user has created a share with settings
 			| path | textfile0.txt |
 			| shareType | 3 |
 			| password | publicpw |
 			| expireDate | +3 days |
 			| permissions | 1 |
 			| name | sharedlink2 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And creating a share with
+		And the user has created a share with settings
 			| path | textfile0.txt |
 			| shareType | 3 |
 			| password | publicpw |
 			| expireDate | +3 days |
 			| permissions | 1 |
 			| name | sharedlink3 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		When updating last share with
+		When the user updates the last share using the API with
 			| permissions | 1 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "user0" checks public shares of file "/textfile0.txt"
+		And as user "user0" the public shares of file "/textfile0.txt" should be
 			| /textfile0.txt | 1 | sharedlink2 |
 			| /textfile0.txt | 1 | sharedlink1 |
 			| /textfile0.txt | 1 | sharedlink3 |
 
 	Scenario: Check that updating password doesn't remove name of links
-		Given user "user0" exists
-		And as an "user0"
-		And creating a share with
+		Given the user has created a share with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| password | publicpw |
@@ -96,9 +80,7 @@ Feature: multilinksharing
 			| publicUpload | true |
 			| permissions | 15 |
 			| name | sharedlink1 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And creating a share with
+		And the user has created a share with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| password | publicpw |
@@ -106,109 +88,87 @@ Feature: multilinksharing
 			| publicUpload | true |
 			| permissions | 15 |
 			| name | sharedlink2 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		When updating last share with
+		When the user updates the last share using the API with
 			| password | newpassword |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "user0" checks public shares of folder "/FOLDER"
+		And as user "user0" the public shares of folder "/FOLDER" should be
 			| /FOLDER | 15 | sharedlink2 |
 			| /FOLDER | 15 | sharedlink1 |
 
 	Scenario: Deleting a file deletes also its public links
-	 Given user "user0" exists
-		And as an "user0"
-		And creating a share with
+		Given the user has created a share with settings
 			| path | textfile0.txt |
 			| shareType | 3 |
 			| password | publicpw |
 			| expireDate | +3 days |
 			| permissions | 1 |
 			| name | sharedlink1 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And creating a share with
+		And the user has created a share with settings
 			| path | textfile0.txt |
 			| shareType | 3 |
 			| password | publicpw |
 			| expireDate | +3 days |
 			| permissions | 1 |
 			| name | sharedlink2 |
-		And user "user0" deletes file "/textfile0.txt"
+		And user "user0" has deleted file "/textfile0.txt"
 		And the HTTP status code should be "204"
-		When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt"
+		When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt" using the API
 		Then the HTTP status code should be "201"
-		And user "user0" checks public shares of file "/textfile0.txt"
+		And as user "user0" the public shares of file "/textfile0.txt" should be
 			| | | |
 
 	Scenario: Deleting one public share of a file doesn't affect the rest
-		Given user "user0" exists
-		And as an "user0"
-		And creating a share with
+		Given the user has created a share with settings
 			| path | textfile0.txt |
 			| shareType | 3 |
 			| password | publicpw |
 			| expireDate | +3 days |
 			| permissions | 1 |
 			| name | sharedlink1 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And creating a share with
+		And the user has created a share with settings
 			| path | textfile0.txt |
 			| shareType | 3 |
 			| password | publicpw |
 			| expireDate | +3 days |
 			| permissions | 1 |
 			| name | sharedlink2 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And creating a share with
+		And the user has created a share with settings
 			| path | textfile0.txt |
 			| shareType | 3 |
 			| password | publicpw |
 			| expireDate | +3 days |
 			| permissions | 1 |
 			| name | sharedlink3 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		When user "user0" deletes public share named "sharedlink2" in file "/textfile0.txt"
+		When user "user0" deletes public share named "sharedlink2" in file "/textfile0.txt" using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "user0" checks public shares of file "/textfile0.txt"
+		And as user "user0" the public shares of file "/textfile0.txt" should be
 			| /textfile0.txt | 1 | sharedlink1 |
 			| /textfile0.txt | 1 | sharedlink3 |
 
 	Scenario: Overwriting a file doesn't remove its public shares
-		Given user "user0" exists
-		And as an "user0"
-		And creating a share with
+		Given the user has created a share with settings
 			| path | textfile0.txt |
 			| shareType | 3 |
 			| password | publicpw |
 			| expireDate | +3 days |
 			| permissions | 1 |
 			| name | sharedlink1 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And creating a share with
+		And the user has created a share with settings
 			| path | textfile0.txt |
 			| shareType | 3 |
 			| password | publicpw |
 			| expireDate | +3 days |
 			| permissions | 1 |
 			| name | sharedlink2 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt"
-		Then user "user0" checks public shares of file "/textfile0.txt"
+		When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt" using the API
+		Then as user "user0" the public shares of file "/textfile0.txt" should be
 			| /textfile0.txt | 1 | sharedlink1 |
 			| /textfile0.txt | 1 | sharedlink2 |
 
 	Scenario: Renaming a folder doesn't remove its public shares
-		Given user "user0" exists
-		And as an "user0"
-		And creating a share with
+		Given the user has created a share with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| password | publicpw |
@@ -216,9 +176,7 @@ Feature: multilinksharing
 			| publicUpload | true |
 			| permissions | 15 |
 			| name | sharedlink1 |
-		And the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And creating a share with
+		And the user has created a share with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| password | publicpw |
@@ -226,7 +184,7 @@ Feature: multilinksharing
 			| publicUpload | true |
 			| permissions | 15 |
 			| name | sharedlink2 |
-		When user "user0" moves folder "/FOLDER" to "/FOLDER_RENAMED"
-		Then user "user0" checks public shares of file "/FOLDER_RENAMED"
+		When user "user0" moves folder "/FOLDER" to "/FOLDER_RENAMED" using the API
+		Then as user "user0" the public shares of file "/FOLDER_RENAMED" should be
 			| /FOLDER_RENAMED | 15 | sharedlink1 |
 			| /FOLDER_RENAMED | 15 | sharedlink2 |

--- a/tests/integration/features/provisioning-v1.feature
+++ b/tests/integration/features/provisioning-v1.feature
@@ -1,122 +1,109 @@
 Feature: provisioning
 	Background:
-		Given using api version "1"
+		Given using API version "1"
 
 	Scenario: Getting a not existing user
-		Given as an "admin"
-		When sending "GET" to "/cloud/users/test"
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/test"
 		Then the OCS status code should be "998"
 		And the HTTP status code should be "200"
 
 	Scenario: Listing all users
-		Given as an "admin"
-		When sending "GET" to "/cloud/users"
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: Create a user
-		Given as an "admin"
-		And user "brand-new-user" does not exist
-		When sending "POST" to "/cloud/users" with
+		Given user "brand-new-user" has been deleted
+		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users" with body
 			| userid   | brand-new-user |
 			| password | 456firstpwd    |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "brand-new-user" already exists
+		And user "brand-new-user" should exist
 
 	Scenario: Create an existing user
-		Given as an "admin"
-		And user "brand-new-user" exists
-		When sending "POST" to "/cloud/users" with
+		Given user "brand-new-user" has been created
+		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users" with body
 			| userid   | brand-new-user |
 			| password | 456newpwd      |
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
 
 	Scenario: Get an existing user
-		Given as an "admin"
-		And user "brand-new-user" exists
-		When sending "GET" to "/cloud/users/brand-new-user"
+		Given user "brand-new-user" has been created
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: Getting all users
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And user "admin" exists
-		When sending "GET" to "/cloud/users"
-		Then users returned are
+		Given user "brand-new-user" has been created
+		And user "admin" has been created
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users"
+		Then the users returned by the API should be
 			| brand-new-user |
 			| admin |
 
 	Scenario: Edit a user
-		Given as an "admin"
-		And user "brand-new-user" exists
-		When sending "PUT" to "/cloud/users/brand-new-user" with
+		Given user "brand-new-user" has been created
+		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
 			| key | quota |
 			| value | 12MB |
 			| key | email |
 			| value | brand-new-user@gmail.com |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "brand-new-user" already exists
+		And user "brand-new-user" should exist
 
 	Scenario: Create a group
-		Given as an "admin"
-		And group "new-group" does not exist
-		When sending "POST" to "/cloud/groups" with
+		Given group "new-group" has been deleted
+		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And group "new-group" already exists
+		And group "new-group" should exist
 
 	Scenario: Create a group with special characters
-		Given as an "admin"
-		And group "España" does not exist
-		When sending "POST" to "/cloud/groups" with
+		Given group "España" has been deleted
+		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
 			| groupid | España |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And group "España" already exists
+		And group "España" should exist
 
 	Scenario: Create a group named "0"
-		Given as an "admin"
-		And group "0" does not exist
-		When sending "POST" to "/cloud/groups" with
+		Given group "0" has been deleted
+		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
 			| groupid | 0 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And group "0" already exists
+		And group "0" should exist
 
 	Scenario: adding user to a group without sending the group
-		Given as an "admin"
-		And user "brand-new-user" exists
-		When sending "POST" to "/cloud/users/brand-new-user/groups" with
+		Given user "brand-new-user" has been created
+		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid |  |
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
 
 	Scenario: adding user to a group which doesn't exist
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And group "not-group" does not exist
-		When sending "POST" to "/cloud/users/brand-new-user/groups" with
+		Given user "brand-new-user" has been created
+		And group "not-group" has been deleted
+		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | not-group |
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
 
 	Scenario: adding user to a group without privileges
-		Given as an "brand-new-user"
-		When sending "POST" to "/cloud/users/brand-new-user/groups" with
+		Given user "brand-new-user" has been created
+		When user "brand-new-user" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 
 	Scenario Outline: adding a user to a group
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And group "<group_id>" exists
-		When sending "POST" to "/cloud/users/brand-new-user/groups" with
+		Given user "brand-new-user" has been created
+		And group "<group_id>" has been created
+		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -126,188 +113,168 @@ Feature: provisioning
 			| 0         |
 
 	Scenario: getting groups of an user
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And group "new-group" exists
-		And group "0" exists
-		And user "brand-new-user" belongs to group "new-group"
-		And user "brand-new-user" belongs to group "0"
-		When sending "GET" to "/cloud/users/brand-new-user/groups"
-		Then groups returned are
+		Given user "brand-new-user" has been created
+		And group "new-group" has been created
+		And group "0" has been created
+		And user "brand-new-user" has been added to group "new-group"
+		And user "brand-new-user" has been added to group "0"
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user/groups"
+		Then the groups returned by the API should be
 			| new-group |
 			| 0 |
 		And the OCS status code should be "100"
 
 	Scenario: adding a user which doesn't exist to a group
-		Given as an "admin"
-		And user "not-user" does not exist
-		And group "new-group" exists
-		When sending "POST" to "/cloud/users/not-user/groups" with
+		Given user "not-user" has been deleted
+		And group "new-group" has been created
+		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/not-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "103"
 		And the HTTP status code should be "200"
 
 	Scenario: getting a group
-		Given as an "admin"
-		And group "new-group" exists
-		When sending "GET" to "/cloud/groups/new-group"
+		Given group "new-group" has been created
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: Getting all groups
-		Given as an "admin"
-		And group "0" exists
-		And group "new-group" exists
-		And group "admin" exists
-		And group "España" exists
-		When sending "GET" to "/cloud/groups"
-		Then groups returned are
+		Given group "0" has been created
+		And group "new-group" has been created
+		And group "admin" has been created
+		And group "España" has been created
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups"
+		Then the groups returned by the API should be
 			| España |
 			| admin |
 			| new-group |
 			| 0 |
 
 	Scenario: create a subadmin
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And group "new-group" exists
-		When sending "POST" to "/cloud/users/brand-new-user/subadmins" with
+		Given user "brand-new-user" has been created
+		And group "new-group" has been created
+		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: get users using a subadmin
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And group "new-group" exists
-		And user "brand-new-user" belongs to group "new-group"
-		And assure user "brand-new-user" is subadmin of group "new-group"
-		And as an "brand-new-user"
-		When sending "GET" to "/cloud/users"
-		Then users returned are
+		Given user "brand-new-user" has been created
+		And group "new-group" has been created
+		And user "brand-new-user" has been added to group "new-group"
+		And user "brand-new-user" has been made a subadmin of group "new-group"
+		When user "brand-new-user" sends HTTP method "GET" to API endpoint "/cloud/users"
+		Then the users returned by the API should be
 			| brand-new-user |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: removing a user from a group which doesn't exist
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And group "not-group" does not exist
-		When sending "DELETE" to "/cloud/users/brand-new-user/groups" with
+		Given user "brand-new-user" has been created
+		And group "not-group" has been deleted
+		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | not-group |
 		Then the OCS status code should be "102"
 
 	Scenario Outline: removing a user from a group
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And group "<group_id>" exists
-		And user "brand-new-user" belongs to group "<group_id>"
-		When sending "DELETE" to "/cloud/users/brand-new-user/groups" with
+		Given user "brand-new-user" has been created
+		And group "<group_id>" has been created
+		And user "brand-new-user" has been added to group "<group_id>"
+		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "100"
-		And user "brand-new-user" does not belong to group "<group_id>"
+		And user "brand-new-user" should not belong to group "<group_id>"
 		Examples:
 			| group_id  |
 			| new-group |
 			| 0         |
 
 	Scenario: create a subadmin using a user which does not exist
-		Given as an "admin"
-		And user "not-user" does not exist
-		And group "new-group" exists
-		When sending "POST" to "/cloud/users/not-user/subadmins" with
+		Given user "not-user" has been deleted
+		And group "new-group" has been created
+		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/not-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
 
 	Scenario: create a subadmin using a group which does not exist
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And group "not-group" does not exist
-		When sending "POST" to "/cloud/users/brand-new-user/subadmins" with
+		Given user "brand-new-user" has been created
+		And group "not-group" has been deleted
+		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | not-group |
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
 
-	Scenario: Getting subadmin groups
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And group "new-group" exists
-		And assure user "brand-new-user" is subadmin of group "new-group"
-		When sending "GET" to "/cloud/users/brand-new-user/subadmins"
-		Then subadmin groups returned are
+	Scenario: Getting subadmin groups of a user
+		Given user "brand-new-user" has been created
+		And group "new-group" has been created
+		And user "brand-new-user" has been made a subadmin of group "new-group"
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user/subadmins"
+		Then the subadmin groups returned by the API should be
 			| new-group |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: Getting subadmin groups of a user which do not exist
-		Given as an "admin"
-		And user "not-user" does not exist
-		And group "new-group" exists
-		When sending "GET" to "/cloud/users/not-user/subadmins"
+		Given user "not-user" has been deleted
+		And group "new-group" has been created
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/not-user/subadmins"
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
 
 	Scenario: Getting subadmin users of a group
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And group "new-group" exists
-		And assure user "brand-new-user" is subadmin of group "new-group"
-		When sending "GET" to "/cloud/groups/new-group/subadmins"
-		Then subadmin users returned are
+		Given user "brand-new-user" has been created
+		And group "new-group" has been created
+		And user "brand-new-user" has been made a subadmin of group "new-group"
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group/subadmins"
+		Then the subadmin users returned by the API should be
 			| brand-new-user |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: Getting subadmin users of a group which doesn't exist
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And group "not-group" does not exist
-		When sending "GET" to "/cloud/groups/not-group/subadmins"
+		Given user "brand-new-user" has been created
+		And group "not-group" has been deleted
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/not-group/subadmins"
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
 
 	Scenario: Removing subadmin from a group
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And group "new-group" exists
-		And assure user "brand-new-user" is subadmin of group "new-group"
-		When sending "DELETE" to "/cloud/users/brand-new-user/subadmins" with
+		Given user "brand-new-user" has been created
+		And group "new-group" has been created
+		And user "brand-new-user" has been made a subadmin of group "new-group"
+		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: Delete a user
-		Given as an "admin"
-		And user "brand-new-user" exists
-		When sending "DELETE" to "/cloud/users/brand-new-user" 
+		Given user "brand-new-user" has been created
+		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "brand-new-user" does not already exist
+		And user "brand-new-user" should not exist
 
 	Scenario: Delete a group
-		Given as an "admin"
-		And group "new-group" exists
-		When sending "DELETE" to "/cloud/groups/new-group"
+		Given group "new-group" has been created
+		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And group "new-group" does not already exist
+		And group "new-group" should not exist
 
 	Scenario: Delete a group with special characters
-	    Given as an "admin"
-		And group "España" exists
-		When sending "DELETE" to "/cloud/groups/España"
+		Given group "España" has been created
+		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/groups/España"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And group "España" does not already exist
+		And group "España" should not exist
 
 	@no_encryption
 	Scenario: get enabled apps
-		Given as an "admin"
-		When sending "GET" to "/cloud/apps?filter=enabled"
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/apps?filter=enabled"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And apps returned are
+		And the apps returned by the API should include
 			| comments |
 			| dav |
 			| federatedfilesharing |
@@ -322,8 +289,7 @@ Feature: provisioning
 			| files_external |
 
 	Scenario: get app info
-		Given as an "admin"
-		When sending "GET" to "/cloud/apps/files"
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/apps/files"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the XML "data" "id" value should be "files"
@@ -333,288 +299,236 @@ Feature: provisioning
 		And the XML "data" "dependencies" "owncloud" "max-version" attribute value should be a valid version string
 
 #	Scenario: enable an app
-#		Given as an "admin"
-#		And app "comments" is disabled
-#		When sending "POST" to "/cloud/apps/comments"
+#		Given app "comments" is disabled
+#		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/apps/comments"
 #		Then the OCS status code should be "100"
 #		And the HTTP status code should be "200"
 #		And app "comments" is enabled
 #
 #	Scenario: disable an app
-#		Given as an "admin"
-#		And app "comments" is enabled
-#		When sending "DELETE" to "/cloud/apps/comments"
+#		Given app "comments" is enabled
+#		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/apps/comments"
 #		Then the OCS status code should be "100"
 #		And the HTTP status code should be "200"
 #		And app "comments" is disabled
 
 	Scenario: disable an user
-		Given as an "admin"
-		And user "user1" exists
-		When sending "PUT" to "/cloud/users/user1/disable"
+		Given user "user1" has been created
+		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/user1/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "user1" is disabled
+		And user "user1" should be disabled
 
 	Scenario: enable an user
-		Given as an "admin"
-		And user "user1" exists
-		And assure user "user1" is disabled
-		When sending "PUT" to "/cloud/users/user1/enable"
+		Given user "user1" has been created
+		And user "user1" has been disabled
+		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/user1/enable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "user1" is enabled
+		And user "user1" should be enabled
 
 	Scenario: Subadmin should be able to enable or disable an user in their group
-		Given as an "admin"
-		And user "subadmin" exists
-		And user "user1" exists
-		And group "new-group" exists
-		And user "subadmin" belongs to group "new-group"
-		And user "user1" belongs to group "new-group"
-		And assure user "subadmin" is subadmin of group "new-group"
-		And as an "subadmin"
-		When sending "PUT" to "/cloud/users/user1/disable"
+		Given user "subadmin" has been created
+		And user "user1" has been created
+		And group "new-group" has been created
+		And user "subadmin" has been added to group "new-group"
+		And user "user1" has been added to group "new-group"
+		And user "subadmin" has been made a subadmin of group "new-group"
+		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/user1/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And as an "admin"
-		And user "user1" is disabled
+		And user "user1" should be disabled
 
 	Scenario: Subadmin should not be able to enable or disable an user not in their group
-		Given as an "admin"
-		And user "subadmin" exists
-		And user "user1" exists
-		And group "new-group" exists
-		And group "another-group" exists
-		And user "subadmin" belongs to group "new-group"
-		And user "user1" belongs to group "another-group"
-		And assure user "subadmin" is subadmin of group "new-group"
-		And as an "subadmin"
-		When sending "PUT" to "/cloud/users/user1/disable"
+		Given user "subadmin" has been created
+		And user "user1" has been created
+		And group "new-group" has been created
+		And group "another-group" has been created
+		And user "subadmin" has been added to group "new-group"
+		And user "user1" has been added to group "another-group"
+		And user "subadmin" has been made a subadmin of group "new-group"
+		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/user1/disable"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
-		And as an "admin"
-		And user "user1" is enabled
+		And user "user1" should be enabled
 
 	Scenario: Subadmins should not be able to disable users that have admin permissions in their group
-		Given as an "admin"
-		And user "another-admin" exists
-		And user "subadmin" exists
-		And group "new-group" exists
-		And user "another-admin" belongs to group "admin"
-		And user "subadmin" belongs to group "new-group"
-		And user "another-admin" belongs to group "new-group"
-		And assure user "subadmin" is subadmin of group "new-group"
-		And as an "subadmin"
-		When sending "PUT" to "/cloud/users/another-admin/disable"
+		Given user "another-admin" has been created
+		And user "subadmin" has been created
+		And group "new-group" has been created
+		And user "another-admin" has been added to group "admin"
+		And user "subadmin" has been added to group "new-group"
+		And user "another-admin" has been added to group "new-group"
+		And user "subadmin" has been made a subadmin of group "new-group"
+		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/disable"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
-		And as an "admin"
-		And user "another-admin" is enabled
+		And user "another-admin" should be enabled
 
 	Scenario: Admin can disable another admin user
-		Given as an "admin"
-		And user "another-admin" exists
-		And user "another-admin" belongs to group "admin"
-		When sending "PUT" to "/cloud/users/another-admin/disable"
+		Given user "another-admin" has been created
+		And user "another-admin" has been added to group "admin"
+		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "another-admin" is disabled
+		And user "another-admin" should be disabled
 
 	Scenario: Admin can enable another admin user
-		Given as an "admin"
-		And user "another-admin" exists
-		And user "another-admin" belongs to group "admin"
-		And assure user "another-admin" is disabled
-		When sending "PUT" to "/cloud/users/another-admin/enable"
+		Given user "another-admin" has been created
+		And user "another-admin" has been added to group "admin"
+		And user "another-admin" has been disabled
+		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/enable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "another-admin" is enabled
+		And user "another-admin" should be enabled
 
 	Scenario: Admin can disable subadmins in the same group
-		Given as an "admin"
-		And user "subadmin" exists
-		And group "new-group" exists
-		And user "subadmin" belongs to group "new-group"
-		And user "admin" belongs to group "new-group"
-		And assure user "subadmin" is subadmin of group "new-group"
-		When sending "PUT" to "/cloud/users/subadmin/disable"
+		Given user "subadmin" has been created
+		And group "new-group" has been created
+		And user "subadmin" has been added to group "new-group"
+		And user "admin" has been added to group "new-group"
+		And user "subadmin" has been made a subadmin of group "new-group"
+		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/subadmin/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "subadmin" is disabled
+		And user "subadmin" should be disabled
 
 	Scenario: Admin can enable subadmins in the same group
-		Given as an "admin"
-		And user "subadmin" exists
-		And group "new-group" exists
-		And user "subadmin" belongs to group "new-group"
-		And user "admin" belongs to group "new-group"
-		And assure user "subadmin" is subadmin of group "new-group"
-		And assure user "another-admin" is disabled
-		When sending "PUT" to "/cloud/users/subadmin/disable"
+		Given user "subadmin" has been created
+		And group "new-group" has been created
+		And user "subadmin" has been added to group "new-group"
+		And user "admin" has been added to group "new-group"
+		And user "subadmin" has been made a subadmin of group "new-group"
+		And user "another-admin" has been disabled
+		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/subadmin/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "subadmin" is disabled
+		And user "subadmin" should be disabled
 
 	Scenario: Admin user cannot disable himself
-		Given as an "admin"
-		And user "another-admin" exists
-		And user "another-admin" belongs to group "admin"
-		And as an "another-admin"
-		When sending "PUT" to "/cloud/users/another-admin/disable"
+		Given user "another-admin" has been created
+		And user "another-admin" has been added to group "admin"
+		When user "another-admin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/disable"
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
-		And as an "admin"
-		And user "another-admin" is enabled
+		And user "another-admin" should be enabled
 
 	Scenario:Admin user cannot enable himself
-		Given as an "admin"
-		And user "another-admin" exists
-		And user "another-admin" belongs to group "admin"
-		And assure user "another-admin" is disabled
-		And as an "another-admin"
-		When sending "PUT" to "/cloud/users/another-admin/enable"
-		And as an "admin"
-		Then user "another-admin" is disabled
+		And user "another-admin" has been created
+		And user "another-admin" has been added to group "admin"
+		And user "another-admin" has been disabled
+		When user "another-admin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/enable"
+		Then user "another-admin" should be disabled
 
 	Scenario: disable an user with a regular user
-		Given as an "admin"
-		And user "user1" exists
-		And user "user2" exists
-		And as an "user1"
-		When sending "PUT" to "/cloud/users/user2/disable"
+		Given user "user1" has been created
+		And user "user2" has been created
+		When user "user1" sends HTTP method "PUT" to API endpoint "/cloud/users/user2/disable"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
-		And as an "admin"
-		And user "user2" is enabled
+		And user "user2" should be enabled
 
 	Scenario: enable an user with a regular user
-		Given as an "admin"
-		And user "user1" exists
-		And user "user2" exists
-		And assure user "user2" is disabled
-		And as an "user1"
-		When sending "PUT" to "/cloud/users/user2/enable"
+		Given user "user1" has been created
+		And user "user2" has been created
+		And user "user2" has been disabled
+		When user "user1" sends HTTP method "PUT" to API endpoint "/cloud/users/user2/enable"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
-		And as an "admin"
-		And user "user2" is disabled
+		And user "user2" should be disabled
 
 	Scenario: Subadmin should not be able to disable himself
-		Given as an "admin"
-		And user "subadmin" exists
-		And group "new-group" exists
-		And user "subadmin" belongs to group "new-group"
-		And assure user "subadmin" is subadmin of group "new-group"
-		And as an "subadmin"
-		When sending "PUT" to "/cloud/users/subadmin/disable"
+		Given user "subadmin" has been created
+		And group "new-group" has been created
+		And user "subadmin" has been added to group "new-group"
+		And user "subadmin" has been made a subadmin of group "new-group"
+		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/subadmin/disable"
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
-		And as an "admin"
-		And user "subadmin" is enabled
+		And user "subadmin" should be enabled
 
 	Scenario: Subadmin should not be able to enable himself
-		Given as an "admin"
-		And user "subadmin" exists
-		And group "new-group" exists
-		And user "subadmin" belongs to group "new-group"
-		And assure user "subadmin" is subadmin of group "new-group"
-		And assure user "subadmin" is disabled
-		And as an "subadmin"
-		When sending "PUT" to "/cloud/users/subadmin/enabled"
-		Then as an "admin"
-		And user "subadmin" is disabled
+		Given user "subadmin" has been created
+		And group "new-group" has been created
+		And user "subadmin" has been added to group "new-group"
+		And user "subadmin" has been made a subadmin of group "new-group"
+		And user "subadmin" has been disabled
+		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/subadmin/enabled"
+		And user "subadmin" should be disabled
 
 	Scenario: a subadmin can add users to groups the subadmin is responsible for
-		Given as an "admin"
-		And user "subadmin" exists
-		And user "brand-new-user" exists
-		And group "new-group" exists
-		And assure user "subadmin" is subadmin of group "new-group"
-		And as an "subadmin"
-		When sending "POST" to "/cloud/users/brand-new-user/groups" with
+		Given user "subadmin" has been created
+		And user "brand-new-user" has been created
+		And group "new-group" has been created
+		And user "subadmin" has been made a subadmin of group "new-group"
+		When user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And as an "admin"
-		And check that user "brand-new-user" belongs to group "new-group"
+		And user "brand-new-user" should belong to group "new-group"
 
 	Scenario: a subadmin cannot add users to groups the subadmin is not responsible for
-		Given as an "admin"
-		And user "other-subadmin" exists
-		And user "brand-new-user" exists
-		And group "new-group" exists
-		And group "other-group" exists
-		And assure user "other-subadmin" is subadmin of group "other-group"
-		And as an "other-subadmin"
-		When sending "POST" to "/cloud/users/brand-new-user/groups" with
+		Given user "other-subadmin" has been created
+		And user "brand-new-user" has been created
+		And group "new-group" has been created
+		And group "other-group" has been created
+		And user "other-subadmin" has been made a subadmin of group "other-group"
+		When user "other-subadmin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "104"
 		And the HTTP status code should be "200"
-		And as an "admin"
-		And check that user "brand-new-user" does not belong to group "new-group"
+		And user "brand-new-user" should not belong to group "new-group"
 
 	Scenario: a subadmin can remove users from groups the subadmin is responsible for
-		Given as an "admin"
-		And user "subadmin" exists
-		And user "brand-new-user" exists
-		And group "new-group" exists
-		And user "brand-new-user" belongs to group "new-group"
-		And assure user "subadmin" is subadmin of group "new-group"
-		And as an "subadmin"
-		When sending "DELETE" to "/cloud/users/brand-new-user/groups" with
+		Given user "subadmin" has been created
+		And user "brand-new-user" has been created
+		And group "new-group" has been created
+		And user "brand-new-user" has been added to group "new-group"
+		And user "subadmin" has been made a subadmin of group "new-group"
+		When user "subadmin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And as an "admin"
-		And check that user "brand-new-user" does not belong to group "new-group"
+		And user "brand-new-user" should not belong to group "new-group"
 
 	Scenario: a subadmin cannot remove users from groups the subadmin is not responsible for
-		Given as an "admin"
-		And user "other-subadmin" exists
-		And user "brand-new-user" exists
-		And group "new-group" exists
-		And group "other-group" exists
-		And user "brand-new-user" belongs to group "new-group"
-		And assure user "other-subadmin" is subadmin of group "other-group"
-		And as an "other-subadmin"
-		When sending "DELETE" to "/cloud/users/brand-new-user/groups" with
+		Given user "other-subadmin" has been created
+		And user "brand-new-user" has been created
+		And group "new-group" has been created
+		And group "other-group" has been created
+		And user "brand-new-user" has been added to group "new-group"
+		And user "other-subadmin" has been made a subadmin of group "other-group"
+		When user "other-subadmin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "104"
 		And the HTTP status code should be "200"
-		And as an "admin"
-		And check that user "brand-new-user" belongs to group "new-group"
+		And user "brand-new-user" should belong to group "new-group"
 
 	Scenario: Making a web request with an enabled user
-	    Given as an "admin"
-		And user "user0" exists
-		And as an "user0"
-		When sending "GET" with exact url to "/index.php/apps/files"
+		Given user "user0" has been created
+		When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
 		Then the HTTP status code should be "200"
 
 	Scenario: Making a web request with a disabled user
-	    Given as an "admin"
-		And user "user0" exists
-		And assure user "user0" is disabled
-		And as an "user0"
-		When sending "GET" with exact url to "/index.php/apps/files"
+		Given user "user0" has been created
+		And user "user0" has been disabled
+		When user "user0" sends HTTP method "GET" to URL "/index.php/apps/files"
 		Then the HTTP status code should be "403"
 
 	Scenario: Edit a user email twice
-		Given as an "admin"
-		And user "brand-new-user" exists
-		And sending "PUT" to "/cloud/users/brand-new-user" with
+		Given user "brand-new-user" has been created
+		And user "admin" has sent HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
 			| key | email |
 			| value | brand-new-user@gmail.com |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And sending "PUT" to "/cloud/users/brand-new-user" with
+		And user "admin" has sent HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
 			| key | email |
 			| value | brand-new-user@example.com |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		When sending "GET" to "/cloud/users/brand-new-user"
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user attributes match with
+		And the user attributes returned by the API should include
 			| email | brand-new-user@example.com |

--- a/tests/integration/features/provisioning-v1.feature
+++ b/tests/integration/features/provisioning-v1.feature
@@ -41,14 +41,14 @@ Feature: provisioning
 		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users"
 		Then the users returned by the API should be
 			| brand-new-user |
-			| admin |
+			| admin          |
 
 	Scenario: Edit a user
 		Given user "brand-new-user" has been created
 		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
-			| key | quota |
-			| value | 12MB |
-			| key | email |
+			| key   | quota                    |
+			| value | 12MB                     |
+			| key   | email                    |
 			| value | brand-new-user@gmail.com |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -121,7 +121,7 @@ Feature: provisioning
 		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user/groups"
 		Then the groups returned by the API should be
 			| new-group |
-			| 0 |
+			| 0         |
 		And the OCS status code should be "100"
 
 	Scenario: adding a user which doesn't exist to a group
@@ -145,10 +145,10 @@ Feature: provisioning
 		And group "España" has been created
 		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups"
 		Then the groups returned by the API should be
-			| España |
-			| admin |
+			| España    |
+			| admin     |
 			| new-group |
-			| 0 |
+			| 0         |
 
 	Scenario: create a subadmin
 		Given user "brand-new-user" has been created
@@ -275,18 +275,18 @@ Feature: provisioning
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the apps returned by the API should include
-			| comments |
-			| dav |
+			| comments             |
+			| dav                  |
 			| federatedfilesharing |
-			| federation |
-			| files |
-			| files_sharing |
-			| files_trashbin |
-			| files_versions |
-			| provisioning_api |
-			| systemtags |
-			| updatenotification |
-			| files_external |
+			| federation           |
+			| files                |
+			| files_sharing        |
+			| files_trashbin       |
+			| files_versions       |
+			| provisioning_api     |
+			| systemtags           |
+			| updatenotification   |
+			| files_external       |
 
 	Scenario: get app info
 		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/apps/files"
@@ -518,12 +518,12 @@ Feature: provisioning
 	Scenario: Edit a user email twice
 		Given user "brand-new-user" has been created
 		And user "admin" has sent HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
-			| key | email |
+			| key   | email                    |
 			| value | brand-new-user@gmail.com |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "admin" has sent HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
-			| key | email |
+			| key   | email                      |
 			| value | brand-new-user@example.com |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"

--- a/tests/integration/features/provisioning-v2.feature
+++ b/tests/integration/features/provisioning-v2.feature
@@ -1,17 +1,15 @@
 Feature: provisioning
   Background:
-    Given using api version "2"
+    Given using API version "2"
 
   Scenario: Getting a not existing user
-    Given as an "admin"
-    When sending "GET" to "/cloud/users/test"
+    When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/test"
     Then the HTTP status code should be "404"
 
   Scenario Outline: adding a user to a group
-    Given as an "admin"
-    And user "brand-new-user" exists
-    And group "<group_id>" exists
-    When sending "POST" to "/cloud/users/brand-new-user/groups" with
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
       | groupid | <group_id> |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -21,14 +19,13 @@ Feature: provisioning
       | 0         |
 
   Scenario Outline: removing a user from a group
-    Given as an "admin"
-    And user "brand-new-user" exists
-    And group "<group_id>" exists
-    And user "brand-new-user" belongs to group "<group_id>"
-    When sending "DELETE" to "/cloud/users/brand-new-user/groups" with
+    Given user "brand-new-user" has been created
+    And group "<group_id>" has been created
+    And user "brand-new-user" has been added to group "<group_id>"
+    When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
       | groupid | <group_id> |
     Then the OCS status code should be "200"
-    And user "brand-new-user" does not belong to group "<group_id>"
+    And user "brand-new-user" should not belong to group "<group_id>"
     Examples:
       | group_id  |
       | new-group |

--- a/tests/integration/features/quota.feature
+++ b/tests/integration/features/quota.feature
@@ -1,133 +1,112 @@
 Feature: quota
 	Background:
-		Given using api version "1"
+		Given using API version "1"
 
 	# Owner
 
 	Scenario: Uploading a file as owner having enough quota
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user0" has a quota of "10 MB"
-		When user "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms
+		Given using new DAV path
+		And user "user0" has been created
+		And the quota of user "user0" has been set to "10 MB"
+		When user "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the API
 		Then the HTTP status code of all upload responses should be "201"
 
 	Scenario: Uploading a file as owner having insufficient quota
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user0" has a quota of "20 B"
-		When user "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms
+		Given using new DAV path
+		And user "user0" has been created
+		And the quota of user "user0" has been set to "20 B"
+		When user "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the API
 		Then the HTTP status code of all upload responses should be "507"
-		And as "user0" the file "/testquota.txt" does not exist
+		And as "user0" the file "/testquota.txt" should not exist
 
 	Scenario: Overwriting a file as owner having enough quota
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user0" has a quota of "10 MB"
-		And user "user0" uploads file with content "test" to "/testquota.txt"
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms
+		Given using new DAV path
+		And user "user0" has been created
+		And the quota of user "user0" has been set to "10 MB"
+		And user "user0" has uploaded file with content "test" to "/testquota.txt"
+		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the API
 		Then the HTTP status code of all upload responses should be "204"
 
 	Scenario: Overwriting a file as owner having insufficient quota
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user0" has a quota of "20 B"
-		And user "user0" uploads file with content "test" to "/testquota.txt"
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms
+		Given using new DAV path
+		And user "user0" has been created
+		And the quota of user "user0" has been set to "20 B"
+		And user "user0" has uploaded file with content "test" to "/testquota.txt"
+		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the API
 		Then the HTTP status code of all upload responses should be "507"
-		And as "user0" the file "/testquota.txt" does not exist
+		And as "user0" the file "/testquota.txt" should not exist
 
 	# Received shared folder
 
 	Scenario: Uploading a file in received folder having enough quota
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" has a quota of "20 B"
-		And user "user1" has a quota of "10 MB"
-		And as an "user1"
-		And user "user1" created a folder "/testquota"
-		And folder "/testquota" of user "user1" is shared with user "user0" with permissions 31
-		And as an "user0"
-		When user "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And the quota of user "user0" has been set to "20 B"
+		And the quota of user "user1" has been set to "10 MB"
+		And user "user1" has created a folder "/testquota"
+		And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
+		When user "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the API
 		Then the HTTP status code of all upload responses should be "201"
 
 	Scenario: Uploading a file in received folder having insufficient quota
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" has a quota of "10 MB"
-		And user "user1" has a quota of "20 B"
-		And as an "user1"
-		And user "user1" created a folder "/testquota"
-		And folder "/testquota" of user "user1" is shared with user "user0" with permissions 31
-		And as an "user0"
-		When user "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And the quota of user "user0" has been set to "10 MB"
+		And the quota of user "user1" has been set to "20 B"
+		And user "user1" has created a folder "/testquota"
+		And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
+		When user "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the API
 		Then the HTTP status code of all upload responses should be "507"
-		And as "user0" the file "/testquota/testquota.txt" does not exist
+		And as "user0" the file "/testquota/testquota.txt" should not exist
 
 	Scenario: Overwriting a file in received folder having enough quota
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" has a quota of "20 B"
-		And user "user1" has a quota of "10 MB"
-		And as an "user1"
-		And user "user1" created a folder "/testquota"
-		And user "user1" uploads file with content "test" to "/testquota/testquota.txt"
-		And folder "/testquota" of user "user1" is shared with user "user0" with permissions 31
-		And as an "user0"
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And the quota of user "user0" has been set to "20 B"
+		And the quota of user "user1" has been set to "10 MB"
+		And user "user1" has created a folder "/testquota"
+		And user "user1" has uploaded file with content "test" to "/testquota/testquota.txt"
+		And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
+		When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the API
 		Then the HTTP status code of all upload responses should be "204"
 
 	Scenario: Overwriting a file in received folder having insufficient quota
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" has a quota of "10 MB"
-		And user "user1" has a quota of "20 B"
-		And as an "user1"
-		And user "user1" created a folder "/testquota"
-		And user "user1" uploads file with content "test" to "/testquota/testquota.txt"
-		And folder "/testquota" of user "user1" is shared with user "user0" with permissions 31
-		And as an "user0"
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And the quota of user "user0" has been set to "10 MB"
+		And the quota of user "user1" has been set to "20 B"
+		And user "user1" has created a folder "/testquota"
+		And user "user1" has uploaded file with content "test" to "/testquota/testquota.txt"
+		And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
+		When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the API
 		Then the HTTP status code of all upload responses should be "507"
-		And as "user0" the file "/testquota/testquota.txt" does not exist
+		And as "user0" the file "/testquota/testquota.txt" should not exist
 
 	# Received shared file
 
 	Scenario: Overwriting a received file having enough quota
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" has a quota of "20 B"
-		And user "user1" has a quota of "10 MB"
-		And as an "user1"
-		And user "user1" uploads file with content "test" to "/testquota.txt"
-		And file "/testquota.txt" of user "user1" is shared with user "user0" with permissions 19
-		And as an "user0"
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And the quota of user "user0" has been set to "20 B"
+		And the quota of user "user1" has been set to "10 MB"
+		And user "user1" has uploaded file with content "test" to "/testquota.txt"
+		And user "user1" has shared file "/testquota.txt" with user "user0" with permissions 19
+		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the API
 		Then the HTTP status code of all upload responses should be "204"
 
 	Scenario: Overwriting a received file having insufficient quota
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" has a quota of "10 MB"
-		And user "user1" has a quota of "20 B"
-		And as an "user1"
-		And user "user1" moves file "/textfile0.txt" to "/testquota.txt"
-		And file "/testquota.txt" of user "user1" is shared with user "user0" with permissions 19
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And the quota of user "user0" has been set to "10 MB"
+		And the quota of user "user1" has been set to "20 B"
+		And user "user1" has moved file "/textfile0.txt" to "/testquota.txt"
+		And user "user1" has shared file "/testquota.txt" with user "user0" with permissions 19
+		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the API
 		Then the HTTP status code of all upload responses should be "507"
 

--- a/tests/integration/features/recreatemasterkey.feature
+++ b/tests/integration/features/recreatemasterkey.feature
@@ -2,24 +2,20 @@ Feature: recreate-master-key
 
 	@masterkey_encryption
 	Scenario: recreate masterkey
-		Given user "admin" exists
-		And user "admin" uploads file "data/textfile.txt" to "/somefile.txt"
-		When recreating masterkey by deleting old one and encrypting the filesystem
-		Then the command was successful
-		And logging in using web as "admin"
-		And logging in using web as "admin"
-		And as an "admin"
-		And downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
+		Given user "admin" has been created
+		And user "admin" has uploaded file "data/textfile.txt" to "/somefile.txt"
+		When the administrator successfully recreates the encryption masterkey using the occ command
+		And user "admin" logs in to a web-style session using the API
+		And user "admin" logs in to a web-style session using the API
+		Then the downloaded content when downloading file "/somefile.txt" for user "admin" with range "bytes=0-6" should be "This is"
 
 	@masterkey_encryption
 	Scenario: recreate masterkey and upload data
-		Given user "user0" exists
-		And user "user0" uploads file "data/textfile.txt" to "/somefile.txt"
-		And recreating masterkey by deleting old one and encrypting the filesystem
-		And the command was successful
-		And logging in using web as "admin"
-		And logging in using web as "user0"
-		And as an "user0"
-		When user "user0" uploads chunk file "1" of "1" with "AA" to "/somefile.txt"
-		Then downloaded content when downloading file "/somefile.txt" with range "bytes=0-3" should be "AA"
+		Given user "user0" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
+		When the administrator successfully recreates the encryption masterkey using the occ command
+		And user "admin" logs in to a web-style session using the API
+		And user "user0" logs in to a web-style session using the API
+		And user "user0" uploads chunk file "1" of "1" with "AA" to "/somefile.txt" using the API
+		Then the downloaded content when downloading file "/somefile.txt" for user "user0" with range "bytes=0-3" should be "AA"
 

--- a/tests/integration/features/sharing-v1.feature
+++ b/tests/integration/features/sharing-v1.feature
@@ -7,9 +7,9 @@ Feature: sharing
 		Given user "user0" has been created
 		And user "user1" has been created
 		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path | welcome.txt |
-			| shareWith | user1 |
-			| shareType | 0 |
+			| path      | welcome.txt |
+			| shareWith | user1       |
+			| shareType | 0           |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
@@ -18,9 +18,9 @@ Feature: sharing
 		And user "user1" has been created
 		And group "sharing-group" has been created
 		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path | welcome.txt |
+			| path      | welcome.txt   |
 			| shareWith | sharing-group |
-			| shareType | 1 |
+			| shareType | 1             |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
@@ -31,17 +31,17 @@ Feature: sharing
 		And user "user1" has been added to group "sharing-group"
 		And user "user0" has shared file "welcome.txt" with group "sharing-group"
 		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path | welcome.txt |
-			| shareWith | user1 |
-			| shareType | 0 |
+			| path      | welcome.txt |
+			| shareWith | user1       |
+			| shareType | 0           |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: Creating a new public share
 		Given user "user0" has been created
 		When user "user0" creates a share using the API with settings
-			| path | welcome.txt |
-			| shareType | 3 |
+			| path      | welcome.txt |
+			| shareType | 3           |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the last public shared file should be able to be downloaded without a password
@@ -49,9 +49,9 @@ Feature: sharing
 	Scenario: Creating a new public share with password
 		Given user "user0" has been created
 		When user "user0" creates a share using the API with settings
-			| path | welcome.txt |
-			| shareType | 3 |
-			| password | publicpw |
+			| path      | welcome.txt |
+			| shareType | 3           |
+			| password  | publicpw    |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the last public shared file should be able to be downloaded with password "publicpw"
@@ -59,29 +59,29 @@ Feature: sharing
 	Scenario: Creating a new public share of a folder
 		Given user "user0" has been created
 		When user "user0" creates a share using the API with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| password | publicpw |
-			| expireDate | +3 days |
-			| publicUpload | true |
-			| permissions | 7 |
+			| path         | FOLDER   |
+			| shareType    | 3        |
+			| password     | publicpw |
+			| expireDate   | +3 days  |
+			| publicUpload | true     |
+			| permissions  | 7        |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| permissions | 15 |
-			| expiration | +3 days |
-			| url | AN_URL |
-			| token | A_TOKEN |
-			| mimetype | httpd/unix-directory |
+			| id          | A_NUMBER             |
+			| permissions | 15                   |
+			| expiration  | +3 days              |
+			| url         | AN_URL               |
+			| token       | A_TOKEN              |
+			| mimetype    | httpd/unix-directory |
 
 	Scenario: Creating a new public share with password and adding an expiration date
 		Given user "user0" has been created
 		And as user "user0"
 		When the user creates a share using the API with settings
-			| path | welcome.txt |
-			| shareType | 3 |
-			| password | publicpw |
+			| path      | welcome.txt |
+			| shareType | 3           |
+			| password  | publicpw    |
 		And the user updates the last share using the API with
 			| expireDate | +3 days |
 		Then the OCS status code should be "100"
@@ -92,130 +92,130 @@ Feature: sharing
 		Given user "user0" has been created
 		And as user "user0"
 		When the user creates a share using the API with settings
-			| path | FOLDER |
-			| shareType | 3 |
+			| path      | FOLDER |
+			| shareType | 3      |
 		And the user updates the last share using the API with
 			| expireDate | +3 days |
 		And the user gets the info of the last share using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| item_type | folder |
-			| item_source | A_NUMBER |
-			| share_type | 3 |
-			| file_source | A_NUMBER |
-			| file_target | /FOLDER |
-			| permissions | 1 |
-			| stime | A_NUMBER |
-			| expiration | +3 days |
-			| token | A_TOKEN |
-			| storage | A_NUMBER |
-			| mail_send | 0 |
-			| uid_owner | user0 |
-			| storage_id | home::user0 |
-			| file_parent | A_NUMBER |
-			| displayname_owner | user0 |
-			| url | AN_URL |
-			| mimetype | httpd/unix-directory |
+			| id                | A_NUMBER             |
+			| item_type         | folder               |
+			| item_source       | A_NUMBER             |
+			| share_type        | 3                    |
+			| file_source       | A_NUMBER             |
+			| file_target       | /FOLDER              |
+			| permissions       | 1                    |
+			| stime             | A_NUMBER             |
+			| expiration        | +3 days              |
+			| token             | A_TOKEN              |
+			| storage           | A_NUMBER             |
+			| mail_send         | 0                    |
+			| uid_owner         | user0                |
+			| storage_id        | home::user0          |
+			| file_parent       | A_NUMBER             |
+			| displayname_owner | user0                |
+			| url               | AN_URL               |
+			| mimetype          | httpd/unix-directory |
 
 	Scenario: Creating a new public share, updating its password and getting its info
 		Given user "user0" has been created
 		And as user "user0"
 		When the user creates a share using the API with settings
-			| path | FOLDER |
-			| shareType | 3 |
+			| path      | FOLDER |
+			| shareType | 3      |
 		And the user updates the last share using the API with
 			| password | publicpw |
 		And the user gets the info of the last share using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| item_type | folder |
-			| item_source | A_NUMBER |
-			| share_type | 3 |
-			| file_source | A_NUMBER |
-			| file_target | /FOLDER |
-			| permissions | 1 |
-			| stime | A_NUMBER |
-			| token | A_TOKEN |
-			| storage | A_NUMBER |
-			| mail_send | 0 |
-			| uid_owner | user0 |
-			| storage_id | home::user0 |
-			| file_parent | A_NUMBER |
-			| displayname_owner | user0 |
-			| url | AN_URL |
-			| mimetype | httpd/unix-directory |
+			| id                | A_NUMBER             |
+			| item_type         | folder               |
+			| item_source       | A_NUMBER             |
+			| share_type        | 3                    |
+			| file_source       | A_NUMBER             |
+			| file_target       | /FOLDER              |
+			| permissions       | 1                    |
+			| stime             | A_NUMBER             |
+			| token             | A_TOKEN              |
+			| storage           | A_NUMBER             |
+			| mail_send         | 0                    |
+			| uid_owner         | user0                |
+			| storage_id        | home::user0          |
+			| file_parent       | A_NUMBER             |
+			| displayname_owner | user0                |
+			| url               | AN_URL               |
+			| mimetype          | httpd/unix-directory |
 
 	Scenario: Creating a new public share, updating its permissions and getting its info
 		Given user "user0" has been created
 		And as user "user0"
 		When the user creates a share using the API with settings
-			| path | FOLDER |
-			| shareType | 3 |
+			| path      | FOLDER |
+			| shareType | 3      |
 		And the user updates the last share using the API with
 			| permissions | 7 |
 		And the user gets the info of the last share using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| item_type | folder |
-			| item_source | A_NUMBER |
-			| share_type | 3 |
-			| file_source | A_NUMBER |
-			| file_target | /FOLDER |
-			| permissions | 15 |
-			| stime | A_NUMBER |
-			| token | A_TOKEN |
-			| storage | A_NUMBER |
-			| mail_send | 0 |
-			| uid_owner | user0 |
-			| storage_id | home::user0 |
-			| file_parent | A_NUMBER |
-			| displayname_owner | user0 |
-			| url | AN_URL |
-			| mimetype | httpd/unix-directory |
+			| id                | A_NUMBER             |
+			| item_type         | folder               |
+			| item_source       | A_NUMBER             |
+			| share_type        | 3                    |
+			| file_source       | A_NUMBER             |
+			| file_target       | /FOLDER              |
+			| permissions       | 15                   |
+			| stime             | A_NUMBER             |
+			| token             | A_TOKEN              |
+			| storage           | A_NUMBER             |
+			| mail_send         | 0                    |
+			| uid_owner         | user0                |
+			| storage_id        | home::user0          |
+			| file_parent       | A_NUMBER             |
+			| displayname_owner | user0                |
+			| url               | AN_URL               |
+			| mimetype          | httpd/unix-directory |
 
 	Scenario: Creating a new public share, updating publicUpload option and getting its info
 		Given user "user0" has been created
 		And as user "user0"
 		When the user creates a share using the API with settings
-			| path | FOLDER |
-			| shareType | 3 |
+			| path      | FOLDER |
+			| shareType | 3      |
 		And the user updates the last share using the API with
 			| publicUpload | true |
 		And the user gets the info of the last share using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| item_type | folder |
-			| item_source | A_NUMBER |
-			| share_type | 3 |
-			| file_source | A_NUMBER |
-			| file_target | /FOLDER |
-			| permissions | 15 |
-			| stime | A_NUMBER |
-			| token | A_TOKEN |
-			| storage | A_NUMBER |
-			| mail_send | 0 |
-			| uid_owner | user0 |
-			| storage_id | home::user0 |
-			| file_parent | A_NUMBER |
-			| displayname_owner | user0 |
-			| url | AN_URL |
-			| mimetype | httpd/unix-directory |
+			| id                | A_NUMBER             |
+			| item_type         | folder               |
+			| item_source       | A_NUMBER             |
+			| share_type        | 3                    |
+			| file_source       | A_NUMBER             |
+			| file_target       | /FOLDER              |
+			| permissions       | 15                   |
+			| stime             | A_NUMBER             |
+			| token             | A_TOKEN              |
+			| storage           | A_NUMBER             |
+			| mail_send         | 0                    |
+			| uid_owner         | user0                |
+			| storage_id        | home::user0          |
+			| file_parent       | A_NUMBER             |
+			| displayname_owner | user0                |
+			| url               | AN_URL               |
+			| mimetype          | httpd/unix-directory |
 
 	Scenario: Uploading to a public upload-only share
 		Given user "user0" has been created
 		And as user "user0"
 		And the user has created a share with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| permissions | 4 |
+			| path        | FOLDER |
+			| shareType   | 3      |
+			| permissions | 4      |
 		And the public has uploaded file "test.txt" with content "test"
 		When the user downloads the file "/FOLDER/test.txt" using the API
 		Then the downloaded content should be "test"
@@ -224,10 +224,10 @@ Feature: sharing
 		Given user "user0" has been created
 		And as user "user0"
 		And the user has created a share with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| password | publicpw |
-			| permissions | 4 |
+			| path        | FOLDER   |
+			| shareType   | 3        |
+			| password    | publicpw |
+			| permissions | 4        |
 		And the public has uploaded file "test.txt" with password "publicpw" and content "test"
 		When the user downloads the file "/FOLDER/test.txt" using the API
 		Then the downloaded content should be "test"
@@ -236,9 +236,9 @@ Feature: sharing
 		Given user "user0" has been created
 		And user "user0" has moved file "/textfile0.txt" to "/FOLDER/test.txt"
 		When user "user0" creates a share using the API with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| permissions | 4 |
+			| path        | FOLDER |
+			| shareType   | 3      |
+			| permissions | 4      |
 		Then the public shared file "test.txt" should not be able to be downloaded
 		And the HTTP status code should be "404"
 
@@ -246,9 +246,9 @@ Feature: sharing
 		Given user "user0" has been created
 		And as user "user0"
 		And the user has created a share with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| permissions | 4 |
+			| path        | FOLDER |
+			| shareType   | 3      |
+			| permissions | 4      |
 		And the public has uploaded file "test.txt" with content "test"
 		And the public has uploaded file "test.txt" with content "test2" with autorename mode
 		When the user downloads the file "/FOLDER/test.txt" using the API
@@ -259,9 +259,9 @@ Feature: sharing
 	Scenario: Uploading file to a public upload-only share that was deleted does not work
 		Given user "user0" has been created
 		And user "user0" has created a share with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| permissions | 4 |
+			| path        | FOLDER |
+			| shareType   | 3      |
+			| permissions | 4      |
 		When user "user0" deletes file "/FOLDER" using the API
 		Then publicly uploading a file should not work
 		And the HTTP status code should be "404"
@@ -269,9 +269,9 @@ Feature: sharing
 	Scenario: Uploading file to a public read-only share does not work
 		Given user "user0" has been created
 		When user "user0" creates a share using the API with settings
-			| path | FOLDER |
-			| shareType | 3 |
-			| permissions | 1 |
+			| path        | FOLDER |
+			| shareType   | 3      |
+			| permissions | 1      |
 		Then publicly uploading a file should not work
 		And the HTTP status code should be "403"
 
@@ -344,24 +344,24 @@ Feature: sharing
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| item_type | file |
-			| item_source | A_NUMBER |
-			| share_type | 0 |
-			| share_with | user1 |
-			| file_source | A_NUMBER |
-			| file_target | /file_to_share.txt |
-			| path | /file_to_share.txt |
-			| permissions | 19 |
-			| stime | A_NUMBER |
-			| storage | A_NUMBER |
-			| mail_send | 0 |
-			| uid_owner | user0 |
-			| storage_id | home::user0 |
-			| file_parent | A_NUMBER |
-			| share_with_displayname | user1 |
-			| displayname_owner | user0 |
-			| mimetype | text/plain |
+			| id                     | A_NUMBER           |
+			| item_type              | file               |
+			| item_source            | A_NUMBER           |
+			| share_type             | 0                  |
+			| share_with             | user1              |
+			| file_source            | A_NUMBER           |
+			| file_target            | /file_to_share.txt |
+			| path                   | /file_to_share.txt |
+			| permissions            | 19                 |
+			| stime                  | A_NUMBER           |
+			| storage                | A_NUMBER           |
+			| mail_send              | 0                  |
+			| uid_owner              | user0              |
+			| storage_id             | home::user0        |
+			| file_parent            | A_NUMBER           |
+			| share_with_displayname | user1              |
+			| displayname_owner      | user0              |
+			| mimetype               | text/plain         |
 
 	Scenario: keep group permissions in sync
 		Given user "user0" has been created
@@ -377,21 +377,21 @@ Feature: sharing
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| item_type | file |
-			| item_source | A_NUMBER |
-			| share_type | 1 |
-			| file_source | A_NUMBER |
-			| file_target | /textfile0.txt |
-			| permissions | 1 |
-			| stime | A_NUMBER |
-			| storage | A_NUMBER |
-			| mail_send | 0 |
-			| uid_owner | user0 |
-			| storage_id | home::user0 |
-			| file_parent | A_NUMBER |
-			| displayname_owner | user0 |
-			| mimetype | text/plain |
+			| id                | A_NUMBER       |
+			| item_type         | file           |
+			| item_source       | A_NUMBER       |
+			| share_type        | 1              |
+			| file_source       | A_NUMBER       |
+			| file_target       | /textfile0.txt |
+			| permissions       | 1              |
+			| stime             | A_NUMBER       |
+			| storage           | A_NUMBER       |
+			| mail_send         | 0              |
+			| uid_owner         | user0          |
+			| storage_id        | home::user0    |
+			| file_parent       | A_NUMBER       |
+			| displayname_owner | user0          |
+			| mimetype          | text/plain     |
 
 	Scenario: Sharee can see the share
 		Given user "user0" has been created
@@ -438,15 +438,15 @@ Feature: sharing
 		And user "user1" has been created
 		And user "user2" has been created
 		And user "user0" has created a share with settings
-			| path | /textfile0.txt |
-			| shareType | 0 |
-			| shareWith | user1 |
-			| permissions | 8 |
+			| path        | /textfile0.txt |
+			| shareType   | 0              |
+			| shareWith   | user1          |
+			| permissions | 8              |
 		When user "user1" creates a share using the API with settings
-			| path | /textfile0 (2).txt |
-			| shareType | 0 |
-			| shareWith | user2 |
-			| permissions | 31 |
+			| path        | /textfile0 (2).txt |
+			| shareType   | 0                  |
+			| shareWith   | user2              |
+			| permissions | 31                 |
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "200"
 
@@ -455,15 +455,15 @@ Feature: sharing
 		And user "user1" has been created
 		And user "user2" has been created
 		And user "user0" has created a share with settings
-			| path | /textfile0.txt |
-			| shareType | 0 |
-			| shareWith | user1 |
-			| permissions | 16 |
+			| path        | /textfile0.txt |
+			| shareType   | 0              |
+			| shareWith   | user1          |
+			| permissions | 16             |
 		When user "user1" creates a share using the API with settings
-			| path | /textfile0 (2).txt |
-			| shareType | 0 |
-			| shareWith | user2 |
-			| permissions | 31 |
+			| path        | /textfile0 (2).txt |
+			| shareType   | 0                  |
+			| shareWith   | user2              |
+			| permissions | 31                 |
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "200"
 
@@ -484,11 +484,11 @@ Feature: sharing
 		When user "user0" shares file "/PARENT" with user "user1" using the API
 		And user "user0" shares file "/PARENT/CHILD" with group "group0" using the API
 		Then user "user1" should see the following elements
-			| /FOLDER/ |
-			| /PARENT/ |
-			| /CHILD/ |
+			| /FOLDER/           |
+			| /PARENT/           |
+			| /CHILD/            |
 			| /PARENT/parent.txt |
-			| /CHILD/child.txt |
+			| /CHILD/child.txt   |
 		And the HTTP status code should be "200"
 
 	Scenario: Share a file by multiple channels and download from sub-folder
@@ -577,7 +577,7 @@ Feature: sharing
 	Scenario: Don't allow sharing of the root
 		Given user "user0" has been created
 		When user "user0" creates a share using the API with settings
-			| path | / |
+			| path      | / |
 			| shareType | 3 |
 		Then the OCS status code should be "403"
 
@@ -598,16 +598,16 @@ Feature: sharing
 		And user "user2" has been created
 		And user "user0" has created a folder "/TMP"
 		And user "user0" has created a share with settings
-			| path | /TMP |
-			| shareType | 0 |
-			| shareWith | user1 |
-			| permissions | 21 |
+			| path        | /TMP  |
+			| shareType   | 0     |
+			| shareWith   | user1 |
+			| permissions | 21    |
 		And as user "user1"
 		And the user has created a share with settings
-			| path | /TMP |
-			| shareType | 0 |
-			| shareWith | user2 |
-			| permissions | 21 |
+			| path        | /TMP  |
+			| shareType   | 0     |
+			| shareWith   | user2 |
+			| permissions | 21    |
 		When the user updates the last share using the API with
 			| permissions | 31 |
 		Then the OCS status code should be "404"
@@ -616,12 +616,12 @@ Feature: sharing
 		Given user "user0" has been created
 		And as user "user0"
 		And the user has created a share with settings
-			| path | welcome.txt |
-			| shareType | 3 |
+			| path      | welcome.txt |
+			| shareType | 3           |
 		And the last share id has been remembered
 		When the user creates a share using the API with settings
-			| path | welcome.txt |
-			| shareType | 3 |
+			| path      | welcome.txt |
+			| shareType | 3           |
 		Then the share ids should match
 
 	Scenario: Correct webdav share-permissions for owned file
@@ -731,7 +731,7 @@ Feature: sharing
 		When user "user0" shares file "/foo" with user "user2" using the API
 		And user "user1" shares file "/foo" with user "user2" using the API
 		Then user "user2" should see the following elements
-			| /foo/		|
+			| /foo/       |
 			| /foo%20(2)/ |
 
 	Scenario: Creating a new share with a disabled user
@@ -739,9 +739,9 @@ Feature: sharing
 		And user "user1" has been created
 		And user "user0" has been disabled
 		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path | welcome.txt |
-			| shareWith | user1 |
-			| shareType | 0 |
+			| path      | welcome.txt |
+			| shareWith | user1       |
+			| shareType | 0           |
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 
@@ -903,9 +903,9 @@ Feature: sharing
 		And user "user0" has shared file "welcome.txt" with group "sharing-group"
 		And user "user0" has deleted the last share
 		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path | welcome.txt |
+			| path      | welcome.txt   |
 			| shareWith | sharing-group |
-			| shareType | 1 |
+			| shareType | 1             |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
@@ -917,9 +917,9 @@ Feature: sharing
 		And user "user0" has created a folder "/test/sub"
 		And user "user0" has shared file "/test" with group "sharing-group"
 		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path | /test/sub |
-			| shareWith | user1 |
-			| shareType | 0 |
+			| path      | /test/sub |
+			| shareWith | user1     |
+			| shareType | 0         |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And as "user1" the folder "/sub" should exist
@@ -933,9 +933,9 @@ Feature: sharing
 		And user "user0" has created a folder "/test/sub"
 		And user "user0" has shared file "/test" with group "sharing-group"
 		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path | /test/sub |
-			| shareWith | user1 |
-			| shareType | 0 |
+			| path      | /test/sub |
+			| shareWith | user1     |
+			| shareType | 0         |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And as "user1" the folder "/sub" should exist
@@ -997,10 +997,10 @@ Feature: sharing
 		Given user "user0" has been created
 		And user "user1" has been created
 		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
-			| path | welcome.txt |
-			| shareWith | user1 |
-			| shareType | 0 |
-			| permissions | 0 |
+			| path        | welcome.txt |
+			| shareWith   | user1       |
+			| shareType   | 0           |
+			| permissions | 0           |
 		Then the OCS status code should be "400"
 
 	Scenario: Cannot set permissions to zero
@@ -1022,8 +1022,8 @@ Feature: sharing
 		And user "user0" has shared folder "/test" with user "user1" with permissions 17
 		And as user "user1"
 		And the user has created a share with settings
-			| path | /test |
-			| shareType | 3 |
+			| path         | /test |
+			| shareType    | 3     |
 			| publicUpload | false |
 		When the user updates the last share using the API with
 			| publicUpload | true |
@@ -1037,8 +1037,8 @@ Feature: sharing
 		And user "user0" has shared folder "/test" with user "user1" with permissions 31
 		And as user "user1"
 		And the user has created a share with settings
-			| path | /test |
-			| shareType | 3 |
+			| path         | /test |
+			| shareType    | 3     |
 			| publicUpload | false |
 		When the user updates the last share using the API with
 			| publicUpload | true |
@@ -1052,9 +1052,9 @@ Feature: sharing
 		And user "user0" has shared folder "/test" with user "user1" with permissions 17
 		And as user "user1"
 		And the user has created a share with settings
-			| path | /test |
-			| shareType | 3 |
-			| permissions | 1 |
+			| path        | /test |
+			| shareType   | 3     |
+			| permissions | 1     |
 		When the user updates the last share using the API with
 			| permissions | 15 |
 		Then the OCS status code should be "404"
@@ -1067,9 +1067,9 @@ Feature: sharing
 		And user "user0" has shared folder "/test" with user "user1" with permissions 31
 		And as user "user1"
 		And the user has created a share with settings
-			| path | /test |
-			| shareType | 3 |
-			| permissions | 1 |
+			| path        | /test |
+			| shareType   | 3     |
+			| permissions | 1     |
 		When the user updates the last share using the API with
 			| permissions | 15 |
 		Then the OCS status code should be "100"
@@ -1079,42 +1079,42 @@ Feature: sharing
 		Given user "user0" has been created
 		And user "user0" has created a folder "/afolder"
 		When user "user0" creates a share using the API with settings
-			| path | /afolder |
-			| shareType | 3 |
+			| path      | /afolder |
+			| shareType | 3        |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| share_type | 3 |
-			| permissions | 1 |
+			| id          | A_NUMBER |
+			| share_type  | 3        |
+			| permissions | 1        |
 
 	Scenario: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally
 		Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
 		And user "user0" has been created
 		And user "user0" has created a folder "/afolder"
 		When user "user0" creates a share using the API with settings
-			| path | /afolder |
-			| shareType | 3 |
+			| path      | /afolder |
+			| shareType | 3        |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| share_type | 3 |
-			| permissions | 1 |
+			| id          | A_NUMBER |
+			| share_type  | 3        |
+			| permissions | 1        |
 
 	Scenario: Creating a link share with edit permissions keeps it
 		Given user "user0" has been created
 		And user "user0" has created a folder "/afolder"
 		When user "user0" creates a share using the API with settings
-			| path | /afolder |
-			| shareType | 3 |
-			| permissions | 15 |
+			| path        | /afolder |
+			| shareType   | 3        |
+			| permissions | 15       |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| share_type | 3 |
-			| permissions | 15 |
+			| id          | A_NUMBER |
+			| share_type  | 3        |
+			| permissions | 15       |
 
 	Scenario: resharing using a public link with read only permissions is not allowed
 		Given user "user0" has been created
@@ -1122,8 +1122,8 @@ Feature: sharing
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 1
 		When user "user1" creates a share using the API with settings
-			| path | /test |
-			| shareType | 3 |
+			| path         | /test |
+			| shareType    | 3     |
 			| publicUpload | false |
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "200"
@@ -1134,8 +1134,8 @@ Feature: sharing
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 15
 		When user "user1" creates a share using the API with settings
-			| path | /test |
-			| shareType | 3 |
+			| path         | /test |
+			| shareType    | 3     |
 			| publicUpload | false |
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "200"
@@ -1228,21 +1228,21 @@ Feature: sharing
 		When user "user1" moves folder "/folder1/folder2" to "/moved-out/folder2" using the API
 		And user "user1" gets the info of the last share using the API
 		Then the share fields of the last share should include
-			| id | A_NUMBER |
-			| item_type | folder |
-			| item_source | A_NUMBER |
-			| share_type | 0 |
-			| file_source | A_NUMBER |
-			| file_target | /folder2 |
-			| permissions | 31 |
-			| stime | A_NUMBER |
-			| storage | A_NUMBER |
-			| mail_send | 0 |
-			| uid_owner | user1 |
-			| storage_id | home::user1 |
-			| file_parent | A_NUMBER |
-			| displayname_owner | user1 |
-			| mimetype | httpd/unix-directory |
+			| id                | A_NUMBER             |
+			| item_type         | folder               |
+			| item_source       | A_NUMBER             |
+			| share_type        | 0                    |
+			| file_source       | A_NUMBER             |
+			| file_target       | /folder2             |
+			| permissions       | 31                   |
+			| stime             | A_NUMBER             |
+			| storage           | A_NUMBER             |
+			| mail_send         | 0                    |
+			| uid_owner         | user1                |
+			| storage_id        | home::user1          |
+			| file_parent       | A_NUMBER             |
+			| displayname_owner | user1                |
+			| mimetype          | httpd/unix-directory |
 		And as "user0" the folder "/folder1/folder2" should not exist
 		And as "user2" the folder "/folder2" should exist
 
@@ -1258,20 +1258,20 @@ Feature: sharing
 		When user "user1" moves folder "/user0-folder/folder2" to "/user2-folder/folder2" using the API
 		And user "user1" gets the info of the last share using the API
 		Then the share fields of the last share should include
-			| id | A_NUMBER |
-			| item_type | folder |
-			| item_source | A_NUMBER |
-			| share_type | 0 |
-			| file_source | A_NUMBER |
-			| file_target | /user2-folder |
-			| permissions | 31 |
-			| stime | A_NUMBER |
-			| storage | A_NUMBER |
-			| mail_send | 0 |
-			| uid_owner | user2 |
-			| file_parent | A_NUMBER |
-			| displayname_owner | user2 |
-			| mimetype | httpd/unix-directory |
+			| id                | A_NUMBER             |
+			| item_type         | folder               |
+			| item_source       | A_NUMBER             |
+			| share_type        | 0                    |
+			| file_source       | A_NUMBER             |
+			| file_target       | /user2-folder        |
+			| permissions       | 31                   |
+			| stime             | A_NUMBER             |
+			| storage           | A_NUMBER             |
+			| mail_send         | 0                    |
+			| uid_owner         | user2                |
+			| file_parent       | A_NUMBER             |
+			| displayname_owner | user2                |
+			| mimetype          | httpd/unix-directory |
 		And as "user0" the folder "/user0-folder/folder2" should not exist
 		And as "user2" the folder "/user2-folder/folder2" should exist
 

--- a/tests/integration/features/sharing-v1.feature
+++ b/tests/integration/features/sharing-v1.feature
@@ -1,13 +1,12 @@
 Feature: sharing
 	Background:
-		Given using api version "1"
-		Given using old dav path
+		Given using API version "1"
+		And using old DAV path
 
 	Scenario: Creating a new share with user
-		Given user "user0" exists
-		And user "user1" exists
-		And as an "user0"
-		When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+		Given user "user0" has been created
+		And user "user1" has been created
+		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path | welcome.txt |
 			| shareWith | user1 |
 			| shareType | 0 |
@@ -15,11 +14,10 @@ Feature: sharing
 		And the HTTP status code should be "200"
 
 	Scenario: Creating a share with a group
-		Given user "user0" exists
-		And user "user1" exists
-		And group "sharing-group" exists
-		And as an "user0"
-		When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "sharing-group" has been created
+		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path | welcome.txt |
 			| shareWith | sharing-group |
 			| shareType | 1 |
@@ -27,13 +25,12 @@ Feature: sharing
 		And the HTTP status code should be "200"
 
 	Scenario: Creating a new share with user who already received a share through their group
-		Given user "user0" exists
-		And user "user1" exists
-		And group "sharing-group" exists
-		And user "user1" belongs to group "sharing-group"
-		And file "welcome.txt" of user "user0" is shared with group "sharing-group"
-		And as an "user0"
-		Then sending "POST" to "/apps/files_sharing/api/v1/shares" with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "sharing-group" has been created
+		And user "user1" has been added to group "sharing-group"
+		And user "user0" has shared file "welcome.txt" with group "sharing-group"
+		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path | welcome.txt |
 			| shareWith | user1 |
 			| shareType | 0 |
@@ -41,30 +38,27 @@ Feature: sharing
 		And the HTTP status code should be "200"
 
 	Scenario: Creating a new public share
-		Given user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given user "user0" has been created
+		When user "user0" creates a share using the API with settings
 			| path | welcome.txt |
 			| shareType | 3 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And public shared file "welcome.txt" can be downloaded
+		And the last public shared file should be able to be downloaded without a password
 
 	Scenario: Creating a new public share with password
-		Given user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given user "user0" has been created
+		When user "user0" creates a share using the API with settings
 			| path | welcome.txt |
 			| shareType | 3 |
 			| password | publicpw |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And public shared file "welcome.txt" with password "publicpw" can be downloaded
+		And the last public shared file should be able to be downloaded with password "publicpw"
 
 	Scenario: Creating a new public share of a folder
-		Given user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given user "user0" has been created
+		When user "user0" creates a share using the API with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| password | publicpw |
@@ -73,7 +67,7 @@ Feature: sharing
 			| permissions | 7 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| permissions | 15 |
 			| expiration | +3 days |
@@ -82,30 +76,30 @@ Feature: sharing
 			| mimetype | httpd/unix-directory |
 
 	Scenario: Creating a new public share with password and adding an expiration date
-		Given user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given user "user0" has been created
+		And as user "user0"
+		When the user creates a share using the API with settings
 			| path | welcome.txt |
 			| shareType | 3 |
 			| password | publicpw |
-		And updating last share with
+		And the user updates the last share using the API with
 			| expireDate | +3 days |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And public shared file "welcome.txt" with password "publicpw" can be downloaded
+		And the last public shared file should be able to be downloaded with password "publicpw"
 
 	Scenario: Creating a new public share, updating its expiration date and getting its info
-		Given user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given user "user0" has been created
+		And as user "user0"
+		When the user creates a share using the API with settings
 			| path | FOLDER |
 			| shareType | 3 |
-		And updating last share with
+		And the user updates the last share using the API with
 			| expireDate | +3 days |
-		And getting info of last share
+		And the user gets the info of the last share using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| item_type | folder |
 			| item_source | A_NUMBER |
@@ -126,17 +120,17 @@ Feature: sharing
 			| mimetype | httpd/unix-directory |
 
 	Scenario: Creating a new public share, updating its password and getting its info
-		Given user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given user "user0" has been created
+		And as user "user0"
+		When the user creates a share using the API with settings
 			| path | FOLDER |
 			| shareType | 3 |
-		And updating last share with
+		And the user updates the last share using the API with
 			| password | publicpw |
-		And getting info of last share
+		And the user gets the info of the last share using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| item_type | folder |
 			| item_source | A_NUMBER |
@@ -156,17 +150,17 @@ Feature: sharing
 			| mimetype | httpd/unix-directory |
 
 	Scenario: Creating a new public share, updating its permissions and getting its info
-		Given user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given user "user0" has been created
+		And as user "user0"
+		When the user creates a share using the API with settings
 			| path | FOLDER |
 			| shareType | 3 |
-		And updating last share with
+		And the user updates the last share using the API with
 			| permissions | 7 |
-		And getting info of last share
+		And the user gets the info of the last share using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| item_type | folder |
 			| item_source | A_NUMBER |
@@ -186,17 +180,17 @@ Feature: sharing
 			| mimetype | httpd/unix-directory |
 
 	Scenario: Creating a new public share, updating publicUpload option and getting its info
-		Given user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given user "user0" has been created
+		And as user "user0"
+		When the user creates a share using the API with settings
 			| path | FOLDER |
 			| shareType | 3 |
-		And updating last share with
+		And the user updates the last share using the API with
 			| publicUpload | true |
-		And getting info of last share
+		And the user gets the info of the last share using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| item_type | folder |
 			| item_source | A_NUMBER |
@@ -216,104 +210,98 @@ Feature: sharing
 			| mimetype | httpd/unix-directory |
 
 	Scenario: Uploading to a public upload-only share
-		Given user "user0" exists
-		And as an "user0"
-		And creating a share with
+		Given user "user0" has been created
+		And as user "user0"
+		And the user has created a share with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| permissions | 4 |
-		And publicly uploading file "test.txt" with content "test"
-		When downloading file "/FOLDER/test.txt"
-		Then downloaded content should be "test"
+		And the public has uploaded file "test.txt" with content "test"
+		When the user downloads the file "/FOLDER/test.txt" using the API
+		Then the downloaded content should be "test"
 
 	Scenario: Uploading to a public upload-only share with password
-		Given user "user0" exists
-		And as an "user0"
-		And creating a share with
+		Given user "user0" has been created
+		And as user "user0"
+		And the user has created a share with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| password | publicpw |
 			| permissions | 4 |
-		And publicly uploading file "test.txt" with password "publicpw" and content "test"
-		When downloading file "/FOLDER/test.txt"
-		Then downloaded content should be "test"
+		And the public has uploaded file "test.txt" with password "publicpw" and content "test"
+		When the user downloads the file "/FOLDER/test.txt" using the API
+		Then the downloaded content should be "test"
 
 	Scenario: Downloading from upload-only share is forbidden
-		Given user "user0" exists
-		And as an "user0"
-		And user "user0" moves file "/textfile0.txt" to "/FOLDER/test.txt"
-		When creating a share with
+		Given user "user0" has been created
+		And user "user0" has moved file "/textfile0.txt" to "/FOLDER/test.txt"
+		When user "user0" creates a share using the API with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| permissions | 4 |
-		Then public shared file "test.txt" cannot be downloaded
+		Then the public shared file "test.txt" should not be able to be downloaded
 		And the HTTP status code should be "404"
 
 	Scenario: Uploading same file to a public upload-only share multiple times
-		Given user "user0" exists
-		And as an "user0"
-		And creating a share with
+		Given user "user0" has been created
+		And as user "user0"
+		And the user has created a share with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| permissions | 4 |
-		And publicly uploading file "test.txt" with content "test"
-		And publicly uploading file "test.txt" with content "test2" with autorename mode
-		When downloading file "/FOLDER/test.txt"
-		Then downloaded content should be "test"
-		And downloading file "/FOLDER/test (2).txt"
-		And downloaded content should be "test2"
+		And the public has uploaded file "test.txt" with content "test"
+		And the public has uploaded file "test.txt" with content "test2" with autorename mode
+		When the user downloads the file "/FOLDER/test.txt" using the API
+		Then the downloaded content should be "test"
+		And the user downloads the file "/FOLDER/test (2).txt" using the API
+		And the downloaded content should be "test2"
 
 	Scenario: Uploading file to a public upload-only share that was deleted does not work
-		Given user "user0" exists
-		And as an "user0"
-		And creating a share with
+		Given user "user0" has been created
+		And user "user0" has created a share with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| permissions | 4 |
-		When user "user0" deletes file "/FOLDER"
-		Then publicly uploading a file does not work
+		When user "user0" deletes file "/FOLDER" using the API
+		Then publicly uploading a file should not work
 		And the HTTP status code should be "404"
 
 	Scenario: Uploading file to a public read-only share does not work
-		Given user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given user "user0" has been created
+		When user "user0" creates a share using the API with settings
 			| path | FOLDER |
 			| shareType | 3 |
 			| permissions | 1 |
-		Then publicly uploading a file does not work
+		Then publicly uploading a file should not work
 		And the HTTP status code should be "403"
 
 	Scenario: getting all shares of a user using that user
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" moved file "/textfile0.txt" to "/file_to_share.txt"
-		And file "file_to_share.txt" of user "user0" is shared with user "user1"
-		And as an "user0"
-		When sending "GET" to "/apps/files_sharing/api/v1/shares"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has moved file "/textfile0.txt" to "/file_to_share.txt"
+		And user "user0" has shared file "file_to_share.txt" with user "user1"
+		When user "user0" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And file "file_to_share.txt" should be included in the response
 
 	Scenario: getting all shares of a user using another user
-		Given user "user0" exists
-		And user "user1" exists
-		And file "textfile0.txt" of user "user0" is shared with user "user1"
-		And as an "admin"
-		When sending "GET" to "/apps/files_sharing/api/v1/shares"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has shared file "textfile0.txt" with user "user1"
+		When user "admin" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And file "textfile0.txt" should not be included in the response
 
 	Scenario: getting all shares of a file
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user3" exists
-		And file "textfile0.txt" of user "user0" is shared with user "user1"
-		And file "textfile0.txt" of user "user0" is shared with user "user2"
-		And as an "user0"
-		When sending "GET" to "/apps/files_sharing/api/v1/shares?path=textfile0.txt"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user3" has been created
+		And user "user0" has shared file "textfile0.txt" with user "user1"
+		And user "user0" has shared file "textfile0.txt" with user "user2"
+		When user "user0" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?path=textfile0.txt"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "user1" should be included in the response
@@ -321,14 +309,13 @@ Feature: sharing
 		And user "user3" should not be included in the response
 
 	Scenario: getting all shares of a file with reshares
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user3" exists
-		And file "textfile0.txt" of user "user0" is shared with user "user1"
-		And file "textfile0 (2).txt" of user "user1" is shared with user "user2"
-		And as an "user0"
-		When sending "GET" to "/apps/files_sharing/api/v1/shares?reshares=true&path=textfile0.txt"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user3" has been created
+		And user "user0" has shared file "textfile0.txt" with user "user1"
+		And user "user1" has shared file "textfile0 (2).txt" with user "user2"
+		When user "user0" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?reshares=true&path=textfile0.txt"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "user1" should be included in the response
@@ -336,30 +323,27 @@ Feature: sharing
 		And user "user3" should not be included in the response
 
 	Scenario: Reshared files can be still accessed if a user in the middle removes it.
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user3" exists
-		And file "textfile0.txt" of user "user0" is shared with user "user1"
-		And user "user1" moved file "/textfile0 (2).txt" to "/textfile0_shared.txt"
-		And file "textfile0_shared.txt" of user "user1" is shared with user "user2"
-		And file "textfile0_shared.txt" of user "user2" is shared with user "user3"
-		And as an "user1"
-		When user "user1" deletes file "/textfile0_shared.txt"
-		And as an "user3"
-		And downloading file "/textfile0_shared.txt" with range "bytes=1-7"
-		Then downloaded content should be "wnCloud"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user3" has been created
+		And user "user0" has shared file "textfile0.txt" with user "user1"
+		And user "user1" has moved file "/textfile0 (2).txt" to "/textfile0_shared.txt"
+		And user "user1" has shared file "textfile0_shared.txt" with user "user2"
+		And user "user2" has shared file "textfile0_shared.txt" with user "user3"
+		When user "user1" deletes file "/textfile0_shared.txt" using the API
+		And user "user3" downloads file "/textfile0_shared.txt" with range "bytes=1-7" using the API
+		Then the downloaded content should be "wnCloud"
 
 	Scenario: getting share info of a share
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" moved file "/textfile0.txt" to "/file_to_share.txt"
-		And file "file_to_share.txt" of user "user0" is shared with user "user1"
-		And as an "user0"
-		When getting info of last share
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has moved file "/textfile0.txt" to "/file_to_share.txt"
+		And user "user0" has shared file "file_to_share.txt" with user "user1"
+		When user "user0" gets the info of the last share using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| item_type | file |
 			| item_source | A_NUMBER |
@@ -380,19 +364,19 @@ Feature: sharing
 			| mimetype | text/plain |
 
 	Scenario: keep group permissions in sync
-		Given user "user0" exists
-		And user "user1" exists
-		And group "group1" exists
-		And user "user1" belongs to group "group1"
-		And file "textfile0.txt" of user "user0" is shared with group "group1"
-		And user "user1" moved file "/textfile0.txt" to "/FOLDER/textfile0.txt"
-		And as an "user0"
-		When updating last share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "group1" has been created
+		And user "user1" has been added to group "group1"
+		And user "user0" has shared file "textfile0.txt" with group "group1"
+		And user "user1" has moved file "/textfile0.txt" to "/FOLDER/textfile0.txt"
+		And as user "user0"
+		When the user updates the last share using the API with
 			| permissions | 1 |
-		And getting info of last share
+		And the user gets the info of the last share using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| item_type | file |
 			| item_source | A_NUMBER |
@@ -410,61 +394,55 @@ Feature: sharing
 			| mimetype | text/plain |
 
 	Scenario: Sharee can see the share
-		Given user "user0" exists
-		And user "user1" exists
-		And file "textfile0.txt" of user "user0" is shared with user "user1"
-		And as an "user1"
-		When sending "GET" to "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has shared file "textfile0.txt" with user "user1"
+		When user "user1" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And last share_id is included in the answer
+		And the last share_id should be included in the response
 
 	Scenario: Sharee can see the filtered share
-		Given user "user0" exists
-		And user "user1" exists
-		And file "textfile0.txt" of user "user0" is shared with user "user1"
-		And file "textfile1.txt" of user "user0" is shared with user "user1"
-		And as an "user1"
-		When sending "GET" to "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile1 (2).txt"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has shared file "textfile0.txt" with user "user1"
+		And user "user0" has shared file "textfile1.txt" with user "user1"
+		When user "user1" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile1 (2).txt"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And last share_id is included in the answer
+		And the last share_id should be included in the response
 
 	Scenario: Sharee can't see the share that is filtered out
-		Given user "user0" exists
-		And user "user1" exists
-		And file "textfile0.txt" of user "user0" is shared with user "user1"
-		And file "textfile1.txt" of user "user0" is shared with user "user1"
-		And as an "user1"
-		When sending "GET" to "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile0 (2).txt"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has shared file "textfile0.txt" with user "user1"
+		And user "user0" has shared file "textfile1.txt" with user "user1"
+		When user "user1" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile0 (2).txt"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And last share_id is not included in the answer
+		And the last share_id should not be included in the response
 
 	Scenario: Sharee can see the group share
-		Given user "user0" exists
-		And user "user1" exists
-		And group "group0" exists
-		And user "user1" belongs to group "group0"
-		And file "textfile0.txt" of user "user0" is shared with group "group0"
-		And as an "user1"
-		When sending "GET" to "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "group0" has been created
+		And user "user1" has been added to group "group0"
+		And user "user0" has shared file "textfile0.txt" with group "group0"
+		When user "user1" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And last share_id is included in the answer
+		And the last share_id should be included in the response
 
 	Scenario: User is not allowed to reshare file
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And as an "user0"
-		And creating a share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has created a share with settings
 			| path | /textfile0.txt |
 			| shareType | 0 |
 			| shareWith | user1 |
 			| permissions | 8 |
-		And as an "user1"
-		When creating a share with
+		When user "user1" creates a share using the API with settings
 			| path | /textfile0 (2).txt |
 			| shareType | 0 |
 			| shareWith | user2 |
@@ -473,17 +451,15 @@ Feature: sharing
 		And the HTTP status code should be "200"
 
 	Scenario: User is not allowed to reshare file with more permissions
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And as an "user0"
-		And creating a share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has created a share with settings
 			| path | /textfile0.txt |
 			| shareType | 0 |
 			| shareWith | user1 |
 			| permissions | 16 |
-		And as an "user1"
-		When creating a share with
+		When user "user1" creates a share using the API with settings
 			| path | /textfile0 (2).txt |
 			| shareType | 0 |
 			| shareWith | user2 |
@@ -492,23 +468,22 @@ Feature: sharing
 		And the HTTP status code should be "200"
 
 	Scenario: Get a share with a user that didn't receive the share
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And file "textfile0.txt" of user "user0" is shared with user "user1"
-		And as an "user2"
-		When getting info of last share
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has shared file "textfile0.txt" with user "user1"
+		When user "user2" gets the info of the last share using the API
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "200"
 
 	Scenario: Share of folder and sub-folder to same user - core#20645
-		Given user "user0" exists
-		And user "user1" exists
-		And group "group0" exists
-		And user "user1" belongs to group "group0"
-		And file "/PARENT" of user "user0" is shared with user "user1"
-		When file "/PARENT/CHILD" of user "user0" is shared with group "group0"
-		Then user "user1" should see following elements
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "group0" has been created
+		And user "user1" has been added to group "group0"
+		When user "user0" shares file "/PARENT" with user "user1" using the API
+		And user "user0" shares file "/PARENT/CHILD" with group "group0" using the API
+		Then user "user1" should see the following elements
 			| /FOLDER/ |
 			| /PARENT/ |
 			| /CHILD/ |
@@ -517,270 +492,253 @@ Feature: sharing
 		And the HTTP status code should be "200"
 
 	Scenario: Share a file by multiple channels and download from sub-folder
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And group "group0" exists
-		And user "user1" belongs to group "group0"
-		And user "user2" belongs to group "group0"
-		And user "user0" created a folder "/common"
-		And user "user0" created a folder "/common/sub"
-		And folder "common" of user "user0" is shared with group "group0"
-		And file "textfile0.txt" of user "user1" is shared with user "user2"
-		And user "user1" moved file "/textfile0.txt" to "/common/textfile0.txt"
-		And user "user1" moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
-		And as an "user2"
-		When downloading file "/common/sub/textfile0.txt" with range "bytes=9-17"
-		Then downloaded content should be "test text"
-		And downloaded content when downloading file "/textfile0.txt" with range "bytes=9-17" should be "test text"
-		And user "user2" should see following elements
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And group "group0" has been created
+		And user "user1" has been added to group "group0"
+		And user "user2" has been added to group "group0"
+		And user "user0" has created a folder "/common"
+		And user "user0" has created a folder "/common/sub"
+		And user "user0" has shared folder "common" with group "group0"
+		And user "user1" has shared file "textfile0.txt" with user "user2"
+		And user "user1" has moved file "/textfile0.txt" to "/common/textfile0.txt"
+		And user "user1" has moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
+		When user "user2" downloads file "/common/sub/textfile0.txt" with range "bytes=9-17" using the API
+		Then the downloaded content should be "test text"
+		And the downloaded content when downloading file "/textfile0.txt" for user "user2" with range "bytes=9-17" should be "test text"
+		And user "user2" should see the following elements
 			| /common/sub/textfile0.txt |
 
 	Scenario: Share a file by multiple channels and download from direct file share
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And group "group0" exists
-		And user "user1" belongs to group "group0"
-		And user "user2" belongs to group "group0"
-		And user "user0" created a folder "/common"
-		And user "user0" created a folder "/common/sub"
-		And folder "common" of user "user0" is shared with group "group0"
-		And file "textfile0.txt" of user "user1" is shared with user "user2"
-		And user "user1" moved file "/textfile0.txt" to "/common/textfile0.txt"
-		And user "user1" moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
-		And as an "user2"
-		When downloading file "/textfile0.txt" with range "bytes=9-17"
-		Then downloaded content should be "test text"
-		And user "user2" should see following elements
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And group "group0" has been created
+		And user "user1" has been added to group "group0"
+		And user "user2" has been added to group "group0"
+		And user "user0" has created a folder "/common"
+		And user "user0" has created a folder "/common/sub"
+		And user "user0" has shared folder "common" with group "group0"
+		And user "user1" has shared file "textfile0.txt" with user "user2"
+		And user "user1" has moved file "/textfile0.txt" to "/common/textfile0.txt"
+		And user "user1" has moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
+		When user "user2" downloads file "/textfile0.txt" with range "bytes=9-17" using the API
+		Then the downloaded content should be "test text"
+		And user "user2" should see the following elements
 			| /common/sub/textfile0.txt |
 
 	Scenario: Delete all group shares
-		Given user "user0" exists
-		And user "user1" exists
-		And group "group1" exists
-		And user "user1" belongs to group "group1"
-		And file "textfile0.txt" of user "user0" is shared with group "group1"
-		And user "user1" moved file "/textfile0.txt" to "/FOLDER/textfile0.txt"
-		And as an "user0"
-		And deleting last share
-		And as an "user1"
-		When sending "GET" to "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "group1" has been created
+		And user "user1" has been added to group "group1"
+		And user "user0" has shared file "textfile0.txt" with group "group1"
+		And user "user1" has moved file "/textfile0.txt" to "/FOLDER/textfile0.txt"
+		When user "user0" deletes the last share using the API
+		And user "user1" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And last share_id is not included in the answer
+		And the last share_id should not be included in the response
 
 	Scenario: delete a share
-		Given user "user0" exists
-		And user "user1" exists
-		And file "textfile0.txt" of user "user0" is shared with user "user1"
-		And as an "user0"
-		When deleting last share
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has shared file "textfile0.txt" with user "user1"
+		When user "user0" deletes the last share using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: Keep usergroup shares (#22143)
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And group "group" exists
-		And user "user1" belongs to group "group"
-		And user "user2" belongs to group "group"
-		And user "user0" created a folder "/TMP"
-		And file "TMP" of user "user0" is shared with group "group"
-		And user "user1" created a folder "/myFOLDER"
-		And user "user1" moves file "/TMP" to "/myFOLDER/myTMP"
-		And user "user2" does not exist
-		And user "user1" should see following elements
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And group "group" has been created
+		And user "user1" has been added to group "group"
+		And user "user2" has been added to group "group"
+		And user "user0" has created a folder "/TMP"
+		When user "user0" shares file "TMP" with group "group" using the API
+		And user "user1" creates a folder "/myFOLDER" using the API
+		And user "user1" moves file "/TMP" to "/myFOLDER/myTMP" using the API
+		And the administrator deletes user "user2" using the API
+		Then user "user1" should see the following elements
 			| /myFOLDER/myTMP/ |
 
 	Scenario: Check quota of owners parent directory of a shared file
-		Given using old dav path
-		And user "user0" exists
-		And user "user1" exists
-		And as an "admin"
-		And user "user1" has a quota of "0"
-		And user "user0" moved file "/welcome.txt" to "/myfile.txt"
-		And file "myfile.txt" of user "user0" is shared with user "user1"
-		When user "user1" uploads file "data/textfile.txt" to "/myfile.txt"
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And the quota of user "user1" has been set to "0"
+		And user "user0" has moved file "/welcome.txt" to "/myfile.txt"
+		And user "user0" has shared file "myfile.txt" with user "user1"
+		When user "user1" uploads file "data/textfile.txt" to "/myfile.txt" using the API
 		Then the HTTP status code should be "204"
 
 	Scenario: Don't allow sharing of the root
-		Given user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given user "user0" has been created
+		When user "user0" creates a share using the API with settings
 			| path | / |
 			| shareType | 3 |
 		Then the OCS status code should be "403"
 
 	Scenario: Allow modification of reshare
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user0" created a folder "/TMP"
-		And file "TMP" of user "user0" is shared with user "user1"
-		And file "TMP" of user "user1" is shared with user "user2"
-		And as an "user1"
-		When updating last share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has created a folder "/TMP"
+		And user "user0" has shared file "TMP" with user "user1"
+		And user "user1" has shared file "TMP" with user "user2"
+		When user "user1" updates the last share using the API with
 			| permissions | 1 |
 		Then the OCS status code should be "100"
 
 	Scenario: Do not allow reshare to exceed permissions
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user0" created a folder "/TMP"
-		And as an "user0"
-		And creating a share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has created a folder "/TMP"
+		And user "user0" has created a share with settings
 			| path | /TMP |
 			| shareType | 0 |
 			| shareWith | user1 |
 			| permissions | 21 |
-		And as an "user1"
-		And creating a share with
+		And as user "user1"
+		And the user has created a share with settings
 			| path | /TMP |
 			| shareType | 0 |
 			| shareWith | user2 |
 			| permissions | 21 |
-		When updating last share with
+		When the user updates the last share using the API with
 			| permissions | 31 |
 		Then the OCS status code should be "404"
 
 	Scenario: Only allow 1 link share per file/folder
-		Given user "user0" exists
-		And as an "user0"
-		And creating a share with
+		Given user "user0" has been created
+		And as user "user0"
+		And the user has created a share with settings
 			| path | welcome.txt |
 			| shareType | 3 |
-		When save last share id
-		And creating a share with
+		And the last share id has been remembered
+		When the user creates a share using the API with settings
 			| path | welcome.txt |
 			| shareType | 3 |
-		Then share ids should match
+		Then the share ids should match
 
 	Scenario: Correct webdav share-permissions for owned file
-		Given user "user0" exists
-		And user "user0" uploads file with content "foo" to "/tmp.txt"
-		When as "user0" gets properties of folder "/tmp.txt" with
+		Given user "user0" has been created
+		And user "user0" has uploaded file with content "foo" to "/tmp.txt"
+		When user "user0" gets the following properties of folder "/tmp.txt" using the API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
 
 	Scenario: Correct webdav share-permissions for received file with edit and reshare permissions
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" uploads file with content "foo" to "/tmp.txt"
-		And file "/tmp.txt" of user "user0" is shared with user "user1"
-		When as "user1" gets properties of folder "/tmp.txt" with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has uploaded file with content "foo" to "/tmp.txt"
+		And user "user0" has shared file "/tmp.txt" with user "user1"
+		When user "user1" gets the following properties of folder "/tmp.txt" using the API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
 
 	Scenario: Correct webdav share-permissions for received file with edit permissions but no reshare permissions
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" uploads file with content "foo" to "/tmp.txt"
-		And file "tmp.txt" of user "user0" is shared with user "user1"
-		And as an "user0"
-		And updating last share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has uploaded file with content "foo" to "/tmp.txt"
+		And user "user0" has shared file "tmp.txt" with user "user1"
+		When user "user0" updates the last share using the API with
 			| permissions | 3 |
-		When as "user1" gets properties of folder "/tmp.txt" with
+		And user "user1" gets the following properties of folder "/tmp.txt" using the API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
 
 	Scenario: Correct webdav share-permissions for received file with reshare permissions but no edit permissions
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" uploads file with content "foo" to "/tmp.txt"
-		And file "tmp.txt" of user "user0" is shared with user "user1"
-		And as an "user0"
-		And updating last share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has uploaded file with content "foo" to "/tmp.txt"
+		And user "user0" has shared file "tmp.txt" with user "user1"
+		When user "user0" updates the last share using the API with
 			| permissions | 17 |
-		When as "user1" gets properties of folder "/tmp.txt" with
+		And user "user1" gets the following properties of folder "/tmp.txt" using the API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
 
 	Scenario: Correct webdav share-permissions for owned folder
-		Given user "user0" exists
-		And user "user0" created a folder "/tmp"
-		When as "user0" gets properties of folder "/" with
+		Given user "user0" has been created
+		And user "user0" has created a folder "/tmp"
+		When user "user0" gets the following properties of folder "/" using the API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
 
 	Scenario: Correct webdav share-permissions for received folder with all permissions
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/tmp"
-		And file "/tmp" of user "user0" is shared with user "user1"
-		When as "user1" gets properties of folder "/tmp" with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/tmp"
+		And user "user0" has shared file "/tmp" with user "user1"
+		When user "user1" gets the following properties of folder "/tmp" using the API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
 
 	Scenario: Correct webdav share-permissions for received folder with all permissions but edit
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/tmp"
-		And file "/tmp" of user "user0" is shared with user "user1"
-		And as an "user0"
-		And updating last share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/tmp"
+		And user "user0" has shared file "/tmp" with user "user1"
+		When user "user0" updates the last share using the API with
 			| permissions | 29 |
-		When as "user1" gets properties of folder "/tmp" with
+		And user "user1" gets the following properties of folder "/tmp" using the API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
 
 	Scenario: Correct webdav share-permissions for received folder with all permissions but create
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/tmp"
-		And file "/tmp" of user "user0" is shared with user "user1"
-		And as an "user0"
-		And updating last share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/tmp"
+		And user "user0" has shared file "/tmp" with user "user1"
+		When user "user0" updates the last share using the API with
 			| permissions | 27 |
-		When as "user1" gets properties of folder "/tmp" with
+		And user "user1" gets the following properties of folder "/tmp" using the API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
 
 	Scenario: Correct webdav share-permissions for received folder with all permissions but delete
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/tmp"
-		And file "/tmp" of user "user0" is shared with user "user1"
-		And as an "user0"
-		And updating last share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/tmp"
+		And user "user0" has shared file "/tmp" with user "user1"
+		When user "user0" updates the last share using the API with
 			| permissions | 23 |
-		When as "user1" gets properties of folder "/tmp" with
+		And user "user1" gets the following properties of folder "/tmp" using the API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
 
 	Scenario: Correct webdav share-permissions for received folder with all permissions but share
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/tmp"
-		And file "/tmp" of user "user0" is shared with user "user1"
-		And as an "user0"
-		And updating last share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/tmp"
+		And user "user0" has shared file "/tmp" with user "user1"
+		When user "user0" updates the last share using the API with
 			| permissions | 15 |
-		When as "user1" gets properties of folder "/tmp" with
+		And user "user1" gets the following properties of folder "/tmp" using the API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"
 
 	Scenario: unique target names for incoming shares
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user0" created a folder "/foo"
-		And user "user1" created a folder "/foo"
-		When file "/foo" of user "user0" is shared with user "user2"
-		And file "/foo" of user "user1" is shared with user "user2"
-		Then user "user2" should see following elements
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has created a folder "/foo"
+		And user "user1" has created a folder "/foo"
+		When user "user0" shares file "/foo" with user "user2" using the API
+		And user "user1" shares file "/foo" with user "user2" using the API
+		Then user "user2" should see the following elements
 			| /foo/		|
 			| /foo%20(2)/ |
 
 	Scenario: Creating a new share with a disabled user
-		Given as an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And assure user "user0" is disabled
-		And as an "user0"
-		When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has been disabled
+		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path | welcome.txt |
 			| shareWith | user1 |
 			| shareType | 0 |
@@ -788,164 +746,163 @@ Feature: sharing
 		And the HTTP status code should be "401"
 
 	Scenario: Merging shares for recipient when shared from outside with group and member
-		Given using old dav path
-		And user "user0" exists
-		And user "user1" exists
-		And group "group1" exists
-		And user "user1" belongs to group "group1"
-		And user "user0" created a folder "/merge-test-outside"
-		When folder "/merge-test-outside" of user "user0" is shared with group "group1"
-		And folder "/merge-test-outside" of user "user0" is shared with user "user1"
-		Then as "user1" the folder "/merge-test-outside" exists
-		And as "user1" the folder "/merge-test-outside (2)" does not exist
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And group "group1" has been created
+		And user "user1" has been added to group "group1"
+		And user "user0" has created a folder "/merge-test-outside"
+		When user "user0" shares folder "/merge-test-outside" with group "group1" using the API
+		And user "user0" shares folder "/merge-test-outside" with user "user1" using the API
+		Then as "user1" the folder "/merge-test-outside" should exist
+		And as "user1" the folder "/merge-test-outside (2)" should not exist
 
 	Scenario: Merging shares for recipient when shared from outside with group and member with different permissions
-		Given user "user0" exists
-		And user "user1" exists
-		And group "group1" exists
-		And user "user1" belongs to group "group1"
-		And user "user0" created a folder "/merge-test-outside-perms"
-		When folder "/merge-test-outside-perms" of user "user0" is shared with group "group1" with permissions 1
-		And folder "/merge-test-outside-perms" of user "user0" is shared with user "user1" with permissions 31
-		Then as "user1" gets properties of folder "/merge-test-outside-perms" with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "group1" has been created
+		And user "user1" has been added to group "group1"
+		And user "user0" has created a folder "/merge-test-outside-perms"
+		When user "user0" shares folder "/merge-test-outside-perms" with group "group1" with permissions 1 using the API
+		And user "user0" shares folder "/merge-test-outside-perms" with user "user1" with permissions 31 using the API
+		And user "user1" gets the following properties of folder "/merge-test-outside-perms" using the API
 			|{http://owncloud.org/ns}permissions|
-		And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-		And as "user1" the folder "/merge-test-outside-perms (2)" does not exist
+		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+		And as "user1" the folder "/merge-test-outside-perms (2)" should not exist
 
 	Scenario: Merging shares for recipient when shared from outside with two groups
-		Given user "user0" exists
-		And user "user1" exists
-		And group "group1" exists
-		And group "group2" exists
-		And user "user1" belongs to group "group1"
-		And user "user1" belongs to group "group2"
-		And user "user0" created a folder "/merge-test-outside-twogroups"
-		When folder "/merge-test-outside-twogroups" of user "user0" is shared with group "group1"
-		And folder "/merge-test-outside-twogroups" of user "user0" is shared with group "group2"
-		Then as "user1" the folder "/merge-test-outside-twogroups" exists
-		And as "user1" the folder "/merge-test-outside-twogroups (2)" does not exist
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "group1" has been created
+		And group "group2" has been created
+		And user "user1" has been added to group "group1"
+		And user "user1" has been added to group "group2"
+		And user "user0" has created a folder "/merge-test-outside-twogroups"
+		When user "user0" shares folder "/merge-test-outside-twogroups" with group "group1" using the API
+		And user "user0" shares folder "/merge-test-outside-twogroups" with group "group2" using the API
+		Then as "user1" the folder "/merge-test-outside-twogroups" should exist
+		And as "user1" the folder "/merge-test-outside-twogroups (2)" should not exist
 
 	Scenario: Merging shares for recipient when shared from outside with two groups with different permissions
-		Given user "user0" exists
-		And user "user1" exists
-		And group "group1" exists
-		And group "group2" exists
-		And user "user1" belongs to group "group1"
-		And user "user1" belongs to group "group2"
-		And user "user0" created a folder "/merge-test-outside-twogroups-perms"
-		When folder "/merge-test-outside-twogroups-perms" of user "user0" is shared with group "group1" with permissions 1
-		And folder "/merge-test-outside-twogroups-perms" of user "user0" is shared with group "group2" with permissions 31
-		Then as "user1" gets properties of folder "/merge-test-outside-twogroups-perms" with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "group1" has been created
+		And group "group2" has been created
+		And user "user1" has been added to group "group1"
+		And user "user1" has been added to group "group2"
+		And user "user0" has created a folder "/merge-test-outside-twogroups-perms"
+		When user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "group1" with permissions 1 using the API
+		And user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "group2" with permissions 31 using the API
+		And user "user1" gets the following properties of folder "/merge-test-outside-twogroups-perms" using the API
 			|{http://owncloud.org/ns}permissions|
-		And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-		And as "user1" the folder "/merge-test-outside-twogroups-perms (2)" does not exist
+		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+		And as "user1" the folder "/merge-test-outside-twogroups-perms (2)" should not exist
 
 	Scenario: Merging shares for recipient when shared from outside with two groups and member
-		Given user "user0" exists
-		And user "user1" exists
-		And group "group1" exists
-		And group "group2" exists
-		And user "user1" belongs to group "group1"
-		And user "user1" belongs to group "group2"
-		And user "user0" created a folder "/merge-test-outside-twogroups-member-perms"
-		When folder "/merge-test-outside-twogroups-member-perms" of user "user0" is shared with group "group1" with permissions 1
-		And folder "/merge-test-outside-twogroups-member-perms" of user "user0" is shared with group "group2" with permissions 31
-		And folder "/merge-test-outside-twogroups-member-perms" of user "user0" is shared with user "user1" with permissions 1
-		Then as "user1" gets properties of folder "/merge-test-outside-twogroups-member-perms" with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "group1" has been created
+		And group "group2" has been created
+		And user "user1" has been added to group "group1"
+		And user "user1" has been added to group "group2"
+		And user "user0" has created a folder "/merge-test-outside-twogroups-member-perms"
+		When user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "group1" with permissions 1 using the API
+		And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "group2" with permissions 31 using the API
+		And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with user "user1" with permissions 1 using the API
+		And user "user1" gets the following properties of folder "/merge-test-outside-twogroups-member-perms" using the API
 			|{http://owncloud.org/ns}permissions|
-		And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-		And as "user1" the folder "/merge-test-outside-twogroups-member-perms (2)" does not exist
+		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+		And as "user1" the folder "/merge-test-outside-twogroups-member-perms (2)" should not exist
 
 	Scenario: Merging shares for recipient when shared from inside with group
-		Given user "user0" exists
-		And group "group1" exists
-		And user "user0" belongs to group "group1"
-		And user "user0" created a folder "/merge-test-inside-group"
-		When folder "/merge-test-inside-group" of user "user0" is shared with group "group1"
-		Then as "user0" the folder "/merge-test-inside-group" exists
-		And as "user0" the folder "/merge-test-inside-group (2)" does not exist
+		Given user "user0" has been created
+		And group "group1" has been created
+		And user "user0" has been added to group "group1"
+		And user "user0" has created a folder "/merge-test-inside-group"
+		When user "user0" shares folder "/merge-test-inside-group" with group "group1" using the API
+		Then as "user0" the folder "/merge-test-inside-group" should exist
+		And as "user0" the folder "/merge-test-inside-group (2)" should not exist
 
 	Scenario: Merging shares for recipient when shared from inside with two groups
-		Given user "user0" exists
-		And group "group1" exists
-		And group "group2" exists
-		And user "user0" belongs to group "group1"
-		And user "user0" belongs to group "group2"
-		And user "user0" created a folder "/merge-test-inside-twogroups"
-		When folder "/merge-test-inside-twogroups" of user "user0" is shared with group "group1"
-		And folder "/merge-test-inside-twogroups" of user "user0" is shared with group "group2"
-		Then as "user0" the folder "/merge-test-inside-twogroups" exists
-		And as "user0" the folder "/merge-test-inside-twogroups (2)" does not exist
-		And as "user0" the folder "/merge-test-inside-twogroups (3)" does not exist
+		Given user "user0" has been created
+		And group "group1" has been created
+		And group "group2" has been created
+		And user "user0" has been added to group "group1"
+		And user "user0" has been added to group "group2"
+		And user "user0" has created a folder "/merge-test-inside-twogroups"
+		When user "user0" shares folder "/merge-test-inside-twogroups" with group "group1" using the API
+		And user "user0" shares folder "/merge-test-inside-twogroups" with group "group2" using the API
+		Then as "user0" the folder "/merge-test-inside-twogroups" should exist
+		And as "user0" the folder "/merge-test-inside-twogroups (2)" should not exist
+		And as "user0" the folder "/merge-test-inside-twogroups (3)" should not exist
 
 	Scenario: Merging shares for recipient when shared from inside with group with less permissions
-		Given user "user0" exists
-		And group "group1" exists
-		And group "group2" exists
-		And user "user0" belongs to group "group1"
-		And user "user0" belongs to group "group2"
-		And user "user0" created a folder "/merge-test-inside-twogroups-perms"
-		When folder "/merge-test-inside-twogroups-perms" of user "user0" is shared with group "group1"
-		And folder "/merge-test-inside-twogroups-perms" of user "user0" is shared with group "group2"
-		Then as "user0" gets properties of folder "/merge-test-inside-twogroups-perms" with
+		Given user "user0" has been created
+		And group "group1" has been created
+		And group "group2" has been created
+		And user "user0" has been added to group "group1"
+		And user "user0" has been added to group "group2"
+		And user "user0" has created a folder "/merge-test-inside-twogroups-perms"
+		When user "user0" shares folder "/merge-test-inside-twogroups-perms" with group "group1" using the API
+		And user "user0" shares folder "/merge-test-inside-twogroups-perms" with group "group2" using the API
+		And user "user0" gets the following properties of folder "/merge-test-inside-twogroups-perms" using the API
 			|{http://owncloud.org/ns}permissions|
-		And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK"
-		And as "user0" the folder "/merge-test-inside-twogroups-perms (2)" does not exist
-		And as "user0" the folder "/merge-test-inside-twogroups-perms (3)" does not exist
+		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK"
+		And as "user0" the folder "/merge-test-inside-twogroups-perms (2)" should not exist
+		And as "user0" the folder "/merge-test-inside-twogroups-perms (3)" should not exist
 
 	@skip @issue-29016
 	Scenario: Merging shares for recipient when shared from outside with group then user and recipient renames in between
-		Given user "user0" exists
-		And user "user1" exists
-		And group "group1" exists
-		And user "user1" belongs to group "group1"
-		And user "user0" created a folder "/merge-test-outside-groups-renamebeforesecondshare"
-		When folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with group "group1"
-		And user "user1" moved folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed"
-		And folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with user "user1"
-		Then as "user1" gets properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "group1" has been created
+		And user "user1" has been added to group "group1"
+		And user "user0" has created a folder "/merge-test-outside-groups-renamebeforesecondshare"
+		When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "group1" using the API
+		And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the API
+		And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the API
+		And user "user1" gets the following properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the API
 			|{http://owncloud.org/ns}permissions|
-		And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-		And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" does not exist
+		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+		And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
 
 	Scenario: Merging shares for recipient when shared from outside with user then group and recipient renames in between
-		Given user "user0" exists
-		And user "user1" exists
-		And group "group1" exists
-		And user "user1" belongs to group "group1"
-		And user "user0" created a folder "/merge-test-outside-groups-renamebeforesecondshare"
-		When folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with user "user1"
-		And user "user1" moved folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed"
-		And folder "/merge-test-outside-groups-renamebeforesecondshare" of user "user0" is shared with group "group1"
-		Then as "user1" gets properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "group1" has been created
+		And user "user1" has been added to group "group1"
+		And user "user0" has created a folder "/merge-test-outside-groups-renamebeforesecondshare"
+		When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the API
+		And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the API
+		And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "group1" using the API
+		And user "user1" gets the following properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the API
 			|{http://owncloud.org/ns}permissions|
-		And the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
-		And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" does not exist
+		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
+		And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
 
 	Scenario: Emptying trashbin
-		Given user "user0" exists
-		And user "user0" deletes file "/textfile0.txt"
-		When user "user0" empties the trashbin
+		Given user "user0" has been created
+		And user "user0" has deleted file "/textfile0.txt"
+		When user "user0" empties the trashbin using the API
 		Then the HTTP status code should be "200"
 
 	Scenario: orphaned shares
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/common"
-		And user "user0" created a folder "/common/sub"
-		And file "/common/sub" of user "user0" is shared with user "user1"
-		And user "user0" deletes folder "/common"
-		When user "user0" empties the trashbin
-		Then as "user1" the folder "/sub" does not exist
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/common"
+		And user "user0" has created a folder "/common/sub"
+		And user "user0" has shared file "/common/sub" with user "user1"
+		And user "user0" has deleted folder "/common"
+		When user "user0" empties the trashbin using the API
+		Then as "user1" the folder "/sub" should not exist
 
 	Scenario: sharing again an own file while belonging to a group
-		Given user "user0" exists
-		And group "sharing-group" exists
-		And user "user0" belongs to group "sharing-group"
-		And file "welcome.txt" of user "user0" is shared with group "sharing-group"
-		And as an "user0"
-		And deleting last share
-		When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+		Given user "user0" has been created
+		And group "sharing-group" has been created
+		And user "user0" has been added to group "sharing-group"
+		And user "user0" has shared file "welcome.txt" with group "sharing-group"
+		And user "user0" has deleted the last share
+		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path | welcome.txt |
 			| shareWith | sharing-group |
 			| shareType | 1 |
@@ -953,98 +910,93 @@ Feature: sharing
 		And the HTTP status code should be "200"
 
 	Scenario: sharing subfolder when parent already shared
-		Given user "user0" exists
-		Given user "user1" exists
-		And group "sharing-group" exists
-		And user "user0" created a folder "/test"
-		And user "user0" created a folder "/test/sub"
-		And file "/test" of user "user0" is shared with group "sharing-group"
-		And as an "user0"
-		When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+		Given user "user0" has been created
+		Given user "user1" has been created
+		And group "sharing-group" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has created a folder "/test/sub"
+		And user "user0" has shared file "/test" with group "sharing-group"
+		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path | /test/sub |
 			| shareWith | user1 |
 			| shareType | 0 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And as "user1" the folder "/sub" exists
+		And as "user1" the folder "/sub" should exist
 
 	Scenario: sharing subfolder when parent already shared with group of sharer
-		Given user "user0" exists
-		And user "user1" exists
-		And group "sharing-group" exists
-		And user "user0" belongs to group "sharing-group"
-		And user "user0" created a folder "/test"
-		And user "user0" created a folder "/test/sub"
-		And file "/test" of user "user0" is shared with group "sharing-group"
-		And as an "user0"
-		When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "sharing-group" has been created
+		And user "user0" has been added to group "sharing-group"
+		And user "user0" has created a folder "/test"
+		And user "user0" has created a folder "/test/sub"
+		And user "user0" has shared file "/test" with group "sharing-group"
+		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path | /test/sub |
 			| shareWith | user1 |
 			| shareType | 0 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And as "user1" the folder "/sub" exists
+		And as "user1" the folder "/sub" should exist
 
 	Scenario: sharing subfolder of already shared folder, GET result is correct
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user3" exists
-		And user "user4" exists
-		And user "user0" created a folder "/folder1"
-		And file "/folder1" of user "user0" is shared with user "user1"
-		And file "/folder1" of user "user0" is shared with user "user2"
-		And user "user0" created a folder "/folder1/folder2"
-		And file "/folder1/folder2" of user "user0" is shared with user "user3"
-		And file "/folder1/folder2" of user "user0" is shared with user "user4"
-		And as an "user0"
-		When sending "GET" to "/apps/files_sharing/api/v1/shares"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user3" has been created
+		And user "user4" has been created
+		And user "user0" has created a folder "/folder1"
+		And user "user0" has shared file "/folder1" with user "user1"
+		And user "user0" has shared file "/folder1" with user "user2"
+		And user "user0" has created a folder "/folder1/folder2"
+		And user "user0" has shared file "/folder1/folder2" with user "user3"
+		And user "user0" has shared file "/folder1/folder2" with user "user4"
+		And as user "user0"
+		When the user sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And the response contains 4 entries
+		And the response should contain 4 entries
 		And file "/folder1" should be included as path in the response
 		And file "/folder1/folder2" should be included as path in the response
-		And sending "GET" to "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
-		And the response contains 2 entries
+		And the user sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
+		And the response should contain 2 entries
 		And file "/folder1" should not be included as path in the response
 		And file "/folder1/folder2" should be included as path in the response
 
 	Scenario: unshare from self
-		Given user "user0" exists
-		And user "user1" exists
-		And group "sharing-group" exists
-		And user "user0" belongs to group "sharing-group"
-		And user "user1" belongs to group "sharing-group"
-		And file "/PARENT/parent.txt" of user "user0" is shared with group "sharing-group"
-		And user "user0" stores etag of element "/PARENT"
-		And user "user1" stores etag of element "/"
-		And as an "user1"
-		When deleting last share
-		Then etag of element "/" of user "user1" has changed
-		And etag of element "/PARENT" of user "user0" has not changed
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "sharing-group" has been created
+		And user "user0" has been added to group "sharing-group"
+		And user "user1" has been added to group "sharing-group"
+		And user "user0" has shared file "/PARENT/parent.txt" with group "sharing-group"
+		And user "user0" has stored etag of element "/PARENT"
+		And user "user1" has stored etag of element "/"
+		When user "user1" deletes the last share using the API
+		Then the etag of element "/" of user "user1" should have changed
+		And the etag of element "/PARENT" of user "user0" should not have changed
 
 	Scenario: Increasing permissions is allowed for owner
-		Given as an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And group "new-group" exists
-		And user "user0" belongs to group "new-group"
-		And user "user1" belongs to group "new-group"
-		And assure user "user0" is subadmin of group "new-group"
-		And as an "user0"
-		And folder "/FOLDER" of user "user0" is shared with group "new-group"
-		And updating last share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "new-group" has been created
+		And user "user0" has been added to group "new-group"
+		And user "user1" has been added to group "new-group"
+		And user "user0" has been made a subadmin of group "new-group"
+		And as user "user0"
+		And the user has shared folder "/FOLDER" with group "new-group"
+		And the user has updated the last share with
 			| permissions | 1 |
-		When updating last share with
+		When the user updates the last share using the API with
 			| permissions | 31 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: Cannot create share with zero permissions
-		Given user "user0" exists
-		And user "user1" exists
-		And as an "user0"
-		When sending "POST" to "/apps/files_sharing/api/v1/shares" with
+		Given user "user0" has been created
+		And user "user1" has been created
+		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path | welcome.txt |
 			| shareWith | user1 |
 			| shareType | 0 |
@@ -1052,135 +1004,124 @@ Feature: sharing
 		Then the OCS status code should be "400"
 
 	Scenario: Cannot set permissions to zero
-		Given as an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And group "new-group" exists
-		And user "user0" belongs to group "new-group"
-		And user "user1" belongs to group "new-group"
-		And assure user "user0" is subadmin of group "new-group"
-		And as an "user0"
-		And folder "/FOLDER" of user "user0" is shared with group "new-group"
-		And updating last share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "new-group" has been created
+		And user "user0" has been added to group "new-group"
+		And user "user1" has been added to group "new-group"
+		And user "user0" has been made a subadmin of group "new-group"
+		And user "user0" has shared folder "/FOLDER" with group "new-group"
+		When user "user0" updates the last share using the API with
 			| permissions | 0 |
 		Then the OCS status code should be "400"
 
 	Scenario: Adding public upload to a read only shared folder as recipient is not allowed
-		Given user "user0" exists
-		And user "user1" exists
-		And as an "user0"
-		And user "user0" created a folder "/test"
-		And folder "/test" of user "user0" is shared with user "user1" with permissions 17
-		And as an "user1"
-		And creating a share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has shared folder "/test" with user "user1" with permissions 17
+		And as user "user1"
+		And the user has created a share with settings
 			| path | /test |
 			| shareType | 3 |
 			| publicUpload | false |
-		When updating last share with
+		When the user updates the last share using the API with
 			| publicUpload | true |
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "200"
 
 	Scenario: Adding public upload to a shared folder as recipient is allowed with permissions
-		Given user "user0" exists
-		And user "user1" exists
-		And as an "user0"
-		And user "user0" created a folder "/test"
-		And folder "/test" of user "user0" is shared with user "user1" with permissions 31
-		And as an "user1"
-		And creating a share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has shared folder "/test" with user "user1" with permissions 31
+		And as user "user1"
+		And the user has created a share with settings
 			| path | /test |
 			| shareType | 3 |
 			| publicUpload | false |
-		When updating last share with
+		When the user updates the last share using the API with
 			| publicUpload | true |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: Adding public upload to a read only shared folder as recipient is not allowed
-		Given user "user0" exists
-		And user "user1" exists
-		And as an "user0"
-		And user "user0" created a folder "/test"
-		And folder "/test" of user "user0" is shared with user "user1" with permissions 17
-		And as an "user1"
-		And creating a share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has shared folder "/test" with user "user1" with permissions 17
+		And as user "user1"
+		And the user has created a share with settings
 			| path | /test |
 			| shareType | 3 |
 			| permissions | 1 |
-		When updating last share with
+		When the user updates the last share using the API with
 			| permissions | 15 |
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "200"
 
 	Scenario: Adding public upload to a shared folder as recipient is allowed with permissions
-		Given user "user0" exists
-		And user "user1" exists
-		And as an "user0"
-		And user "user0" created a folder "/test"
-		And folder "/test" of user "user0" is shared with user "user1" with permissions 31
-		And as an "user1"
-		And creating a share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has shared folder "/test" with user "user1" with permissions 31
+		And as user "user1"
+		And the user has created a share with settings
 			| path | /test |
 			| shareType | 3 |
 			| permissions | 1 |
-		When updating last share with
+		When the user updates the last share using the API with
 			| permissions | 15 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: Creating a link share with no specified permissions defaults to read permissions
-		Given user "user0" exists
-		And user "user0" created a folder "/afolder"
-		And as an "user0"
-		And creating a share with
+		Given user "user0" has been created
+		And user "user0" has created a folder "/afolder"
+		When user "user0" creates a share using the API with settings
 			| path | /afolder |
 			| shareType | 3 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| share_type | 3 |
 			| permissions | 1 |
 
 	Scenario: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally
-		Given parameter "shareapi_allow_public_upload" of app "core" is set to "no"
-		And user "user0" exists
-		And user "user0" created a folder "/afolder"
-		And as an "user0"
-		And creating a share with
+		Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+		And user "user0" has been created
+		And user "user0" has created a folder "/afolder"
+		When user "user0" creates a share using the API with settings
 			| path | /afolder |
 			| shareType | 3 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| share_type | 3 |
 			| permissions | 1 |
 
 	Scenario: Creating a link share with edit permissions keeps it
-		Given user "user0" exists
-		And user "user0" created a folder "/afolder"
-		And as an "user0"
-		And creating a share with
+		Given user "user0" has been created
+		And user "user0" has created a folder "/afolder"
+		When user "user0" creates a share using the API with settings
 			| path | /afolder |
 			| shareType | 3 |
 			| permissions | 15 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| share_type | 3 |
 			| permissions | 15 |
 
 	Scenario: resharing using a public link with read only permissions is not allowed
-		Given user "user0" exists
-		And user "user1" exists
-		And as an "user0"
-		And user "user0" created a folder "/test"
-		And folder "/test" of user "user0" is shared with user "user1" with permissions 1
-		And as an "user1"
-		And creating a share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has shared folder "/test" with user "user1" with permissions 1
+		When user "user1" creates a share using the API with settings
 			| path | /test |
 			| shareType | 3 |
 			| publicUpload | false |
@@ -1188,13 +1129,11 @@ Feature: sharing
 		And the HTTP status code should be "200"
 
 	Scenario: resharing using a public link with read and write permissions only is not allowed
-		Given user "user0" exists
-		And user "user1" exists
-		And as an "user0"
-		And user "user0" created a folder "/test"
-		And folder "/test" of user "user0" is shared with user "user1" with permissions 15
-		And as an "user1"
-		And creating a share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has shared folder "/test" with user "user1" with permissions 15
+		When user "user1" creates a share using the API with settings
 			| path | /test |
 			| shareType | 3 |
 			| publicUpload | false |
@@ -1202,97 +1141,93 @@ Feature: sharing
 		And the HTTP status code should be "200"
 
 	Scenario: deleting a file out of a share as recipient creates a backup for the owner
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		When user "user1" deletes file "/shared/shared_file.txt"
-		Then as "user1" the file "/shared/shared_file.txt" does not exist
-		And as "user0" the file "/shared/shared_file.txt" does not exist
-		And as "user0" the file "/shared_file.txt" exists in trash
-		And as "user1" the file "/shared_file.txt" exists in trash
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user0" has shared folder "/shared" with user "user1"
+		When user "user1" deletes file "/shared/shared_file.txt" using the API
+		Then as "user1" the file "/shared/shared_file.txt" should not exist
+		And as "user0" the file "/shared/shared_file.txt" should not exist
+		And as "user0" the file "/shared_file.txt" should exist in trash
+		And as "user1" the file "/shared_file.txt" should exist in trash
 
 	Scenario: deleting a folder out of a share as recipient creates a backup for the owner
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" created a folder "/shared/sub"
-		And user "user0" moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		When user "user1" deletes folder "/shared/sub"
-		Then as "user1" the folder "/shared/sub" does not exist
-		And as "user0" the folder "/shared/sub" does not exist
-		And as "user0" the folder "/sub" exists in trash
-		And as "user0" the file "/sub/shared_file.txt" exists in trash
-		And as "user1" the folder "/sub" exists in trash
-		And as "user1" the file "/sub/shared_file.txt" exists in trash
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has created a folder "/shared/sub"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
+		And user "user0" has shared folder "/shared" with user "user1"
+		When user "user1" deletes folder "/shared/sub" using the API
+		Then as "user1" the folder "/shared/sub" should not exist
+		And as "user0" the folder "/shared/sub" should not exist
+		And as "user0" the folder "/sub" should exist in trash
+		And as "user0" the file "/sub/shared_file.txt" should exist in trash
+		And as "user1" the folder "/sub" should exist in trash
+		And as "user1" the file "/sub/shared_file.txt" should exist in trash
 
 	Scenario: moving a file into a share as recipient
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		When user "user1" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		Then as "user1" the file "/shared/shared_file.txt" exists
-		And as "user0" the file "/shared/shared_file.txt" exists
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has shared folder "/shared" with user "user1"
+		When user "user1" moves file "/textfile0.txt" to "/shared/shared_file.txt" using the API
+		Then as "user1" the file "/shared/shared_file.txt" should exist
+		And as "user0" the file "/shared/shared_file.txt" should exist
 
 	Scenario: moving a file out of a share as recipient creates a backup for the owner
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And file "/shared" of user "user0" is shared with user "user1"
-		And user "user1" moved folder "/shared" to "/shared_renamed"
-		When user "user1" moved file "/shared_renamed/shared_file.txt" to "/taken_out.txt"
-		Then as "user1" the file "/taken_out.txt" exists
-		And as "user0" the file "/shared/shared_file.txt" does not exist
-		And as "user0" the file "/shared_file.txt" exists in trash
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user0" has shared file "/shared" with user "user1"
+		And user "user1" has moved folder "/shared" to "/shared_renamed"
+		When user "user1" moves file "/shared_renamed/shared_file.txt" to "/taken_out.txt" using the API
+		Then as "user1" the file "/taken_out.txt" should exist
+		And as "user0" the file "/shared/shared_file.txt" should not exist
+		And as "user0" the file "/shared_file.txt" should exist in trash
 
 	Scenario: moving a folder out of a share as recipient creates a backup for the owner
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" created a folder "/shared/sub"
-		And user "user0" moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
-		And file "/shared" of user "user0" is shared with user "user1"
-		And user "user1" moved folder "/shared" to "/shared_renamed"
-		When user "user1" moved folder "/shared_renamed/sub" to "/taken_out"
-		Then as "user1" the file "/taken_out" exists
-		And as "user0" the folder "/shared/sub" does not exist
-		And as "user0" the folder "/sub" exists in trash
-		And as "user0" the file "/sub/shared_file.txt" exists in trash
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has created a folder "/shared/sub"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
+		And user "user0" has shared file "/shared" with user "user1"
+		And user "user1" has moved folder "/shared" to "/shared_renamed"
+		When user "user1" moves folder "/shared_renamed/sub" to "/taken_out" using the API
+		Then as "user1" the file "/taken_out" should exist
+		And as "user0" the folder "/shared/sub" should not exist
+		And as "user0" the folder "/sub" should exist in trash
+		And as "user0" the file "/sub/shared_file.txt" should exist in trash
 
 	Scenario: User's own shares reshared to him don't appear when getting "shared with me" shares
-		Given user "user0" exists
-		And user "user1" exists
-		And group "group0" exists
-		And user "user0" belongs to group "group0"
-		And user "user0" created a folder "/shared"
-		And as an "user0"
-		And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		And as an "user1"
-		And folder "/shared" of user "user1" is shared with group "group0"
-		And as an "user0"
-		When sending "GET" to "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And group "group0" has been created
+		And user "user0" has been added to group "group0"
+		And user "user0" has created a folder "/shared"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user0" has shared folder "/shared" with user "user1"
+		And user "user1" has shared folder "/shared" with group "group0"
+		When user "user0" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And last share_id is not included in the answer
+		And the last share_id should not be included in the response
 
 	Scenario: Share ownership change after moving a shared file outside of an outer share
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user0" created a folder "/folder1"
-		And user "user0" created a folder "/folder1/folder2"
-		And user "user1" created a folder "/moved-out"
-		And folder "/folder1" of user "user0" is shared with user "user1" with permissions 31
-		And folder "/folder1/folder2" of user "user1" is shared with user "user2" with permissions 31
-		And as an "user1"
-		When user "user1" moves folder "/folder1/folder2" to "/moved-out/folder2"
-		And getting info of last share
-		Then share fields of last share match with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has created a folder "/folder1"
+		And user "user0" has created a folder "/folder1/folder2"
+		And user "user1" has created a folder "/moved-out"
+		And user "user0" has shared folder "/folder1" with user "user1" with permissions 31
+		And user "user1" has shared folder "/folder1/folder2" with user "user2" with permissions 31
+		When user "user1" moves folder "/folder1/folder2" to "/moved-out/folder2" using the API
+		And user "user1" gets the info of the last share using the API
+		Then the share fields of the last share should include
 			| id | A_NUMBER |
 			| item_type | folder |
 			| item_source | A_NUMBER |
@@ -1308,22 +1243,21 @@ Feature: sharing
 			| file_parent | A_NUMBER |
 			| displayname_owner | user1 |
 			| mimetype | httpd/unix-directory |
-		And as "user0" the folder "/folder1/folder2" does not exist
-		And as "user2" the folder "/folder2" exists
+		And as "user0" the folder "/folder1/folder2" should not exist
+		And as "user2" the folder "/folder2" should exist
 
 	Scenario: Share ownership change after moving a shared file to another share
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user0" created a folder "/user0-folder"
-		And user "user0" created a folder "/user0-folder/folder2"
-		And user "user2" created a folder "/user2-folder"
-		And folder "/user0-folder" of user "user0" is shared with user "user1" with permissions 31
-		And folder "/user2-folder" of user "user2" is shared with user "user1" with permissions 31
-		And as an "user1"
-		When user "user1" moves folder "/user0-folder/folder2" to "/user2-folder/folder2"
-		And getting info of last share
-		Then share fields of last share match with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has created a folder "/user0-folder"
+		And user "user0" has created a folder "/user0-folder/folder2"
+		And user "user2" has created a folder "/user2-folder"
+		And user "user0" has shared folder "/user0-folder" with user "user1" with permissions 31
+		And user "user2" has shared folder "/user2-folder" with user "user1" with permissions 31
+		When user "user1" moves folder "/user0-folder/folder2" to "/user2-folder/folder2" using the API
+		And user "user1" gets the info of the last share using the API
+		Then the share fields of the last share should include
 			| id | A_NUMBER |
 			| item_type | folder |
 			| item_source | A_NUMBER |
@@ -1338,6 +1272,6 @@ Feature: sharing
 			| file_parent | A_NUMBER |
 			| displayname_owner | user2 |
 			| mimetype | httpd/unix-directory |
-		And as "user0" the folder "/user0-folder/folder2" does not exist
-		And as "user2" the folder "/user2-folder/folder2" exists
+		And as "user0" the folder "/user0-folder/folder2" should not exist
+		And as "user2" the folder "/user2-folder/folder2" should exist
 

--- a/tests/integration/features/status.feature
+++ b/tests/integration/features/status.feature
@@ -1,8 +1,8 @@
 Feature: Status
 
   Scenario: Status.php is correct
-      When requesting status.php
-      Then the status.php with versions fixed responded should match with
+      When the admin requests status.php using the API
+      Then the status.php response should match with
       """
       {"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"$CURRENT_VERSION","versionstring":"$CURRENT_VERSION_STRING","edition":"Community","productname":"ownCloud"}
       """

--- a/tests/integration/features/tags.feature
+++ b/tests/integration/features/tags.feature
@@ -1,10 +1,10 @@
 Feature: tags
   Background:
-    Given using new dav path
+    Given using new DAV path
 
   Scenario Outline: Creating a normal tag as regular user should work
-    Given user "user0" exists
-    When "user0" creates a "normal" tag with name "<tag_name>"
+    Given user "user0" has been created
+    When user "user0" creates a "normal" tag with name "<tag_name>" using the API
     Then the HTTP status code should be "201"
     And the following tags should exist for "admin"
       |<tag_name>|normal|
@@ -17,33 +17,33 @@ Feature: tags
     |😀|
 
   Scenario: Creating a not user-assignable tag as regular user should fail
-    Given user "user0" exists
-    When "user0" creates a "not user-assignable" tag with name "JustARegularTagName"
+    Given user "user0" has been created
+    When user "user0" creates a "not user-assignable" tag with name "JustARegularTagName" using the API
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Creating a not user-visible tag as regular user should fail
-    Given user "user0" exists
-    When "user0" creates a "not user-visible" tag with name "JustARegularTagName"
+    Given user "user0" has been created
+    When user "user0" creates a "not user-visible" tag with name "JustARegularTagName" using the API
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Creating a not user-assignable tag with groups as admin should work
-    Given user "user0" exists
-    When "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
+    Given user "user0" has been created
+    When user "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the API
     Then the HTTP status code should be "201"
-    And the "not user-assignable" tag with name "TagWithGroups" has the groups "group1|group2"
+    And the "not user-assignable" tag with name "TagWithGroups" should have the groups "group1|group2"
 
   Scenario: Creating a normal tag with groups as regular user should fail
-    Given user "user0" exists
-    When "user0" creates a "normal" tag with name "JustARegularTagName" and groups "group1|group2"
+    Given user "user0" has been created
+    When user "user0" creates a "normal" tag with name "JustARegularTagName" and groups "group1|group2" using the API
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for "user0"
 
   Scenario Outline: Renaming a normal tag as regular user should work
-    Given user "user0" exists
-    And "admin" creates a "normal" tag with name "<tag_name>"
-    When "user0" edits the tag with name "<tag_name>" and sets its name to "AnotherTagName"
+    Given user "user0" has been created
+    And user "admin" has created a "normal" tag with name "<tag_name>"
+    When user "user0" edits the tag with name "<tag_name>" and sets its name to "AnotherTagName" using the API
     Then the following tags should exist for "admin"
       |AnotherTagName|normal|
 
@@ -53,339 +53,339 @@ Feature: tags
     |😀|
 
   Scenario: Renaming a not user-assignable tag as regular user should fail
-    Given user "user0" exists
-    And "admin" creates a "not user-assignable" tag with name "JustARegularTagName"
-    When "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName"
+    Given user "user0" has been created
+    And user "admin" has created a "not user-assignable" tag with name "JustARegularTagName"
+    When user "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the API
     Then the following tags should exist for "admin"
       |JustARegularTagName|not user-assignable|
 
   Scenario: Renaming a not user-visible tag as regular user should fail
-    Given user "user0" exists
-    And "admin" creates a "not user-visible" tag with name "JustARegularTagName"
-    When "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName"
+    Given user "user0" has been created
+    And user "admin" has created a "not user-visible" tag with name "JustARegularTagName"
+    When user "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the API
     Then the following tags should exist for "admin"
       |JustARegularTagName|not user-visible|
 
   Scenario: Editing tag groups as admin should work
-    Given user "user0" exists
-    And "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
-    When "admin" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3"
-    Then the "not user-assignable" tag with name "TagWithGroups" has the groups "group1|group3"
+    Given user "user0" has been created
+    And user "admin" has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
+    When user "admin" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the API
+    Then the "not user-assignable" tag with name "TagWithGroups" should have the groups "group1|group3"
 
   Scenario: Editing tag groups as regular user should fail
-    Given user "user0" exists
-    And "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
-    When "user0" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3"
-    Then the "not user-assignable" tag with name "TagWithGroups" has the groups "group1|group2"
+    Given user "user0" has been created
+    And user "admin" has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
+    When user "user0" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the API
+    Then the "not user-assignable" tag with name "TagWithGroups" should have the groups "group1|group2"
 
   Scenario: Deleting a normal tag as regular user should work
-    Given user "user0" exists
-    And "admin" creates a "normal" tag with name "JustARegularTagName"
-    When "user0" deletes the tag with name "JustARegularTagName"
+    Given user "user0" has been created
+    And user "admin" has created a "normal" tag with name "JustARegularTagName"
+    When user "user0" deletes the tag with name "JustARegularTagName" using the API
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Deleting a not user-assignable tag as regular user should fail
-    Given user "user0" exists
-    And "admin" creates a "not user-assignable" tag with name "JustARegularTagName"
-    When "user0" deletes the tag with name "JustARegularTagName"
+    Given user "user0" has been created
+    And user "admin" has created a "not user-assignable" tag with name "JustARegularTagName"
+    When user "user0" deletes the tag with name "JustARegularTagName" using the API
     Then the HTTP status code should be "403"
     And the following tags should exist for "admin"
       |JustARegularTagName|not user-assignable|
 
   Scenario: Deleting a not user-visible tag as regular user should fail
-    Given user "user0" exists
-    And "admin" creates a "not user-visible" tag with name "JustARegularTagName"
-    When "user0" deletes the tag with name "JustARegularTagName"
+    Given user "user0" has been created
+    And user "admin" has created a "not user-visible" tag with name "JustARegularTagName"
+    When user "user0" deletes the tag with name "JustARegularTagName" using the API
     Then the HTTP status code should be "404"
     And the following tags should exist for "admin"
       |JustARegularTagName|not user-visible|
 
   Scenario: Deleting a not user-assignable tag as admin should work
-    Given "admin" creates a "not user-assignable" tag with name "JustARegularTagName"
-    When "admin" deletes the tag with name "JustARegularTagName"
+    Given user "admin" has created a "not user-assignable" tag with name "JustARegularTagName"
+    When user "admin" deletes the tag with name "JustARegularTagName" using the API
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Deleting a not user-visible tag as admin should work
-    Given "admin" creates a "not user-visible" tag with name "JustARegularTagName"
-    When "admin" deletes the tag with name "JustARegularTagName"
+    Given user "admin" has created a "not user-visible" tag with name "JustARegularTagName"
+    When user "admin" deletes the tag with name "JustARegularTagName" using the API
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Assigning a normal tag to a file shared by someone else as regular user should work
-    Given user "user0" exists
-    And user "user1" exists
-    And "admin" creates a "normal" tag with name "JustARegularTagName"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
-    When "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "admin" has created a "normal" tag with name "JustARegularTagName"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "201"
-    And "/myFileToTag.txt" shared by "user0" has the following tags
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags
       |JustARegularTagName|normal|
 
   Scenario: Assigning a normal tag to a file belonging to someone else as regular user should fail
-    Given user "user0" exists
-    And user "user1" exists
-    And "admin" creates a "normal" tag with name "MyFirstTag"
-    And "admin" creates a "normal" tag with name "MySecondTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
-    And "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" owned by "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "admin" has created a "normal" tag with name "MyFirstTag"
+    And user "admin" has created a "normal" tag with name "MySecondTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the API
+    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" owned by "user0" using the API
     Then the HTTP status code should be "404"
-    And "/myFileToTag.txt" owned by "user0" has the following tags
+    And file "/myFileToTag.txt" owned by "user0" should have the following tags
       |MyFirstTag|normal|
 
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as regular user should fail
-    Given user "user0" exists
-    And user "user1" exists
-    And "admin" creates a "normal" tag with name "MyFirstTag"
-    And "admin" creates a "not user-assignable" tag with name "MySecondTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
-    And "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
-    When "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "admin" has created a "normal" tag with name "MyFirstTag"
+    And user "admin" has created a "not user-assignable" tag with name "MySecondTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the API
+    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "403"
-    And "/myFileToTag.txt" shared by "user0" has the following tags
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags
       |MyFirstTag|normal|
 
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as regular user belongs to tag's groups should work
-    Given user "user0" exists
-    And user "user1" exists
-    And group "group1" exists
-    And user "user1" belongs to group "group1"
-    And "admin" creates a "not user-assignable" tag with name "JustARegularTagName" and groups "group1"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
-    When "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And group "group1" has been created
+    And user "user1" has been added to group "group1"
+    And user "admin" has created a "not user-assignable" tag with name "JustARegularTagName" and groups "group1"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "201"
-    And "/myFileToTag.txt" shared by "user0" has the following tags
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags
       |JustARegularTagName|not user-assignable|
 
   Scenario: Assigning a not user-visible tag to a file shared by someone else as regular user should fail
-    Given user "user0" exists
-    And user "user1" exists
-    And "admin" creates a "normal" tag with name "MyFirstTag"
-    And "admin" creates a "not user-visible" tag with name "MySecondTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
-    And "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
-    When "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "admin" has created a "normal" tag with name "MyFirstTag"
+    And user "admin" has created a "not user-visible" tag with name "MySecondTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the API
+    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "412"
-    And "/myFileToTag.txt" shared by "user0" has the following tags
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags
       |MyFirstTag|normal|
 
   Scenario: Assigning a not user-visible tag to a file shared by someone else as admin user should work
-    Given user "user0" exists
-    And user "another_admin" exists
-    And user "another_admin" belongs to group "admin"
-    And "another_admin" creates a "normal" tag with name "MyFirstTag"
-    And "another_admin" creates a "not user-visible" tag with name "MySecondTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
-    And "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
-    When "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "another_admin" has been created
+    And user "another_admin" has been added to group "admin"
+    And user "another_admin" has created a "normal" tag with name "MyFirstTag"
+    And user "another_admin" has created a "not user-visible" tag with name "MySecondTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the API
+    And user "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "201"
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "another_admin"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "another_admin"
       |MyFirstTag|normal|
       |MySecondTag|not user-visible|
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
       |MyFirstTag|normal|
 
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as admin user should work
-    Given user "user0" exists
-    And user "another_admin" exists
-    And user "another_admin" belongs to group "admin"
-    And "another_admin" creates a "normal" tag with name "MyFirstTag"
-    And "another_admin" creates a "not user-assignable" tag with name "MySecondTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
-    And "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    When "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "another_admin" has been created
+    And user "another_admin" has been added to group "admin"
+    And user "another_admin" has created a "normal" tag with name "MyFirstTag"
+    And user "another_admin" has created a "not user-assignable" tag with name "MySecondTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0" using the API
+    And user "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "201"
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "another_admin"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "another_admin"
       |MyFirstTag|normal|
       |MySecondTag|not user-assignable|
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
       |MyFirstTag|normal|
       |MySecondTag|not user-assignable|
 
   Scenario: Unassigning a normal tag from a file shared by someone else as regular user should work
-    Given user "user0" exists
-    And user "user1" exists
-    And "admin" creates a "normal" tag with name "MyFirstTag"
-    And "admin" creates a "normal" tag with name "MySecondTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
-    And "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
-    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" owned by "user0"
-    When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "admin" has created a "normal" tag with name "MyFirstTag"
+    And user "admin" has created a "normal" tag with name "MySecondTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" owned by "user0"
+    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "204"
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
       |MySecondTag|normal|
 
   Scenario: Unassigning a normal tag from a file unshared by someone else as regular user should fail
-    Given user "user0" exists
-    And user "user1" exists
-    And "admin" creates a "normal" tag with name "MyFirstTag"
-    And "admin" creates a "normal" tag with name "MySecondTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "admin" has created a "normal" tag with name "MyFirstTag"
+    And user "admin" has created a "normal" tag with name "MySecondTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "404"
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
       |MyFirstTag|normal|
       |MySecondTag|normal|
 
   Scenario: Unassigning a not user-visible tag from a file shared by someone else as regular user should fail
-    Given user "user0" exists
-    And user "user1" exists
-    And user "another_admin" exists
-    And user "another_admin" belongs to group "admin"
-    And "another_admin" creates a "not user-visible" tag with name "MyFirstTag"
-    And "another_admin" creates a "normal" tag with name "MySecondTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
-    And "another_admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "another_admin" has been created
+    And user "another_admin" has been added to group "admin"
+    And user "another_admin" has created a "not user-visible" tag with name "MyFirstTag"
+    And user "another_admin" has created a "normal" tag with name "MySecondTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
+    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "404"
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
       |MySecondTag|normal|
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "another_admin"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "another_admin"
       |MyFirstTag|not user-visible|
       |MySecondTag|normal|
 
   Scenario: Unassigning a not user-visible tag from a file shared by someone else as admin should work
-    Given user "user0" exists
-    And user "user1" exists
-    And user "another_admin" exists
-    And user "another_admin" belongs to group "admin"
-    And "another_admin" creates a "not user-visible" tag with name "MyFirstTag"
-    And "another_admin" creates a "normal" tag with name "MySecondTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
-    And "another_admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    When "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "another_admin" has been created
+    And user "another_admin" has been added to group "admin"
+    And user "another_admin" has created a "not user-visible" tag with name "MyFirstTag"
+    And user "another_admin" has created a "normal" tag with name "MySecondTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
+    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "204"
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
       |MySecondTag|normal|
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "another_admin"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "another_admin"
       |MySecondTag|normal|
 
   Scenario: Unassigning a not user-visible tag from a file unshared by someone else should fail
-    Given user "user0" exists
-    And user "user1" exists
-    And user "another_admin" exists
-    And user "another_admin" belongs to group "admin"
-    And "another_admin" creates a "not user-visible" tag with name "MyFirstTag"
-    And "another_admin" creates a "normal" tag with name "MySecondTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
-    And "another_admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    And as "user0" remove all shares from the file named "/myFileToTag.txt"
-    When "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "another_admin" has been created
+    And user "another_admin" has been added to group "admin"
+    And user "another_admin" has created a "not user-visible" tag with name "MyFirstTag"
+    And user "another_admin" has created a "normal" tag with name "MySecondTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
+    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user0" has removed all shares from the file named "/myFileToTag.txt"
+    When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "404"
 
   Scenario: Unassigning a not user-assignable tag from a file shared by someone else as regular user should fail
-    Given user "user0" exists
-    And user "user1" exists
-    And user "another_admin" exists
-    And user "another_admin" belongs to group "admin"
-    And "another_admin" creates a "not user-assignable" tag with name "MyFirstTag"
-    And "another_admin" creates a "normal" tag with name "MySecondTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
-    And "another_admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    When "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "another_admin" has been created
+    And user "another_admin" has been added to group "admin"
+    And user "another_admin" has created a "not user-assignable" tag with name "MyFirstTag"
+    And user "another_admin" has created a "normal" tag with name "MySecondTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
+    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "403"
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
       |MyFirstTag|not user-assignable|
       |MySecondTag|normal|
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "another_admin"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "another_admin"
       |MyFirstTag|not user-assignable|
       |MySecondTag|normal|
 
   Scenario: Unassigning a not user-assignable tag from a file shared by someone else as admin should work
-    Given user "user0" exists
-    And user "user1" exists
-    And user "another_admin" exists
-    And user "another_admin" belongs to group "admin"
-    And "another_admin" creates a "not user-assignable" tag with name "MyFirstTag"
-    And "another_admin" creates a "normal" tag with name "MySecondTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
-    And "another_admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    When "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "another_admin" has been created
+    And user "another_admin" has been added to group "admin"
+    And user "another_admin" has created a "not user-assignable" tag with name "MyFirstTag"
+    And user "another_admin" has created a "normal" tag with name "MySecondTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
+    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "204"
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
       |MySecondTag|normal|
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "another_admin"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "another_admin"
       |MySecondTag|normal|
 
   Scenario: Unassigning a not user-assignable tag from a file unshared by someone else should fail
-    Given user "user0" exists
-    And user "user1" exists
-    And user "another_admin" exists
-    And user "another_admin" belongs to group "admin"
-    And "another_admin" creates a "not user-assignable" tag with name "MyFirstTag"
-    And "another_admin" creates a "normal" tag with name "MySecondTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "user1"
-    And file "/myFileToTag.txt" of user "user0" is shared with user "another_admin"
-    And "another_admin" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    And "user0" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    And as "user0" remove all shares from the file named "/myFileToTag.txt"
-    When "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "another_admin" has been created
+    And user "another_admin" has been added to group "admin"
+    And user "another_admin" has created a "not user-assignable" tag with name "MyFirstTag"
+    And user "another_admin" has created a "normal" tag with name "MySecondTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has shared file "/myFileToTag.txt" with user "user1"
+    And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
+    And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
+    And user "user0" has removed all shares from the file named "/myFileToTag.txt"
+    When user "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "404"
 
   Scenario: Overwriting existing normal tags should fail
-    Given user "user0" exists
-    And "user0" creates a "normal" tag with name "MyFirstTag"
-    When "user0" creates a "normal" tag with name "MyFirstTag"
+    Given user "user0" has been created
+    And user "user0" has created a "normal" tag with name "MyFirstTag"
+    When user "user0" creates a "normal" tag with name "MyFirstTag" using the API
     Then the HTTP status code should be "409"
 
   Scenario: Overwriting existing not user-assignable tags should fail
-    Given "admin" creates a "not user-assignable" tag with name "MyFirstTag"
-    When "admin" creates a "not user-assignable" tag with name "MyFirstTag"
+    Given user "admin" has created a "not user-assignable" tag with name "MyFirstTag"
+    When user "admin" creates a "not user-assignable" tag with name "MyFirstTag" using the API
     Then the HTTP status code should be "409"
 
   Scenario: Overwriting existing not user-visible tags should fail
-    Given "admin" creates a "not user-visible" tag with name "MyFirstTag"
-    When "admin" creates a "not user-visible" tag with name "MyFirstTag"
+    Given user "admin" has created a "not user-visible" tag with name "MyFirstTag"
+    When user "admin" creates a "not user-visible" tag with name "MyFirstTag" using the API
     Then the HTTP status code should be "409"
 
   Scenario: Getting tags only works with access to the file
-    Given user "user0" exists
-    And user "user1" exists
-    And "admin" creates a "normal" tag with name "MyFirstTag"
-    And user "user0" uploads file "data/textfile.txt" to "/myFileToTag.txt"
-    When "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
-    Then "/myFileToTag.txt" shared by "user0" has the following tags for "user0"
+    Given user "user0" has been created
+    And user "user1" has been created
+    And user "admin" has created a "normal" tag with name "MyFirstTag"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0" using the API
+    Then file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
       |MyFirstTag|normal|
-    And "/myFileToTag.txt" shared by "user0" has the following tags for "user1"
+    And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user1"
       ||
 
   Scenario: User can assign tags when in the tag's groups
-    Given user "user0" exists
-    And group "group1" exists
-    And user "user0" belongs to group "group1"
-    When "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
+    Given user "user0" has been created
+    And group "group1" has been created
+    And user "user0" has been added to group "group1"
+    When user "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the API
     Then the HTTP status code should be "201"
-    And the user "user0" can assign the "not user-assignable" tag with name "TagWithGroups"
+    And the user "user0" should be able to assign the "not user-assignable" tag with name "TagWithGroups"
 
   Scenario: User cannot assign tags when not in the tag's groups
-    Given user "user0" exists
-    When "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
+    Given user "user0" has been created
+    When user "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the API
     Then the HTTP status code should be "201"
-    And the user "user0" cannot assign the "not user-assignable" tag with name "TagWithGroups"
+    And the user "user0" should not be able to assign the "not user-assignable" tag with name "TagWithGroups"

--- a/tests/integration/features/tags.feature
+++ b/tests/integration/features/tags.feature
@@ -11,10 +11,10 @@ Feature: tags
     And the following tags should exist for "user0"
       |<tag_name>|normal|
 
-  Examples:
-    |tag_name|
-    |JustARegularTagName|
-    |😀|
+    Examples:
+      | tag_name            |
+      | JustARegularTagName |
+      | 😀                  |
 
   Scenario: Creating a not user-assignable tag as regular user should fail
     Given user "user0" has been created
@@ -45,26 +45,26 @@ Feature: tags
     And user "admin" has created a "normal" tag with name "<tag_name>"
     When user "user0" edits the tag with name "<tag_name>" and sets its name to "AnotherTagName" using the API
     Then the following tags should exist for "admin"
-      |AnotherTagName|normal|
+      | AnotherTagName | normal |
 
-  Examples:
-    |tag_name|
-    |JustARegularTagName|
-    |😀|
+    Examples:
+      | tag_name            |
+      | JustARegularTagName |
+      | 😀                  |
 
   Scenario: Renaming a not user-assignable tag as regular user should fail
     Given user "user0" has been created
     And user "admin" has created a "not user-assignable" tag with name "JustARegularTagName"
     When user "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the API
     Then the following tags should exist for "admin"
-      |JustARegularTagName|not user-assignable|
+      | JustARegularTagName | not user-assignable |
 
   Scenario: Renaming a not user-visible tag as regular user should fail
     Given user "user0" has been created
     And user "admin" has created a "not user-visible" tag with name "JustARegularTagName"
     When user "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the API
     Then the following tags should exist for "admin"
-      |JustARegularTagName|not user-visible|
+      | JustARegularTagName | not user-visible |
 
   Scenario: Editing tag groups as admin should work
     Given user "user0" has been created
@@ -91,7 +91,7 @@ Feature: tags
     When user "user0" deletes the tag with name "JustARegularTagName" using the API
     Then the HTTP status code should be "403"
     And the following tags should exist for "admin"
-      |JustARegularTagName|not user-assignable|
+      | JustARegularTagName | not user-assignable |
 
   Scenario: Deleting a not user-visible tag as regular user should fail
     Given user "user0" has been created
@@ -99,7 +99,7 @@ Feature: tags
     When user "user0" deletes the tag with name "JustARegularTagName" using the API
     Then the HTTP status code should be "404"
     And the following tags should exist for "admin"
-      |JustARegularTagName|not user-visible|
+      | JustARegularTagName | not user-visible |
 
   Scenario: Deleting a not user-assignable tag as admin should work
     Given user "admin" has created a "not user-assignable" tag with name "JustARegularTagName"
@@ -122,7 +122,7 @@ Feature: tags
     When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags
-      |JustARegularTagName|normal|
+      | JustARegularTagName | normal |
 
   Scenario: Assigning a normal tag to a file belonging to someone else as regular user should fail
     Given user "user0" has been created
@@ -134,7 +134,7 @@ Feature: tags
     And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" owned by "user0" using the API
     Then the HTTP status code should be "404"
     And file "/myFileToTag.txt" owned by "user0" should have the following tags
-      |MyFirstTag|normal|
+      | MyFirstTag | normal |
 
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as regular user should fail
     Given user "user0" has been created
@@ -147,7 +147,7 @@ Feature: tags
     And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "403"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags
-      |MyFirstTag|normal|
+      | MyFirstTag | normal |
 
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as regular user belongs to tag's groups should work
     Given user "user0" has been created
@@ -160,7 +160,7 @@ Feature: tags
     When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags
-      |JustARegularTagName|not user-assignable|
+      | JustARegularTagName | not user-assignable |
 
   Scenario: Assigning a not user-visible tag to a file shared by someone else as regular user should fail
     Given user "user0" has been created
@@ -173,7 +173,7 @@ Feature: tags
     And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "412"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags
-      |MyFirstTag|normal|
+      | MyFirstTag | normal |
 
   Scenario: Assigning a not user-visible tag to a file shared by someone else as admin user should work
     Given user "user0" has been created
@@ -187,10 +187,10 @@ Feature: tags
     And user "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "another_admin"
-      |MyFirstTag|normal|
-      |MySecondTag|not user-visible|
+      | MyFirstTag  | normal           |
+      | MySecondTag | not user-visible |
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
-      |MyFirstTag|normal|
+      | MyFirstTag | normal |
 
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as admin user should work
     Given user "user0" has been created
@@ -204,11 +204,11 @@ Feature: tags
     And user "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "another_admin"
-      |MyFirstTag|normal|
-      |MySecondTag|not user-assignable|
+      | MyFirstTag  | normal              |
+      | MySecondTag | not user-assignable |
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
-      |MyFirstTag|normal|
-      |MySecondTag|not user-assignable|
+      | MyFirstTag  | normal              |
+      | MySecondTag | not user-assignable |
 
   Scenario: Unassigning a normal tag from a file shared by someone else as regular user should work
     Given user "user0" has been created
@@ -222,7 +222,7 @@ Feature: tags
     When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "204"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
-      |MySecondTag|normal|
+      | MySecondTag | normal |
 
   Scenario: Unassigning a normal tag from a file unshared by someone else as regular user should fail
     Given user "user0" has been created
@@ -235,8 +235,8 @@ Feature: tags
     When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "404"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
-      |MyFirstTag|normal|
-      |MySecondTag|normal|
+      | MyFirstTag  | normal |
+      | MySecondTag | normal |
 
   Scenario: Unassigning a not user-visible tag from a file shared by someone else as regular user should fail
     Given user "user0" has been created
@@ -253,10 +253,10 @@ Feature: tags
     When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "404"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
-      |MySecondTag|normal|
+      | MySecondTag | normal |
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "another_admin"
-      |MyFirstTag|not user-visible|
-      |MySecondTag|normal|
+      | MyFirstTag  | not user-visible |
+      | MySecondTag | normal           |
 
   Scenario: Unassigning a not user-visible tag from a file shared by someone else as admin should work
     Given user "user0" has been created
@@ -273,9 +273,9 @@ Feature: tags
     When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "204"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
-      |MySecondTag|normal|
+      | MySecondTag | normal |
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "another_admin"
-      |MySecondTag|normal|
+      | MySecondTag | normal |
 
   Scenario: Unassigning a not user-visible tag from a file unshared by someone else should fail
     Given user "user0" has been created
@@ -308,11 +308,11 @@ Feature: tags
     When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "403"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
-      |MyFirstTag|not user-assignable|
-      |MySecondTag|normal|
+      | MyFirstTag  | not user-assignable |
+      | MySecondTag | normal              |
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "another_admin"
-      |MyFirstTag|not user-assignable|
-      |MySecondTag|normal|
+      | MyFirstTag  | not user-assignable |
+      | MySecondTag | normal              |
 
   Scenario: Unassigning a not user-assignable tag from a file shared by someone else as admin should work
     Given user "user0" has been created
@@ -329,9 +329,9 @@ Feature: tags
     When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
     Then the HTTP status code should be "204"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
-      |MySecondTag|normal|
+      | MySecondTag | normal |
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "another_admin"
-      |MySecondTag|normal|
+      | MySecondTag | normal |
 
   Scenario: Unassigning a not user-assignable tag from a file unshared by someone else should fail
     Given user "user0" has been created
@@ -372,7 +372,7 @@ Feature: tags
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0" using the API
     Then file "/myFileToTag.txt" shared by "user0" should have the following tags for "user0"
-      |MyFirstTag|normal|
+      | MyFirstTag | normal |
     And file "/myFileToTag.txt" shared by "user0" should have the following tags for "user1"
       ||
 

--- a/tests/integration/features/transfer-ownership.feature
+++ b/tests/integration/features/transfer-ownership.feature
@@ -2,270 +2,252 @@ Feature: transfer-ownership
 
 	@no_default_encryption
 	Scenario: transferring ownership of a file
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" uploads file "data/textfile.txt" to "/somefile.txt"
-		When transferring ownership from "user0" to "user1"
-		And the command was successful
-		And as an "user1"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
+		When the administrator transfers ownership from "user0" to "user1" using the occ command
+		Then the command should have been successful
 		And using received transfer folder of "user1" as dav path
-		Then downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
+		And the downloaded content when downloading file "/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
 
 	@no_default_encryption
 	Scenario: transferring ownership of a file after updating the file
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" uploads file "data/file_to_overwrite.txt" to "/PARENT/textfile0.txt"
-		And user "user0" uploads chunk file "1" of "3" with "AA" to "/PARENT/textfile0.txt"
-		And user "user0" uploads chunk file "2" of "3" with "BB" to "/PARENT/textfile0.txt"
-		And user "user0" uploads chunk file "3" of "3" with "CC" to "/PARENT/textfile0.txt"
-		When transferring ownership from "user0" to "user1"
-		Then the command was successful
-		And as an "user1"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has uploaded file "data/file_to_overwrite.txt" to "/PARENT/textfile0.txt"
+		And user "user0" has uploaded chunk file "1" of "3" with "AA" to "/PARENT/textfile0.txt"
+		And user "user0" has uploaded chunk file "2" of "3" with "BB" to "/PARENT/textfile0.txt"
+		And user "user0" has uploaded chunk file "3" of "3" with "CC" to "/PARENT/textfile0.txt"
+		When the administrator transfers ownership from "user0" to "user1" using the occ command
+		Then the command should have been successful
 		And using received transfer folder of "user1" as dav path
-		Then downloaded content when downloading file "/PARENT/textfile0.txt" with range "bytes=0-5" should be "AABBCC"
+		And the downloaded content when downloading file "/PARENT/textfile0.txt" for user "user1" with range "bytes=0-5" should be "AABBCC"
 
 	@no_default_encryption
 	Scenario: transferring ownership of a folder
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/test"
-		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
-		When transferring ownership from "user0" to "user1"
-		And the command was successful
-		And as an "user1"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+		When the administrator transfers ownership from "user0" to "user1" using the occ command
+		Then the command should have been successful
 		And using received transfer folder of "user1" as dav path
-		Then downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
 
 	@no_default_encryption
 	Scenario: transferring ownership of file shares
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user0" uploads file "data/textfile.txt" to "/somefile.txt"
-		And file "/somefile.txt" of user "user0" is shared with user "user2" with permissions 19
-		When transferring ownership from "user0" to "user1"
-		And the command was successful
-		And as an "user2"
-		Then downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
+		And user "user0" has shared file "/somefile.txt" with user "user2" with permissions 19
+		When the administrator transfers ownership from "user0" to "user1" using the occ command
+		Then the command should have been successful
+		And the downloaded content when downloading file "/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
 	@no_default_encryption
 	Scenario: transferring ownership of folder shared with third user
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user0" created a folder "/test"
-		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
-		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
-		When transferring ownership from "user0" to "user1"
-		And the command was successful
-		And as an "user2"
-		Then downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+		And user "user0" has shared folder "/test" with user "user2" with permissions 31
+		When the administrator transfers ownership from "user0" to "user1" using the occ command
+		Then the command should have been successful
+		And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
 	@no_default_encryption
 	Scenario: transferring ownership of folder shared with transfer recipient
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/test"
-		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
-		And folder "/test" of user "user0" is shared with user "user1" with permissions 31
-		When transferring ownership from "user0" to "user1"
-		And the command was successful
-		And as an "user1"
-		Then as "user1" the folder "/test" does not exist
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+		And user "user0" has shared folder "/test" with user "user1" with permissions 31
+		When the administrator transfers ownership from "user0" to "user1" using the occ command
+		Then the command should have been successful
+		And as "user1" the folder "/test" should not exist
 		And using received transfer folder of "user1" as dav path
-		And downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
 
 	@no_default_encryption
 	Scenario: transferring ownership of folder doubly shared with third user
-		Given group "group1" exists
-		And user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-    	And user "user2" belongs to group "group1"
-		And user "user0" created a folder "/test"
-		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
-		And folder "/test" of user "user0" is shared with group "group1" with permissions 31
-		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
-		When transferring ownership from "user0" to "user1"
-		And the command was successful
-		And as an "user2"
-		Then downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		Given group "group1" has been created
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+    	And user "user2" has been added to group "group1"
+		And user "user0" has created a folder "/test"
+		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+		And user "user0" has shared folder "/test" with group "group1" with permissions 31
+		And user "user0" has shared folder "/test" with user "user2" with permissions 31
+		When the administrator transfers ownership from "user0" to "user1" using the occ command
+		Then the command should have been successful
+		And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
 	@no_default_encryption
 	Scenario: transferring ownership does not transfer received shares
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user2" created a folder "/test"
-		And folder "/test" of user "user2" is shared with user "user0" with permissions 31
-		When transferring ownership from "user0" to "user1"
-		And the command was successful
-		And as an "user1"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user2" has created a folder "/test"
+		And user "user2" has shared folder "/test" with user "user0" with permissions 31
+		When the administrator transfers ownership from "user0" to "user1" using the occ command
+		Then the command should have been successful
 		And using received transfer folder of "user1" as dav path
-		Then as "user1" the folder "/test" does not exist
+		And as "user1" the folder "/test" should not exist
 
 	@local_storage @no_default_encryption
 	Scenario: transferring ownership does not transfer external storage
-		Given user "user0" exists
-		And user "user1" exists
-		When transferring ownership from "user0" to "user1"
-		And the command was successful
-		And as an "user1"
+		Given user "user0" has been created
+		And user "user1" has been created
+		When the administrator transfers ownership from "user0" to "user1" using the occ command
+		Then the command should have been successful
 		And using received transfer folder of "user1" as dav path
-		Then as "user1" the folder "/local_storage" does not exist
+		And as "user1" the folder "/local_storage" should not exist
 
 	@no_default_encryption
 	Scenario: transferring ownership does not fail with shared trashed files
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user0" created a folder "/sub"
-		And user "user0" created a folder "/sub/test"
-		And folder "/sub/test" of user "user0" is shared with user "user2" with permissions 31
-		And user "user0" deletes folder "/sub"
-		When transferring ownership from "user0" to "user1"
-		Then the command was successful
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has created a folder "/sub"
+		And user "user0" has created a folder "/sub/test"
+		And user "user0" has shared folder "/sub/test" with user "user2" with permissions 31
+		And user "user0" has deleted folder "/sub"
+		When the administrator transfers ownership from "user0" to "user1" using the occ command
+		Then the command should have been successful
 
 	Scenario: transferring ownership fails with invalid source user
-		Given user "user0" exists
-		When transferring ownership from "invalid_user" to "user0"
-		Then the command output contains the text "Unknown source user"
-		And the command failed with exit code 1
+		Given user "user0" has been created
+		When the administrator transfers ownership from "invalid_user" to "user0" using the occ command
+		Then the command output should contain the text "Unknown source user"
+		And the command should have failed with exit code 1
 
 	Scenario: transferring ownership fails with invalid destination user
-		Given user "user0" exists
-		When transferring ownership from "user0" to "invalid_user"
-		Then the command output contains the text "Unknown destination user"
-		And the command failed with exit code 1
+		Given user "user0" has been created
+		When the administrator transfers ownership from "user0" to "invalid_user" using the occ command
+		Then the command output should contain the text "Unknown destination user"
+		And the command should have failed with exit code 1
 
 	@no_default_encryption
 	Scenario: transferring ownership of a folder
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/test"
-		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
-		When transferring ownership of path "test" from "user0" to "user1"
-		And the command was successful
-		And as an "user1"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+		Then the command should have been successful
 		And using received transfer folder of "user1" as dav path
-		Then downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
 
 	@no_default_encryption
 	Scenario: transferring ownership of file shares
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user0" created a folder "/test"
-		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
-		And file "/test/somefile.txt" of user "user0" is shared with user "user2" with permissions 19
-		When transferring ownership of path "test" from "user0" to "user1"
-		And the command was successful
-		And as an "user2"
-		Then downloaded content when downloading file "/somefile.txt" with range "bytes=0-6" should be "This is"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+		And user "user0" has shared file "/test/somefile.txt" with user "user2" with permissions 19
+		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+		Then the command should have been successful
+		And the downloaded content when downloading file "/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
 	@no_default_encryption
 	Scenario: transferring ownership of folder shares which has public link
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user0" created a folder "/test"
-		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
-		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
-		And as an "user1"
-		And creating a share with
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt" using the API
+		And user "user0" has shared folder "/test" with user "user2" with permissions 31
+		And user "user1" creates a share using the API with settings
 			| path | /test/somefile.txt |
 			| shareType | 3 |
-		When transferring ownership of path "test" from "user0" to "user1"
-		And the command was successful
-		And as an "user2"
-		Then downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+		And the command should have been successful
+		Then the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
 	@no_default_encryption
 	Scenario: transferring ownership of folder shared with third user
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user0" created a folder "/test"
-		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
-		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
-		When transferring ownership of path "test" from "user0" to "user1"
-		And the command was successful
-		And as an "user2"
-		Then downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+		And user "user0" has shared folder "/test" with user "user2" with permissions 31
+		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+		Then the command should have been successful
+		And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
 	@no_default_encryption
 	Scenario: transferring ownership of folder shared with transfer recipient
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/test"
-		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
-		And folder "/test" of user "user0" is shared with user "user1" with permissions 31
-		When transferring ownership of path "test" from "user0" to "user1"
-		And the command was successful
-		And as an "user1"
-		Then as "user1" the folder "/test" does not exist
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+		And user "user0" has shared folder "/test" with user "user1" with permissions 31
+		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+		Then the command should have been successful
+		And as "user1" the folder "/test" should not exist
 		And using received transfer folder of "user1" as dav path
-		And downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
 
 	@no_default_encryption
 	Scenario: transferring ownership of folder doubly shared with third user
-		Given group "group1" exists
-		And user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user2" belongs to group "group1"
-		And user "user0" created a folder "/test"
-		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt"
-		And folder "/test" of user "user0" is shared with group "group1" with permissions 31
-		And folder "/test" of user "user0" is shared with user "user2" with permissions 31
-		When transferring ownership of path "test" from "user0" to "user1"
-		And the command was successful
-		And as an "user2"
-		Then downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
+		Given group "group1" has been created
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user2" has been added to group "group1"
+		And user "user0" has created a folder "/test"
+		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
+		And user "user0" has shared folder "/test" with group "group1" with permissions 31
+		And user "user0" has shared folder "/test" with user "user2" with permissions 31
+		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+		Then the command should have been successful
+		And the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
 	Scenario: transferring ownership does not transfer received shares
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And user "user2" created a folder "/test"
-		And user "user0" created a folder "/sub"
-		And folder "/test" of user "user2" is shared with user "user0" with permissions 31
-		And user "user0" moved folder "/test" to "/sub/test"
-		When transferring ownership of path "sub" from "user0" to "user1"
-		And the command was successful
-		And as an "user1"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user2" has been created
+		And user "user2" has created a folder "/test"
+		And user "user0" has created a folder "/sub"
+		And user "user2" has shared folder "/test" with user "user0" with permissions 31
+		And user "user0" has moved folder "/test" to "/sub/test"
+		When the administrator transfers ownership of path "sub" from "user0" to "user1" using the occ command
+		Then the command should have been successful
 		And using received transfer folder of "user1" as dav path
-		Then as "user1" the folder "/sub/test" does not exist
+		And as "user1" the folder "/sub/test" should not exist
 
 	@local_storage
 	Scenario: transferring ownership does not transfer external storage
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/sub"
-		When transferring ownership of path "sub" from "user0" to "user1"
-		And the command was successful
-		And as an "user1"
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/sub"
+		When the administrator transfers ownership of path "sub" from "user0" to "user1" using the occ command
+		Then the command should have been successful
 		And using received transfer folder of "user1" as dav path
-		Then as "user1" the folder "/local_storage" does not exist
+		And as "user1" the folder "/local_storage" should not exist
 
 	Scenario: transferring ownership fails with invalid source user
-		Given user "user0" exists
-		And user "user0" created a folder "/sub"
-		When transferring ownership of path "sub" from "invalid_user" to "user0"
-		Then the command output contains the text "Unknown source user"
-		And the command failed with exit code 1
+		Given user "user0" has been created
+		And user "user0" has created a folder "/sub"
+		When the administrator transfers ownership of path "sub" from "invalid_user" to "user0" using the occ command
+		Then the command output should contain the text "Unknown source user"
+		And the command should have failed with exit code 1
 
 	Scenario: transferring ownership fails with invalid destination user
-		Given user "user0" exists
-		And user "user0" created a folder "/sub"
-		When transferring ownership of path "sub" from "user0" to "invalid_user"
-		Then the command output contains the text "Unknown destination user"
-		And the command failed with exit code 1
+		Given user "user0" has been created
+		And user "user0" has created a folder "/sub"
+		When the administrator transfers ownership of path "sub" from "user0" to "invalid_user" using the occ command
+		Then the command output should contain the text "Unknown destination user"
+		And the command should have failed with exit code 1
 
 	Scenario: transferring ownership fails with invalid path
-		Given user "user0" exists
-		And user "user1" exists
-		When transferring ownership of path "test" from "user0" to "user1"
-		Then the command output contains the text "Unknown path provided"
-		And the command failed with exit code 1
+		Given user "user0" has been created
+		And user "user1" has been created
+		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+		Then the command output should contain the text "Unknown path provided"
+		And the command should have failed with exit code 1

--- a/tests/integration/features/transfer-ownership.feature
+++ b/tests/integration/features/transfer-ownership.feature
@@ -162,8 +162,8 @@ Feature: transfer-ownership
 		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt" using the API
 		And user "user0" has shared folder "/test" with user "user2" with permissions 31
 		And user "user1" creates a share using the API with settings
-			| path | /test/somefile.txt |
-			| shareType | 3 |
+			| path      | /test/somefile.txt |
+			| shareType | 3                  |
 		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
 		And the command should have been successful
 		Then the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"

--- a/tests/integration/features/trashbin-new-endpoint.feature
+++ b/tests/integration/features/trashbin-new-endpoint.feature
@@ -65,7 +65,7 @@ Feature: trashbin-new-endpoint
 		When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the API
 		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
 		And user "user1" should see the following elements
-			| /renamed_shared/ |
+			| /renamed_shared/                |
 			| /renamed_shared/shared_file.txt |
 
 	Scenario: Trashbin can be emptied
@@ -86,14 +86,14 @@ Feature: trashbin-new-endpoint
 		When user "user0" restores the folder with original path "/textfile0.txt" using the API
 		Then as "user0" the folder with original path "/textfile0.txt" should not exist in trash
 		And user "user0" should see the following elements
-			| /FOLDER/ |
-			| /PARENT/ |
+			| /FOLDER/           |
+			| /PARENT/           |
 			| /PARENT/parent.txt |
-			| /textfile0.txt |
-			| /textfile1.txt |
-			| /textfile2.txt |
-			| /textfile3.txt |
-			| /textfile4.txt |
+			| /textfile0.txt     |
+			| /textfile1.txt     |
+			| /textfile2.txt     |
+			| /textfile3.txt     |
+			| /textfile4.txt     |
 
 	@skip
 	Scenario: trashbin can store two files with same name but different origins
@@ -132,6 +132,6 @@ Feature: trashbin-new-endpoint
 		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the API
 		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
 		And user "user0" should see the following elements
-			| /local_storage/ |
-			| /local_storage/tmp/ |
+			| /local_storage/                  |
+			| /local_storage/tmp/              |
 			| /local_storage/tmp/textfile0.txt |

--- a/tests/integration/features/trashbin-new-endpoint.feature
+++ b/tests/integration/features/trashbin-new-endpoint.feature
@@ -1,92 +1,91 @@
 Feature: trashbin-new-endpoint
 	Background:
-		Given using api version "1"
-		And using new dav path
-		And as an "admin"
-		And app "files_trashbin" is enabled
+		Given using API version "1"
+		And using new DAV path
+		And as user "admin"
 
 	Scenario: deleting a file moves it to trashbin
-		Given user "user0" exists
-		When user "user0" deletes file "/textfile0.txt"
-		Then as "user0" the file "/textfile0.txt" exists in trash
+		Given user "user0" has been created
+		When user "user0" deletes file "/textfile0.txt" using the API
+		Then as "user0" the file "/textfile0.txt" should exist in trash
 
 	Scenario: deleting a folder moves it to trashbin
-		Given user "user0" exists
-		And user "user0" created a folder "/tmp"
-		When user "user0" deletes folder "/tmp"
-		Then as "user0" the folder "/tmp" exists in trash
+		Given user "user0" has been created
+		And user "user0" has created a folder "/tmp"
+		When user "user0" deletes folder "/tmp" using the API
+		Then as "user0" the folder "/tmp" should exist in trash
 
 	Scenario: deleting a file of a shared folder moves it to trashbin
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		When user "user0" deletes file "/shared/shared_file.txt"
-		Then as "user0" the folder with original path "/shared/shared_file.txt" exists in trash
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user0" has shared folder "/shared" with user "user1"
+		When user "user0" deletes file "/shared/shared_file.txt" using the API
+		Then as "user0" the folder with original path "/shared/shared_file.txt" should exist in trash
 
 	Scenario: deleting a shared folder moves it to trashbin
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		When user "user0" deletes folder "/shared"
-		Then as "user0" the folder with original path "/shared" exists in trash
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user0" has shared folder "/shared" with user "user1"
+		When user "user0" deletes folder "/shared" using the API
+		Then as "user0" the folder with original path "/shared" should exist in trash
 
 	Scenario: deleting a received folder doesn't move it to trashbin
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		And user "user1" moved folder "/shared" to "/renamed_shared"
-		When user "user1" deletes folder "/renamed_shared"
-		Then as "user1" the folder with original path "/renamed_shared" does not exist in trash
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user0" has shared folder "/shared" with user "user1"
+		And user "user1" has moved folder "/shared" to "/renamed_shared"
+		When user "user1" deletes folder "/renamed_shared" using the API
+		Then as "user1" the folder with original path "/renamed_shared" should not exist in trash
 
 	Scenario: deleting a file in a received folder moves it to trashbin
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		And user "user1" moved file "/shared" to "/renamed_shared"
-		When user "user1" deletes file "/renamed_shared/shared_file.txt"
-		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" exists in trash
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user0" has shared folder "/shared" with user "user1"
+		And user "user1" has moved file "/shared" to "/renamed_shared"
+		When user "user1" deletes file "/renamed_shared/shared_file.txt" using the API
+		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should exist in trash
 
 	Scenario: deleting a file in a received folder when restored it comes back to the original path
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		And user "user1" moved file "/shared" to "/renamed_shared"
-		And user "user1" deletes file "/renamed_shared/shared_file.txt"
-		And logging in using web as "user1"
-		When as "user1" the file with original path "/renamed_shared/shared_file.txt" is restored
-		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" does not exist in trash
-		And user "user1" should see following elements
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user0" has shared folder "/shared" with user "user1"
+		And user "user1" has moved file "/shared" to "/renamed_shared"
+		And user "user1" has deleted file "/renamed_shared/shared_file.txt"
+		And user "user1" has logged in to a web-style session using the API
+		When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the API
+		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
+		And user "user1" should see the following elements
 			| /renamed_shared/ |
 			| /renamed_shared/shared_file.txt |
 
 	Scenario: Trashbin can be emptied
-		Given user "user0" exists
-		And user "user0" deletes file "/textfile0.txt"
-		And user "user0" deletes file "/textfile1.txt"
-		And as "user0" the file "/textfile0.txt" exists in trash
-		And as "user0" the file "/textfile0.txt" exists in trash
-		When user "user0" empties the trashbin
-		Then as "user0" the file with original path "/textfile0.txt" does not exist in trash
-		And as "user0" the file with original path "/textfile1.txt" does not exist in trash
+		Given user "user0" has been created
+		And user "user0" has deleted file "/textfile0.txt"
+		And user "user0" has deleted file "/textfile1.txt"
+		And as "user0" the file "/textfile0.txt" should exist in trash
+		And as "user0" the file "/textfile0.txt" should exist in trash
+		When user "user0" empties the trashbin using the API
+		Then as "user0" the file with original path "/textfile0.txt" should not exist in trash
+		And as "user0" the file with original path "/textfile1.txt" should not exist in trash
 
 	Scenario: A deleted file can be restored
-		Given user "user0" exists
-		And user "user0" deletes file "/textfile0.txt"
-		And as "user0" the file "/textfile0.txt" exists in trash
-		And logging in using web as "user0"
-		When as "user0" the folder with original path "/textfile0.txt" is restored
-		Then as "user0" the folder with original path "/textfile0.txt" does not exist in trash
-		And user "user0" should see following elements
+		Given user "user0" has been created
+		And user "user0" has deleted file "/textfile0.txt"
+		And as "user0" the file "/textfile0.txt" should exist in trash
+		And user "user0" has logged in to a web-style session using the API
+		When user "user0" restores the folder with original path "/textfile0.txt" using the API
+		Then as "user0" the folder with original path "/textfile0.txt" should not exist in trash
+		And user "user0" should see the following elements
 			| /FOLDER/ |
 			| /PARENT/ |
 			| /PARENT/parent.txt |
@@ -98,41 +97,41 @@ Feature: trashbin-new-endpoint
 
 	@skip
 	Scenario: trashbin can store two files with same name but different origins
-		Given user "user0" exists
-		And user "user0" created a folder "/folderA"
-		And user "user0" created a folder "/folderB"
-		And user "user0" copies file "/textfile0.txt" to "/folderA/textfile0.txt"
-		And user "user0" copies file "/textfile0.txt" to "/folderB/textfile0.txt"
-		When user "user0" deletes file "/folderA/textfile0.txt"
-		And user "user0" deletes file "/folderB/textfile0.txt"
-		And user "user0" deletes file "/textfile0.txt"
-		Then as "user0" the folder with original path "/folderA/textfile0.txt" exists in trash
-		And as "user0" the folder with original path "/folderB/textfile0.txt" exists in trash
-		And as "user0" the folder with original path "/textfile0.txt" exists in trash
+		Given user "user0" has been created
+		And user "user0" has created a folder "/folderA"
+		And user "user0" has created a folder "/folderB"
+		And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
+		And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
+		When user "user0" deletes file "/folderA/textfile0.txt" using the API
+		And user "user0" deletes file "/folderB/textfile0.txt" using the API
+		And user "user0" deletes file "/textfile0.txt" using the API
+		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
+		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
+		And as "user0" the folder with original path "/textfile0.txt" should exist in trash
 
 	@local_storage
 	@no_default_encryption
 	Scenario: Deleting a folder in external storage moves it to the trashbin
-		Given invoking occ with "files:scan --all"
-		And user "user0" exists
-		And user "user0" created a folder "/local_storage/tmp"
-		And user "user0" moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
-		When user "user0" deletes folder "/local_storage/tmp"
-		Then as "user0" the folder with original path "/local_storage/tmp" exists in trash
+		Given the administrator has invoked occ command "files:scan --all"
+		And user "user0" has been created
+		And user "user0" has created a folder "/local_storage/tmp"
+		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
+		When user "user0" deletes folder "/local_storage/tmp" using the API
+		Then as "user0" the folder with original path "/local_storage/tmp" should exist in trash
 
 	@local_storage
 	@no_default_encryption
 	Scenario: Deleting a file in external storage moves it to the trashbin and can be restored
-		Given invoking occ with "files:scan --all"
-		And user "user0" exists
-		And user "user0" created a folder "/local_storage/tmp"
-		And user "user0" moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
-		And user "user0" deletes file "/local_storage/tmp/textfile0.txt"
-		And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" exists in trash
-		And logging in using web as "user0"
-		When as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" is restored
-		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" does not exist in trash
-		And user "user0" should see following elements
+		Given the administrator has invoked occ command "files:scan --all"
+		And user "user0" has been created
+		And user "user0" has created a folder "/local_storage/tmp"
+		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
+		And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
+		And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
+		And user "user0" has logged in to a web-style session using the API
+		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the API
+		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
+		And user "user0" should see the following elements
 			| /local_storage/ |
 			| /local_storage/tmp/ |
 			| /local_storage/tmp/textfile0.txt |

--- a/tests/integration/features/trashbin-old-endpoint.feature
+++ b/tests/integration/features/trashbin-old-endpoint.feature
@@ -65,7 +65,7 @@ Feature: trashbin-new-endpoint
 		When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the API
 		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
 		And user "user1" should see the following elements
-			| /renamed_shared/ |
+			| /renamed_shared/                |
 			| /renamed_shared/shared_file.txt |
 
 	Scenario: Trashbin can be emptied
@@ -86,14 +86,14 @@ Feature: trashbin-new-endpoint
 		When user "user0" restores the folder with original path "/textfile0.txt" using the API
 		Then as "user0" the folder with original path "/textfile0.txt" should not exist in trash
 		And user "user0" should see the following elements
-			| /FOLDER/ |
-			| /PARENT/ |
+			| /FOLDER/           |
+			| /PARENT/           |
 			| /PARENT/parent.txt |
-			| /textfile0.txt |
-			| /textfile1.txt |
-			| /textfile2.txt |
-			| /textfile3.txt |
-			| /textfile4.txt |
+			| /textfile0.txt     |
+			| /textfile1.txt     |
+			| /textfile2.txt     |
+			| /textfile3.txt     |
+			| /textfile4.txt     |
 
 	@skip
 	Scenario: trashbin can store two files with same name but different origins
@@ -132,8 +132,8 @@ Feature: trashbin-new-endpoint
 		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the API
 		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
 		And user "user0" should see the following elements
-			| /local_storage/ |
-			| /local_storage/tmp/ |
+			| /local_storage/                  |
+			| /local_storage/tmp/              |
 			| /local_storage/tmp/textfile0.txt |
 
 	@local_storage

--- a/tests/integration/features/trashbin-old-endpoint.feature
+++ b/tests/integration/features/trashbin-old-endpoint.feature
@@ -1,92 +1,91 @@
 Feature: trashbin-new-endpoint
 	Background:
-		Given using api version "1"
-		And using old dav path
-		And as an "admin"
-		And app "files_trashbin" is enabled
+		Given using API version "1"
+		And using old DAV path
+		And as user "admin"
 
 	Scenario: deleting a file moves it to trashbin
-		Given user "user0" exists
-		When user "user0" deletes file "/textfile0.txt"
-		Then as "user0" the file "/textfile0.txt" exists in trash
+		Given user "user0" has been created
+		When user "user0" deletes file "/textfile0.txt" using the API
+		Then as "user0" the file "/textfile0.txt" should exist in trash
 
 	Scenario: deleting a folder moves it to trashbin
-		Given user "user0" exists
-		And user "user0" created a folder "/tmp"
-		When user "user0" deletes folder "/tmp"
-		Then as "user0" the folder "/tmp" exists in trash
+		Given user "user0" has been created
+		And user "user0" has created a folder "/tmp"
+		When user "user0" deletes folder "/tmp" using the API
+		Then as "user0" the folder "/tmp" should exist in trash
 
 	Scenario: deleting a file of a shared folder moves it to trashbin
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		When user "user0" deletes file "/shared/shared_file.txt"
-		Then as "user0" the folder with original path "/shared/shared_file.txt" exists in trash
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user0" has shared folder "/shared" with user "user1"
+		When user "user0" deletes file "/shared/shared_file.txt" using the API
+		Then as "user0" the folder with original path "/shared/shared_file.txt" should exist in trash
 
 	Scenario: deleting a shared folder moves it to trashbin
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		When user "user0" deletes folder "/shared"
-		Then as "user0" the folder with original path "/shared" exists in trash
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user0" has shared folder "/shared" with user "user1"
+		When user "user0" deletes folder "/shared" using the API
+		Then as "user0" the folder with original path "/shared" should exist in trash
 
 	Scenario: deleting a received folder doesn't move it to trashbin
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		And user "user1" moved folder "/shared" to "/renamed_shared"
-		When user "user1" deletes folder "/renamed_shared"
-		Then as "user1" the folder with original path "/renamed_shared" does not exist in trash
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user0" has shared folder "/shared" with user "user1"
+		And user "user1" has moved folder "/shared" to "/renamed_shared"
+		When user "user1" deletes folder "/renamed_shared" using the API
+		Then as "user1" the folder with original path "/renamed_shared" should not exist in trash
 
 	Scenario: deleting a file in a received folder moves it to trashbin
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		And user "user1" moved file "/shared" to "/renamed_shared"
-		When user "user1" deletes file "/renamed_shared/shared_file.txt"
-		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" exists in trash
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user0" has shared folder "/shared" with user "user1"
+		And user "user1" has moved file "/shared" to "/renamed_shared"
+		When user "user1" deletes file "/renamed_shared/shared_file.txt" using the API
+		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should exist in trash
 
 	Scenario: deleting a file in a received folder when restored it comes back to the original path
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/shared"
-		And user "user0" moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And folder "/shared" of user "user0" is shared with user "user1"
-		And user "user1" moved file "/shared" to "/renamed_shared"
-		And user "user1" deletes file "/renamed_shared/shared_file.txt"
-		And logging in using web as "user1"
-		When as "user1" the file with original path "/renamed_shared/shared_file.txt" is restored
-		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" does not exist in trash
-		And user "user1" should see following elements
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/shared"
+		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user0" has shared folder "/shared" with user "user1"
+		And user "user1" has moved file "/shared" to "/renamed_shared"
+		And user "user1" has deleted file "/renamed_shared/shared_file.txt"
+		And user "user1" has logged in to a web-style session using the API
+		When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the API
+		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
+		And user "user1" should see the following elements
 			| /renamed_shared/ |
 			| /renamed_shared/shared_file.txt |
 
 	Scenario: Trashbin can be emptied
-		Given user "user0" exists
-		And user "user0" deletes file "/textfile0.txt"
-		And user "user0" deletes file "/textfile1.txt"
-		And as "user0" the file "/textfile0.txt" exists in trash
-		And as "user0" the file "/textfile0.txt" exists in trash
-		When user "user0" empties the trashbin
-		Then as "user0" the file with original path "/textfile0.txt" does not exist in trash
-		And as "user0" the file with original path "/textfile1.txt" does not exist in trash
+		Given user "user0" has been created
+		And user "user0" has deleted file "/textfile0.txt"
+		And user "user0" has deleted file "/textfile1.txt"
+		And as "user0" the file "/textfile0.txt" should exist in trash
+		And as "user0" the file "/textfile0.txt" should exist in trash
+		When user "user0" empties the trashbin using the API
+		Then as "user0" the file with original path "/textfile0.txt" should not exist in trash
+		And as "user0" the file with original path "/textfile1.txt" should not exist in trash
 
 	Scenario: A deleted file can be restored
-		Given user "user0" exists
-		And user "user0" deletes file "/textfile0.txt"
-		And as "user0" the file "/textfile0.txt" exists in trash
-		And logging in using web as "user0"
-		When as "user0" the folder with original path "/textfile0.txt" is restored
-		Then as "user0" the folder with original path "/textfile0.txt" does not exist in trash
-		And user "user0" should see following elements
+		Given user "user0" has been created
+		And user "user0" has deleted file "/textfile0.txt"
+		And as "user0" the file "/textfile0.txt" should exist in trash
+		And user "user0" has logged in to a web-style session using the API
+		When user "user0" restores the folder with original path "/textfile0.txt" using the API
+		Then as "user0" the folder with original path "/textfile0.txt" should not exist in trash
+		And user "user0" should see the following elements
 			| /FOLDER/ |
 			| /PARENT/ |
 			| /PARENT/parent.txt |
@@ -98,41 +97,41 @@ Feature: trashbin-new-endpoint
 
 	@skip
 	Scenario: trashbin can store two files with same name but different origins
-		Given user "user0" exists
-		And user "user0" created a folder "/folderA"
-		And user "user0" created a folder "/folderB"
-		And user "user0" copies file "/textfile0.txt" to "/folderA/textfile0.txt"
-		And user "user0" copies file "/textfile0.txt" to "/folderB/textfile0.txt"
-		When user "user0" deletes file "/folderA/textfile0.txt"
-		And user "user0" deletes file "/folderB/textfile0.txt"
-		And user "user0" deletes file "/textfile0.txt"
-		Then as "user0" the folder with original path "/folderA/textfile0.txt" exists in trash
-		And as "user0" the folder with original path "/folderB/textfile0.txt" exists in trash
-		And as "user0" the folder with original path "/textfile0.txt" exists in trash
+		Given user "user0" has been created
+		And user "user0" has created a folder "/folderA"
+		And user "user0" has created a folder "/folderB"
+		And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
+		And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
+		When user "user0" deletes file "/folderA/textfile0.txt" using the API
+		And user "user0" deletes file "/folderB/textfile0.txt" using the API
+		And user "user0" deletes file "/textfile0.txt" using the API
+		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
+		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
+		And as "user0" the folder with original path "/textfile0.txt" should exist in trash
 
 	@local_storage
 	@no_default_encryption
 	Scenario: Deleting a folder into external storage moves it to the trashbin
-		Given invoking occ with "files:scan --all"
-		And user "user0" exists
-		And user "user0" created a folder "/local_storage/tmp"
-		And user "user0" moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
-		When user "user0" deletes folder "/local_storage/tmp"
-		Then as "user0" the folder with original path "/local_storage/tmp" exists in trash
+		Given the administrator has invoked occ command "files:scan --all"
+		And user "user0" has been created
+		And user "user0" has created a folder "/local_storage/tmp"
+		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
+		When user "user0" deletes folder "/local_storage/tmp" using the API
+		Then as "user0" the folder with original path "/local_storage/tmp" should exist in trash
 
 	@local_storage
 	@no_default_encryption
 	Scenario: Deleting a file into external storage moves it to the trashbin and can be restored
-		Given invoking occ with "files:scan --all"
-		And user "user0" exists
-		And user "user0" created a folder "/local_storage/tmp"
-		And user "user0" moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
-		And user "user0" deletes file "/local_storage/tmp/textfile0.txt"
-		And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" exists in trash
-		And logging in using web as "user0"
-		When as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" is restored
-		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" does not exist in trash
-		And user "user0" should see following elements
+		Given the administrator has invoked occ command "files:scan --all"
+		And user "user0" has been created
+		And user "user0" has created a folder "/local_storage/tmp"
+		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
+		And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
+		And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
+		And user "user0" has logged in to a web-style session using the API
+		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the API
+		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
+		And user "user0" should see the following elements
 			| /local_storage/ |
 			| /local_storage/tmp/ |
 			| /local_storage/tmp/textfile0.txt |
@@ -140,14 +139,14 @@ Feature: trashbin-new-endpoint
 	@local_storage
 	@no_default_encryption
 	Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored
-		Given invoking occ with "files:scan --all"
-		And user "user0" exists
-		And user "user0" created a folder "/local_storage/tmp"
-		And user "user0" moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
-		And user "user0" uploads chunk file "1" of "1" with "AA" to "/local_storage/tmp/textfile0.txt"
-		And user "user0" deletes file "/local_storage/tmp/textfile0.txt"
-		And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" exists in trash
-		And logging in using web as "user0"
-		When as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" is restored
-		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" does not exist in trash
-		And downloaded content when downloading file "/local_storage/tmp/textfile0.txt" with range "bytes=0-1" should be "AA"
+		Given the administrator has invoked occ command "files:scan --all"
+		And user "user0" has been created
+		And user "user0" has created a folder "/local_storage/tmp"
+		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
+		And user "user0" has uploaded chunk file "1" of "1" with "AA" to "/local_storage/tmp/textfile0.txt"
+		And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
+		And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
+		And user "user0" has logged in to a web-style session using the API
+		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the API
+		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
+		And the downloaded content when downloading file "/local_storage/tmp/textfile0.txt" for user "user0" with range "bytes=0-1" should be "AA"

--- a/tests/integration/features/webdav-related-new-endpoint.feature
+++ b/tests/integration/features/webdav-related-new-endpoint.feature
@@ -1,226 +1,201 @@
 Feature: webdav-related-new-endpoint
 	Background:
-		Given using api version "1"
+		Given using API version "1"
 
 	Scenario: Unauthenticated call
-		Given using new dav path
-		When connecting to dav endpoint
+		Given using new DAV path
+		When an unauthenticated client connects to the dav endpoint using the API
 		Then the HTTP status code should be "401"
-		And there are no duplicate headers
+		And there should be no duplicate headers
 		And the following headers should be set
 			|WWW-Authenticate|Basic realm="ownCloud"|
 
 	Scenario: Moving a file
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" moves file "/welcome.txt" to "/FOLDER/welcome.txt"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/FOLDER/welcome.txt" using the API
 		Then the HTTP status code should be "201"
-		And downloaded content when downloading file "/FOLDER/welcome.txt" with range "bytes=0-6" should be "Welcome"
+		And the downloaded content when downloading file "/FOLDER/welcome.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: Moving and overwriting a file
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" moves file "/welcome.txt" to "/textfile0.txt"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/textfile0.txt" using the API
 		Then the HTTP status code should be "204"
-		And downloaded content when downloading file "/textfile0.txt" with range "bytes=0-6" should be "Welcome"
+		And the downloaded content when downloading file "/textfile0.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: Moving a file to a folder with no permissions
-		Given using new dav path
-		And user "user0" exists
-		And user "user1" exists
-		And as an "user1"
-		And user "user1" created a folder "/testshare"
-		And as "user1" creating a share with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user1" has created a folder "/testshare"
+		And user "user1" has created a share with settings
 		  | path | testshare |
 		  | shareType | 0 |
 		  | permissions | 1 |
 		  | shareWith | user0 |
-		And as an "user0"
-		And user "user0" moves file "/textfile0.txt" to "/testshare/textfile0.txt"
-		And the HTTP status code should be "403"
-		When downloading file "/testshare/textfile0.txt"
+		When user "user0" moves file "/textfile0.txt" to "/testshare/textfile0.txt" using the API
+		Then the HTTP status code should be "403"
+		When user "user0" downloads the file "/testshare/textfile0.txt" using the API
  		Then the HTTP status code should be "404"
 
 	Scenario: Moving a file to overwrite a file in a folder with no permissions
-		Given using new dav path
-		And user "user0" exists
-		And user "user1" exists
-		And as an "user1"
-		And user "user1" created a folder "/testshare"
-		And as "user1" creating a share with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user1" has created a folder "/testshare"
+		And user "user1" has created a share with settings
 		  | path | testshare |
 		  | shareType | 0 |
 		  | permissions | 1 |
 		  | shareWith | user0 |
-		And user "user1" copies file "/welcome.txt" to "/testshare/overwritethis.txt"
-		And as an "user0"
-		When user "user0" moves file "/textfile0.txt" to "/testshare/overwritethis.txt"
+		And user "user1" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"
+		When user "user0" moves file "/textfile0.txt" to "/testshare/overwritethis.txt" using the API
 		Then the HTTP status code should be "403"
-		And downloaded content when downloading file "/testshare/overwritethis.txt" with range "bytes=0-6" should be "Welcome"
+		And the downloaded content when downloading file "/testshare/overwritethis.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: move file into a not-existing folder
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" moves file "/welcome.txt" to "/not-existing/welcome.txt"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/not-existing/welcome.txt" using the API
 		Then the HTTP status code should be "409"
 
 	Scenario: rename a file into an invalid filename
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" moves file "/welcome.txt" to "/a\\a"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/a\\a" using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: rename a file into a banned filename
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" moves file "/welcome.txt" to "/.htaccess"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/.htaccess" using the API
 		Then the HTTP status code should be "403"
 
 	Scenario: Copying a file
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" copies file "/welcome.txt" to "/FOLDER/welcome.txt"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" copies file "/welcome.txt" to "/FOLDER/welcome.txt" using the API
 		Then the HTTP status code should be "201"
-		And downloaded content when downloading file "/FOLDER/welcome.txt" with range "bytes=0-6" should be "Welcome"
+		And the downloaded content when downloading file "/FOLDER/welcome.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: Copying and overwriting a file
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" copies file "/welcome.txt" to "/textfile1.txt"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" copies file "/welcome.txt" to "/textfile1.txt" using the API
 		Then the HTTP status code should be "204"
-		And downloaded content when downloading file "/textfile1.txt" with range "bytes=0-6" should be "Welcome"
+		And the downloaded content when downloading file "/textfile1.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: Copying a file to a folder with no permissions
-		Given using new dav path
-		And user "user0" exists
-		And user "user1" exists
-		And as an "user1"
-		And user "user1" created a folder "/testshare"
-		And as "user1" creating a share with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user1" has created a folder "/testshare"
+		And user "user1" has created a share with settings
 		  | path | testshare |
 		  | shareType | 0 |
 		  | permissions | 1 |
 		  | shareWith | user0 |
-		And as an "user0"
-		When user "user0" copies file "/textfile0.txt" to "/testshare/textfile0.txt"
+		When user "user0" copies file "/textfile0.txt" to "/testshare/textfile0.txt" using the API
 		Then the HTTP status code should be "403"
-		And downloading file "/testshare/textfile0.txt"
+		And user "user0" downloads the file "/testshare/textfile0.txt" using the API
 		And the HTTP status code should be "404"
 
 	Scenario: Copying a file to overwrite a file into a folder with no permissions
-		Given using new dav path
-		And user "user0" exists
-		And user "user1" exists
-		And as an "user1"
-		And user "user1" created a folder "/testshare"
-		And as "user1" creating a share with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user1" has created a folder "/testshare"
+		And user "user1" has created a share with settings
 		  | path | testshare |
 		  | shareType | 0 |
 		  | permissions | 1 |
 		  | shareWith | user0 |
-		And user "user1" copies file "/welcome.txt" to "/testshare/overwritethis.txt"
-		And as an "user0"
-		When user "user0" copies file "/textfile0.txt" to "/testshare/overwritethis.txt"
+		And user "user1" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"
+		When user "user0" copies file "/textfile0.txt" to "/testshare/overwritethis.txt" using the API
 		Then the HTTP status code should be "403"
-		And downloaded content when downloading file "/testshare/overwritethis.txt" with range "bytes=0-6" should be "Welcome"
+		And the downloaded content when downloading file "/testshare/overwritethis.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: download a file with range
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When downloading file "/welcome.txt" with range "bytes=51-77"
-		Then downloaded content should be "example file for developers"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" downloads file "/welcome.txt" with range "bytes=51-77" using the API
+		Then the downloaded content should be "example file for developers"
 
 	Scenario: Retrieving folder quota when no quota is set
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		When user "user0" has unlimited quota
-		Then as "user0" gets properties of folder "/" with
+		Given using new DAV path
+		And user "user0" has been created
+		When the administrator gives unlimited quota to user "user0" using the API
+		And user "user0" gets the following properties of folder "/" using the API
 		  |{DAV:}quota-available-bytes|
-		And the single response should contain a property "{DAV:}quota-available-bytes" with value "-3"
+		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "-3"
 
 	Scenario: Retrieving folder quota when quota is set
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		When user "user0" has a quota of "10 MB"
-		Then as "user0" gets properties of folder "/" with
+		Given using new DAV path
+		And user "user0" has been created
+		When the administrator sets the quota of user "user0" to "10 MB" using the API
+		And user "user0" gets the following properties of folder "/" using the API
 		  |{DAV:}quota-available-bytes|
-		And the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
+		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
 
 	Scenario: Retrieving folder quota of shared folder with quota when no quota is set for recipient
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" has unlimited quota
-		And user "user1" has a quota of "10 MB"
-		And as an "user1"
-		And user "user1" created a folder "/testquota"
-		And as "user1" creating a share with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has been given unlimited quota
+		And the quota of user "user1" has been set to "10 MB"
+		And user "user1" has created a folder "/testquota"
+		And user "user1" has created a share with settings
 		  | path | testquota |
 		  | shareType | 0 |
 		  | permissions | 31 |
 		  | shareWith | user0 |
-		When as "user0" gets properties of folder "/testquota" with
+		When user "user0" gets the following properties of folder "/testquota" using the API
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
 
 	Scenario: Retrieving folder quota when quota is set and a file was uploaded
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user0" has a quota of "1 KB"
-		And user "user0" adds a file of 93 bytes to "/prueba.txt"
-		When as "user0" gets properties of folder "/" with
+		Given using new DAV path
+		And user "user0" has been created
+		And the quota of user "user0" has been set to "1 KB"
+		And user "user0" has added file "/prueba.txt" of 93 bytes
+		When user "user0" gets the following properties of folder "/" using the API
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "529"
 
 	Scenario: Retrieving folder quota when quota is set and a file was recieved
-		Given using new dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And user "user1" has a quota of "1 KB"
-		And user "user0" adds a file of 93 bytes to "/user0.txt"
-		And file "user0.txt" of user "user0" is shared with user "user1"
-		When as "user1" gets properties of folder "/" with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And the quota of user "user1" has been set to "1 KB"
+		And user "user0" has added file "/user0.txt" of 93 bytes
+		And user "user0" has shared file "user0.txt" with user "user1"
+		When user "user1" gets the following properties of folder "/" using the API
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "622"
 
 	Scenario: download a public shared file with range
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" creates a share using the API with settings
 			| path | welcome.txt |
 			| shareType | 3 |
-		And downloading last public shared file with range "bytes=51-77"
-		Then downloaded content should be "example file for developers"
+		And the public downloads the last public shared file with range "bytes=51-77" using the API
+		Then the downloaded content should be "example file for developers"
 
 	Scenario: download a public shared file inside a folder with range
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" creates a share using the API with settings
 			| path | PARENT |
 			| shareType | 3 |
-		And downloading last public shared file inside a folder "/parent.txt" with range "bytes=1-7"
-		Then downloaded content should be "wnCloud"
+		And the public downloads file "/parent.txt" from inside the last public shared folder with range "bytes=1-7" using the API
+		Then the downloaded content should be "wnCloud"
 
 	Scenario: Downloading a file on the new endpoint should serve security headers
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When downloading file "/welcome.txt"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" downloads the file "/welcome.txt" using the API
 		Then the following headers should be set
 			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
 			|Content-Security-Policy|default-src 'none';|
@@ -230,80 +205,80 @@ Feature: webdav-related-new-endpoint
 			|X-Permitted-Cross-Domain-Policies|none|
 			|X-Robots-Tag|none|
 			|X-XSS-Protection|1; mode=block|
-		And downloaded content should start with "Welcome to your ownCloud account!"
+		And the downloaded content should start with "Welcome to your ownCloud account!"
 
 	Scenario: A file that is not shared does not have a share-types property
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" created a folder "/test"
-		When as "user0" gets properties of folder "/test" with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/test"
+		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain an empty property "{http://owncloud.org/ns}share-types"
 
 	Scenario: A file that is shared to a user has a share-types property
-		Given using new dav path
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/test"
-		And as "user0" creating a share with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has created a share with settings
 			| path | test |
 			| shareType | 0 |
 			| permissions | 31 |
 			| shareWith | user1 |
-		When as "user0" gets properties of folder "/test" with
+		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
 			| 0 |
 
 	Scenario: A file that is shared to a group has a share-types property
-		Given using new dav path
-		And user "user0" exists
-		And group "group1" exists
-		And user "user0" created a folder "/test"
-		And as "user0" creating a share with
+		Given using new DAV path
+		And user "user0" has been created
+		And group "group1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has created a share with settings
 			| path | test |
 			| shareType | 1 |
 			| permissions | 31 |
 			| shareWith | group1 |
-		When as "user0" gets properties of folder "/test" with
+		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
 			| 1 |
 
 	Scenario: A file that is shared by link has a share-types property
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" created a folder "/test"
-		And as "user0" creating a share with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has created a share with settings
 			| path | test |
 			| shareType | 3 |
 			| permissions | 31 |
-		When as "user0" gets properties of folder "/test" with
+		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
 			| 3 |
 
 	Scenario: A file that is shared by user,group and link has a share-types property
-		Given using new dav path
-		And user "user0" exists
-		And user "user1" exists
-		And group "group2" exists
-		And user "user0" created a folder "/test"
-		And as "user0" creating a share with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And group "group2" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has created a share with settings
 			| path        | test  |
 			| shareType   | 0     |
 			| permissions | 31    |
 			| shareWith   | user1 |
-		And as "user0" creating a share with
+		And user "user0" has created a share with settings
 			| path        | test  |
 			| shareType   | 1     |
 			| permissions | 31    |
 			| shareWith   | group2 |
-		And as "user0" creating a share with
+		And user "user0" has created a share with settings
 			| path        | test  |
 			| shareType   | 3     |
 			| permissions | 31    |
-		When as "user0" gets properties of folder "/test" with
+		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
 			| 0 |
@@ -311,38 +286,36 @@ Feature: webdav-related-new-endpoint
 			| 3 |
 
 	Scenario: A disabled user cannot use webdav
-		Given using new dav path
-		And user "userToBeDisabled" exists
-		And as an "admin"
-		And assure user "userToBeDisabled" is disabled
-		When downloading file "/welcome.txt" as "userToBeDisabled"
+		Given using new DAV path
+		And user "userToBeDisabled" has been created
+		And user "userToBeDisabled" has been disabled
+		When user "userToBeDisabled" downloads the file "/welcome.txt" using the API
 		Then the HTTP status code should be "503"
 
 	Scenario: Creating a folder
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" created a folder "/test_folder"
-		When as "user0" gets properties of folder "/test_folder" with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/test_folder"
+		When user "user0" gets the following properties of folder "/test_folder" using the API
 		  |{DAV:}resourcetype|
 		Then the single response should contain a property "{DAV:}resourcetype" with value "{DAV:}collection"
 
 	Scenario: Creating a folder with special chars
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" created a folder "/test_folder:5"
-		When as "user0" gets properties of folder "/test_folder:5" with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/test_folder:5"
+		When user "user0" gets the following properties of folder "/test_folder:5" using the API
 		  |{DAV:}resourcetype|
 		Then the single response should contain a property "{DAV:}resourcetype" with value "{DAV:}collection"
 
 	Scenario: Removing everything of a folder
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		And user "user0" moves file "/welcome.txt" to "/FOLDER/welcome.txt"
-		And user "user0" created a folder "/FOLDER/SUBFOLDER"
-		And user "user0" copies file "/textfile0.txt" to "/FOLDER/SUBFOLDER/testfile0.txt"
-		When user "user0" deletes everything from folder "/FOLDER/"
-		Then user "user0" should see following elements
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has moved file "/welcome.txt" to "/FOLDER/welcome.txt"
+		And user "user0" has created a folder "/FOLDER/SUBFOLDER"
+		And user "user0" has copied file "/textfile0.txt" to "/FOLDER/SUBFOLDER/testfile0.txt"
+		When user "user0" deletes everything from folder "/FOLDER/" using the API
+		Then user "user0" should see the following elements
 			| /FOLDER/ |
 			| /PARENT/ |
 			| /PARENT/parent.txt |
@@ -353,52 +326,51 @@ Feature: webdav-related-new-endpoint
 			| /textfile4.txt |
 
 	Scenario: Checking file id after a move
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" stores id of file "/textfile0.txt"
-		When user "user0" moves file "/textfile0.txt" to "/FOLDER/textfile0.txt"
-		Then user "user0" checks id of file "/FOLDER/textfile0.txt"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has stored id of file "/textfile0.txt"
+		When user "user0" moves file "/textfile0.txt" to "/FOLDER/textfile0.txt" using the API
+		Then user "user0" file "/FOLDER/textfile0.txt" should have the previously stored id
 
 	Scenario: Renaming a folder to a backslash encoded should return an error using new endpoint
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/%5C"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/testshare"
+		When user "user0" moves folder "/testshare" to "/%5C" using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: Renaming a folder beginning with a backslash encoded should return an error using new endpoint
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/%5Ctestshare"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/testshare"
+		When user "user0" moves folder "/testshare" to "/%5Ctestshare" using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: Renaming a folder including a backslash encoded should return an error using new endpoint
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/hola%5Chola"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/testshare"
+		When user "user0" moves folder "/testshare" to "/hola%5Chola" using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: Renaming a folder into a banned name
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/.htaccess"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/testshare"
+		When user "user0" moves folder "/testshare" to "/.htaccess" using the API
 		Then the HTTP status code should be "403"
 
 	Scenario: Move a folder into a not existing one
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/not-existing/testshare"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/testshare"
+		When user "user0" moves folder "/testshare" to "/not-existing/testshare" using the API
 		Then the HTTP status code should be "409"
 
 	Scenario: Downloading a file on the new endpoint should serve security headers
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When downloading file "/welcome.txt"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" downloads the file "/welcome.txt" using the API
 		Then the following headers should be set
 			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
 			|Content-Security-Policy|default-src 'none';|
@@ -408,262 +380,244 @@ Feature: webdav-related-new-endpoint
 			|X-Permitted-Cross-Domain-Policies|none|
 			|X-Robots-Tag|none|
 			|X-XSS-Protection|1; mode=block|
-		And downloaded content should start with "Welcome to your ownCloud account!"
+		And the downloaded content should start with "Welcome to your ownCloud account!"
 
 	Scenario: Doing a GET with a web login should work without CSRF token on the new backend
-		Given user "user0" exists
-		And logging in using web as "user0"
-		When sending a "GET" to "/remote.php/dav/files/user0/welcome.txt" without requesttoken
-		Then downloaded content should start with "Welcome to your ownCloud account!"
+		Given user "user0" has been created
+		And user "user0" has logged in to a web-style session using the API
+		When the client sends a "GET" to "/remote.php/dav/files/user0/welcome.txt" without requesttoken using the API
+		Then the downloaded content should start with "Welcome to your ownCloud account!"
 		And the HTTP status code should be "200"
 
 	Scenario: Doing a GET with a web login should work with CSRF token on the new backend
-		Given user "user0" exists
-		And logging in using web as "user0"
-		When sending a "GET" to "/remote.php/dav/files/user0/welcome.txt" with requesttoken
-		Then downloaded content should start with "Welcome to your ownCloud account!"
+		Given user "user0" has been created
+		And user "user0" has logged in to a web-style session using the API
+		When the client sends a "GET" to "/remote.php/dav/files/user0/welcome.txt" with requesttoken using the API
+		Then the downloaded content should start with "Welcome to your ownCloud account!"
 		And the HTTP status code should be "200"
 
 	Scenario: Doing a PROPFIND with a web login should work with CSRF token on the new backend
-		Given user "user0" exists
-		And logging in using web as "user0"
-		When sending a "PROPFIND" to "/remote.php/dav/files/user0/welcome.txt" with requesttoken
+		Given user "user0" has been created
+		And user "user0" has logged in to a web-style session using the API
+		When the client sends a "PROPFIND" to "/remote.php/dav/files/user0/welcome.txt" with requesttoken using the API
 		Then the HTTP status code should be "207"
 
 	Scenario: Setting custom DAV property and reading it
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		And user "user0" uploads file "data/textfile.txt" to "/testcustomprop.txt"
-		And "user0" sets property "{http://whatever.org/ns}very-custom-prop" of file "/testcustomprop.txt" to "veryCustomPropValue"
-		When as "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testcustomprop.txt"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/testcustomprop.txt"
+		And user "user0" has set property "{http://whatever.org/ns}very-custom-prop" of file "/testcustomprop.txt" to "veryCustomPropValue"
+		When user "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testcustomprop.txt"
 		Then the response should contain a custom "{http://whatever.org/ns}very-custom-prop" property with "veryCustomPropValue"
 
 	Scenario: Setting custom DAV property and reading it after the file is renamed
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		And user "user0" uploads file "data/textfile.txt" to "/testcustompropwithmove.txt"
-		And "user0" sets property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropwithmove.txt" to "valueForMovetest"
-		And user "user0" moved file "/testcustompropwithmove.txt" to "/catchmeifyoucan.txt"
-		When as "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/catchmeifyoucan.txt"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/testcustompropwithmove.txt"
+		And user "user0" has set property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropwithmove.txt" to "valueForMovetest"
+		And user "user0" has moved file "/testcustompropwithmove.txt" to "/catchmeifyoucan.txt"
+		When user "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/catchmeifyoucan.txt"
 		Then the response should contain a custom "{http://whatever.org/ns}very-custom-prop" property with "valueForMovetest"
 
 	Scenario: Setting custom DAV property on a shared file as an owner and reading as a recipient
-		Given using new dav path
-		And user "user0" exists
-		And user "user1" exists
-		And as an "user0"
-		And user "user0" uploads file "data/textfile.txt" to "/testcustompropshared.txt"
-		And as "user0" creating a share with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/testcustompropshared.txt"
+		And user "user0" has created a share with settings
 		  | path | testcustompropshared.txt |
 		  | shareType | 0 |
 		  | permissions | 31 |
 		  | shareWith | user1 |
-		And "user0" sets property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropshared.txt" to "valueForSharetest"
-		And as an "user1"
-		When as "user1" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropshared.txt"
+		And user "user0" has set property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropshared.txt" to "valueForSharetest"
+		When user "user1" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropshared.txt"
 		Then the response should contain a custom "{http://whatever.org/ns}very-custom-prop" property with "valueForSharetest"
 
 	Scenario: Setting custom DAV property using a new endpoint and reading it using an old endpoint
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		And user "user0" uploads file "data/textfile.txt" to "/testnewold.txt"
-		And "user0" sets property "{http://whatever.org/ns}very-custom-prop" of file "/testnewold.txt" to "lucky"
-		And using old dav path
-		When as "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testnewold.txt"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/testnewold.txt"
+		And user "user0" has set property "{http://whatever.org/ns}very-custom-prop" of file "/testnewold.txt" to "lucky"
+		And using old DAV path
+		When user "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testnewold.txt"
 		Then the response should contain a custom "{http://whatever.org/ns}very-custom-prop" property with "lucky"
 
 	## Specific scenarios for new endpoint	
 
 	Scenario: Upload chunked file asc with new chunking
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" creates a new chunking upload with id "chunking-42"
-		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
-		And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt"
-		When as an "user0"
-		And downloading file "/myChunkedFile.txt"
-		Then downloaded content should be "AAAAABBBBBCCCCC"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a new chunking upload with id "chunking-42"
+		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
+		And user "user0" has moved new chunk file with id "chunking-42" to "/myChunkedFile.txt"
+		When user "user0" downloads the file "/myChunkedFile.txt" using the API
+		Then the downloaded content should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file desc with new chunking
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" creates a new chunking upload with id "chunking-42"
-		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
-		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt"
-		When as an "user0"
-		And downloading file "/myChunkedFile.txt"
-		Then downloaded content should be "AAAAABBBBBCCCCC"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a new chunking upload with id "chunking-42"
+		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
+		And user "user0" has moved new chunk file with id "chunking-42" to "/myChunkedFile.txt"
+		When user "user0" downloads the file "/myChunkedFile.txt" using the API
+		Then the downloaded content should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file random with new chunking
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" creates a new chunking upload with id "chunking-42"
-		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
-		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt"
-		When as an "user0"
-		And downloading file "/myChunkedFile.txt"
-		Then downloaded content should be "AAAAABBBBBCCCCC"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a new chunking upload with id "chunking-42"
+		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
+		And user "user0" has moved new chunk file with id "chunking-42" to "/myChunkedFile.txt"
+		When user "user0" downloads the file "/myChunkedFile.txt" using the API
+		Then the downloaded content should be "AAAAABBBBBCCCCC"
 
 	Scenario: Checking file id after a move overwrite using new chunking endpoint
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" copies file "/textfile0.txt" to "/existingFile.txt"
-		And user "user0" stores id of file "/existingFile.txt"
-		And user "user0" creates a new chunking upload with id "chunking-42"
-		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
-		When user "user0" moves new chunk file with id "chunking-42" to "/existingFile.txt"
-		Then user "user0" checks id of file "/existingFile.txt"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has copied file "/textfile0.txt" to "/existingFile.txt"
+		And user "user0" has stored id of file "/existingFile.txt"
+		And user "user0" has created a new chunking upload with id "chunking-42"
+		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
+		When user "user0" moves new chunk file with id "chunking-42" to "/existingFile.txt" using the API
+		Then user "user0" file "/existingFile.txt" should have the previously stored id
 
 	Scenario: Checking file id after a move between received shares
-		Given using new dav path
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/folderA"
-		And user "user0" created a folder "/folderB"
-		And folder "/folderA" of user "user0" is shared with user "user1"
-		And folder "/folderB" of user "user0" is shared with user "user1"
-		And user "user1" created a folder "/folderA/ONE"
-		And user "user1" stores id of file "/folderA/ONE"
-		And user "user1" created a folder "/folderA/ONE/TWO"
-		When user "user1" moves folder "/folderA/ONE" to "/folderB/ONE"
-		Then as "user1" the folder "/folderA" exists
-		And as "user1" the folder "/folderA/ONE" does not exist
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/folderA"
+		And user "user0" has created a folder "/folderB"
+		And user "user0" has shared folder "/folderA" with user "user1"
+		And user "user0" has shared folder "/folderB" with user "user1"
+		And user "user1" has created a folder "/folderA/ONE"
+		And user "user1" has stored id of file "/folderA/ONE"
+		And user "user1" has created a folder "/folderA/ONE/TWO"
+		When user "user1" moves folder "/folderA/ONE" to "/folderB/ONE" using the API
+		Then as "user1" the folder "/folderA" should exist
+		And as "user1" the folder "/folderA/ONE" should not exist
 		# yes, a weird bug used to make this one fail
-		And as "user1" the folder "/folderA/ONE/TWO" does not exist
-		And as "user1" the folder "/folderB/ONE" exists
-		And as "user1" the folder "/folderB/ONE/TWO" exists
-		And user "user1" checks id of file "/folderB/ONE"
+		And as "user1" the folder "/folderA/ONE/TWO" should not exist
+		And as "user1" the folder "/folderB/ONE" should exist
+		And as "user1" the folder "/folderB/ONE/TWO" should exist
+		And user "user1" file "/folderB/ONE" should have the previously stored id
 
    ## Validation Plugin or Old Endpoint Specific
 
-	Scenario: New chunked upload MKDIR using old dav path should fail
-		Given using old dav path
-		And user "user0" exists
-		When user "user0" creates a new chunking upload with id "chunking-42"
+	Scenario: New chunked upload MKDIR using old DAV path should fail
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" creates a new chunking upload with id "chunking-42" using the API
 		Then the HTTP status code should be "409"
 
-	Scenario: New chunked upload PUT using old dav path should fail
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" creates a new chunking upload with id "chunking-42"
-		When using old dav path
-		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
+	Scenario: New chunked upload PUT using old DAV path should fail
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a new chunking upload with id "chunking-42"
+		When using old DAV path
+		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the API
 		Then the HTTP status code should be "404"
 
-	Scenario: New chunked upload MOVE using old dav path should fail
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" creates a new chunking upload with id "chunking-42"
-		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
-		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
-		When using old dav path
-		And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt"
+	Scenario: New chunked upload MOVE using old DAV path should fail
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a new chunking upload with id "chunking-42"
+		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
+		When using old DAV path
+		And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" using the API
 		Then the HTTP status code should be "404"
 
 	Scenario: Upload to new dav path using old way should fail
-		Given using new dav path
-		And user "user0" exists
-		When user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt" using the API
 		Then the HTTP status code should be "503"
 
 	Scenario: Upload file via new chunking endpoint with wrong size header
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" creates a new chunking upload with id "chunking-42"
-		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
-		When user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with size 5
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a new chunking upload with id "chunking-42"
+		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
+		When user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with size 5 using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: Upload file via new chunking endpoint with correct size header
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" creates a new chunking upload with id "chunking-42"
-		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
-		When user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with size 15
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a new chunking upload with id "chunking-42"
+		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
+		When user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with size 15 using the API
 		Then the HTTP status code should be "201"
 
 	Scenario Outline: Upload files with difficult names using new chunking
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" creates a new chunking upload with id "chunking-42"
-		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
-		And user "user0" moves new chunk file with id "chunking-42" to "/<file-name>"
-		When as an "user0"
-		And downloading file "/<file-name>"
-		Then downloaded content should be "AAAAABBBBBCCCCC"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a new chunking upload with id "chunking-42"
+		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
+		And user "user0" has moved new chunk file with id "chunking-42" to "/<file-name>"
+		When user "user0" downloads the file "/<file-name>" using the API
+		Then the downloaded content should be "AAAAABBBBBCCCCC"
 		Examples:
 		|file-name|
 		|&#?      |
 		|TIÄFÜ    |
 
-	#this test should be intergrated into the previous scenario after fixing the issue
+	#this test should be integrated into the previous scenario after fixing the issue
 	@skip @issue-29599
 	Scenario: Upload a file called "0" using new chunking
-		Given using new dav path
-		And user "user0" exists
-		And user "user0" creates a new chunking upload with id "chunking-42"
-		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42"
-		And user "user0" moves new chunk file with id "chunking-42" to "/0"
-		When as an "user0"
-		And downloading file "/0"
-		Then downloaded content should be "AAAAABBBBBCCCCC"
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has created a new chunking upload with id "chunking-42"
+		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
+		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
+		And user "user0" has moved new chunk file with id "chunking-42" to "/0"
+		When user "user0" downloads the file "/0" using the API
+		Then the downloaded content should be "AAAAABBBBBCCCCC"
 		
 	Scenario: Retrieving private link
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		And user "user0" uploads file "data/textfile.txt" to "/somefile.txt"
-		Then as "user0" gets properties of file "/somefile.txt" with
+		Given using new DAV path
+		And user "user0" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
+		When user "user0" gets the following properties of file "/somefile.txt" using the API
 			|{http://owncloud.org/ns}privatelink|
-		And the single response should contain a property "{http://owncloud.org/ns}privatelink" with value like "/(\/index.php\/f\/[0-9]*)/"
+		Then the single response should contain a property "{http://owncloud.org/ns}privatelink" with value like "/(\/index.php\/f\/[0-9]*)/"
 
 	Scenario: Copying file to a path with extension .part should not be possible
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" copies file "/welcome.txt" to "/welcome.part"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" copies file "/welcome.txt" to "/welcome.part" using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: Uploading file to path with extension .part should not be possible
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		And user "user0" uploads file "data/textfile.txt" to "/textfile.part"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" uploads file "data/textfile.txt" to "/textfile.part" using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: Renaming a file to a path with extension .part should not be possible
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" moves file "/welcome.txt" to "/welcome.part"
-		Then the HTTP status code should be "400"
-		And as an "user0"
-		When user "user0" moves file "/welcome.txt" to "/welcome.part"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/welcome.part" using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: Creating a directory which contains .part should not be possible
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" created a folder "/folder.with.ext.part"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" creates a folder "/folder.with.ext.part" using the API
 		Then the HTTP status code should be "400"

--- a/tests/integration/features/webdav-related-new-endpoint.feature
+++ b/tests/integration/features/webdav-related-new-endpoint.feature
@@ -8,7 +8,7 @@ Feature: webdav-related-new-endpoint
 		Then the HTTP status code should be "401"
 		And there should be no duplicate headers
 		And the following headers should be set
-			|WWW-Authenticate|Basic realm="ownCloud"|
+			| WWW-Authenticate | Basic realm="ownCloud" |
 
 	Scenario: Moving a file
 		Given using new DAV path
@@ -30,10 +30,10 @@ Feature: webdav-related-new-endpoint
 		And user "user1" has been created
 		And user "user1" has created a folder "/testshare"
 		And user "user1" has created a share with settings
-		  | path | testshare |
-		  | shareType | 0 |
-		  | permissions | 1 |
-		  | shareWith | user0 |
+			| path        | testshare |
+			| shareType   | 0         |
+			| permissions | 1         |
+			| shareWith   | user0     |
 		When user "user0" moves file "/textfile0.txt" to "/testshare/textfile0.txt" using the API
 		Then the HTTP status code should be "403"
 		When user "user0" downloads the file "/testshare/textfile0.txt" using the API
@@ -45,10 +45,10 @@ Feature: webdav-related-new-endpoint
 		And user "user1" has been created
 		And user "user1" has created a folder "/testshare"
 		And user "user1" has created a share with settings
-		  | path | testshare |
-		  | shareType | 0 |
-		  | permissions | 1 |
-		  | shareWith | user0 |
+			| path        | testshare |
+			| shareType   | 0         |
+			| permissions | 1         |
+			| shareWith   | user0     |
 		And user "user1" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"
 		When user "user0" moves file "/textfile0.txt" to "/testshare/overwritethis.txt" using the API
 		Then the HTTP status code should be "403"
@@ -92,10 +92,10 @@ Feature: webdav-related-new-endpoint
 		And user "user1" has been created
 		And user "user1" has created a folder "/testshare"
 		And user "user1" has created a share with settings
-		  | path | testshare |
-		  | shareType | 0 |
-		  | permissions | 1 |
-		  | shareWith | user0 |
+			| path        | testshare |
+			| shareType   | 0         |
+			| permissions | 1         |
+			| shareWith   | user0     |
 		When user "user0" copies file "/textfile0.txt" to "/testshare/textfile0.txt" using the API
 		Then the HTTP status code should be "403"
 		And user "user0" downloads the file "/testshare/textfile0.txt" using the API
@@ -107,10 +107,10 @@ Feature: webdav-related-new-endpoint
 		And user "user1" has been created
 		And user "user1" has created a folder "/testshare"
 		And user "user1" has created a share with settings
-		  | path | testshare |
-		  | shareType | 0 |
-		  | permissions | 1 |
-		  | shareWith | user0 |
+			| path        | testshare |
+			| shareType   | 0         |
+			| permissions | 1         |
+			| shareWith   | user0     |
 		And user "user1" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"
 		When user "user0" copies file "/textfile0.txt" to "/testshare/overwritethis.txt" using the API
 		Then the HTTP status code should be "403"
@@ -146,10 +146,10 @@ Feature: webdav-related-new-endpoint
 		And the quota of user "user1" has been set to "10 MB"
 		And user "user1" has created a folder "/testquota"
 		And user "user1" has created a share with settings
-		  | path | testquota |
-		  | shareType | 0 |
-		  | permissions | 31 |
-		  | shareWith | user0 |
+			| path        | testquota |
+			| shareType   | 0         |
+			| permissions | 31        |
+			| shareWith   | user0     |
 		When user "user0" gets the following properties of folder "/testquota" using the API
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
@@ -178,8 +178,8 @@ Feature: webdav-related-new-endpoint
 		Given using new DAV path
 		And user "user0" has been created
 		When user "user0" creates a share using the API with settings
-			| path | welcome.txt |
-			| shareType | 3 |
+			| path      | welcome.txt |
+			| shareType | 3           |
 		And the public downloads the last public shared file with range "bytes=51-77" using the API
 		Then the downloaded content should be "example file for developers"
 
@@ -187,8 +187,8 @@ Feature: webdav-related-new-endpoint
 		Given using new DAV path
 		And user "user0" has been created
 		When user "user0" creates a share using the API with settings
-			| path | PARENT |
-			| shareType | 3 |
+			| path      | PARENT |
+			| shareType | 3      |
 		And the public downloads file "/parent.txt" from inside the last public shared folder with range "bytes=1-7" using the API
 		Then the downloaded content should be "wnCloud"
 
@@ -197,14 +197,14 @@ Feature: webdav-related-new-endpoint
 		And user "user0" has been created
 		When user "user0" downloads the file "/welcome.txt" using the API
 		Then the following headers should be set
-			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
-			|Content-Security-Policy|default-src 'none';|
-			|X-Content-Type-Options |nosniff|
-			|X-Download-Options|noopen|
-			|X-Frame-Options|SAMEORIGIN|
-			|X-Permitted-Cross-Domain-Policies|none|
-			|X-Robots-Tag|none|
-			|X-XSS-Protection|1; mode=block|
+			| Content-Disposition               | attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt" |
+			| Content-Security-Policy           | default-src 'none';                                              |
+			| X-Content-Type-Options            | nosniff                                                          |
+			| X-Download-Options                | noopen                                                           |
+			| X-Frame-Options                   | SAMEORIGIN                                                       |
+			| X-Permitted-Cross-Domain-Policies | none                                                             |
+			| X-Robots-Tag                      | none                                                             |
+			| X-XSS-Protection                  | 1; mode=block                                                    |
 		And the downloaded content should start with "Welcome to your ownCloud account!"
 
 	Scenario: A file that is not shared does not have a share-types property
@@ -221,10 +221,10 @@ Feature: webdav-related-new-endpoint
 		And user "user1" has been created
 		And user "user0" has created a folder "/test"
 		And user "user0" has created a share with settings
-			| path | test |
-			| shareType | 0 |
-			| permissions | 31 |
-			| shareWith | user1 |
+			| path        | test  |
+			| shareType   | 0     |
+			| permissions | 31    |
+			| shareWith   | user1 |
 		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
@@ -236,10 +236,10 @@ Feature: webdav-related-new-endpoint
 		And group "group1" has been created
 		And user "user0" has created a folder "/test"
 		And user "user0" has created a share with settings
-			| path | test |
-			| shareType | 1 |
-			| permissions | 31 |
-			| shareWith | group1 |
+			| path        | test   |
+			| shareType   | 1      |
+			| permissions | 31     |
+			| shareWith   | group1 |
 		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
@@ -250,9 +250,9 @@ Feature: webdav-related-new-endpoint
 		And user "user0" has been created
 		And user "user0" has created a folder "/test"
 		And user "user0" has created a share with settings
-			| path | test |
-			| shareType | 3 |
-			| permissions | 31 |
+			| path        | test |
+			| shareType   | 3    |
+			| permissions | 31   |
 		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
@@ -270,9 +270,9 @@ Feature: webdav-related-new-endpoint
 			| permissions | 31    |
 			| shareWith   | user1 |
 		And user "user0" has created a share with settings
-			| path        | test  |
-			| shareType   | 1     |
-			| permissions | 31    |
+			| path        | test   |
+			| shareType   | 1      |
+			| permissions | 31     |
 			| shareWith   | group2 |
 		And user "user0" has created a share with settings
 			| path        | test  |
@@ -316,14 +316,14 @@ Feature: webdav-related-new-endpoint
 		And user "user0" has copied file "/textfile0.txt" to "/FOLDER/SUBFOLDER/testfile0.txt"
 		When user "user0" deletes everything from folder "/FOLDER/" using the API
 		Then user "user0" should see the following elements
-			| /FOLDER/ |
-			| /PARENT/ |
+			| /FOLDER/           |
+			| /PARENT/           |
 			| /PARENT/parent.txt |
-			| /textfile0.txt |
-			| /textfile1.txt |
-			| /textfile2.txt |
-			| /textfile3.txt |
-			| /textfile4.txt |
+			| /textfile0.txt     |
+			| /textfile1.txt     |
+			| /textfile2.txt     |
+			| /textfile3.txt     |
+			| /textfile4.txt     |
 
 	Scenario: Checking file id after a move
 		Given using new DAV path
@@ -372,14 +372,14 @@ Feature: webdav-related-new-endpoint
 		And user "user0" has been created
 		When user "user0" downloads the file "/welcome.txt" using the API
 		Then the following headers should be set
-			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
-			|Content-Security-Policy|default-src 'none';|
-			|X-Content-Type-Options |nosniff|
-			|X-Download-Options|noopen|
-			|X-Frame-Options|SAMEORIGIN|
-			|X-Permitted-Cross-Domain-Policies|none|
-			|X-Robots-Tag|none|
-			|X-XSS-Protection|1; mode=block|
+			| Content-Disposition               | attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt" |
+			| Content-Security-Policy           | default-src 'none';                                              |
+			| X-Content-Type-Options            | nosniff                                                          |
+			| X-Download-Options                | noopen                                                           |
+			| X-Frame-Options                   | SAMEORIGIN                                                       |
+			| X-Permitted-Cross-Domain-Policies | none                                                             |
+			| X-Robots-Tag                      | none                                                             |
+			| X-XSS-Protection                  | 1; mode=block                                                    |
 		And the downloaded content should start with "Welcome to your ownCloud account!"
 
 	Scenario: Doing a GET with a web login should work without CSRF token on the new backend
@@ -425,10 +425,10 @@ Feature: webdav-related-new-endpoint
 		And user "user1" has been created
 		And user "user0" has uploaded file "data/textfile.txt" to "/testcustompropshared.txt"
 		And user "user0" has created a share with settings
-		  | path | testcustompropshared.txt |
-		  | shareType | 0 |
-		  | permissions | 31 |
-		  | shareWith | user1 |
+			| path        | testcustompropshared.txt |
+			| shareType   | 0                        |
+			| permissions | 31                       |
+			| shareWith   | user1                    |
 		And user "user0" has set property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropshared.txt" to "valueForSharetest"
 		When user "user1" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropshared.txt"
 		Then the response should contain a custom "{http://whatever.org/ns}very-custom-prop" property with "valueForSharetest"
@@ -573,9 +573,9 @@ Feature: webdav-related-new-endpoint
 		When user "user0" downloads the file "/<file-name>" using the API
 		Then the downloaded content should be "AAAAABBBBBCCCCC"
 		Examples:
-		|file-name|
-		|&#?      |
-		|TIÄFÜ    |
+			| file-name |
+			| &#?       |
+			| TIÄFÜ     |
 
 	#this test should be integrated into the previous scenario after fixing the issue
 	@skip @issue-29599

--- a/tests/integration/features/webdav-related-old-endpoint.feature
+++ b/tests/integration/features/webdav-related-old-endpoint.feature
@@ -8,7 +8,7 @@ Feature: webdav-related-old-endpoint
 		Then the HTTP status code should be "401"
 		And there should be no duplicate headers
 		And the following headers should be set
-			|WWW-Authenticate|Basic realm="ownCloud"|
+			| WWW-Authenticate | Basic realm="ownCloud" |
 
 	Scenario: Moving a file
 		Given using old DAV path
@@ -31,10 +31,10 @@ Feature: webdav-related-old-endpoint
 		And user "user1" has been created
 		And user "user1" has created a folder "/testshare"
 		And user "user1" has created a share with settings
-		  | path | testshare |
-		  | shareType | 0 |
-		  | permissions | 1 |
-		  | shareWith | user0 |
+			| path        | testshare |
+			| shareType   | 0         |
+			| permissions | 1         |
+			| shareWith   | user0     |
 		When user "user0" moves file "/textfile0.txt" to "/testshare/textfile0.txt" using the API
 		Then the HTTP status code should be "403"
 		When user "user0" downloads the file "/testshare/textfile0.txt" using the API
@@ -46,10 +46,10 @@ Feature: webdav-related-old-endpoint
 		And user "user1" has been created
 		And user "user1" has created a folder "/testshare"
 		And user "user1" has created a share with settings
-		  | path | testshare |
-		  | shareType | 0 |
-		  | permissions | 1 |
-		  | shareWith | user0 |
+			| path        | testshare |
+			| shareType   | 0         |
+			| permissions | 1         |
+			| shareWith   | user0     |
 		And user "user1" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"
 		When user "user0" moves file "/textfile0.txt" to "/testshare/overwritethis.txt" using the API
 		Then the HTTP status code should be "403"
@@ -93,10 +93,10 @@ Feature: webdav-related-old-endpoint
 		And user "user1" has been created
 		And user "user1" has created a folder "/testshare"
 		And user "user1" has created a share with settings
-		  | path | testshare |
-		  | shareType | 0 |
-		  | permissions | 1 |
-		  | shareWith | user0 |
+			| path        | testshare |
+			| shareType   | 0         |
+			| permissions | 1         |
+			| shareWith   | user0     |
 		When user "user0" copies file "/textfile0.txt" to "/testshare/textfile0.txt" using the API
 		Then the HTTP status code should be "403"
 		And user "user0" downloads the file "/testshare/textfile0.txt" using the API
@@ -108,10 +108,10 @@ Feature: webdav-related-old-endpoint
 		And user "user1" has been created
 		And user "user1" has created a folder "/testshare"
 		And user "user1" has created a share with settings
-		  | path | testshare |
-		  | shareType | 0 |
-		  | permissions | 1 |
-		  | shareWith | user0 |
+			| path        | testshare |
+			| shareType   | 0         |
+			| permissions | 1         |
+			| shareWith   | user0     |
 		And user "user1" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"
 		When user "user0" copies file "/textfile0.txt" to "/testshare/overwritethis.txt" using the API
 		Then the HTTP status code should be "403"
@@ -147,10 +147,10 @@ Feature: webdav-related-old-endpoint
 		And the quota of user "user1" has been set to "10 MB"
 		And user "user1" has created a folder "/testquota"
 		And user "user1" has created a share with settings
-		  | path | testquota |
-		  | shareType | 0 |
-		  | permissions | 31 |
-		  | shareWith | user0 |
+			| path        | testquota |
+			| shareType   | 0         |
+			| permissions | 31        |
+			| shareWith   | user0     |
 		When user "user0" gets the following properties of folder "/testquota" using the API
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
@@ -179,8 +179,8 @@ Feature: webdav-related-old-endpoint
 		Given using old DAV path
 		And user "user0" has been created
 		When user "user0" creates a share using the API with settings
-			| path | welcome.txt |
-			| shareType | 3 |
+			| path      | welcome.txt |
+			| shareType | 3           |
 		And the public downloads the last public shared file with range "bytes=51-77" using the API
 		Then the downloaded content should be "example file for developers"
 
@@ -188,8 +188,8 @@ Feature: webdav-related-old-endpoint
 		Given using old DAV path
 		And user "user0" has been created
 		When user "user0" creates a share using the API with settings
-			| path | PARENT |
-			| shareType | 3 |
+			| path      | PARENT |
+			| shareType | 3      |
 		And the public downloads file "/parent.txt" from inside the last public shared folder with range "bytes=1-7" using the API
 		Then the downloaded content should be "wnCloud"
 
@@ -207,10 +207,10 @@ Feature: webdav-related-old-endpoint
 		And user "user1" has been created
 		And user "user0" has created a folder "/test"
 		And user "user0" has created a share with settings
-			| path | test |
-			| shareType | 0 |
-			| permissions | 31 |
-			| shareWith | user1 |
+			| path        | test  |
+			| shareType   | 0     |
+			| permissions | 31    |
+			| shareWith   | user1 |
 		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
@@ -222,10 +222,10 @@ Feature: webdav-related-old-endpoint
 		And group "group1" has been created
 		And user "user0" has created a folder "/test"
 		And user "user0" has created a share with settings
-			| path | test |
-			| shareType | 1 |
-			| permissions | 31 |
-			| shareWith | group1 |
+			| path        | test   |
+			| shareType   | 1      |
+			| permissions | 31     |
+			| shareWith   | group1 |
 		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
@@ -236,9 +236,9 @@ Feature: webdav-related-old-endpoint
 		And user "user0" has been created
 		And user "user0" has created a folder "/test"
 		And user "user0" has created a share with settings
-			| path | test |
-			| shareType | 3 |
-			| permissions | 31 |
+			| path        | test |
+			| shareType   | 3    |
+			| permissions | 31   |
 		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
@@ -256,9 +256,9 @@ Feature: webdav-related-old-endpoint
 			| permissions | 31    |
 			| shareWith   | user1 |
 		And user "user0" has created a share with settings
-			| path        | test  |
-			| shareType   | 1     |
-			| permissions | 31    |
+			| path        | test   |
+			| shareType   | 1      |
+			| permissions | 31     |
 			| shareWith   | group2 |
 		And user "user0" has created a share with settings
 			| path        | test  |
@@ -302,14 +302,14 @@ Feature: webdav-related-old-endpoint
 		And user "user0" has copied file "/textfile0.txt" to "/FOLDER/SUBFOLDER/testfile0.txt"
 		When user "user0" deletes everything from folder "/FOLDER/" using the API
 		Then user "user0" should see the following elements
-			| /FOLDER/ |
-			| /PARENT/ |
+			| /FOLDER/           |
+			| /PARENT/           |
 			| /PARENT/parent.txt |
-			| /textfile0.txt |
-			| /textfile1.txt |
-			| /textfile2.txt |
-			| /textfile3.txt |
-			| /textfile4.txt |
+			| /textfile0.txt     |
+			| /textfile1.txt     |
+			| /textfile2.txt     |
+			| /textfile3.txt     |
+			| /textfile4.txt     |
 
 	Scenario: Checking file id after a move
 		Given using old DAV path
@@ -358,14 +358,14 @@ Feature: webdav-related-old-endpoint
 		And user "user0" has been created
 		When user "user0" downloads the file "/welcome.txt" using the API
 		Then the following headers should be set
-			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
-			|Content-Security-Policy|default-src 'none';|
-			|X-Content-Type-Options |nosniff|
-			|X-Download-Options|noopen|
-			|X-Frame-Options|SAMEORIGIN|
-			|X-Permitted-Cross-Domain-Policies|none|
-			|X-Robots-Tag|none|
-			|X-XSS-Protection|1; mode=block|
+			| Content-Disposition               | attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt" |
+			| Content-Security-Policy           | default-src 'none';                                              |
+			| X-Content-Type-Options            | nosniff                                                          |
+			| X-Download-Options                | noopen                                                           |
+			| X-Frame-Options                   | SAMEORIGIN                                                       |
+			| X-Permitted-Cross-Domain-Policies | none                                                             |
+			| X-Robots-Tag                      | none                                                             |
+			| X-XSS-Protection                  | 1; mode=block                                                    |
 		And the downloaded content should start with "Welcome to your ownCloud account!"
 
 	Scenario: Doing a GET with a web login should work without CSRF token on the old backend
@@ -414,10 +414,10 @@ Feature: webdav-related-old-endpoint
 		And user "user1" has been created
 		And user "user0" has uploaded file "data/textfile.txt" to "/testcustompropshared.txt"
 		And user "user0" has created a share with settings
-		  | path | testcustompropshared.txt |
-		  | shareType | 0 |
-		  | permissions | 31 |
-		  | shareWith | user1 |
+			| path        | testcustompropshared.txt |
+			| shareType   | 0                        |
+			| permissions | 31                       |
+			| shareWith   | user1                    |
 		And user "user0" has set property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropshared.txt" to "valueForSharetest"
 		When user "user1" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropshared.txt"
 		Then the response should contain a custom "{http://whatever.org/ns}very-custom-prop" property with "valueForSharetest"
@@ -465,10 +465,10 @@ Feature: webdav-related-old-endpoint
 		When user "user0" downloads the file "/<file-name>" using the API
 		Then the downloaded content should be "AAAAABBBBBCCCCC"
 		Examples:
-		|file-name|
-		|0        |
-		|&#?      |
-		|TIÄFÜ    |
+			| file-name |
+			| 0         |
+			| &#?       |
+			| TIÄFÜ     |
 
 	Scenario: Checking file id after a move between received shares
 		Given using old DAV path

--- a/tests/integration/features/webdav-related-old-endpoint.feature
+++ b/tests/integration/features/webdav-related-old-endpoint.feature
@@ -1,293 +1,270 @@
 Feature: webdav-related-old-endpoint
 	Background:
-		Given using api version "1"
+		Given using API version "1"
 
 	Scenario: Unauthenticated call
-		Given using old dav path
-		When connecting to dav endpoint
+		Given using old DAV path
+		When an unauthenticated client connects to the dav endpoint using the API
 		Then the HTTP status code should be "401"
-		And there are no duplicate headers
+		And there should be no duplicate headers
 		And the following headers should be set
 			|WWW-Authenticate|Basic realm="ownCloud"|
 
 	Scenario: Moving a file
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" moves file "/welcome.txt" to "/FOLDER/welcome.txt"
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/FOLDER/welcome.txt" using the API
 		Then the HTTP status code should be "201"
-		And downloaded content when downloading file "/FOLDER/welcome.txt" with range "bytes=0-6" should be "Welcome"
+		And the downloaded content when downloading file "/FOLDER/welcome.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
+		And the downloaded content when downloading file "/FOLDER/welcome.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: Moving and overwriting a file old way
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" moves file "/welcome.txt" to "/textfile0.txt"
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/textfile0.txt" using the API
 		Then the HTTP status code should be "204"
-		And downloaded content when downloading file "/textfile0.txt" with range "bytes=0-6" should be "Welcome"
+		And the downloaded content when downloading file "/textfile0.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: Moving a file to a folder with no permissions
-		Given using old dav path
-		And user "user0" exists
-		And user "user1" exists
-		And as an "user1"
-		And user "user1" created a folder "/testshare"
-		And as "user1" creating a share with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user1" has created a folder "/testshare"
+		And user "user1" has created a share with settings
 		  | path | testshare |
 		  | shareType | 0 |
 		  | permissions | 1 |
 		  | shareWith | user0 |
-		And as an "user0"
-		And user "user0" moves file "/textfile0.txt" to "/testshare/textfile0.txt"
-		And the HTTP status code should be "403"
-		When downloading file "/testshare/textfile0.txt"
+		When user "user0" moves file "/textfile0.txt" to "/testshare/textfile0.txt" using the API
+		Then the HTTP status code should be "403"
+		When user "user0" downloads the file "/testshare/textfile0.txt" using the API
  		Then the HTTP status code should be "404"
 
 	Scenario: Moving a file to overwrite a file in a folder with no permissions
-		Given using old dav path
-		And user "user0" exists
-		And user "user1" exists
-		And as an "user1"
-		And user "user1" created a folder "/testshare"
-		And as "user1" creating a share with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user1" has created a folder "/testshare"
+		And user "user1" has created a share with settings
 		  | path | testshare |
 		  | shareType | 0 |
 		  | permissions | 1 |
 		  | shareWith | user0 |
-		And user "user1" copies file "/welcome.txt" to "/testshare/overwritethis.txt"
-		And as an "user0"
-		When user "user0" moves file "/textfile0.txt" to "/testshare/overwritethis.txt"
+		And user "user1" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"
+		When user "user0" moves file "/textfile0.txt" to "/testshare/overwritethis.txt" using the API
 		Then the HTTP status code should be "403"
-		And downloaded content when downloading file "/testshare/overwritethis.txt" with range "bytes=0-6" should be "Welcome"
+		And the downloaded content when downloading file "/testshare/overwritethis.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: move file into a not-existing folder
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" moves file "/welcome.txt" to "/not-existing/welcome.txt"
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/not-existing/welcome.txt" using the API
 		Then the HTTP status code should be "409"
 
 	Scenario: rename a file into an invalid filename
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" moves file "/welcome.txt" to "/a\\a"
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/a\\a" using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: rename a file into a banned filename
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" moves file "/welcome.txt" to "/.htaccess"
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/.htaccess" using the API
 		Then the HTTP status code should be "403"
 
 	Scenario: Copying a file
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" copies file "/welcome.txt" to "/FOLDER/welcome.txt"
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" copies file "/welcome.txt" to "/FOLDER/welcome.txt" using the API
 		Then the HTTP status code should be "201"
-		And downloaded content when downloading file "/FOLDER/welcome.txt" with range "bytes=0-6" should be "Welcome"
+		And the downloaded content when downloading file "/FOLDER/welcome.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: Copying and overwriting a file
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" copies file "/welcome.txt" to "/textfile1.txt"
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" copies file "/welcome.txt" to "/textfile1.txt" using the API
 		Then the HTTP status code should be "204"
-		And downloaded content when downloading file "/textfile1.txt" with range "bytes=0-6" should be "Welcome"
+		And the downloaded content when downloading file "/textfile1.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: Copying a file to a folder with no permissions
-		Given using old dav path
-		And user "user0" exists
-		And user "user1" exists
-		And as an "user1"
-		And user "user1" created a folder "/testshare"
-		And as "user1" creating a share with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user1" has created a folder "/testshare"
+		And user "user1" has created a share with settings
 		  | path | testshare |
 		  | shareType | 0 |
 		  | permissions | 1 |
 		  | shareWith | user0 |
-		And as an "user0"
-		When user "user0" copies file "/textfile0.txt" to "/testshare/textfile0.txt"
+		When user "user0" copies file "/textfile0.txt" to "/testshare/textfile0.txt" using the API
 		Then the HTTP status code should be "403"
-		And downloading file "/testshare/textfile0.txt"
+		And user "user0" downloads the file "/testshare/textfile0.txt" using the API
 		And the HTTP status code should be "404"
 
 	Scenario: Copying a file to overwrite a file into a folder with no permissions
-		Given using old dav path
-		And user "user0" exists
-		And user "user1" exists
-		And as an "user1"
-		And user "user1" created a folder "/testshare"
-		And as "user1" creating a share with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user1" has created a folder "/testshare"
+		And user "user1" has created a share with settings
 		  | path | testshare |
 		  | shareType | 0 |
 		  | permissions | 1 |
 		  | shareWith | user0 |
-		And user "user1" copies file "/welcome.txt" to "/testshare/overwritethis.txt"
-		And as an "user0"
-		When user "user0" copies file "/textfile0.txt" to "/testshare/overwritethis.txt"
+		And user "user1" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"
+		When user "user0" copies file "/textfile0.txt" to "/testshare/overwritethis.txt" using the API
 		Then the HTTP status code should be "403"
-		And downloaded content when downloading file "/testshare/overwritethis.txt" with range "bytes=0-6" should be "Welcome"
+		And the downloaded content when downloading file "/testshare/overwritethis.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 
 	Scenario: download a file with range
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		When downloading file "/welcome.txt" with range "bytes=51-77"
-		Then downloaded content should be "example file for developers"
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" downloads file "/welcome.txt" with range "bytes=51-77" using the API
+		Then the downloaded content should be "example file for developers"
 
 	Scenario: Retrieving folder quota when no quota is set
-		Given using old dav path
-		And as an "admin"
-		And user "user0" exists
-		When user "user0" has unlimited quota
-		Then as "user0" gets properties of folder "/" with
+		Given using old DAV path
+		And user "user0" has been created
+		When the administrator gives unlimited quota to user "user0" using the API
+		And user "user0" gets the following properties of folder "/" using the API
 		  |{DAV:}quota-available-bytes|
-		And the single response should contain a property "{DAV:}quota-available-bytes" with value "-3"
+		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "-3"
 
 	Scenario: Retrieving folder quota when quota is set
-		Given using old dav path
-		And as an "admin"
-		And user "user0" exists
-		When user "user0" has a quota of "10 MB"
-		Then as "user0" gets properties of folder "/" with
+		Given using old DAV path
+		And user "user0" has been created
+		When the administrator sets the quota of user "user0" to "10 MB" using the API
+		And user "user0" gets the following properties of folder "/" using the API
 		  |{DAV:}quota-available-bytes|
-		And the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
+		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
 
 	Scenario: Retrieving folder quota of shared folder with quota when no quota is set for recipient
-		Given using old dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" has unlimited quota
-		And user "user1" has a quota of "10 MB"
-		And as an "user1"
-		And user "user1" created a folder "/testquota"
-		And as "user1" creating a share with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has been given unlimited quota
+		And the quota of user "user1" has been set to "10 MB"
+		And user "user1" has created a folder "/testquota"
+		And user "user1" has created a share with settings
 		  | path | testquota |
 		  | shareType | 0 |
 		  | permissions | 31 |
 		  | shareWith | user0 |
-		When as "user0" gets properties of folder "/testquota" with
+		When user "user0" gets the following properties of folder "/testquota" using the API
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
 
 	Scenario: Retrieving folder quota when quota is set and a file was uploaded
-		Given using old dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user0" has a quota of "1 KB"
-		And user "user0" adds a file of 93 bytes to "/prueba.txt"
-		When as "user0" gets properties of folder "/" with
+		Given using old DAV path
+		And user "user0" has been created
+		And the quota of user "user0" has been set to "1 KB"
+		And user "user0" has added file "/prueba.txt" of 93 bytes
+		When user "user0" gets the following properties of folder "/" using the API
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "529"
 
 	Scenario: Retrieving folder quota when quota is set and a file was recieved
-		Given using old dav path
-		And as an "admin"
-		And user "user0" exists
-		And user "user1" exists
-		And user "user1" has a quota of "1 KB"
-		And user "user0" adds a file of 93 bytes to "/user0.txt"
-		And file "user0.txt" of user "user0" is shared with user "user1"
-		When as "user1" gets properties of folder "/" with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And the quota of user "user1" has been set to "1 KB"
+		And user "user0" has added file "/user0.txt" of 93 bytes
+		And user "user0" has shared file "user0.txt" with user "user1"
+		When user "user1" gets the following properties of folder "/" using the API
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "622"
 
 	Scenario: download a public shared file with range
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" creates a share using the API with settings
 			| path | welcome.txt |
 			| shareType | 3 |
-		And downloading last public shared file with range "bytes=51-77"
-		Then downloaded content should be "example file for developers"
+		And the public downloads the last public shared file with range "bytes=51-77" using the API
+		Then the downloaded content should be "example file for developers"
 
 	Scenario: download a public shared file inside a folder with range
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		When creating a share with
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" creates a share using the API with settings
 			| path | PARENT |
 			| shareType | 3 |
-		And downloading last public shared file inside a folder "/parent.txt" with range "bytes=1-7"
-		Then downloaded content should be "wnCloud"
+		And the public downloads file "/parent.txt" from inside the last public shared folder with range "bytes=1-7" using the API
+		Then the downloaded content should be "wnCloud"
 
 	Scenario: A file that is not shared does not have a share-types property
-		Given using old dav path
-		And user "user0" exists
-		And user "user0" created a folder "/test"
-		When as "user0" gets properties of folder "/test" with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/test"
+		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain an empty property "{http://owncloud.org/ns}share-types"
 
 	Scenario: A file that is shared to a user has a share-types property
-		Given using old dav path
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/test"
-		And as "user0" creating a share with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has created a share with settings
 			| path | test |
 			| shareType | 0 |
 			| permissions | 31 |
 			| shareWith | user1 |
-		When as "user0" gets properties of folder "/test" with
+		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
 			| 0 |
 
 	Scenario: A file that is shared to a group has a share-types property
-		Given using old dav path
-		And user "user0" exists
-		And group "group1" exists
-		And user "user0" created a folder "/test"
-		And as "user0" creating a share with
+		Given using old DAV path
+		And user "user0" has been created
+		And group "group1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has created a share with settings
 			| path | test |
 			| shareType | 1 |
 			| permissions | 31 |
 			| shareWith | group1 |
-		When as "user0" gets properties of folder "/test" with
+		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
 			| 1 |
 
 	Scenario: A file that is shared by link has a share-types property
-		Given using old dav path
-		And user "user0" exists
-		And user "user0" created a folder "/test"
-		And as "user0" creating a share with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has created a share with settings
 			| path | test |
 			| shareType | 3 |
 			| permissions | 31 |
-		When as "user0" gets properties of folder "/test" with
+		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
 			| 3 |
 
 	Scenario: A file that is shared by user,group and link has a share-types property
-		Given using old dav path
-		And user "user0" exists
-		And user "user1" exists
-		And group "group2" exists
-		And user "user0" created a folder "/test"
-		And as "user0" creating a share with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And group "group2" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has created a share with settings
 			| path        | test  |
 			| shareType   | 0     |
 			| permissions | 31    |
 			| shareWith   | user1 |
-		And as "user0" creating a share with
+		And user "user0" has created a share with settings
 			| path        | test  |
 			| shareType   | 1     |
 			| permissions | 31    |
 			| shareWith   | group2 |
-		And as "user0" creating a share with
+		And user "user0" has created a share with settings
 			| path        | test  |
 			| shareType   | 3     |
 			| permissions | 31    |
-		When as "user0" gets properties of folder "/test" with
+		When user "user0" gets the following properties of folder "/test" using the API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
 			| 0 |
@@ -295,38 +272,36 @@ Feature: webdav-related-old-endpoint
 			| 3 |
 
 	Scenario: A disabled user cannot use webdav
-		Given using old dav path
-		And user "userToBeDisabled" exists
-		And as an "admin"
-		And assure user "userToBeDisabled" is disabled
-		When downloading file "/welcome.txt" as "userToBeDisabled"
+		Given using old DAV path
+		And user "userToBeDisabled" has been created
+		And user "userToBeDisabled" has been disabled
+		When user "userToBeDisabled" downloads the file "/welcome.txt" using the API
 		Then the HTTP status code should be "503"
 
 	Scenario: Creating a folder
-		Given using old dav path
-		And user "user0" exists
-		And user "user0" created a folder "/test_folder"
-		When as "user0" gets properties of folder "/test_folder" with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/test_folder"
+		When user "user0" gets the following properties of folder "/test_folder" using the API
 		  |{DAV:}resourcetype|
 		Then the single response should contain a property "{DAV:}resourcetype" with value "{DAV:}collection"
 
 	Scenario: Creating a folder with special chars
-		Given using old dav path
-		And user "user0" exists
-		And user "user0" created a folder "/test_folder:5"
-		When as "user0" gets properties of folder "/test_folder:5" with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/test_folder:5"
+		When user "user0" gets the following properties of folder "/test_folder:5" using the API
 		  |{DAV:}resourcetype|
 		Then the single response should contain a property "{DAV:}resourcetype" with value "{DAV:}collection"
 
 	Scenario: Removing everything of a folder
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		And user "user0" moves file "/welcome.txt" to "/FOLDER/welcome.txt"
-		And user "user0" created a folder "/FOLDER/SUBFOLDER"
-		And user "user0" copies file "/textfile0.txt" to "/FOLDER/SUBFOLDER/testfile0.txt"
-		When user "user0" deletes everything from folder "/FOLDER/"
-		Then user "user0" should see following elements
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has moved file "/welcome.txt" to "/FOLDER/welcome.txt"
+		And user "user0" has created a folder "/FOLDER/SUBFOLDER"
+		And user "user0" has copied file "/textfile0.txt" to "/FOLDER/SUBFOLDER/testfile0.txt"
+		When user "user0" deletes everything from folder "/FOLDER/" using the API
+		Then user "user0" should see the following elements
 			| /FOLDER/ |
 			| /PARENT/ |
 			| /PARENT/parent.txt |
@@ -337,52 +312,51 @@ Feature: webdav-related-old-endpoint
 			| /textfile4.txt |
 
 	Scenario: Checking file id after a move
-		Given using old dav path
-		And user "user0" exists
-		And user "user0" stores id of file "/textfile0.txt"
-		When user "user0" moves file "/textfile0.txt" to "/FOLDER/textfile0.txt"
-		Then user "user0" checks id of file "/FOLDER/textfile0.txt"
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has stored id of file "/textfile0.txt"
+		When user "user0" moves file "/textfile0.txt" to "/FOLDER/textfile0.txt" using the API
+		Then user "user0" file "/FOLDER/textfile0.txt" should have the previously stored id
 
 	Scenario: Renaming a folder to a backslash encoded should return an error using old endpoint
-		Given using old dav path
-		And user "user0" exists
-		And user "user0" created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/%5C"
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/testshare"
+		When user "user0" moves folder "/testshare" to "/%5C" using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: Renaming a folder beginning with a backslash encoded should return an error using old endpoint
-		Given using old dav path
-		And user "user0" exists
-		And user "user0" created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/%5Ctestshare"
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/testshare"
+		When user "user0" moves folder "/testshare" to "/%5Ctestshare" using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: Renaming a folder including a backslash encoded should return an error using old endpoint
-		Given using old dav path
-		And user "user0" exists
-		And user "user0" created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/hola%5Chola"
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/testshare"
+		When user "user0" moves folder "/testshare" to "/hola%5Chola" using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: Renaming a folder into a banned name
-		Given using old dav path
-		And user "user0" exists
-		And user "user0" created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/.htaccess"
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/testshare"
+		When user "user0" moves folder "/testshare" to "/.htaccess" using the API
 		Then the HTTP status code should be "403"
 
 	Scenario: Move a folder into a not existing one
-		Given using old dav path
-		And user "user0" exists
-		And user "user0" created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/not-existing/testshare"
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "/testshare"
+		When user "user0" moves folder "/testshare" to "/not-existing/testshare" using the API
 		Then the HTTP status code should be "409"
 
 	Scenario: Downloading a file on the old endpoint should serve security headers
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		When downloading file "/welcome.txt"
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" downloads the file "/welcome.txt" using the API
 		Then the following headers should be set
 			|Content-Disposition|attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt"|
 			|Content-Security-Policy|default-src 'none';|
@@ -392,113 +366,104 @@ Feature: webdav-related-old-endpoint
 			|X-Permitted-Cross-Domain-Policies|none|
 			|X-Robots-Tag|none|
 			|X-XSS-Protection|1; mode=block|
-		And downloaded content should start with "Welcome to your ownCloud account!"
+		And the downloaded content should start with "Welcome to your ownCloud account!"
 
 	Scenario: Doing a GET with a web login should work without CSRF token on the old backend
-		Given using old dav path
-		And user "user0" exists
-		And logging in using web as "user0"
-		When sending a "GET" to "/remote.php/webdav/welcome.txt" without requesttoken
-		Then downloaded content should start with "Welcome to your ownCloud account!"
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has logged in to a web-style session using the API
+		When the client sends a "GET" to "/remote.php/webdav/welcome.txt" without requesttoken using the API
+		Then the downloaded content should start with "Welcome to your ownCloud account!"
 		And the HTTP status code should be "200"
 
 	Scenario: Doing a GET with a web login should work with CSRF token on the old backend
-		Given using old dav path
-		And user "user0" exists
-		And logging in using web as "user0"
-		When sending a "GET" to "/remote.php/webdav/welcome.txt" with requesttoken
-		Then downloaded content should start with "Welcome to your ownCloud account!"
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has logged in to a web-style session using the API
+		When the client sends a "GET" to "/remote.php/webdav/welcome.txt" with requesttoken using the API
+		Then the downloaded content should start with "Welcome to your ownCloud account!"
 		And the HTTP status code should be "200"
 
 	Scenario: Doing a PROPFIND with a web login should work with CSRF token on the old backend
-		Given using old dav path
-		And user "user0" exists
-		And logging in using web as "user0"
-		When sending a "PROPFIND" to "/remote.php/webdav/welcome.txt" with requesttoken
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has logged in to a web-style session using the API
+		When the client sends a "PROPFIND" to "/remote.php/webdav/welcome.txt" with requesttoken using the API
 		Then the HTTP status code should be "207"
 
 	Scenario: Setting custom DAV property and reading it
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		And user "user0" uploads file "data/textfile.txt" to "/testcustomprop.txt"
-		And "user0" sets property "{http://whatever.org/ns}very-custom-prop" of file "/testcustomprop.txt" to "veryCustomPropValue"
-		When as "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testcustomprop.txt"
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/testcustomprop.txt"
+		And user "user0" has set property "{http://whatever.org/ns}very-custom-prop" of file "/testcustomprop.txt" to "veryCustomPropValue"
+		When user "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testcustomprop.txt"
 		Then the response should contain a custom "{http://whatever.org/ns}very-custom-prop" property with "veryCustomPropValue"
 
 	Scenario: Setting custom DAV property and reading it after the file is renamed
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		And user "user0" uploads file "data/textfile.txt" to "/testcustompropwithmove.txt"
-		And "user0" sets property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropwithmove.txt" to "valueForMovetest"
-		And user "user0" moved file "/testcustompropwithmove.txt" to "/catchmeifyoucan.txt"
-		When as "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/catchmeifyoucan.txt"
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/testcustompropwithmove.txt"
+		And user "user0" has set property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropwithmove.txt" to "valueForMovetest"
+		And user "user0" has moved file "/testcustompropwithmove.txt" to "/catchmeifyoucan.txt"
+		When user "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/catchmeifyoucan.txt"
 		Then the response should contain a custom "{http://whatever.org/ns}very-custom-prop" property with "valueForMovetest"
 		
 	Scenario: Setting custom DAV property on a shared file as an owner and reading as a recipient
-		Given using old dav path
-		And user "user0" exists
-		And user "user1" exists
-		And as an "user0"
-		And user "user0" uploads file "data/textfile.txt" to "/testcustompropshared.txt"
-		And as "user0" creating a share with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/testcustompropshared.txt"
+		And user "user0" has created a share with settings
 		  | path | testcustompropshared.txt |
 		  | shareType | 0 |
 		  | permissions | 31 |
 		  | shareWith | user1 |
-		And "user0" sets property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropshared.txt" to "valueForSharetest"
-		And as an "user1"
-		When as "user1" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropshared.txt"
+		And user "user0" has set property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropshared.txt" to "valueForSharetest"
+		When user "user1" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testcustompropshared.txt"
 		Then the response should contain a custom "{http://whatever.org/ns}very-custom-prop" property with "valueForSharetest"
 
 	Scenario: Setting custom DAV property using an old endpoint and reading it using a new endpoint
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		And user "user0" uploads file "data/textfile.txt" to "/testoldnew.txt"
-		And "user0" sets property "{http://whatever.org/ns}very-custom-prop" of file "/testoldnew.txt" to "constant"
-		And using new dav path
-		When as "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testoldnew.txt"
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/testoldnew.txt"
+		And user "user0" has set property "{http://whatever.org/ns}very-custom-prop" of file "/testoldnew.txt" to "constant"
+		And using new DAV path
+		When user "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testoldnew.txt"
 		Then the response should contain a custom "{http://whatever.org/ns}very-custom-prop" property with "constant"
 
 	### Scenarios specific to old endpoint
 
 	Scenario: Upload chunked file asc
-		Given user "user0" exists
-		And user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt"
-		And user "user0" uploads chunk file "2" of "3" with "BBBBB" to "/myChunkedFile.txt"
-		And user "user0" uploads chunk file "3" of "3" with "CCCCC" to "/myChunkedFile.txt"
-		When as an "user0"
-		And downloading file "/myChunkedFile.txt"
-		Then downloaded content should be "AAAAABBBBBCCCCC"
+		Given user "user0" has been created
+		And user "user0" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt"
+		And user "user0" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChunkedFile.txt"
+		And user "user0" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChunkedFile.txt"
+		When user "user0" downloads the file "/myChunkedFile.txt" using the API
+		Then the downloaded content should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file desc
-		Given user "user0" exists
-		And user "user0" uploads chunk file "3" of "3" with "CCCCC" to "/myChunkedFile.txt"
-		And user "user0" uploads chunk file "2" of "3" with "BBBBB" to "/myChunkedFile.txt"
-		And user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt"
-		When as an "user0"
-		And downloading file "/myChunkedFile.txt"
-		Then downloaded content should be "AAAAABBBBBCCCCC"
+		Given user "user0" has been created
+		And user "user0" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChunkedFile.txt"
+		And user "user0" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChunkedFile.txt"
+		And user "user0" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt"
+		When user "user0" downloads the file "/myChunkedFile.txt" using the API
+		Then the downloaded content should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file random
-		Given user "user0" exists
-		And user "user0" uploads chunk file "2" of "3" with "BBBBB" to "/myChunkedFile.txt"
-		And user "user0" uploads chunk file "3" of "3" with "CCCCC" to "/myChunkedFile.txt"
-		And user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt"
-		When as an "user0"
-		And downloading file "/myChunkedFile.txt"
-		Then downloaded content should be "AAAAABBBBBCCCCC"
+		Given user "user0" has been created
+		And user "user0" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChunkedFile.txt"
+		And user "user0" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChunkedFile.txt"
+		And user "user0" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt"
+		When user "user0" downloads the file "/myChunkedFile.txt" using the API
+		Then the downloaded content should be "AAAAABBBBBCCCCC"
 
 	Scenario Outline: Chunked upload files with difficult name
-		Given user "user0" exists
-		And user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/<file-name>"
-		And user "user0" uploads chunk file "2" of "3" with "BBBBB" to "/<file-name>"
-		And user "user0" uploads chunk file "3" of "3" with "CCCCC" to "/<file-name>"
-		When as an "user0"
-		And downloading file "/<file-name>"
-		Then downloaded content should be "AAAAABBBBBCCCCC"
+		Given user "user0" has been created
+		And user "user0" has uploaded chunk file "1" of "3" with "AAAAA" to "/<file-name>"
+		And user "user0" has uploaded chunk file "2" of "3" with "BBBBB" to "/<file-name>"
+		And user "user0" has uploaded chunk file "3" of "3" with "CCCCC" to "/<file-name>"
+		When user "user0" downloads the file "/<file-name>" using the API
+		Then the downloaded content should be "AAAAABBBBBCCCCC"
 		Examples:
 		|file-name|
 		|0        |
@@ -506,59 +471,54 @@ Feature: webdav-related-old-endpoint
 		|TIÄFÜ    |
 
 	Scenario: Checking file id after a move between received shares
-		Given using old dav path
-		And user "user0" exists
-		And user "user1" exists
-		And user "user0" created a folder "/folderA"
-		And user "user0" created a folder "/folderB"
-		And folder "/folderA" of user "user0" is shared with user "user1"
-		And folder "/folderB" of user "user0" is shared with user "user1"
-		And user "user1" created a folder "/folderA/ONE"
-		And user "user1" stores id of file "/folderA/ONE"
-		And user "user1" created a folder "/folderA/ONE/TWO"
-		When user "user1" moves folder "/folderA/ONE" to "/folderB/ONE"
-		Then as "user1" the folder "/folderA" exists
-		And as "user1" the folder "/folderA/ONE" does not exist
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/folderA"
+		And user "user0" has created a folder "/folderB"
+		And user "user0" has shared folder "/folderA" with user "user1"
+		And user "user0" has shared folder "/folderB" with user "user1"
+		And user "user1" has created a folder "/folderA/ONE"
+		And user "user1" has stored id of file "/folderA/ONE"
+		And user "user1" has created a folder "/folderA/ONE/TWO"
+		When user "user1" moves folder "/folderA/ONE" to "/folderB/ONE" using the API
+		Then as "user1" the folder "/folderA" should exist
+		And as "user1" the folder "/folderA/ONE" should not exist
 		# yes, a weird bug used to make this one fail
-		And as "user1" the folder "/folderA/ONE/TWO" does not exist
-		And as "user1" the folder "/folderB/ONE" exists
-		And as "user1" the folder "/folderB/ONE/TWO" exists
-		And user "user1" checks id of file "/folderB/ONE"
+		And as "user1" the folder "/folderA/ONE/TWO" should not exist
+		And as "user1" the folder "/folderB/ONE" should exist
+		And as "user1" the folder "/folderB/ONE/TWO" should exist
+		And user "user1" file "/folderB/ONE" should have the previously stored id
 
 	Scenario: Retrieving private link
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		And user "user0" uploads file "data/textfile.txt" to "/somefile.txt"
-		Then as "user0" gets properties of file "/somefile.txt" with
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
+		When user "user0" gets the following properties of file "/somefile.txt" using the API
 			|{http://owncloud.org/ns}privatelink|
-		And the single response should contain a property "{http://owncloud.org/ns}privatelink" with value like "/(\/index.php\/f\/[0-9]*)/"
+		Then the single response should contain a property "{http://owncloud.org/ns}privatelink" with value like "/(\/index.php\/f\/[0-9]*)/"
 
 	Scenario: Copying file to a path with extension .part should not be possible
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" copies file "/welcome.txt" to "/welcome.part"
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" copies file "/welcome.txt" to "/welcome.part" using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: Uploading file to path with extension .part should not be possible
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		And user "user0" uploads file "data/textfile.txt" to "/textfile.part"
+		Given using old DAV path
+		And user "user0" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/textfile.part"
 		Then the HTTP status code should be "400"
 
 	Scenario: Renaming a file to a path with extension .part should not be possible
-		Given using old dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" moves file "/welcome.txt" to "/welcome.part"
+		Given using old DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/welcome.part" using the API
 		Then the HTTP status code should be "400"
 
 	Scenario: Creating a directory which contains .part should not be possible
-		Given using new dav path
-		And user "user0" exists
-		And as an "user0"
-		When user "user0" created a folder "/folder.with.ext.part"
+		Given using new DAV path
+		And user "user0" has been created
+		When user "user0" creates a folder "/folder.with.ext.part" using the API
 		Then the HTTP status code should be "400"
 

--- a/tests/integration/federation_features/federated.feature
+++ b/tests/integration/federation_features/federated.feature
@@ -1,16 +1,16 @@
 Feature: federated
 	Background:
-		Given using api version "1"
+		Given using API version "1"
 
 	Scenario: Federate share a file with another server
 		Given using server "REMOTE"
-		And user "user1" exists
+		And user "user1" has been created
 		And using server "LOCAL"
-		And user "user0" exists
-		When user "user0" from server "LOCAL" shares "/textfile0.txt" with user "user1" from server "REMOTE"
+		And user "user0" has been created
+		When user "user0" from server "LOCAL" shares "/textfile0.txt" with user "user1" from server "REMOTE" using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| item_type | file |
 			| item_source | A_NUMBER |
@@ -30,13 +30,13 @@ Feature: federated
 
 	Scenario: Federate share a file with local server
 		Given using server "LOCAL"
-		And user "user0" exists
+		And user "user0" has been created
 		And using server "REMOTE"
-		And user "user1" exists
-		When user "user1" from server "REMOTE" shares "/textfile0.txt" with user "user0" from server "LOCAL"
+		And user "user1" has been created
+		When user "user1" from server "REMOTE" shares "/textfile0.txt" with user "user0" from server "LOCAL" using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| item_type | file |
 			| item_source | A_NUMBER |
@@ -56,16 +56,15 @@ Feature: federated
 
 	Scenario: Remote sharee can see the pending share
 		Given using server "REMOTE"
-		And user "user1" exists
+		And user "user1" has been created
 		And using server "LOCAL"
-		And user "user0" exists
-		And user "user0" from server "LOCAL" shares "/textfile0.txt" with user "user1" from server "REMOTE"
+		And user "user0" has been created
+		And user "user0" from server "LOCAL" has shared "/textfile0.txt" with user "user1" from server "REMOTE"
 		And using server "REMOTE"
-		And as an "user1"
-		When sending "GET" to "/apps/files_sharing/api/v1/remote_shares/pending"
+		When user "user1" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/remote_shares/pending"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| remote | LOCAL |
 			| remote_id | A_NUMBER |
@@ -78,32 +77,31 @@ Feature: federated
 
 	Scenario: accept a pending remote share
 		Given using server "REMOTE"
-		And user "user1" exists
+		And user "user1" has been created
 		And using server "LOCAL"
-		And user "user0" exists
-		And user "user0" from server "LOCAL" shares "/textfile0.txt" with user "user1" from server "REMOTE"
-		When user "user1" from server "REMOTE" accepts last pending share
+		And user "user0" has been created
+		And user "user0" from server "LOCAL" has shared "/textfile0.txt" with user "user1" from server "REMOTE"
+		When user "user1" from server "REMOTE" accepts the last pending share using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
 	Scenario: Reshare a federated shared file
 		Given using server "REMOTE"
-		And user "user1" exists
-		And user "user2" exists
+		And user "user1" has been created
+		And user "user2" has been created
 		And using server "LOCAL"
-		And user "user0" exists
-		And user "user0" from server "LOCAL" shares "/textfile0.txt" with user "user1" from server "REMOTE"
-		And user "user1" from server "REMOTE" accepts last pending share
+		And user "user0" has been created
+		And user "user0" from server "LOCAL" has shared "/textfile0.txt" with user "user1" from server "REMOTE"
+		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		And as an "user1"
-		When creating a share with
+		When user "user1" creates a share using the API with settings
 			| path | /textfile0 (2).txt |
 			| shareType | 0 |
 			| shareWith | user2 |
 			| permissions | 19 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And share fields of last share match with
+		And the share fields of the last share should include
 			| id | A_NUMBER |
 			| item_type | file |
 			| item_source | A_NUMBER |
@@ -122,132 +120,118 @@ Feature: federated
 
 	Scenario: Overwrite a federated shared file as recipient
 		Given using server "REMOTE"
-		And user "user1" exists
-		And user "user2" exists
+		And user "user1" has been created
+		And user "user2" has been created
 		And using server "LOCAL"
-		And user "user0" exists
-		And user "user0" from server "LOCAL" shares "/textfile0.txt" with user "user1" from server "REMOTE"
-		And user "user1" from server "REMOTE" accepts last pending share
+		And user "user0" has been created
+		And user "user0" from server "LOCAL" has shared "/textfile0.txt" with user "user1" from server "REMOTE"
+		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		And as an "user1"
-		When user "user1" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt"
+		When user "user1" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the API
 		And using server "LOCAL"
-		And as an "user0"
-		And downloading file "/textfile0.txt" with range "bytes=0-8"
-		Then downloaded content should be "BLABLABLA"
+		And user "user0" downloads file "/textfile0.txt" with range "bytes=0-8" using the API
+		Then the downloaded content should be "BLABLABLA"
 
 	Scenario: Overwrite a federated shared folder as recipient
 		Given using server "REMOTE"
-		And user "user1" exists
-		And user "user2" exists
+		And user "user1" has been created
+		And user "user2" has been created
 		And using server "LOCAL"
-		And user "user0" exists
-		And user "user0" from server "LOCAL" shares "/PARENT" with user "user1" from server "REMOTE"
-		And user "user1" from server "REMOTE" accepts last pending share
+		And user "user0" has been created
+		And user "user0" from server "LOCAL" has shared "/PARENT" with user "user1" from server "REMOTE"
+		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		And as an "user1"
-		When user "user1" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt"
+		When user "user1" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the API
 		And using server "LOCAL"
-		And as an "user0"
-		And downloading file "/PARENT/textfile0.txt" with range "bytes=0-8"
-		Then downloaded content should be "BLABLABLA"
+		And user "user0" downloads file "/PARENT/textfile0.txt" with range "bytes=0-8" using the API
+		Then the downloaded content should be "BLABLABLA"
 
 	Scenario: Overwrite a federated shared file as recipient using old chunking
 		Given using server "REMOTE"
-		And user "user1" exists
-		And user "user2" exists
+		And user "user1" has been created
+		And user "user2" has been created
 		And using server "LOCAL"
-		And user "user0" exists
-		And user "user0" from server "LOCAL" shares "/textfile0.txt" with user "user1" from server "REMOTE"
-		And user "user1" from server "REMOTE" accepts last pending share
+		And user "user0" has been created
+		And user "user0" from server "LOCAL" has shared "/textfile0.txt" with user "user1" from server "REMOTE"
+		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		And as an "user1"
-		And user "user1" uploads chunk file "1" of "3" with "AAAAA" to "/textfile0 (2).txt"
-		And user "user1" uploads chunk file "2" of "3" with "BBBBB" to "/textfile0 (2).txt"
-		And user "user1" uploads chunk file "3" of "3" with "CCCCC" to "/textfile0 (2).txt"
-		When downloading file "/textfile0 (2).txt" with range "bytes=0-4"
-		Then downloaded content should be "AAAAA"
+		And user "user1" has uploaded chunk file "1" of "3" with "AAAAA" to "/textfile0 (2).txt"
+		And user "user1" has uploaded chunk file "2" of "3" with "BBBBB" to "/textfile0 (2).txt"
+		And user "user1" has uploaded chunk file "3" of "3" with "CCCCC" to "/textfile0 (2).txt"
+		When user "user1" downloads file "/textfile0 (2).txt" with range "bytes=0-4" using the API
+		Then the downloaded content should be "AAAAA"
 
 	Scenario: Overwrite a federated shared folder as recipient using old chunking
 		Given using server "REMOTE"
-		And user "user1" exists
-		And user "user2" exists
+		And user "user1" has been created
+		And user "user2" has been created
 		And using server "LOCAL"
-		And user "user0" exists
-		And user "user0" from server "LOCAL" shares "/PARENT" with user "user1" from server "REMOTE"
-		And user "user1" from server "REMOTE" accepts last pending share
+		And user "user0" has been created
+		And user "user0" from server "LOCAL" has shared "/PARENT" with user "user1" from server "REMOTE"
+		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		And as an "user1"
-		And user "user1" uploads chunk file "1" of "3" with "AAAAA" to "/PARENT (2)/textfile0.txt"
-		And user "user1" uploads chunk file "2" of "3" with "BBBBB" to "/PARENT (2)/textfile0.txt"
-		And user "user1" uploads chunk file "3" of "3" with "CCCCC" to "/PARENT (2)/textfile0.txt"
-		When downloading file "/PARENT (2)/textfile0.txt" with range "bytes=3-13"
-		Then downloaded content should be "AABBBBBCCCC"
+		And user "user1" has uploaded chunk file "1" of "3" with "AAAAA" to "/PARENT (2)/textfile0.txt"
+		And user "user1" has uploaded chunk file "2" of "3" with "BBBBB" to "/PARENT (2)/textfile0.txt"
+		And user "user1" has uploaded chunk file "3" of "3" with "CCCCC" to "/PARENT (2)/textfile0.txt"
+		When user "user1" downloads file "/PARENT (2)/textfile0.txt" with range "bytes=3-13" using the API
+		Then the downloaded content should be "AABBBBBCCCC"
 
 	Scenario: Trusted server handshake does not require authenticated requests - we force 403 by sending an empty body
 		Given using server "LOCAL"
-		And using api version "2"
-		And as an "UNAUTHORIZED_USER"
-		When sending "POST" to "/apps/federation/api/v1/request-shared-secret"
+		And using API version "2"
+		When user "UNAUTHORIZED_USER" sends HTTP method "POST" to API endpoint "/apps/federation/api/v1/request-shared-secret"
 		Then the HTTP status code should be "403"
 
 	Scenario: Overwrite a federated shared folder as recipient propagates etag for recipient
 		Given using server "REMOTE"
-		And user "user1" exists
+		And user "user1" has been created
 		And using server "LOCAL"
-		And user "user0" exists
-		And user "user0" from server "LOCAL" shares "/PARENT" with user "user1" from server "REMOTE"
-		And user "user1" from server "REMOTE" accepts last pending share
+		And user "user0" has been created
+		And user "user0" from server "LOCAL" has shared "/PARENT" with user "user1" from server "REMOTE"
+		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		And user "user1" stores etag of element "/PARENT (2)"
+		And user "user1" has stored etag of element "/PARENT (2)"
 		And using server "LOCAL"
-		And as an "user0"
-		When User "user0" uploads file "data/file_to_overwrite.txt" to "/PARENT/textfile0.txt"
+		When user "user0" uploads file "data/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the API
 		Then using server "REMOTE"
-		And as an "user1"
-		And etag of element "/PARENT (2)" of user "user1" has changed
+		And the etag of element "/PARENT (2)" of user "user1" should have changed
 
 	Scenario: Overwrite a federated shared folder as recipient propagates etag for sharer
 		Given using server "REMOTE"
-		And user "user1" exists
+		And user "user1" has been created
 		And using server "LOCAL"
-		And user "user0" exists
-		And user "user0" from server "LOCAL" shares "/PARENT" with user "user1" from server "REMOTE"
-		And user "user0" stores etag of element "/PARENT"
-		And user "user1" from server "REMOTE" accepts last pending share
+		And user "user0" has been created
+		And user "user0" from server "LOCAL" has shared "/PARENT" with user "user1" from server "REMOTE"
+		And user "user0" has stored etag of element "/PARENT"
+		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		And as an "user1"
-		When user "user1" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt"
+		When user "user1" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the API
 		Then using server "LOCAL"
-		And as an "user0"
-		And etag of element "/PARENT" of user "user0" has changed
+		And the etag of element "/PARENT" of user "user0" should have changed
 
 	Scenario: Upload file to received federated share while quota is set on home storage
 		Given using server "REMOTE"
-		And as an "admin"
-		And user "user1" exists
-		And user "user1" has a quota of "20 B"
+		And user "user1" has been created
+		And the quota of user "user1" has been set to "20 B"
 		And using server "LOCAL"
-		And user "user0" exists
-		And user "user0" from server "LOCAL" shares "/PARENT" with user "user1" from server "REMOTE"
-		And user "user1" from server "REMOTE" accepts last pending share
+		And user "user0" has been created
+		And user "user0" from server "LOCAL" has shared "/PARENT" with user "user1" from server "REMOTE"
+		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		When user "user1" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms
+		When user "user1" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms using the API
 		Then the HTTP status code of all upload responses should be "201"
 		And using server "LOCAL"
-		And as "user0" the files uploaded to "/PARENT/testquota.txt" with all mechanisms exist
+		And as "user0" the files uploaded to "/PARENT/testquota.txt" with all mechanisms should exist
 
 	Scenario: Upload file to received federated share while quota is set on remote storage
 		Given using server "REMOTE"
-		And as an "admin"
-		And user "user1" exists
+		And user "user1" has been created
 		And using server "LOCAL"
-		And as an "admin"
-		And user "user0" exists
-		And user "user0" has a quota of "20 B"
-		And user "user0" from server "LOCAL" shares "/PARENT" with user "user1" from server "REMOTE"
-		And user "user1" from server "REMOTE" accepts last pending share
+		And user "user0" has been created
+		And the quota of user "user0" has been set to "20 B"
+		And user "user0" from server "LOCAL" has shared "/PARENT" with user "user1" from server "REMOTE"
+		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		When user "user1" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms
+		When user "user1" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms using the API
 		Then the HTTP status code of all upload responses should be "507"
 

--- a/tests/integration/federation_features/federated.feature
+++ b/tests/integration/federation_features/federated.feature
@@ -11,22 +11,22 @@ Feature: federated
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| item_type | file |
-			| item_source | A_NUMBER |
-			| share_type | 6 |
-			| file_source | A_NUMBER |
-			| path | /textfile0.txt |
-			| permissions | 19 |
-			| stime | A_NUMBER |
-			| storage | A_NUMBER |
-			| mail_send | 0 |
-			| uid_owner | user0 |
-			| storage_id | home::user0 |
-			| file_parent | A_NUMBER |
-			| displayname_owner | user0 |
-			| share_with | user1@REMOTE |
-			| share_with_displayname | user1@REMOTE |
+			| id                     | A_NUMBER       |
+			| item_type              | file           |
+			| item_source            | A_NUMBER       |
+			| share_type             | 6              |
+			| file_source            | A_NUMBER       |
+			| path                   | /textfile0.txt |
+			| permissions            | 19             |
+			| stime                  | A_NUMBER       |
+			| storage                | A_NUMBER       |
+			| mail_send              | 0              |
+			| uid_owner              | user0          |
+			| storage_id             | home::user0    |
+			| file_parent            | A_NUMBER       |
+			| displayname_owner      | user0          |
+			| share_with             | user1@REMOTE   |
+			| share_with_displayname | user1@REMOTE   |
 
 	Scenario: Federate share a file with local server
 		Given using server "LOCAL"
@@ -37,22 +37,22 @@ Feature: federated
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| item_type | file |
-			| item_source | A_NUMBER |
-			| share_type | 6 |
-			| file_source | A_NUMBER |
-			| path | /textfile0.txt |
-			| permissions | 19 |
-			| stime | A_NUMBER |
-			| storage | A_NUMBER |
-			| mail_send | 0 |
-			| uid_owner | user1 |
-			| storage_id | home::user1 |
-			| file_parent | A_NUMBER |
-			| displayname_owner | user1 |
-			| share_with | user0@LOCAL |
-			| share_with_displayname | user0@LOCAL |
+			| id                     | A_NUMBER       |
+			| item_type              | file           |
+			| item_source            | A_NUMBER       |
+			| share_type             | 6              |
+			| file_source            | A_NUMBER       |
+			| path                   | /textfile0.txt |
+			| permissions            | 19             |
+			| stime                  | A_NUMBER       |
+			| storage                | A_NUMBER       |
+			| mail_send              | 0              |
+			| uid_owner              | user1          |
+			| storage_id             | home::user1    |
+			| file_parent            | A_NUMBER       |
+			| displayname_owner      | user1          |
+			| share_with             | user0@LOCAL    |
+			| share_with_displayname | user0@LOCAL    |
 
 	Scenario: Remote sharee can see the pending share
 		Given using server "REMOTE"
@@ -65,15 +65,15 @@ Feature: federated
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| remote | LOCAL |
-			| remote_id | A_NUMBER |
-			| share_token | A_TOKEN |
-			| name | /textfile0.txt |
-			| owner | user0 |
-			| user | user1 |
-			| mountpoint | {{TemporaryMountPointName#/textfile0.txt}} |
-			| accepted | 0 |
+			| id          | A_NUMBER                                   |
+			| remote      | LOCAL                                      |
+			| remote_id   | A_NUMBER                                   |
+			| share_token | A_TOKEN                                    |
+			| name        | /textfile0.txt                             |
+			| owner       | user0                                      |
+			| user        | user1                                      |
+			| mountpoint  | {{TemporaryMountPointName#/textfile0.txt}} |
+			| accepted    | 0                                          |
 
 	Scenario: accept a pending remote share
 		Given using server "REMOTE"
@@ -95,28 +95,28 @@ Feature: federated
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
 		When user "user1" creates a share using the API with settings
-			| path | /textfile0 (2).txt |
-			| shareType | 0 |
-			| shareWith | user2 |
-			| permissions | 19 |
+			| path        | /textfile0 (2).txt |
+			| shareType   | 0                  |
+			| shareWith   | user2              |
+			| permissions | 19                 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
-			| id | A_NUMBER |
-			| item_type | file |
-			| item_source | A_NUMBER |
-			| share_type | 0 |
-			| file_source | A_NUMBER |
-			| path | /textfile0 (2).txt |
-			| permissions | 19 |
-			| stime | A_NUMBER |
-			| storage | A_NUMBER |
-			| mail_send | 0 |
-			| uid_owner | user1 |
-			| file_parent | A_NUMBER |
-			| displayname_owner | user1 |
-			| share_with | user2 |
-			| share_with_displayname | user2 |
+			| id                     | A_NUMBER           |
+			| item_type              | file               |
+			| item_source            | A_NUMBER           |
+			| share_type             | 0                  |
+			| file_source            | A_NUMBER           |
+			| path                   | /textfile0 (2).txt |
+			| permissions            | 19                 |
+			| stime                  | A_NUMBER           |
+			| storage                | A_NUMBER           |
+			| mail_send              | 0                  |
+			| uid_owner              | user1              |
+			| file_parent            | A_NUMBER           |
+			| displayname_owner      | user1              |
+			| share_with             | user2              |
+			| share_with_displayname | user2              |
 
 	Scenario: Overwrite a federated shared file as recipient
 		Given using server "REMOTE"

--- a/tests/integration/sharees_features/sharees.feature
+++ b/tests/integration/sharees_features/sharees.feature
@@ -1,377 +1,354 @@
 Feature: sharees
 	Background:
-		Given using api version "1"
-		And user "test" exists
-		And user "Sharee1" exists
-		And group "ShareeGroup" exists
-		And group "ShareeGroup2" exists
-		And user "test" belongs to group "ShareeGroup2"
+		Given using API version "1"
+		And user "test" has been created
+		And user "Sharee1" has been created
+		And group "ShareeGroup" has been created
+		And group "ShareeGroup2" has been created
+		And user "test" has been added to group "ShareeGroup2"
 
 	Scenario: Search without exact match
-		Given as an "test"
-		When getting sharees for
+		When user "test" gets the sharees using the API with parameters
 			| search | Sharee |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be
 			| Sharee1 | 0 | Sharee1 |
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned are
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be
 			| ShareeGroup | 1 | ShareeGroup |
 			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search without exact match not-exact casing
-		Given as an "test"
-		When getting sharees for
+		When user "test" gets the sharees using the API with parameters
 			| search | sharee |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be
 			| Sharee1 | 0 | Sharee1 |
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned are
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be
 			| ShareeGroup | 1 | ShareeGroup |
 			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search only with group members - denied
-		Given as an "test"
-		And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
-		When getting sharees for
+		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+		When user "test" gets the sharees using the API with parameters
 			| search | sharee |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned is empty
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be
 			| ShareeGroup | 1 | ShareeGroup |
 			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search only with group members - allowed
-		Given as an "test"
-		And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
-		And user "Sharee1" belongs to group "ShareeGroup2"
-		When getting sharees for
+		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+		And user "Sharee1" has been added to group "ShareeGroup2"
+		When user "test" gets the sharees using the API with parameters
 			| search | sharee |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be
 			| Sharee1 | 0 | Sharee1 |
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned are
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be
 			| ShareeGroup | 1 | ShareeGroup |
 			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search only with group members - no group as non-member
-		Given as an "Sharee1"
-		And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
-		And parameter "shareapi_only_share_with_membership_groups" of app "core" is set to "yes"
-		When getting sharees for
+		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+		And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+		When user "Sharee1" gets the sharees using the API with parameters
 			| search | sharee |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned is empty
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned is empty
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search only with membership groups - denied
-		Given as an "Sharee1"
-		And parameter "shareapi_only_share_with_membership_groups" of app "core" is set to "yes"
-		When getting sharees for
+		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+		When user "Sharee1" gets the sharees using the API with parameters
 			| search | ShareeGroup |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned is empty
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned is empty
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search only with membership groups - denied but users match
-		Given as an "Sharee1"
-		And parameter "shareapi_only_share_with_membership_groups" of app "core" is set to "yes"
-		When getting sharees for
+		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+		When user "Sharee1" gets the sharees using the API with parameters
 			| search | sharee |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be
 			| Sharee1 | 0 | Sharee1 |
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned is empty
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search only with membership groups - allowed
-		Given as an "test"
-		And parameter "shareapi_only_share_with_membership_groups" of app "core" is set to "yes"
-		When getting sharees for
+		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+		When user "test" gets the sharees using the API with parameters
 			| search | ShareeGroup |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned is empty
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be
 			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search only with membership groups - allowed including users
-		Given as an "test"
-		And parameter "shareapi_only_share_with_membership_groups" of app "core" is set to "yes"
-		When getting sharees for
+		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+		When user "test" gets the sharees using the API with parameters
 			| search | Sharee |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be
 			| Sharee1 | 0 | Sharee1 |
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned are
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be
 			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search without exact match no iteration allowed
-		Given as an "test"
-		And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
-		When getting sharees for
+		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+		When user "test" gets the sharees using the API with parameters
 			| search | Sharee |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned is empty
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned is empty
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search with exact match no iteration allowed
-		Given as an "test"
-		And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
-		When getting sharees for
+		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+		When user "test" gets the sharees using the API with parameters
 			| search | Sharee1 |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned are
+		And the "exact users" sharees returned should be
 			| Sharee1 | 0 | Sharee1 |
-		And "users" sharees returned is empty
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned is empty
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search with exact match group no iteration allowed
-		Given as an "test"
-		And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
-		When getting sharees for
+		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+		When user "test" gets the sharees using the API with parameters
 			| search | ShareeGroup |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned is empty
-		And "exact groups" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be
 			| ShareeGroup | 1 | ShareeGroup |
-		And "groups" sharees returned is empty
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search with exact match
-		Given as an "test"
-		When getting sharees for
+		When user "test" gets the sharees using the API with parameters
 			| search | Sharee1 |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		Then "exact users" sharees returned are
+		And the "exact users" sharees returned should be
 			| Sharee1 | 0 | Sharee1 |
-		Then "users" sharees returned is empty
-		Then "exact groups" sharees returned is empty
-		Then "groups" sharees returned is empty
-		Then "exact remotes" sharees returned is empty
-		Then "remotes" sharees returned is empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search with exact match not-exact casing
-		Given as an "test"
-		When getting sharees for
+		When user "test" gets the sharees using the API with parameters
 			| search | sharee1 |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		Then "exact users" sharees returned are
+		And the "exact users" sharees returned should be
 			| Sharee1 | 0 | Sharee1 |
-		Then "users" sharees returned is empty
-		Then "exact groups" sharees returned is empty
-		Then "groups" sharees returned is empty
-		Then "exact remotes" sharees returned is empty
-		Then "remotes" sharees returned is empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search with exact match not-exact casing group
-		Given as an "test"
-		When getting sharees for
+		When user "test" gets the sharees using the API with parameters
 			| search | shareegroup2 |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		Then "exact users" sharees returned is empty
-		Then "users" sharees returned is empty
-		Then "exact groups" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be
 			| ShareeGroup2 | 1 | ShareeGroup2 |
-		Then "groups" sharees returned is empty
-		Then "exact remotes" sharees returned is empty
-		Then "remotes" sharees returned is empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Search with "self"
-		Given as an "Sharee1"
-		When getting sharees for
+		When user "Sharee1" gets the sharees using the API with parameters
 			| search | Sharee1 |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		Then "exact users" sharees returned are
+		And the "exact users" sharees returned should be
 			| Sharee1 | 0 | Sharee1 |
-		Then "users" sharees returned is empty
-		Then "exact groups" sharees returned is empty
-		Then "groups" sharees returned is empty
-		Then "exact remotes" sharees returned is empty
-		Then "remotes" sharees returned is empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Remote sharee for files
-		Given as an "test"
-		When getting sharees for
+		When user "test" gets the sharees using the API with parameters
 			| search | test@localhost |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		Then "exact users" sharees returned is empty
-		Then "users" sharees returned is empty
-		Then "exact groups" sharees returned is empty
-		Then "groups" sharees returned is empty
-		Then "exact remotes" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be
 			| test@localhost | 6 | test@localhost |
-		Then "remotes" sharees returned is empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Remote sharee for calendars not allowed
-		Given as an "test"
-		When getting sharees for
+		When user "test" gets the sharees using the API with parameters
 			| search | test@localhost |
 			| itemType | calendar |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		Then "exact users" sharees returned is empty
-		Then "users" sharees returned is empty
-		Then "exact groups" sharees returned is empty
-		Then "groups" sharees returned is empty
-		Then "exact remotes" sharees returned is empty
-		Then "remotes" sharees returned is empty
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Group sharees not returned when group sharing is disabled
-		Given as an "test"
-		And parameter "shareapi_allow_group_sharing" of app "core" is set to "no"
-		When getting sharees for
+		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
+		When user "test" gets the sharees using the API with parameters
 			| search | sharee |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be
 			| Sharee1 | 0 | Sharee1 |
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned is empty
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Enumerate only group members - only show partial results from member groups
-		Given as an "test"
-		And user "Another" exists
-		And user "Another" belongs to group "ShareeGroup2"
-		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" is set to "yes"
-		When getting sharees for
+		Given user "Another" has been created
+		And user "Another" has been added to group "ShareeGroup2"
+		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
+		When user "test" gets the sharees using the API with parameters
 			| search | ano |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be
 			| Another | 0 | Another |
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned is empty
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Enumerate only group members - accept exact match from non-member groups
-		Given as an "test"
-		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" is set to "yes"
-		When getting sharees for
+		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
+		When user "test" gets the sharees using the API with parameters
 			| search | Sharee1 |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned are
+		And the "exact users" sharees returned should be
 			| Sharee1 | 0 | Sharee1 |
-		And "users" sharees returned is empty
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned is empty
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Enumerate only group members - only show partial results from member groups
-		Given as an "test"
-		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" is set to "yes"
-		When getting sharees for
+		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
+		When user "test" gets the sharees using the API with parameters
 			| search | ShareeG |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned is empty
-		And "exact groups" sharees returned is empty
-		And "groups" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be empty
+		And the "groups" sharees returned should be
 			| ShareeGroup2 | 1 | ShareeGroup2 |
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty
 
 	Scenario: Enumerate only group members - only accept exact group match from non-memberships
-		Given as an "test"
-		And group "ShareeGroupNonMember" exists
-		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" is set to "yes"
-		When getting sharees for
+		Given group "ShareeGroupNonMember" has been created
+		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
+		When user "test" gets the sharees using the API with parameters
 			| search | ShareeGroupNonMember |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And "exact users" sharees returned is empty
-		And "users" sharees returned is empty
-		And "exact groups" sharees returned are
+		And the "exact users" sharees returned should be empty
+		And the "users" sharees returned should be empty
+		And the "exact groups" sharees returned should be
 			| ShareeGroupNonMember | 1 | ShareeGroupNonMember |
-		And "groups" sharees returned is empty
-		And "exact remotes" sharees returned is empty
-		And "remotes" sharees returned is empty
+		And the "groups" sharees returned should be empty
+		And the "exact remotes" sharees returned should be empty
+		And the "remotes" sharees returned should be empty

--- a/tests/integration/sharees_features/sharees.feature
+++ b/tests/integration/sharees_features/sharees.feature
@@ -9,8 +9,8 @@ Feature: sharees
 
 	Scenario: Search without exact match
 		When user "test" gets the sharees using the API with parameters
-			| search | Sharee |
-			| itemType | file |
+			| search   | Sharee |
+			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -18,15 +18,15 @@ Feature: sharees
 			| Sharee1 | 0 | Sharee1 |
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be
-			| ShareeGroup | 1 | ShareeGroup |
+			| ShareeGroup  | 1 | ShareeGroup  |
 			| ShareeGroup2 | 1 | ShareeGroup2 |
 		And the "exact remotes" sharees returned should be empty
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Search without exact match not-exact casing
 		When user "test" gets the sharees using the API with parameters
-			| search | sharee |
-			| itemType | file |
+			| search   | sharee |
+			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -34,7 +34,7 @@ Feature: sharees
 			| Sharee1 | 0 | Sharee1 |
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be
-			| ShareeGroup | 1 | ShareeGroup |
+			| ShareeGroup  | 1 | ShareeGroup  |
 			| ShareeGroup2 | 1 | ShareeGroup2 |
 		And the "exact remotes" sharees returned should be empty
 		And the "remotes" sharees returned should be empty
@@ -42,15 +42,15 @@ Feature: sharees
 	Scenario: Search only with group members - denied
 		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
 		When user "test" gets the sharees using the API with parameters
-			| search | sharee |
-			| itemType | file |
+			| search   | sharee |
+			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
 		And the "users" sharees returned should be empty
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be
-			| ShareeGroup | 1 | ShareeGroup |
+			| ShareeGroup  | 1 | ShareeGroup  |
 			| ShareeGroup2 | 1 | ShareeGroup2 |
 		And the "exact remotes" sharees returned should be empty
 		And the "remotes" sharees returned should be empty
@@ -59,8 +59,8 @@ Feature: sharees
 		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
 		And user "Sharee1" has been added to group "ShareeGroup2"
 		When user "test" gets the sharees using the API with parameters
-			| search | sharee |
-			| itemType | file |
+			| search   | sharee |
+			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -68,7 +68,7 @@ Feature: sharees
 			| Sharee1 | 0 | Sharee1 |
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be
-			| ShareeGroup | 1 | ShareeGroup |
+			| ShareeGroup  | 1 | ShareeGroup  |
 			| ShareeGroup2 | 1 | ShareeGroup2 |
 		And the "exact remotes" sharees returned should be empty
 		And the "remotes" sharees returned should be empty
@@ -77,8 +77,8 @@ Feature: sharees
 		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
 		And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
 		When user "Sharee1" gets the sharees using the API with parameters
-			| search | sharee |
-			| itemType | file |
+			| search   | sharee |
+			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -91,8 +91,8 @@ Feature: sharees
 	Scenario: Search only with membership groups - denied
 		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
 		When user "Sharee1" gets the sharees using the API with parameters
-			| search | ShareeGroup |
-			| itemType | file |
+			| search   | ShareeGroup |
+			| itemType | file        |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -105,8 +105,8 @@ Feature: sharees
 	Scenario: Search only with membership groups - denied but users match
 		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
 		When user "Sharee1" gets the sharees using the API with parameters
-			| search | sharee |
-			| itemType | file |
+			| search   | sharee |
+			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -120,8 +120,8 @@ Feature: sharees
 	Scenario: Search only with membership groups - allowed
 		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
 		When user "test" gets the sharees using the API with parameters
-			| search | ShareeGroup |
-			| itemType | file |
+			| search   | ShareeGroup |
+			| itemType | file        |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -135,8 +135,8 @@ Feature: sharees
 	Scenario: Search only with membership groups - allowed including users
 		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
 		When user "test" gets the sharees using the API with parameters
-			| search | Sharee |
-			| itemType | file |
+			| search   | Sharee |
+			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -151,8 +151,8 @@ Feature: sharees
 	Scenario: Search without exact match no iteration allowed
 		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
 		When user "test" gets the sharees using the API with parameters
-			| search | Sharee |
-			| itemType | file |
+			| search   | Sharee |
+			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -165,8 +165,8 @@ Feature: sharees
 	Scenario: Search with exact match no iteration allowed
 		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
 		When user "test" gets the sharees using the API with parameters
-			| search | Sharee1 |
-			| itemType | file |
+			| search   | Sharee1 |
+			| itemType | file    |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be
@@ -180,8 +180,8 @@ Feature: sharees
 	Scenario: Search with exact match group no iteration allowed
 		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
 		When user "test" gets the sharees using the API with parameters
-			| search | ShareeGroup |
-			| itemType | file |
+			| search   | ShareeGroup |
+			| itemType | file        |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -194,8 +194,8 @@ Feature: sharees
 
 	Scenario: Search with exact match
 		When user "test" gets the sharees using the API with parameters
-			| search | Sharee1 |
-			| itemType | file |
+			| search   | Sharee1 |
+			| itemType | file    |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be
@@ -208,8 +208,8 @@ Feature: sharees
 
 	Scenario: Search with exact match not-exact casing
 		When user "test" gets the sharees using the API with parameters
-			| search | sharee1 |
-			| itemType | file |
+			| search   | sharee1 |
+			| itemType | file    |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be
@@ -222,8 +222,8 @@ Feature: sharees
 
 	Scenario: Search with exact match not-exact casing group
 		When user "test" gets the sharees using the API with parameters
-			| search | shareegroup2 |
-			| itemType | file |
+			| search   | shareegroup2 |
+			| itemType | file         |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -236,8 +236,8 @@ Feature: sharees
 
 	Scenario: Search with "self"
 		When user "Sharee1" gets the sharees using the API with parameters
-			| search | Sharee1 |
-			| itemType | file |
+			| search   | Sharee1 |
+			| itemType | file    |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be
@@ -250,8 +250,8 @@ Feature: sharees
 
 	Scenario: Remote sharee for files
 		When user "test" gets the sharees using the API with parameters
-			| search | test@localhost |
-			| itemType | file |
+			| search   | test@localhost |
+			| itemType | file           |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -264,8 +264,8 @@ Feature: sharees
 
 	Scenario: Remote sharee for calendars not allowed
 		When user "test" gets the sharees using the API with parameters
-			| search | test@localhost |
-			| itemType | calendar |
+			| search   | test@localhost |
+			| itemType | calendar       |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -278,8 +278,8 @@ Feature: sharees
 	Scenario: Group sharees not returned when group sharing is disabled
 		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
 		When user "test" gets the sharees using the API with parameters
-			| search | sharee |
-			| itemType | file |
+			| search   | sharee |
+			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -295,7 +295,7 @@ Feature: sharees
 		And user "Another" has been added to group "ShareeGroup2"
 		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
 		When user "test" gets the sharees using the API with parameters
-			| search | ano |
+			| search   | ano  |
 			| itemType | file |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -310,8 +310,8 @@ Feature: sharees
 	Scenario: Enumerate only group members - accept exact match from non-member groups
 		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
 		When user "test" gets the sharees using the API with parameters
-			| search | Sharee1 |
-			| itemType | file |
+			| search   | Sharee1 |
+			| itemType | file    |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be
@@ -325,8 +325,8 @@ Feature: sharees
 	Scenario: Enumerate only group members - only show partial results from member groups
 		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
 		When user "test" gets the sharees using the API with parameters
-			| search | ShareeG |
-			| itemType | file |
+			| search   | ShareeG |
+			| itemType | file    |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
@@ -341,8 +341,8 @@ Feature: sharees
 		Given group "ShareeGroupNonMember" has been created
 		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
 		When user "test" gets the sharees using the API with parameters
-			| search | ShareeGroupNonMember |
-			| itemType | file |
+			| search   | ShareeGroupNonMember |
+			| itemType | file                 |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty

--- a/tests/integration/sharees_features/sharees_provisioningapiv2.feature
+++ b/tests/integration/sharees_features/sharees_provisioningapiv2.feature
@@ -1,310 +1,291 @@
 Feature: sharees_provisioningapiv2
   Background:
-    Given using api version "2"
-    And user "test" exists
-    And user "Sharee1" exists
-    And group "ShareeGroup" exists
-    And group "ShareeGroup2" exists
-    And user "test" belongs to group "ShareeGroup2"
+    Given using API version "2"
+    And user "test" has been created
+    And user "Sharee1" has been created
+    And group "ShareeGroup" has been created
+    And group "ShareeGroup2" has been created
+    And user "test" has been added to group "ShareeGroup2"
 
   Scenario: Search without exact match
-    Given as an "test"
-    When getting sharees for
+    When user "test" gets the sharees using the API with parameters
       | search | Sharee |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned are
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
       | Sharee1 | 0 | Sharee1 |
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned are
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
       | ShareeGroup | 1 | ShareeGroup |
       | ShareeGroup2 | 1 | ShareeGroup2 |
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search without exact match not-exact casing
-    Given as an "test"
-    When getting sharees for
+    When user "test" gets the sharees using the API with parameters
       | search | sharee |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned are
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
       | Sharee1 | 0 | Sharee1 |
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned are
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
       | ShareeGroup | 1 | ShareeGroup |
       | ShareeGroup2 | 1 | ShareeGroup2 |
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search only with group members - denied
-    Given as an "test"
-    And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
-    When getting sharees for
+    Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+    When user "test" gets the sharees using the API with parameters
       | search | sharee |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned is empty
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned are
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
       | ShareeGroup | 1 | ShareeGroup |
       | ShareeGroup2 | 1 | ShareeGroup2 |
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search only with group members - allowed
-    Given as an "test"
-    And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
-    And user "Sharee1" belongs to group "ShareeGroup2"
-    When getting sharees for
+    Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+    And user "Sharee1" has been added to group "ShareeGroup2"
+    When user "test" gets the sharees using the API with parameters
       | search | sharee |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned are
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
       | Sharee1 | 0 | Sharee1 |
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned are
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
       | ShareeGroup | 1 | ShareeGroup |
       | ShareeGroup2 | 1 | ShareeGroup2 |
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search only with group members - no group as non-member
-    Given as an "Sharee1"
-    And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
-    And parameter "shareapi_only_share_with_membership_groups" of app "core" is set to "yes"
-    When getting sharees for
+    Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
+    And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    When user "Sharee1" gets the sharees using the API with parameters
       | search | sharee |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned is empty
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned is empty
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search only with membership groups - denied
-    Given as an "Sharee1"
-    And parameter "shareapi_only_share_with_membership_groups" of app "core" is set to "yes"
-    When getting sharees for
+    Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    When user "Sharee1" gets the sharees using the API with parameters
       | search | ShareeGroup |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned is empty
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned is empty
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search only with membership groups - denied but users match
-    Given as an "Sharee1"
-    And parameter "shareapi_only_share_with_membership_groups" of app "core" is set to "yes"
-    When getting sharees for
+    Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    When user "Sharee1" gets the sharees using the API with parameters
       | search | sharee |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned are
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
       | Sharee1 | 0 | Sharee1 |
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned is empty
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search only with membership groups - allowed
-    Given as an "test"
-    And parameter "shareapi_only_share_with_membership_groups" of app "core" is set to "yes"
-    When getting sharees for
+    Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    When user "test" gets the sharees using the API with parameters
       | search | ShareeGroup |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned is empty
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned are
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
       | ShareeGroup2 | 1 | ShareeGroup2 |
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search only with membership groups - allowed including users
-    Given as an "test"
-    And parameter "shareapi_only_share_with_membership_groups" of app "core" is set to "yes"
-    When getting sharees for
+    Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    When user "test" gets the sharees using the API with parameters
       | search | Sharee |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned are
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
       | Sharee1 | 0 | Sharee1 |
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned are
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
       | ShareeGroup2 | 1 | ShareeGroup2 |
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search without exact match no iteration allowed
-    Given as an "test"
-    And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
-    When getting sharees for
+    Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+    When user "test" gets the sharees using the API with parameters
       | search | Sharee |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned is empty
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned is empty
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search with exact match no iteration allowed
-    Given as an "test"
-    And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
-    When getting sharees for
+    Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+    When user "test" gets the sharees using the API with parameters
       | search | Sharee1 |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And "exact users" sharees returned are
+    And the "exact users" sharees returned should be
       | Sharee1 | 0 | Sharee1 |
-    And "users" sharees returned is empty
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned is empty
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search with exact match group no iteration allowed
-    Given as an "test"
-    And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" is set to "no"
-    When getting sharees for
+    Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
+    When user "test" gets the sharees using the API with parameters
       | search | ShareeGroup |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned is empty
-    And "exact groups" sharees returned are
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be
       | ShareeGroup | 1 | ShareeGroup |
-    And "groups" sharees returned is empty
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search with exact match
-    Given as an "test"
-    When getting sharees for
+    When user "test" gets the sharees using the API with parameters
       | search | Sharee1 |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    Then "exact users" sharees returned are
+    And the "exact users" sharees returned should be
       | Sharee1 | 0 | Sharee1 |
-    Then "users" sharees returned is empty
-    Then "exact groups" sharees returned is empty
-    Then "groups" sharees returned is empty
-    Then "exact remotes" sharees returned is empty
-    Then "remotes" sharees returned is empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search with exact match not-exact casing
-    Given as an "test"
-    When getting sharees for
+    When user "test" gets the sharees using the API with parameters
       | search | sharee1 |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    Then "exact users" sharees returned are
+    And the "exact users" sharees returned should be
       | Sharee1 | 0 | Sharee1 |
-    Then "users" sharees returned is empty
-    Then "exact groups" sharees returned is empty
-    Then "groups" sharees returned is empty
-    Then "exact remotes" sharees returned is empty
-    Then "remotes" sharees returned is empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search with exact match not-exact casing group
-    Given as an "test"
-    When getting sharees for
+    When user "test" gets the sharees using the API with parameters
       | search | shareegroup2 |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    Then "exact users" sharees returned is empty
-    Then "users" sharees returned is empty
-    Then "exact groups" sharees returned are
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be
       | ShareeGroup2 | 1 | ShareeGroup2 |
-    Then "groups" sharees returned is empty
-    Then "exact remotes" sharees returned is empty
-    Then "remotes" sharees returned is empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Search with "self"
-    Given as an "Sharee1"
-    When getting sharees for
+    When user "Sharee1" gets the sharees using the API with parameters
       | search | Sharee1 |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    Then "exact users" sharees returned are
+    And the "exact users" sharees returned should be
       | Sharee1 | 0 | Sharee1 |
-    Then "users" sharees returned is empty
-    Then "exact groups" sharees returned is empty
-    Then "groups" sharees returned is empty
-    Then "exact remotes" sharees returned is empty
-    Then "remotes" sharees returned is empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Remote sharee for files
-    Given as an "test"
-    When getting sharees for
+    When user "test" gets the sharees using the API with parameters
       | search | test@localhost |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    Then "exact users" sharees returned is empty
-    Then "users" sharees returned is empty
-    Then "exact groups" sharees returned is empty
-    Then "groups" sharees returned is empty
-    Then "exact remotes" sharees returned are
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be
       | test@localhost | 6 | test@localhost |
-    Then "remotes" sharees returned is empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Remote sharee for calendars not allowed
-    Given as an "test"
-    When getting sharees for
+    When user "test" gets the sharees using the API with parameters
       | search | test@localhost |
       | itemType | calendar |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    Then "exact users" sharees returned is empty
-    Then "users" sharees returned is empty
-    Then "exact groups" sharees returned is empty
-    Then "groups" sharees returned is empty
-    Then "exact remotes" sharees returned is empty
-    Then "remotes" sharees returned is empty
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
 
   Scenario: Group sharees not returned when group sharing is disabled
-    Given as an "test"
-    And parameter "shareapi_allow_group_sharing" of app "core" is set to "no"
-    When getting sharees for
+    Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
+    When user "test" gets the sharees using the API with parameters
       | search | sharee |
       | itemType | file |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And "exact users" sharees returned is empty
-    And "users" sharees returned are
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
       | Sharee1 | 0 | Sharee1 |
-    And "exact groups" sharees returned is empty
-    And "groups" sharees returned is empty
-    And "exact remotes" sharees returned is empty
-    And "remotes" sharees returned is empty
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be empty
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty

--- a/tests/integration/sharees_features/sharees_provisioningapiv2.feature
+++ b/tests/integration/sharees_features/sharees_provisioningapiv2.feature
@@ -9,8 +9,8 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search without exact match
     When user "test" gets the sharees using the API with parameters
-      | search | Sharee |
-      | itemType | file |
+      | search   | Sharee |
+      | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
@@ -18,15 +18,15 @@ Feature: sharees_provisioningapiv2
       | Sharee1 | 0 | Sharee1 |
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be
-      | ShareeGroup | 1 | ShareeGroup |
+      | ShareeGroup  | 1 | ShareeGroup  |
       | ShareeGroup2 | 1 | ShareeGroup2 |
     And the "exact remotes" sharees returned should be empty
     And the "remotes" sharees returned should be empty
 
   Scenario: Search without exact match not-exact casing
     When user "test" gets the sharees using the API with parameters
-      | search | sharee |
-      | itemType | file |
+      | search   | sharee |
+      | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
@@ -34,7 +34,7 @@ Feature: sharees_provisioningapiv2
       | Sharee1 | 0 | Sharee1 |
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be
-      | ShareeGroup | 1 | ShareeGroup |
+      | ShareeGroup  | 1 | ShareeGroup  |
       | ShareeGroup2 | 1 | ShareeGroup2 |
     And the "exact remotes" sharees returned should be empty
     And the "remotes" sharees returned should be empty
@@ -42,15 +42,15 @@ Feature: sharees_provisioningapiv2
   Scenario: Search only with group members - denied
     Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     When user "test" gets the sharees using the API with parameters
-      | search | sharee |
-      | itemType | file |
+      | search   | sharee |
+      | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
     And the "users" sharees returned should be empty
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be
-      | ShareeGroup | 1 | ShareeGroup |
+      | ShareeGroup  | 1 | ShareeGroup  |
       | ShareeGroup2 | 1 | ShareeGroup2 |
     And the "exact remotes" sharees returned should be empty
     And the "remotes" sharees returned should be empty
@@ -59,8 +59,8 @@ Feature: sharees_provisioningapiv2
     Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     And user "Sharee1" has been added to group "ShareeGroup2"
     When user "test" gets the sharees using the API with parameters
-      | search | sharee |
-      | itemType | file |
+      | search   | sharee |
+      | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
@@ -68,7 +68,7 @@ Feature: sharees_provisioningapiv2
       | Sharee1 | 0 | Sharee1 |
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be
-      | ShareeGroup | 1 | ShareeGroup |
+      | ShareeGroup  | 1 | ShareeGroup  |
       | ShareeGroup2 | 1 | ShareeGroup2 |
     And the "exact remotes" sharees returned should be empty
     And the "remotes" sharees returned should be empty
@@ -77,8 +77,8 @@ Feature: sharees_provisioningapiv2
     Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     When user "Sharee1" gets the sharees using the API with parameters
-      | search | sharee |
-      | itemType | file |
+      | search   | sharee |
+      | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
@@ -91,8 +91,8 @@ Feature: sharees_provisioningapiv2
   Scenario: Search only with membership groups - denied
     Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     When user "Sharee1" gets the sharees using the API with parameters
-      | search | ShareeGroup |
-      | itemType | file |
+      | search   | ShareeGroup |
+      | itemType | file        |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
@@ -105,8 +105,8 @@ Feature: sharees_provisioningapiv2
   Scenario: Search only with membership groups - denied but users match
     Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     When user "Sharee1" gets the sharees using the API with parameters
-      | search | sharee |
-      | itemType | file |
+      | search   | sharee |
+      | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
@@ -120,8 +120,8 @@ Feature: sharees_provisioningapiv2
   Scenario: Search only with membership groups - allowed
     Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     When user "test" gets the sharees using the API with parameters
-      | search | ShareeGroup |
-      | itemType | file |
+      | search   | ShareeGroup |
+      | itemType | file        |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
@@ -135,8 +135,8 @@ Feature: sharees_provisioningapiv2
   Scenario: Search only with membership groups - allowed including users
     Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     When user "test" gets the sharees using the API with parameters
-      | search | Sharee |
-      | itemType | file |
+      | search   | Sharee |
+      | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
@@ -151,8 +151,8 @@ Feature: sharees_provisioningapiv2
   Scenario: Search without exact match no iteration allowed
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
     When user "test" gets the sharees using the API with parameters
-      | search | Sharee |
-      | itemType | file |
+      | search   | Sharee |
+      | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
@@ -165,8 +165,8 @@ Feature: sharees_provisioningapiv2
   Scenario: Search with exact match no iteration allowed
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
     When user "test" gets the sharees using the API with parameters
-      | search | Sharee1 |
-      | itemType | file |
+      | search   | Sharee1 |
+      | itemType | file    |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be
@@ -180,8 +180,8 @@ Feature: sharees_provisioningapiv2
   Scenario: Search with exact match group no iteration allowed
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
     When user "test" gets the sharees using the API with parameters
-      | search | ShareeGroup |
-      | itemType | file |
+      | search   | ShareeGroup |
+      | itemType | file        |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
@@ -194,8 +194,8 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search with exact match
     When user "test" gets the sharees using the API with parameters
-      | search | Sharee1 |
-      | itemType | file |
+      | search   | Sharee1 |
+      | itemType | file    |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be
@@ -208,8 +208,8 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search with exact match not-exact casing
     When user "test" gets the sharees using the API with parameters
-      | search | sharee1 |
-      | itemType | file |
+      | search   | sharee1 |
+      | itemType | file    |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be
@@ -222,8 +222,8 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search with exact match not-exact casing group
     When user "test" gets the sharees using the API with parameters
-      | search | shareegroup2 |
-      | itemType | file |
+      | search   | shareegroup2 |
+      | itemType | file         |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
@@ -236,8 +236,8 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search with "self"
     When user "Sharee1" gets the sharees using the API with parameters
-      | search | Sharee1 |
-      | itemType | file |
+      | search   | Sharee1 |
+      | itemType | file    |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be
@@ -250,8 +250,8 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Remote sharee for files
     When user "test" gets the sharees using the API with parameters
-      | search | test@localhost |
-      | itemType | file |
+      | search   | test@localhost |
+      | itemType | file           |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
@@ -264,8 +264,8 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Remote sharee for calendars not allowed
     When user "test" gets the sharees using the API with parameters
-      | search | test@localhost |
-      | itemType | calendar |
+      | search   | test@localhost |
+      | itemType | calendar       |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
@@ -278,8 +278,8 @@ Feature: sharees_provisioningapiv2
   Scenario: Group sharees not returned when group sharing is disabled
     Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     When user "test" gets the sharees using the API with parameters
-      | search | sharee |
-      | itemType | file |
+      | search   | sharee |
+      | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty


### PR DESCRIPTION
## Description
Change the "integration" (=API) gherkin test steps to a new "standard" format.
Refactor the code behind to do what the steps say - adding new methods etc to handle the extra variations in possible step text.
Behat Gherkin is able to match any of multiple ``Given`` ``When`` annotations in the PHPdoc for a single method, so make use of that when there are different wordings for a step which have the same parameter order. 

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
Make the integration-API test steps have a consistent agreed style. Then we can move on to analysing the test coverage, effectiveness, merging in UI tests, renaming the "integration" folder to "acceptance" and so on...

## How Has This Been Tested?
CI passes

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (tests only)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
