### PR TITLE
add group_concat to expression builder

### DIFF
--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
@@ -378,4 +378,19 @@ class ExpressionBuilder implements IExpressionBuilder {
 		$column = $this->helper->quoteColumnName($column);
 		return new QueryFunction("LENGTH({$column})");
 	}
+
+	/**
+	 * Returns a query function to concatenate values within each group defined by GROUP BY clause
+	 * @param string $column
+	 * @param string $orderBy ignored
+	 * @param string $separator default is ','
+	 * @return string
+	 *
+	 * TODO Max length for sqlite seems to be ?, @see http://gemmingforcode.blogspot.de/2011/03/groupconcat-sqlite-gem-and-devil-in.html
+	 */
+	public function groupConcat($column, $orderBy = null, $separator = ',') {
+		$column = $this->helper->quoteColumnName($column);
+		$separator = str_replace(["'",'\\'], ["\'",'\\\\'], $separator);
+		return new QueryFunction("GROUP_CONCAT({$column}, '$separator')");
+	}
 }

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/MySqlExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/MySqlExpressionBuilder.php
@@ -46,4 +46,23 @@ class MySqlExpressionBuilder extends ExpressionBuilder {
 		return new QueryFunction("CHAR_LENGTH({$column})");
 	}
 
+	/**
+	 * Returns a query function to concatenate values within each group defined by GROUP BY clause
+	 * @param string $column
+	 * @param string $orderBy optional
+	 * @param string $separator default is ','
+	 * @return string
+	 *
+	 * Max length seems to be 1024, but can be increased @see https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_group_concat_max_len
+	 */
+	public function groupConcat($column, $orderBy = null, $separator = ',') {
+		$column = $this->helper->quoteColumnName($column);
+		if ($orderBy !== null) {
+			$orderBy = ' ORDER BY '.$this->helper->quoteColumnName($orderBy);
+		} else {
+			$orderBy = '';
+		}
+		$separator = str_replace(["'",'\\'], ["\'",'\\\\'], $separator);
+		return new QueryFunction("GROUP_CONCAT({$column}{$orderBy} SEPARATOR '$separator')");
+	}
 }

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/OCIExpressionBuilder.php
@@ -169,4 +169,24 @@ class OCIExpressionBuilder extends ExpressionBuilder {
 		$column = $this->helper->quoteColumnName($column);
 		return new QueryFunction("LENGTHC({$column})");
 	}
+
+	/**
+	 * Returns a query function to concatenate values within each group defined by GROUP BY clause
+	 * @param string $column
+	 * @param string $orderBy optional
+	 * @param string $separator default is ','
+	 * @return string
+	 *
+	 * Max length seems to be 4000, @see https://community.oracle.com/thread/2548234
+	 */
+	public function groupConcat($column, $orderBy = null, $separator = ',') {
+		$column = $this->helper->quoteColumnName($column);
+		if ($orderBy !== null) {
+			$orderBy = $this->helper->quoteColumnName($orderBy);
+		} else {
+			$orderBy = 'NULL';
+		}
+		$separator = str_replace(["'",'\\'], ["\'",'\\\\'], $separator);
+		return new QueryFunction("LISTAGG({$column}, '$separator') WITHIN GROUP (ORDER BY {$orderBy})");
+	}
 }

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/PgSqlExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/PgSqlExpressionBuilder.php
@@ -53,4 +53,23 @@ class PgSqlExpressionBuilder extends ExpressionBuilder {
 		return $this->expressionBuilder->comparison($x, 'ILIKE', $y);
 	}
 
+	/**
+	 * Returns a query function to concatenate values within each group defined by GROUP BY clause
+	 * @param string $column
+	 * @param string $orderBy optional
+	 * @param string $separator default is ','
+	 * @return string
+	 *
+	 * TODO Max length seems to be ?, @see ?
+	 */
+	public function groupConcat($column, $orderBy = null, $separator = ',') {
+		$column = $this->helper->quoteColumnName($column);
+		if ($orderBy !== null) {
+			$orderBy = ' ORDER BY '.$this->helper->quoteColumnName($orderBy);
+		} else {
+			$orderBy = '';
+		}
+		$separator = str_replace(["'",'\\'], ["\'",'\\\\'], $separator);
+		return new QueryFunction("STRING_AGG({$column}, '{$separator}'{$orderBy})");
+	}
 }

--- a/lib/public/DB/QueryBuilder/IExpressionBuilder.php
+++ b/lib/public/DB/QueryBuilder/IExpressionBuilder.php
@@ -331,4 +331,14 @@ interface IExpressionBuilder {
 	 * @since 10.0.3
 	 */
 	public function length($column);
+
+	/**
+	 * Returns a query function to concatenate values within each group defined by GROUP BY clause
+	 * @param string $column
+	 * @param string $orderBy optional
+	 * @param string $separator default is ','
+	 * @return string
+	 * @since 10.0.8
+	 */
+	public function groupConcat($column, $orderBy = null, $separator = ',');
 }

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
@@ -348,6 +348,36 @@ class ExpressionBuilderTest extends TestCase {
 		);
 	}
 
+	public function testGroupConcat() {
+
+		$appId = $this->getUniqueID('testgroupconcat');
+		$this->createConfig($appId, 1, 4);
+		$this->createConfig($appId, 2, 5);
+		$this->createConfig($appId, 3, 6);
+		$this->createConfig($appId, 4, 4);
+		$this->createConfig($appId, 5, 5);
+		$this->createConfig($appId, 6, 6);
+		$this->createConfig($appId, 7, 4);
+		$this->createConfig($appId, 8, 5);
+		$this->createConfig($appId, 9, 6);
+
+		$query = $this->connection->getQueryBuilder();
+		$query->select([$query->expr()->groupConcat('configkey', 'configkey', ' ')])
+			->from('appconfig')
+			->where($query->expr()->eq('appid', $query->createNamedParameter($appId)))
+			->groupBy(['appid']);
+
+		$result = $query->execute();
+
+		$this->assertEquals([0 => '1 2 3 4 5 6 7 8 9'], $result->fetch(\PDO::FETCH_NUM));
+		$result->closeCursor();
+
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('appconfig')
+			->where($query->expr()->eq('appid', $query->createNamedParameter($appId)))
+			->execute();
+	}
+
 	public function dataClobComparisons() {
 		return [
 			['eq', '5', IQueryBuilder::PARAM_STR, false, 3],


### PR DESCRIPTION
would allow reducing queries related to fetching account terms

see http://www.sqlines.com/mysql/functions/group_concat

- we only store 191 chars per term, which allows at least 5 search terms on mysql (group_concat max length is 1024 by default), 20 search terms on oracle, and we don't know how many on sqlite or postgres

@tomneedham we could add a fallback that detects if the rterms are longer than 1000 chars and do a subselect in that case. but i wouldn't bother 'til the first bug report.