### PR TITLE
[hotfix-10.0.7] When verifying the request authentication …

### DIFF
--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -95,6 +95,7 @@ class Internal extends Session {
 	public function clear() {
 		session_unset();
 		$this->regenerateId();
+		@session_destroy();
 		@session_start();
 		$_SESSION = [];
 	}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -272,15 +272,15 @@ class Session implements IUserSession, Emitter {
 	public function getLoginName() {
 		if ($this->activeUser) {
 			return $this->session->get('loginname');
-		} else {
-			$uid = $this->session->get('user_id');
-			if ($uid) {
-				$this->activeUser = $this->manager->get($uid);
-				return $this->session->get('loginname');
-			} else {
-				return null;
-			}
 		}
+
+		$uid = $this->session->get('user_id');
+		if ($uid) {
+			$this->activeUser = $this->manager->get($uid);
+			return $this->session->get('loginname');
+		}
+
+		return null;
 	}
 
 	/**
@@ -309,6 +309,7 @@ class Session implements IUserSession, Emitter {
 	 * @param string $user
 	 * @param string $password
 	 * @param IRequest $request
+	 * @throws \InvalidArgumentException
 	 * @throws LoginException
 	 * @throws PasswordLoginForbiddenException
 	 * @return boolean
@@ -887,21 +888,33 @@ class Session implements IUserSession, Emitter {
 	}
 
 	public function verifyAuthHeaders($request) {
-		foreach ($this->getAuthModules(true) as $module) {
-			$user = $module->auth($request);
-			if ($user !== null) {
-				if ($this->isLoggedIn() && $this->getUser()->getUID() !== $user->getUID()) {
-					// the session is bad -> kill it
-					$this->logout();
-					return false;
+		$shallLogout = false;
+		try {
+			$lastUser = null;
+			foreach ($this->getAuthModules(true) as $module) {
+				$user = $module->auth($request);
+				if ($user !== null) {
+					if ($this->isLoggedIn() && $this->getUser()->getUID() !== $user->getUID()) {
+						$shallLogout = true;
+						break;
+					}
+					if ($lastUser !== null && $user->getUID() !== $lastUser->getUID()) {
+						$shallLogout = true;
+						break;
+					}
+					$lastUser = $user;
 				}
-				return true;
 			}
-		}
 
-		// the session is bad -> kill it
-		$this->logout();
-		return false;
+		} catch (Exception $ex) {
+			$shallLogout = true;
+		}
+		if ($shallLogout) {
+			// the session is bad -> kill it
+			$this->logout();
+			return false;
+		}
+		return true;
 	}
 
 	/**
@@ -909,7 +922,7 @@ class Session implements IUserSession, Emitter {
 	 * @return \Generator | IAuthModule[]
 	 * @throws Exception
 	 */
-	private function getAuthModules($includeBuiltIn) {
+	protected function getAuthModules($includeBuiltIn) {
 		if ($includeBuiltIn) {
 			yield new TokenAuthModule($this->session, $this->tokenProvider, $this->manager);
 			yield new BasicAuthModule($this->manager);

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -22,6 +22,7 @@ use OC\User\Manager;
 use OC\User\Session;
 use OCP\App\IServiceLoader;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\IAuthModule;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\ISession;
@@ -1017,6 +1018,85 @@ class SessionTest extends TestCase {
 		$this->assertInstanceOf(GenericEvent::class, $calledBeforeLogout[1]);
 		$this->assertArrayHasKey('uid', $calledBeforeLogout[1]);
 		$this->assertEquals('user.beforelogout', $calledBeforeLogout[0]);
+	}
+
+	public function testApacheLogin() {
+		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		$userManager = $this->createMock(IUserManager::class);
+		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		$session = $this->createMock(ISession::class);
+		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		$timeFactory = $this->createMock(ITimeFactory::class);
+		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		$tokenProvider = $this->createMock(IProvider::class);
+		$userSession = new Session($userManager, $session, $timeFactory,
+			$tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+
+		// Fail if not userid returned
+		$apacheBackend = $this->createMock(IApacheBackend::class);
+		$apacheBackend->expects($this->once())->method('getCurrentUserId')->willReturn(null);
+		$loginVal = $userSession->loginWithApache($apacheBackend);
+		$this->assertFalse($loginVal);
+
+		// Fail if not a user interface supplied
+		$apacheBackend = $this->createMock(IApacheBackend::class);
+		$apacheBackend->expects($this->once())->method('getCurrentUserId')->willReturn('userid');
+		$loginVal = $userSession->loginWithApache($apacheBackend);
+		$this->assertFalse($loginVal);
+	}
+
+	public function providesModules() {
+		$nullModule = $this->createMock(IAuthModule::class);
+		$nullModule->expects($this->any())->method('auth')->willReturn(null);
+		$throwingModule = $this->createMock(IAuthModule::class);
+		$throwingModule->expects($this->any())->method('auth')->willThrowException(new \Exception('Invalid token'));
+		$user1 = $this->createMock(IUser::class);
+		$user1->expects($this->any())->method('getUID')->willReturn('user1');
+		$user1Module = $this->createMock(IAuthModule::class);
+		$user1Module->expects($this->any())->method('auth')->willReturn($user1);
+		$user2 = $this->createMock(IUser::class);
+		$user2->expects($this->any())->method('getUID')->willReturn('user2');
+		$user2Module = $this->createMock(IAuthModule::class);
+		$user2Module->expects($this->any())->method('auth')->willReturn($user2);
+		return [
+			'no modules' => [true, []],
+			'module returning null' => [true, [$nullModule]],
+			'module returning a user' => [true, [$user1Module]],
+			'module throwing an exception' => [false, [$throwingModule]],
+			'modules returning different user' => [false, [$user1Module, $user2Module]],
+			'logged in user does not match' => [false, [$user2Module], $user1],
+		];
+	}
+
+	/**
+	 * @dataProvider providesModules
+	 * @param $expectedReturn
+	 * @param array $modules
+	 */
+	public function testVerifyAuthHeaders($expectedReturn, array $modules, $loggedInUser = null) {
+		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
+		$request = $this->createMock(IRequest::class);
+		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
+		$userManager = $this->createMock(IUserManager::class);
+		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
+		$session = $this->createMock(ISession::class);
+		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
+		$timeFactory = $this->createMock(ITimeFactory::class);
+		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
+		$tokenProvider = $this->createMock(IProvider::class);
+
+		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $session */
+		$session = $this->getMockBuilder(Session::class)
+			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setMethods(['getAuthModules', 'logout', 'isLoggedIn', 'getUser'])
+			->getMock();
+		$session->expects($this->any())->method('getAuthModules')->willReturn($modules);
+
+		$session->expects($this->any())->method('isLoggedIn')->willReturn($loggedInUser !== null);
+		$session->expects($this->any())->method('getUser')->willReturn($loggedInUser);
+
+		$session->expects($expectedReturn ? $this->never() : $this->once())->method('logout');
+		$this->assertEquals( $expectedReturn, $session->verifyAuthHeaders($request));
 	}
 
 }

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -1020,31 +1020,6 @@ class SessionTest extends TestCase {
 		$this->assertEquals('user.beforelogout', $calledBeforeLogout[0]);
 	}
 
-	public function testApacheLogin() {
-		/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject $userManager */
-		$userManager = $this->createMock(IUserManager::class);
-		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
-		$session = $this->createMock(ISession::class);
-		/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject $timeFactory */
-		$timeFactory = $this->createMock(ITimeFactory::class);
-		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
-		$tokenProvider = $this->createMock(IProvider::class);
-		$userSession = new Session($userManager, $session, $timeFactory,
-			$tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
-
-		// Fail if not userid returned
-		$apacheBackend = $this->createMock(IApacheBackend::class);
-		$apacheBackend->expects($this->once())->method('getCurrentUserId')->willReturn(null);
-		$loginVal = $userSession->loginWithApache($apacheBackend);
-		$this->assertFalse($loginVal);
-
-		// Fail if not a user interface supplied
-		$apacheBackend = $this->createMock(IApacheBackend::class);
-		$apacheBackend->expects($this->once())->method('getCurrentUserId')->willReturn('userid');
-		$loginVal = $userSession->loginWithApache($apacheBackend);
-		$this->assertFalse($loginVal);
-	}
-
 	public function providesModules() {
 		$nullModule = $this->createMock(IAuthModule::class);
 		$nullModule->expects($this->any())->method('auth')->willReturn(null);
@@ -1087,7 +1062,7 @@ class SessionTest extends TestCase {
 
 		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $session */
 		$session = $this->getMockBuilder(Session::class)
-			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->serviceLoader])
 			->setMethods(['getAuthModules', 'logout', 'isLoggedIn', 'getUser'])
 			->getMock();
 		$session->expects($this->any())->method('getAuthModules')->willReturn($modules);


### PR DESCRIPTION
…mechanisms we need to loop over all modules and allow each of them

to verify the headers and in case something is terribly wrong the user will be logged out and the session will be destroyed.

The BasicAuthModule now handles app passwords as well - this was missing before and caused users being locked out of ldap.

Solves OAuth token expiry issue - fixes owncloud/oauth2#103


backport of #30365 to hotfix-10.0.7