### PR TITLE
[stable10] FIx wording if you are not a member of any groups

### DIFF
--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -81,10 +81,15 @@ if($_['displayNameChangeSupported']) {
 
 <div id="groups" class="section">
 	<h2><?php p($l->t('Groups')); ?></h2>
-	<p><?php p($l->t('You are member of the following groups:')); ?></p>
-	<p>
-	<?php p(implode(', ', $_['groups'])); ?>
-	</p>
+	<?php if (count($_['groups']) > 0) { ?>
+		<p><?php p($l->t('You are member of the following groups:')); ?></p>
+		<p>
+			<?php p(implode(', ', $_['groups'])); ?>
+		</p>
+	<?php } else { ?>
+		<p><?php p($l->t('You are not a member of any groups.')); ?></p>
+	<?php } ?>
+
 </div>
 
 <?php


### PR DESCRIPTION
Backport #30551 

This seems like it is not a "new feature" but a "UI fix" to make the words nicer - so I am putting a backport here.