### PR TITLE
Use type juggling for comparison on size in chunking plugin

### DIFF
--- a/apps/dav/lib/Upload/ChunkingPlugin.php
+++ b/apps/dav/lib/Upload/ChunkingPlugin.php
@@ -45,6 +45,9 @@ class ChunkingPlugin extends ServerPlugin {
 	/**
 	 * @param string $sourcePath source path
 	 * @param string $destination destination path
+	 * @return bool|void
+	 * @throws BadRequest
+	 * @throws \Sabre\DAV\Exception\NotFound
 	 */
 	function beforeMove($sourcePath, $destination) {
 		$this->sourceNode = $this->server->tree->getNodeForPath($sourcePath);
@@ -98,7 +101,7 @@ class ChunkingPlugin extends ServerPlugin {
 			return;
 		}
 		$actualSize = $this->sourceNode->getSize();
-		if ((int)$expectedSize !== $actualSize) {
+		if ($expectedSize != $actualSize) {
 			throw new BadRequest("Chunks on server do not sum up to $expectedSize but to $actualSize");
 		}
 	}

--- a/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
+++ b/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
@@ -164,4 +164,53 @@ class ChunkingPluginTest extends TestCase {
 		$this->assertFalse($this->plugin->beforeMove('source', 'target'));
 	}
 
+	/**
+	 * We provide data to validate expectedSize and Actual size.
+	 * The actual size can be float too. So we check that too.
+	 * @return array
+	 */
+	public function expectedAndActualSizeData() {
+		return [
+			['12345678910', 12345678910.0],
+			['12345678910', 12345678910.0123],
+			['9999999999999', 9999999999999.0],
+			['9999999999999.9999', 9999999999999.9999],
+			['999999999999999.9999', 999999999999999.9999],
+			['9999999999999999999', 9999999999999999999],
+		];
+	}
+
+	/**
+	 * @dataProvider expectedAndActualSizeData
+	 * @param $expectedSize
+	 * @param $actualSize
+	 */
+	public function testVerifySizeFordifferentTypes($expectedSize, $actualSize) {
+		$reflector = new \ReflectionClass($this->plugin);
+		$property = $reflector->getProperty('sourceNode');
+		$property->setAccessible(true);
+
+		$sourceNode = $this->createMock(FutureFile::class);
+		$property->setValue($this->plugin, $sourceNode);
+		$sourceNode->expects($this->once())
+			->method('getSize')
+			->willReturn($actualSize);
+
+		$this->tree->expects($this->any())
+			->method('getNodeForPath')
+			->with('source')
+			->will($this->returnValue($sourceNode));
+		$this->request->expects($this->once())
+			->method('getHeader')
+			->with('OC-Total-Length')
+			->willReturn($expectedSize);
+
+		if ($expectedSize != $actualSize) {
+			$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
+			$this->expectExceptionMessage(sprintf("Chunks on server do not sum up to %s but to %.3f", $expectedSize, $actualSize));
+		} else {
+			$this->assertTrue(true);
+		}
+		$this->invokePrivate($this->plugin, 'verifySize', []);
+	}
 }


### PR DESCRIPTION
Intially we tried to go ahead with int comparison.
But that didn't worked with 32 bit systems. Because of
explicit conversion of double to int. So in this patch
decided to move ahead with type juggling comparison
or loose comparison of size in chunking plugin

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Loose type comparison of size in chunk plugin helps when large files are uploaded.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Loose type comparison of size in chunk plugin helps when large files are uploaded.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Verified by uploading various large files 3 GB, 3.8 GB, 4 GB, 4.8 GB, 7.6 GB from web UI.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

