### PR TITLE
Fix link share email subject

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -187,8 +187,9 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 
 			$l10n = \OC::$server->getL10N('lib');
 
+			$sendingUser = \OC::$server->getUserSession()->getUser();
 			$mailNotification = new \OC\Share\MailNotifications(
-				\OC::$server->getUserSession()->getUser(),
+				$sendingUser,
 				$l10n,
 				\OC::$server->getMailer(),
 				\OC::$server->getLogger(),
@@ -206,11 +207,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				}
 			}
 
-			$result = $mailNotification->sendLinkShareMail(
-				$filter->getToAddress(), $filter->getFile(), $filter->getLink(), $expiration
-			);
-
-			$subject = (string)$l10n->t('%s shared »%s« with you', [$this->senderDisplayName, $filename]);
+			$subject = (string)$l10n->t('%s shared »%s« with you', [$sendingUser->getDisplayName(), $filter->getFile()]);
 			if ($emailBody === null || $emailBody === '') {
 				list($htmlBody, $textBody) = $mailNotification->createMailBody($file, $link, $expiration);
 			} else {


### PR DESCRIPTION
## Description
Also removed redundant call to sendLinkShareMail as we want to always
use the given message body.

## Related Issue
Fixes https://github.com/owncloud/core/issues/30557

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual testing with a single email address, the subject looks good now and only one email is received instead of two.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Note: no unit tests possible in this section of the code... Would be good to have acceptance tests for this that verify subject and body @owncloud/qa