### PR TITLE
skip moving test on Firefox

### DIFF
--- a/tests/ui/features/moveFilesFolders/moveFiles.feature
+++ b/tests/ui/features/moveFilesFolders/moveFiles.feature
@@ -32,6 +32,7 @@ So that I can organise my data structure
 			|Could not move "data.zip", target exists|
 		And the file "data.zip" should be listed
 
+	@skipOnFIREFOX47+
 	Scenario: move a file into a folder where a file with the same name already exists
 		When I move the file "strängé filename (duplicate #2 &).txt" into the folder "strängé नेपाली folder"
 		Then notifications should be displayed with the text


### PR DESCRIPTION
skip a test that is known to fail in Firefox

no backport needed as its included in #30436
