### PR TITLE
More bumps to PHP 7.1 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,21 +63,21 @@ matrix:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="manageUsersGroups" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="manageQuota" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="personalSettings" PLATFORM="Windows 10" TEST_DAV=0
       addons:
@@ -126,7 +126,7 @@ matrix:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="sharingInternalUsers" PLATFORM="Windows 10" TEST_DAV=0
       addons:
@@ -161,21 +161,21 @@ matrix:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="manageUsersGroups" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="manageQuota" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="personalSettings" PLATFORM="Windows 10" TEST_DAV=0
       addons:
@@ -231,7 +231,7 @@ matrix:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="sharingExternal" PLATFORM="Windows 10" TEST_DAV=0
       addons:
@@ -273,21 +273,21 @@ matrix:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="manageUsersGroups" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="manageQuota" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="personalSettings" PLATFORM="Windows 10" TEST_DAV=0
       addons:
@@ -336,7 +336,7 @@ matrix:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="sharingInternalUsers" PLATFORM="Windows 10" TEST_DAV=0
       addons:
@@ -371,21 +371,21 @@ matrix:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="manageUsersGroups" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="manageQuota" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="personalSettings" PLATFORM="Windows 10" TEST_DAV=0
       addons:
@@ -434,7 +434,7 @@ matrix:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="sharingInternalUsers" PLATFORM="Windows 10" TEST_DAV=0
       addons:
@@ -469,28 +469,28 @@ matrix:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="manageUsersGroups" PLATFORM="Windows 7" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="manageQuota" PLATFORM="Windows 7" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="personalSettings" PLATFORM="Windows 7" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
         sauce_connect: true
-    - php: 5.6
+    - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="files" PLATFORM="Windows 7" TEST_DAV=0
       addons:


### PR DESCRIPTION
These got missed in various merges that re-organized the UI test suites vs the ownCloud 10.1 PHP 5.6->7.1 changes.