### PR TITLE
[stable10] Check exec and stat method before using it

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -180,12 +180,26 @@ class Local extends \OC\Files\Storage\Common {
 			return false;
 		}
 		if (PHP_INT_SIZE === 4) {
-			if (\OC_Util::runningOn('linux')) {
-				return (int) exec ('stat -c %Y '. escapeshellarg ($fullPath));
-			} else if (\OC_Util::runningOn('bsd') || \OC_Util::runningOn('mac')) {
-				return (int) exec ('stat -f %m '. escapeshellarg ($fullPath));
+			/**
+			 * Check if exec is available to use before calling it.
+			 */
+			if (function_exists('exec') === true) {
+				$result = 0;
+				$returnVar = 0;
+				if (\OC_Util::runningOn('linux')) {
+					$result = (int)exec('stat -c %Y ' . escapeshellarg($fullPath), $output, $returnVar);
+				} else if (\OC_Util::runningOn('bsd') || \OC_Util::runningOn('mac')) {
+					$result = (int)exec('stat -f %m ' . escapeshellarg($fullPath), $output, $returnVar);
+				}
+
+				/**
+				 * If the result is zero, then stat is missing.
+				 * Additionally check the return status from the shell.
+				 */
+				if ($returnVar === 0) {
+					return $result;
+				}
 			}
-			return false;
 		}
 		return filemtime($fullPath);
 	}


### PR DESCRIPTION
Before using exec and stat method in 32 bit
machines, a check is required if they are
available or not. Else fallback to the
filemtime(path);

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Check if the functions exec and stat are not disabled before using them.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/29287

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the exec and stat were not checked before using them the mtime was stored as zero in the filecache table. So this will help us avoid the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x]  Added `exec, stat,` to `disable_functions` into file /etc/php/7.0/apache2/php.ini ( distro : Linux Mint 18.3 Sylvia) and restart apache.
- [x]  Modified the Local.php's filemtime method to have a check for `PHP_INT_SIZE === 8`.
- [x] Verified that if exec and stat are disabled the `return filemtime($fullPath);` gets called.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

