### PR TITLE
No need to handle authentication that early aka in here at all

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -894,7 +894,6 @@ class OC {
 			} else {
 				// For guests: Load only filesystem and logging
 				OC_App::loadApps(['filesystem', 'logging']);
-				self::handleLogin($request);
 			}
 		}
 

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -353,8 +353,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$app->getServer()->getNavigationManager(),
 				$app->getServer()->getURLGenerator(),
 				$app->getServer()->getLogger(),
+				$app->getServer()->getUserSession(),
 				$c['AppName'],
-				$app->isLoggedIn(),
 				$app->isAdminUser(),
 				$app->getServer()->getContentSecurityPolicyManager()
 			);

--- a/lib/private/AppFramework/Utility/ControllerMethodReflector.php
+++ b/lib/private/AppFramework/Utility/ControllerMethodReflector.php
@@ -46,8 +46,9 @@ class ControllerMethodReflector implements IControllerMethodReflector{
 
 
 	/**
-	 * @param object $object an object or classname
+	 * @param object|string $object an object or classname
 	 * @param string $method the method which we want to inspect
+	 * @throws \ReflectionException
 	 */
 	public function reflect($object, $method){
 		$reflection = new \ReflectionMethod($object, $method);

--- a/lib/private/legacy/json.php
+++ b/lib/private/legacy/json.php
@@ -67,6 +67,12 @@ class OC_JSON{
 	 * @deprecated Use annotation based ACLs from the AppFramework instead
 	 */
 	public static function checkLoggedIn() {
+		static $loginCalled = false;
+		if (!$loginCalled && !OC_User::isLoggedIn()) {
+			\OC::handleLogin(\OC::$server->getRequest());
+			$loginCalled = true;
+		}
+
 		$twoFactorAuthManger = \OC::$server->getTwoFactorAuthManager();
 		if( !OC_User::isLoggedIn()
 			|| $twoFactorAuthManger->needsSecondFactor()) {


### PR DESCRIPTION
## Description
For an unauthenticated request there is no need to try to login implicitly in base.php

Login is done in the login controller.

## Related Issue
https://github.com/owncloud/core/pull/30398#issuecomment-363830803


## How Has This Been Tested?
- [x] manually browser
  - various apps load and seem to function properly: activity, files, calendar, contacts
- [x] desktop client with oauth
  - sync folder
  - auto completion of sharee
  - share

- [ ] ldap
- [ ] shib
- [x] mobile clients
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

