### PR TITLE
[Stable10] Free resources in preview providers

### DIFF
--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -63,6 +63,7 @@ class Movie extends Provider {
 			// in some cases 1MB was no enough to generate thumbnail
 			$firstmb = stream_get_contents($handle, 5242880);
 			file_put_contents($absPath, $firstmb);
+			fclose($handle);
 		}
 
 		$result = $this->generateThumbNail($maxX, $maxY, $absPath, 5);

--- a/lib/private/Preview/SVG.php
+++ b/lib/private/Preview/SVG.php
@@ -39,10 +39,12 @@ class SVG extends Provider {
 			$svg = new \Imagick();
 			$svg->setBackgroundColor(new \ImagickPixel('transparent'));
 
-			$content = stream_get_contents($fileview->fopen($path, 'r'));
+			$stream = $fileview->fopen($path, 'r');
+			$content = stream_get_contents($stream);
 			if (substr($content, 0, 5) !== '<?xml') {
 				$content = '<?xml version="1.0" encoding="UTF-8" standalone="no"?>' . $content;
 			}
+			fclose($stream);
 
 			// Do not parse SVG files with references
 			if (stripos($content, 'xlink:href') !== false) {

--- a/lib/private/Preview/TXT.php
+++ b/lib/private/Preview/TXT.php
@@ -44,8 +44,9 @@ class TXT extends Provider {
 	 * {@inheritDoc}
 	 */
 	public function getThumbnail($path, $maxX, $maxY, $scalingup, $fileview) {
-		$content = $fileview->fopen($path, 'r');
-		$content = stream_get_contents($content,3000);
+		$stream = $fileview->fopen($path, 'r');
+		$content = stream_get_contents($stream,3000);
+		fclose($stream);
 
 		//don't create previews of empty text files
 		if(trim($content) === '') {


### PR DESCRIPTION
## Description
Dispose unneeded resources ASAP
Backport of  https://github.com/owncloud/core/pull/30507
Note: it was not cherry-pickable so I did `grep -R fopen lib/private/Preview/` and found a slightly different set of providers affected.

## Related Issue
https://github.com/owncloud/core/issues/30506

## Motivation and Context
Driven by random build failures

## How Has This Been Tested?
Not tested in general as original issue is a Heisenbug
So I just checked that previews are still shown for affected mimes

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

