### PR TITLE
Integration step definitions for when given

### DIFF
--- a/tests/integration/features/bootstrap/AppConfiguration.php
+++ b/tests/integration/features/bootstrap/AppConfiguration.php
@@ -70,6 +70,7 @@ trait AppConfiguration {
 
 	/**
 	 * @When /^the administrator sets parameter "([^"]*)" of app "([^"]*)" to "([^"]*)" using the API$/
+	 *
 	 * @param string $parameter
 	 * @param string $app
 	 * @param string $value
@@ -86,6 +87,7 @@ trait AppConfiguration {
 
 	/**
 	 * @Given /^parameter "([^"]*)" of app "([^"]*)" has been set to "([^"]*)"$/
+	 *
 	 * @param string $parameter
 	 * @param string $app
 	 * @param string $value
@@ -97,6 +99,7 @@ trait AppConfiguration {
 
 	/**
 	 * @Then the capabilities setting of :capabilitiesApp path :capabilitiesPath should be :expectedValue
+	 *
 	 * @param string $capabilitiesApp the "app" name in the capabilities response
 	 * @param string $capabilitiesPath the path to the element
 	 * @param string $expectedValue
@@ -128,6 +131,7 @@ trait AppConfiguration {
 
 	/**
 	 * @When the user retrieves the capabilities using the API
+	 *
 	 * @return void
 	 */
 	public function getCapabilitiesCheckResponse() {

--- a/tests/integration/features/bootstrap/AppManagementContext.php
+++ b/tests/integration/features/bootstrap/AppManagementContext.php
@@ -123,6 +123,7 @@ class AppManagementContext implements  Context {
 	
 	/**
 	 * @When the administrator loads app :appId using the console
+	 * @Given the administrator has loaded app :appId using the console
 	 * @param string $appId app id
 	 */
 	public function loadApp($appId) {

--- a/tests/integration/features/bootstrap/AppManagementContext.php
+++ b/tests/integration/features/bootstrap/AppManagementContext.php
@@ -58,6 +58,7 @@ class AppManagementContext implements  Context {
 	
 	/**
 	 * @Given apps have been put in two directories :dir1 and :dir2
+	 *
 	 * @param string $dir1
 	 * @param string $dir2
 	 */
@@ -75,6 +76,7 @@ class AppManagementContext implements  Context {
 	
 	/**
 	 * @Given app :appId with version :version has been put in dir :dir
+	 *
 	 * @param string $appId app id
 	 * @param string $version app version
 	 * @param string $dir app directory
@@ -124,6 +126,7 @@ class AppManagementContext implements  Context {
 	/**
 	 * @When the administrator loads app :appId using the console
 	 * @Given the administrator has loaded app :appId using the console
+	 *
 	 * @param string $appId app id
 	 */
 	public function loadApp($appId) {
@@ -146,6 +149,7 @@ class AppManagementContext implements  Context {
 	
 	/**
 	 * @Then the path to :appId should be :dir
+	 *
 	 * @param string $appId
 	 * @param string $dir
 	 */

--- a/tests/integration/features/bootstrap/Auth.php
+++ b/tests/integration/features/bootstrap/Auth.php
@@ -18,6 +18,7 @@ trait Auth {
 	/**
 	 * @When a user requests :url with :method and no authentication
 	 * @Given a user has requested :url with :method and no authentication
+	 *
 	 * @param string $url
 	 * @param string $method
 	 */
@@ -55,6 +56,7 @@ trait Auth {
 	/**
 	 * @When user :user generates a new client token using the API
 	 * @Given a new client token for :user has been generated
+	 *
 	 * @param string $user
 	 */
 	public function aNewClientTokenHasBeenGenerated($user) {
@@ -71,6 +73,7 @@ trait Auth {
 	/**
 	 * @When user :user requests :url with :method using basic auth
 	 * @Given user :user has requested :url with :method using basic auth
+	 *
 	 * @param string $user
 	 * @param string $url
 	 * @param string $method
@@ -83,6 +86,7 @@ trait Auth {
 	/**
 	 * @When user :user requests :url with :method using basic token auth
 	 * @Given user :user has requested :url with :method using basic token auth
+	 *
 	 * @param string $user
 	 * @param string $url
 	 * @param string $method
@@ -94,6 +98,7 @@ trait Auth {
 	/**
 	 * @When the user requests :url with :method using the generated client token
 	 * @Given the user has requested :url with :method using the generated client token
+	 *
 	 * @param string $url
 	 * @param string $method
 	 */
@@ -104,6 +109,7 @@ trait Auth {
 	/**
 	 * @When the user requests :url with :method using the browser session
 	 * @Given the user has requested :url with :method using the browser session
+	 *
 	 * @param string $url
 	 * @param string $method
 	 */
@@ -113,6 +119,7 @@ trait Auth {
 
 	/**
 	 * @Given a new browser session for :user has been started
+	 *
 	 * @param string $user
 	 */
 	public function aNewBrowserSessionForHasBeenStarted($user) {

--- a/tests/integration/features/bootstrap/Auth.php
+++ b/tests/integration/features/bootstrap/Auth.php
@@ -17,6 +17,7 @@ trait Auth {
 
 	/**
 	 * @When a user requests :url with :method and no authentication
+	 * @Given a user has requested :url with :method and no authentication
 	 * @param string $url
 	 * @param string $method
 	 */
@@ -52,6 +53,7 @@ trait Auth {
 	}
 
 	/**
+	 * @When user :user generates a new client token using the API
 	 * @Given a new client token for :user has been generated
 	 * @param string $user
 	 */
@@ -68,6 +70,7 @@ trait Auth {
 
 	/**
 	 * @When user :user requests :url with :method using basic auth
+	 * @Given user :user has requested :url with :method using basic auth
 	 * @param string $user
 	 * @param string $url
 	 * @param string $method
@@ -79,6 +82,7 @@ trait Auth {
 
 	/**
 	 * @When user :user requests :url with :method using basic token auth
+	 * @Given user :user has requested :url with :method using basic token auth
 	 * @param string $user
 	 * @param string $url
 	 * @param string $method
@@ -89,6 +93,7 @@ trait Auth {
 
 	/**
 	 * @When the user requests :url with :method using the generated client token
+	 * @Given the user has requested :url with :method using the generated client token
 	 * @param string $url
 	 * @param string $method
 	 */
@@ -98,6 +103,7 @@ trait Auth {
 
 	/**
 	 * @When the user requests :url with :method using the browser session
+	 * @Given the user has requested :url with :method using the browser session
 	 * @param string $url
 	 * @param string $method
 	 */

--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -121,6 +121,7 @@ trait BasicStructure {
 
 	/**
 	 * @When /^the user sends HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
+	 * @Given /^the user has sent HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
 	 * @param string $verb
 	 * @param string $url
 	 */
@@ -130,6 +131,7 @@ trait BasicStructure {
 
 	/**
 	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
+	 * @Given /^user "([^"]*)" has sent HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
 	 * @param string $user
 	 * @param string $verb
 	 * @param string $url
@@ -255,6 +257,7 @@ trait BasicStructure {
 
 	/**
 	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to URL "([^"]*)"$/
+	 * @Given /^user "([^"]*)" has sent HTTP method "([^"]*)" to URL "([^"]*)"$/
 	 * @param string $user
 	 * @param string $verb
 	 * @param string $url
@@ -407,6 +410,7 @@ trait BasicStructure {
 
 	/**
 	 * @When the client sends a :method to :url with requesttoken using the API
+	 * @Given the client has sent a :method to :url with requesttoken
 	 * @param string $method
 	 * @param string $url
 	 */
@@ -431,6 +435,7 @@ trait BasicStructure {
 
 	/**
 	 * @When the client sends a :method to :url without requesttoken using the API
+	 * @Given the client has sent a :method to :url without requesttoken
 	 * @param string $method
 	 * @param string $url
 	 */

--- a/tests/integration/features/bootstrap/BasicStructure.php
+++ b/tests/integration/features/bootstrap/BasicStructure.php
@@ -88,6 +88,7 @@ trait BasicStructure {
 
 	/**
 	 * @Given /^using (?:api|API) version "([^"]*)"$/
+	 *
 	 * @param string $version
 	 */
 	public function usingApiVersion($version) {
@@ -96,6 +97,7 @@ trait BasicStructure {
 
 	/**
 	 * @Given /^as user "([^"]*)"$/
+	 *
 	 * @param string $user
 	 */
 	public function asUser($user) {
@@ -104,6 +106,7 @@ trait BasicStructure {
 
 	/**
 	 * @Given /^using server "(LOCAL|REMOTE)"$/
+	 *
 	 * @param string $server
 	 * @return string Previous used server
 	 */
@@ -122,6 +125,7 @@ trait BasicStructure {
 	/**
 	 * @When /^the user sends HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
 	 * @Given /^the user has sent HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
+	 *
 	 * @param string $verb
 	 * @param string $url
 	 */
@@ -132,6 +136,7 @@ trait BasicStructure {
 	/**
 	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
 	 * @Given /^user "([^"]*)" has sent HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $verb
 	 * @param string $url
@@ -196,6 +201,7 @@ trait BasicStructure {
 
 	/**
 	 * This function is needed to use a vertical fashion in the gherkin tables.
+	 *
 	 * @param array $arrayOfArrays
 	 * @return array
 	 */
@@ -207,6 +213,7 @@ trait BasicStructure {
 	/**
 	 * @When /^the user sends HTTP method "([^"]*)" to API endpoint "([^"]*)" with body$/
 	 * @Given /^the user has sent HTTP method "([^"]*)" to API endpoint "([^"]*)" with body$/
+	 *
 	 * @param string $verb
 	 * @param string $url
 	 * @param \Behat\Gherkin\Node\TableNode $body
@@ -223,6 +230,7 @@ trait BasicStructure {
 	/**
 	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to API endpoint "([^"]*)" with body$/
 	 * @Given /^user "([^"]*)" has sent HTTP method "([^"]*)" to API endpoint "([^"]*)" with body$/
+	 *
 	 * @param string $user
 	 * @param string $verb
 	 * @param string $url
@@ -258,6 +266,7 @@ trait BasicStructure {
 	/**
 	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to URL "([^"]*)"$/
 	 * @Given /^user "([^"]*)" has sent HTTP method "([^"]*)" to URL "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $verb
 	 * @param string $url
@@ -311,6 +320,7 @@ trait BasicStructure {
 
 	/**
 	 * @Then /^the OCS status code should be "([^"]*)"$/
+	 *
 	 * @param int $statusCode
 	 */
 	public function theOCSStatusCodeShouldBe($statusCode) {
@@ -319,6 +329,7 @@ trait BasicStructure {
 
 	/**
 	 * @Then /^the HTTP status code should be "([^"]*)"$/
+	 *
 	 * @param int $statusCode
 	 */
 	public function theHTTPStatusCodeShouldBe($statusCode) {
@@ -327,6 +338,7 @@ trait BasicStructure {
 
 	/**
 	 * @Then /^the XML "([^"]*)" "([^"]*)" value should be "([^"]*)"$/
+	 *
 	 * @param string $key1
 	 * @param string $key2
 	 * @param string $idText
@@ -340,6 +352,7 @@ trait BasicStructure {
 
 	/**
 	 * @Then /^the XML "([^"]*)" "([^"]*)" "([^"]*)" value should be "([^"]*)"$/
+	 *
 	 * @param string $key1
 	 * @param string $key2
 	 * @param string $key3
@@ -354,6 +367,7 @@ trait BasicStructure {
 
 	/**
 	 * @Then /^the XML "([^"]*)" "([^"]*)" "([^"]*)" "([^"]*)" attribute value should be a valid version string$/
+	 *
 	 * @param string $key1
 	 * @param string $key2
 	 * @param string $key3
@@ -377,6 +391,7 @@ trait BasicStructure {
 	/**
 	 * @When /^user "([^"]*)" logs in to a web-style session using the API$/
 	 * @Given /^user "([^"]*)" has logged in to a web-style session using the API$/
+	 *
 	 * @param string $user
 	 */
 	public function userHasLoggedInToAWebStyleSessionUsingTheAPI($user) {
@@ -411,6 +426,7 @@ trait BasicStructure {
 	/**
 	 * @When the client sends a :method to :url with requesttoken using the API
 	 * @Given the client has sent a :method to :url with requesttoken
+	 *
 	 * @param string $method
 	 * @param string $url
 	 */
@@ -436,6 +452,7 @@ trait BasicStructure {
 	/**
 	 * @When the client sends a :method to :url without requesttoken using the API
 	 * @Given the client has sent a :method to :url without requesttoken
+	 *
 	 * @param string $method
 	 * @param string $url
 	 */
@@ -470,6 +487,7 @@ trait BasicStructure {
 	/**
 	 * @When user :user modifies text of :filename with text :text using the API
 	 * @Given user :user has modified text of :filename with text :text
+	 *
 	 * @param string $user
 	 * @param string $filename
 	 * @param string $text
@@ -502,6 +520,7 @@ trait BasicStructure {
 
 	/**
 	 * @Given file :filename of size :size has been created in local storage
+	 *
 	 * @param string $filename
 	 * @param string $size
 	 */
@@ -511,6 +530,7 @@ trait BasicStructure {
 
 	/**
 	 * @Given file :filename with text :text has been created in local storage
+	 *
 	 * @param string $filename
 	 * @param string $text
 	 */
@@ -520,6 +540,7 @@ trait BasicStructure {
 
 	/**
 	 * @Given file :filename has been deleted in local storage
+	 *
 	 * @param string $filename
 	 */
 	public function fileHasBeenDeletedInLocalStorage($filename) {
@@ -584,6 +605,7 @@ trait BasicStructure {
 
 	/**
 	 * @Then the json responded should match with
+	 *
 	 * @param PyStringNode $jsonExpected
 	 */
 	public function jsonRespondedShouldMatch(PyStringNode $jsonExpected) {
@@ -594,6 +616,7 @@ trait BasicStructure {
 
 	/**
 	 * @Then the status.php response should match with
+	 *
 	 * @param PyStringNode $jsonExpected
 	 */
 	public function statusPhpRespondedShouldMatch(PyStringNode $jsonExpected) {

--- a/tests/integration/features/bootstrap/CalDavContext.php
+++ b/tests/integration/features/bootstrap/CalDavContext.php
@@ -69,7 +69,9 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 		$this->responseXml = '';
 	}
 
-	/** @AfterScenario @caldav */
+	/**
+	 * @AfterScenario @caldav
+	 */
 	public function afterScenario() {
 		$davUrl = $this->baseUrl. '/remote.php/dav/calendars/admin/MyCalendar';
 		try {
@@ -84,6 +86,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @When user :user requests calendar :calendar using the API
+	 *
 	 * @param string $user
 	 * @param string $calendar
 	 */
@@ -104,6 +107,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @Then the CalDAV HTTP status code should be :code
+	 *
 	 * @param int $code
 	 * @throws \Exception
 	 */
@@ -128,6 +132,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @Then the CalDAV exception should be :message
+	 *
 	 * @param string $message
 	 * @throws \Exception
 	 */
@@ -147,6 +152,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @Then the CalDAV error message should be :message
+	 *
 	 * @param string $message
 	 * @throws \Exception
 	 */
@@ -166,6 +172,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @Given user :user has successfully created a calendar named :name
+	 *
 	 * @param string $user
 	 * @param string $name
 	 */

--- a/tests/integration/features/bootstrap/CapabilitiesContext.php
+++ b/tests/integration/features/bootstrap/CapabilitiesContext.php
@@ -36,6 +36,7 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 
 	/**
 	 * @Then the capabilities should contain
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $formData
 	 * @return void
 	 */

--- a/tests/integration/features/bootstrap/CardDavContext.php
+++ b/tests/integration/features/bootstrap/CardDavContext.php
@@ -69,7 +69,9 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 		$this->responseXml = '';
 	}
 
-	/** @AfterScenario @carddav*/
+	/**
+	 * @AfterScenario @carddav
+	 */
 	public function afterScenario() {
 		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/admin/MyAddressbook';
 		try {
@@ -84,6 +86,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @When user :user requests addressbook :addressBook using the API
+	 *
 	 * @param string $user
 	 * @param string $addressBook
 	 * @throws \Exception
@@ -105,6 +108,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @Given user :user has successfully created an addressbook named :addressBook
+	 *
 	 * @param string $user
 	 * @param string $addressBook
 	 * @throws \Exception
@@ -139,6 +143,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @Then the CardDAV HTTP status code should be :code
+	 *
 	 * @param int $code
 	 * @throws \Exception
 	 */
@@ -163,6 +168,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @Then the CardDAV exception should be :message
+	 *
 	 * @param string $message
 	 * @throws \Exception
 	 */
@@ -182,6 +188,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @Then the CardDAV error message should be :arg1
+	 *
 	 * @param string $message
 	 * @throws \Exception
 	 */

--- a/tests/integration/features/bootstrap/Checksums.php
+++ b/tests/integration/features/bootstrap/Checksums.php
@@ -9,6 +9,7 @@ trait Checksums {
 	/**
 	 * @When user :user uploads file :source to :destination with checksum :checksum using the API
 	 * @Given user :user has uploaded file :source to :destination with checksum :checksum
+	 *
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
@@ -26,6 +27,7 @@ trait Checksums {
 
 	/**
 	 * @Then the webdav response should have a status code :statusCode
+	 *
 	 * @param int $statusCode
 	 * @throws \Exception
 	 */
@@ -37,6 +39,7 @@ trait Checksums {
 
 	/**
 	 * @When user :user requests the checksum of :path via propfind
+	 *
 	 * @param string $user
 	 * @param string $path
 	 */
@@ -60,6 +63,7 @@ trait Checksums {
 
 	/**
 	 * @Then the webdav checksum should match :checksum
+	 *
 	 * @param string $checksum
 	 * @throws \Exception
 	 */
@@ -81,6 +85,7 @@ trait Checksums {
 
 	/**
 	 * @Then the header checksum should match :checksum
+	 *
 	 * @param string $checksum
 	 * @throws \Exception
 	 */
@@ -123,6 +128,7 @@ trait Checksums {
 	/**
 	 * @When user :user uploads chunk file :num of :total with :data to :destination with checksum :checksum using the API
 	 * @Given user :user has uploaded chunk file :num of :total with :data to :destination with checksum :checksum
+	 *
 	 * @param string $user
 	 * @param int $num
 	 * @param int $total

--- a/tests/integration/features/bootstrap/CommandLine.php
+++ b/tests/integration/features/bootstrap/CommandLine.php
@@ -60,6 +60,7 @@ trait CommandLine {
 	/**
 	 * @When /^the administrator invokes occ command "([^"]*)"$/
 	 * @Given /^the administrator has invoked occ command "([^"]*)"$/
+	 *
 	 * @param string $cmd
 	 */
 	public function invokingTheCommand($cmd) {
@@ -125,6 +126,7 @@ trait CommandLine {
 
 	/**
 	 * @Then /^the command should have failed with exit code ([0-9]+)$/
+	 *
 	 * @param int $exitCode
 	 * @throws Exception
 	 */
@@ -136,6 +138,7 @@ trait CommandLine {
 
 	/**
 	 * @Then /^the command should have failed with exception text "([^"]*)"$/
+	 *
 	 * @param string $exceptionText
 	 * @throws Exception
 	 */
@@ -152,6 +155,7 @@ trait CommandLine {
 
 	/**
 	 * @Then /^the command output should contain the text "([^"]*)"$/
+	 *
 	 * @param string $text
 	 * @throws Exception
 	 */
@@ -164,6 +168,7 @@ trait CommandLine {
 
 	/**
 	 * @Then /^the command error output should contain the text "([^"]*)"$/
+	 *
 	 * @param string $text
 	 * @throws Exception
 	 */
@@ -217,6 +222,7 @@ trait CommandLine {
 	/**
 	 * @When /^the administrator transfers ownership from "([^"]+)" to "([^"]+)" using the occ command$/
 	 * @Given /^the administrator has transferred ownership from "([^"]+)" to "([^"]+)"$/
+	 *
 	 * @param string $user1
 	 * @param string $user2
 	 */
@@ -241,6 +247,7 @@ trait CommandLine {
 	/**
 	 * @When /^the administrator transfers ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)" using the occ command$/
 	 * @Given /^the administrator has transferred ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)"$/
+	 *
 	 * @param string $path
 	 * @param string $user1
 	 * @param string $user2
@@ -257,6 +264,7 @@ trait CommandLine {
 
 	/**
 	 * @Given /^using received transfer folder of "([^"]+)" as dav path$/
+	 *
 	 * @param string $user
 	 */
 	public function usingTransferFolderAsDavPath($user) {

--- a/tests/integration/features/bootstrap/CommandLine.php
+++ b/tests/integration/features/bootstrap/CommandLine.php
@@ -58,6 +58,7 @@ trait CommandLine {
 	}
 
 	/**
+	 * @When /^the administrator invokes occ command "([^"]*)"$/
 	 * @Given /^the administrator has invoked occ command "([^"]*)"$/
 	 * @param string $cmd
 	 */
@@ -255,7 +256,7 @@ trait CommandLine {
 	}
 
 	/**
-	 * @When /^using received transfer folder of "([^"]+)" as dav path$/
+	 * @Given /^using received transfer folder of "([^"]+)" as dav path$/
 	 * @param string $user
 	 */
 	public function usingTransferFolderAsDavPath($user) {

--- a/tests/integration/features/bootstrap/Comments.php
+++ b/tests/integration/features/bootstrap/Comments.php
@@ -36,6 +36,7 @@ trait Comments {
 	/**
 	 * @When /^user "([^"]*)" comments with content "([^"]*)" on (file|folder) "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has commented with content "([^"]*)" on (file|folder) "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $content
 	 * @param string $type
@@ -71,6 +72,7 @@ trait Comments {
 
 	/**
 	 * @Then /^user "([^"]*)" should have the following comments on (file|folder) "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $type
 	 * @param string $path
@@ -108,6 +110,7 @@ trait Comments {
 
 	/**
 	 * @Then /^user "([^"]*)" should have (\d+) comments on (file|folder) "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $numberOfComments
 	 * @param string $type
@@ -152,6 +155,7 @@ trait Comments {
 	/**
 	 * @When user :user deletes the last created comment using the API
 	 * @Given user :user has deleted the last created comment
+	 *
 	 * @param string $user
 	 * @throws \Exception
 	 */
@@ -161,6 +165,7 @@ trait Comments {
 
 	/**
 	 * @Then the response should contain a property :key with value :value
+	 *
 	 * @param string $key
 	 * @param string $value
 	 * @throws \Exception
@@ -182,6 +187,7 @@ trait Comments {
 
 	/**
 	 * @Then the response should contain only :number comments
+	 *
 	 * @param int $number
 	 * @throws \Exception
 	 */
@@ -222,6 +228,7 @@ trait Comments {
 	/**
 	 * @When /^user "([^"]*)" edits the last created comment with content "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has edited the last created comment with content "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $content
 	 * @throws \Exception

--- a/tests/integration/features/bootstrap/Federation.php
+++ b/tests/integration/features/bootstrap/Federation.php
@@ -52,6 +52,7 @@ trait Federation {
 	/**
 	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" accepts the last pending share using the API$/
 	 * @Given /^user "([^"]*)" from server "(LOCAL|REMOTE)" has accepted the last pending share$/
+	 *
 	 * @param string $user
 	 * @param string $server
 	 * @return void

--- a/tests/integration/features/bootstrap/Provisioning.php
+++ b/tests/integration/features/bootstrap/Provisioning.php
@@ -23,6 +23,7 @@ trait Provisioning {
 	/**
 	 * @When /^the administrator creates the user "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has been created$/
+	 *
 	 * @param string $user
 	 */
 	public function adminCreatesUserUsingTheAPI($user) {
@@ -37,6 +38,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^user "([^"]*)" should exist$/
+	 *
 	 * @param string $user
 	 */
 	public function userShouldExist($user) {
@@ -46,6 +48,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^user "([^"]*)" should not exist$/
+	 *
 	 * @param string $user
 	 */
 	public function userShouldNotExist($user) {
@@ -54,6 +57,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^group "([^"]*)" should exist$/
+	 *
 	 * @param string $group
 	 */
 	public function groupShouldExist($group) {
@@ -63,6 +67,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^group "([^"]*)" should not exist$/
+	 *
 	 * @param string $group
 	 */
 	public function groupShouldNotExist($group) {
@@ -72,6 +77,7 @@ trait Provisioning {
 	/**
 	 * @When /^the administrator deletes user "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has been deleted$/
+	 *
 	 * @param string $user
 	 */
 	public function adminDeletesUserUsingTheAPI($user) {
@@ -187,6 +193,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^user "([^"]*)" should belong to group "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $group
 	 */
@@ -205,6 +212,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^user "([^"]*)" should not belong to group "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $group
 	 */
@@ -247,6 +255,7 @@ trait Provisioning {
 	/**
 	 * @When /^the administrator adds user "([^"]*)" to group "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has been added to group "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $group
 	 */
@@ -276,6 +285,7 @@ trait Provisioning {
 	/**
 	 * @When /^the administrator creates group "([^"]*)" using the API$/
 	 * @Given /^group "([^"]*)" has been created$/
+	 *
 	 * @param string $group
 	 */
 	public function adminCreatesGroupUsingTheAPI($group) {
@@ -310,6 +320,7 @@ trait Provisioning {
 	/**
 	 * @When /^the administrator disables user "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has been disabled$/
+	 *
 	 * @param string $user
 	 */
 	public function adminDisablesUserUsingTheAPI($user) {
@@ -338,6 +349,7 @@ trait Provisioning {
 	/**
 	 * @When /^the administrator deletes group "([^"]*)" using the API$/
 	 * @Given /^group "([^"]*)" has been deleted$/
+	 *
 	 * @param string $group
 	 */
 	public function adminDeletesGroupUsingTheAPI($group) {
@@ -403,6 +415,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^user "([^"]*)" should be a subadmin of group "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $group
 	 */
@@ -424,6 +437,7 @@ trait Provisioning {
 	/**
 	 * @When /^the administrator makes user "([^"]*)" a subadmin of group "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has been made a subadmin of group "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $group
 	 */
@@ -442,6 +456,7 @@ trait Provisioning {
 	/**
 	 * @When /^the administrator makes user "([^"]*)" not a subadmin of group "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has been made not a subadmin of group "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $group
 	 */
@@ -462,6 +477,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^the users returned by the API should be$/
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $usersList
 	 */
 	public function theUsersShouldBe($usersList) {
@@ -476,6 +492,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^the groups returned by the API should be$/
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $groupsList
 	 */
 	public function theGroupsShouldBe($groupsList) {
@@ -500,6 +517,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^the subadmin groups returned by the API should be$/
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $groupsList
 	 */
 	public function theSubadminGroupsShouldBe($groupsList) {
@@ -508,6 +526,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^the subadmin users returned by the API should be$/
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $usersList
 	 */
 	public function theSubadminUsersShouldBe($usersList) {
@@ -516,6 +535,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^the apps returned by the API should include$/
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $appList
 	 */
 	public function theAppsShouldInclude($appList) {
@@ -529,6 +549,7 @@ trait Provisioning {
 
 	/**
 	 * Parses the xml answer to get the array of users returned.
+	 *
 	 * @param ResponseInterface $resp
 	 * @return array
 	 */
@@ -540,6 +561,7 @@ trait Provisioning {
 
 	/**
 	 * Parses the xml answer to get the array of groups returned.
+	 *
 	 * @param ResponseInterface $resp
 	 * @return array
 	 */
@@ -551,6 +573,7 @@ trait Provisioning {
 
 	/**
 	 * Parses the xml answer to get the array of apps returned.
+	 *
 	 * @param ResponseInterface $resp
 	 * @return array
 	 */
@@ -562,6 +585,7 @@ trait Provisioning {
 
 	/**
 	 * Parses the xml answer to get the array of subadmins returned.
+	 *
 	 * @param ResponseInterface $resp
 	 * @return array
 	 */
@@ -573,6 +597,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^app "([^"]*)" should be disabled$/
+	 *
 	 * @param string $app
 	 */
 	public function appShouldBeDisabled($app) {
@@ -591,6 +616,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^app "([^"]*)" should be enabled$/
+	 *
 	 * @param string $app
 	 */
 	public function appShouldBeEnabled($app) {
@@ -609,6 +635,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^user "([^"]*)" should be disabled$/
+	 *
 	 * @param string $user
 	 */
 	public function userShouldBeDisabled($user) {
@@ -623,6 +650,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^user "([^"]*)" should be enabled$/
+	 *
 	 * @param string $user
 	 */
 	public function useShouldBeEnabled($user) {
@@ -638,6 +666,7 @@ trait Provisioning {
 	/**
 	 * @When the administrator sets the quota of user :user to :quota using the API
 	 * @Given the quota of user :user has been set to :quota
+	 *
 	 * @param string $user
 	 * @param string $quota
 	 */
@@ -659,6 +688,7 @@ trait Provisioning {
 	/**
 	 * @When the administrator gives unlimited quota to user :user using the API
 	 * @Given user :user has been given unlimited quota
+	 *
 	 * @param string $user
 	 */
 	public function adminGivesUnlimitedQuotaToUserUsingTheAPI($user)
@@ -668,6 +698,7 @@ trait Provisioning {
 
 	/**
 	 * Returns home path of the given user
+	 *
 	 * @param string $user
 	 */
 	public function getUserHome($user) {
@@ -681,6 +712,7 @@ trait Provisioning {
 
 	/**
 	 * @Then /^the user attributes returned by the API should include$/
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
 	 */
 	public function checkUserAttributes($body) {

--- a/tests/integration/features/bootstrap/ShareesContext.php
+++ b/tests/integration/features/bootstrap/ShareesContext.php
@@ -36,6 +36,7 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 
 	/**
 	 * @When /^the user gets the sharees using the API with parameters$/
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode $body
 	 * @return void
 	 */
@@ -45,6 +46,7 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 
 	/**
 	 * @When /^user "([^"]*)" gets the sharees using the API with parameters$/
+	 *
 	 * @param string $user
 	 * @param \Behat\Gherkin\Node\TableNode $body
 	 * @return void
@@ -68,6 +70,7 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 
 	/**
 	 * @Then /^the "([^"]*)" sharees returned should be$/
+	 *
 	 * @param string $shareeType
 	 * @param \Behat\Gherkin\Node\TableNode $shareesList
 	 * @return void
@@ -82,6 +85,7 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 
 	/**
 	 * @Then /^the "([^"]*)" sharees returned should be empty$/
+	 *
 	 * @param string $shareeType
 	 * @return void
 	 */

--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -56,6 +56,7 @@ trait Sharing {
 	/**
 	 * @When /^user "([^"]*)" creates a share using the API with settings$/
 	 * @Given /^user "([^"]*)" has created a share with settings$/
+	 *
 	 * @param string $user
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
 	 * @return void
@@ -88,6 +89,7 @@ trait Sharing {
 
 	/**
 	 * @When /^the user creates a share using the API with settings$/
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
 	 * @return void
 	 */
@@ -97,6 +99,7 @@ trait Sharing {
 
 	/**
 	 * @Given /^the user has created a share with settings$/
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
 	 * @return void
 	 */
@@ -139,6 +142,7 @@ trait Sharing {
 	/**
 	 * @When /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has created a public share of (?:file|folder) "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $path
 	 * @return void
@@ -150,6 +154,7 @@ trait Sharing {
 	/**
 	 * @When /^the user creates a public share of (?:file|folder) "([^"]*)" using the API$/
 	 * @Given /^the user has created a public share of (?:file|folder) "([^"]*)"$/
+	 *
 	 * @param string $path
 	 * @return void
 	 */
@@ -160,6 +165,7 @@ trait Sharing {
 	/**
 	 * @When /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)" using the API with (read|update|create|delete|change|share|all) permission(?:s|)$/
 	 * @Given /^user "([^"]*)" has created a public share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 *
 	 * @param string $user
 	 * @param string $path
 	 * @param string|int|string[]|int[]|null $permissions
@@ -172,6 +178,7 @@ trait Sharing {
 	/**
 	 * @When /^the user creates a public share of (?:file|folder) "([^"]*)" using the API with (read|update|create|delete|change|share|all) permission(?:s|)$/
 	 * @Given /^the user has created a public share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 *
 	 * @param string $path
 	 * @param string|int|string[]|int[]|null $permissions
 	 * @return void
@@ -182,6 +189,7 @@ trait Sharing {
 
 	/**
 	 * @Then /^the public shared file "([^"]*)" should not be able to be downloaded$/
+	 *
 	 * @param string $path
 	 * @return void
 	 */
@@ -208,6 +216,7 @@ trait Sharing {
 
 	/**
 	 * @Then /^the last public shared file should be able to be downloaded without a password$/
+	 *
 	 * @return void
 	 */
 	public function checkLastPublicSharedFileDownload() {
@@ -222,6 +231,7 @@ trait Sharing {
 
 	/**
 	 * @Then /^the last public shared file should be able to be downloaded with password "([^"]*)"$/
+	 *
 	 * @param string $filename unused
 	 * @param string $password
 	 * @return void
@@ -271,6 +281,7 @@ trait Sharing {
 	/**
 	 * @When the public uploads file ":filename" with content ":body"
 	 * @Given the public has uploaded file ":filename" with content ":body"
+	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
 	 * @return void
@@ -282,6 +293,7 @@ trait Sharing {
 	/**
 	 * @When the public overwrites file ":filename" with content ":body" using the API
 	 * @Given the public has overwritten file ":filename" with content ":body" using the API
+	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
 	 * @return void
@@ -293,6 +305,7 @@ trait Sharing {
 	/**
 	 * @When the public uploads file ":filename" with password ":password" and content ":body"
 	 * @Given the public has uploaded file ":filename" with password ":password" and content ":body"
+	 *
 	 * @param string $filename target file name
 	 * @param string $password
 	 * @param string $body content to upload
@@ -307,6 +320,7 @@ trait Sharing {
 	/**
 	 * @When the public uploads file ":filename" with content ":body" with autorename mode
 	 * @Given the public has uploaded file ":filename" with content ":body" with autorename mode
+	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
 	 * @return void
@@ -317,6 +331,7 @@ trait Sharing {
 
 	/**
 	 * @Then publicly uploading a file should not work
+	 *
 	 * @return void
 	 */
 	public function publiclyUploadingShouldNotWork() {
@@ -371,6 +386,7 @@ trait Sharing {
 	/**
 	 * @When /^the user adds an expiration date to the last share using the API$/
 	 * @Given /^the user has added an expiration date to the last share using the API$/
+	 *
 	 * @return void
 	 */
 	public function theUserAddsExpirationDateToLastShare() {
@@ -393,6 +409,7 @@ trait Sharing {
 	/**
 	 * @When /^the user updates the last share using the API with$/
 	 * @Given /^the user has updated the last share with$/
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
 	 * @return void
 	 */
@@ -403,6 +420,7 @@ trait Sharing {
 	/**
 	 * @When /^user "([^"]*)" updates the last share using the API with$/
 	 * @Given /^user "([^"]*)" has updated the last share with$/
+	 *
 	 * @param string $user
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
 	 * @return void
@@ -718,6 +736,7 @@ trait Sharing {
 	/**
 	 * @When /^the user deletes the last share using the API$/
 	 * @Given /^the user has deleted the last share using the API$/
+	 *
 	 * @return void
 	 */
 	public function theUserDeletesLastShareUsingTheAPI() {
@@ -727,6 +746,7 @@ trait Sharing {
 	/**
 	 * @When /^user "([^"]*)" deletes the last share using the API$/
 	 * @Given /^user "([^"]*)" has deleted the last share$/
+	 *
 	 * @param string $user
 	 * @return void
 	 */
@@ -738,6 +758,7 @@ trait Sharing {
 
 	/**
 	 * @When /^the user gets the info of the last share using the API$/
+	 *
 	 * @return void
 	 */
 	public function theUserGetsInfoOfLastShareUsingTheAPI() {
@@ -746,6 +767,7 @@ trait Sharing {
 
 	/**
 	 * @When /^user "([^"]*)" gets the info of the last share using the API$/
+	 *
 	 * @param string $user
 	 * @return void
 	 */
@@ -757,6 +779,7 @@ trait Sharing {
 
 	/**
 	 * @Then /^the last share_id should be included in the response/
+	 *
 	 * @return void
 	 */
 	public function checkingLastShareIDIsIncluded() {
@@ -770,6 +793,7 @@ trait Sharing {
 
 	/**
 	 * @Then /^the last share_id should not be included in the response/
+	 *
 	 * @return void
 	 */
 	public function checkingLastShareIDIsNotIncluded() {
@@ -783,6 +807,7 @@ trait Sharing {
 
 	/**
 	 * @Then /^the response should contain ([0-9]+) entries$/
+	 *
 	 * @param int $count
 	 * @return void
 	 */
@@ -793,6 +818,7 @@ trait Sharing {
 
 	/**
 	 * @Then /^the share fields of the last share should include$/
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
 	 * @return void
 	 */
@@ -836,6 +862,7 @@ trait Sharing {
 	/**
 	 * @When user :user removes all shares from the file named :fileName using the API
 	 * @Given user :user has removed all shares from the file named :fileName
+	 *
 	 * @param string $user
 	 * @param string $fileName
 	 * @throws Exception
@@ -878,6 +905,7 @@ trait Sharing {
 
 	/**
 	 * @Given the last share id has been remembered
+	 *
 	 * @return void
 	 */
 	public function rememberLastShareId() {
@@ -886,6 +914,7 @@ trait Sharing {
 
 	/**
 	 * @Then the share ids should match
+	 *
 	 * @return void
 	 */
 	public function shareIdsShouldMatch() {
@@ -917,6 +946,7 @@ trait Sharing {
 
 	/**
 	 * @Then /^as user "([^"]*)" the public shares of (file|folder) "([^"]*)" should be$/
+	 *
 	 * @param string $user
 	 * @param string $type
 	 * @param string $path
@@ -979,6 +1009,7 @@ trait Sharing {
 	/**
 	 * @When /^user "([^"]*)" deletes public share named "([^"]*)" in (file|folder) "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has deleted public share named "([^"]*)" in (file|folder) "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $name
 	 * @param string $type unused

--- a/tests/integration/features/bootstrap/Sharing.php
+++ b/tests/integration/features/bootstrap/Sharing.php
@@ -269,6 +269,7 @@ trait Sharing {
 	}
 
 	/**
+	 * @When the public uploads file ":filename" with content ":body"
 	 * @Given the public has uploaded file ":filename" with content ":body"
 	 * @param string $filename target file name
 	 * @param string $body content to upload
@@ -280,6 +281,7 @@ trait Sharing {
 
 	/**
 	 * @When the public overwrites file ":filename" with content ":body" using the API
+	 * @Given the public has overwritten file ":filename" with content ":body" using the API
 	 * @param string $filename target file name
 	 * @param string $body content to upload
 	 * @return void
@@ -289,6 +291,7 @@ trait Sharing {
 	}
 
 	/**
+	 * @When the public uploads file ":filename" with password ":password" and content ":body"
 	 * @Given the public has uploaded file ":filename" with password ":password" and content ":body"
 	 * @param string $filename target file name
 	 * @param string $password
@@ -302,6 +305,7 @@ trait Sharing {
 	}
 
 	/**
+	 * @When the public uploads file ":filename" with content ":body" with autorename mode
 	 * @Given the public has uploaded file ":filename" with content ":body" with autorename mode
 	 * @param string $filename target file name
 	 * @param string $body content to upload
@@ -366,6 +370,7 @@ trait Sharing {
 
 	/**
 	 * @When /^the user adds an expiration date to the last share using the API$/
+	 * @Given /^the user has added an expiration date to the last share using the API$/
 	 * @return void
 	 */
 	public function theUserAddsExpirationDateToLastShare() {
@@ -712,6 +717,7 @@ trait Sharing {
 
 	/**
 	 * @When /^the user deletes the last share using the API$/
+	 * @Given /^the user has deleted the last share using the API$/
 	 * @return void
 	 */
 	public function theUserDeletesLastShareUsingTheAPI() {
@@ -972,6 +978,7 @@ trait Sharing {
 
 	/**
 	 * @When /^user "([^"]*)" deletes public share named "([^"]*)" in (file|folder) "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has deleted public share named "([^"]*)" in (file|folder) "([^"]*)"$/
 	 * @param string $user
 	 * @param string $name
 	 * @param string $type unused

--- a/tests/integration/features/bootstrap/Tags.php
+++ b/tests/integration/features/bootstrap/Tags.php
@@ -73,6 +73,7 @@ trait Tags {
 	/**
 	 * @When user :user creates a :type tag with name :name using the API
 	 * @Given user :user has created a :type tag with name :name
+	 *
 	 * @param string $user
 	 * @param string $type
 	 * @param string $name
@@ -85,6 +86,7 @@ trait Tags {
 	/**
 	 * @When user :user creates a :type tag with name :name and groups :groups using the API
 	 * @Given user :user has created a :type tag with name :name and groups :groups
+	 *
 	 * @param string $user
 	 * @param string $type
 	 * @param string $name
@@ -128,6 +130,7 @@ trait Tags {
 
 	/**
 	 * @Then the following tags should exist for :user
+	 *
 	 * @param string $user
 	 * @param TableNode $table
 	 * @throws \Exception
@@ -145,6 +148,7 @@ trait Tags {
 
 	/**
 	 * @Then tag :tagDisplayName should not exist for :user
+	 *
 	 * @param string $tagDisplayName
 	 * @param string $user
 	 */
@@ -155,6 +159,7 @@ trait Tags {
 
 	/**
 	 * @Then /^the user "([^"]*)" (should|should not) be able to assign the "([^"]*)" tag with name "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $shouldOrNot should or should not
 	 * @param string $type
@@ -178,6 +183,7 @@ trait Tags {
 
 	/**
 	 * @Then the :type tag with name :tagName should have the groups :groups
+	 *
 	 * @param string $type
 	 * @param string $tagName
 	 * @param string $groups list of groups separated by "|"
@@ -192,6 +198,7 @@ trait Tags {
 
 	/**
 	 * @Then :count tags should exist for :user
+	 *
 	 * @param int $count
 	 * @param string $user
 	 * @throws \Exception
@@ -236,6 +243,7 @@ trait Tags {
 	/**
 	 * @When user :user edits the tag with name :oldName and sets its name to :newName using the API
 	 * @Given user :user has edited the tag with name :oldName and set its name to :newName
+	 *
 	 * @param string $user
 	 * @param string $oldName
 	 * @param string $newName
@@ -251,6 +259,7 @@ trait Tags {
 	/**
 	 * @When user :user edits the tag with name :oldName and sets its groups to :groups using the API
 	 * @Given user :user has edited the tag with name :oldName and set its groups to :groups
+	 *
 	 * @param string $user
 	 * @param string $oldName
 	 * @param string $groups
@@ -266,6 +275,7 @@ trait Tags {
 	/**
 	 * @When user :user deletes the tag with name :name using the API
 	 * @Given user :user has deleted the tag with name :name
+	 *
 	 * @param string $user
 	 * @param string $name
 	 */
@@ -339,6 +349,7 @@ trait Tags {
 	/**
 	 * @When /^user "([^"]*)" adds the tag "([^"]*)" to "([^"]*)" (shared|owned) by "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has added the tag "([^"]*)" to "([^"]*)" (shared|owned) by "([^"]*)"$/
+	 *
 	 * @param string $taggingUser
 	 * @param string $tagName
 	 * @param string $fileName
@@ -351,6 +362,7 @@ trait Tags {
 
 	/**
 	 * @Then /^(?:file|folder|entry) "([^"]*)" (shared|owned) by "([^"]*)" should have the following tags$/
+	 *
 	 * @param string $fileName
 	 * @param string $sharedOrOwnedBy unused
 	 * @param string $sharingUser
@@ -382,6 +394,7 @@ trait Tags {
 
 	/**
 	 * @Then file :fileName shared by :sharingUser should have the following tags for :user
+	 *
 	 * @param string $fileName
 	 * @param string $sharingUser unused
 	 * @param string $user
@@ -412,6 +425,7 @@ trait Tags {
 	/**
 	 * @When user :user removes the tag :tagName from :fileName shared by :shareUser using the API
 	 * @Given user :user has removed the tag :tagName from :fileName shared by :shareUser
+	 *
 	 * @param string $user
 	 * @param string $tagName
 	 * @param string $fileName

--- a/tests/integration/features/bootstrap/Trashbin.php
+++ b/tests/integration/features/bootstrap/Trashbin.php
@@ -29,6 +29,7 @@ trait Trashbin {
 	/**
 	 * @When user :user empties the trashbin using the API
 	 * @Given user :user has emptied the trashbin
+	 *
 	 * @param string $user user
 	 */
 	public function emptyTrashbin($user) {
@@ -57,6 +58,7 @@ trait Trashbin {
 
 	/**
 	 * @Then /^as "([^"]*)" the (file|folder|entry) "([^"]*)" should exist in trash$/
+	 *
 	 * @param string $user
 	 * @param string $entryText unused
 	 * @param string $path
@@ -98,6 +100,7 @@ trait Trashbin {
 
 	/**
 	 * Function to check if an element is in trashbin
+	 *
 	 * @param string $user
 	 * @param string $originalPath
 	 * @return bool
@@ -151,6 +154,7 @@ trait Trashbin {
 	/**
 	 * @When /^user "([^"]*)" restores the (file|folder|entry) with original path "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has restored the (file|folder|entry) with original path "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $entryText unused
 	 * @param string $originalPath
@@ -163,6 +167,7 @@ trait Trashbin {
 
 	/**
 	 * @Then /^as "([^"]*)" the (file|folder|entry) with original path "([^"]*)" should exist in trash$/
+	 *
 	 * @param string $user
 	 * @param string $entryText unused
 	 * @param string $originalPath
@@ -174,6 +179,7 @@ trait Trashbin {
 
 	/**
 	 * @Then /^as "([^"]*)" the (file|folder|entry) with original path "([^"]*)" should not exist in trash$/
+	 *
 	 * @param string $user
 	 * @param string $entryText
 	 * @param string $originalPath

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -1086,6 +1086,7 @@ trait WebDav {
 
 	/**
 	 * @When user :user moves new chunk file with id :id to :dest with size :size using the API
+	 * @Given user :user has moved new chunk file with id :id to :dest with size :size
 	 * @param string $user
 	 * @param string $id
 	 * @param string $dest
@@ -1097,6 +1098,7 @@ trait WebDav {
 
 	/**
 	 * @When user :user moves new chunk file with id :id to :dest with checksum :checksum using the API
+	 * @Given user :user has moved new chunk file with id :id to :dest with checksum :checksum
 	 * @param string $user
 	 * @param string $id
 	 * @param string $dest
@@ -1222,6 +1224,7 @@ trait WebDav {
 
 	/**
 	 * @When an unauthenticated client connects to the dav endpoint using the API
+	 * @Given an unauthenticated client has connected to the dav endpoint using the API
 	 */
 	public function connectingToDavEndpoint() {
 		try {
@@ -1338,6 +1341,7 @@ trait WebDav {
 
 	/**
 	 * @When user :user restores version index :versionIndex of file :path using the API
+	 * @Given user :user has restored version index :versionIndex of file :path
 	 * @param string $user
 	 * @param int $versionIndex
 	 * @param string $path

--- a/tests/integration/features/bootstrap/WebDav.php
+++ b/tests/integration/features/bootstrap/WebDav.php
@@ -31,6 +31,7 @@ trait WebDav {
 
 	/**
 	 * @Given /^using dav path "([^"]*)"$/
+	 *
 	 * @param string $davPath
 	 */
 	public function usingDavPath($davPath) {
@@ -68,6 +69,9 @@ trait WebDav {
 		}
 	}
 
+	/**
+	 * @return int DAV path version (1 or 2)
+	 */
 	private function getDavPathVersion ()
 	{
 		if ($this->usingOldDavPath === true) {
@@ -110,6 +114,7 @@ trait WebDav {
 
 	/**
 	 * @Given /^user "([^"]*)" has moved (file|folder|entry) "([^"]*)" to "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $entry unused
 	 * @param string $fileSource
@@ -124,6 +129,7 @@ trait WebDav {
 
 	/**
 	 * @When /^user "([^"]*)" moves (file|folder|entry) "([^"]*)" to "([^"]*)" using the API$/
+	 *
 	 * @param string $user
 	 * @param string $entry unused
 	 * @param string $fileSource
@@ -142,6 +148,7 @@ trait WebDav {
 	/**
 	 * @When /^user "([^"]*)" copies file "([^"]*)" to "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has copied file "([^"]*)" to "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $fileSource
 	 * @param string $fileDestination
@@ -158,6 +165,7 @@ trait WebDav {
 
 	/**
 	 * @When /^the user downloads file "([^"]*)" with range "([^"]*)" using the API$/
+	 *
 	 * @param string $fileSource
 	 * @param string $range
 	 */
@@ -167,6 +175,7 @@ trait WebDav {
 
 	/**
 	 * @When /^user "([^"]*)" downloads file "([^"]*)" with range "([^"]*)" using the API$/
+	 *
 	 * @param string $user
 	 * @param string $fileSource
 	 * @param string $range
@@ -178,6 +187,7 @@ trait WebDav {
 
 	/**
 	 * @When /^the public downloads the last public shared file with range "([^"]*)" using the API$/
+	 *
 	 * @param string $range
 	 */
 	public function downloadPublicFileWithRange($range) {
@@ -196,6 +206,7 @@ trait WebDav {
 
 	/**
 	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with range "([^"]*)" using the API$/
+	 *
 	 * @param string $path
 	 * @param string $range
 	 */
@@ -215,6 +226,7 @@ trait WebDav {
 
 	/**
 	 * @Then /^the downloaded content should be "([^"]*)"$/
+	 *
 	 * @param string $content
 	 */
 	public function downloadedContentShouldBe($content) {
@@ -223,6 +235,7 @@ trait WebDav {
 
 	/**
 	 * @Then /^the downloaded content when downloading file "([^"]*)" with range "([^"]*)" should be "([^"]*)"$/
+	 *
 	 * @param string $fileSource
 	 * @param string $range
 	 * @param string $content
@@ -234,6 +247,7 @@ trait WebDav {
 
 	/**
 	 * @Then /^the downloaded content when downloading file "([^"]*)" for user "([^"]*)" with range "([^"]*)" should be "([^"]*)"$/
+	 *
 	 * @param string $fileSource
 	 * @param string $user
 	 * @param string $range
@@ -246,6 +260,7 @@ trait WebDav {
 
 	/**
 	 * @When the user downloads the file :fileName using the API
+	 *
 	 * @param string $fileName
 	 */
 	public function theUserDownloadsTheFileUsingTheAPI($fileName) {
@@ -254,6 +269,7 @@ trait WebDav {
 
 	/**
 	 * @When user :user downloads the file :fileName using the API
+	 *
 	 * @param string $fileName
 	 * @param string $user
 	 */
@@ -267,6 +283,7 @@ trait WebDav {
 
 	/**
 	 * @Then the following headers should be set
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode $table
 	 * @throws \Exception
 	 */
@@ -290,6 +307,7 @@ trait WebDav {
 
 	/**
 	 * @Then the downloaded content should start with :start
+	 *
 	 * @param string $start
 	 * @throws \Exception
 	 */
@@ -307,6 +325,7 @@ trait WebDav {
 
 	/**
 	 * @When /^user "([^"]*)" gets the following properties of (file|folder|entry) "([^"]*)" using the API$/
+	 *
 	 * @param string $user
 	 * @param string $elementType unused
 	 * @param string $path
@@ -324,6 +343,7 @@ trait WebDav {
 
 	/**
 	 * @When user :user gets a custom property :propertyName of file :path
+	 *
 	 * @param string $user
 	 * @param string $propertyName
 	 * @param string $path
@@ -340,6 +360,7 @@ trait WebDav {
 	/**
 	 * @When /^user "([^"]*)" sets property "([^"]*)" of (file|folder|entry) "([^"]*)" to "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has set property "([^"]*)" of (file|folder|entry) "([^"]*)" to "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $propertyName
 	 * @param string $elementType unused
@@ -356,6 +377,7 @@ trait WebDav {
 
 	/**
 	 * @Then /^the response should contain a custom "([^"]*)" property with "([^"]*)"$/
+	 *
 	 * @param string $propertyName
 	 * @param string $propertyValue
 	 * @param null $table unused
@@ -374,6 +396,7 @@ trait WebDav {
 
 	/**
 	 * @Then /^as "([^"]*)" the (file|folder|entry) "([^"]*)" should not exist$/
+	 *
 	 * @param string $user
 	 * @param string $entry
 	 * @param string $path
@@ -392,6 +415,7 @@ trait WebDav {
 
 	/**
 	 * @Then /^as "([^"]*)" the (file|folder|entry) "([^"]*)" should exist$/
+	 *
 	 * @param string $user
 	 * @param string $entry
 	 * @param string $path
@@ -406,6 +430,7 @@ trait WebDav {
 
 	/**
 	 * @Then the single response should contain a property :key with value :value
+	 *
 	 * @param string $key
 	 * @param string $expectedValue
 	 * @throws \Exception
@@ -441,6 +466,7 @@ trait WebDav {
 
 	/**
 	 * @Then the single response should contain a property :key with value like :regex
+	 *
 	 * @param string $key
 	 * @param string $regex
 	 * @throws \Exception
@@ -471,6 +497,7 @@ trait WebDav {
 
 	/**
 	 * @Then the response should contain a share-types property with
+	 *
 	 * @param \Behat\Gherkin\Node\TableNode $table
 	 * @throws Exception
 	 */
@@ -507,6 +534,7 @@ trait WebDav {
 
 	/**
 	 * @Then the response should contain an empty property :property
+	 *
 	 * @param string $property
 	 * @throws \Exception
 	 */
@@ -523,6 +551,7 @@ trait WebDav {
 
 	/**
 	 * Returns the elements of a propfind
+	 *
 	 * @param string $user
 	 * @param string $path
 	 * @param int $folderDepth requires 1 to see elements without children
@@ -570,6 +599,7 @@ trait WebDav {
 
 	/**
 	 * @Then the version folder of file :path for user :user should contain :count element(s)
+	 *
 	 * @param string $path
 	 * @param string $user
 	 * @param int $count
@@ -582,6 +612,7 @@ trait WebDav {
 
 	/**
 	 * @Then the version folder of fileId :fileId for user :user should contain :count element(s)
+	 *
 	 * @param int $fileId
 	 * @param string $user
 	 * @param int $count
@@ -593,6 +624,7 @@ trait WebDav {
 
 	/**
 	 * @Then the content length of file :path with version index :index for user :user in versions folder should be :length
+	 *
 	 * @param string $path
 	 * @param int $index
 	 * @param string $user
@@ -649,7 +681,9 @@ trait WebDav {
 		return $parsedResponse;
 	}
 
-	/* Returns the elements of a report command special for comments
+	/**
+	 * Returns the elements of a report command special for comments
+	 *
 	 * @param string $user
 	 * @param string $path
 	 * @param string $properties properties which needs to be included in the report
@@ -699,6 +733,7 @@ trait WebDav {
 
 	/**
 	 * @Then /^user "([^"]*)" should see the following elements$/
+	 *
 	 * @param string $user
 	 * @param \Behat\Gherkin\Node\TableNode|null $expectedElements
 	 */
@@ -719,6 +754,7 @@ trait WebDav {
 	/**
 	 * @When user :user uploads file :source to :destination using the API
 	 * @Given user :user has uploaded file :source to :destination
+	 *
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
@@ -735,6 +771,7 @@ trait WebDav {
 
 	/**
 	 * @When user :user uploads file :source to :destination with chunks using the API
+	 *
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
@@ -784,6 +821,7 @@ trait WebDav {
 	 * Uploading with old/new dav and chunked/non-chunked.
 	 *
 	 * @When user :user uploads file :source to :destination with all mechanisms using the API
+	 *
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
@@ -796,6 +834,7 @@ trait WebDav {
 	 * Overwriting with old/new dav and chunked/non-chunked.
 	 *
 	 * @When user :user overwrites file :source to :destination with all mechanisms using the API
+	 *
 	 * @param string $user
 	 * @param string $source
 	 * @param string $destination
@@ -865,6 +904,7 @@ trait WebDav {
 
 	/**
 	 * @Then /^the HTTP status code of all upload responses should be "([^"]*)"$/
+	 *
 	 * @param int $statusCode
 	 */
 	public function theHTTPStatusCodeOfAllUploadResponsesShouldBe($statusCode) {
@@ -881,6 +921,7 @@ trait WebDav {
 	 * Check that all the files uploaded with old/new dav and chunked/non-chunked exist.
 	 *
 	 * @Then as :user the files uploaded to :destination with all mechanisms should exist
+	 *
 	 * @param string $user
 	 * @param string $destination
 	 */
@@ -894,6 +935,7 @@ trait WebDav {
 
 	/**
 	 * @Given user :user has added file :destination of :bytes bytes
+	 *
 	 * @param string $user
 	 * @param string $bytes
 	 * @param string $destination
@@ -911,6 +953,7 @@ trait WebDav {
 	/**
 	 * @When user :user uploads file with content :content to :destination using the API
 	 * @Given user :user has uploaded file with content :content to :destination
+	 *
 	 * @param string $user
 	 * @param string $content
 	 * @param string $destination
@@ -932,6 +975,7 @@ trait WebDav {
 	/**
 	 * @When user :user uploads file with checksum :checksum and content :content to :destination using the API
 	 * @Given user :user has uploaded file with checksum :checksum and content :content to :destination
+	 *
 	 * @param string $user
 	 * @param string $checksum
 	 * @param string $content
@@ -957,6 +1001,7 @@ trait WebDav {
 
 	/**
 	 * @Given file :file has been deleted for user :user
+	 *
 	 * @param string $file
 	 * @param string $user
 	 */
@@ -971,6 +1016,7 @@ trait WebDav {
 	 *
 	 * @When /^user "([^"]*)" waits and deletes (file|folder) "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has waited and deleted (file|folder) "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $type unused
 	 * @param string $file
@@ -986,6 +1032,7 @@ trait WebDav {
 	/**
 	 * @When /^user "([^"]*)" deletes (file|folder) "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has deleted (file|folder) "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $type unused
 	 * @param string $file
@@ -1002,6 +1049,7 @@ trait WebDav {
 	/**
 	 * @When user :user creates a folder :destination using the API
 	 * @Given user :user has created a folder :destination
+	 *
 	 * @param string $user
 	 * @param string $destination
 	 */
@@ -1020,6 +1068,7 @@ trait WebDav {
 	 *
 	 * @When user :user uploads chunk file :num of :total with :data to :destination using the API
 	 * @Given user :user has uploaded chunk file :num of :total with :data to :destination
+	 *
 	 * @param string $user
 	 * @param int $num
 	 * @param int $total
@@ -1041,6 +1090,7 @@ trait WebDav {
 	/**
 	 * @When user :user creates a new chunking upload with id :id using the API
 	 * @Given user :user has created a new chunking upload with id :id
+	 *
 	 * @param string $user
 	 * @param string $id
 	 */
@@ -1057,6 +1107,7 @@ trait WebDav {
 	/**
 	 * @When user :user uploads new chunk file :num with :data to id :id using the API
 	 * @Given user :user has uploaded new chunk file :num with :data to id :id
+	 *
 	 * @param string $user
 	 * @param int $num
 	 * @param string $data
@@ -1076,6 +1127,7 @@ trait WebDav {
 	/**
 	 * @When user :user moves new chunk file with id :id to :dest using the API
 	 * @Given user :user has moved new chunk file with id :id to :dest
+	 *
 	 * @param string $user
 	 * @param string $id
 	 * @param string $dest
@@ -1087,6 +1139,7 @@ trait WebDav {
 	/**
 	 * @When user :user moves new chunk file with id :id to :dest with size :size using the API
 	 * @Given user :user has moved new chunk file with id :id to :dest with size :size
+	 *
 	 * @param string $user
 	 * @param string $id
 	 * @param string $dest
@@ -1099,6 +1152,7 @@ trait WebDav {
 	/**
 	 * @When user :user moves new chunk file with id :id to :dest with checksum :checksum using the API
 	 * @Given user :user has moved new chunk file with id :id to :dest with checksum :checksum
+	 *
 	 * @param string $user
 	 * @param string $id
 	 * @param string $dest
@@ -1143,6 +1197,7 @@ trait WebDav {
 	/**
 	 * @When user :user favorites element :path using the API
 	 * @Given user :user has favorited element :path
+	 *
 	 * @param string $user
 	 * @param string $path
 	 */
@@ -1153,6 +1208,7 @@ trait WebDav {
 	/**
 	 * @When user :user unfavorites element :path using the API
 	 * @Given user :user has unfavorited element :path
+	 *
 	 * @param string $user
 	 * @param string $path
 	 */
@@ -1162,6 +1218,7 @@ trait WebDav {
 
 	/**
 	 * Set the elements of a proppatch
+	 *
 	 * @param string $user
 	 * @param string $path
 	 * @param int $favOrUnfav 1 = favorite, 0 = unfavorite
@@ -1190,6 +1247,7 @@ trait WebDav {
 	/**
 	 * @When user :user stores etag of element :path using the API
 	 * @Given user :user has stored etag of element :path
+	 *
 	 * @param string $user
 	 * @param string $path
 	 */
@@ -1202,6 +1260,7 @@ trait WebDav {
 
 	/**
 	 * @Then the etag of element :path of user :user should not have changed
+	 *
 	 * @param string $path
 	 * @param string $user
 	 */
@@ -1213,6 +1272,7 @@ trait WebDav {
 
 	/**
 	 * @Then the etag of element :path of user :user should have changed
+	 *
 	 * @param string $path
 	 * @param string $user
 	 */
@@ -1249,6 +1309,7 @@ trait WebDav {
 
     /**
 	 * @Then /^user "([^"]*)" in folder "([^"]*)" should have favorited the following elements$/
+	 *
 	 * @param string $user
 	 * @param string $folder
 	 * @param \Behat\Gherkin\Node\TableNode|null $expectedElements
@@ -1259,6 +1320,7 @@ trait WebDav {
 
     /**
 	 * @Then /^user "([^"]*)" in folder "([^"]*)" should have favorited the following elements from offset ([\d*]) and limit ([\d*])$/
+	 *
 	 * @param string $user
 	 * @param string $folder
 	 * @param \Behat\Gherkin\Node\TableNode|null $expectedElements
@@ -1285,6 +1347,7 @@ trait WebDav {
 	/**
 	 * @When /^user "([^"]*)" deletes everything from folder "([^"]*)" using the API$/
 	 * @Given /^user "([^"]*)" has deleted everything from folder "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $folder
 	 */
@@ -1320,6 +1383,7 @@ trait WebDav {
 
 	/**
 	 * @Given /^user "([^"]*)" has stored id of file "([^"]*)"$/
+	 *
 	 * @param string $user
 	 * @param string $path
 	 * @return void
@@ -1330,6 +1394,7 @@ trait WebDav {
 
 	/**
 	 * @Then /^user "([^"]*)" file "([^"]*)" should have the previously stored id$/
+	 *
 	 * @param string $user
 	 * @param string $path
 	 * @return void
@@ -1342,6 +1407,7 @@ trait WebDav {
 	/**
 	 * @When user :user restores version index :versionIndex of file :path using the API
 	 * @Given user :user has restored version index :versionIndex of file :path
+	 * 
 	 * @param string $user
 	 * @param int $versionIndex
 	 * @param string $path


### PR DESCRIPTION
## Description
1) Wherever there is a "when" or "given" type step definition, if it could also be used in a "given" or "when" context, then add the relevant step definition form of words.
2) Separate the Given/When/Then annotations from the ``param`` annotations in the doc blocks. This had been done in some places, so do it consistently. It fits draft PSR-5 doc block standard anyway.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
Sometimes a new change wants to add a test that uses an existing "when" or "given" worded step but in the opposite context. If the new change is in an app, then it is annoying that the "correct" form of words is not available in the core step definitions.

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

