### PR TITLE
[WIP] More flexible file actions API in web UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,11 +168,11 @@ test-external: $(composer_dev_deps)
 
 .PHONY: test-js
 test-js: $(nodejs_deps)
-	NODE_PATH='$(NODE_PREFIX)/node_modules' $(KARMA) start tests/karma.config.js --single-run
+	ulimit -Sv 2000000 && NODE_PATH='$(NODE_PREFIX)/node_modules' $(KARMA) start tests/karma.config.js --single-run
 
 .PHONY: test-js-debug
 test-js-debug: $(nodejs_deps)
-	NODE_PATH='$(NODE_PREFIX)/node_modules' $(KARMA) start tests/karma.config.js
+	ulimit -Sv 2000000 && NODE_PATH='$(NODE_PREFIX)/node_modules' $(KARMA) start tests/karma.config.js
 
 .PHONY: test-integration
 test-integration: $(composer_dev_deps)

--- a/Makefile
+++ b/Makefile
@@ -168,11 +168,11 @@ test-external: $(composer_dev_deps)
 
 .PHONY: test-js
 test-js: $(nodejs_deps)
-	ulimit -Sv 2000000 && NODE_PATH='$(NODE_PREFIX)/node_modules' $(KARMA) start tests/karma.config.js --single-run
+	ulimit -Sv 3000000 && NODE_PATH='$(NODE_PREFIX)/node_modules' $(KARMA) start tests/karma.config.js --single-run
 
 .PHONY: test-js-debug
 test-js-debug: $(nodejs_deps)
-	ulimit -Sv 2000000 && NODE_PATH='$(NODE_PREFIX)/node_modules' $(KARMA) start tests/karma.config.js
+	ulimit -Sv 3000000 && NODE_PATH='$(NODE_PREFIX)/node_modules' $(KARMA) start tests/karma.config.js
 
 .PHONY: test-integration
 test-integration: $(composer_dev_deps)

