### PR TITLE
Fixup phpcs on UI tests

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -25,6 +25,7 @@
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 		<exclude name="Generic.Commenting.DocComment.TagValueIndent" />
 		<exclude name="Generic.Commenting.DocComment.NonParamGroup" />
+		<exclude name="PEAR.Commenting.FileComment.IncompleteCopyright" />
 		<exclude name="PEAR.Commenting.FileComment.MissingVersion" />
 		<exclude name="PEAR.Commenting.FileComment.MissingCategoryTag" />
 		<exclude name="PEAR.Commenting.FileComment.MissingPackageTag" />

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -510,11 +510,12 @@ trait BasicStructure {
 	/**
 	 * returns an array of the real displayed names
 	 * if no "Display Name" is set the user-name is returned instead
+	 *
 	 * @return array
 	 */
 	public function getCreatedUserDisplayNames() {
 		$result = array();
-		foreach ($this->getCreatedUsers() as $username=>$user) {
+		foreach ($this->getCreatedUsers() as $username => $user) {
 			if (is_null($user['displayname'])) {
 				$result[] = $username;
 			} else {

--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -351,11 +351,11 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given the following files/folders are deleted
-	 * @param TableNode $namePartsTable table headings: must be: |name|
+	 * @param TableNode $filesTable table headings: must be: |name|
 	 * @return void
 	 */
-	public function theFollowingFilesFoldersAreDeleted(TableNode $table) {
-		foreach ($table as $file) {
+	public function theFollowingFilesFoldersAreDeleted(TableNode $filesTable) {
+		foreach ($filesTable as $file) {
 			$username = $this->featureContext->getCurrentUser();
 			$currentTime = microtime(true);
 			$end = $currentTime + (LONGUIWAITTIMEOUTMILLISEC / 1000);
@@ -762,12 +762,16 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theFollowingFileFolderShouldBeListed(
-		$shouldOrNot, $typeOfFilesPage, $folder = "", TableNode $namePartsTable
+		$shouldOrNot, $typeOfFilesPage, $folder = "", TableNode $namePartsTable = null
 	) {
 		$fileNameParts = [];
 
-		foreach ($namePartsTable as $namePartsRow) {
-			$fileNameParts[] = $namePartsRow['name-parts'];
+		if ($namePartsTable !== null) {
+			foreach ($namePartsTable as $namePartsRow) {
+				$fileNameParts[] = $namePartsRow['name-parts'];
+			}
+		} else {
+			PHPUnit_Framework_Assert::fail('no table of file name parts passed to theFollowingFileFolderShouldBeListed');
 		}
 
 		// The capturing groups of the regex include the quotes at each

--- a/tests/ui/features/bootstrap/SharingContext.php
+++ b/tests/ui/features/bootstrap/SharingContext.php
@@ -284,7 +284,10 @@ class SharingContext extends RawMinkContext implements Context {
 	/**
 	 * @When I add the public link to :server as user :username with the password :password
 	 * @param string $server
+	 * @param string $username
+	 * @param string $password
 	 * @return void
+	 * @throws Exception
 	 */
 	public function iAddThePublicLinkTo($server, $username, $password) {
 		if (!$this->publicLinkFilesPage->isOpen()) {

--- a/tests/ui/features/lib/FilesPageElement/FileRow.php
+++ b/tests/ui/features/lib/FilesPageElement/FileRow.php
@@ -295,6 +295,8 @@ class FileRow extends OwnCloudPage {
 	
 	/**
 	 * restore the current deleted file and folder by clicking on the restore link
+	 *
+	 * @return void
 	 */
 	public function restore() {
 		$rowElement = $this->rowElement->find('xpath', $this->restoreLinkXpath);


### PR DESCRIPTION
## Description
1) My recent "Welcome 2018" change also made all the copyright tags on files have ``@copyright Copyright (c) YYYY name etc`` format, which is what most of the ownCloud files already had. The UI test files had been in a format ``@copyright YYYY name etc`` which passed the ``phpcs`` check. The other format does not pass the check.
Since the format now in the files is what is used in 1000+ files through ownCloud, disable the check

2) Fixup other little things pointed out by ``phpcs``

## Related Issue

## Motivation and Context
Run ``phpcs`` on the UI test code just to see if some PRs have missed PHPdoc etc.

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

