### PR TITLE
[Stable10] Fix path resolution for appdirs above ocwebroot

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -523,7 +523,12 @@ class AppManager implements IAppManager {
 	 */
 	public function getAppWebPath($appId) {
 		if (($appRoot = $this->findAppInDirectories($appId)) !== false) {
-			return \OC::$WEBROOT . $appRoot['url'];
+			$ocWebRoot = \OC::$WEBROOT;
+			while (strpos($appRoot['url'], '..') === 0) {
+				$appRoot['url'] = substr($appRoot['url'],3);
+				$ocWebRoot = dirname($ocWebRoot);
+			}
+			return $ocWebRoot . '/' . $appRoot['url'];
 		}
 		return false;
 	}

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -523,12 +523,14 @@ class AppManager implements IAppManager {
 	 */
 	public function getAppWebPath($appId) {
 		if (($appRoot = $this->findAppInDirectories($appId)) !== false) {
-			$ocWebRoot = \OC::$WEBROOT;
-			while (strpos($appRoot['url'], '..') === 0) {
-				$appRoot['url'] = substr($appRoot['url'],3);
+			$ocWebRoot = $this->getOcWebRoot();
+			// consider all relative ../ in the app web path as an adjustment
+			// for oC web root
+			while (strpos($appRoot['url'], '../') === 0) {
+				$appRoot['url'] = substr($appRoot['url'], 3);
 				$ocWebRoot = dirname($ocWebRoot);
 			}
-			return $ocWebRoot . '/' . $appRoot['url'];
+			return $ocWebRoot . '/' . ltrim($appRoot['url'], '/');
 		}
 		return false;
 	}
@@ -582,6 +584,15 @@ class AppManager implements IAppManager {
 	 */
 	protected function saveAppPath($appId, $appData) {
 		$this->appDirs[$appId] = $appData;
+	}
+
+	/**
+	 * Get OC web root
+	 * Wrapper for easy mocking
+	 * @return string
+	 */
+	protected function getOcWebRoot() {
+		return \OC::$WEBROOT;
 	}
 
 	/**

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -372,7 +372,7 @@ class Factory implements IFactory {
 	protected function getActiveAppThemeDirectory() {
 		$theme = $this->themeService->getTheme();
 		if ($theme instanceof ITheme && $theme->getDirectory() !== '' ) {
-			return $this->serverRoot . '/' . $theme->getDirectory();
+			return $theme->getBaseDirectory(). '/' . $theme->getDirectory();
 		}
 		return '';
 	}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -847,7 +847,10 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 		});
 
 		$this->registerService('ThemeService', function ($c) {
-			return new ThemeService($this->getSystemConfig()->getValue('theme'));
+			return new ThemeService(
+				$this->getSystemConfig()->getValue('theme'),
+				\OC::$SERVERROOT
+			);
 		});
 		$this->registerAlias('OCP\Theme\IThemeService', 'ThemeService');
 		$this->registerAlias('OCP\IUserSession', 'UserSession');

--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -77,19 +77,14 @@ class Base {
 	/**
 	 * @param ITheme $theme
 	 * @param string $app
-	 * @param string $serverRoot
 	 * @param string|false $appDir
 	 * @return string[]
 	 */
-	protected function getAppTemplateDirs(ITheme $theme, $app, $serverRoot, $appDir) {
+	protected function getAppTemplateDirs(ITheme $theme, $app, $appDir) {
 		$templateDirectories = [];
 		// Templates dir from the active theme first
 		if ($theme->getDirectory() !== '') {
-			$baseDirectory = $theme->getBaseDirectory();
-			if ($baseDirectory === ''){
-				$baseDirectory = $serverRoot;
-			}
-			$templateDirectories[] = $baseDirectory . '/' . $theme->getDirectory() . '/apps/' . $app . '/templates/';
+			$templateDirectories[] = $theme->getBaseDirectory() . '/' . $theme->getDirectory() . '/apps/' . $app . '/templates/';
 		}
 
 		// Templates dir from the app dir then
@@ -130,13 +125,9 @@ class Base {
 	protected function getTemplateDirs(ITheme $theme, $basePath, $relativePath) {
 		$directories = [];
 		if ($theme->getDirectory() !== '') {
-			$baseDirectory = $theme->getBaseDirectory();
-			if ($baseDirectory === ''){
-				$baseDirectory = $basePath;
-			}
-			$directories[] =  $baseDirectory . '/' . $theme->getDirectory() . $relativePath;
+			$directories[] = $theme->getBaseDirectory() . '/' . $theme->getDirectory() . $relativePath;
 		}
-		$directories[] =  $basePath . $relativePath;
+		$directories[] = $basePath . $relativePath;
 
 		return $directories;
 	}

--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -85,7 +85,11 @@ class Base {
 		$templateDirectories = [];
 		// Templates dir from the active theme first
 		if ($theme->getDirectory() !== '') {
-			$templateDirectories[] = $serverRoot . '/' . $theme->getDirectory() . '/apps/' . $app . '/templates/';
+			$baseDirectory = $theme->getBaseDirectory();
+			if ($baseDirectory === ''){
+				$baseDirectory = $serverRoot;
+			}
+			$templateDirectories[] = $baseDirectory . '/' . $theme->getDirectory() . '/apps/' . $app . '/templates/';
 		}
 
 		// Templates dir from the app dir then
@@ -126,7 +130,11 @@ class Base {
 	protected function getTemplateDirs(ITheme $theme, $basePath, $relativePath) {
 		$directories = [];
 		if ($theme->getDirectory() !== '') {
-			$directories[] =  $basePath . '/' . $theme->getDirectory() . $relativePath;
+			$baseDirectory = $theme->getBaseDirectory();
+			if ($baseDirectory === ''){
+				$baseDirectory = $basePath;
+			}
+			$directories[] =  $baseDirectory . '/' . $theme->getDirectory() . $relativePath;
 		}
 		$directories[] =  $basePath . $relativePath;
 

--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -51,17 +51,24 @@ class CSSResourceLocator extends ResourceLocator {
 	 * @param string $style
 	 */
 	public function doFindTheme($style) {
+		$fullStyle = $style . '.css';
 		$themeDirectory = $this->theme->getDirectory();
 		$baseDirectory = $this->theme->getBaseDirectory();
-		$webroot = null;
-		if ($baseDirectory === '') {
-			$baseDirectory = $this->serverroot;
-		} else {
-			$webroot = rtrim($this->theme->getWebPath(), $themeDirectory);
+		$webRoot = '';
+		if ($baseDirectory !== $this->serverroot) {
+			$webRoot = substr($this->theme->getWebPath(), 0, -strlen($themeDirectory));
 		}
 
-		$this->appendOnceIfExist($baseDirectory, $themeDirectory . '/apps/' . $style . '.css', $webroot)
-			|| $this->appendOnceIfExist($baseDirectory, $themeDirectory . '/' . $style . '.css', $webroot)
-			|| $this->appendOnceIfExist($baseDirectory, $themeDirectory . '/core/' . $style . '.css', $webroot);
+		$searchLocations = [
+			$this->buildPath([$themeDirectory, '/apps', $fullStyle]),
+			$this->buildPath([$themeDirectory, $fullStyle]),
+			$this->buildPath([$themeDirectory, '/core', $fullStyle]),
+		];
+
+		foreach ($searchLocations as $location) {
+			if ($this->appendOnceIfExist($baseDirectory, $location, $webRoot)) {
+				break;
+			}
+		}
 	}
 }

--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -52,9 +52,16 @@ class CSSResourceLocator extends ResourceLocator {
 	 */
 	public function doFindTheme($style) {
 		$themeDirectory = $this->theme->getDirectory();
+		$baseDirectory = $this->theme->getBaseDirectory();
+		$webroot = null;
+		if ($baseDirectory === '') {
+			$baseDirectory = $this->serverroot;
+		} else {
+			$webroot = rtrim($this->theme->getWebPath(), $themeDirectory);
+		}
 
-		$this->appendOnceIfExist($this->serverroot, $themeDirectory . '/apps/' . $style . '.css')
-			|| $this->appendOnceIfExist($this->serverroot, $themeDirectory . '/' . $style . '.css')
-			|| $this->appendOnceIfExist($this->serverroot, $themeDirectory . '/core/' . $style . '.css');
+		$this->appendOnceIfExist($baseDirectory, $themeDirectory . '/apps/' . $style . '.css', $webroot)
+			|| $this->appendOnceIfExist($baseDirectory, $themeDirectory . '/' . $style . '.css', $webroot)
+			|| $this->appendOnceIfExist($baseDirectory, $themeDirectory . '/core/' . $style . '.css', $webroot);
 	}
 }

--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -31,9 +31,8 @@ class CSSResourceLocator extends ResourceLocator {
 	 * @param string $style
 	 */
 	public function doFind($style) {
-		if (strpos($style, '3rdparty') === 0
-			&& $this->appendOnceIfExist($this->thirdpartyroot, $style.'.css')
-			|| $this->appendOnceIfExist($this->serverroot, $style.'.css')
+		if (
+			$this->appendOnceIfExist($this->serverroot, $style.'.css')
 			|| $this->appendOnceIfExist($this->serverroot, 'core/'.$style.'.css')
 		) {
 			return;

--- a/lib/private/Template/CSSResourceLocator.php
+++ b/lib/private/Template/CSSResourceLocator.php
@@ -31,27 +31,28 @@ class CSSResourceLocator extends ResourceLocator {
 	 * @param string $style
 	 */
 	public function doFind($style) {
+		$fullStyle = $this->addExtension($style);
 		if (
-			$this->appendOnceIfExist($this->serverroot, $style.'.css')
-			|| $this->appendOnceIfExist($this->serverroot, 'core/'.$style.'.css')
+			$this->appendOnceIfExist($this->serverroot, $fullStyle)
+			|| $this->appendOnceIfExist($this->serverroot, 'core/' . $fullStyle)
 		) {
 			return;
 		}
-		$app = substr($style, 0, strpos($style, '/'));
-		$style = substr($style, strpos($style, '/')+1);
+		$app = substr($fullStyle, 0, strpos($fullStyle, '/'));
+		$fullStyle = substr($fullStyle, strpos($fullStyle, '/')+1);
 
-		$app_path = \OC_App::getAppPath($app);
+		$app_path = $this->appManager->getAppPath($app);
 		if( $app_path === false ) { return; }
-		$app_url = \OC_App::getAppWebPath($app);
+		$app_url = $this->appManager->getAppWebPath($app);
 		$app_url = ($app_url !== false) ? $app_url : null;
-		$this->appendOnceIfExist($app_path, $style.'.css', $app_url);
+		$this->appendOnceIfExist($app_path, $fullStyle, $app_url);
 	}
 
 	/**
 	 * @param string $style
 	 */
 	public function doFindTheme($style) {
-		$fullStyle = $style . '.css';
+		$fullStyle = $this->addExtension($style);
 		$themeDirectory = $this->theme->getDirectory();
 		$baseDirectory = $this->theme->getBaseDirectory();
 		$webRoot = '';
@@ -60,9 +61,9 @@ class CSSResourceLocator extends ResourceLocator {
 		}
 
 		$searchLocations = [
-			$this->buildPath([$themeDirectory, '/apps', $fullStyle]),
+			$this->buildPath([$themeDirectory, 'apps', $fullStyle]),
 			$this->buildPath([$themeDirectory, $fullStyle]),
-			$this->buildPath([$themeDirectory, '/core', $fullStyle]),
+			$this->buildPath([$themeDirectory, 'core', $fullStyle]),
 		];
 
 		foreach ($searchLocations as $location) {
@@ -70,5 +71,13 @@ class CSSResourceLocator extends ResourceLocator {
 				break;
 			}
 		}
+	}
+
+	/**
+	 * @param string $path
+	 * @return string
+	 */
+	protected function addExtension($path) {
+		return $path . '.css';
 	}
 }

--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -33,11 +33,6 @@ class JSResourceLocator extends ResourceLocator {
 	public function doFind($script) {
 		$themeDirectory = $this->theme->getDirectory();
 
-		if (strpos($script, '3rdparty') === 0
-			&& $this->appendOnceIfExist($this->thirdpartyroot, $script.'.js')) {
-			return;
-		}
-
 		if (strpos($script, '/l10n/') !== false) {
 			// For language files we try to load them all, so themes can overwrite
 			// single l10n strings without having to translate all of them.

--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -32,24 +32,31 @@ class JSResourceLocator extends ResourceLocator {
 	 */
 	public function doFind($script) {
 		$themeDirectory = $this->theme->getDirectory();
+		$baseDirectory = $this->theme->getBaseDirectory();
+		$webroot = null;
+		if ($baseDirectory === '') {
+			$baseDirectory = $this->serverroot;
+		} else {
+			$webroot = rtrim($this->theme->getWebPath(), $themeDirectory);
+		}
 
 		if (strpos($script, '/l10n/') !== false) {
 			// For language files we try to load them all, so themes can overwrite
 			// single l10n strings without having to translate all of them.
 			$found = 0;
 			$found += $this->appendOnceIfExist($this->serverroot, 'core/'.$script.'.js');
-			$found += $this->appendOnceIfExist($this->serverroot, $themeDirectory.'/core/'.$script.'.js');
+			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/core/'.$script.'.js', $webroot);
 			$found += $this->appendOnceIfExist($this->serverroot, $script.'.js');
-			$found += $this->appendOnceIfExist($this->serverroot, $themeDirectory.'/'.$script.'.js');
-			$found += $this->appendOnceIfExist($this->serverroot, $themeDirectory.'/apps/'.$script.'.js');
+			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/'.$script.'.js', $webroot);
+			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/apps/'.$script.'.js', $webroot);
 
 			if ($found) {
 				return;
 			}
-		} else if ($this->appendOnceIfExist($this->serverroot, $themeDirectory.'/apps/'.$script.'.js')
-			|| $this->appendOnceIfExist($this->serverroot, $themeDirectory.'/'.$script.'.js')
+		} else if ($this->appendOnceIfExist($baseDirectory, $themeDirectory.'/apps/'.$script.'.js', $webroot)
+			|| $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/'.$script.'.js', $webroot)
 			|| $this->appendOnceIfExist($this->serverroot, $script.'.js')
-			|| $this->appendOnceIfExist($this->serverroot, $themeDirectory.'/core/'.$script.'.js')
+			|| $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/core/'.$script.'.js', $webroot)
 			|| $this->appendOnceIfExist($this->serverroot, 'core/'.$script.'.js')
 		) {
 			return;

--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -31,46 +31,45 @@ class JSResourceLocator extends ResourceLocator {
 	 * @param string $script
 	 */
 	public function doFind($script) {
+		$fullScript = $script . '.js';
 		$themeDirectory = $this->theme->getDirectory();
 		$baseDirectory = $this->theme->getBaseDirectory();
-		$webroot = null;
-		if ($baseDirectory === '') {
-			$baseDirectory = $this->serverroot;
-		} else {
-			$webroot = rtrim($this->theme->getWebPath(), $themeDirectory);
+		$webRoot = '';
+		if ($baseDirectory !== $this->serverroot) {
+			$webRoot = substr($this->theme->getWebPath(), 0, -strlen($themeDirectory));
 		}
 
 		if (strpos($script, '/l10n/') !== false) {
 			// For language files we try to load them all, so themes can overwrite
 			// single l10n strings without having to translate all of them.
 			$found = 0;
-			$found += $this->appendOnceIfExist($this->serverroot, 'core/'.$script.'.js');
-			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/core/'.$script.'.js', $webroot);
-			$found += $this->appendOnceIfExist($this->serverroot, $script.'.js');
-			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/'.$script.'.js', $webroot);
-			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/apps/'.$script.'.js', $webroot);
+			$found += $this->appendOnceIfExist($this->serverroot, 'core/'.$fullScript);
+			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/core/'.$fullScript, $webRoot);
+			$found += $this->appendOnceIfExist($this->serverroot, $fullScript);
+			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/'.$fullScript, $webRoot);
+			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/apps/'.$fullScript, $webRoot);
 
 			if ($found) {
 				return;
 			}
-		} else if ($this->appendOnceIfExist($baseDirectory, $themeDirectory.'/apps/'.$script.'.js', $webroot)
-			|| $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/'.$script.'.js', $webroot)
-			|| $this->appendOnceIfExist($this->serverroot, $script.'.js')
-			|| $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/core/'.$script.'.js', $webroot)
-			|| $this->appendOnceIfExist($this->serverroot, 'core/'.$script.'.js')
+		} else if ($this->appendOnceIfExist($baseDirectory, $themeDirectory.'/apps/'.$fullScript, $webRoot)
+			|| $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/'.$fullScript, $webRoot)
+			|| $this->appendOnceIfExist($this->serverroot, $fullScript)
+			|| $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/core/'.$fullScript, $webRoot)
+			|| $this->appendOnceIfExist($this->serverroot, 'core/'.$fullScript)
 		) {
 			return;
 		}
 
-		$app = substr($script, 0, strpos($script, '/'));
-		$script = substr($script, strpos($script, '/')+1);
+		$app = substr($fullScript, 0, strpos($fullScript, '/'));
+		$fullScript = substr($fullScript, strpos($fullScript, '/')+1);
 		$app_path = \OC_App::getAppPath($app);
 		if( $app_path === false ) { return; }
 		$app_url = \OC_App::getAppWebPath($app);
 		$app_url = ($app_url !== false) ? $app_url : null;
 
 		// missing translations files fill be ignored
-		$this->appendOnceIfExist($app_path, $script . '.js', $app_url);
+		$this->appendOnceIfExist($app_path, $fullScript, $app_url);
 	}
 
 	/**

--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -31,7 +31,7 @@ class JSResourceLocator extends ResourceLocator {
 	 * @param string $script
 	 */
 	public function doFind($script) {
-		$fullScript = $script . '.js';
+		$fullScript = $this->addExtension($script);
 		$themeDirectory = $this->theme->getDirectory();
 		$baseDirectory = $this->theme->getBaseDirectory();
 		$webRoot = '';
@@ -63,12 +63,12 @@ class JSResourceLocator extends ResourceLocator {
 
 		$app = substr($fullScript, 0, strpos($fullScript, '/'));
 		$fullScript = substr($fullScript, strpos($fullScript, '/')+1);
-		$app_path = \OC_App::getAppPath($app);
+		$app_path = $this->appManager->getAppPath($app);
 		if( $app_path === false ) { return; }
-		$app_url = \OC_App::getAppWebPath($app);
+		$app_url = $this->appManager->getAppWebPath($app);
 		$app_url = ($app_url !== false) ? $app_url : null;
 
-		// missing translations files fill be ignored
+		// missing translations files will be ignored
 		$this->appendOnceIfExist($app_path, $fullScript, $app_url);
 	}
 
@@ -76,5 +76,13 @@ class JSResourceLocator extends ResourceLocator {
 	 * @param string $script
 	 */
 	public function doFindTheme($script) {
+	}
+
+	/**
+	 * @param string $path
+	 * @return string
+	 */
+	protected function addExtension($path) {
+		return $path . '.js';
 	}
 }

--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -38,7 +38,6 @@ abstract class ResourceLocator {
 
 	protected $mapping;
 	protected $serverroot;
-	protected $thirdpartyroot;
 	protected $webroot;
 
 	protected $resources = [];
@@ -50,14 +49,12 @@ abstract class ResourceLocator {
 	 * @param \OCP\ILogger $logger
 	 * @param ITheme $theme
 	 * @param array $core_map
-	 * @param array $party_map
 	 */
-	public function __construct(\OCP\ILogger $logger, $theme, $core_map, $party_map) {
+	public function __construct(\OCP\ILogger $logger, $theme, $core_map) {
 		$this->logger = $logger;
 		$this->theme = $theme;
-		$this->mapping = $core_map + $party_map;
+		$this->mapping = $core_map;
 		$this->serverroot = key($core_map);
-		$this->thirdpartyroot = key($party_map);
 		$this->webroot = $this->mapping[$this->serverroot];
 	}
 

--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -141,8 +141,14 @@ abstract class ResourceLocator {
 	 * @param string[] $parts path parts to concatenate
 	 * @return string $parts concatenated
 	 */
-	private function buildPath($parts){
-		return join(DIRECTORY_SEPARATOR, $parts);
+	protected function buildPath($parts){
+		$trimmedParts = array_map(
+			function($part){
+				return rtrim($part, '/');
+			},
+			$parts
+		);
+		return join(DIRECTORY_SEPARATOR, $trimmedParts);
 	}
 
 	/**

--- a/lib/private/Template/ResourceLocator.php
+++ b/lib/private/Template/ResourceLocator.php
@@ -28,6 +28,8 @@
 
 namespace OC\Template;
 
+use OCP\App\IAppManager;
+use OCP\ILogger;
 use OCP\Theme\ITheme;
 
 abstract class ResourceLocator {
@@ -42,17 +44,22 @@ abstract class ResourceLocator {
 
 	protected $resources = [];
 
-	/** @var \OCP\ILogger */
+	/** @var $appManager */
+	protected $appManager;
+
+	/** @var ILogger */
 	protected $logger;
 
 	/**
-	 * @param \OCP\ILogger $logger
 	 * @param ITheme $theme
+	 * @param IAppManager $appManager
+	 * @param ILogger $logger
 	 * @param array $core_map
 	 */
-	public function __construct(\OCP\ILogger $logger, $theme, $core_map) {
-		$this->logger = $logger;
+	public function __construct(ITheme $theme, IAppManager $appManager, ILogger $logger, $core_map) {
 		$this->theme = $theme;
+		$this->logger = $logger;
+		$this->appManager = $appManager;
 		$this->mapping = $core_map;
 		$this->serverroot = key($core_map);
 		$this->webroot = $this->mapping[$this->serverroot];
@@ -67,6 +74,12 @@ abstract class ResourceLocator {
 	 * @param string $resource
 	 */
 	abstract public function doFindTheme($resource);
+
+	/**
+	 * @param string $path
+	 * @return string
+	 */
+	abstract protected function addExtension($path);
 
 	/**
 	 * Finds the resources and adds them to the list

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -164,7 +164,6 @@ class TemplateLayout extends \OC_Template {
 		$locator = new \OC\Template\CSSResourceLocator(
 			\OC::$server->getLogger(),
 			\OC_Util::getTheme(),
-			[\OC::$SERVERROOT => \OC::$WEBROOT],
 			[\OC::$SERVERROOT => \OC::$WEBROOT]);
 		$locator->find($styles);
 		return $locator->getResources();
@@ -178,7 +177,6 @@ class TemplateLayout extends \OC_Template {
 		$locator = new \OC\Template\JSResourceLocator(
 			\OC::$server->getLogger(),
 			\OC_Util::getTheme(),
-			[\OC::$SERVERROOT => \OC::$WEBROOT],
 			[\OC::$SERVERROOT => \OC::$WEBROOT]);
 		$locator->find($scripts);
 		return $locator->getResources();

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -162,8 +162,9 @@ class TemplateLayout extends \OC_Template {
 	 */
 	static public function findStylesheetFiles($styles) {
 		$locator = new \OC\Template\CSSResourceLocator(
-			\OC::$server->getLogger(),
 			\OC_Util::getTheme(),
+			\OC::$server->getAppManager(),
+			\OC::$server->getLogger(),
 			[\OC::$SERVERROOT => \OC::$WEBROOT]);
 		$locator->find($styles);
 		return $locator->getResources();
@@ -175,8 +176,9 @@ class TemplateLayout extends \OC_Template {
 	 */
 	static public function findJavascriptFiles($scripts) {
 		$locator = new \OC\Template\JSResourceLocator(
-			\OC::$server->getLogger(),
 			\OC_Util::getTheme(),
+			\OC::$server->getAppManager(),
+			\OC::$server->getLogger(),
 			[\OC::$SERVERROOT => \OC::$WEBROOT]);
 		$locator->find($scripts);
 		return $locator->getResources();

--- a/lib/private/Theme/Theme.php
+++ b/lib/private/Theme/Theme.php
@@ -28,6 +28,8 @@ class Theme implements ITheme {
 	 */
 	private $name;
 
+	private $baseDirectory = '';
+
 	/**
 	 * @var string
 	 */
@@ -54,6 +56,21 @@ class Theme implements ITheme {
 	 */
 	public function getName() {
 		return $this->name;
+	}
+
+	/**
+	 * @param string $baseDirectory
+	 * @return string
+	 */
+	public function setBaseDirectory($baseDirectory) {
+		$this->baseDirectory = $baseDirectory;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getBaseDirectory() {
+		return $this->baseDirectory;
 	}
 
 	/**

--- a/lib/private/Theme/Theme.php
+++ b/lib/private/Theme/Theme.php
@@ -28,7 +28,10 @@ class Theme implements ITheme {
 	 */
 	private $name;
 
-	private $baseDirectory = '';
+	/**
+	 * @var string
+	 */
+	private $baseDirectory;
 
 	/**
 	 * @var string

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -76,8 +76,29 @@ class ThemeService implements IThemeService {
 	 * @return Theme
 	 */
 	private function makeTheme($themeName, $appTheme = true, Theme $theme = null) {
-		$directory = $this->getDirectory($themeName, $appTheme);
-		$webPath = $this->getWebPath($themeName, $appTheme);
+		$baseDirectory = '';
+		$directory = '';
+		$webPath = '';
+		if ($themeName !== '') {
+			if ($appTheme) {
+				$themeDirectory = \OC_App::getAppPath($themeName);
+				if (strpos($themeDirectory, \OC::$SERVERROOT)===0) {
+					$directory = substr($themeDirectory, strlen(\OC::$SERVERROOT) + 1);
+				} else {
+					foreach (\OC::$APPSROOTS as $appRoot) {
+						if (strpos($themeDirectory, $appRoot['path'])===0) {
+							$baseDirectory = $appRoot['path'];
+							$directory = substr($themeDirectory, strlen($appRoot['path']) + 1);
+						}
+					}
+				}
+
+				$webPath =  \OC_App::getAppWebPath($themeName);
+			} else {
+				$directory = 'themes/' . $themeName;
+				$webPath = '/themes/' . $themeName;
+			}
+		}
 
 		if (is_null($theme)) {
 			$theme = new Theme(
@@ -90,41 +111,9 @@ class ThemeService implements IThemeService {
 			$theme->setDirectory($directory);
 			$theme->setWebPath($webPath);
 		}
+		$theme->setBaseDirectory($baseDirectory);
 
 		return $theme;
-	}
-
-	/**
-	 * @param string $themeName
-	 * @param bool $appTheme
-	 * @return string
-	 */
-	private function getDirectory($themeName, $appTheme = true) {
-		if ($themeName !== '') {
-			if ($appTheme) {
-				return substr(\OC_App::getAppPath($themeName), strlen(\OC::$SERVERROOT) + 1);
-			}
-			return 'themes/' . $themeName;
-		}
-
-		return '';
-	}
-
-	/**
-	 * @param $themeName
-	 * @param bool $appTheme
-	 * @return false|string
-	 */
-	private function getWebPath($themeName, $appTheme = true) {
-		if ($themeName !== '') {
-			if ($appTheme) {
-				$appWebPath = \OC_App::getAppWebPath($themeName);
-				return $appWebPath ? $appWebPath : '';
-			}
-			return '/themes/' . $themeName;
-		}
-
-		return '';
 	}
 
 	/**

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -76,7 +76,7 @@ class ThemeService implements IThemeService {
 	 * @return Theme
 	 */
 	private function makeTheme($themeName, $appTheme = true, Theme $theme = null) {
-		$baseDirectory = '';
+		$baseDirectory = \OC::$SERVERROOT;
 		$directory = '';
 		$webPath = '';
 		if ($themeName !== '') {
@@ -93,7 +93,7 @@ class ThemeService implements IThemeService {
 					}
 				}
 
-				$webPath =  \OC_App::getAppWebPath($themeName);
+				$webPath = \OC_App::getAppWebPath($themeName);
 			} else {
 				$directory = 'themes/' . $themeName;
 				$webPath = '/themes/' . $themeName;

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -29,6 +29,9 @@ class ThemeService implements IThemeService {
 	 * @var Theme
 	 */
 	private $theme;
+	
+	/** @var string */
+	private $serverRoot;
 
 	/** @var string */
 	private $defaultThemeDirectory;
@@ -37,9 +40,11 @@ class ThemeService implements IThemeService {
 	 * ThemeService constructor.
 	 *
 	 * @param string $themeName
+	 * @param string $serverRoot
 	 */
-	public function __construct($themeName = '') {
-		$this->defaultThemeDirectory = \OC::$SERVERROOT . self::DEFAULT_THEME_PATH;
+	public function __construct($themeName, $serverRoot) {
+		$this->serverRoot = $serverRoot;
+		$this->defaultThemeDirectory = $this->serverRoot . self::DEFAULT_THEME_PATH;
 
 		if ($themeName === '' && $this->defaultThemeExists()) {
 			$themeName = 'default';
@@ -66,24 +71,26 @@ class ThemeService implements IThemeService {
 	 * @param string $themeName
 	 */
 	public function setAppTheme($themeName = '') {
-		$this->theme = $this->makeTheme($themeName, true, $this->getTheme());
+		$this->theme = $this->makeTheme($themeName, true);
 	}
 
 	/**
 	 * @param string $themeName
 	 * @param bool $appTheme
-	 * @param Theme $theme
 	 * @return Theme
 	 */
-	private function makeTheme($themeName, $appTheme = true, Theme $theme = null) {
-		$baseDirectory = \OC::$SERVERROOT;
+	private function makeTheme($themeName, $appTheme = true) {
+		$baseDirectory = $this->serverRoot;
 		$directory = '';
 		$webPath = '';
 		if ($themeName !== '') {
 			if ($appTheme) {
 				$themeDirectory = \OC_App::getAppPath($themeName);
-				if (strpos($themeDirectory, \OC::$SERVERROOT)===0) {
-					$directory = substr($themeDirectory, strlen(\OC::$SERVERROOT) + 1);
+				// Use OC server root as a theme base directory if theme is located below it
+				// Use path to an app root as a theme base directory otherwise
+				// in any case theme directory is relative to theme base directory
+				if (strpos($themeDirectory, $this->serverRoot)===0) {
+					$directory = substr($themeDirectory, strlen($this->serverRoot) + 1);
 				} else {
 					foreach (\OC::$APPSROOTS as $appRoot) {
 						if (strpos($themeDirectory, $appRoot['path'])===0) {
@@ -100,20 +107,16 @@ class ThemeService implements IThemeService {
 			}
 		}
 
-		if (is_null($theme)) {
-			$theme = new Theme(
-				$themeName,
-				$directory,
-				$webPath
-			);
+		if (is_null($this->theme)) {
+			$this->theme = new Theme($themeName, $directory, $webPath);
 		} else {
-			$theme->setName($themeName);
-			$theme->setDirectory($directory);
-			$theme->setWebPath($webPath);
+			$this->theme->setName($themeName);
+			$this->theme->setDirectory($directory);
+			$this->theme->setWebPath($webPath);
 		}
-		$theme->setBaseDirectory($baseDirectory);
+		$this->theme->setBaseDirectory($baseDirectory);
 
-		return $theme;
+		return $this->theme;
 	}
 
 	/**
@@ -141,13 +144,13 @@ class ThemeService implements IThemeService {
 	 */
 	private function getAllLegacyThemes() {
 		$themes = [];
-		if (is_dir(\OC::$SERVERROOT . '/themes')) {
-			if ($handle = opendir(\OC::$SERVERROOT . '/themes')) {
+		if (is_dir($this->serverRoot . '/themes')) {
+			if ($handle = opendir($this->serverRoot . '/themes')) {
 				while (false !== ($entry = readdir($handle))) {
 					if ($entry === '.' || $entry === '..') {
 						continue;
 					}
-					if (is_dir(\OC::$SERVERROOT . '/themes/' . $entry)) {
+					if (is_dir($this->serverRoot . '/themes/' . $entry)) {
 						$themes[$entry] = $this->makeTheme($entry, false);
 					}
 				}

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -180,20 +180,19 @@ class URLGenerator implements IURLGenerator {
 			array_unshift($directories, "$appPath", "/$app");
 		}
 
+		$themeDirectory = $this->theme->getDirectory();
 		foreach($directories as $directory) {
 			$directory = $directory . "/img/";
-			$themeDirectory = $this->theme->getDirectory();
-
 			$file = $directory . $imageName;
 
-			if (!empty($themeDirectory)) {
-				if ($imagePath = $this->getImagePathOrFallback('/' . $this->theme->getDirectory() . $file)) {
-					return $imagePath;
-				}
+			if ($themeDirectory !== ''
+				&& $imagePath = $this->getImagePathOrFallback( $this->theme->getBaseDirectory() . '/' . $themeDirectory . $file)
+			) {
+				return $this->theme->getWebPath() . $file;
 			}
 
-			if ($imagePath = $this->getImagePathOrFallback($file)) {
-				return $imagePath;
+			if ($imagePath = $this->getImagePathOrFallback(\OC::$SERVERROOT . $file)) {
+				return \OC::$WEBROOT . $file;
 			}
 		}
 	}
@@ -203,15 +202,12 @@ class URLGenerator implements IURLGenerator {
 	 * @return string
 	 */
 	private function getImagePathOrFallback($file) {
-
-		if (file_exists(\OC::$SERVERROOT . $file)) {
-			return \OC::$WEBROOT . $file;
-		}
-
 		$fallback = substr($file, 0, -3) . 'png';
-
-		if (file_exists(\OC::$SERVERROOT . $fallback)) {
-			return \OC::$WEBROOT . $fallback;
+		$locations = [ $file, $fallback ];
+		foreach ($locations as $location) {
+			if (file_exists($location)) {
+				return $location;
+			}
 		}
 	}
 

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -194,7 +194,7 @@ class OC_Template extends \OC\Template\Base {
 		} elseif ($app === 'settings') {
 			$dirs = $this->getSettingsTemplateDirs($theme, OC::$SERVERROOT);
 		} else {
-			$dirs = $this->getAppTemplateDirs($theme, $app, OC::$SERVERROOT, OC_App::getAppPath($app));
+			$dirs = $this->getAppTemplateDirs($theme, $app, OC_App::getAppPath($app));
 		}
 
 		$locator = new \OC\Template\TemplateFileLocator( $dirs );

--- a/lib/public/Theme/ITheme.php
+++ b/lib/public/Theme/ITheme.php
@@ -34,6 +34,12 @@ interface ITheme {
 
 	/**
 	 * @return string
+	 * @since 10.0.8
+	 */
+	public function getBaseDirectory();
+
+	/**
+	 * @return string
 	 * @since 10.0.3
 	 */
 	public function getDirectory();

--- a/tests/lib/App/ManagerTest.php
+++ b/tests/lib/App/ManagerTest.php
@@ -529,4 +529,28 @@ class ManagerTest extends TestCase {
 		$appPath = $appManager->getAppPath($appId);
 		$this->assertFalse($appPath);
 	}
+
+	public function testAppWebRootAboveOcWebroot() {
+		$appId = 'notexistingapp';
+
+		$appManager = $this->getMockBuilder(AppManager::class)
+			->setMethods(['findAppInDirectories', 'getOcWebRoot'])
+			->disableOriginalConstructor()
+			->getMock();
+
+		$appManager->expects($this->any())
+			->method('getOcWebRoot')
+			->willReturn('some/host/path');
+
+		$appManager->expects($this->any())
+			->method('findAppInDirectories')
+			->with($appId)
+			->willReturn([
+				'path' => '/not/essential',
+				'url' => '../../relative',
+			]);
+
+		$appWebPath = $appManager->getAppWebPath($appId);
+		$this->assertEquals('some/relative', $appWebPath);
+	}
 }

--- a/tests/lib/Template/BaseTest.php
+++ b/tests/lib/Template/BaseTest.php
@@ -38,12 +38,16 @@ class BaseTest extends \Test\TestCase {
 			->method('getDirectory')
 			->willReturn('theme-test');
 
+		$this->theme->expects($this->any())
+			->method('getBaseDirectory')
+			->willReturn($this->serverRoot);
+
 		$app = 'anyapp';
 
 		$directories = self::invokePrivate(
 			$base,
 			'getAppTemplateDirs',
-			[$this->theme, $app, $this->serverRoot, $this->serverRoot . '/apps3/anyapp']
+			[$this->theme, $app, $this->serverRoot . '/apps3/anyapp']
 		);
 		$this->assertEquals(
 			[
@@ -68,7 +72,7 @@ class BaseTest extends \Test\TestCase {
 		$directories = self::invokePrivate(
 			$base,
 			'getAppTemplateDirs',
-			[$this->theme, $app, $this->serverRoot, $this->serverRoot . '/apps3/anyapp']
+			[$this->theme, $app, $this->serverRoot . '/apps3/anyapp']
 		);
 		$this->assertEquals(
 			[

--- a/tests/lib/Template/CSSResourceLocatorTest.php
+++ b/tests/lib/Template/CSSResourceLocatorTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright (c) 2018 Viktar Dubiniuk <dubiniuk@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Template;
+
+use OC\App\AppManager;
+use OC\Template\CSSResourceLocator;
+use OC\Theme\Theme;
+use OCP\ILogger;
+use Test\TestCase;
+
+class CSSResourceLocatorTest extends TestCase {
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $logger;
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $appManager;
+	protected $serverRoot = '/var/www/owncloud';
+	protected $appRoot = '/var/www/apps';
+	protected $themeAppDir = 'theme-best';
+
+
+	protected function setUp() {
+		parent::setUp();
+		$this->logger = $this->createMock(ILogger::class);
+	}
+
+	/**
+	 * @param string $theme
+	 * @param array $core_map
+	 * @param array $appsRoots
+	 * @return \PHPUnit_Framework_MockObject_MockObject
+	 */
+	public function getResourceLocator($theme, $core_map, $appsRoots) {
+		$themeInstance = $this->createMock(Theme::class);
+		$themeInstance->method('getName')->willReturn($theme);
+		$themeInstance->method('getBaseDirectory')->willReturn($this->appRoot);
+		$themeInstance->method('getDirectory')->willReturn($this->themeAppDir);
+
+		$this->appManager = $this->getMockBuilder(AppManager::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		return $this->getMockBuilder(CSSResourceLocator::class)
+			->setConstructorArgs([$themeInstance, $this->appManager, $this->logger, $core_map, $appsRoots])
+			->setMethods(['appendOnceIfExist'])
+			->getMock();
+	}
+
+	public function testFindCoreStyle() {
+		/** @var \OC\Template\CSSResourceLocator $locator */
+		$locator = $this->getResourceLocator(
+			'theme',
+			[$this->serverRoot => 'map'],
+			['foo' => 'bar']
+		);
+		$this->appManager->expects($this->any())
+			->method('getAppPath')
+			->with('core')
+			->willReturn(false);
+
+		$locator->expects($this->exactly(5))
+			->method('appendOnceIfExist')
+			->withConsecutive(
+				['/var/www/owncloud', 'core/css/style.css', ''],
+				['/var/www/owncloud', 'core/core/css/style.css', ''],
+				['/var/www/apps', 'theme-best/apps/core/css/style.css', ''],
+				['/var/www/apps', 'theme-best/core/css/style.css', ''],
+				['/var/www/apps', 'theme-best/core/core/css/style.css', '']
+
+			);
+
+		$locator->find(['core/css/style']);
+	}
+
+	public function testFindAppStyle() {
+		/** @var \OC\Template\CSSResourceLocator $locator */
+		$locator = $this->getResourceLocator(
+			'theme',
+			[$this->serverRoot => 'map'],
+			['foo' => 'bar']
+		);
+		$this->appManager->expects($this->any())
+			->method('getAppPath')
+			->with('randomapp')
+			->willReturn('/var/www/apps/randomapp');
+
+		$locator->expects($this->exactly(6))
+			->method('appendOnceIfExist')
+			->withConsecutive(
+				['/var/www/owncloud', 'randomapp/css/style.css', ''],
+				['/var/www/owncloud', 'core/randomapp/css/style.css', ''],
+				['/var/www/apps/randomapp', 'css/style.css', ''],
+				['/var/www/apps', 'theme-best/apps/randomapp/css/style.css', ''],
+				['/var/www/apps', 'theme-best/randomapp/css/style.css', ''],
+				['/var/www/apps', 'theme-best/core/randomapp/css/style.css', '']
+			);
+
+		$locator->find(['randomapp/css/style']);
+	}
+
+}

--- a/tests/lib/Template/JSResourceLocatorTest.php
+++ b/tests/lib/Template/JSResourceLocatorTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Copyright (c) 2018 Viktar Dubiniuk <dubiniuk@owncloud.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Template;
+
+use OC\App\AppManager;
+use OC\Template\JSResourceLocator;
+use OC\Theme\Theme;
+use OCP\ILogger;
+use Test\TestCase;
+
+class JSResourceLocatorTest extends TestCase {
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $logger;
+	/** @var \PHPUnit_Framework_MockObject_MockObject */
+	protected $appManager;
+	protected $serverRoot = '/var/www/owncloud';
+	protected $appRoot = '/var/www/apps';
+	protected $themeAppDir = 'theme-best';
+
+
+	protected function setUp() {
+		parent::setUp();
+		$this->logger = $this->createMock(ILogger::class);
+	}
+
+	/**
+	 * @param string $theme
+	 * @param array $core_map
+	 * @param array $appsRoots
+	 * @return \PHPUnit_Framework_MockObject_MockObject
+	 */
+	public function getResourceLocator($theme, $core_map, $appsRoots) {
+		$themeInstance = $this->createMock(Theme::class);
+		$themeInstance->method('getName')->willReturn($theme);
+		$themeInstance->method('getBaseDirectory')->willReturn($this->appRoot);
+		$themeInstance->method('getDirectory')->willReturn($this->themeAppDir);
+
+		$this->appManager = $this->getMockBuilder(AppManager::class)
+									->disableOriginalConstructor()
+									->getMock();
+
+		return $this->getMockBuilder(JSResourceLocator::class)
+			->setConstructorArgs([$themeInstance, $this->appManager, $this->logger, $core_map, $appsRoots])
+			->setMethods(['appendOnceIfExist'])
+			->getMock();
+	}
+
+	public function testFindCoreScript() {
+		/** @var \OC\Template\JSResourceLocator $locator */
+		$locator = $this->getResourceLocator(
+			'theme',
+			[$this->serverRoot => 'map'],
+			['foo' => 'bar']
+		);
+		$this->appManager->expects($this->any())
+			->method('getAppPath')
+			->with('core')
+			->willReturn(false);
+
+		$locator->expects($this->exactly(5))
+			->method('appendOnceIfExist')
+			->withConsecutive(
+				['/var/www/apps', 'theme-best/apps/core/js/script.js', ''],
+				['/var/www/apps', 'theme-best/core/js/script.js', ''],
+				['/var/www/owncloud', 'core/js/script.js', ''],
+				['/var/www/apps', 'theme-best/core/core/js/script.js', ''],
+				['/var/www/owncloud', 'core/core/js/script.js', '']
+			);
+
+		$locator->find(['core/js/script']);
+	}
+
+	public function testFindAppScript() {
+		/** @var \OC\Template\JSResourceLocator $locator */
+		$locator = $this->getResourceLocator(
+			'theme',
+			[$this->serverRoot => 'map'],
+			['foo' => 'bar']
+		);
+		$this->appManager->expects($this->any())
+			->method('getAppPath')
+			->with('randomapp')
+			->willReturn('/var/www/apps/randomapp');
+
+		$locator->expects($this->exactly(6))
+			->method('appendOnceIfExist')
+			->withConsecutive(
+				['/var/www/apps', 'theme-best/apps/randomapp/js/script.js', ''],
+				['/var/www/apps', 'theme-best/randomapp/js/script.js', ''],
+				['/var/www/owncloud', 'randomapp/js/script.js', ''],
+				['/var/www/apps', 'theme-best/core/randomapp/js/script.js', ''],
+				['/var/www/owncloud', 'core/randomapp/js/script.js', ''],
+				['/var/www/apps/randomapp', 'js/script.js', '']
+			);
+
+		$locator->find(['randomapp/js/script']);
+	}
+
+
+	public function testFindL10nScript() {
+		/** @var \OC\Template\JSResourceLocator $locator */
+		$locator = $this->getResourceLocator(
+			'theme',
+			[$this->serverRoot => 'map'],
+			['foo' => 'bar']
+		);
+		$this->appManager->expects($this->any())
+			->method('getAppPath')
+			->with('randomapp')
+			->willReturn('/var/www/apps/randomapp');
+
+		$locator->expects($this->exactly(6))
+			->method('appendOnceIfExist')
+			->withConsecutive(
+				['/var/www/owncloud', 'core/randomapp/l10n/en_GB.js', ''],
+				['/var/www/apps', 'theme-best/core/randomapp/l10n/en_GB.js', ''],
+				['/var/www/owncloud', 'randomapp/l10n/en_GB.js', ''],
+				['/var/www/apps', 'theme-best/randomapp/l10n/en_GB.js', ''],
+				['/var/www/apps', 'theme-best/apps/randomapp/l10n/en_GB.js', ''],
+				['/var/www/apps/randomapp', 'l10n/en_GB.js', '']
+			);
+
+		$locator->find(['randomapp/l10n/en_GB']);
+	}
+
+}

--- a/tests/lib/Template/ResourceLocatorTest.php
+++ b/tests/lib/Template/ResourceLocatorTest.php
@@ -40,33 +40,30 @@ class ResourceLocatorTest extends \Test\TestCase {
 	/**
 	 * @param string $theme
 	 * @param array $core_map
-	 * @param array $party_map
 	 * @param array $appsRoots
 	 * @return \PHPUnit_Framework_MockObject_MockObject
 	 */
-	public function getResourceLocator($theme, $core_map, $party_map, $appsRoots) {
+	public function getResourceLocator($theme, $core_map, $appsRoots) {
 		$themeInstance = $this->createMock('OC\Theme\Theme');
 		$themeInstance->method('getName')->willReturn($theme);
 
 		return $this->getMockForAbstractClass('OC\Template\ResourceLocator',
-			[$this->logger, $themeInstance, $core_map, $party_map, $appsRoots],
+			[$this->logger, $themeInstance, $core_map, $appsRoots],
 			'', true, true, true, []);
 	}
 
 	public function testConstructor() {
-		$locator = $this->getResourceLocator('theme',
-			['core'=>'map'], ['3rd'=>'party'], ['foo'=>'bar']);
+		$locator = $this->getResourceLocator('theme',	['core'=>'map'], ['foo'=>'bar']);
 		$this->assertAttributeInstanceOf('OC\Theme\Theme', 'theme', $locator);
 		$this->assertAttributeEquals('core', 'serverroot', $locator);
-		$this->assertAttributeEquals(['core'=>'map','3rd'=>'party'], 'mapping', $locator);
-		$this->assertAttributeEquals('3rd', 'thirdpartyroot', $locator);
+		$this->assertAttributeEquals(['core'=>'map'], 'mapping', $locator);
 		$this->assertAttributeEquals('map', 'webroot', $locator);
 		$this->assertAttributeEquals([], 'resources', $locator);
 	}
 
 	public function testFind() {
 		$locator = $this->getResourceLocator('theme',
-			['core' => 'map'], ['3rd' => 'party'], ['foo' => 'bar']);
+			['core' => 'map'], ['foo' => 'bar']);
 		$locator->expects($this->once())
 			->method('doFind')
 			->with('foo');
@@ -78,8 +75,7 @@ class ResourceLocatorTest extends \Test\TestCase {
 	}
 
 	public function testFindNotFound() {
-		$locator = $this->getResourceLocator('theme',
-			['core'=>'map'], ['3rd'=>'party'], ['foo'=>'bar']);
+		$locator = $this->getResourceLocator('theme',	['core'=>'map'], ['foo'=>'bar']);
 		$locator->expects($this->once())
 			->method('doFind')
 			->with('foo')
@@ -98,12 +94,10 @@ class ResourceLocatorTest extends \Test\TestCase {
 	public function testAppendOnceIfExist() {
 		
 		/** @var \OC\Template\ResourceLocator $locator */
-		$locator = $this->getResourceLocator('theme',
-			[__DIR__=>'map'], [vfsStream::url('resources')=>'party'], ['foo'=>'bar']);
+		$locator = $this->getResourceLocator('theme', [__DIR__=>'map'], ['foo'=>'bar']);
 		
 		$method = new \ReflectionMethod($locator, 'appendOnceIfExist');
 		$method->setAccessible(true);
-
 
 		$method->invoke($locator, __DIR__, basename(__FILE__), 'webroot');
 		$resource1 = [__DIR__, 'webroot', basename(__FILE__)];
@@ -114,22 +108,6 @@ class ResourceLocatorTest extends \Test\TestCase {
 
 		$method->invoke($locator, __DIR__, 'does-not-exist');
 		$this->assertEquals([__FILE__ => $resource1], $locator->getResources());
-		
-		
-		$method->invoke($locator, vfsStream::url('resources'), $this->filenames[0]);
-		$resource2 = [vfsStream::url('resources'), 'party', $this->filenames[0]];
-		$this->assertEquals([
-				__FILE__ => $resource1,
-				vfsStream::url('resources') . '/' . $this->filenames[0] => $resource2
-		], $locator->getResources());
-		
-		$method->invoke($locator, vfsStream::url('resources'), $this->filenames[1]);
-		$resource3 = [vfsStream::url('resources'), 'party', $this->filenames[1]];
-		$this->assertEquals([
-				__FILE__ => $resource1,
-				vfsStream::url('resources') . '/' . $this->filenames[0] => $resource2,
-				vfsStream::url('resources') . '/' . $this->filenames[1] => $resource3
-		], $locator->getResources());
 	}
 }
 

--- a/tests/lib/Template/ResourceLocatorTest.php
+++ b/tests/lib/Template/ResourceLocatorTest.php
@@ -8,6 +8,7 @@
 
 namespace Test\Template;
 
+use OC\App\AppManager;
 use OC\Template\ResourceNotFoundException;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamWrapper;
@@ -47,8 +48,10 @@ class ResourceLocatorTest extends \Test\TestCase {
 		$themeInstance = $this->createMock('OC\Theme\Theme');
 		$themeInstance->method('getName')->willReturn($theme);
 
+		$appManagerInstance = $this->createMock(AppManager::class);
+
 		return $this->getMockForAbstractClass('OC\Template\ResourceLocator',
-			[$this->logger, $themeInstance, $core_map, $appsRoots],
+			[$themeInstance, $appManagerInstance, $this->logger, $core_map, $appsRoots],
 			'', true, true, true, []);
 	}
 

--- a/tests/lib/Theme/ThemeServiceTest.php
+++ b/tests/lib/Theme/ThemeServiceTest.php
@@ -7,7 +7,7 @@ use OC\Theme\ThemeService;
 class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 
 	public function testCreatesThemeByGivenName() {
-		$themeService = new ThemeService('theme-name');
+		$themeService = new ThemeService('theme-name', \OC::$SERVERROOT);
 		$theme = $themeService->getTheme();
 		$this->assertEquals('theme-name', $theme->getName());
 		$this->assertEquals('themes/theme-name', $theme->getDirectory());
@@ -23,7 +23,7 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 			->method('defaultThemeExists')
 			->willReturn(false);
 
-		$themeService->__construct('');
+		$themeService->__construct('', \OC::$SERVERROOT);
 		$theme = $themeService->getTheme();
 
 		$this->assertEquals('', $theme->getName());
@@ -40,7 +40,7 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 			->method('defaultThemeExists')
 			->willReturn(true);
 
-		$themeService->__construct('');
+		$themeService->__construct('', \OC::$SERVERROOT);
 		$theme = $themeService->getTheme();
 
 		$this->assertEquals('default', $theme->getName());
@@ -48,7 +48,7 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testSetAppThemeSetsName() {
-		$themeService = new ThemeService();
+		$themeService = new ThemeService('', \OC::$SERVERROOT);
 		$this->assertEmpty($themeService->getTheme()->getName());
 		$themeService->setAppTheme('some-app-theme');
 		$this->assertEquals('some-app-theme', $themeService->getTheme()->getName());


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/30200

TL;DR

## Description
Allows app-theme to be in the directory located above oC webroot
Note: this app directory should be accessible from the web to serve js/css files properly

Checklist
- [x]  CSS
- [x] JS
- [x] templates
- [x] frontend translations *.js 
- [x] backend translations *.json 
- [x] Image path


## Related Issue
Fixes https://github.com/owncloud/core/issues/28778

## Motivation and Context

## How Has This Been Tested?
Sample config:
```
  'apps_paths' => 
  array (
    0 => 
    array (
      'path' => '/var/www/oc-tmp/apps',
      'url' => '/apps',
      'writable' => false,
    ),
    1 => 
    array (
      'path' => '/var/www/appsinhell',
      'url' => '../appsinhell',
      'writable' => true,
    ),
  ),
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

