### PR TITLE
[WIP] Try to avoid filed lock issues in UI tests

### DIFF
--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -456,6 +456,12 @@ trait BasicStructure {
 		}
 
 		foreach ($this->getCreatedGroupNames() as $group) {
+			// Tests can complete so quickly that there is still some background
+			// server activity for a user(s). Deleting the user too quickly
+			// sometimes leaves file locks behind that cause problems for the
+			// next scenario.
+			// First try a really long wait (hack) to see if this helps.
+			sleep(5);
 			$result = UserHelper::deleteGroup(
 				$baseUrl,
 				$group,


### PR DESCRIPTION
Sometimes at the end of a scenario a file is left "locked" for a user that is now deleted. That causes failures in the next scenario. See what we can do about that.

First hack, just to see if it helps - sleep 5 before deleting users.
