### PR TITLE
Skip failing public link share tests on Edge browser

### DIFF
--- a/tests/ui/features/sharingExternalOther/shareByPublicLink.feature
+++ b/tests/ui/features/sharingExternalOther/shareByPublicLink.feature
@@ -41,7 +41,7 @@ So that public sharing is limited according to organization policy
 		And I access the last created public link
 		Then it should not be possible to delete the file "lorem.txt"
 
-	@skipOnINTERNETEXPLORER @issue_30392
+	@skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue_30392
 	Scenario: mount public link
 		Given these users exist:
 		|username|password|displayname|email       |
@@ -57,7 +57,7 @@ So that public sharing is limited according to organization policy
 		And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 		And it should not be possible to delete the file "lorem.txt"
 
-	@skipOnINTERNETEXPLORER @issue_30392
+	@skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue_30392
 	Scenario: mount public link and overwrite file
 		Given these users exist:
 		|username|password|displayname|email       |


### PR DESCRIPTION
## Description
Skip tests that are always failing on Microsoft Edge.
They can be investigated in more detail without having always-failing CI.

## Related Issue
#30392 

## Motivation and Context
These public link sharing tests are failing on Microsoft Edge, in addition to IE.
We do not want always-failing tests on ``master`` branch.

## How Has This Been Tested?
Noticed in multiple attempts to run in the hotfix-10.0.7 branch.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

