### PR TITLE
Catch if parent row exists when we try to add it

### DIFF
--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -127,7 +127,10 @@ class Repair implements IOutput{
 	public static function getRepairSteps() {
 		return [
 			new RepairMimeTypes(\OC::$server->getConfig()),
-			new RepairMismatchFileCachePath(\OC::$server->getDatabaseConnection(), \OC::$server->getMimeTypeLoader()),
+			new RepairMismatchFileCachePath(
+				\OC::$server->getDatabaseConnection(),
+				\OC::$server->getMimeTypeLoader(),
+				\OC::$server->getLogger()),
 			new FillETags(\OC::$server->getDatabaseConnection()),
 			new CleanTags(\OC::$server->getDatabaseConnection(), \OC::$server->getUserManager()),
 			new DropOldTables(\OC::$server->getDatabaseConnection()),

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -8,12 +8,12 @@
 
 namespace Test\Repair;
 
-
 use OC\Repair\RepairMismatchFileCachePath;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Test\TestCase;
+use OCP\ILogger;
 
 /**
  * Tests for repairing mismatch file cache paths
@@ -41,7 +41,10 @@ class RepairMismatchFileCachePathTest extends TestCase {
 				['httpd', 1],
 				['httpd/unix-directory', 2],
 			]));
-		$this->repair = new RepairMismatchFileCachePath($this->connection, $mimeLoader);
+
+		/** @var \PHPUnit_Framework_MockObject_MockObject | ILogger $logger */
+		$logger = $this->createMock(ILogger::class);
+		$this->repair = new RepairMismatchFileCachePath($this->connection, $mimeLoader, $logger);
 		$this->repair->setCountOnly(false);
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Sometimes the row that we are trying to insert (in order to use metadata where present) already exists which throws an exception and this cancels the whole repair operation. Instead it is safe to skip this.

## Motivation and Context
Running repair step and getting an exception that the row already exists which stops the repair step.

## How Has This Been Tested?
Manual repair run and unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

