### PR TITLE
Minimize scenario settings calls

### DIFF
--- a/apps/testing/appinfo/routes.php
+++ b/apps/testing/appinfo/routes.php
@@ -48,6 +48,22 @@ API::register(
 	API::ADMIN_AUTH
 );
 
+API::register(
+	'post',
+	'/apps/testing/api/v1/apps',
+	[$config, 'setAppValues'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+API::register(
+	'delete',
+	'/apps/testing/api/v1/apps',
+	[$config, 'deleteAppValues'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
 $locking = new Provisioning(
 	\OC::$server->getLockingProvider(),
 	\OC::$server->getDatabaseConnection(),

--- a/apps/testing/lib/Config.php
+++ b/apps/testing/lib/Config.php
@@ -67,4 +67,44 @@ class Config {
 
 		return new \OC_OCS_Result();
 	}
+
+	/**
+	 * @return \OC_OCS_Result
+	 */
+	public function setAppValues() {
+		$values = $this->request->getParam('values');
+
+		if (is_array($values)) {
+			foreach ($values as $appEntry) {
+				if (is_array($appEntry)) {
+					$this->config->setAppValue(
+						$appEntry['appid'],
+						$appEntry['configkey'],
+						$appEntry['value']);
+				}
+			}
+		}
+
+		return new \OC_OCS_Result();
+	}
+
+	/**
+	 * @return \OC_OCS_Result
+	 */
+	public function deleteAppValues() {
+		$values = $this->request->getParam('values');
+
+		if (is_array($values)) {
+			foreach ($values as $appEntry) {
+				if (is_array($appEntry)) {
+					$this->config->deleteAppValue(
+						$appEntry['appid'],
+						$appEntry['configkey']
+					);
+				}
+			}
+		}
+
+		return new \OC_OCS_Result();
+	}
 }

--- a/tests/integration/features/bootstrap/CapabilitiesContext.php
+++ b/tests/integration/features/bootstrap/CapabilitiesContext.php
@@ -64,49 +64,56 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 		$this->getCapabilitiesCheckResponse();
 		$this->savedCapabilitiesXml = $this->getCapabilitiesXml();
 		// Set the required starting values for testing
-		$this->setupCommonSharingConfigs();
-		$this->setupCommonFederationConfigs();
-		$this->setCapability(
-			'files_sharing',
-			'resharing',
-			'core',
-			'shareapi_allow_resharing',
-			true
+		$capabilitiesArray = $this->getCommonSharingConfigs();
+		$capabilitiesArray = array_merge($capabilitiesArray, $this->getCommonFederationConfigs());
+		$capabilitiesArray = array_merge(
+			$capabilitiesArray,
+			[
+				[
+					'capabilitiesApp' => 'files_sharing',
+					'capabilitiesParameter' => 'resharing',
+					'testingApp' => 'core',
+					'testingParameter' => 'shareapi_allow_resharing',
+					'testingState' => true
+				],
+				[
+					'capabilitiesApp' => 'files_sharing',
+					'capabilitiesParameter' => 'public@@@password@@@enforced',
+					'testingApp' => 'core',
+					'testingParameter' => 'shareapi_enforce_links_password',
+					'testingState' => false
+				],
+				[
+					'capabilitiesApp' => 'files_sharing',
+					'capabilitiesParameter' => 'public@@@send_mail',
+					'testingApp' => 'core',
+					'testingParameter' => 'shareapi_allow_public_notification',
+					'testingState' => false
+				],
+				[
+					'capabilitiesApp' => 'files_sharing',
+					'capabilitiesParameter' => 'public@@@social_share',
+					'testingApp' => 'core',
+					'testingParameter' => 'shareapi_allow_social_share',
+					'testingState' => true
+				],
+				[
+					'capabilitiesApp' => 'files_sharing',
+					'capabilitiesParameter' => 'public@@@expire_date@@@enabled',
+					'testingApp' => 'core',
+					'testingParameter' => 'shareapi_default_expire_date',
+					'testingState' => false
+				],
+				[
+					'capabilitiesApp' => 'files_sharing',
+					'capabilitiesParameter' => 'public@@@expire_date@@@enforced',
+					'testingApp' => 'core',
+					'testingParameter' => 'shareapi_enforce_expire_date',
+					'testingState' => false
+				]
+			]
 		);
-		$this->setCapability(
-			'files_sharing',
-			'public@@@password@@@enforced',
-			'core',
-			'shareapi_enforce_links_password',
-			false
-		);
-		$this->setCapability(
-			'files_sharing',
-			'public@@@send_mail',
-			'core',
-			'shareapi_allow_public_notification',
-			false
-		);
-		$this->setCapability(
-			'files_sharing',
-			'public@@@social_share',
-			'core',
-			'shareapi_allow_social_share',
-			true
-		);
-		$this->setCapability(
-			'files_sharing',
-			'public@@@expire_date@@@enabled',
-			'core',
-			'shareapi_default_expire_date',
-			false
-		);
-		$this->setCapability(
-			'files_sharing',
-			'public@@@expire_date@@@enforced',
-			'core',
-			'shareapi_enforce_expire_date',
-			false
-		);
+
+		$this->setCapabilities($capabilitiesArray);
 	}
 }

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -39,6 +39,6 @@ class FeatureContext extends \rdx\behatvars\BehatVariablesContext {
 		$this->getCapabilitiesCheckResponse();
 		$this->savedCapabilitiesXml = $this->getCapabilitiesXml();
 		// Set the required starting values for testing
-		$this->setupCommonSharingConfigs();
+		$this->setCapabilities($this->getCommonSharingConfigs());
 	}
 }

--- a/tests/integration/features/bootstrap/FederationContext.php
+++ b/tests/integration/features/bootstrap/FederationContext.php
@@ -44,14 +44,21 @@ class FederationContext implements Context, SnippetAcceptingContext {
 		$this->getCapabilitiesCheckResponse();
 		$this->savedCapabilitiesXml = $this->getCapabilitiesXml();
 		// Set the required starting values for testing
-		$this->setupCommonSharingConfigs();
-		$this->setupCommonFederationConfigs();
-		$this->setCapability(
-			'files_sharing',
-			'resharing',
-			'core',
-			'shareapi_allow_resharing',
-			true
+		$capabilitiesArray = $this->getCommonSharingConfigs();
+		$capabilitiesArray = array_merge($capabilitiesArray, $this->getCommonFederationConfigs());
+		$capabilitiesArray = array_merge(
+			$capabilitiesArray,
+			[
+				[
+					'capabilitiesApp' => 'files_sharing',
+					'capabilitiesParameter' => 'resharing',
+					'testingApp' => 'core',
+					'testingParameter' => 'shareapi_allow_resharing',
+					'testingState' => true
+				]
+			]
 		);
+
+		$this->setCapabilities($capabilitiesArray);
 	}
 }

--- a/tests/integration/features/bootstrap/ShareesContext.php
+++ b/tests/integration/features/bootstrap/ShareesContext.php
@@ -121,7 +121,8 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 		$this->getCapabilitiesCheckResponse();
 		$this->savedCapabilitiesXml = $this->getCapabilitiesXml();
 		// Set the required starting values for testing
-		$this->setupCommonSharingConfigs();
-		$this->setupCommonFederationConfigs();
+		$capabilitiesArray = $this->getCommonSharingConfigs();
+		$capabilitiesArray = array_merge($capabilitiesArray, $this->getCommonFederationConfigs());
+		$this->setCapabilities($capabilitiesArray);
 	}
 }

