### PR TITLE
Introduce single user and seen users sync

### DIFF
--- a/core/Migrations/Version20170221114437.php
+++ b/core/Migrations/Version20170221114437.php
@@ -4,6 +4,7 @@ namespace OC\Migrations;
 use OC\User\AccountMapper;
 use OC\User\AccountTermMapper;
 use OC\User\Database;
+use OC\User\Sync\AllUsersIterator;
 use OC\User\SyncService;
 use OCP\Migration\ISimpleMigration;
 use OCP\Migration\IOutput;
@@ -24,7 +25,7 @@ class Version20170221114437 implements ISimpleMigration {
 		// insert/update known users
 		$out->info("Insert new users ...");
 		$out->startProgress($backend->countUsers());
-		$syncService->run($backend, function () use ($out) {
+		$syncService->run($backend, new AllUsersIterator($backend), function () use ($out) {
 			$out->advance();
 		});
 		$out->finishProgress();

--- a/lib/private/User/AccountMapper.php
+++ b/lib/private/User/AccountMapper.php
@@ -234,13 +234,47 @@ class AccountMapper extends Mapper {
 		}
 		$stmt = $qb->execute();
 		while ($row = $stmt->fetch()) {
-			$return =$callback($this->mapRowToEntity($row));
+			$return = $callback($this->mapRowToEntity($row));
 			if ($return === false) {
 				break;
 			}
 		}
 
 		$stmt->closeCursor();
+	}
+
+	/**
+	 * @param string $backend
+	 * @param bool $hasLoggedIn
+	 * @param integer $limit
+	 * @param integer $offset
+	 * @return string[]
+	 */
+	public function findUserIds($backend = null, $hasLoggedIn = null, $limit = null, $offset = null) {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('user_id')
+			->from($this->getTableName())
+			->orderBy('user_id'); // needed for predictable limit & offset
+
+		if ($backend !== null) {
+			$qb->andWhere($qb->expr()->eq('backend', $qb->createNamedParameter($backend)));
+		}
+		if ($hasLoggedIn === true) {
+			$qb->andWhere($qb->expr()->gt('last_login', new Literal(0)));
+		} else if ($hasLoggedIn === false) {
+			$qb->andWhere($qb->expr()->eq('last_login', new Literal(0)));
+		}
+		if ($limit !== null) {
+			$qb->setMaxResults($limit);
+		}
+		if ($offset !== null) {
+			$qb->setFirstResult($offset);
+		}
+
+		$stmt = $qb->execute();
+		$rows = $stmt->fetchAll(\PDO::FETCH_COLUMN);
+		$stmt->closeCursor();
+		return $rows;
 	}
 
 }

--- a/lib/private/User/Sync/AllUsersIterator.php
+++ b/lib/private/User/Sync/AllUsersIterator.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\User\Sync;
+
+use OCP\UserInterface;
+
+class AllUsersIterator extends UsersIterator {
+	/**
+	 * @var UserInterface
+	 */
+	private $backend;
+
+	public function __construct(UserInterface $backend) {
+		$this->backend = $backend;
+	}
+
+	public function rewind() {
+		parent::rewind();
+		$this->data = $this->backend->getUsers('', self::LIMIT, 0);
+	}
+
+	public function next() {
+		$this->position++;
+		if ($this->currentDataPos() === 0) {
+			$this->page++;
+			$offset = $this->page * self::LIMIT;
+			$this->data = $this->backend->getUsers('', self::LIMIT, $offset);
+		}
+	}
+}

--- a/lib/private/User/Sync/SeenUsersIterator.php
+++ b/lib/private/User/Sync/SeenUsersIterator.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\User\Sync;
+
+use OC\User\AccountMapper;
+
+class SeenUsersIterator extends UsersIterator {
+	/**
+	 * @var AccountMapper
+	 */
+	private $mapper;
+	/**
+	 * @var string class name
+	 */
+	private $backend;
+
+	public function __construct(AccountMapper $mapper, $backend) {
+		$this->mapper = $mapper;
+		$this->backend = $backend;
+	}
+
+	public function rewind() {
+		parent::rewind();
+		$this->data = $this->mapper->findUserIds($this->backend, true, self::LIMIT, 0);
+	}
+
+	public function next() {
+		$this->position++;
+		if ($this->currentDataPos() === 0) {
+			$this->page++;
+			$offset = $this->page * self::LIMIT;
+			$this->data = $this->mapper->findUserIds($this->backend, true, self::LIMIT, $offset);
+		}
+	}
+}

--- a/lib/private/User/Sync/UsersIterator.php
+++ b/lib/private/User/Sync/UsersIterator.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\User\Sync;
+
+abstract class UsersIterator implements \Iterator {
+	protected $position = 0;
+	protected $page;
+	protected $data;
+
+	const LIMIT = 500;
+
+
+	public function rewind() {
+		$this->position = 0;
+		$this->page = 0;
+	}
+
+	public function current() {
+		return $this->data[$this->currentDataPos()];
+	}
+
+	public function key() {
+		return $this->position;
+	}
+
+	public abstract function next();
+
+	public function valid() {
+		return isset($this->data[$this->currentDataPos()]);
+	}
+
+	protected function currentDataPos() {
+		return $this->position % self::LIMIT;
+	}
+}

--- a/lib/private/User/SyncService.php
+++ b/lib/private/User/SyncService.php
@@ -109,7 +109,8 @@ class SyncService {
 				$this->cleanPreferences($uid);
 			} catch (\Exception $e) {
 				// Error syncing this user
-				$this->logger->error("Error syncing user with uid: $uid and backend: {get_class($backend)}");
+				$backendClass = get_class($backend);
+				$this->logger->error("Error syncing user with uid: $uid and backend: $backendClass");
 				$this->logger->logException($e);
 			}
 

--- a/tests/lib/Command/User/SyncBackendTest.php
+++ b/tests/lib/Command/User/SyncBackendTest.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace Test\Command\User;
+
+use OC\Core\Command\Integrity\SignApp;
+use OC\Core\Command\User\SyncBackend;
+use OC\IntegrityCheck\Checker;
+use OC\IntegrityCheck\Helpers\FileAccessHelper;
+use OC\User\AccountMapper;
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\IURLGenerator;
+use OCP\IUserBackend;
+use OCP\IUserManager;
+use OCP\UserInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Test\TestCase;
+
+class SyncBackendTest extends TestCase {
+
+	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
+	/** @var AccountMapper | \PHPUnit_Framework_MockObject_MockObject */
+	private $mapper;
+	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $userManager;
+	/** @var SyncBackend */
+	private $command;
+
+	/** @var UserInterface | \PHPUnit_Framework_MockObject_MockObject */
+	private $dummyBackend;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->mapper = $this->createMock(AccountMapper::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+
+		$this->dummyBackend = $this->createMock(UserInterface::class);
+
+		$this->userManager->expects($this->any())
+			->method('getBackends')
+			->willReturn([$this->dummyBackend]);
+
+		$this->command = new SyncBackend(
+			$this->mapper,
+			$this->config,
+			$this->userManager,
+			$this->logger
+		);
+
+	}
+
+	public function testListBackends() {
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
+
+		$inputInterface
+			->expects($this->at(0))
+			->method('getOption')
+			->with('list')
+			->will($this->returnValue(true));
+
+		$outputInterface
+			->expects($this->at(0))
+			->method('writeln')
+			->with(get_class($this->dummyBackend));
+
+		$this->assertEquals(0, static::invokePrivate($this->command, 'execute', [$inputInterface, $outputInterface]));
+	}
+
+	public function testNoBackendIsGivenShowsError() {
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
+
+		$inputInterface
+			->expects($this->at(0))
+			->method('getOption')
+			->with('list')
+			->will($this->returnValue(null));
+
+		$inputInterface
+			->expects($this->at(1))
+			->method('getArgument')
+			->with('backend-class')
+			->will($this->returnValue(null));
+
+		$outputInterface
+			->expects($this->at(0))
+			->method('writeln')
+			->with('<error>No backend class name given. Please run ./occ help user:sync to understand how this command works.</error>');
+
+		$this->assertEquals(1, static::invokePrivate($this->command, 'execute', [$inputInterface, $outputInterface]));
+	}
+
+	public function testNotExistingBackendIsGivenShowsError() {
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
+
+		$inputInterface
+			->expects($this->at(0))
+			->method('getOption')
+			->with('list')
+			->will($this->returnValue(null));
+
+		$backendClassName = '\OCP\Some\Backend';
+		$inputInterface
+			->expects($this->at(1))
+			->method('getArgument')
+			->with('backend-class')
+			->will($this->returnValue($backendClassName));
+
+		$outputInterface
+			->expects($this->at(0))
+			->method('writeln')
+			->with("<error>The backend <$backendClassName> does not exist. Did you miss to enable the app?</error>");
+
+		$this->assertEquals(1, static::invokePrivate($this->command, 'execute', [$inputInterface, $outputInterface]));
+	}
+
+	public function testUnsupportedBackendIsGivenShowsError() {
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
+
+		$inputInterface
+			->expects($this->at(0))
+			->method('getOption')
+			->with('list')
+			->will($this->returnValue(null));
+
+		$backendClassName = get_class($this->dummyBackend);
+		$inputInterface
+			->expects($this->at(1))
+			->method('getArgument')
+			->with('backend-class')
+			->will($this->returnValue($backendClassName));
+
+		$this->dummyBackend
+			->expects($this->at(0))
+			->method('hasUserListings')
+			->will($this->returnValue(false));
+
+		$outputInterface
+			->expects($this->at(0))
+			->method('writeln')
+			->with("<error>The backend <$backendClassName> does not allow user listing. No sync is possible</error>");
+
+		$this->assertEquals(1, static::invokePrivate($this->command, 'execute', [$inputInterface, $outputInterface]));
+	}
+
+	public function testInvalidAccountActionShowsError() {
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
+
+		$inputInterface
+			->expects($this->at(0))
+			->method('getOption')
+			->with('list')
+			->will($this->returnValue(null));
+
+		$backendClassName = get_class($this->dummyBackend);
+
+		$inputInterface
+			->expects($this->at(1))
+			->method('getArgument')
+			->with('backend-class')
+			->will($this->returnValue($backendClassName));
+
+		$this->dummyBackend
+			->expects($this->at(0))
+			->method('hasUserListings')
+			->will($this->returnValue(true));
+
+		$inputInterface
+			->expects($this->at(2))
+			->method('getOption')
+			->with('missing-account-action')
+			->will($this->returnValue('invalid'));
+
+		$outputInterface
+			->expects($this->at(0))
+			->method('writeln')
+			->with('<error>Unknown action. Choose between "disable" or "remove"</error>');
+
+		$this->assertEquals(1, static::invokePrivate($this->command, 'execute', [$inputInterface, $outputInterface]));
+	}
+
+	public function testSingleUserSync() {
+		$inputInterface = $this->createMock(InputInterface::class);
+		$outputInterface = $this->createMock(OutputInterface::class);
+
+		$inputInterface
+			->expects($this->at(0))
+			->method('getOption')
+			->with('list')
+			->will($this->returnValue(null));
+
+		$backendClassName = get_class($this->dummyBackend);
+
+		$inputInterface
+			->expects($this->at(1))
+			->method('getArgument')
+			->with('backend-class')
+			->will($this->returnValue($backendClassName));
+
+		$this->dummyBackend
+			->expects($this->at(0))
+			->method('hasUserListings')
+			->will($this->returnValue(true));
+
+		$inputInterface
+			->expects($this->at(2))
+			->method('getOption')
+			->with('missing-account-action')
+			->will($this->returnValue('disable'));
+		$inputInterface
+			->expects($this->at(3))
+			->method('getOption')
+			->with('missing-account-action')
+			->will($this->returnValue('disable'));
+
+		$inputInterface
+			->expects($this->at(4))
+			->method('getOption')
+			->with('uid')
+			->will($this->returnValue('foo'));
+
+		$outputInterface
+			->expects($this->at(0))
+			->method('writeln')
+			->with('Syncing foo ...');
+
+		// TODO add more tests
+
+		$this->assertEquals(0, static::invokePrivate($this->command, 'execute', [$inputInterface, $outputInterface]));
+	}
+
+}

--- a/tests/lib/User/Sync/AllUsersIteratorTest.php
+++ b/tests/lib/User/Sync/AllUsersIteratorTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\User\Sync;
+
+
+use OCP\UserInterface;
+use Test\TestCase;
+
+/**
+ * Class AllUsersIteratorTest
+ *
+ * @package OC\User\Sync
+ *
+ * @see http://php.net/manual/en/class.iterator.php for the order of calls on an iterator
+ */
+class AllUsersIteratorTest extends TestCase {
+
+	/**
+	 * @var UserInterface|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $backend;
+	/**
+	 * @var \Iterator
+	 */
+	private $iterator;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->backend = $this->createMock(UserInterface::class);
+
+		$this->iterator = new AllUsersIterator($this->backend);
+	}
+
+	/**
+	 * Iterators are initialized by a call to rewind
+	 */
+	public function testRewind() {
+
+		$this->backend->expects($this->once())
+			->method('getUsers')
+			->with(
+				$this->equalTo(''),					// all users
+				$this->equalTo(UsersIterator::LIMIT),	// limit 500
+				$this->equalTo(0)						// at the beginning
+			)
+			->willReturn(['user0']);
+		$this->iterator->rewind();
+		$this->assertTrue($this->iterator->valid());
+		$this->assertEquals('user0', $this->iterator->current());
+		$this->assertEquals(0, $this->iterator->key());
+	}
+
+	/**
+	 * test three pages of results
+	 */
+	public function testNext() {
+
+		// create pages for 1001 users (0..1000)
+		$page1 = [];
+		for ( $i=0; $i<500; $i++ ) {
+			$page1[] = "user$i";
+		}
+		$page2 = [];
+		for ( $i=500; $i<1000; $i++ ) {
+			$page2[] = "user$i";
+		}
+		$page3 = ['user1000'];
+
+		$this->backend->expects($this->exactly(3))
+			->method('getUsers')
+			->withConsecutive(
+				[
+					$this->equalTo(''),					// all users
+					$this->equalTo(UsersIterator::LIMIT),	// limit 500
+					$this->equalTo(0)						// at the beginning
+				],[
+				$this->equalTo(''),					// all users
+				$this->equalTo(UsersIterator::LIMIT),	// limit 500
+				$this->equalTo(500)					// second page
+			],[
+					$this->equalTo(''),					// all users
+					$this->equalTo(UsersIterator::LIMIT),	// limit 500
+					$this->equalTo(1000)					// last page
+				]
+			)
+			->willReturnOnConsecutiveCalls($page1, $page2, $page3);
+
+		// loop over iterator manually to check key() and valid()
+
+		$this->iterator->rewind();
+		$this->assertTrue($this->iterator->valid());
+		$this->assertEquals('user0', $this->iterator->current());
+		$this->assertEquals(0, $this->iterator->key());
+		for ( $i=1; $i<=1000; $i++ ) {
+			$this->iterator->next();
+			$this->assertTrue($this->iterator->valid());
+			$this->assertEquals("user$i", $this->iterator->current());
+			$this->assertEquals($i, $this->iterator->key());
+		}
+		$this->iterator->next();
+		$this->assertFalse($this->iterator->valid());
+	}
+
+}

