### PR TITLE
Address a few code inspections

### DIFF
--- a/console.php
+++ b/console.php
@@ -50,13 +50,13 @@ if (version_compare(PHP_VERSION, '7.3.0alpha1') !== -1) {
 
 // running oC on Windows is unsupported since 8.1, this has to happen here because
 // is seems that the autoloader on Windows fails later and just throws an exception.
-if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+if (stripos(PHP_OS, 'WIN') === 0) {
 	echo 'ownCloud Server does not support Microsoft Windows.';
 	return;
 }
 
 function exceptionHandler($exception) {
-	echo "An unhandled exception has been thrown:" . PHP_EOL;
+	echo 'An unhandled exception has been thrown:' . PHP_EOL;
 	echo $exception;
 	exit(1);
 }
@@ -67,38 +67,38 @@ try {
 	set_time_limit(0);
 
 	if (!OC::$CLI) {
-		echo "This script can be run from the command line only" . PHP_EOL;
+		echo 'This script can be run from the command line only' . PHP_EOL;
 		exit(1);
 	}
 
 	set_exception_handler('exceptionHandler');
 
 	if (!function_exists('posix_getuid')) {
-		echo "The posix extensions are required - see http://php.net/manual/en/book.posix.php" . PHP_EOL;
+		echo 'The posix extensions are required - see http://php.net/manual/en/book.posix.php' . PHP_EOL;
 		exit(1);
 	}
 	$user = posix_getpwuid(posix_getuid());
 	$configUser = posix_getpwuid(fileowner(OC::$configDir . 'config.php'));
 	if ($user['name'] !== $configUser['name']) {
-		echo "Console has to be executed with the user that owns the file config/config.php" . PHP_EOL;
-		echo "Current user: " . $user['name'] . PHP_EOL;
-		echo "Owner of config.php: " . $configUser['name'] . PHP_EOL;
-		echo "Try adding 'sudo -u " . $configUser['name'] . " ' to the beginning of the command (without the single quotes)" . PHP_EOL;
+		echo 'Console has to be executed with the user that owns the file config/config.php' . PHP_EOL;
+		echo "Current user: {$user['name']}" . PHP_EOL;
+		echo "Owner of config.php: {$configUser['name']}" . PHP_EOL;
+		echo "Try adding 'sudo -u {$configUser['name']}' to the beginning of the command (without the single quotes)" . PHP_EOL;
 		exit(1);
 	}
 
 	$oldWorkingDir = getcwd();
 	if ($oldWorkingDir === false) {
-		echo "This script can be run from the ownCloud root directory only." . PHP_EOL;
-		echo "Can't determine current working dir - the script will continue to work but be aware of the above fact." . PHP_EOL;
+		echo 'This script can be run from the ownCloud root directory only.' . PHP_EOL;
+		echo 'Can\'t determine current working dir - the script will continue to work but be aware of the above fact.' . PHP_EOL;
 	} else if ($oldWorkingDir !== __DIR__ && !chdir(__DIR__)) {
-		echo "This script can be run from the ownCloud root directory only." . PHP_EOL;
-		echo "Can't change to ownCloud root directory." . PHP_EOL;
+		echo 'This script can be run from the ownCloud root directory only.' . PHP_EOL;
+		echo 'Can\'t change to ownCloud root directory.' . PHP_EOL;
 		exit(1);
 	}
 
-	if (!function_exists('pcntl_signal') && !in_array('--no-warnings', $argv)) {
-		echo "The process control (PCNTL) extensions are required in case you want to interrupt long running commands - see http://php.net/manual/en/book.pcntl.php" . PHP_EOL;
+	if (!function_exists('pcntl_signal') && !in_array('--no-warnings', $argv, true)) {
+		echo 'The process control (PCNTL) extensions are required in case you want to interrupt long running commands - see http://php.net/manual/en/book.pcntl.php' . PHP_EOL;
 	}
 
 	$application = new Application(\OC::$server->getConfig(), \OC::$server->getEventDispatcher(), \OC::$server->getRequest());

--- a/index.php
+++ b/index.php
@@ -44,7 +44,7 @@ if (version_compare(PHP_VERSION, '7.3.0alpha1') !== -1) {
 
 // running oC on Windows is unsupported since 8.1, this has to happen here because
 // is seems that the autoloader on Windows fails later and just throws an exception.
-if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+if (stripos(PHP_OS, 'WIN') === 0) {
 	echo 'ownCloud Server does not support Microsoft Windows.';
 	return;
 }
@@ -80,7 +80,7 @@ try {
 		// with some env issues, it can happen that the logger couldn't log properly,
 		// so print out the exception directly
 		echo('<html><body>');
-		echo('Exception occurred while logging exception: ' . $ex->getMessage() . '<br/>');
+		echo("Exception occurred while logging exception: {$ex->getMessage()}<br/>");
 		echo(str_replace("\n", '<br/>', $ex->getTraceAsString()));
 		echo('</body></html>');
 	}

--- a/public.php
+++ b/public.php
@@ -50,14 +50,18 @@ try {
 			OC::$server->getRequest()
 		));
 		exit;
-	} elseif ($request->getParam('service', '')) {
+	}
+
+	if ($request->getParam('service', '')) {
 		$service = $request->getParam('service', '');
 	} else {
 		$pathInfo = trim($pathInfo, '/');
 		list($service) = explode('/', $pathInfo);
 	}
-	$file = OCP\Config::getAppValue('core', 'public_' . strip_tags($service));
-	if (is_null($file)) {
+	$service = strip_tags($service);
+
+	$file = OC::$server->getConfig()->getAppValue('core', "public_$service");
+	if ($file === null) {
 		header('HTTP/1.0 404 Not Found');
 		$dispatcher = \OC::$server->getEventDispatcher();
 		$dispatcher->dispatch(\OCP\Http\HttpEvents::EVENT_404, new OCP\Http\HttpEvents(
@@ -81,9 +85,8 @@ try {
 	OC_App::loadApp($app);
 	OC_User::setIncognitoMode(true);
 
-	$baseuri = OC::$WEBROOT . '/public.php/' . $service . '/';
-
-	require_once OC_App::getAppPath($app) . '/' . $parts[1];
+	$baseuri = OC::$WEBROOT . "/public.php/$service/";
+	require_once OC_App::getAppPath($app) . "/$parts[1]";
 
 } catch (Exception $ex) {
 	if ($ex instanceof \OC\ServiceUnavailableException) {

--- a/remote.php
+++ b/remote.php
@@ -103,7 +103,7 @@ function resolveService($service) {
 		return $services[$service];
 	}
 
-	return \OC::$server->getConfig()->getAppValue('core', 'remote_' . $service);
+	return \OC::$server->getConfig()->getAppValue('core', "remote_$service");
 }
 
 try {
@@ -137,7 +137,7 @@ try {
 
 	$file = resolveService($service);
 
-	if(is_null($file)) {
+	if($file === null) {
 		$dispatcher = \OC::$server->getEventDispatcher();
 		$dispatcher->dispatch(\OCP\Http\HttpEvents::EVENT_404, new OCP\Http\HttpEvents(
 			\OCP\Http\HttpEvents::EVENT_404,
@@ -159,19 +159,17 @@ try {
 	OC_App::loadApps(['authentication']);
 	OC_App::loadApps(['filesystem', 'logging']);
 
-	switch ($app) {
-		case 'core':
-			$file =  OC::$SERVERROOT .'/'. $file;
-			break;
-		default:
-			if (!\OC::$server->getAppManager()->isInstalled($app)) {
-				throw new RemoteException('App not installed: ' . $app);
-			}
-			OC_App::loadApp($app);
-			$file = OC_App::getAppPath($app) .'/'. $parts[1];
-			break;
+	if ($app === 'core') {
+		$file = OC::$SERVERROOT . "/$file";
+	} else {
+		if (!\OC::$server->getAppManager()->isInstalled($app)) {
+			throw new RemoteException("App not installed: $app");
+		}
+		OC_App::loadApp($app);
+		$file = OC_App::getAppPath($app) . "/$parts[1]";
 	}
-	$baseuri = OC::$WEBROOT . '/remote.php/'.$service.'/';
+
+	$baseuri = OC::$WEBROOT . "/remote.php/$service/";
 	require_once $file;
 
 } catch (Exception $ex) {

--- a/status.php
+++ b/status.php
@@ -35,7 +35,7 @@ try {
 	require_once __DIR__ . '/lib/base.php';
 
 	# show the version details based on config.php parameter, 
-	# but do not expose the servername in the public via url
+	# but do not expose the server name in the public via url
 	$values = \OCP\Util::getStatusInfo(
 		null,
 		\OC::$server->getConfig()->getSystemValue('show_server_hostname', false) !== true);


### PR DESCRIPTION
Only for php files in the root folder ... I initially also addressed `'Exception', superclass of exception class 'Error', has already been caught` but it turns out that seems to be a false positive in the PHPStorm Inspectien triggered by the Error Polyfill from Paragonie random_compat or Symphony. Double checked with

```php
try {
	throw new Error();
} catch (Exception $e) {
	echo 'caught Exception';
} catch (Error $e) {
	echo 'caught Error';
}
// gives 'caught Error'
```

@DeepDiver1975 @PVince81 Should we return 500 Status for the JSON responses in cron.php? In theory yes. The old code didn't. It uses the borked oc json error in payload ... I added a TODO because I think we should change it (but not as part of this PR).