### PR TITLE
Show warning message if no files to be transferred

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -57,8 +57,11 @@ class TransferOwnership extends Command {
 	/** @var ILogger  */
 	private  $logger;
 
-	/** @var FileInfo[] */
-	private $allFiles = [];
+	/** @var bool */
+	private $filesExist = false;
+
+	/** @var bool */
+	private $foldersExist = false;
 
 	/** @var FileInfo[] */
 	private $encryptedFiles = [];
@@ -153,6 +156,11 @@ class TransferOwnership extends Command {
 		// analyse source folder
 		$this->analyse($output);
 
+		if (!$this->filesExist and !$this->foldersExist) {
+			$output->writeln("<comment>No files/folders to transfer</comment>");
+			return 1;
+		}
+
 		// collect all the shares
 		$this->collectUsersShares($output);
 
@@ -188,6 +196,7 @@ class TransferOwnership extends Command {
 		if ( strlen($this->inputPath) > 0) {
 			if ($this->inputPath !== "$this->sourceUser/files") {
 				$walkPath = $this->inputPath;
+				$this->foldersExist = true;
 			}
 		}
 
@@ -199,10 +208,12 @@ class TransferOwnership extends Command {
 						if ($fileInfo->getInternalPath() === '' && $fileInfo->getPath() !== '') {
 							return false;
 						}
+
+						$this->foldersExist = true;
 						return true;
 					}
 					$progress->advance();
-					$this->allFiles[] = $fileInfo;
+					$this->filesExist = true;
 					if ($fileInfo->isEncrypted()) {
 						if (\OC::$server->getAppConfig()->getValue('encryption', 'useMasterKey', 0) !== 0) {
 							/**

--- a/tests/integration/features/transfer-ownership.feature
+++ b/tests/integration/features/transfer-ownership.feature
@@ -251,3 +251,11 @@ Feature: transfer-ownership
 		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
 		Then the command output should contain the text "Unknown path provided"
 		And the command should have failed with exit code 1
+
+	Scenario: transferring ownership fails with empty files
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" deletes everything from folder "/" using the API
+		When the administrator transfers ownership from "user0" to "user1" using the occ command
+		Then the command output should contain the text "No files/folders to transfer"
+		And the command should have failed with exit code 1


### PR DESCRIPTION
## Description
When run:
`sudo -u www-data ./occ files:transfer-ownership user1 user2`
Added check if files/folders exist for transfer and if not then show warning message.

## Related Issue
[#24061](https://github.com/owncloud/core/issues/24061)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

