### PR TITLE
[stable10] Decrypt seen users only

### DIFF
--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -30,6 +30,7 @@ use OC\Encryption\Exceptions\DecryptionFailedException;
 use OC\Files\View;
 use \OCP\Encryption\IEncryptionModule;
 use OCP\ILogger;
+use OCP\IUser;
 use OCP\IUserManager;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -145,7 +146,7 @@ class DecryptAll {
 	}
 
 	/**
-	 * iterate over all user and encrypt their files
+	 * iterate over all seen users and decrypt their files
 	 *
 	 * @param string $user which users files should be decrypted, default = all users
 	 * @return bool
@@ -154,53 +155,28 @@ class DecryptAll {
 
 		$this->output->writeln("\n");
 
-		$userList = [];
-		if ($user === '') {
-
-			$fetchUsersProgress = new ProgressBar($this->output);
-			$fetchUsersProgress->setFormat(" %message% \n [%bar%]");
-			$fetchUsersProgress->start();
-			$fetchUsersProgress->setMessage("Fetch list of users...");
-			$fetchUsersProgress->advance();
-
-			foreach ($this->userManager->getBackends() as $backend) {
-				$limit = 500;
-				$offset = 0;
-				do {
-					$users = $backend->getUsers('', $limit, $offset);
-					foreach ($users as $user) {
-						$userList[] = $user;
-					}
-					$offset += $limit;
-					$fetchUsersProgress->advance();
-				} while (count($users) >= $limit);
-				$fetchUsersProgress->setMessage("Fetch list of users... finished");
-				$fetchUsersProgress->finish();
-			}
-		} else {
-			$userList[] = $user;
-		}
-
-		$this->output->writeln("\n\n");
-
 		$progress = new ProgressBar($this->output);
 		$progress->setFormat(" %message% \n [%bar%]");
 		$progress->start();
 		$progress->setMessage("starting to decrypt files...");
 		$progress->advance();
 
-		$numberOfUsers = count($userList);
-		$userNo = 1;
-		foreach ($userList as $uid) {
-			$userCount = "$uid ($userNo of $numberOfUsers)";
-			if (\OC::$server->getAppConfig()->getValue('encryption', 'userSpecificKey', '0') !== '0') {
-				if ($this->prepareEncryptionModules($uid) === false) {
-					return false;
-				}
-			}
-			$this->decryptUsersFiles($uid, $progress, $userCount);
-			$userNo++;
+		if ($user === '') {
+			$userNo = 1;
+			$numberOfUsers = $this->userManager->countSeenUsers();
+			$this->userManager->callForSeenUsers(function(IUser $user) use ($progress, &$userNo, $numberOfUsers) {
+				$this->decryptUsersFiles(
+					$user->getUID(),
+					$progress,
+					"{$user->getUID()} ($userNo of $numberOfUsers)"
+				);
+				$userNo++;
+			});
+		} else {
+			$this->decryptUsersFiles($user, $progress, "$user (1 of 1)");
 		}
+
+		$this->output->writeln("\n\n");
 
 		$progress->setMessage("starting to decrypt files... finished");
 		$progress->finish();

--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -164,6 +164,9 @@ class DecryptAll {
 		if ($user === '') {
 			$userNo = 1;
 			$numberOfUsers = $this->userManager->countSeenUsers();
+			if ($numberOfUsers === 0) {
+				return false;
+			}
 			$this->userManager->callForSeenUsers(function(IUser $user) use ($progress, &$userNo, $numberOfUsers) {
 				$this->decryptUsersFiles(
 					$user->getUID(),

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -40,6 +40,7 @@ use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 use OCP\Files\Storage\IStorage;
+use Test\Traits\UserTrait;
 
 /**
  * Class DecryptAllTest
@@ -50,6 +51,7 @@ use OCP\Files\Storage\IStorage;
  */
 class DecryptAllTest extends TestCase {
 
+	use UserTrait;
 	/** @var \PHPUnit_Framework_MockObject_MockObject | IUserManager */
 	protected $userManager;
 
@@ -209,6 +211,37 @@ class DecryptAllTest extends TestCase {
 		);
 	}
 
+	public function testNoUsersSeen() {
+		static::createUser('user1', 'user1');
+		/** @var DecryptAll | \PHPUnit_Framework_MockObject_MockObject |  $instance */
+		$instance = $this->getMockBuilder(DecryptAll::class)
+			->setConstructorArgs(
+				[
+					$this->encryptionManager,
+					$this->userManager,
+					$this->view,
+					$this->logger
+				]
+			)
+			->setMethods(['decryptUsersFiles'])
+			->getMock();
+
+		$this->invokePrivate($instance, 'input', [$this->inputInterface]);
+		$this->invokePrivate($instance, 'output', [$this->outputInterface]);
+
+
+		$function = function (IUser $user)  {
+			$users[] = $user->getUID();
+		};
+
+		$this->userManager->expects($this->once())
+			->method('countSeenUsers')
+			->willReturn(0);
+
+		$result = $this->invokePrivate($instance, 'decryptAllUsersFiles', []);
+		$this->assertEquals(false, $result);
+	}
+
 	/**
 	 * @dataProvider dataTestDecryptAllUsersFiles
 	 */
@@ -230,13 +263,22 @@ class DecryptAllTest extends TestCase {
 		$this->invokePrivate($instance, 'input', [$this->inputInterface]);
 		$this->invokePrivate($instance, 'output', [$this->outputInterface]);
 
+
+		$function = function (IUser $user)  {
+			$users[] = $user->getUID();
+		};
+
 		if (empty($user)) {
+			$progress = new ProgressBar($this->outputInterface);
 			$this->userManager->expects($this->once())
-				->method('getBackends')
-				->willReturn([$this->userInterface]);
-			$this->userInterface->expects($this->any())
-				->method('getUsers')
-				->willReturn(['user1', 'user2']);
+				->method('countSeenUsers')
+				->willReturn(2);
+			$this->userManager->expects($this->once())
+				->method('callForSeenUsers')
+				->will($this->returnCallback(function() use ($instance, $progress) {
+					$this->invokePrivate($instance, 'decryptUsersFiles', ['user1', $progress, '']);
+					$this->invokePrivate($instance, 'decryptUsersFiles', ['user2', $progress, '']);
+			}));
 			$instance->expects($this->at(0))
 				->method('decryptUsersFiles')
 				->with('user1');
@@ -249,7 +291,8 @@ class DecryptAllTest extends TestCase {
 				->with($user);
 		}
 
-		$this->invokePrivate($instance, 'decryptAllUsersFiles', [$user]);
+		$result = $this->invokePrivate($instance, 'decryptAllUsersFiles', [$user]);
+		$this->assertEquals(true, $result);
 	}
 
 	public function dataTestDecryptAllUsersFiles() {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
This change would help to use decrypt-all on seen users, or the users who have logged in once at least. It doesn't make sense to iterate over the entire users when they have not logged in once.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change would help to use decrypt-all on seen users, or the users who have logged in once at least. It doesn't make sense to iterate over the entire users when they have not logged in once.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

