### PR TITLE
Minimize scenario settings calls in UI tests

### DIFF
--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -388,15 +388,17 @@ class FeatureContext extends RawMinkContext implements Context {
 	 * 
 	 * @param array $change
 	 *        [
-	 *         'testingApp' => string,
-	 *         'testingParameter' => string,
-	 *         'savedState' => bool
+	 *         'appid' => string,
+	 *         'configkey' => string,
+	 *         'value' => bool
 	 *        ]
 	 * @return void
 	 */
 	public function addToSavedCapabilitiesChanges($change) {
 		if (sizeof($change) > 0) {
-			$this->savedCapabilitiesChanges[] = $change;
+			$this->savedCapabilitiesChanges = array_merge(
+				$this->savedCapabilitiesChanges, $change
+			);
 		}
 	}
 
@@ -466,17 +468,13 @@ class FeatureContext extends RawMinkContext implements Context {
 	 * @AfterScenario
 	 */
 	public function tearDownSuite() {
-		foreach ($this->savedCapabilitiesChanges as $capabilitiesChange) {
-			AppConfigHelper::modifyServerConfig(
-				$this->getMinkParameter('base_url'),
-				"admin",
-				$this->getUserPassword("admin"),
-				$capabilitiesChange['appid'],
-				$capabilitiesChange['configkey'],
-				$capabilitiesChange['value']
-			);
-		}
-		
+		AppConfigHelper::modifyServerConfigs(
+			$this->getMinkParameter('base_url'),
+			"admin",
+			$this->getUserPassword("admin"),
+			$this->savedCapabilitiesChanges
+		);
+
 		if ($this->oldCSRFSetting === "") {
 			SetupHelper::runOcc(['config:system:delete', 'csrf.disabled']);
 		} elseif (!is_null($this->oldCSRFSetting)) {

--- a/tests/ui/features/bootstrap/SharingContext.php
+++ b/tests/ui/features/bootstrap/SharingContext.php
@@ -565,20 +565,14 @@ class SharingContext extends RawMinkContext implements Context {
 			]
 		];
 
-		foreach ($settings as $setting) {
-			$change = AppConfigHelper::setCapability(
-				$this->getMinkParameter('base_url'),
-				"admin",
-				$this->featureContext->getUserPassword("admin"),
-				$setting['capabilitiesApp'],
-				$setting['capabilitiesParameter'],
-				$setting['testingApp'],
-				$setting['testingParameter'],
-				$setting['testingState'],
-				$this->featureContext->getSavedCapabilitiesXml()
-			);
-			$this->featureContext->addToSavedCapabilitiesChanges($change);
-		}
+		$change = AppConfigHelper::setCapabilities(
+			$this->getMinkParameter('base_url'),
+			"admin",
+			$this->featureContext->getUserPassword("admin"),
+			$settings,
+			$this->featureContext->getSavedCapabilitiesXml()
+		);
+		$this->featureContext->addToSavedCapabilitiesChanges($change);
 	}
 
 }


### PR DESCRIPTION
## Description
Use the new testing app endpoints that can accept an array of settings to change all in 1 go.

## Related Issue
https://github.com/owncloud/QA/issues/533

## Motivation and Context
Improve the way settings are established for each scenario when running UI tests.
Make use of what was done for the API tests in PR #30453 

## How Has This Been Tested?
Local run of a sharing scenario and observe just a single call to the testing app endpoint at scednario setup and teardown.
CI will run the whole suite of tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

