### PR TITLE
[stable10] Flag to enable http fallback when creating fed shares

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1130,6 +1130,11 @@ $CONFIG = array(
  */
 'sharing.managerFactory' => '\OC\Share20\ProviderFactory',
 
+/**
+ * When talking with federated sharing server, allow falling back to HTTP
+ * instead of hard forcing HTTPS
+ */
+'sharing.federation.allowHttpFallback' => false,
 
 
 /**
@@ -1428,4 +1433,5 @@ $CONFIG = array(
  * Set this property to true if you want to enable debug logging for SMB access.
  */
 'smb.logging.enable' => false, 
+
 );


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/30198 to stable10

cc @pmaier1 for release notes / changelog. We now default to now allowing http communication for federated sharing. However it can be enabled with a config flag

`'sharing.federation.allowHttpFallback' => false,`