### PR TITLE
Fix contexts needed for manageUsersGroups UI test suite

### DIFF
--- a/tests/ui/config/behat.yml
+++ b/tests/ui/config/behat.yml
@@ -136,6 +136,7 @@ default:
         - LoginContext:
         - UsersContext:
         - FilesContext:
+        - PersonalGeneralSettingsContext:
 
     manageQuota:
       paths:


### PR DESCRIPTION
I was too severe removing contexts form the ``manageUsersGroups`` suite in PR #30584 
The "redirect after login" tests use ``PersonalGeneralSettings`` page as a test destination.