### PR TITLE
[stable10] Remove config value 'appstoreurl' - the appstore is long g…

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -724,26 +724,6 @@ $CONFIG = array(
 	'https://itunes.apple.com/us/app/owncloud/id543672169?mt=8',
 
 /**
- * Apps
- *
- * Options for the Apps folder, Apps store, and App code checker.
- */
-
-/**
- * The URL of the appstore to use.
- */
-'appstoreurl' => 'https://api.owncloud.com/v1',
-
-/**
- * Whether to show experimental apps in the appstore interface
- *
- * Experimental apps are not checked for security issues and are new or known
- * to be unstable and under heavy development. Installing these can cause data
- * loss or security breaches.
- */
-'appstore.experimental.enabled' => false,
-
-/**
  * Use the ``apps_paths`` parameter to set the location of the Apps directory,
  * which should be scanned for available apps, and where user-specific apps
  * should be installed from the Apps store. The ``path`` defines the absolute


### PR DESCRIPTION
…one - long live the marketplace

backport of #30400 
Fixes https://github.com/owncloud/core/issues/30397