### PR TITLE
Improve notificationsShouldBeDisplayedWithTheText failure message

### DIFF
--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -208,28 +208,37 @@ class FeatureContext extends RawMinkContext implements Context {
 	/**
 	 * @Then /^notifications should be displayed with the text\s?(matching|)$/
 	 * @param string $matching contains "matching" when notification text
-	 * 						   has to be checked against regular expression
+	 *                         has to be checked against regular expression
 	 * @param TableNode $table of expected notification text
 	 * @return void
+	 * @throws Exception
 	 */
 	public function notificationsShouldBeDisplayedWithTheText($matching, TableNode $table) {
-		$notifications = $this->owncloudPage->getNotifications();
-		$tableRows = $table->getRows();
+		$actualNotifications = $this->owncloudPage->getNotifications();
+		$numActualNotifications = count($actualNotifications);
+		$expectedNotifications = $table->getRows();
+		$numExpectedNotifications = count($expectedNotifications);
+
 		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
-			count($tableRows),
-			count($notifications)
+			$numExpectedNotifications,
+			$numActualNotifications,
+			"expected at least $numExpectedNotifications notifications but only found $numActualNotifications"
 		);
 
 		$notificationCounter = 0;
-		foreach ($tableRows as $row) {
+		foreach ($expectedNotifications as $expectedNotification) {
+			$expectedNotificationText = $expectedNotification[0];
+			$actualNotificationText = $actualNotifications[$notificationCounter];
 			if ($matching === "matching") {
-				if (!preg_match($row[0], $notifications[$notificationCounter])) {
-					throw new Exception($notifications[$notificationCounter] . " does not match " . $row[0]);
+				if (!preg_match($expectedNotificationText, $actualNotificationText)) {
+					throw new Exception(
+						$actualNotificationText . " does not match " . $expectedNotificationText
+					);
 				}
 			} else {
 				PHPUnit_Framework_Assert::assertEquals(
-					$row[0],
-					$notifications[$notificationCounter]
+					$expectedNotificationText,
+					$actualNotificationText
 				);
 			}
 			$notificationCounter++;


### PR DESCRIPTION
## Description
1) give some more useful message text when the expected number of notifications are not found
```
expected at least $numExpectedNotifications notifications but only found $numActualNotifications
```
2) refactored a bunch of ``count()`` and ``$row[0]`` bits to avoid repitition and (hopefully) use meaningful variable names.

## Related Issue

## Motivation and Context
While running UI tests on IE11 I got failures like:
```
    Then notifications should be displayed with the text                                                 # FeatureContext::notificationsShouldBeDisplayedWithTheText()
      | Could not move "strängé filename (duplicate #2 &).txt", target exists |
      Failed asserting that 0 is equal to 1 or is greater than 1.
    And the file "strängé filename (duplicate #2 &).txt" should be listed                                # FilesContext::theFileFolderShouldBeListed()
SAUCELABS RESULT: (fail) https://saucelabs.com/jobs/04364cc08a19425697a5342bed6c6f53
```
Well yes, I know that 0 is not equal to or greater than 1. That is a fun fact of number theory. But actually I want to know what in the heck is wrong about the notifications.

## How Has This Been Tested?
CI knows.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

