### PR TITLE
UI-test - extra behat step to initialize users

### DIFF
--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -174,6 +174,23 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @Given these users are initialized:
+	 * expects a table of users with the heading
+	 * "|username|password|"
+	 *
+	 * @param TableNode $table
+	 * @return void
+	 */
+	public function theseUsersAreInitialized(TableNode $table) {
+		foreach ($table as $row) {
+			$this->initializeUser(
+				$row ['username'],
+				$row ['password']
+			);
+		}
+	}
+	
+	/**
 	 * creates a single user
 	 *
 	 * @param string $user
@@ -236,17 +253,27 @@ trait BasicStructure {
 
 		$this->addUserToCreatedUsersList($user, $password, $displayName, $email);
 		if ($initialize) {
-			// Download a skeleton file. That will force the server to fully
-			// initialize the user, including their skeleton files.
-			DownloadHelper::download(
-				$baseUrl,
-				$user,
-				$password,
-				"lorem.txt"
-			);
+			$this->initializeUser($user, $password);
 		}
 	}
 
+	/**
+	 * Download a skeleton file. That will force the server to fully
+	 * initialize the user, including their skeleton files.
+	 * 
+	 * @param string $user
+	 * @param string $password
+	 * @return void
+	 */
+	public function initializeUser($user, $password) {
+		$baseUrl = $this->getMinkParameter("base_url");
+		DownloadHelper::download(
+			$baseUrl,
+			$user,
+			$password,
+			"lorem.txt"
+		);
+	}
 	/**
 	 * @Given these groups exist:
 	 * expects a table of groups with the heading "groupname"


### PR DESCRIPTION
## Description
One extra step to be able to initialize users without having the create them first

## Motivation and Context
useful if we test with external user DB like LDAP, where we do not create users but assume they exist. Still we want to initialize them

## How Has This Been Tested?
created tests (in user_ldap) that use the new step

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

