### PR TITLE
Test unlock on exception during scanning

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -36,9 +36,12 @@ namespace OC\Files\Cache;
 
 use OC\Files\Filesystem;
 use OC\Hooks\BasicEmitter;
+use OCA\Files_Sharing\ISharedStorage;
 use OCP\Config;
 use OCP\Files\Cache\IScanner;
 use OCP\Files\ForbiddenException;
+use OCP\Files\IHomeStorage;
+use OCP\Files\Storage\ILockingStorage;
 use OCP\Lock\ILockingProvider;
 
 /**
@@ -113,7 +116,7 @@ class Scanner extends BasicEmitter implements IScanner {
 		if (is_null($data)) {
 			\OCP\Util::writeLog('OC\Files\Cache\Scanner', "!!! Path '$path' is not accessible or present !!!", \OCP\Util::DEBUG);
 			// Last Line of Defence against potential Metadata-loss
-			if ($this->storage->instanceOfStorage('\OCP\Files\IHomeStorage') && !$this->storage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage') && ($path === '' || $path === 'files')) {
+			if ($this->storage->instanceOfStorage(IHomeStorage::class) && !$this->storage->instanceOfStorage(ISharedStorage::class) && ($path === '' || $path === 'files')) {
 				\OCP\Util::writeLog('OC\Files\Cache\Scanner', 'Missing important folder "' . $path . '" in home storage!!! - ' . $this->storageId, \OCP\Util::ERROR);
 				throw new \OCP\Files\StorageNotAvailableException('Missing important folder "' . $path . '" in home storage - ' . $this->storageId);
 			}
@@ -140,7 +143,7 @@ class Scanner extends BasicEmitter implements IScanner {
 
 			//acquire a lock
 			if ($lock) {
-				if ($this->storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
+				if ($this->storage->instanceOfStorage(ILockingStorage::class)) {
 					$this->storage->acquireLock($file, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
 				}
 			}
@@ -229,7 +232,7 @@ class Scanner extends BasicEmitter implements IScanner {
 
 			//release the acquired lock
 			if ($lock) {
-				if ($this->storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
+				if ($this->storage->instanceOfStorage(ILockingStorage::class)) {
 					$this->storage->releaseLock($file, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
 				}
 			}

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -306,7 +306,7 @@ class Scanner extends BasicEmitter implements IScanner {
 			$reuse = ($recursive === self::SCAN_SHALLOW) ? self::REUSE_ETAG | self::REUSE_SIZE : self::REUSE_ETAG;
 		}
 		if ($lock) {
-			if ($this->storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
+			if ($this->storage->instanceOfStorage(ILockingStorage::class)) {
 				$this->storage->acquireLock('scanner::' . $path, ILockingProvider::LOCK_EXCLUSIVE, $this->lockingProvider);
 				$this->storage->acquireLock($path, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
 			}
@@ -317,7 +317,7 @@ class Scanner extends BasicEmitter implements IScanner {
 			$data['size'] = $size;
 		}
 		if ($lock) {
-			if ($this->storage->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
+			if ($this->storage->instanceOfStorage(ILockingStorage::class)) {
 				$this->storage->releaseLock($path, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
 				$this->storage->releaseLock('scanner::' . $path, ILockingProvider::LOCK_EXCLUSIVE, $this->lockingProvider);
 			}

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -110,14 +110,15 @@ class Scanner extends BasicEmitter implements IScanner {
 	 *
 	 * @param string $path
 	 * @return array an array of metadata of the file
+	 * @throws \OCP\Files\StorageNotAvailableException
 	 */
 	protected function getData($path) {
 		$data = $this->storage->getMetaData($path);
-		if (is_null($data)) {
-			\OCP\Util::writeLog('OC\Files\Cache\Scanner', "!!! Path '$path' is not accessible or present !!!", \OCP\Util::DEBUG);
+		if ($data === null) {
+			\OCP\Util::writeLog(Scanner::class, "!!! Path '$path' is not accessible or present !!!", \OCP\Util::DEBUG);
 			// Last Line of Defence against potential Metadata-loss
 			if ($this->storage->instanceOfStorage(IHomeStorage::class) && !$this->storage->instanceOfStorage(ISharedStorage::class) && ($path === '' || $path === 'files')) {
-				\OCP\Util::writeLog('OC\Files\Cache\Scanner', 'Missing important folder "' . $path . '" in home storage!!! - ' . $this->storageId, \OCP\Util::ERROR);
+				\OCP\Util::writeLog(Scanner::class, 'Missing important folder "' . $path . '" in home storage!!! - ' . $this->storageId, \OCP\Util::ERROR);
 				throw new \OCP\Files\StorageNotAvailableException('Missing important folder "' . $path . '" in home storage - ' . $this->storageId);
 			}
 		}
@@ -133,8 +134,10 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @param array | null $cacheData existing data in the cache for the file to be scanned
 	 * @param bool $lock set to false to disable getting an additional read lock during scanning
 	 * @return array an array of metadata of the scanned file
-	 * @throws \OC\ServerNotAvailableException
+	 * @throws \OCP\Files\StorageNotAvailableException
 	 * @throws \OCP\Lock\LockedException
+	 * @throws \OC\HintException
+	 * @throws \OC\ServerNotAvailableException
 	 */
 	public function scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = null, $lock = true) {
 
@@ -142,105 +145,100 @@ class Scanner extends BasicEmitter implements IScanner {
 		if (!self::isPartialFile($file) and !Filesystem::isFileBlacklisted($file)) {
 
 			//acquire a lock
-			if ($lock) {
-				if ($this->storage->instanceOfStorage(ILockingStorage::class)) {
-					$this->storage->acquireLock($file, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
-				}
+			if ($lock && $this->storage->instanceOfStorage(ILockingStorage::class)) {
+				$this->storage->acquireLock($file, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
 			}
 
 			try {
 				$data = $this->getData($file);
+				if ($data) {
+
+					// pre-emit only if it was a file. By that we avoid counting/treating folders as files
+					if ($data['mimetype'] !== 'httpd/unix-directory') {
+						$this->emit('\OC\Files\Cache\Scanner', 'scanFile', [$file, $this->storageId]);
+						\OC_Hook::emit('\OC\Files\Cache\Scanner', 'scan_file', ['path' => $file, 'storage' => $this->storageId]);
+					}
+
+					$parent = dirname($file);
+					if ($parent === '.' or $parent === '/') {
+						$parent = '';
+					}
+					if ($parentId === -1) {
+						$parentId = $this->cache->getId($parent);
+					}
+
+					// scan the parent if it's not in the cache (id -1) and the current file is not the root folder
+					if ($file and $parentId === -1) {
+						$parentData = $this->scanFile($parent);
+						$parentId = $parentData['fileid'];
+					}
+					if ($parent) {
+						$data['parent'] = $parentId;
+					}
+					if (is_null($cacheData)) {
+						/** @var CacheEntry $cacheData */
+						$cacheData = $this->cache->get($file);
+					}
+					if ($cacheData and $reuseExisting and isset($cacheData['fileid'])) {
+						// prevent empty etag
+						if (empty($cacheData['etag'])) {
+							$etag = $data['etag'];
+						} else {
+							$etag = $cacheData['etag'];
+						}
+						$fileId = $cacheData['fileid'];
+						$data['fileid'] = $fileId;
+						// only reuse data if the file hasn't explicitly changed
+						if (isset($data['storage_mtime']) && isset($cacheData['storage_mtime']) && $data['storage_mtime'] === $cacheData['storage_mtime']) {
+							$data['mtime'] = $cacheData['mtime'];
+							if (($reuseExisting & self::REUSE_SIZE) && ($data['size'] === -1)) {
+								$data['size'] = $cacheData['size'];
+							}
+							if ($reuseExisting & self::REUSE_ETAG) {
+								$data['etag'] = $etag;
+							}
+						}
+						// Only update metadata that has changed
+						$newData = array_diff_assoc($data, $cacheData->getData());
+					} else {
+						$newData = $data;
+						$fileId = -1;
+					}
+					if (!empty($newData)) {
+						$data['fileid'] = $this->addToCache($file, $newData, $fileId);
+					}
+					if (isset($cacheData['size'])) {
+						$data['oldSize'] = $cacheData['size'];
+					} else {
+						$data['oldSize'] = 0;
+					}
+
+					if (isset($cacheData['encrypted'])) {
+						$data['encrypted'] = $cacheData['encrypted'];
+					}
+
+					// post-emit only if it was a file. By that we avoid counting/treating folders as files
+					if ($data['mimetype'] !== 'httpd/unix-directory') {
+						$this->emit('\OC\Files\Cache\Scanner', 'postScanFile', [$file, $this->storageId]);
+						\OC_Hook::emit('\OC\Files\Cache\Scanner', 'post_scan_file', ['path' => $file, 'storage' => $this->storageId]);
+					}
+
+				} else {
+					$this->removeFromCache($file);
+				}
+
+				if ($data && !isset($data['encrypted'])) {
+					$data['encrypted'] = false;
+				}
+				return $data;
 			} catch (ForbiddenException $e) {
 				return null;
-			}
-
-			if ($data) {
-
-				// pre-emit only if it was a file. By that we avoid counting/treating folders as files
-				if ($data['mimetype'] !== 'httpd/unix-directory') {
-					$this->emit('\OC\Files\Cache\Scanner', 'scanFile', [$file, $this->storageId]);
-					\OC_Hook::emit('\OC\Files\Cache\Scanner', 'scan_file', ['path' => $file, 'storage' => $this->storageId]);
-				}
-
-				$parent = dirname($file);
-				if ($parent === '.' or $parent === '/') {
-					$parent = '';
-				}
-				if ($parentId === -1) {
-					$parentId = $this->cache->getId($parent);
-				}
-
-				// scan the parent if it's not in the cache (id -1) and the current file is not the root folder
-				if ($file and $parentId === -1) {
-					$parentData = $this->scanFile($parent);
-					$parentId = $parentData['fileid'];
-				}
-				if ($parent) {
-					$data['parent'] = $parentId;
-				}
-				if (is_null($cacheData)) {
-					/** @var CacheEntry $cacheData */
-					$cacheData = $this->cache->get($file);
-				}
-				if ($cacheData and $reuseExisting and isset($cacheData['fileid'])) {
-					// prevent empty etag
-					if (empty($cacheData['etag'])) {
-						$etag = $data['etag'];
-					} else {
-						$etag = $cacheData['etag'];
-					}
-					$fileId = $cacheData['fileid'];
-					$data['fileid'] = $fileId;
-					// only reuse data if the file hasn't explicitly changed
-					if (isset($data['storage_mtime']) && isset($cacheData['storage_mtime']) && $data['storage_mtime'] === $cacheData['storage_mtime']) {
-						$data['mtime'] = $cacheData['mtime'];
-						if (($reuseExisting & self::REUSE_SIZE) && ($data['size'] === -1)) {
-							$data['size'] = $cacheData['size'];
-						}
-						if ($reuseExisting & self::REUSE_ETAG) {
-							$data['etag'] = $etag;
-						}
-					}
-					// Only update metadata that has changed
-					$newData = array_diff_assoc($data, $cacheData->getData());
-				} else {
-					$newData = $data;
-					$fileId = -1;
-				}
-				if (!empty($newData)) {
-					$data['fileid'] = $this->addToCache($file, $newData, $fileId);
-				}
-				if (isset($cacheData['size'])) {
-					$data['oldSize'] = $cacheData['size'];
-				} else {
-					$data['oldSize'] = 0;
-				}
-
-				if (isset($cacheData['encrypted'])) {
-					$data['encrypted'] = $cacheData['encrypted'];
-				}
-
-				// post-emit only if it was a file. By that we avoid counting/treating folders as files
-				if ($data['mimetype'] !== 'httpd/unix-directory') {
-					$this->emit('\OC\Files\Cache\Scanner', 'postScanFile', [$file, $this->storageId]);
-					\OC_Hook::emit('\OC\Files\Cache\Scanner', 'post_scan_file', ['path' => $file, 'storage' => $this->storageId]);
-				}
-
-			} else {
-				$this->removeFromCache($file);
-			}
-
-			//release the acquired lock
-			if ($lock) {
-				if ($this->storage->instanceOfStorage(ILockingStorage::class)) {
+			} finally {
+				//release the acquired lock
+				if ($lock && $this->storage->instanceOfStorage(ILockingStorage::class)) {
 					$this->storage->releaseLock($file, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
 				}
 			}
-
-			if ($data && !isset($data['encrypted'])) {
-				$data['encrypted'] = false;
-			}
-			return $data;
 		}
 
 		return null;
@@ -259,6 +257,8 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @param array $data
 	 * @param int $fileId
 	 * @return int the id of the added file
+	 * @throws \OC\HintException
+	 * @throws \OC\ServerNotAvailableException
 	 */
 	protected function addToCache($path, $data, $fileId = -1) {
 		\OC_Hook::emit('Scanner', 'addToCache', ['file' => $path, 'data' => $data]);
@@ -267,18 +267,20 @@ class Scanner extends BasicEmitter implements IScanner {
 			if ($fileId !== -1) {
 				$this->cache->update($fileId, $data);
 				return $fileId;
-			} else {
-				return $this->cache->put($path, $data);
 			}
-		} else {
-			return -1;
+
+			return $this->cache->put($path, $data);
 		}
+
+		return -1;
 	}
 
 	/**
 	 * @param string $path
 	 * @param array $data
 	 * @param int $fileId
+	 * @throws \OC\HintException
+	 * @throws \OC\ServerNotAvailableException
 	 */
 	protected function updateCache($path, $data, $fileId = -1) {
 		\OC_Hook::emit('Scanner', 'addToCache', ['file' => $path, 'data' => $data]);
@@ -300,24 +302,25 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @param int $reuse
 	 * @param bool $lock set to false to disable getting an additional read lock during scanning
 	 * @return array an array of the meta data of the scanned file or folder
+	 * @throws \OCP\Lock\LockedException
+	 * @throws \OC\ServerNotAvailableException
 	 */
 	public function scan($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $lock = true) {
 		if ($reuse === -1) {
 			$reuse = ($recursive === self::SCAN_SHALLOW) ? self::REUSE_ETAG | self::REUSE_SIZE : self::REUSE_ETAG;
 		}
-		if ($lock) {
-			if ($this->storage->instanceOfStorage(ILockingStorage::class)) {
-				$this->storage->acquireLock('scanner::' . $path, ILockingProvider::LOCK_EXCLUSIVE, $this->lockingProvider);
-				$this->storage->acquireLock($path, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
+		if ($lock && $this->storage->instanceOfStorage(ILockingStorage::class)) {
+			$this->storage->acquireLock('scanner::' . $path, ILockingProvider::LOCK_EXCLUSIVE, $this->lockingProvider);
+			$this->storage->acquireLock($path, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
+		}
+		try {
+			$data = $this->scanFile($path, $reuse, -1, null, $lock);
+			if ($data and $data['mimetype'] === 'httpd/unix-directory') {
+				$size = $this->scanChildren($path, $recursive, $reuse, $data['fileid'], $lock);
+				$data['size'] = $size;
 			}
-		}
-		$data = $this->scanFile($path, $reuse, -1, null, $lock);
-		if ($data and $data['mimetype'] === 'httpd/unix-directory') {
-			$size = $this->scanChildren($path, $recursive, $reuse, $data['fileid'], $lock);
-			$data['size'] = $size;
-		}
-		if ($lock) {
-			if ($this->storage->instanceOfStorage(ILockingStorage::class)) {
+		} finally {
+			if ($lock && $this->storage->instanceOfStorage(ILockingStorage::class)) {
 				$this->storage->releaseLock($path, ILockingProvider::LOCK_SHARED, $this->lockingProvider);
 				$this->storage->releaseLock('scanner::' . $path, ILockingProvider::LOCK_EXCLUSIVE, $this->lockingProvider);
 			}
@@ -369,6 +372,7 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @param int $folderId id for the folder to be scanned
 	 * @param bool $lock set to false to disable getting an additional read lock during scanning
 	 * @return int the size of the scanned folder or -1 if the size is unknown at this stage
+	 * @throws \OCP\Lock\LockedException
 	 */
 	protected function scanChildren($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $folderId = null, $lock = true) {
 		if ($reuse === -1) {
@@ -408,7 +412,7 @@ class Scanner extends BasicEmitter implements IScanner {
 		$exceptionOccurred = false;
 		$childQueue = [];
 		foreach ($newChildren as $file) {
-			$child = ($path) ? $path . '/' . $file : $file;
+			$child = $path ? $path . '/' . $file : $file;
 			try {
 				$existingData = isset($existingChildren[$file]) ? $existingChildren[$file] : null;
 				$data = $this->scanFile($child, $reuse, $folderId, $existingData, $lock);
@@ -432,14 +436,14 @@ class Scanner extends BasicEmitter implements IScanner {
 				$exceptionOccurred = true;
 			} catch (\OCP\Lock\LockedException $e) {
 				if ($this->useTransactions) {
-					\OC::$server->getDatabaseConnection()->rollback();
+					\OC::$server->getDatabaseConnection()->rollBack();
 				}
 				throw $e;
 			}
 		}
 		$removedChildren = \array_diff(array_keys($existingChildren), $newChildren);
 		foreach ($removedChildren as $childName) {
-			$child = ($path) ? $path . '/' . $childName : $childName;
+			$child = $path ? $path . '/' . $childName : $childName;
 			$this->removeFromCache($child);
 		}
 		if ($this->useTransactions) {

--- a/lib/private/Files/Storage/Temporary.php
+++ b/lib/private/Files/Storage/Temporary.php
@@ -27,7 +27,7 @@ namespace OC\Files\Storage;
 /**
  * local storage backend in temporary folder for testing purpose
  */
-class Temporary extends Local{
+class Temporary extends Local {
 	public function __construct($arguments = null) {
 		parent::__construct(['datadir' => \OC::$server->getTempManager()->getTemporaryFolder()]);
 	}

--- a/tests/lib/Files/Cache/ScannerTest.php
+++ b/tests/lib/Files/Cache/ScannerTest.php
@@ -351,9 +351,10 @@ class ScannerTest extends \Test\TestCase {
 		return [
 			// throws for empty path and "files" in home storage
 			[true, false, '', true],
-			[true, true, '', true],
 			[true, false, 'files', true],
-			[true, true, 'files', true],
+			// but in shared storage
+			[true, true, '', false],
+			[true, true, 'files', false],
 
 			// doesn't throw for federated shares (non-home)
 			[false, true, '', false],

--- a/tests/lib/Files/Cache/ScannerTest.php
+++ b/tests/lib/Files/Cache/ScannerTest.php
@@ -407,7 +407,7 @@ class ScannerTest extends \Test\TestCase {
 	 * @throws \OC\HintException
 	 * @throws \OC\ServerNotAvailableException
 	 */
-	public function testUnLockInCaseOfException() {
+	public function testUnLockInCaseOfExceptionInScanFile() {
 		/** @var Storage | \PHPUnit_Framework_MockObject_MockObject $storage */
 		$storage = $this->createMock(Storage::class);
 		$storage->expects($this->any())
@@ -421,5 +421,30 @@ class ScannerTest extends \Test\TestCase {
 		$storage->expects($this->any())->method('getMetaData')->willThrowException(new \Exception('No MetaData'));
 		$this->scanner = new \OC\Files\Cache\Scanner($storage);
 		$this->scanner->scanFile('file/test.txt');
+	}
+
+	/**
+	 * @expectedException \Exception
+	 * @expectedExceptionMessage No MetaData
+	 *
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 * @throws \OCP\Lock\LockedException
+	 * @throws \OC\HintException
+	 * @throws \OC\ServerNotAvailableException
+	 */
+	public function testUnLockInCaseOfExceptionInScan() {
+		/** @var Storage | \PHPUnit_Framework_MockObject_MockObject $storage */
+		$storage = $this->createMock(Storage::class);
+		$storage->expects($this->any())
+			->method('instanceOfStorage')
+			->will($this->returnValueMap([
+				[ILockingStorage::class, true],
+			]));
+
+		$storage->expects($this->exactly(3))->method('acquireLock');
+		$storage->expects($this->exactly(3))->method('releaseLock');
+		$storage->expects($this->any())->method('getMetaData')->willThrowException(new \Exception('No MetaData'));
+		$this->scanner = new \OC\Files\Cache\Scanner($storage);
+		$this->scanner->scan('file/test.txt');
 	}
 }


### PR DESCRIPTION
## Description
In case of an exception during scanning the lock is not released

## Related Issue
detected while working on #28043 

## How Has This Been Tested?
- unit tests added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

