### PR TITLE
hotfix branch rebased onto stable10

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ workspace:
   base: /drone
   path: src
 
-branches: [master, stable10, stable9.1, stable9]
+branches: [master, stable10, stable9.1, stable9, hotfix-*]
 
 clone:
   git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ branches:
   only:
     - master
     - /^stable\d+(\.\d+)?$/
+    - /^hotfix-.*$/ 
 
 addons:
   apt: &common_apt
@@ -57,70 +58,70 @@ script:
 matrix:
   include:
     - php: 5.6
-      if: type = cron
+      if: branch = stable10 OR branch =~ ^hotfix-.*$ OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="other" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: type = cron
+      if: branch = stable10 OR branch =~ ^hotfix-.*$ OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="files" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: type = cron
+      if: branch = stable10 OR branch =~ ^hotfix-.*$ OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="moveFilesFolders" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: type = cron
+      if: branch = stable10 OR branch =~ ^hotfix-.*$ OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="renameFiles" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: type = cron
+      if: branch = stable10 OR branch =~ ^hotfix-.*$ OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="renameFolders" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: type = cron
+      if: branch = stable10 OR branch =~ ^hotfix-.*$ OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="trashbin" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: type = cron
+      if: branch = stable10 OR branch =~ ^hotfix-.*$ OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="sharingInternalGroupsUsers" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: type = cron
+      if: branch = stable10 OR branch =~ ^hotfix-.*$ OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="sharingExternalOther" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: type = cron
+      if: branch = stable10 OR branch =~ ^hotfix-.*$ OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="restrictSharing" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      if: type = cron
+      if: branch = stable10 OR branch =~ ^hotfix-.*$ OR type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="upload" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+## 10.0.7
+### Fixed
+- Fixed issues related to app passwords and account lock-outs - [#30157](https://github.com/owncloud/core/issues/30157)
+
 ## 10.0.6 - 2018-01-29
 ### Fixed
 - Fix missing build dependency for L18N - [#30265](https://github.com/owncloud/core/pull/30265)
@@ -425,7 +429,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - provisioning API now also returns the user's home path: [#26850](https://github.com/owncloud/core/issues/26850)
 - web updater shows link to changelog in admin page: [#26796](https://github.com/owncloud/core/issues/26796)
 
-[Unreleased]: https://github.com/owncloud/core/compare/v10.0.5...stable10
+[Unreleased]: https://github.com/owncloud/core/compare/v10.0.6...stable10
+[10.0.6]: https://github.com/owncloud/core/compare/v10.0.5...v10.0.6
 [10.0.5]: https://github.com/owncloud/core/compare/v10.0.4...v10.0.5
 [10.0.4]: https://github.com/owncloud/core/compare/v10.0.3...v10.0.4
 [10.0.3]: https://github.com/owncloud/core/compare/v10.0.2...v10.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ## 10.0.7
 ### Fixed
-- Fixed issues related to app passwords and account lock-outs - [#30157](https://github.com/owncloud/core/issues/30157)
+- Fix various issues about null user errors - [#30450](https://github.com/owncloud/core/issues/30450)
+- Solve OAuth token expiry issue - [#30481](https://github.com/owncloud/core/issues/30481)
+- Fixed issues related to app passwords and account lock-outs - [#30363](https://github.com/owncloud/core/issues/30363)
 
 ## 10.0.6 - 2018-01-29
 ### Fixed

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 0, 6, 1];
+$OC_Version = [10, 0, 7, 0];
 
 // The human readable string
-$OC_VersionString = '10.0.6';
+$OC_VersionString = '10.0.7 RC1';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 0, 7, 1];
+$OC_Version = [10, 0, 7, 2];
 
 // The human readable string
-$OC_VersionString = '10.0.7 RC2';
+$OC_VersionString = '10.0.7';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 0, 7, 0];
+$OC_Version = [10, 0, 7, 1];
 
 // The human readable string
-$OC_VersionString = '10.0.7 RC1';
+$OC_VersionString = '10.0.7 RC2';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
This is the hotfix-10.0.7 branch **before** the merge commit from https://github.com/owncloud/core/pull/30535, rebased onto stable10.

I'm a bit worried that those version changing commits will not be accurate after merge.

In the future we should refrain to backport stuff onto stable10 if the target is the hotfix branch. They will then eventually land on stable10 through the final "merge release branch into stable10" and keep their proper order.

Thoughts ? Should we move forward with this PR this time and improve next time ?