### PR TITLE
[stable10] Adjust timeout and tests for federated share access

### DIFF
--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -200,7 +200,7 @@ class FilesPage extends FilesPageBasic {
 			);
 		}
 		$uploadField->attachFile(getenv("FILES_FOR_UPLOAD") . $name);
-		$this->waitForAjaxCallsToStartAndFinish($session);
+		$this->waitForAjaxCallsToStartAndFinish($session, 20000);
 		$this->waitForUploadProgressbarToFinish();
 	}
 

--- a/tests/ui/features/sharingExternalOther/federationSharing.feature
+++ b/tests/ui/features/sharingExternalOther/federationSharing.feature
@@ -36,22 +36,46 @@ So that other users have access to these files
 		And I open the folder "simple-folder (2)"
 		Then it should not be possible to delete the file "lorem.txt"
 
-	Scenario: rename and delete files in a received share
+	Scenario: overwrite a file in a received share
 		When the folder "simple-folder" is shared with the remote user "user1@%remote_server%"
 		And I relogin with username "user1" and password "1234" to "http://%remote_server%"
 		And the offered remote shares are accepted
 		And I open the folder "simple-folder (2)"
 		And I upload overwriting the file "lorem.txt"
-		And I upload the file "new-lorem.txt"
-		And I rename the file "lorem-big.txt" to "renamed file.txt"
-		And I delete the file "data.zip"
 		And I relogin with username "user2" and password "1234" to "%base_url%"
 		And I open the folder "simple-folder"
 		Then the file "lorem.txt" should be listed
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"
+
+	Scenario: upload a new file in a received share
+		When the folder "simple-folder" is shared with the remote user "user1@%remote_server%"
+		And I relogin with username "user1" and password "1234" to "http://%remote_server%"
+		And the offered remote shares are accepted
+		And I open the folder "simple-folder (2)"
+		And I upload the file "new-lorem.txt"
+		And I relogin with username "user2" and password "1234" to "%base_url%"
+		And I open the folder "simple-folder"
 		And the file "new-lorem.txt" should be listed
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
+
+	Scenario: rename a file in a received share
+		When the folder "simple-folder" is shared with the remote user "user1@%remote_server%"
+		And I relogin with username "user1" and password "1234" to "http://%remote_server%"
+		And the offered remote shares are accepted
+		And I open the folder "simple-folder (2)"
+		And I rename the file "lorem-big.txt" to "renamed file.txt"
+		And I relogin with username "user2" and password "1234" to "%base_url%"
+		And I open the folder "simple-folder"
 		And the file "renamed file.txt" should be listed
 		And the content of "renamed file.txt" should be the same as the original "simple-folder/lorem-big.txt"
 		But the file "lorem-big.txt" should not be listed
+
+	Scenario: delete a file in a received share
+		When the folder "simple-folder" is shared with the remote user "user1@%remote_server%"
+		And I relogin with username "user1" and password "1234" to "http://%remote_server%"
+		And the offered remote shares are accepted
+		And I open the folder "simple-folder (2)"
+		And I delete the file "data.zip"
+		And I relogin with username "user2" and password "1234" to "%base_url%"
+		And I open the folder "simple-folder"
 		And the file "data.zip" should not be listed


### PR DESCRIPTION
Backport from #29319 the changed UI test federatedSharing scenarios. The backported commit also includes a longer timeout in ``waitForAjaxCallsToStartAndFinish`` when doing ``uploadFile``.

It is handy to have the reorganized/extended test scenarios running in ``stable10`` like they are in ``master``, and it avoids getting merge conflicts for other changes/enhancements to this feature file.

The extra timeout will do no harm - it was observed to be needed in ``master`` as the "Preview via DAV" changes (which are not backported to ``stable10``) were causing some extra time lag.