--- a/apps/files/tests/js/appSpec.js
+++ b/apps/files/tests/js/appSpec.js
@@ -68,7 +68,7 @@ describe('OCA.Files.App tests', function() {
 	describe('initialization', function() {
 		it('initializes the default file list with the default file actions', function() {
 			expect(App.fileList).toBeDefined();
-			expect(App.fileList.fileActions.actions.all).toBeDefined();
+			expect(App.fileList.fileActions.getActions('all', 'file', 31).Download).toBeDefined();
 			expect(App.fileList.$el.is('#app-content-files')).toEqual(true);
 		});
 		it('merges the legacy file actions with the default ones', function() {
@@ -111,12 +111,13 @@ describe('OCA.Files.App tests', function() {
 
 			App.initialize();
 
-			var actions = App.fileList.fileActions.actions;
-			expect(actions.all.OverwriteThis.action).toBe(actionStub);
-			expect(actions.all.LegacyTest.action).toBe(legacyActionStub);
-			expect(actions.all.RegularTest.action).toBe(actionStub);
+			var actions = App.fileList.fileActions.getActions('all', 'file', 31);
+			expect(actions.OverwriteThis.action).toBe(actionStub);
+			expect(actions.LegacyTest.action).toBe(legacyActionStub);
+			expect(actions.RegularTest.action).toBe(actionStub);
 			// default one still there
-			expect(actions.dir.Open.action).toBeDefined();
+			actions = App.fileList.fileActions.getActions('httpd/unix-directory', 'dir', 31);
+			expect(actions.Open).toBeDefined();
 		});
 	});
 

--- a/apps/files/tests/js/favoritespluginspec.js
+++ b/apps/files/tests/js/favoritespluginspec.js
@@ -53,10 +53,10 @@ describe('OCA.Files.FavoritesPlugin tests', function() {
 		it('provides default file actions', function() {
 			var fileActions = fileList.fileActions;
 
-			expect(fileActions.actions.all).toBeDefined();
-			expect(fileActions.actions.all.Delete).toBeDefined();
-			expect(fileActions.actions.all.Rename).toBeDefined();
-			expect(fileActions.actions.all.Download).toBeDefined();
+			var actions = fileList.fileActions.getActions('all', 'file', 31);
+			expect(actions.Delete).toBeDefined();
+			expect(actions.Rename).toBeDefined();
+			expect(actions.Download).toBeDefined();
 
 			expect(fileActions.defaults.dir).toEqual('Open');
 		});
@@ -74,7 +74,7 @@ describe('OCA.Files.FavoritesPlugin tests', function() {
 			Plugin.favoritesFileList = null;
 			fileList = Plugin.showFileList($('#app-content-favorites'));
 
-			expect(fileList.fileActions.actions.all.RegularTest).toBeDefined();
+			expect(fileList.fileActions.getActions('all', 'file', 31).RegularTest).toBeDefined();
 		});
 		it('does not provide legacy file actions', function() {
 			var actionStub = sinon.stub();
@@ -90,7 +90,7 @@ describe('OCA.Files.FavoritesPlugin tests', function() {
 			Plugin.favoritesFileList = null;
 			fileList = Plugin.showFileList($('#app-content-favorites'));
 
-			expect(fileList.fileActions.actions.all.LegacyTest).not.toBeDefined();
+			expect(fileList.fileActions.getActions('all', 'file', 31).LegacyTest).not.toBeDefined();
 		});
 		it('redirects to files app when opening a directory', function() {
 			var oldList = OCA.Files.App.fileList;

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -69,9 +69,8 @@ describe('OCA.Files.FileActions tests', function() {
 	});
 	it('calling clear() clears file actions', function() {
 		fileActions.clear();
-		expect(fileActions.actions).toEqual({});
+		expect(fileActions._actionFunctions).toEqual([]);
 		expect(fileActions.defaults).toEqual({});
-		expect(fileActions.icons).toEqual({});
 		expect(fileActions.currentFile).toBe(null);
 	});
 	describe('displaying actions', function() {

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -237,7 +237,8 @@ OCA.Sharing.PublicApp = {
 			});
 
 			// do not allow sharing from the public page
-			delete this.fileList.fileActions.actions.all.Share;
+			// FIXME find a way: register handler that deletes action?
+			//delete this.fileList.fileActions.actions.all.Share;
 
 			this.fileList.changeDirectory(this.initialDir || '/', false, true);
 

--- a/apps/files_sharing/tests/js/appSpec.js
+++ b/apps/files_sharing/tests/js/appSpec.js
@@ -71,10 +71,10 @@ describe('OCA.Sharing.App tests', function() {
 			_.each([fileListIn, fileListOut], function(fileList) {
 				var fileActions = fileList.fileActions;
 
-				expect(fileActions.actions.all).toBeDefined();
-				expect(fileActions.actions.all.Delete).toBeDefined();
-				expect(fileActions.actions.all.Rename).toBeDefined();
-				expect(fileActions.actions.all.Download).toBeDefined();
+				var actions = fileActions.getActions('all', 'file', 31);
+				expect(actions.Delete).toBeDefined();
+				expect(actions.Rename).toBeDefined();
+				expect(actions.Download).toBeDefined();
 
 				expect(fileActions.defaults.dir).toEqual('Open');
 			});
@@ -93,7 +93,8 @@ describe('OCA.Sharing.App tests', function() {
 			App._inFileList = null;
 			fileListIn = App.initSharingIn($('#app-content-sharingin'));
 
-			expect(fileListIn.fileActions.actions.all.RegularTest).toBeDefined();
+			var actions = fileListIn.fileActions.getActions('all', 'file', 31);
+			expect(actions.RegularTest).toBeDefined();
 		});
 		it('does not provide legacy file actions', function() {
 			var actionStub = sinon.stub();
@@ -109,7 +110,8 @@ describe('OCA.Sharing.App tests', function() {
 			App._inFileList = null;
 			fileListIn = App.initSharingIn($('#app-content-sharingin'));
 
-			expect(fileListIn.fileActions.actions.all.LegacyTest).not.toBeDefined();
+			var actions = fileListIn.fileActions.getActions('all', 'file', 31);
+			expect(actions.LegacyTest).not.toBeDefined();
 		});
 		it('redirects to files app when opening a directory', function() {
 			var oldList = OCA.Files.App.fileList;

--- a/apps/files_trashbin/tests/js/appSpec.js
+++ b/apps/files_trashbin/tests/js/appSpec.js
@@ -56,12 +56,12 @@ describe('OCA.Trashbin.App tests', function() {
 
 			fileActions = App.fileList.fileActions;
 
-			expect(fileActions.actions.all).toBeDefined();
-			expect(fileActions.actions.all.Restore).toBeDefined();
-			expect(fileActions.actions.all.Delete).toBeDefined();
+			var actions = fileActions.getActions('all', 'file', 31);
+			expect(actions.Restore).toBeDefined();
+			expect(actions.Delete).toBeDefined();
 
-			expect(fileActions.actions.all.Rename).not.toBeDefined();
-			expect(fileActions.actions.all.Download).not.toBeDefined();
+			expect(actions.Rename).not.toBeDefined();
+			expect(actions.Download).not.toBeDefined();
 
 			expect(fileActions.defaults.dir).toEqual('Open');
 		});

--- a/core/js/tests/specHelper.js
+++ b/core/js/tests/specHelper.js
@@ -185,6 +185,18 @@ window.isPhantom = /phantom/i.test(navigator.userAgent);
 		OC.Util.History._handlers = [];
 
 		$(window).off('beforeunload');
+
+		OCA.Files.fileActions.clear();
+		OCA.Files.legacyFileActions.clear();
 	});
 })();
+
+var reporterCurrentSpec = {
+     specStarted: function(result) {
+		 console.log(result.fullName);
+     }
+ };
+
+// uncomment this to log the test name, useful for debugging browser crashes in case of memory leaks / infinite loops
+//jasmine.getEnv().addReporter(reporterCurrentSpec);
 


### PR DESCRIPTION
## Description
Make it possible to register functions instead of action specifications.
The function takes a `FileInfoModel` as input and decides whether to return an array of matching actions or not. This way it is possible to customize file actions based on any kind of attributes of the file model.

## Related Issue
Required for https://github.com/owncloud/core/pull/30106 list pending shares.

## Motivation and Context
Required for https://github.com/owncloud/core/pull/30106 list pending shares where the file actions for pending shares would depend on the share state.

## How Has This Been Tested?
Not yet.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

