### PR TITLE
[WIP] Adding symfony events for shares

### DIFF
--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -36,6 +36,7 @@ use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IProviderFactory;
 use OCP\Share\IShare;
 use OCP\Share\IShareProvider;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Class ManagerTest
@@ -231,7 +232,26 @@ class ManagerTest extends \Test\TestCase {
 			->method('post')
 			->with($hookListnerExpectsPost);
 
+		$calledBeforeDeleteEvent = [];
+		$calledAfterDeleteEvent = [];
+
+		\OC::$server->getEventDispatcher()->addListener('file.beforeunshare',
+			function (GenericEvent $event) use (&$calledBeforeDeleteEvent) {
+			$calledBeforeDeleteEvent[] = 'file.beforeunshare';
+			$calledBeforeDeleteEvent[] = $event;
+		});
+		\OC::$server->getEventDispatcher()->addListener('file.afterunshare',
+			function (GenericEvent $event) use (&$calledAfterDeleteEvent) {
+			$calledAfterDeleteEvent[] = 'file.afterunshare';
+			$calledAfterDeleteEvent[] = $event;
+		});
 		$manager->deleteShare($share);
+
+		$this->assertInstanceOf(GenericEvent::class, $calledBeforeDeleteEvent[1]);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterDeleteEvent[1]);
+		$this->assertEquals('file.beforeunshare', $calledBeforeDeleteEvent[0]);
+		$this->assertEquals('file.afterunshare', $calledAfterDeleteEvent[0]);
+		$this->assertArrayHasKey('share', $calledAfterDeleteEvent[1]);
 	}
 
 	public function testDeleteLazyShare() {
@@ -310,7 +330,25 @@ class ManagerTest extends \Test\TestCase {
 			->method('post')
 			->with($hookListnerExpectsPost);
 
+		$calledBeforeDeleteEvent = [];
+		$calledAfterDeleteEvent = [];
+		\OC::$server->getEventDispatcher()->addListener('file.beforeunshare',
+			function (GenericEvent $event) use (&$calledBeforeDeleteEvent) {
+				$calledBeforeDeleteEvent[] = 'file.beforeunshare';
+				$calledBeforeDeleteEvent[] = $event;
+		});
+		\OC::$server->getEventDispatcher()->addListener('file.afterunshare',
+			function (GenericEvent $event) use (&$calledAfterDeleteEvent) {
+				$calledAfterDeleteEvent[] = 'file.afterunshare';
+				$calledAfterDeleteEvent[] = $event;
+		});
 		$manager->deleteShare($share);
+
+		$this->assertInstanceOf(GenericEvent::class, $calledBeforeDeleteEvent[1]);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterDeleteEvent[1]);
+		$this->assertEquals('file.afterunshare', $calledAfterDeleteEvent[0]);
+		$this->assertEquals('file.beforeunshare', $calledBeforeDeleteEvent[0]);
+		$this->assertArrayHasKey('share', $calledAfterDeleteEvent[1]);
 	}
 
 	public function testDeleteNested() {
@@ -433,7 +471,25 @@ class ManagerTest extends \Test\TestCase {
 			->method('post')
 			->with($hookListnerExpectsPost);
 
+		$calledBeforeDeleteEvent = [];
+		$calledAfterDeleteEvent = [];
+		\OC::$server->getEventDispatcher()->addListener('file.beforeunshare',
+			function (GenericEvent $event) use (&$calledBeforeDeleteEvent) {
+				$calledBeforeDeleteEvent[] = 'file.beforeunshare';
+				$calledBeforeDeleteEvent[] = $event;
+			});
+		\OC::$server->getEventDispatcher()->addListener('file.afterunshare',
+			function (GenericEvent $event) use (&$calledAfterDeleteEvent) {
+				$calledAfterDeleteEvent[] = 'file.afterunshare';
+				$calledAfterDeleteEvent[] = $event;
+			});
 		$manager->deleteShare($share1);
+
+		$this->assertInstanceOf(GenericEvent::class, $calledBeforeDeleteEvent[1]);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterDeleteEvent[1]);
+		$this->assertEquals('file.afterunshare', $calledAfterDeleteEvent[0]);
+		$this->assertEquals('file.beforeunshare', $calledBeforeDeleteEvent[0]);
+		$this->assertArrayHasKey('share', $calledAfterDeleteEvent[1]);
 	}
 
 	public function testDeleteChildren() {
@@ -1662,7 +1718,27 @@ class ManagerTest extends \Test\TestCase {
 			->method('setTarget')
 			->with('/target');
 
+		$calledBeforeCreateEvent = [];
+		$calledAfterCreateEvent = [];
+		\OC::$server->getEventDispatcher()->addListener('file.beforeshare',
+			function (GenericEvent $event) use (&$calledBeforeCreateEvent) {
+				$calledBeforeCreateEvent[] = 'file.beforeshare';
+				$calledBeforeCreateEvent[] = $event;
+		});
+		\OC::$server->getEventDispatcher()->addListener('file.aftershare',
+			function (GenericEvent $event) use (&$calledAfterCreateEvent) {
+				$calledAfterCreateEvent[] = 'file.aftershare';
+				$calledAfterCreateEvent[] = $event;
+		});
+
 		$manager->createShare($share);
+
+		$this->assertInstanceOf(GenericEvent::class, $calledBeforeCreateEvent[1]);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterCreateEvent[1]);
+		$this->assertArrayHasKey('sharedata', $calledBeforeCreateEvent[1]);
+		$this->assertArrayHasKey('sharedata', $calledAfterCreateEvent[1]);
+		$this->assertEquals('file.beforeshare', $calledBeforeCreateEvent[0]);
+		$this->assertEquals('file.aftershare', $calledAfterCreateEvent[0]);
 	}
 
 	public function testCreateShareGroup() {
@@ -1715,7 +1791,27 @@ class ManagerTest extends \Test\TestCase {
 			->method('setTarget')
 			->with('/target');
 
+		$calledBeforeCreateEvent = [];
+		$calledAfterCreateEvent = [];
+		\OC::$server->getEventDispatcher()->addListener('file.beforeshare',
+			function (GenericEvent $event) use (&$calledBeforeCreateEvent) {
+				$calledBeforeCreateEvent[] = 'file.beforeshare';
+				$calledBeforeCreateEvent[] = $event;
+			});
+		\OC::$server->getEventDispatcher()->addListener('file.aftershare',
+			function (GenericEvent $event) use (&$calledAfterCreateEvent) {
+				$calledAfterCreateEvent[] = 'file.aftershare';
+				$calledAfterCreateEvent[] = $event;
+			});
+
 		$manager->createShare($share);
+
+		$this->assertInstanceOf(GenericEvent::class, $calledBeforeCreateEvent[1]);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterCreateEvent[1]);
+		$this->assertArrayHasKey('sharedata', $calledBeforeCreateEvent[1]);
+		$this->assertArrayHasKey('sharedata', $calledAfterCreateEvent[1]);
+		$this->assertEquals('file.beforeshare', $calledBeforeCreateEvent[0]);
+		$this->assertEquals('file.aftershare', $calledAfterCreateEvent[0]);
 	}
 
 	public function testCreateShareLink() {
@@ -1978,7 +2074,27 @@ class ManagerTest extends \Test\TestCase {
 			->method('setTarget')
 			->with('/target');
 
+		$calledBeforeCreateEvent = [];
+		$calledAfterCreateEvent = [];
+		\OC::$server->getEventDispatcher()->addListener('file.beforeshare',
+			function (GenericEvent $event) use (&$calledBeforeCreateEvent) {
+				$calledBeforeCreateEvent[] = 'file.beforeshare';
+				$calledBeforeCreateEvent[] = $event;
+			});
+		\OC::$server->getEventDispatcher()->addListener('file.aftershare',
+			function (GenericEvent $event) use (&$calledAfterCreateEvent) {
+				$calledAfterCreateEvent[] = 'file.aftershare';
+				$calledAfterCreateEvent[] = $event;
+			});
+
 		$manager->createShare($share);
+
+		$this->assertInstanceOf(GenericEvent::class, $calledBeforeCreateEvent[1]);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterCreateEvent[1]);
+		$this->assertArrayHasKey('sharedata', $calledBeforeCreateEvent[1]);
+		$this->assertArrayHasKey('sharedata', $calledAfterCreateEvent[1]);
+		$this->assertEquals('file.beforeshare', $calledBeforeCreateEvent[0]);
+		$this->assertEquals('file.aftershare', $calledAfterCreateEvent[0]);
 	}
 
 	public function testGetAllSharesBy() {


### PR DESCRIPTION
Adding before and after events for shares
using symfony's event dispatcher.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Adding before and after symfony dispatcher events for shares

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding before and after symfony dispatcher events for shares.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

