### PR TITLE
[stable10] Check the return value of getUserSession before using it

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -35,6 +35,7 @@ namespace OC;
 use InterfaSys\LogNormalizer\Normalizer;
 
 use \OCP\ILogger;
+use OCP\IUserSession;
 use OCP\Util;
 
 /**
@@ -292,12 +293,15 @@ class Log implements ILogger {
 
 					// check for user
 					if (!empty($logCondition['users'])) {
-						$user = \OC::$server->getUserSession()->getUser();
+						$userSession = \OC::$server->getUserSession();
+						if ($userSession instanceof IUserSession) {
+							$user = $userSession->getUser();
 
-						// if the user matches set the log condition to satisfied
-						if ($user !== null && in_array($user->getUID(), $logCondition['users'], true)) {
-							$this->logConditionSatisfied = true;
-							break;
+							// if the user matches set the log condition to satisfied
+							if ($user !== null && in_array($user->getUID(), $logCondition['users'], true)) {
+								$this->logConditionSatisfied = true;
+								break;
+							}
 						}
 					}
 				}

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -41,6 +41,7 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IConfig;
 use OCP\IUserBackend;
+use OCP\IUserSession;
 use OCP\User\IChangePasswordBackend;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -331,11 +332,17 @@ class User implements IUser {
 	 * @return bool
 	 */
 	public function canChangeDisplayName() {
-		if (($this->config->getSystemValue('allow_user_to_change_display_name') === false) &&
-			(!$this->groupManager->isAdmin($this->userSession->getUser()->getUID())) &&
-			(!$this->groupManager->getSubAdmin()->isSubAdmin($this->userSession->getUser()))) {
-			return false;
+		if ($this->userSession instanceof IUserSession) {
+			$user = $this->userSession->getUser();
+			if (
+				($this->config->getSystemValue('allow_user_to_change_display_name') === false) &&
+				(($user !== null) && (!$this->groupManager->isAdmin($user->getUID()))) &&
+				(($user !== null) && (!$this->groupManager->getSubAdmin()->isSubAdmin($user)))
+			) {
+				return false;
+			}
 		}
+
 		$backend = $this->account->getBackendInstance();
 		if (is_null($backend)) {
 			return false;

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -10,6 +10,7 @@ namespace Test;
 
 use OC\Log;
 use OCP\IConfig;
+use OCP\IUserSession;
 use OCP\Util;
 
 class LoggerTest extends TestCase {
@@ -74,6 +75,27 @@ class LoggerTest extends TestCase {
 		$expected = [
 			'1 Show info messages of files app',
 		];
+		$this->assertEquals($expected, $this->getLogs());
+	}
+
+	public function testNullUserSession() {
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->expects($this->any())
+			->method('getUser')
+			->willReturn(null);
+		$this->config->expects($this->any())
+			->method('getValue')
+			->will(($this->returnValueMap([
+				['loglevel', Util::WARN, Util::WARN],
+				['log.conditions', [], [['users' => ['foo'], 'apps' => ['files'], 'logfile' => '/tmp/test.log']]]
+			])));
+		$logger = $this->logger;
+
+		$logger->warning('Don\'t display info messages');
+
+		$expected = [
+			'2 Don\'t display info messages',
+			];
 		$this->assertEquals($expected, $this->getLogs());
 	}
 

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -313,6 +313,45 @@ class UserTest extends TestCase {
 		$this->assertEquals($expected, $user->setDisplayName('Foo'));
 	}
 
+	public function provideNullorFalseData() {
+		return [
+			[null, null, false],
+			[null, true, false],
+			[null, true, true]
+		];
+	}
+
+	/**
+	 * @dataProvider provideNullorFalseData
+	 * @param $user
+	 * @param $backendinstance
+	 * @param $setDisplayName
+	 */
+	public function testCanChangeDisplayNameWhenNullSession($getUser, $backendinstance, $setDisplayName) {
+		$this->sessionUser->method('getUser')
+			->willReturn($getUser);
+		$backend = $this->getMockBuilder(Database::class)
+			->setMethods(['implementsActions'])
+			->getMock();
+
+		/** @var Account | \PHPUnit_Framework_MockObject_MockObject $account */
+		$account = $this->getMockBuilder(Account::class)
+			->setMethods(['getBackendInstance', 'getDisplayName', 'setDisplayName'])
+			->getMock();
+		if ($backendinstance !== null) {
+			$backendinstance = $backend;
+		}
+		$account->expects($this->any())->method('getBackendInstance')->willReturn($backendinstance);
+		$account->expects($this->any())->method('getDisplayName')->willReturn('admin');
+		$account->expects($this->any())->method('setDisplayName')->willReturn($setDisplayName);
+		$user = new User($account, $this->accountMapper, null, $this->config, null, null, $this->groupManager, null);
+		if ($setDisplayName !== true) {
+			$this->assertEquals($setDisplayName, $user->canChangeDisplayName());
+		} else {
+			$this->assertEquals(null, $user->canChangeDisplayName());
+		}
+	}
+
 	/**
 	 * don't allow display names containing whitespaces only
 	 */


### PR DESCRIPTION
Checking if the value returned by getUserSession
and getUser is null or not before using it.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
There were situations where userSession was directly calling getUser which returned null and the return value was never checked. Another case was getUserSession was returning null. Hence getUser was called on null. This caused breaking the code flow under certain conditions. This change is to fix the assumptions made.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/30335
https://github.com/owncloud/core/issues/30416

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

