### PR TITLE
Stop searching apps in OC::SERVERROOT sibling

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -198,12 +198,6 @@ class OC {
 			}
 		} elseif (file_exists(OC::$SERVERROOT . '/apps')) {
 			OC::$APPSROOTS[] = ['path' => OC::$SERVERROOT . '/apps', 'url' => '/apps', 'writable' => true];
-		} elseif (file_exists(OC::$SERVERROOT . '/../apps')) {
-			OC::$APPSROOTS[] = [
-				'path' => rtrim(dirname(OC::$SERVERROOT), '/') . '/apps',
-				'url' => '/apps',
-				'writable' => true
-			];
 		}
 
 		if (empty(OC::$APPSROOTS)) {


### PR DESCRIPTION
## Description
Remove fallback to `OC::$SERVERROOT . '/../apps'` when 
`apps_paths` is not set via `config.php`


## Motivation and Context
1. This is not documented. 
2. I don't think it is used by anybody.
3. Why just not put it into `config.php` as an 'apps_paths' content
4. I can't stop thinking of this piece of code


## How Has This Been Tested?
commented in `config.php`
```
 /* 'apps_paths' => 
  array (
    0 => 
    array (
      'path' => '/dev/oc-tmp/apps',
      'url' => '/apps',
      'writable' => false,
    ),
  ), */
```

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

