### PR TITLE
Move rename-into-folder tests to move suites

### DIFF
--- a/tests/ui/features/moveFilesFolders/moveFiles.feature
+++ b/tests/ui/features/moveFilesFolders/moveFiles.feature
@@ -9,6 +9,10 @@ So that I can organise my data structure
 		And I am logged in as a regular user
 		And I am on the files page
 
+	Scenario: An attempt to move a file into a sub-folder using rename is not allowed
+		When I rename the file "data.zip" to "simple-folder/data.zip"
+		Then near the file "data.zip" a tooltip with the text 'File name cannot contain "/".' should be displayed
+
 	@skipOnFIREFOX47+
 	Scenario: move a file into a folder
 		When I move the file "data.zip" into the folder "simple-empty-folder"

--- a/tests/ui/features/moveFilesFolders/moveFolders.feature
+++ b/tests/ui/features/moveFilesFolders/moveFolders.feature
@@ -9,6 +9,10 @@ So that I can organise my data structure
 		And I am logged in as a regular user
 		And I am on the files page
 
+	Scenario: An attempt to move a folder into a sub-folder using rename is not allowed
+		When I rename the folder "simple-empty-folder" to "simple-folder/simple-empty-folder"
+		Then near the folder "simple-empty-folder" a tooltip with the text 'File name cannot contain "/".' should be displayed
+
 	@skipOnFIREFOX47+
 	Scenario: move a folder into another folder
 		When I move the folder "simple-folder" into the folder "simple-empty-folder"

--- a/tests/ui/features/renameFiles/renameFiles.feature
+++ b/tests/ui/features/renameFiles/renameFiles.feature
@@ -109,10 +109,6 @@ So that I can organise my data structure
 		When I rename the file "data.zip" to "lorem.txt"
 		Then near the file "data.zip" a tooltip with the text 'lorem.txt already exists' should be displayed
 
-	Scenario: Rename a file using forward slash
-		When I rename the file "data.zip" to "lorem/txt"
-		Then near the file "data.zip" a tooltip with the text 'File name cannot contain "/".' should be displayed
-
 	Scenario: Rename a file to ..
 		When I rename the file "data.zip" to ".."
 		Then near the file "data.zip" a tooltip with the text '".." is an invalid file name.' should be displayed

--- a/tests/ui/features/renameFolders/renameFolders.feature
+++ b/tests/ui/features/renameFolders/renameFolders.feature
@@ -87,10 +87,6 @@ So that I can organise my data structure
 		When I rename the folder "simple-folder" to "lorem.txt"
 		Then near the folder "simple-folder" a tooltip with the text 'lorem.txt already exists' should be displayed
 
-	Scenario: Rename a folder using forward slash
-		When I rename the folder "simple-folder" to "simple/folder"
-		Then near the folder "simple-folder" a tooltip with the text 'File name cannot contain "/".' should be displayed
-
 	Scenario: Rename a folder to ..
 		When I rename the folder "simple-folder" to ".."
 		Then near the folder "simple-folder" a tooltip with the text '".." is an invalid file name.' should be displayed


### PR DESCRIPTION
## Description
Put the "attempt to move a file into a sub-folder by rename" tests into the ``moveFilesFolders`` suite.
This ensures that there are always some tests in this suite that run on every browser. 
This avoids the problem that ``moveFilesFolders`` had all tests skipped on Firefox.

## Related Issue
#30604

## Motivation and Context
1) Make ``moveFilesFolders`` suite have scenario(s) that always run something, so the suite does not fail on Firefox due to all scenarios being skipped.
2) Choose scenarios that could be logically part of ``moveFilesFolders`` anyway, so as not to mess up the logic of which scenarios are where.


## How Has This Been Tested?
I will run some Firefox in CI on top of this to show it works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

