### PR TITLE
[stable10] Fixing logout for app password scenario

### DIFF
--- a/lib/private/User/BasicAuthModule.php
+++ b/lib/private/User/BasicAuthModule.php
@@ -25,6 +25,7 @@ namespace OC\User;
 
 use OCP\Authentication\IAuthModule;
 use OCP\IRequest;
+use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserManager;
 
@@ -32,9 +33,12 @@ class BasicAuthModule implements IAuthModule {
 
 	/** @var IUserManager */
 	private $manager;
+	/** @var ISession */
+	private $session;
 
-	public function __construct(IUserManager $manager) {
+	public function __construct(IUserManager $manager, ISession $session) {
 		$this->manager = $manager;
+		$this->session = $session;
 	}
 
 	/**
@@ -42,6 +46,9 @@ class BasicAuthModule implements IAuthModule {
 	 */
 	public function auth(IRequest $request) {
 		if (!isset($request->server['PHP_AUTH_USER'], $request->server['PHP_AUTH_PW'])) {
+			return null;
+		}
+		if ($this->session->exists('app_password')) {
 			return null;
 		}
 		$authUser = $request->server['PHP_AUTH_USER'];

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -934,7 +934,7 @@ class Session implements IUserSession, Emitter {
 	protected function getAuthModules($includeBuiltIn) {
 		if ($includeBuiltIn) {
 			yield new TokenAuthModule($this->session, $this->tokenProvider, $this->manager);
-			yield new BasicAuthModule($this->manager);
+			yield new BasicAuthModule($this->manager, $this->session);
 		}
 
 		$modules = $this->serviceLoader->load(['auth-modules']);


### PR DESCRIPTION
## Description
Yet another fix to the app password trouble ....

## Related Issue
fixes https://github.com/owncloud/core/issues/30157


## How Has This Been Tested?
- tail server log
- generate app password
- connect desktop client
- use generated app password
- login
- no 'Login failed' message is to be observed in the server log

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

