### PR TITLE
Be strict on behat runs for UI tests

### DIFF
--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -341,7 +341,7 @@ then
 	echo "WARNING: cannot write to upload folder '$FILES_FOR_UPLOAD', some upload tests might fail"
 fi
 
-lib/composer/bin/behat -c $BEHAT_YML $BEHAT_SUITE_OPTION $BEHAT_TAG_OPTION $BEHAT_TAGS $BEHAT_FEATURE -v  2>&1 | tee -a $TEST_LOG_FILE
+lib/composer/bin/behat --strict -c $BEHAT_YML $BEHAT_SUITE_OPTION $BEHAT_TAG_OPTION $BEHAT_TAGS $BEHAT_FEATURE -v  2>&1 | tee -a $TEST_LOG_FILE
 
 BEHAT_EXIT_STATUS=${PIPESTATUS[0]}
 
@@ -362,7 +362,7 @@ then
 		do
 			SOME_SCENARIO_RERUN=true
 			echo rerun failed tests: $FEATURE
-			lib/composer/bin/behat -c $BEHAT_YML $BEHAT_SUITE_OPTION $BEHAT_TAG_OPTION $BEHAT_TAGS $FEATURE -v  2>&1 | tee -a $TEST_LOG_FILE
+			lib/composer/bin/behat --strict -c $BEHAT_YML $BEHAT_SUITE_OPTION $BEHAT_TAG_OPTION $BEHAT_TAGS $FEATURE -v  2>&1 | tee -a $TEST_LOG_FILE
 			BEHAT_EXIT_STATUS=${PIPESTATUS[0]}
 			if [ $BEHAT_EXIT_STATUS -ne 0 ]
 			then


### PR DESCRIPTION
## Description
Add the ``--strict`` option to the ``behat`` command in the UI tests script.
This will make ``behat`` exit with non-zero status when there is any problem, including missing step definitions.

## Related Issue
#30590 

## Motivation and Context
We really want CI to fail when there is any problem.

## How Has This Been Tested?
drone CI should fail here at first, because current ``master`` does actually have this problem.
Then we can fix ``master`` and re-base here to see CI passing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) - of testing code
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

