### PR TITLE
Wait for personal general settings page to load

### DIFF
--- a/tests/ui/features/bootstrap/PersonalGeneralSettingsContext.php
+++ b/tests/ui/features/bootstrap/PersonalGeneralSettingsContext.php
@@ -61,11 +61,19 @@ class PersonalGeneralSettingsContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given I go to the personal general settings page
+	 * @Given /^I (attempt to |)go to the personal general settings page$/
 	 * @return void
 	 */
-	public function iGoToThePersonalGeneralSettingsPage() {
+	public function iGoToThePersonalGeneralSettingsPage($attemptTo) {
+		$pageIsExpectedToLoad = ($attemptTo === "");
 		$this->visitPath($this->personalGeneralSettingsPage->getPagePath());
+
+		if ($pageIsExpectedToLoad) {
+			$this->personalGeneralSettingsPage->waitTillPageIsLoaded(
+				$this->getSession()
+			);
+		}
+
 		$this->personalGeneralSettingsPage->waitForOutstandingAjaxCalls(
 			$this->getSession()
 		);

--- a/tests/ui/features/manageUsersGroups/login.feature
+++ b/tests/ui/features/manageUsersGroups/login.feature
@@ -26,13 +26,13 @@ So that unauthorised access is impossible
 		Then I should be redirected to a page with the title "ownCloud"
 
 	Scenario: access the personal general settings page when not logged in
-		Given I go to the personal general settings page
+		Given I attempt to go to the personal general settings page
 		Then I should be redirected to a page with the title "ownCloud"
 		When I login with username "admin" and password "admin" after a redirect from the "personal general settings" page
 		Then I should be redirected to a page with the title "Settings - ownCloud"
 
 	Scenario: access the personal general settings page when not logged in using incorrect then correct password
-		Given I go to the personal general settings page
+		Given I attempt to go to the personal general settings page
 		Then I should be redirected to a page with the title "ownCloud"
 		When I login with username "admin" and invalid password "qwerty"
 		Then I should be redirected to a page with the title "ownCloud"


### PR DESCRIPTION
## Description
1) Call ``waitTillPageIsLoaded`` when going to the ``personalGeneralSettingsPage`` to make sure (as reasonably best we can) that the page is loaded, before continuing with other page actions.

## Related Issue
#30630 

## Motivation and Context
The UI tests for the ``personalSettings`` suite fail on Microsoft Edge browser. The test code seems to try and enter data before the page is properly rendered. Somehow the problem is not seen on the other browsers - some timing issue evident only in the Edge test case.

## How Has This Been Tested?
Run the ``personalSettings`` suite on all 5 browser combinations on Travis and demostrate that it now passes. PR #30633 Travis tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) to tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