--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -926,84 +926,88 @@ trait Sharing {
 	}
 
 	/**
-	 * @return void
+	 * @return array of common sharing capability settings for testing
 	 */
-	protected function setupCommonSharingConfigs() {
-		$this->setCapability(
-			'files_sharing',
-			'api_enabled',
-			'core',
-			'shareapi_enabled',
-			true
-		);
-		$this->setCapability(
-			'files_sharing',
-			'public@@@enabled',
-			'core',
-			'shareapi_allow_links',
-			true
-		);
-		$this->setCapability(
-			'files_sharing',
-			'public@@@upload',
-			'core',
-			'shareapi_allow_public_upload',
-			true
-		);
-		$this->setCapability(
-			'files_sharing',
-			'group_sharing',
-			'core',
-			'shareapi_allow_group_sharing',
-			true
-		);
-		$this->setCapability(
-			'files_sharing',
-			'share_with_group_members_only',
-			'core',
-			'shareapi_only_share_with_group_members',
-			false
-		);
-		$this->setCapability(
-			'files_sharing',
-			'share_with_membership_groups_only',
-			'core',
-			'shareapi_only_share_with_membership_groups',
-			false
-		);
-		$this->setCapability(
-			'files_sharing',
-			'user_enumeration@@@enabled',
-			'core',
-			'shareapi_allow_share_dialog_user_enumeration',
-			true
-		);
-		$this->setCapability(
-			'files_sharing',
-			'user_enumeration@@@group_members_only',
-			'core',
-			'shareapi_share_dialog_user_enumeration_group_members',
-			false
-		);
+	protected function getCommonSharingConfigs() {
+		return [
+			[
+				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'api_enabled',
+				'testingApp' => 'core',
+				'testingParameter' => 'shareapi_enabled',
+				'testingState' => true
+			],
+			[
+				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'public@@@enabled',
+				'testingApp' => 'core',
+				'testingParameter' => 'shareapi_allow_links',
+				'testingState' => true
+			],
+			[
+				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'public@@@upload',
+				'testingApp' => 'core',
+				'testingParameter' => 'shareapi_allow_public_upload',
+				'testingState' => true
+			],
+			[
+				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'group_sharing',
+				'testingApp' => 'core',
+				'testingParameter' => 'shareapi_allow_group_sharing',
+				'testingState' => true
+			],
+			[
+				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'share_with_group_members_only',
+				'testingApp' => 'core',
+				'testingParameter' => 'shareapi_only_share_with_group_members',
+				'testingState' => false
+			],
+			[
+				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'share_with_membership_groups_only',
+				'testingApp' => 'core',
+				'testingParameter' => 'shareapi_only_share_with_membership_groups',
+				'testingState' => false
+			],
+			[
+				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'user_enumeration@@@enabled',
+				'testingApp' => 'core',
+				'testingParameter' => 'shareapi_allow_share_dialog_user_enumeration',
+				'testingState' => true
+			],
+			[
+				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'user_enumeration@@@group_members_only',
+				'testingApp' => 'core',
+				'testingParameter' => 'shareapi_share_dialog_user_enumeration_group_members',
+				'testingState' => false
+			],
+		];
 	}
 
 	/**
-	 * @return void
+	 * @return array of common federation capability settings for testing
 	 */
-	protected function setupCommonFederationConfigs() {
-		$this->setCapability(
-			'federation',
-			'outgoing',
-			'files_sharing',
-			'outgoing_server2server_share_enabled',
-			true
-		);
-		$this->setCapability(
-			'federation',
-			'incoming',
-			'files_sharing',
-			'incoming_server2server_share_enabled',
-			true
-		);
+	protected function getCommonFederationConfigs() {
+		return [
+			[
+				'capabilitiesApp' => 'federation',
+				'capabilitiesParameter' => 'outgoing',
+				'testingApp' => 'files_sharing',
+				'testingParameter' => 'outgoing_server2server_share_enabled',
+				'testingState' => true
+			],
+			[
+				'capabilitiesApp' => 'federation',
+				'capabilitiesParameter' => 'incoming',
+				'testingApp' => 'files_sharing',
+				'testingParameter' => 'incoming_server2server_share_enabled',
+				'testingState' => true
+			],
+		];
 	}
 }

--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -471,9 +471,9 @@ class FeatureContext extends RawMinkContext implements Context {
 				$this->getMinkParameter('base_url'),
 				"admin",
 				$this->getUserPassword("admin"),
-				$capabilitiesChange['testingApp'],
-				$capabilitiesChange['testingParameter'],
-				$capabilitiesChange['savedState'] ? 'yes' : 'no'
+				$capabilitiesChange['appid'],
+				$capabilitiesChange['configkey'],
+				$capabilitiesChange['value']
 			);
 		}
 		


### PR DESCRIPTION
## Description
Accumulate all the desired "default" settings into an array of settings to be made, then send them all in 1 testing app request.
Make a new ``apps`` endpoint to the testing app that takes a ``post`` with the value being any array of all the ``appid``, ``configkey``, ``value`` settings that are required. Have the code behind that endpoint loop through the array and make the settings.

## Related Issue

## Motivation and Context
There are many (about 10) calls made to the testing app to set each of the required "default" settings for sharing, federation etc. These happen before each and every scenario. Any settings that were changed are also reverted at the end of the scenario. This all takes significant time.

Make a way to call the testing app and pass it all the required settings in 1 go - that will run much faster because a lot of the overhead is in all the multiple call overhead.

## How Has This Been Tested?
Local runs while developing. CI passes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Ref: https://github.com/owncloud/QA/issues/533