### PR TITLE
Improve message when UI test file should be listed check fails

### DIFF
--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -725,7 +725,7 @@ class FilesContext extends RawMinkContext implements Context {
 		$name, $shouldOrNot, $typeOfFilesPage = "", $folder = ""
 	) {
 		$should = ($shouldOrNot !== "not");
-		$message = null;
+		$exceptionMessage = null;
 		if ($typeOfFilesPage === "trashbin") {
 			$this->iAmOnTheTrashbinPage();
 		}
@@ -740,20 +740,43 @@ class FilesContext extends RawMinkContext implements Context {
 
 		try {
 			$fileRowElement = $pageObject->findFileRowByName($name, $this->getSession());
-			$message = '';
+			$exceptionMessage = '';
 		} catch (ElementNotFoundException $e) {
-			$message = $e->getMessage();
+			$exceptionMessage = $e->getMessage();
 			$fileRowElement = null;
 		}
+
+		if (is_array($name)) {
+			$nameText = implode($name);
+		} else {
+			$nameText = $name;
+		}
+
+		$fileLocationText = " file '" . $nameText . "'";
+
+		if ($folder !== "") {
+			$fileLocationText .= " in folder '" . $folder . "'";
+		} else {
+			$fileLocationText .= " in current folder";
+		}
+
+		if ($typeOfFilesPage !== "") {
+			$fileLocationText .= " in " . $typeOfFilesPage;
+		}
+
 		if ($should) {
-			PHPUnit_Framework_Assert::assertNotNull($fileRowElement);
+			PHPUnit_Framework_Assert::assertNotNull(
+				$fileRowElement,
+				"could not find" . $fileLocationText . " when it should be listed"
+			);
 		} else {
 			if (is_array($name)) {
 				$name = implode($name);
 			}
 			PHPUnit_Framework_Assert::assertContains(
 				"could not find file with the name '" . $name . "'",
-				$message
+				$exceptionMessage,
+				"found " . $fileLocationText . " when it should not be listed"
 			);
 		}
 	}


### PR DESCRIPTION
## Description
When we do a step like:
```
Then the file "lorem.txt" should be listed
Then the file "lorem.txt" should not be listed
```
and it fails (the file "is not" or "is" listed), then emit a more decent looking explanation of what the problem was.

## Related Issue

## Motivation and Context
This output appeared in a test result just now:
```
    Then the folder "simple-folder (2)" should be listed                                           # FilesContext::theFileFolderShouldBeListed()
      Failed asserting that null is not null.
```
Even though I am an IT nerd, this message did not seem helpful:)
We can do better.

## How Has This Been Tested?
CI knows.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

