### PR TITLE
 Always remember all original capability settings for integration test scenarios

### DIFF
--- a/tests/acceptance/capabilities_features/capabilities.feature
+++ b/tests/acceptance/capabilities_features/capabilities.feature
@@ -4,18 +4,26 @@ Feature: capabilities
 		And as user "admin"
 
 	Scenario: Check that the sharing API can be enabled
+		Given parameter "shareapi_enabled" of app "core" has been set to "no"
+		And the capabilities setting of "files_sharing" path "api_enabled" has been confirmed to be ""
 		When the administrator sets parameter "shareapi_enabled" of app "core" to "yes" using the API
 		Then the capabilities setting of "files_sharing" path "api_enabled" should be "1"
 
 	Scenario: Check that the sharing API can be disabled
+		Given parameter "shareapi_enabled" of app "core" has been set to "yes"
+		And the capabilities setting of "files_sharing" path "api_enabled" has been confirmed to be "1"
 		When the administrator sets parameter "shareapi_enabled" of app "core" to "no" using the API
 		Then the capabilities setting of "files_sharing" path "api_enabled" should be ""
 
 	Scenario: Check that group sharing can be enabled
+		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
+		And the capabilities setting of "files_sharing" path "group_sharing" has been confirmed to be ""
 		When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "yes" using the API
 		Then the capabilities setting of "files_sharing" path "group_sharing" should be "1"
 
 	Scenario: Check that group sharing can be disabled
+		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "yes"
+		And the capabilities setting of "files_sharing" path "group_sharing" has been confirmed to be "1"
 		When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "no" using the API
 		Then the capabilities setting of "files_sharing" path "group_sharing" should be ""
 

--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -99,6 +99,7 @@ trait AppConfiguration {
 
 	/**
 	 * @Then the capabilities setting of :capabilitiesApp path :capabilitiesPath should be :expectedValue
+	 * @Given the capabilities setting of :capabilitiesApp path :capabilitiesPath has been confirmed to be :expectedValue
 	 *
 	 * @param string $capabilitiesApp the "app" name in the capabilities response
 	 * @param string $capabilitiesPath the path to the element


### PR DESCRIPTION
## Description
Keep a record of the original state of all capabilities settings that were touched, even if the setting was already in that state before the scenario started. Explicitly restore all those settings - just in case some explicit step in the scenario messed with the setting.

## Related Issue
https://github.com/owncloud/QA/issues/534

## Motivation and Context
When running the capabilities integration test scenarios, some existing sharing capabilities settings may not be returned to their original state. For local testing this can be annoying, because some setting is unexpectedly left on or off. 

It could also be an issue for later (naughty) tests in a multi-stage automated test run that re-use the same database/settings left from an integration test run, that have assumed that the database/settings are in a pristine "default" state.

Motivation is be as nice as reasonably possible to the existing settings when setting up, running and tearing down each scenario.

## How Has This Been Tested?
Running integration tests for capabilities locally.
CI will do the rest.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

