### PR TITLE
[WIP] Error handling for skeleton trigger in ui tests

### DIFF
--- a/tests/TestHelpers/DownloadHelper.php
+++ b/tests/TestHelpers/DownloadHelper.php
@@ -21,6 +21,7 @@
  */
 namespace TestHelpers;
 
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\FutureResponse;
 use GuzzleHttp\Message\ResponseInterface;
 
@@ -45,6 +46,7 @@ class DownloadHelper {
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
 	 * @return FutureResponse|ResponseInterface|NULL
+	 * @throws BadResponseException
 	 */
 	public static function download(
 		$baseUrl,

--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -60,11 +60,11 @@ class UserHelper {
 			return $return;
 		}
 		if ($displayName !== null) {
-			$editReponse = self::editUser(
+			$editResponse = self::editUser(
 				$baseUrl, $user, "display", $displayName, $adminUser, $adminPassword
 			);
-			$return[] = $editReponse;
-			if ($editReponse->getStatusCode() !== 200) {
+			$return[] = $editResponse;
+			if ($editResponse->getStatusCode() !== 200) {
 				return $return;
 			}
 		}


### PR DESCRIPTION
## Description
Catch ``BadResponseException`` when we try to download ``lorem.txt`` as the way of initializing a new user's skeleton. If this happens, then loop around trying again. 

## Related Issue

## Motivation and Context
The UI tests on ``drone`` quite often have a problem downloading ``lorem.txt`` to initialize a new user. They sometimes get a ``404`` ``not found`` and the scenario bombs out. Maybe it just needs to wait a little bit and try again after a user has just been created, before access to the user files is possible.

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

