### PR TITLE
Teach UI tests to know if a user should exist or not

### DIFF
--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -439,17 +439,17 @@ trait BasicStructure {
 	 */
 	public function tearDownScenarioDeleteCreatedUsersAndGroups() {
 		$baseUrl = $this->getMinkParameter("base_url");
-		foreach ($this->getCreatedUserNames() as $user) {
+		foreach ($this->getCreatedUsers() as $username => $user) {
 			$result = UserHelper::deleteUser(
 				$baseUrl,
-				$user,
+				$username,
 				"admin",
 				$this->getUserPassword("admin")
 			);
 			
-			if ($result->getStatusCode() !== 200) {
+			if ($user['shouldHaveBeenCreated'] && ($result->getStatusCode() !== 200)) {
 				error_log(
-					"INFORMATION: could not delete user. '" . $user . "'"
+					"INFORMATION: could not delete user '" . $username . "' "
 					. $result->getStatusCode() . " " . $result->getBody()
 				);
 			}
@@ -558,12 +558,13 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function addUserToCreatedUsersList(
-		$user, $password, $displayName = null, $email = null
+		$user, $password, $displayName = null, $email = null, $shouldHaveBeenCreated = true
 	) {
 		$this->createdUsers [$user] = [
 			"password" => $password,
 			"displayname" => $displayName,
-			"email" => $email
+			"email" => $email,
+			"shouldHaveBeenCreated" => $shouldHaveBeenCreated
 		];
 	}
 

--- a/tests/ui/features/bootstrap/UsersContext.php
+++ b/tests/ui/features/bootstrap/UsersContext.php
@@ -82,7 +82,7 @@ class UsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When /^I create a user with the name "([^"]*)" (?:and )?the password "([^"]*)"(?: and the email "([^"]*)")?(?: that is a member of these groups)?$/
+	 * @When /^I (attempt to |)create a user with the name "([^"]*)" (?:and )?the password "([^"]*)"(?: and the email "([^"]*)")?(?: that is a member of these groups)?$/
 	 * @param string $username
 	 * @param string $password
 	 * @param string $email
@@ -90,7 +90,7 @@ class UsersContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function iCreateAUserInTheGUI(
-		$username, $password, $email=null, TableNode $groupsTable=null
+		$attemptTo, $username, $password, $email=null, TableNode $groupsTable=null
 	) {
 		if (!is_null($groupsTable)) {
 			$groups = $groupsTable->getColumn(0);
@@ -102,8 +102,11 @@ class UsersContext extends RawMinkContext implements Context {
 		$this->usersPage->createUser(
 			$this->getSession(), $username, $password, $email, $groups
 		);
+
+		$shouldHaveBeenCreated = ($attemptTo === "");
+
 		$this->featureContext->addUserToCreatedUsersList(
-			$username, $password, "", $email
+			$username, $password, "", $email, $shouldHaveBeenCreated
 		);
 		if (is_array($groups)) {
 			foreach ($groups as $group) {

--- a/tests/ui/features/bootstrap/UsersContext.php
+++ b/tests/ui/features/bootstrap/UsersContext.php
@@ -82,7 +82,7 @@ class UsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When /^I create a user with the name "([^"]*)" (?:and )?the password "([^"]*)"(?: and the email "([^"]*)")?(?: that is member of these groups)?$/
+	 * @When /^I create a user with the name "([^"]*)" (?:and )?the password "([^"]*)"(?: and the email "([^"]*)")?(?: that is a member of these groups)?$/
 	 * @param string $username
 	 * @param string $password
 	 * @param string $email
@@ -103,7 +103,7 @@ class UsersContext extends RawMinkContext implements Context {
 			$this->getSession(), $username, $password, $email, $groups
 		);
 		$this->featureContext->addUserToCreatedUsersList(
-			$username, $password, $email
+			$username, $password, "", $email
 		);
 		if (is_array($groups)) {
 			foreach ($groups as $group) {

--- a/tests/ui/features/other/login.feature
+++ b/tests/ui/features/other/login.feature
@@ -34,7 +34,7 @@ So that unauthorised access is impossible
 	Scenario Outline: use the webUI to create a user with special invalid characters
 		Given I am logged in as admin
 		And I am on the users page
-		When I create a user with the name <user> and the password <pwd>
+		When I attempt to create a user with the name <user> and the password <pwd>
 		Then notifications should be displayed with the text
 			|Error creating user: Only the following characters are allowed in a username: "a-z", "A-Z", "0-9", and "_.@-'"|
 		And I should be redirected to a page with the title "Users - ownCloud"
@@ -49,7 +49,7 @@ So that unauthorised access is impossible
 	Scenario: use the webUI to create a user with empty password
 		Given I am logged in as admin
 		And I am on the users page
-		When I create a user with the name "bijay" and the password ""
+		When I attempt to create a user with the name "bijay" and the password ""
 		Then notifications should be displayed with the text
 			|Error creating user: A valid password must be provided|
 		And I should be redirected to a page with the title "Users - ownCloud"
@@ -57,7 +57,7 @@ So that unauthorised access is impossible
 	Scenario Outline: use the webUI to create a user with less than 3 characters
 		Given I am logged in as admin
 		And I am on the users page
-		When I create a user with the name <user> and the password <pwd>
+		When I attempt to create a user with the name <user> and the password <pwd>
 		Then notifications should be displayed with the text
 		|Error creating user: The username must be at least 3 characters long|
 		Examples:


### PR DESCRIPTION
## Description
1a) change step text from ``that is member of these groups`` to ``that is a member of these groups`` (minor grammar)
1b) Fix ``displayName`` and ``email`` parameter positions in a ``addUserToCreatedUsersList`` call (small bug noticed)
2) In step ``When I create a user with the name`` allow the form ``When I attempt to create a user with the name``. When the latter form is used, remember that the user is not expected to exist. Still attempt to delete the user at the end of the scenario (in case it did get created) but do not emit output spam when the delete fails.

## Related Issue

## Motivation and Context
When a test scenario attempts to create a user, but it is purposely expected to not succeed (invalid username, no password etc), the code at the end of the scenario tries to delete the user that has not actually been created. The delete "fails" and the test output is spammed with output like:
```
INFORMATION: could not delete user. 'a1'400 <?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>400</statuscode>
  <message/>
 </meta>
 <data/>
</ocs>
```
this sort of "normal test output noise" makes it difficult for developers trying to diagnose what really went wrong vs normal spam.

## How Has This Been Tested?
Local UI login feature runs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