--- a/tests/lib/User/Sync/SeenUsersIteratorTest.php
+++ b/tests/lib/User/Sync/SeenUsersIteratorTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\User\Sync;
+
+
+use OC\User\AccountMapper;
+use OCP\UserInterface;
+use Test\TestCase;
+
+/**
+ * Class SeenUsersIteratorTest
+ *
+ * @package OC\User\Sync
+ *
+ * @see http://php.net/manual/en/class.iterator.php for the order of calls on an iterator
+ */
+class SeenUsersIteratorTest extends TestCase {
+
+	/**
+	 * @var AccountMapper|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $mapper;
+	/**
+	 * @var \Iterator
+	 */
+	private $iterator;
+
+	const TEST_BACKEND = 'TestBackend';
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->mapper = $this->createMock(AccountMapper::class);
+
+		$this->iterator = new SeenUsersIterator($this->mapper, self::TEST_BACKEND);
+	}
+
+	/**
+	 * Iterators are initialized by a call to rewind
+	 */
+	public function testRewind() {
+
+		$this->mapper->expects($this->once())
+			->method('findUserIds')
+			->with(
+				$this->equalTo(self::TEST_BACKEND),	// only from this backend
+				$this->equalTo(true),					// only logged in users
+				$this->equalTo(UsersIterator::LIMIT),	// limit 500
+				$this->equalTo(0)						// at the beginning
+			)
+			->willReturn(['user0']);
+		$this->iterator->rewind();
+		$this->assertTrue($this->iterator->valid());
+		$this->assertEquals('user0', $this->iterator->current());
+		$this->assertEquals(0, $this->iterator->key());
+	}
+
+	/**
+	 * test three pages of results
+	 */
+	public function testNext() {
+
+		// create pages for 1001 users (0..1000)
+		$page1 = [];
+		for ( $i=0; $i<500; $i++ ) {
+			$page1[] = "user$i";
+		}
+		$page2 = [];
+		for ( $i=500; $i<1000; $i++ ) {
+			$page2[] = "user$i";
+		}
+		$page3 = ['user1000'];
+
+		$this->mapper->expects($this->exactly(3))
+			->method('findUserIds')
+			->withConsecutive(
+				[
+					$this->equalTo(self::TEST_BACKEND),	// only from this backend
+					$this->equalTo(true),					// only logged in users
+					$this->equalTo(UsersIterator::LIMIT),	// limit 500
+					$this->equalTo(0)						// at the beginning
+				],[
+				$this->equalTo(self::TEST_BACKEND),	// only from this backend
+				$this->equalTo(true),					// only logged in users
+				$this->equalTo(UsersIterator::LIMIT),	// limit 500
+				$this->equalTo(500)					// second page
+			],[
+					$this->equalTo(self::TEST_BACKEND),	// only from this backend
+					$this->equalTo(true),					// only logged in users
+					$this->equalTo(UsersIterator::LIMIT),	// limit 500
+					$this->equalTo(1000)					// last page
+				]
+			)
+			->willReturnOnConsecutiveCalls($page1, $page2, $page3);
+
+		// loop over iterator manually to check key() and valid()
+
+		$this->iterator->rewind();
+		$this->assertTrue($this->iterator->valid());
+		$this->assertEquals('user0', $this->iterator->current());
+		$this->assertEquals(0, $this->iterator->key());
+		for ( $i=1; $i<=1000; $i++ ) {
+			$this->iterator->next();
+			$this->assertTrue($this->iterator->valid());
+			$this->assertEquals("user$i", $this->iterator->current());
+			$this->assertEquals($i, $this->iterator->key());
+		}
+		$this->iterator->next();
+		$this->assertFalse($this->iterator->valid());
+	}
+	
+}

