### PR TITLE
UI-tests clear lock after scenario

### DIFF
--- a/apps/testing/appinfo/routes.php
+++ b/apps/testing/appinfo/routes.php
@@ -75,8 +75,24 @@ API::register('get', '/apps/testing/api/v1/lockprovisioning/{type}/{user}', [$lo
 API::register('post', '/apps/testing/api/v1/lockprovisioning/{type}/{user}', [$locking, 'acquireLock'], 'files_lockprovisioning', API::ADMIN_AUTH);
 API::register('put', '/apps/testing/api/v1/lockprovisioning/{type}/{user}', [$locking, 'changeLock'], 'files_lockprovisioning', API::ADMIN_AUTH);
 API::register('delete', '/apps/testing/api/v1/lockprovisioning/{type}/{user}', [$locking, 'releaseLock'], 'files_lockprovisioning', API::ADMIN_AUTH);
-API::register('delete', '/apps/testing/api/v1/lockprovisioning/{type}', [$locking, 'releaseAll'], 'files_lockprovisioning', API::ADMIN_AUTH);
-API::register('delete', '/apps/testing/api/v1/lockprovisioning', [$locking, 'releaseAll'], 'files_lockprovisioning', API::ADMIN_AUTH);
+
+//release all locks of the given type that were set by the testing app
+API::register(
+	'delete',
+	'/apps/testing/api/v1/lockprovisioning/{type}',
+	[$locking, 'releaseAll'],
+	'files_lockprovisioning',
+	API::ADMIN_AUTH
+);
+//relase all locks that were set by the testing app
+//if global=true in the requests also locks that were not set by the testing app get cleared
+API::register(
+	'delete',
+	'/apps/testing/api/v1/lockprovisioning',
+	[$locking, 'releaseAll'],
+	'files_lockprovisioning',
+	API::ADMIN_AUTH
+);
 
 $bigFileID = new BigFileID(
 	\OC::$server->getDatabaseConnection()

--- a/apps/testing/locking/fakedblockingprovider.php
+++ b/apps/testing/locking/fakedblockingprovider.php
@@ -62,6 +62,16 @@ class FakeDBLockingProvider extends \OC\Lock\DBLockingProvider {
 		parent::releaseLock($path, $type);
 	}
 
+	/**
+	 * sets all locks in the file_locks table to "0"
+	 * @return void
+	 */
+	public function releaseAllGlobally() {
+		$this->db->executeUpdate(
+			'UPDATE `*PREFIX*file_locks` SET `lock` = 0'
+		);
+	}
+
 	public function __destruct() {
 		// Prevent cleaning up at the end of the live time.
 		// parent::__destruct();

--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -29,6 +29,7 @@ use Page\LoginPage;
 use Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use TestHelpers\AppConfigHelper;
+use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\UploadHelper;
 use TestHelpers\UserHelper;
@@ -551,6 +552,24 @@ class FeatureContext extends RawMinkContext implements Context {
 		foreach ($this->createdFiles as $file) {
 			unlink($file);
 		}
+	}
+
+	/**
+	 * After Scenario. clear file locks
+	 *
+	 * @return void
+	 * @AfterScenario
+	 */
+	public function clearFileLocks() {
+		$response = OcsApiHelper::sendRequest(
+			$this->getMinkParameter('base_url'),
+			"admin",
+			$this->getUserPassword("admin"),
+			'delete',
+			"/apps/testing/api/v1/lockprovisioning",
+			["global" => "true"]
+		);
+		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
 	}
 
 	/**


### PR DESCRIPTION
## Description
The former `releaseAll` function was broken, every of the if statements did run the same code, but that actually did not clear anything because a string was passed and not an int.
I've changed it so that:
1. sending a 'delete'  to '/apps/testing/api/v1/lockprovisioning/{type}' clears locks of the given types that were set previously by the testing app
2. sending a 'delete'  to '/apps/testing/api/v1/lockprovisioning/' clears locks of all types that were set previously by the testing app
3. sending a 'delete'  to '/apps/testing/api/v1/lockprovisioning/' and `global=true` in the body of the requests clears all locks in the database regardless of if they were set by the testing app or not

Additionally the UI tests now use that functionality to clear locks after every scenario

## Motivation and Context
sometimes UI tests break because of not released locks after user deletion.

## How Has This Been Tested?
set locks manually, check that they were released after a test-run

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.