### PR TITLE
Add scenarios for transferring folders without files

### DIFF
--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -1281,6 +1281,7 @@ trait WebDav {
 
 	/**
 	 * @When /^user "([^"]*)" deletes everything from folder "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has deleted everything from folder "([^"]*)"$/
 	 * @param string $user
 	 * @param string $folder
 	 */

--- a/tests/integration/features/transfer-ownership.feature
+++ b/tests/integration/features/transfer-ownership.feature
@@ -131,7 +131,7 @@ Feature: transfer-ownership
 		And the command should have failed with exit code 1
 
 	@no_default_encryption
-	Scenario: transferring ownership of a folder
+	Scenario: transferring ownership of only a single folder containing a file
 		Given user "user0" has been created
 		And user "user1" has been created
 		And user "user0" has created a folder "/test"
@@ -140,6 +140,29 @@ Feature: transfer-ownership
 		Then the command should have been successful
 		And using received transfer folder of "user1" as dav path
 		And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
+
+	@no_default_encryption
+	Scenario: transferring ownership of only a single folder containing an empty folder
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/test"
+		And user "user0" has created a folder "/test/subfolder"
+		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
+		Then the command should have been successful
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" should exist
+		And as "user1" the folder "/test/subfolder" should exist
+
+	@no_default_encryption
+	Scenario: transferring ownership of an account containing only an empty folder
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has deleted everything from folder "/"
+		And user "user0" has created a folder "/test"
+		When the administrator transfers ownership from "user0" to "user1" using the occ command
+		Then the command should have been successful
+		And using received transfer folder of "user1" as dav path
+		And as "user1" the folder "/test" should exist
 
 	@no_default_encryption
 	Scenario: transferring ownership of file shares


### PR DESCRIPTION
## Description
Add 2 new scenarios:
1) A folder containing just a subfolder can be transferred, and the folder with sub-folder is received.
2) When the root contains just an empty folder and nothing else - the empty folder is transferred.

## Related Issue
#24061

## Motivation and Context
We should test that sub-folders inside the requested folder are transferred to the new owner in the case where there are only sub-folders and no actual files. This will prevent possible regression of this desired behavior.

## How Has This Been Tested?
New scenarios run locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

