### PR TITLE
Free resources in preview providers

### DIFF
--- a/lib/private/Preview/Bitmap.php
+++ b/lib/private/Preview/Bitmap.php
@@ -49,9 +49,10 @@ abstract class Bitmap implements IProvider2 {
 		} catch (\Exception $e) {
 			Util::writeLog('core', 'ImageMagick says: ' . $e->getmessage(), Util::ERROR);
 			return false;
+		} finally {
+			fclose($stream);
 		}
 
-		fclose($stream);
 
 		//new bitmap image object
 		$image = new \OC_Image();

--- a/lib/private/Preview/SVG.php
+++ b/lib/private/Preview/SVG.php
@@ -42,10 +42,12 @@ class SVG implements IProvider2 {
 			$svg = new \Imagick();
 			$svg->setBackgroundColor(new \ImagickPixel('transparent'));
 
-			$content = stream_get_contents($file->fopen('r'));
+			$stream = $file->fopen('r');
+			$content = stream_get_contents($stream);
 			if (substr($content, 0, 5) !== '<?xml') {
 				$content = '<?xml version="1.0" encoding="UTF-8" standalone="no"?>' . $content;
 			}
+			fclose($stream);
 
 			// Do not parse SVG files with references
 			if (stripos($content, 'xlink:href') !== false) {

--- a/lib/private/Preview/TXT.php
+++ b/lib/private/Preview/TXT.php
@@ -40,8 +40,9 @@ class TXT implements IProvider2 {
 	 * {@inheritDoc}
 	 */
 	public function getThumbnail(File $file, $maxX, $maxY, $scalingUp) {
-		$content = $file->fopen('r');
-		$content = stream_get_contents($content,3000);
+		$stream = $file->fopen('r');
+		$content = stream_get_contents($stream,3000);
+		fclose($stream);
 
 		//don't create previews of empty text files
 		if(trim($content) === '') {


### PR DESCRIPTION
## Description
Dispose unneeded resources ASAP

## Related Issue
https://github.com/owncloud/core/issues/30506

## Motivation and Context
Driven by random build failures

## How Has This Been Tested?
Not tested in general as original issue is a Heisenbug
So I just checked that previews are still shown for affected mimes

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