--- a/tests/lib/User/SyncServiceTest.php
+++ b/tests/lib/User/SyncServiceTest.php
@@ -26,6 +26,7 @@ namespace Test\User;
 use OC\User\Account;
 use OC\User\AccountMapper;
 use OC\User\Database;
+use OC\User\Sync\AllUsersIterator;
 use OC\User\SyncService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IConfig;
@@ -95,7 +96,7 @@ class SyncServiceTest extends TestCase {
 
 
 		$s = new SyncService($config, $logger, $mapper);
-		$s->run($backend, function($uid) {});
+		$s->run($backend, new AllUsersIterator($backend), function($uid) {});
 
 		$this->invokePrivate($s, 'syncHome', [$account, $backend]);
 	}


### PR DESCRIPTION
Restart of https://github.com/owncloud/core/pull/28212, but without additional logging. Based on https://github.com/owncloud/core/pull/30412

We had to add a `findUserIds` method to the Account mapper to iterate over all users in batches. `callForSeenUsers`takes a callback but also initializes the user objects filling caches everywhere, an unwanted side effect that only slows down the sync.

We also introduced Iterators for Iterating over all users of a backend as well as seen users only. The case for a single user uses an ArrayIterator.

One change in behavior: to get a total count you now have to use `--showCount`. Counting might be expensive. So we disable it by default ...

Tasks for another PR:
- [ ] on single user sync show before & after (requires bypassing the cache in the user manager)
- [ ] show only changed values for synced users or highlight them
- [ ] reflect changes in documentation