### PR TITLE
Fix wording if you are not a member of any groups

### DIFF
--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -81,10 +81,15 @@ if($_['displayNameChangeSupported']) {
 
 <div id="groups" class="section">
 	<h2><?php p($l->t('Groups')); ?></h2>
-	<p><?php p($l->t('You are member of the following groups:')); ?></p>
-	<p>
-	<?php p(implode(', ', $_['groups'])); ?>
-	</p>
+	<?php if (count($_['groups']) > 0) { ?>
+		<p><?php p($l->t('You are member of the following groups:')); ?></p>
+		<p>
+			<?php p(implode(', ', $_['groups'])); ?>
+		</p>
+	<?php } else { ?>
+		<p><?php p($l->t('You are not a member of any groups.')); ?></p>
+	<?php } ?>
+
 </div>
 
 <?php


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
When you are not a member of any groups (small instances, first time setup etc) the wording was wrong and it looked like the page could be broken as the list was empty. This makes it cleaner.

## Motivation and Context
Broken wording looked untidy.

## How Has This Been Tested?
Manually with a user with 0 groups, 1 groups and > 1 groups.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

