### PR TITLE
Retry upload overwrite if file locked in UI tests

### DIFF
--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -27,6 +27,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\LoginPage;
 use Page\OwncloudPage;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use TestHelpers\AppConfigHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\UploadHelper;
@@ -173,6 +174,23 @@ class FeatureContext extends RawMinkContext implements Context {
 	 */
 	public function getCurrentPageObject() {
 		return $this->currentPageObject;
+	}
+
+	/**
+	 * @Then no notification should be displayed
+	 * @return void
+	 */
+	public function noNotificationShouldBeDisplayed() {
+		try {
+			$notificationText = $this->owncloudPage->getNotificationText();
+			PHPUnit_Framework_Assert::assertEquals(
+				'',
+				$notificationText,
+				"Expecting no notifications but got $notificationText"
+			);
+		} catch (ElementNotFoundException $e) {
+			// if there is no notification element, then good
+		}
 	}
 
 	/**

--- a/tests/ui/features/bootstrap/SharingContext.php
+++ b/tests/ui/features/bootstrap/SharingContext.php
@@ -89,7 +89,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theFileFolderIsSharedWithTheUser(
-		$folder, $remote, $user, $maxRetries = 5, $quiet = false
+		$folder, $remote, $user, $maxRetries = STANDARDRETRYCOUNT, $quiet = false
 	) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());
 		try {

--- a/tests/ui/features/bootstrap/bootstrap.php
+++ b/tests/ui/features/bootstrap/bootstrap.php
@@ -38,3 +38,5 @@ const LONGUIWAITTIMEOUTMILLISEC = 60000;
 const STANDARDUIWAITTIMEOUTMILLISEC = 10000;
 // Minimum timeout for use in code that needs to wait for the UI
 const MINIMUMUIWAITTIMEOUTMILLISEC = 500;
+// Default number of times to retry where retries are useful
+const STANDARDRETRYCOUNT = 5;

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -241,7 +241,7 @@ class FilesPage extends FilesPageBasic {
 		$fromFileName,
 		$toFileName,
 		Session $session,
-		$maxRetries = 5
+		$maxRetries = STANDARDRETRYCOUNT
 	) {
 		if (is_array($toFileName)) {
 			$toFileName = implode($toFileName);
@@ -281,7 +281,7 @@ class FilesPage extends FilesPageBasic {
 	 * @return void
 	 */
 	public function moveFileTo(
-		$name, $destination, Session $session, $maxRetries = 5
+		$name, $destination, Session $session, $maxRetries = STANDARDRETRYCOUNT
 	) {
 		$toMoveFileRow = $this->findFileRowByName($name, $session);
 		$destinationFileRow = $this->findFileRowByName($destination, $session);

--- a/tests/ui/features/lib/FilesPageBasic.php
+++ b/tests/ui/features/lib/FilesPageBasic.php
@@ -263,7 +263,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	 * @param int $maxRetries
 	 * @return void
 	 */
-	public function deleteFile($name, Session $session, $maxRetries = 5) {
+	public function deleteFile($name, Session $session, $maxRetries = STANDARDRETRYCOUNT) {
 		$this->initAjaxCounters($session);
 		$this->resetSumStartedAjaxRequests($session);
 		

--- a/tests/ui/features/lib/PublicLinkFilesPage.php
+++ b/tests/ui/features/lib/PublicLinkFilesPage.php
@@ -128,7 +128,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 		$fromFileName,
 		$toFileName,
 		Session $session,
-		$maxRetries = 5
+		$maxRetries = STANDARDRETRYCOUNT
 	) {
 		throw new \Exception("not implemented");
 	}
@@ -143,7 +143,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 * @return void
 	 */
 	public function moveFileTo(
-		$name, $destination, Session $session, $maxRetries = 5
+		$name, $destination, Session $session, $maxRetries = STANDARDRETRYCOUNT
 	) {
 		throw new \Exception("not implemented");
 	}

--- a/tests/ui/features/sharingExternalOther/federationSharing.feature
+++ b/tests/ui/features/sharingExternalOther/federationSharing.feature
@@ -41,7 +41,7 @@ So that other users have access to these files
 		And I relogin with username "user1" and password "1234" to "http://%remote_server%"
 		And the offered remote shares are accepted
 		And I open the folder "simple-folder (2)"
-		And I upload overwriting the file "lorem.txt"
+		And I upload overwriting the file "lorem.txt" and retry if the file is locked
 		And I relogin with username "user2" and password "1234" to "%base_url%"
 		And I open the folder "simple-folder"
 		Then the file "lorem.txt" should be listed

--- a/tests/ui/features/sharingExternalOther/shareByPublicLink.feature
+++ b/tests/ui/features/sharingExternalOther/shareByPublicLink.feature
@@ -72,6 +72,6 @@ So that public sharing is limited according to organization policy
 		When I open the folder "simple-folder (2)"
 		Then the file "lorem.txt" should be listed
 		And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
-		When I upload overwriting the file "lorem.txt"
+		When I upload overwriting the file "lorem.txt" and retry if the file is locked
 		Then the file "lorem.txt" should be listed
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"

--- a/tests/ui/features/sharingInternalGroupsUsers/shareWithGroups.feature
+++ b/tests/ui/features/sharingInternalGroupsUsers/shareWithGroups.feature
@@ -40,7 +40,7 @@ So that those groups can access the files and folders
 		And I relogin with username "user1" and password "1234"
 		Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
-		When I upload overwriting the file "new-lorem.txt"
+		When I upload overwriting the file "new-lorem.txt" and retry if the file is locked
 		Then the file "new-lorem.txt" should be listed
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# unshare the received shared file
@@ -61,7 +61,7 @@ So that those groups can access the files and folders
 		And I open the folder "new-simple-folder"
 		Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
-		When I upload overwriting the file "lorem.txt"
+		When I upload overwriting the file "lorem.txt" and retry if the file is locked
 		Then the file "lorem.txt" should be listed
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"
 		# upload a new file into the received share

--- a/tests/ui/features/sharingInternalGroupsUsers/shareWithUsers.feature
+++ b/tests/ui/features/sharingInternalGroupsUsers/shareWithUsers.feature
@@ -32,7 +32,7 @@ So that those users can access the files and folders
 		And I relogin with username "user1" and password "1234"
 		Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
-		When I upload overwriting the file "new-lorem.txt"
+		When I upload overwriting the file "new-lorem.txt" and retry if the file is locked
 		Then the file "new-lorem.txt" should be listed
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# unshare the received shared file
@@ -50,7 +50,7 @@ So that those users can access the files and folders
 		And I open the folder "new-simple-folder"
 		Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
-		When I upload overwriting the file "lorem.txt"
+		When I upload overwriting the file "lorem.txt" and retry if the file is locked
 		Then the file "lorem.txt" should be listed
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"
 		# upload a new file into the received share

--- a/tests/ui/features/upload/upload.feature
+++ b/tests/ui/features/upload/upload.feature
@@ -14,34 +14,33 @@ So that I can store files in ownCloud
 
 	Scenario: simple upload of a file that does not exist before
 		When I upload the file "new-lorem.txt"
-		Then the file "new-lorem.txt" should be listed
+		Then no notification should be displayed
+		And the file "new-lorem.txt" should be listed
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
 	Scenario: chunking upload
 		And a file with the size of "30000000" bytes and the name "big-video.mp4" exists
 		When I upload the file "big-video.mp4"
-		Then the file "big-video.mp4" should be listed
+		Then no notification should be displayed
+		And the file "big-video.mp4" should be listed
 		And the content of "big-video.mp4" should be the same as the local "big-video.mp4"
 
 	Scenario: conflict with a chunked file
 		And a file with the size of "30000000" bytes and the name "big-video.mp4" exists
 		When I rename the file "lorem.txt" to "big-video.mp4"
-		And I upload the file "big-video.mp4"
-		And I choose to keep the new files
-		And I click the "Continue" button
+		And I upload overwriting the file "big-video.mp4" and retry if the file is locked
 		Then the file "big-video.mp4" should be listed
 		And the content of "big-video.mp4" should be the same as the local "big-video.mp4"
 
 	Scenario: upload a new file into a sub folder
 		When I open the folder "simple-folder"
 		And I upload the file "new-lorem.txt"
-		Then the file "new-lorem.txt" should be listed
+		Then no notification should be displayed
+		And the file "new-lorem.txt" should be listed
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
 	Scenario: overwrite an existing file
-		When I upload the file "lorem.txt"
-		And I choose to keep the new files
-		And I click the "Continue" button
+		When I upload overwriting the file "lorem.txt" and retry if the file is locked
 		Then no dialog should be displayed
 		And the file "lorem.txt" should be listed
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"
@@ -53,6 +52,7 @@ So that I can store files in ownCloud
 		And I choose to keep the existing files
 		And I click the "Continue" button
 		Then no dialog should be displayed
+		And no notification should be displayed
 		And the file "lorem.txt" should be listed
 		And the content of "lorem.txt" should not have changed
 		And the file "lorem (2).txt" should be listed
@@ -62,15 +62,14 @@ So that I can store files in ownCloud
 		When I upload the file "lorem.txt"
 		And I click the "Cancel" button
 		Then no dialog should be displayed
+		And no notification should be displayed
 		And the file "lorem.txt" should be listed
 		And the content of "lorem.txt" should not have changed
 		And the file "lorem (2).txt" should not be listed
 
 	Scenario: overwrite an existing file in a sub-folder
 		When I open the folder "simple-folder"
-		When I upload the file "lorem.txt"
-		And I choose to keep the new files
-		And I click the "Continue" button
+		And I upload overwriting the file "lorem.txt" and retry if the file is locked
 		Then the file "lorem.txt" should be listed
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"
 
@@ -81,6 +80,7 @@ So that I can store files in ownCloud
 		And I choose to keep the existing files
 		And I click the "Continue" button
 		Then no dialog should be displayed
+		And no notification should be displayed
 		And the file "lorem.txt" should be listed
 		And the content of "lorem.txt" should not have changed
 		And the file "lorem (2).txt" should be listed

--- a/tests/ui/features/upload/uploadEdgecases.feature
+++ b/tests/ui/features/upload/uploadEdgecases.feature
@@ -52,15 +52,15 @@ that is not academically correct but saves a lot of time
 		| "strängé नेपाली folder" |
 
 	Scenario: overwrite an existing file
-		When I upload overwriting the file "'single'quotes.txt"
+		When I upload overwriting the file "'single'quotes.txt" and retry if the file is locked
 		Then the file "'single'quotes.txt" should be listed
 		And the content of "'single'quotes.txt" should be the same as the local "'single'quotes.txt"
 
-		When I upload overwriting the file "strängé filename (duplicate #2 &).txt"
+		When I upload overwriting the file "strängé filename (duplicate #2 &).txt" and retry if the file is locked
 		Then the file "strängé filename (duplicate #2 &).txt" should be listed
 		And the content of "strängé filename (duplicate #2 &).txt" should be the same as the local "strängé filename (duplicate #2 &).txt"
 
-		When I upload overwriting the file "zzzz-must-be-last-file-in-folder.txt"
+		When I upload overwriting the file "zzzz-must-be-last-file-in-folder.txt" and retry if the file is locked
 		Then the file "zzzz-must-be-last-file-in-folder.txt" should be listed
 		And the content of "zzzz-must-be-last-file-in-folder.txt" should be the same as the local "zzzz-must-be-last-file-in-folder.txt"
 


### PR DESCRIPTION
## Description
For file upload tests that overwrite an existing file, retry the upload process if it gets some notification (probably about "file locked"). Report that a notification was received, and the text of the notification, so that it is possible to see in the test output that "something happened" but try again anyway up to the "standard" number of retries.

The retry actions go through the same sequence of UI actions that the user would do anyway, when they see a "file locked" message after trying to do an upload.

## Related Issue
#30506 

## Motivation and Context
Make upload-overwrite UI tests reliable.

## How Has This Been Tested?
CI passes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

