### PR TITLE
UI tests doc blocks

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -24,7 +24,6 @@
 		<exclude name="Generic.Commenting.DocComment.SpacingAfter" />
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 		<exclude name="Generic.Commenting.DocComment.TagValueIndent" />
-		<exclude name="Generic.Commenting.DocComment.NonParamGroup" />
 		<exclude name="Generic.Commenting.DocComment.ParamNotFirst" />
 		<exclude name="PEAR.Commenting.FileComment.IncompleteCopyright" />
 		<exclude name="PEAR.Commenting.FileComment.MissingVersion" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -25,6 +25,7 @@
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 		<exclude name="Generic.Commenting.DocComment.TagValueIndent" />
 		<exclude name="Generic.Commenting.DocComment.NonParamGroup" />
+		<exclude name="Generic.Commenting.DocComment.ParamNotFirst" />
 		<exclude name="PEAR.Commenting.FileComment.IncompleteCopyright" />
 		<exclude name="PEAR.Commenting.FileComment.MissingVersion" />
 		<exclude name="PEAR.Commenting.FileComment.MissingCategoryTag" />

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -50,6 +50,7 @@ trait BasicStructure {
 
 	/**
 	 * @Given I am logged in as admin
+	 *
 	 * @return void
 	 */
 	public function iAmLoggedInAsAdmin() {
@@ -59,6 +60,7 @@ trait BasicStructure {
 
 	/**
 	 * @Given I am logged in as a regular user
+	 *
 	 * @return void
 	 */
 	public function iAmLoggedInAsARegularUser() {
@@ -98,6 +100,7 @@ trait BasicStructure {
 
 	/**
 	 * @When I logout
+	 *
 	 * @return void
 	 */
 	public function iLogout() {
@@ -111,6 +114,7 @@ trait BasicStructure {
 
 	/**
 	 * @Given /^a regular user exists\s?(but is not initialized|)$/
+	 *
 	 * @param string $doNotInitialize just create the user, do not trigger creating skeleton files etc
 	 * @return void
 	 */
@@ -126,6 +130,7 @@ trait BasicStructure {
 
 	/**
 	 * @Given /^regular users exist\s?(but are not initialized|)$/
+	 *
 	 * @param string $doNotInitialize just create the user, do not trigger creating skeleton files etc
 	 * @return void
 	 */
@@ -277,6 +282,7 @@ trait BasicStructure {
 	/**
 	 * @Given these groups exist:
 	 * expects a table of groups with the heading "groupname"
+	 *
 	 * @param TableNode $table
 	 * @return void
 	 */
@@ -288,6 +294,7 @@ trait BasicStructure {
 
 	/**
 	 * @Given a regular group exists
+	 *
 	 * @return void
 	 */
 	public function aRegularGroupExists() {
@@ -296,6 +303,7 @@ trait BasicStructure {
 
 	/**
 	 * @Given regular groups exist
+	 *
 	 * @return void
 	 */
 	public function regularGroupsExist() {
@@ -355,6 +363,7 @@ trait BasicStructure {
 	}
 	/**
 	 * @Given a regular user is in a regular group
+	 *
 	 * @return void
 	 */
 	public function aRegularUserIsInARegularGroup() {
@@ -368,6 +377,7 @@ trait BasicStructure {
 
 	/**
 	 * @Given the user :user is in the group :group
+	 *
 	 * @param string $user
 	 * @param string $group
 	 * @param string $method how to add the user to the group api|occ
@@ -582,6 +592,7 @@ trait BasicStructure {
 	 * @param string $password
 	 * @param string $displayName
 	 * @param string $email
+	 * @param bool $shouldHaveBeenCreated
 	 * @return void
 	 */
 	public function addUserToCreatedUsersList(

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -82,6 +82,7 @@ trait BasicStructure {
 	 * @param string $username
 	 * @param string $password
 	 * @param string $target
+	 *
 	 * @return \Page\OwncloudPage
 	 */
 	public function loginAs($username, $password, $target = 'FilesPage') {
@@ -116,6 +117,7 @@ trait BasicStructure {
 	 * @Given /^a regular user exists\s?(but is not initialized|)$/
 	 *
 	 * @param string $doNotInitialize just create the user, do not trigger creating skeleton files etc
+	 *
 	 * @return void
 	 */
 	public function aRegularUserExists($doNotInitialize = "") {
@@ -132,6 +134,7 @@ trait BasicStructure {
 	 * @Given /^regular users exist\s?(but are not initialized|)$/
 	 *
 	 * @param string $doNotInitialize just create the user, do not trigger creating skeleton files etc
+	 *
 	 * @return void
 	 */
 	public function regularUsersExist($doNotInitialize) {
@@ -154,6 +157,7 @@ trait BasicStructure {
 	 *
 	 * @param string $doNotInitialize just create the user, do not trigger creating skeleton files etc
 	 * @param TableNode $table
+	 *
 	 * @return void
 	 */
 	public function theseUsersExist($doNotInitialize, TableNode $table) {
@@ -184,6 +188,7 @@ trait BasicStructure {
 	 * "|username|password|"
 	 *
 	 * @param TableNode $table
+	 *
 	 * @return void
 	 */
 	public function theseUsersAreInitialized(TableNode $table) {
@@ -204,6 +209,7 @@ trait BasicStructure {
 	 * @param string $email
 	 * @param bool $initialize initialize the user skeleton files etc
 	 * @param string $method how to create the user api|occ
+	 *
 	 * @return void
 	 * @throws Exception
 	 */
@@ -268,6 +274,7 @@ trait BasicStructure {
 	 * 
 	 * @param string $user
 	 * @param string $password
+	 *
 	 * @return void
 	 */
 	public function initializeUser($user, $password) {
@@ -284,6 +291,7 @@ trait BasicStructure {
 	 * expects a table of groups with the heading "groupname"
 	 *
 	 * @param TableNode $table
+	 *
 	 * @return void
 	 */
 	public function theseGroupsExist(TableNode $table) {
@@ -317,6 +325,7 @@ trait BasicStructure {
 	 *
 	 * @param string $group
 	 * @param string $method how to create the group api|occ
+	 *
 	 * @return void
 	 * @throws Exception
 	 */
@@ -381,6 +390,7 @@ trait BasicStructure {
 	 * @param string $user
 	 * @param string $group
 	 * @param string $method how to add the user to the group api|occ
+	 *
 	 * @return void
 	 * @throws Exception
 	 */
@@ -449,6 +459,7 @@ trait BasicStructure {
 
 	/**
 	 * @param BeforeScenarioScope $scope
+	 *
 	 * @return void
 	 * @BeforeScenario
 	 */
@@ -593,6 +604,7 @@ trait BasicStructure {
 	 * @param string $displayName
 	 * @param string $email
 	 * @param bool $shouldHaveBeenCreated
+	 *
 	 * @return void
 	 */
 	public function addUserToCreatedUsersList(
@@ -612,6 +624,7 @@ trait BasicStructure {
 	 * or to delete them at the end of the test
 	 *
 	 * @param string $group
+	 *
 	 * @return void
 	 */
 	public function addGroupToCreatedGroupsList($group) {
@@ -626,6 +639,7 @@ trait BasicStructure {
 	 * test run. We don't want to try to delete this group again in the tear-down phase
 	 *
 	 * @param string $group
+	 *
 	 * @return void
 	 */
 	public function deleteGroupFromCreatedGroupsList($group) {
@@ -637,6 +651,7 @@ trait BasicStructure {
 	/**
 	 *
 	 * @param string $username
+	 *
 	 * @return string password
 	 * @throws Exception
 	 */
@@ -672,6 +687,7 @@ trait BasicStructure {
 	 * then it is returned unmodified
 	 *
 	 * @param string $value
+	 *
 	 * @return string
 	 */
 	public function substituteInLineCodes($value) {

--- a/tests/ui/features/bootstrap/BasicStructure.php
+++ b/tests/ui/features/bootstrap/BasicStructure.php
@@ -436,9 +436,10 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @return void
 	 * @BeforeScenario
 	 * @TestAlsoOnExternalUserBackend
+	 *
+	 * @return void
 	 */
 	public function setUpExternalUserBackends() {
 		//TODO make it smarter to be able also to work with other backends 
@@ -458,10 +459,11 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @BeforeScenario
+	 *
 	 * @param BeforeScenarioScope $scope
 	 *
 	 * @return void
-	 * @BeforeScenario
 	 */
 	public function setUpScenarioGetRegularUsersAndGroups(
 		BeforeScenarioScope $scope
@@ -481,9 +483,10 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @AfterScenario
+	 *
 	 * @return void
 	 * @throws Exception
-	 * @AfterScenario
 	 */
 	public function tearDownScenarioDeleteCreatedUsersAndGroups() {
 		$baseUrl = $this->getMinkParameter("base_url");

--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -124,6 +124,7 @@ class FeatureContext extends RawMinkContext implements Context {
 
 	/**
 	 * @param string $currentUser
+	 *
 	 * @return void
 	 */
 	public function setCurrentUser($currentUser) {
@@ -143,6 +144,7 @@ class FeatureContext extends RawMinkContext implements Context {
 
 	/**
 	 * @param string $currentServer
+	 *
 	 * @return void
 	 */
 	public function setCurrentServer($currentServer) {
@@ -163,6 +165,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	/**
 	 * 
 	 * @param OwncloudPage $pageObject
+	 *
 	 * @return void
 	 */
 	public function setCurrentPageObject(OwncloudPage $pageObject) {
@@ -199,6 +202,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	 * @Then a notification should be displayed with the text :notificationText
 	 *
 	 * @param string $notificationText expected notification text
+	 *
 	 * @return void
 	 */
 	public function aNotificationShouldBeDisplayedWithTheText($notificationText) {
@@ -213,6 +217,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	 * @param string $matching contains "matching" when notification text
 	 *                         has to be checked against regular expression
 	 * @param TableNode $table of expected notification text
+	 *
 	 * @return void
 	 * @throws Exception
 	 */
@@ -254,6 +259,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	 * @param int|string|null $count
 	 * @param TableNode|null $table of expected dialogs format must be:
 	 *                              | title | content |
+	 *
 	 * @return void
 	 */
 	public function dialogsShouldBeDisplayed(
@@ -309,6 +315,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	 * @Then I should be redirected to a page with the title :title
 	 *
 	 * @param string $title
+	 *
 	 * @return void
 	 */
 	public function iShouldBeRedirectedToAPageWithTheTitle($title) {
@@ -323,6 +330,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	 * @Then the group named :name should not exist
 	 *
 	 * @param string $name
+	 *
 	 * @return void
 	 * @throws Exception
 	 */
@@ -342,6 +350,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $shouldOrNot (not|)
 	 * @param TableNode $table
+	 *
 	 * @return void
 	 * @throws Exception
 	 */
@@ -365,6 +374,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	 * @param string $setting
 	 * @param string $section
 	 * @param string $value
+	 *
 	 * @return void
 	 */
 	public function settingInSectionIs($setting, $section, $value) {
@@ -397,6 +407,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	 *
 	 * @param int $size if not int given it will be cast to int
 	 * @param string $name
+	 *
 	 * @throws InvalidArgumentException
 	 * @return void
 	 */
@@ -429,6 +440,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	 *         'configkey' => string,
 	 *         'value' => bool
 	 *        ]
+	 *
 	 * @return void
 	 */
 	public function addToSavedCapabilitiesChanges($change) {
@@ -441,7 +453,9 @@ class FeatureContext extends RawMinkContext implements Context {
 
 	/**
 	 * @BeforeScenario
+	 *
 	 * @param BeforeScenarioScope $scope
+	 *
 	 * @return void
 	 */
 	public function setUpSuite(BeforeScenarioScope $scope) {
@@ -492,6 +506,7 @@ class FeatureContext extends RawMinkContext implements Context {
 	 * disable the previews on all tests tagged with '@disablePreviews'
 	 * 
 	 * @BeforeScenario @disablePreviews
+	 *
 	 * @return void
 	 */
 	public function disablePreviewBeforeScenario() {
@@ -525,8 +540,9 @@ class FeatureContext extends RawMinkContext implements Context {
 	/**
 	 * After Scenario. Sets back old settings
 	 *
-	 * @return void
 	 * @AfterScenario
+	 *
+	 * @return void
 	 */
 	public function tearDownSuite() {
 		AppConfigHelper::modifyServerConfigs(
@@ -574,8 +590,9 @@ class FeatureContext extends RawMinkContext implements Context {
 	/**
 	 * After Scenario. clear file locks
 	 *
-	 * @return void
 	 * @AfterScenario
+	 *
+	 * @return void
 	 */
 	public function clearFileLocks() {
 		$response = OcsApiHelper::sendRequest(
@@ -592,9 +609,11 @@ class FeatureContext extends RawMinkContext implements Context {
 	/**
 	 * After Scenario. Report the pass/fail status to SauceLabs.
 	 *
-	 * @param AfterScenarioScope $afterScenarioScope
-	 * @return void
 	 * @AfterScenario
+	 *
+	 * @param AfterScenarioScope $afterScenarioScope
+	 *
+	 * @return void
 	 */
 	public function reportResult(AfterScenarioScope $afterScenarioScope) {
 		if ($afterScenarioScope->getTestResult()->isPassed()) {

--- a/tests/ui/features/bootstrap/FeatureContext.php
+++ b/tests/ui/features/bootstrap/FeatureContext.php
@@ -179,6 +179,7 @@ class FeatureContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then no notification should be displayed
+	 *
 	 * @return void
 	 */
 	public function noNotificationShouldBeDisplayed() {
@@ -196,6 +197,7 @@ class FeatureContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then a notification should be displayed with the text :notificationText
+	 *
 	 * @param string $notificationText expected notification text
 	 * @return void
 	 */
@@ -207,6 +209,7 @@ class FeatureContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then /^notifications should be displayed with the text\s?(matching|)$/
+	 *
 	 * @param string $matching contains "matching" when notification text
 	 *                         has to be checked against regular expression
 	 * @param TableNode $table of expected notification text
@@ -247,6 +250,7 @@ class FeatureContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then /^((?:\d)|no)?\s?dialog[s]? should be displayed$/
+	 *
 	 * @param int|string|null $count
 	 * @param TableNode|null $table of expected dialogs format must be:
 	 *                              | title | content |
@@ -303,6 +307,7 @@ class FeatureContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then I should be redirected to a page with the title :title
+	 *
 	 * @param string $title
 	 * @return void
 	 */
@@ -316,6 +321,7 @@ class FeatureContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then the group named :name should not exist
+	 *
 	 * @param string $name
 	 * @return void
 	 * @throws Exception
@@ -355,6 +361,7 @@ class FeatureContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given /^the setting "([^"]*)" in the section "([^"]*)" is (disabled|enabled)$/
+	 *
 	 * @param string $setting
 	 * @param string $section
 	 * @param string $value
@@ -387,6 +394,7 @@ class FeatureContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given a file with the size of :size bytes and the name :name exists
+	 *
 	 * @param int $size if not int given it will be cast to int
 	 * @param string $name
 	 * @throws InvalidArgumentException

--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -131,6 +131,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given I am on the files page
+	 *
 	 * @return void
 	 */
 	public function iAmOnTheFilesPage() {
@@ -143,6 +144,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given I am on the trashbin page
+	 *
 	 * @return void
 	 */
 	public function iAmOnTheTrashbinPage() {
@@ -155,6 +157,7 @@ class FilesContext extends RawMinkContext implements Context {
 	
 	/**
 	 * @Given I am on the favorites page
+	 *
 	 * @return void
 	 */
 	public function iAmOnTheFavoritesPage() {
@@ -167,6 +170,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the files/favorites page is reloaded
+	 *
 	 * @return void
 	 */
 	public function theFilesPageIsReloaded() {
@@ -216,6 +220,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I create a folder with the following name
+	 *
 	 * @param TableNode $namePartsTable table of parts of the file name
 	 *                                  table headings: must be: |name-parts |
 	 * @return void
@@ -232,6 +237,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then there are no files\/folders listed
+	 *
 	 * @return void
 	 */
 	public function thereAreNoFilesFoldersListed() {
@@ -243,6 +249,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given the list of files\/folders does not fit in one browser page
+	 *
 	 * @return void
 	 */
 	public function theListOfFilesFoldersDoesNotFitInOneBrowserPage() {
@@ -271,6 +278,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given I rename the file/folder :fromName to :toName
+	 *
 	 * @param string $fromName
 	 * @param string $toName
 	 * @return void
@@ -282,6 +290,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given I rename the following file/folder to
+	 *
 	 * @param TableNode $namePartsTable table of parts of the from and to file names
 	 *                                  table headings: must be:
 	 *                                  |from-name-parts |to-name-parts |
@@ -305,6 +314,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I rename the file/folder :fromName to one of these names
+	 *
 	 * @param string $fromName
 	 * @param TableNode $table
 	 * @return void
@@ -323,6 +333,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * like delete.
 	 *
 	 * @When I delete/unshare the file/folder :name
+	 *
 	 * @param string $name
 	 * @return void
 	 */
@@ -335,6 +346,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I delete the following file/folder
+	 *
 	 * @param TableNode $namePartsTable table of parts of the file name
 	 *                                  table headings: must be: |name-parts |
 	 * @return void
@@ -351,6 +363,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given the following files/folders are deleted
+	 *
 	 * @param TableNode $filesTable table headings: must be: |name|
 	 * @return void
 	 */
@@ -395,6 +408,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I delete the elements
+	 *
 	 * @param TableNode $table table of file names
 	 *                         table headings: must be: |name|
 	 * @return void
@@ -408,6 +422,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I move the file/folder :name into the folder :destination
+	 *
 	 * @param string|array $name
 	 * @param string|array $destination
 	 * @return void
@@ -418,6 +433,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I move the following file/folder to
+	 *
 	 * @param TableNode $namePartsTable table of parts of the from and to file names
 	 *                                  table headings: must be:
 	 *                                  |item-to-move-name-parts |destination-name-parts |
@@ -436,6 +452,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I batch move these files/folders into the folder :folderName
+	 *
 	 * @param string $folderName
 	 * @param TableNode $files table of file names
 	 *                         table headings: must be: |name|
@@ -452,6 +469,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I upload overwriting the file :name
+	 *
 	 * @param string $name
 	 * @return void
 	 */
@@ -463,6 +481,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I upload overwriting the file :name and retry if the file is locked
+	 *
 	 * @param string $name
 	 * @return void
 	 */
@@ -508,6 +527,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I upload the file :name keeping both new and existing files
+	 *
 	 * @param string $name
 	 * @return void
 	 */
@@ -520,6 +540,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I upload the file :name
+	 *
 	 * @param string $name
 	 * @return void
 	 */
@@ -529,6 +550,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When /^I choose to keep the (new|existing) files$/
+	 *
 	 * @param string $choice
 	 * @return void
 	 */
@@ -564,6 +586,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I click the :label button
+	 *
 	 * @param string $label
 	 * @return void
 	 */
@@ -577,6 +600,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then /^the (?:deleted|moved) elements should (not|)\s?be listed$/
+	 *
 	 * @param string $shouldOrNot
 	 * @return void
 	 */
@@ -595,6 +619,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then /^the (?:deleted|moved) elements should (not|)\s?be listed after a page reload$/
+	 *
 	 * @param string $shouldOrNot
 	 * @return void
 	 */
@@ -607,6 +632,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then the deleted elements should be listed in the trashbin
+	 *
 	 * @return void
 	 */
 	public function theDeletedElementsShouldBeListedInTheTrashbin() {
@@ -619,6 +645,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I batch delete these files
+	 *
 	 * @param TableNode $files table of file names
 	 *                         table headings: must be: |name|
 	 * @return void
@@ -631,6 +658,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I batch delete the marked files
+	 *
 	 * @return void
 	 */
 	public function iBatchDeleteTheMarkedFiles() {
@@ -639,6 +667,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I mark these files for batch action
+	 *
 	 * @param TableNode $files table of file names
 	 *                         table headings: must be: |name|
 	 * @return void
@@ -654,6 +683,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When /^I open the (trashbin|)\s?(file|folder) ((?:'[^']*')|(?:"[^"]*"))$/
+	 *
 	 * @param string $typeOfFilesPage
 	 * @param string $fileOrFolder 
 	 * @param string $name enclosed in single or double quotes
@@ -691,6 +721,7 @@ class FilesContext extends RawMinkContext implements Context {
 	
 	/**
 	 * @Then /^the (?:file|folder) ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(?:in the |)(trashbin|favorites page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))?$/
+	 *
 	 * @param string $name enclosed in single or double quotes
 	 * @param string $shouldOrNot
 	 * @param string $typeOfFilesPage
@@ -783,6 +814,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then /^the moved elements should (not|)\s?be listed in the folder ['"](.*)['"]$/
+	 *
 	 * @param string $shouldOrNot
 	 * @param string $folderName
 	 * @return void
@@ -797,6 +829,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then /^the following (?:file|folder|item) should (not|)\s?be listed in the following folder$/
+	 *
 	 * @param string $shouldOrNot
 	 * @param TableNode $namePartsTable table of parts of the file name
 	 *                                  table headings: must be: | item-name-parts | folder-name-parts |
@@ -822,6 +855,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then /^the following (?:file|folder) should (not|)\s?be listed\s?(?:in the |)(trashbin|favorites page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))?$/
+	 *
 	 * @param string $shouldOrNot
 	 * @param string $typeOfFilesPage
 	 * @param string $folder
@@ -858,6 +892,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then near the file/folder :name a tooltip with the text :toolTipText should be displayed
+	 *
 	 * @param string $name
 	 * @param string $toolTipText
 	 * @return void
@@ -885,6 +920,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then near the folder input field a tooltip with the text :tooltiptext should be displayed
+	 *
 	 * @param string $tooltiptext
 	 * @return void
 	 */
@@ -895,6 +931,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then it should not be possible to delete the file/folder :name
+	 *
 	 * @param string $name
 	 * @return void
 	 */
@@ -911,6 +948,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then the filesactionmenu should be completely visible after clicking on it
+	 *
 	 * @return void
 	 */
 	public function theFilesactionmenuShouldBeCompletelyVisibleAfterClickingOnIt() {
@@ -948,6 +986,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then /^the content of ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be the same as the original ((?:'[^']*')|(?:"[^"]*"))$/
+	 *
 	 * @param string $remoteFile enclosed in single or double quotes
 	 * @param string $shouldOrNot
 	 * @param string $originalFile enclosed in single or double quotes
@@ -966,6 +1005,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then /^the content of ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be the same as the local ((?:'[^']*')|(?:"[^"]*"))$/
+	 *
 	 * @param string $remoteFile enclosed in single or double quotes
 	 * @param string $shouldOrNot
 	 * @param string $localFile enclosed in single or double quotes
@@ -984,6 +1024,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then /^the content of ((?:'[^']*')|(?:"[^"]*")) should not have changed$/
+	 *
 	 * @param string $fileName
 	 * @return void
 	 */
@@ -1003,7 +1044,8 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I mark the file/folder :fileOrFolderName as favorite
-	 * @Given the file/folder :fileOrFolderName is marked as favorite 
+	 * @Given the file/folder :fileOrFolderName is marked as favorite
+	 *
 	 * @param string $fileOrFolderName
 	 * @return void
 	 */
@@ -1015,6 +1057,7 @@ class FilesContext extends RawMinkContext implements Context {
 	
 	/**
 	 * @Then the file/folder :fileOrFolderName should be marked as favorite
+	 *
 	 * @param string $fileOrFolderName
 	 * @return void
 	 */
@@ -1030,6 +1073,7 @@ class FilesContext extends RawMinkContext implements Context {
 	
 	/**
 	 * @When I unmark the file/folder :fileOrFolderName
+	 *
 	 * @param string $fileOrFolderName
 	 * @return void
 	 */
@@ -1041,6 +1085,7 @@ class FilesContext extends RawMinkContext implements Context {
 	
 	/**
 	 * @Then the file/folder :fileOrFolderName should not be marked as favorite
+	 *
 	 * @param string $fileOrFolderName
 	 * @return void
 	 */
@@ -1090,6 +1135,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @BeforeScenario
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
+	 *
 	 * @param BeforeScenarioScope $scope
 	 * @return void
 	 */

--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -1175,9 +1175,10 @@ class FilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @BeforeScenario
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
+	 *
+	 * @BeforeScenario
 	 *
 	 * @param BeforeScenarioScope $scope
 	 *

--- a/tests/ui/features/bootstrap/FilesContext.php
+++ b/tests/ui/features/bootstrap/FilesContext.php
@@ -88,6 +88,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param TrashbinPage $trashbinPage
 	 * @param ConflictDialog $conflictDialog
 	 * @param FavoritesPage $favoritesPage
+	 *
 	 * @return void
 	 */
 	public function __construct(
@@ -185,6 +186,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param string $invalid contains "invalid"
 	 * 						  if the folder creation is expected to fail
 	 * @param string $name enclosed in single or double quotes
+	 *
 	 * @return void
 	 */
 	public function iCreateAFolder($invalid, $name) {
@@ -210,6 +212,7 @@ class FilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @param string $name
+	 *
 	 * @return void
 	 */
 	public function createAFolder($name) {
@@ -223,6 +226,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 *
 	 * @param TableNode $namePartsTable table of parts of the file name
 	 *                                  table headings: must be: |name-parts |
+	 *
 	 * @return void
 	 */
 	public function createTheFollowingFolder(TableNode $namePartsTable) {
@@ -281,6 +285,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $fromName
 	 * @param string $toName
+	 *
 	 * @return void
 	 */
 	public function iRenameTheFileFolderTo($fromName, $toName) {
@@ -294,6 +299,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param TableNode $namePartsTable table of parts of the from and to file names
 	 *                                  table headings: must be:
 	 *                                  |from-name-parts |to-name-parts |
+	 *
 	 * @return void
 	 */
 	public function iRenameTheFollowingFileFolderTo(TableNode $namePartsTable) {
@@ -317,6 +323,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $fromName
 	 * @param TableNode $table
+	 *
 	 * @return void
 	 */
 	public function iRenameTheFileToOneOfThisNames($fromName, TableNode $table) {
@@ -335,6 +342,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @When I delete/unshare the file/folder :name
 	 *
 	 * @param string $name
+	 *
 	 * @return void
 	 */
 	public function iDeleteTheFile($name) {
@@ -349,6 +357,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 *
 	 * @param TableNode $namePartsTable table of parts of the file name
 	 *                                  table headings: must be: |name-parts |
+	 *
 	 * @return void
 	 */
 	public function iDeleteTheFollowingFile(TableNode $namePartsTable) {
@@ -365,6 +374,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @Given the following files/folders are deleted
 	 *
 	 * @param TableNode $filesTable table headings: must be: |name|
+	 *
 	 * @return void
 	 */
 	public function theFollowingFilesFoldersAreDeleted(TableNode $filesTable) {
@@ -411,6 +421,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 *
 	 * @param TableNode $table table of file names
 	 *                         table headings: must be: |name|
+	 *
 	 * @return void
 	 */
 	public function iDeleteTheElements(TableNode $table) {
@@ -425,6 +436,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 *
 	 * @param string|array $name
 	 * @param string|array $destination
+	 *
 	 * @return void
 	 */
 	public function iMoveTheFileFolderTo($name, $destination) {
@@ -437,6 +449,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param TableNode $namePartsTable table of parts of the from and to file names
 	 *                                  table headings: must be:
 	 *                                  |item-to-move-name-parts |destination-name-parts |
+	 *
 	 * @return void
 	 */
 	public function iMoveTheFollowingFileFolderTo(TableNode $namePartsTable) {
@@ -456,6 +469,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param string $folderName
 	 * @param TableNode $files table of file names
 	 *                         table headings: must be: |name|
+	 *
 	 * @return void
 	 */
 	public function iBatchMoveTheseFilesIntoTheFolder(
@@ -471,6 +485,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @When I upload overwriting the file :name
 	 *
 	 * @param string $name
+	 *
 	 * @return void
 	 */
 	public function iUploadOverwritingTheFile($name) {
@@ -483,6 +498,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @When I upload overwriting the file :name and retry if the file is locked
 	 *
 	 * @param string $name
+	 *
 	 * @return void
 	 */
 	public function iUploadOverwritingTheFileRetry($name) {
@@ -529,6 +545,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @When I upload the file :name keeping both new and existing files
 	 *
 	 * @param string $name
+	 *
 	 * @return void
 	 */
 	public function iUploadTheFileKeepingNewExisting($name) {
@@ -542,6 +559,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @When I upload the file :name
 	 *
 	 * @param string $name
+	 *
 	 * @return void
 	 */
 	public function iUploadTheFile($name) {
@@ -552,6 +570,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @When /^I choose to keep the (new|existing) files$/
 	 *
 	 * @param string $choice
+	 *
 	 * @return void
 	 */
 	public function choiceInUploadConflict($choice) {
@@ -588,6 +607,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @When I click the :label button
 	 *
 	 * @param string $label
+	 *
 	 * @return void
 	 */
 	public function iClickTheButton($label) {
@@ -602,6 +622,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @Then /^the (?:deleted|moved) elements should (not|)\s?be listed$/
 	 *
 	 * @param string $shouldOrNot
+	 *
 	 * @return void
 	 */
 	public function theDeletedMovedElementsShouldBeListed($shouldOrNot) {
@@ -621,6 +642,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @Then /^the (?:deleted|moved) elements should (not|)\s?be listed after a page reload$/
 	 *
 	 * @param string $shouldOrNot
+	 *
 	 * @return void
 	 */
 	public function theDeletedMovedElementsShouldBeListedAfterPageReload(
@@ -648,6 +670,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 *
 	 * @param TableNode $files table of file names
 	 *                         table headings: must be: |name|
+	 *
 	 * @return void
 	 */
 	public function iBatchDeleteTheseFiles(TableNode $files) {
@@ -670,6 +693,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 *
 	 * @param TableNode $files table of file names
 	 *                         table headings: must be: |name|
+	 *
 	 * @return void
 	 */
 	public function iMarkTheseFilesForBatchAction(TableNode $files) {
@@ -687,6 +711,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param string $typeOfFilesPage
 	 * @param string $fileOrFolder 
 	 * @param string $name enclosed in single or double quotes
+	 *
 	 * @return void
 	 */
 	public function iOpenTheFolderNamed($typeOfFilesPage, $fileOrFolder, $name) {
@@ -699,6 +724,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param string $typeOfFilesPage
 	 * @param string $fileOrFolder 
 	 * @param string|array $name
+	 *
 	 * @return void
 	 */
 	public function iOpenTheFolder($typeOfFilesPage, $fileOrFolder, $name) {
@@ -726,6 +752,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param string $shouldOrNot
 	 * @param string $typeOfFilesPage
 	 * @param string $folder
+	 *
 	 * @return void
 	 */
 	public function theFileFolderShouldBeListed(
@@ -750,6 +777,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param string $shouldOrNot
 	 * @param string $typeOfFilesPage
 	 * @param string $folder
+	 *
 	 * @return void
 	 */
 	public function checkIfFileFolderIsListed(
@@ -817,6 +845,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $shouldOrNot
 	 * @param string $folderName
+	 *
 	 * @return void
 	 */
 	public function theMovedElementsShouldBeListedInTheFolder(
@@ -833,6 +862,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param string $shouldOrNot
 	 * @param TableNode $namePartsTable table of parts of the file name
 	 *                                  table headings: must be: | item-name-parts | folder-name-parts |
+	 *
 	 * @return void
 	 */
 	public function theFollowingFileFolderShouldBeListedInTheFollowingFolder(
@@ -861,6 +891,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param string $folder
 	 * @param TableNode $namePartsTable table of parts of the file name
 	 *                                  table headings: must be: |name-parts |
+	 *
 	 * @return void
 	 */
 	public function theFollowingFileFolderShouldBeListed(
@@ -895,6 +926,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $name
 	 * @param string $toolTipText
+	 *
 	 * @return void
 	 */
 	public function nearTheFileATooltipWithTheTextShouldBeDisplayed(
@@ -911,6 +943,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @When I restore the file/folder :fname
 	 *
 	 * @param string $fname
+	 *
 	 * @return void
 	 */
 	public function restoreFileAndFolder($fname) {
@@ -922,6 +955,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @Then near the folder input field a tooltip with the text :tooltiptext should be displayed
 	 *
 	 * @param string $tooltiptext
+	 *
 	 * @return void
 	 */
 	public function folderInputFieldTooltipTextShouldBe($tooltiptext) {
@@ -933,6 +967,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @Then it should not be possible to delete the file/folder :name
 	 *
 	 * @param string $name
+	 *
 	 * @return void
 	 */
 	public function itShouldNotBePossibleToDelete($name) {
@@ -990,6 +1025,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param string $remoteFile enclosed in single or double quotes
 	 * @param string $shouldOrNot
 	 * @param string $originalFile enclosed in single or double quotes
+	 *
 	 * @return void
 	 */
 	public function theContentOfShouldBeTheSameAsTheOriginal(
@@ -1009,6 +1045,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param string $remoteFile enclosed in single or double quotes
 	 * @param string $shouldOrNot
 	 * @param string $localFile enclosed in single or double quotes
+	 *
 	 * @return void
 	 */
 	public function theContentOfShouldBeTheSameAsTheLocal(
@@ -1026,6 +1063,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @Then /^the content of ((?:'[^']*')|(?:"[^"]*")) should not have changed$/
 	 *
 	 * @param string $fileName
+	 *
 	 * @return void
 	 */
 	public function theContentOfShouldNotHaveChanged($fileName) {
@@ -1047,6 +1085,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @Given the file/folder :fileOrFolderName is marked as favorite
 	 *
 	 * @param string $fileOrFolderName
+	 *
 	 * @return void
 	 */
 	public function iMarkTheFileAsFavorite($fileOrFolderName) {
@@ -1059,6 +1098,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @Then the file/folder :fileOrFolderName should be marked as favorite
 	 *
 	 * @param string $fileOrFolderName
+	 *
 	 * @return void
 	 */
 	public function theFileShouldBeMarkedAsFavorite($fileOrFolderName) {
@@ -1075,6 +1115,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @When I unmark the file/folder :fileOrFolderName
 	 *
 	 * @param string $fileOrFolderName
+	 *
 	 * @return void
 	 */
 	public function iUnmarkTheFolder($fileOrFolderName) {
@@ -1087,6 +1128,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @Then the file/folder :fileOrFolderName should not be marked as favorite
 	 *
 	 * @param string $fileOrFolderName
+	 *
 	 * @return void
 	 */
 	public function theFolderShouldNotBeMarkedAsFavorite($fileOrFolderName) {
@@ -1108,6 +1150,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * @param string $localFile
 	 * @param bool $shouldBeSame (default true) if true then check that the file contents are the same
 	 *                           otherwise check that the file contents are different
+	 *
 	 * @return void
 	 */
 	private function assertContentOfRemoteAndLocalFileIsSame(
@@ -1137,6 +1180,7 @@ class FilesContext extends RawMinkContext implements Context {
 	 * It will set the properties for this object.
 	 *
 	 * @param BeforeScenarioScope $scope
+	 *
 	 * @return void
 	 */
 	public function before(BeforeScenarioScope $scope) {

--- a/tests/ui/features/bootstrap/Ip.php
+++ b/tests/ui/features/bootstrap/Ip.php
@@ -52,6 +52,7 @@ trait Ip {
 	 *
 	 * @param string $networkScope (loopback|routable)
 	 * @param string $ipAddressFamily (ipv4|ipv6)
+	 *
 	 * @return void
 	 */
 	public function theClientAccessesTheServerFromAddress(
@@ -66,6 +67,7 @@ trait Ip {
 	 * @When the client accesses the server from IP address :sourceIpAddress
 	 *
 	 * @param string $sourceIpAddress an IPv4 or IPv6 address
+	 *
 	 * @return void
 	 */
 	public function theClientAccessesTheServerFromIpAddress($sourceIpAddress) {
@@ -82,6 +84,7 @@ trait Ip {
 
 	/**
 	 * @BeforeScenario
+	 *
 	 * @return void
 	 */
 	public function setUpScenarioGetIpUrls() {

--- a/tests/ui/features/bootstrap/Ip.php
+++ b/tests/ui/features/bootstrap/Ip.php
@@ -49,6 +49,7 @@ trait Ip {
 
 	/**
 	 * @When the client accesses the server from a :networkScope :ipAddressFamily address
+	 *
 	 * @param string $networkScope (loopback|routable)
 	 * @param string $ipAddressFamily (ipv4|ipv6)
 	 * @return void
@@ -63,6 +64,7 @@ trait Ip {
 
 	/**
 	 * @When the client accesses the server from IP address :sourceIpAddress
+	 *
 	 * @param string $sourceIpAddress an IPv4 or IPv6 address
 	 * @return void
 	 */

--- a/tests/ui/features/bootstrap/Logging.php
+++ b/tests/ui/features/bootstrap/Logging.php
@@ -37,11 +37,12 @@ trait Logging {
 	 * order of the table has to be the same as in the log file
 	 * empty cells in the table will not be checked!
 	 *
+	 * @Then the last lines of the log file should contain log-entries with these attributes:
+	 *
 	 * @param TableNode $expectedLogEntries table with headings that correspond
 	 *                                      to the json keys in the log entry
 	 *                                      e.g.
 	 *                                      |user|app|method|message|
-	 * @Then the last lines of the log file should contain log-entries with these attributes:
 	 * @return void
 	 */
 	public function theLastLinesOfTheLogFileShouldContainEntriesWithTheseAttributes(
@@ -83,12 +84,13 @@ trait Logging {
 	 * attributes in the table that are empty will match any value in the
 	 * corresponding attribute in the log file
 	 *
+	 * @Then the log file should not contain any log-entries with these attributes:
+	 *
 	 * @param TableNode $logEntriesExpectedNotToExist table with headings that
 	 *                                                correspond to the json
 	 *                                                keys in the log entry
 	 *                                                e.g.
 	 *                                                |user|app|method|message|
-	 * @Then the log file should not contain any log-entries with these attributes:
 	 * @return void
 	 */
 	public function theLogFileShouldNotContainAnyLogEntriesWithTheseAttributes(
@@ -122,8 +124,9 @@ trait Logging {
 	}
 
 	/**
-	 * @param string $logLevel (debug|info|warning|error)
 	 * @Given owncloud log level is set to :logLevel
+	 *
+	 * @param string $logLevel (debug|info|warning|error)
 	 * @return void
 	 */
 	public function owncloudLogLevelIsSetTo($logLevel) {
@@ -131,8 +134,9 @@ trait Logging {
 	}
 
 	/**
-	 * @param string $backend (owncloud|syslog|errorlog)
 	 * @Given owncloud log backend is set to :backend
+	 *
+	 * @param string $backend (owncloud|syslog|errorlog)
 	 * @return void
 	 */
 	public function owncloudLogBackendIsSetTo($backend) {
@@ -140,8 +144,9 @@ trait Logging {
 	}
 
 	/**
-	 * @param string $timezone
 	 * @Given owncloud log timezone is set to :timezone
+	 *
+	 * @param string $timezone
 	 * @return void
 	 */
 	public function owncloudLogTimezoneIsSetTo($timezone) {
@@ -150,6 +155,7 @@ trait Logging {
 
 	/**
 	 * @Given the owncloud log is cleared
+	 *
 	 * @return void
 	 */
 	public function theOwncloudLogIsCleared() {

--- a/tests/ui/features/bootstrap/Logging.php
+++ b/tests/ui/features/bootstrap/Logging.php
@@ -43,6 +43,7 @@ trait Logging {
 	 *                                      to the json keys in the log entry
 	 *                                      e.g.
 	 *                                      |user|app|method|message|
+	 *
 	 * @return void
 	 */
 	public function theLastLinesOfTheLogFileShouldContainEntriesWithTheseAttributes(
@@ -91,6 +92,7 @@ trait Logging {
 	 *                                                keys in the log entry
 	 *                                                e.g.
 	 *                                                |user|app|method|message|
+	 *
 	 * @return void
 	 */
 	public function theLogFileShouldNotContainAnyLogEntriesWithTheseAttributes(
@@ -127,6 +129,7 @@ trait Logging {
 	 * @Given owncloud log level is set to :logLevel
 	 *
 	 * @param string $logLevel (debug|info|warning|error)
+	 *
 	 * @return void
 	 */
 	public function owncloudLogLevelIsSetTo($logLevel) {
@@ -137,6 +140,7 @@ trait Logging {
 	 * @Given owncloud log backend is set to :backend
 	 *
 	 * @param string $backend (owncloud|syslog|errorlog)
+	 *
 	 * @return void
 	 */
 	public function owncloudLogBackendIsSetTo($backend) {
@@ -147,6 +151,7 @@ trait Logging {
 	 * @Given owncloud log timezone is set to :timezone
 	 *
 	 * @param string $timezone
+	 *
 	 * @return void
 	 */
 	public function owncloudLogTimezoneIsSetTo($timezone) {
@@ -165,8 +170,9 @@ trait Logging {
 	/**
 	 * Before Scenario for logging. Saves current log settings
 	 *
-	 * @return void
 	 * @BeforeScenario
+	 *
+	 * @return void
 	 */
 	public function setUpScenarioLogging() {
 		$this->oldLogLevel = LoggingHelper::getLogLevel();
@@ -177,8 +183,9 @@ trait Logging {
 	/**
 	 * After Scenario for logging. Sets back old log settings
 	 *
-	 * @return void
 	 * @AfterScenario
+	 *
+	 * @return void
 	 */
 	public function tearDownScenarioLogging() {
 		if (!is_null($this->oldLogLevel)

--- a/tests/ui/features/bootstrap/LoginContext.php
+++ b/tests/ui/features/bootstrap/LoginContext.php
@@ -203,9 +203,10 @@ class LoginContext extends RawMinkContext implements Context {
 		
 	}
 	/**
-	 * @BeforeScenario
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
+	 *
+	 * @BeforeScenario
 	 *
 	 * @param BeforeScenarioScope $scope
 	 *

--- a/tests/ui/features/bootstrap/LoginContext.php
+++ b/tests/ui/features/bootstrap/LoginContext.php
@@ -54,6 +54,7 @@ class LoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given I am on the login page
+	 *
 	 * @return void
 	 */
 	public function iAmOnTheLoginPage() {
@@ -62,6 +63,7 @@ class LoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I relogin with username :username and password :password
+	 *
 	 * @param string $username
 	 * @param string $password
 	 * @return void
@@ -73,6 +75,7 @@ class LoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I login with username :username and password :password
+	 *
 	 * @param string $username
 	 * @param string $password
 	 * @return void
@@ -83,6 +86,7 @@ class LoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I relogin with username :username and password :password to :server
+	 *
 	 * @param string $username
 	 * @param string $password
 	 * @param string $server
@@ -97,6 +101,7 @@ class LoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I login with username :username and password :password to :server
+	 *
 	 * @param string $username
 	 * @param string $password
 	 * @param string $server
@@ -118,6 +123,7 @@ class LoginContext extends RawMinkContext implements Context {
 	 * @When I login with username :username and invalid password :password
 	 * @When I login with invalid username :username and password :password
 	 * @When I login with invalid username :username and invalid password :password
+	 *
 	 * @param string $username
 	 * @param string $password
 	 * @return void
@@ -129,6 +135,7 @@ class LoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I login with username :username and password :password after a redirect from the :page page
+	 *
 	 * @param string $username
 	 * @param string $password
 	 * @param string $page text name of a page that I expect to be taken to
@@ -148,6 +155,7 @@ class LoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I login as a regular user with a correct password
+	 *
 	 * @return void
 	 */
 	public function iLoginAsARegularUserWithACorrectPassword() {

--- a/tests/ui/features/bootstrap/LoginContext.php
+++ b/tests/ui/features/bootstrap/LoginContext.php
@@ -66,6 +66,7 @@ class LoginContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $username
 	 * @param string $password
+	 *
 	 * @return void
 	 */
 	public function iReloginWithUsernameAndPassword($username, $password) {
@@ -78,6 +79,7 @@ class LoginContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $username
 	 * @param string $password
+	 *
 	 * @return void
 	 */
 	public function iLoginWithUsernameAndPassword($username, $password) {
@@ -90,6 +92,7 @@ class LoginContext extends RawMinkContext implements Context {
 	 * @param string $username
 	 * @param string $password
 	 * @param string $server
+	 *
 	 * @return void
 	 */
 	public function iReloginWithUsernameAndPasswordToSrv(
@@ -105,6 +108,7 @@ class LoginContext extends RawMinkContext implements Context {
 	 * @param string $username
 	 * @param string $password
 	 * @param string $server
+	 *
 	 * @return void
 	 */
 	public function iLoginWithUsernameAndPasswordToSrv(
@@ -126,6 +130,7 @@ class LoginContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $username
 	 * @param string $password
+	 *
 	 * @return void
 	 */
 	public function iLoginWithUsernameAndInvalidPassword($username, $password) {
@@ -139,6 +144,7 @@ class LoginContext extends RawMinkContext implements Context {
 	 * @param string $username
 	 * @param string $password
 	 * @param string $page text name of a page that I expect to be taken to
+	 *
 	 * @return void
 	 */
 	public function iLoginWithUsernameAndPasswordAfterRedirectFromThePage(
@@ -168,6 +174,7 @@ class LoginContext extends RawMinkContext implements Context {
 	 * @param string $shouldOrNot
 	 * @param string $username
 	 * @param string $password
+	 *
 	 * @return void
 	 */
 	public function itShouldBePossibleToLogin($shouldOrNot, $username, $password) {
@@ -201,6 +208,7 @@ class LoginContext extends RawMinkContext implements Context {
 	 * It will set the properties for this object.
 	 *
 	 * @param BeforeScenarioScope $scope
+	 *
 	 * @return void
 	 */
 	public function before(BeforeScenarioScope $scope) {

--- a/tests/ui/features/bootstrap/PersonalGeneralSettingsContext.php
+++ b/tests/ui/features/bootstrap/PersonalGeneralSettingsContext.php
@@ -65,6 +65,7 @@ class PersonalGeneralSettingsContext extends RawMinkContext implements Context {
 	 * @Given /^I (attempt to |)go to the personal general settings page$/
 	 *
 	 * @param string $attemptTo
+	 *
 	 * @return void
 	 * @throws Exception
 	 */
@@ -87,6 +88,7 @@ class PersonalGeneralSettingsContext extends RawMinkContext implements Context {
 	 * @When I change the language to :language
 	 *
 	 * @param string $language
+	 *
 	 * @return void
 	 */
 	public function iChangeTheLanguageTo($language) {
@@ -142,11 +144,13 @@ class PersonalGeneralSettingsContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @BeforeScenario
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *
+	 * @BeforeScenario
+	 *
 	 * @param BeforeScenarioScope $scope
+	 *
 	 * @return void
 	 */
 	public function before(BeforeScenarioScope $scope) {

--- a/tests/ui/features/bootstrap/PersonalGeneralSettingsContext.php
+++ b/tests/ui/features/bootstrap/PersonalGeneralSettingsContext.php
@@ -51,6 +51,7 @@ class PersonalGeneralSettingsContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given I am on the personal general settings page
+	 *
 	 * @return void
 	 */
 	public function iAmOnThePersonalGeneralSettingsPage() {
@@ -62,7 +63,10 @@ class PersonalGeneralSettingsContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given /^I (attempt to |)go to the personal general settings page$/
+	 *
+	 * @param string $attemptTo
 	 * @return void
+	 * @throws Exception
 	 */
 	public function iGoToThePersonalGeneralSettingsPage($attemptTo) {
 		$pageIsExpectedToLoad = ($attemptTo === "");
@@ -81,6 +85,7 @@ class PersonalGeneralSettingsContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I change the language to :language
+	 *
 	 * @param string $language
 	 * @return void
 	 */
@@ -102,7 +107,8 @@ class PersonalGeneralSettingsContext extends RawMinkContext implements Context {
 		$username = $this->featureContext->getCurrentUser();
 		$oldPassword = trim($this->featureContext->getUserPassword($username));
 		$this->personalGeneralSettingsPage->changePassword(
-			$oldPassword, $newPassword,$this->getSession());
+			$oldPassword, $newPassword, $this->getSession()
+		);
 	}
 	
 	/**
@@ -115,7 +121,8 @@ class PersonalGeneralSettingsContext extends RawMinkContext implements Context {
 	public function iChangeThePasswordToUsingWrongCurrentPassword($newPassword) {
 		$oldPassword = "thisisawrongpassword";
 		$this->personalGeneralSettingsPage->changePassword(
-			$oldPassword, $newPassword, $this->getSession());
+			$oldPassword, $newPassword, $this->getSession()
+		);
 	}
 	
 	/**
@@ -130,7 +137,8 @@ class PersonalGeneralSettingsContext extends RawMinkContext implements Context {
 	) {
 		PHPUnit_Framework_Assert::assertEquals(
 			$wrongPasswordmessageText,
-			$this->personalGeneralSettingsPage->getWrongPasswordMessageText());
+			$this->personalGeneralSettingsPage->getWrongPasswordMessageText()
+		);
 	}
 
 	/**

--- a/tests/ui/features/bootstrap/PersonalSecuritySettingsContext.php
+++ b/tests/ui/features/bootstrap/PersonalSecuritySettingsContext.php
@@ -49,6 +49,7 @@ class PersonalSecuritySettingsContext extends RawMinkContext implements Context 
 
 	/**
 	 * @Given I am on the personal security settings page
+	 *
 	 * @return void
 	 */
 	public function iAmOnThePersonalSecuritySettingsPage() {
@@ -57,6 +58,7 @@ class PersonalSecuritySettingsContext extends RawMinkContext implements Context 
 
 	/**
 	 * @When I create a new App password
+	 *
 	 * @return void
 	 */
 	public function iCreateANewAppPasswordForTheAppNamed() {
@@ -65,6 +67,7 @@ class PersonalSecuritySettingsContext extends RawMinkContext implements Context 
 
 	/**
 	 * @Then the new app should be listed in the App passwords list
+	 *
 	 * @return void
 	 */
 	public function theAppShouldBeListedInTheAppPasswordsList() {
@@ -79,6 +82,7 @@ class PersonalSecuritySettingsContext extends RawMinkContext implements Context 
 
 	/**
 	 * @Then my username and the app password should be displayed
+	 *
 	 * @return void
 	 */
 	public function myUsernameAndTheAppPasswordShouldBeDisplayed() {

--- a/tests/ui/features/bootstrap/SharingContext.php
+++ b/tests/ui/features/bootstrap/SharingContext.php
@@ -81,6 +81,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given /^the (?:file|folder) "([^"]*)" is shared with the (?:(remote|federated)\s)?user "([^"]*)"$/
+	 *
 	 * @param string $folder
 	 * @param string $remote
 	 * @param string $user
@@ -115,6 +116,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given the file/folder :folder is shared with the group :group
+	 *
 	 * @param string $folder
 	 * @param string $group
 	 * @return void
@@ -135,6 +137,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given the share dialog for the file/folder :name is open
+	 *
 	 * @param string $name
 	 * @return void
 	 */
@@ -146,6 +149,7 @@ class SharingContext extends RawMinkContext implements Context {
 	}
 	/**
 	 * @Given I create a new public link for the file/folder :name
+	 *
 	 * @param string $name
 	 * @return void
 	 */
@@ -217,6 +221,7 @@ class SharingContext extends RawMinkContext implements Context {
 	
 	/**
 	 * @Given I close the share dialog
+	 *
 	 * @return void
 	 */
 	public function iCloseTheShareDialog() {
@@ -225,6 +230,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given I type :input in the share-with-field
+	 *
 	 * @param string $input
 	 * @return void
 	 */
@@ -234,6 +240,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given the sharing permissions of :userName for :fileName are set to
+	 *
 	 * @param string $userName
 	 * @param string $fileName
 	 * @param TableNode $permissionsTable table with two columns and no heading
@@ -256,6 +263,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the offered remote shares are accepted
+	 *
 	 * @return void
 	 */
 	public function theOfferedRemoteSharesAreAccepted() {
@@ -266,6 +274,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I access the last created public link
+	 *
 	 * @return void
 	 */
 	public function iAccessTheLastCreatedPublicLink() {
@@ -283,6 +292,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When I add the public link to :server as user :username with the password :password
+	 *
 	 * @param string $server
 	 * @param string $username
 	 * @param string $password
@@ -301,6 +311,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then all users and groups that contain the string :requiredString in their name should be listed in the autocomplete list
+	 *
 	 * @param string $requiredString
 	 * @return void
 	 */
@@ -314,6 +325,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then all users and groups that contain the string :requiredString in their name should be listed in the autocomplete list except :userOrGroup :notToBeListed
+	 *
 	 * @param string $requiredString
 	 * @param string $userOrGroup
 	 * @param string $notToBeListed
@@ -354,6 +366,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then my own name should not be listed in the autocomplete list
+	 *
 	 * @return void
 	 */
 	public function myOwnNameShouldNotBeListedInTheAutocompleteList() {
@@ -365,6 +378,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then a tooltip with the text :text should be shown near the share-with-field
+	 *
 	 * @param string $text
 	 * @return void
 	 */
@@ -377,6 +391,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then the autocomplete list should not be displayed
+	 *
 	 * @return void
 	 */
 	public function theAutocompleteListShouldNotBeDisplayed() {
@@ -387,6 +402,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then /^the (file|folder) "([^"]*)" should be marked as shared(?: with "([^"]*)")? by "([^"]*)"$/
+	 *
 	 * @param string $fileOrFolder
 	 * @param string $itemName
 	 * @param string $sharedWithGroup
@@ -435,6 +451,7 @@ class SharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then /^it should not be possible to share the (?:file|folder) "([^"]*)"(?: with "([^"]*)")?$/
+	 *
 	 * @param string $fileName
 	 * @param string|null $shareWith
 	 * @return void
@@ -475,6 +492,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * @BeforeScenario
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
+	 *
 	 * @param BeforeScenarioScope $scope
 	 * @return void
 	 */

--- a/tests/ui/features/bootstrap/SharingContext.php
+++ b/tests/ui/features/bootstrap/SharingContext.php
@@ -73,6 +73,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * 
 	 * @param string $name
 	 * @param string $url
+	 * 
 	 * @return void
 	 */
 	private function addToListOfCreatedPublicLinks($name, $url) {
@@ -87,6 +88,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * @param string $user
 	 * @param int $maxRetries
 	 * @param boolean $quiet
+	 * 
 	 * @return void
 	 */
 	public function theFileFolderIsSharedWithTheUser(
@@ -119,6 +121,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $folder
 	 * @param string $group
+	 * 
 	 * @return void
 	 */
 	public function theFileFolderIsSharedWithTheGroup($folder, $group) {
@@ -139,6 +142,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * @Given the share dialog for the file/folder :name is open
 	 *
 	 * @param string $name
+	 * 
 	 * @return void
 	 */
 	public function theShareDialogForTheFileFolderIsOpen($name) {
@@ -151,6 +155,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * @Given I create a new public link for the file/folder :name
 	 *
 	 * @param string $name
+	 * 
 	 * @return void
 	 */
 	public function iCreateANewPublicLinkFor($name) {
@@ -164,6 +169,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 *                            password, expiration, email
 	 *                            the permissions values has to be written exactly
 	 *                            the way its written in the UI
+	 * 
 	 * @return void
 	 */
 	public function iCreateANewPublicLinkForWith(
@@ -232,6 +238,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * @Given I type :input in the share-with-field
 	 *
 	 * @param string $input
+	 * 
 	 * @return void
 	 */
 	public function iTypeInTheShareWithField($input) {
@@ -249,6 +256,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 *                                    second column yes|no
 	 *                                    not mentioned permissions will not be
 	 *                                    touched
+	 * 
 	 * @return void
 	 */
 	public function theSharingPermissionsOfAreSetTo(
@@ -296,6 +304,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * @param string $server
 	 * @param string $username
 	 * @param string $password
+	 * 
 	 * @return void
 	 * @throws Exception
 	 */
@@ -313,6 +322,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * @Then all users and groups that contain the string :requiredString in their name should be listed in the autocomplete list
 	 *
 	 * @param string $requiredString
+	 * 
 	 * @return void
 	 */
 	public function allUsersAndGroupsThatContainTheStringInTheirNameShouldBeListedInTheAutocompleteList(
@@ -329,6 +339,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * @param string $requiredString
 	 * @param string $userOrGroup
 	 * @param string $notToBeListed
+	 * 
 	 * @return void
 	 */
 	public function allUsersAndGroupsThatContainTheStringInTheirNameShouldBeListedInTheAutocompleteListExcept(
@@ -380,6 +391,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * @Then a tooltip with the text :text should be shown near the share-with-field
 	 *
 	 * @param string $text
+	 * 
 	 * @return void
 	 */
 	public function aTooltipWithTheTextShouldBeShownNearTheShareWithField($text) {
@@ -407,6 +419,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * @param string $itemName
 	 * @param string $sharedWithGroup
 	 * @param string $sharerName
+	 * 
 	 * @return void
 	 */
 	public function theFileFolderShouldBeMarkedAsSharedBy(
@@ -454,6 +467,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $fileName
 	 * @param string|null $shareWith
+	 * 
 	 * @return void
 	 * @throws Exception
 	 */
@@ -494,6 +508,7 @@ class SharingContext extends RawMinkContext implements Context {
 	 * It will set the properties for this object.
 	 *
 	 * @param BeforeScenarioScope $scope
+	 * 
 	 * @return void
 	 */
 	public function before(BeforeScenarioScope $scope) {

--- a/tests/ui/features/bootstrap/SharingContext.php
+++ b/tests/ui/features/bootstrap/SharingContext.php
@@ -503,9 +503,10 @@ class SharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @BeforeScenario
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
+	 *
+	 * @BeforeScenario
 	 *
 	 * @param BeforeScenarioScope $scope
 	 * 

--- a/tests/ui/features/bootstrap/UsersContext.php
+++ b/tests/ui/features/bootstrap/UsersContext.php
@@ -53,6 +53,7 @@ class UsersContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given I am on the users page
+	 *
 	 * @return void
 	 */
 	public function iAmOnTheUsersPage() {
@@ -73,6 +74,7 @@ class UsersContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Given quota of user :username is set/changed to :quota
+	 *
 	 * @param string $username
 	 * @param string $quota
 	 * @return void
@@ -83,6 +85,8 @@ class UsersContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When /^I (attempt to |)create a user with the name "([^"]*)" (?:and )?the password "([^"]*)"(?: and the email "([^"]*)")?(?: that is a member of these groups)?$/
+	 *
+	 * @param string $attemptTo
 	 * @param string $username
 	 * @param string $password
 	 * @param string $email
@@ -118,6 +122,7 @@ class UsersContext extends RawMinkContext implements Context {
 	/**
 	 * 
 	 * @When I delete the group named :name
+	 *
 	 * @param string $name
 	 * @return void
 	 */
@@ -129,6 +134,7 @@ class UsersContext extends RawMinkContext implements Context {
 	/**
 	 * @When I delete these groups:
 	 * expects a table of groups with the heading "groupname"
+	 *
 	 * @param TableNode $table
 	 * @return void
 	 */
@@ -141,6 +147,7 @@ class UsersContext extends RawMinkContext implements Context {
 	
 	/**
 	 * @Then The group name :groupName should be listed
+	 *
 	 * @param string $groupName
 	 * @return void
 	 */
@@ -153,6 +160,7 @@ class UsersContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then the group named :name should not be listed
+	 *
 	 * @param string $name
 	 * @return void
 	 * @throws Exception
@@ -188,6 +196,7 @@ class UsersContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the users page is reloaded
+	 *
 	 * @return void
 	 */
 	public function theUsersPageIsReloaded() {
@@ -197,6 +206,7 @@ class UsersContext extends RawMinkContext implements Context {
 
 	/**
 	 * @Then quota of user :username should be set to :quota
+	 *
 	 * @param string $username
 	 * @param string $quota
 	 * @return void

--- a/tests/ui/features/bootstrap/UsersContext.php
+++ b/tests/ui/features/bootstrap/UsersContext.php
@@ -234,10 +234,11 @@ class UsersContext extends RawMinkContext implements Context {
 	/**
 	 * This will run before EVERY scenario.
 	 *
+	 * @BeforeScenario
+	 *
 	 * @param BeforeScenarioScope $scope
 	 * 
 	 * @return void
-	 * @BeforeScenario
 	 */
 	public function before(BeforeScenarioScope $scope) {
 		// Get the environment

--- a/tests/ui/features/bootstrap/UsersContext.php
+++ b/tests/ui/features/bootstrap/UsersContext.php
@@ -65,6 +65,7 @@ class UsersContext extends RawMinkContext implements Context {
 	 * substitute codes like "%regularuser%" with the actual name of the user
 	 *
 	 * @param string $username
+	 * 
 	 * @return string
 	 * @Transform :username
 	 */
@@ -77,6 +78,7 @@ class UsersContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $username
 	 * @param string $quota
+	 * 
 	 * @return void
 	 */
 	public function quotaOfUserIsSetTo($username, $quota) {
@@ -91,6 +93,7 @@ class UsersContext extends RawMinkContext implements Context {
 	 * @param string $password
 	 * @param string $email
 	 * @param TableNode $groupsTable table of groups with a heading | group |
+	 * 
 	 * @return void
 	 */
 	public function iCreateAUserInTheGUI(
@@ -124,6 +127,7 @@ class UsersContext extends RawMinkContext implements Context {
 	 * @When I delete the group named :name
 	 *
 	 * @param string $name
+	 * 
 	 * @return void
 	 */
 	public function iDeleteTheGroupNamed($name) {
@@ -136,6 +140,7 @@ class UsersContext extends RawMinkContext implements Context {
 	 * expects a table of groups with the heading "groupname"
 	 *
 	 * @param TableNode $table
+	 * 
 	 * @return void
 	 */
 	public function iDeleteTheseGroups(TableNode $table) {
@@ -149,6 +154,7 @@ class UsersContext extends RawMinkContext implements Context {
 	 * @Then The group name :groupName should be listed
 	 *
 	 * @param string $groupName
+	 * 
 	 * @return void
 	 */
 	public function theGroupNameShouldBeListed($groupName) {
@@ -162,6 +168,7 @@ class UsersContext extends RawMinkContext implements Context {
 	 * @Then the group named :name should not be listed
 	 *
 	 * @param string $name
+	 * 
 	 * @return void
 	 * @throws Exception
 	 */
@@ -177,6 +184,7 @@ class UsersContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $shouldOrNot (not|)
 	 * @param TableNode $table
+	 * 
 	 * @return void
 	 * @throws Exception
 	 */
@@ -209,6 +217,7 @@ class UsersContext extends RawMinkContext implements Context {
 	 *
 	 * @param string $username
 	 * @param string $quota
+	 * 
 	 * @return void
 	 * @throws ExpectationException
 	 */
@@ -226,6 +235,7 @@ class UsersContext extends RawMinkContext implements Context {
 	 * This will run before EVERY scenario.
 	 *
 	 * @param BeforeScenarioScope $scope
+	 * 
 	 * @return void
 	 * @BeforeScenario
 	 */
@@ -240,6 +250,7 @@ class UsersContext extends RawMinkContext implements Context {
 	 * @Given I add a group with the name :groupName
 	 * 
 	 * @param string $groupName
+	 * 
 	 * @return void
 	 */
 	public function iAddAGroupWithTheName($groupName) {

--- a/tests/ui/features/bootstrap/WebUIUserContext.php
+++ b/tests/ui/features/bootstrap/WebUIUserContext.php
@@ -51,6 +51,7 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	 * @Then :displayname should be shown as the name of the current user in the WebUI
 	 * 
 	 * @param string $displayname
+	 *
 	 * @return void
 	 */
 	public function displayNameOfTheCurrentUserInTheWebUiShouldBe($displayname) {

--- a/tests/ui/features/lib/FilesPage.php
+++ b/tests/ui/features/lib/FilesPage.php
@@ -83,6 +83,7 @@ class FilesPage extends FilesPageBasic {
 	 * @param Session $session
 	 * @param string $name
 	 * @param int $timeoutMsec
+	 *
 	 * @throws ElementNotFoundException|\Exception
 	 * @return string name of the created file
 	 */
@@ -188,6 +189,7 @@ class FilesPage extends FilesPageBasic {
 	 *
 	 * @param Session $session
 	 * @param string $name
+	 *
 	 * @return void
 	 */
 	public function uploadFile(Session $session, $name) {
@@ -210,6 +212,7 @@ class FilesPage extends FilesPageBasic {
 	 *
 	 * @param string $fileName
 	 * @param Session $session
+	 *
 	 * @return SharingDialog
 	 */
 	public function openSharingDialog($fileName, Session $session) {
@@ -235,6 +238,7 @@ class FilesPage extends FilesPageBasic {
 	 * @param string|array $toFileName
 	 * @param Session $session
 	 * @param int $maxRetries
+	 *
 	 * @return void
 	 */
 	public function renameFile(
@@ -278,6 +282,7 @@ class FilesPage extends FilesPageBasic {
 	 * @param string|array $destination
 	 * @param Session $session
 	 * @param int $maxRetries
+	 *
 	 * @return void
 	 */
 	public function moveFileTo(
@@ -312,6 +317,7 @@ class FilesPage extends FilesPageBasic {
 	 *
 	 * @param string $fileName
 	 * @param Session $session
+	 *
 	 * @return string
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 */
@@ -326,6 +332,7 @@ class FilesPage extends FilesPageBasic {
 	 * "files/?dir=/&fileid=2"
 	 *
 	 * @param array $urlParameters
+	 *
 	 * @return FilesPage
 	 * @see \SensioLabs\Behat\PageObjectExtension\PageObject\Page::open()
 	 */

--- a/tests/ui/features/lib/FilesPageBasic.php
+++ b/tests/ui/features/lib/FilesPageBasic.php
@@ -83,6 +83,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 
 	/**
 	 * @param int $number
+	 *
 	 * @return \Behat\Mink\Element\NodeElement|null
 	 */
 	public function findActionMenuByNo($number) {
@@ -95,6 +96,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	 *
 	 * @param string|array $name
 	 * @param Session $session
+	 *
 	 * @return FileRow
 	 * @throws ElementNotFoundException
 	 */
@@ -211,6 +213,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	 * scrolls down the file list, to load not yet displayed files
 	 *
 	 * @param Session $session
+	 *
 	 * @return void
 	 */
 	public function scrollDownAppContent(Session $session) {
@@ -249,6 +252,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	 *
 	 * @param string|array $name
 	 * @param Session $session
+	 *
 	 * @return void
 	 */
 	public function openFile($name, Session $session) {
@@ -261,6 +265,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	 * @param string|array $name
 	 * @param Session $session
 	 * @param int $maxRetries
+	 *
 	 * @return void
 	 */
 	public function deleteFile($name, Session $session, $maxRetries = STANDARDRETRYCOUNT) {
@@ -343,6 +348,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	/**
 	 *
 	 * @param Session $session
+	 *
 	 * @return void
 	 */
 	public function deleteAllSelectedFiles(Session $session) {
@@ -354,6 +360,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	 *
 	 * @param string $name
 	 * @param Session $session
+	 *
 	 * @return void
 	 */
 	public function selectFileForBatchAction($name, Session $session) {
@@ -364,6 +371,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	/**
 	 *
 	 * @param int $number
+	 *
 	 * @throws ElementNotFoundException
 	 * @return \Behat\Mink\Element\NodeElement
 	 */
@@ -383,6 +391,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	/**
 	 *
 	 * @param int $number
+	 *
 	 * @return void
 	 */
 	public function clickFileActionsMenuBtnByNo($number) {
@@ -392,6 +401,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	/**
 	 *
 	 * @param int $number
+	 *
 	 * @return FileActionsMenu
 	 */
 	public function openFileActionsMenuByNo($number) {
@@ -408,6 +418,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	 *
 	 * @param Session $session
 	 * @param int $timeout_msec
+	 *
 	 * @return void
 	 */
 	public function waitTillPageIsLoaded(
@@ -487,6 +498,7 @@ abstract class FilesPageBasic extends OwnCloudPage {
 	 *
 	 * @param Session $session
 	 * @param int $timeout_msec
+	 *
 	 * @return void
 	 */
 	public function waitTillFileRowsAreReady(

--- a/tests/ui/features/lib/FilesPageElement/ConflictDialog.php
+++ b/tests/ui/features/lib/FilesPageElement/ConflictDialog.php
@@ -38,6 +38,7 @@ class ConflictDialog extends OCDialog {
 	 * takes the xpath and selects the option with that xpath
 	 * 
 	 * @param string $xpath
+	 * 
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */

--- a/tests/ui/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/ui/features/lib/FilesPageElement/FileActionsMenu.php
@@ -48,6 +48,7 @@ class FileActionsMenu extends OwnCloudPage {
 	 * there is no real __construct() that can take arguments
 	 *
 	 * @param \Behat\Mink\Element\NodeElement $menuElement
+	 *
 	 * @return void
 	 */
 	public function setElement(NodeElement $menuElement) {
@@ -59,6 +60,7 @@ class FileActionsMenu extends OwnCloudPage {
 	 * 
 	 * @param string $xpathToWaitFor wait for this element to appear before returning
 	 * @param int $timeout_msec
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -99,6 +101,7 @@ class FileActionsMenu extends OwnCloudPage {
 	 * finds the actual action link in the action menu
 	 * 
 	 * @param string $action
+	 *
 	 * @return \Behat\Mink\Element\NodeElement
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 */

--- a/tests/ui/features/lib/FilesPageElement/FileRow.php
+++ b/tests/ui/features/lib/FilesPageElement/FileRow.php
@@ -62,6 +62,7 @@ class FileRow extends OwnCloudPage {
 	 * there is no real __construct() that can take arguments
 	 *
 	 * @param \Behat\Mink\Element\NodeElement $rowElement
+	 *
 	 * @return void
 	 */
 	public function setElement(NodeElement $rowElement) {
@@ -71,6 +72,7 @@ class FileRow extends OwnCloudPage {
 	/**
 	 *
 	 * @param string $name
+	 *
 	 * @return void
 	 */
 	public function setName($name) {
@@ -121,6 +123,7 @@ class FileRow extends OwnCloudPage {
 	 * opens the file action menu
 	 *
 	 * @param Session $session
+	 *
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 * @return FileActionsMenu
 	 */
@@ -188,6 +191,7 @@ class FileRow extends OwnCloudPage {
 	 *
 	 * @param string $toName
 	 * @param Session $session
+	 *
 	 * @return void
 	 */
 	public function rename($toName, Session $session) {
@@ -204,6 +208,7 @@ class FileRow extends OwnCloudPage {
 	 * deletes the file
 	 *
 	 * @param Session $session
+	 *
 	 * @return void
 	 */
 	public function delete(Session $session) {

--- a/tests/ui/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/ui/features/lib/FilesPageElement/SharingDialog.php
@@ -81,6 +81,7 @@ class SharingDialog extends OwncloudPage {
 	 * @param string $input
 	 * @param Session $session
 	 * @param int $timeout_msec how long to wait till the autocomplete comes back
+	 *
 	 * @return NodeElement AutocompleteElement
 	 */
 	public function fillShareWithField(
@@ -117,6 +118,7 @@ class SharingDialog extends OwncloudPage {
 	 * returns the group names as they could appear in an autocomplete list
 	 *
 	 * @param string|array $groupNames
+	 *
 	 * @return array
 	 */
 	public function groupStringsToMatchAutoComplete($groupNames) {
@@ -156,6 +158,7 @@ class SharingDialog extends OwncloudPage {
 	 * @param Session $session
 	 * @param int $maxRetries
 	 * @param boolean $quiet
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -201,6 +204,7 @@ class SharingDialog extends OwncloudPage {
 	 * @param Session $session
 	 * @param int $maxRetries
 	 * @param boolean $quiet
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -218,6 +222,7 @@ class SharingDialog extends OwncloudPage {
 	 * @param Session $session
 	 * @param int $maxRetries
 	 * @param boolean $quiet
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -236,6 +241,7 @@ class SharingDialog extends OwncloudPage {
 	 * @param Session $session
 	 * @param int $maxRetries
 	 * @param boolean $quiet
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -252,6 +258,7 @@ class SharingDialog extends OwncloudPage {
 	 *
 	 * @param string $shareReceiverName
 	 * @param array $permissions [['permission' => 'yes|no']]
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */

--- a/tests/ui/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
+++ b/tests/ui/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
@@ -52,6 +52,7 @@ class EditPublicLinkPopup extends OwncloudPage {
 	 * there is no real __construct() that can take arguments
 	 *
 	 * @param \Behat\Mink\Element\NodeElement $popupElement
+	 * 
 	 * @return void
 	 */
 	public function setElement(NodeElement $popupElement) {
@@ -79,6 +80,7 @@ class EditPublicLinkPopup extends OwncloudPage {
 	/**
 	 * 
 	 * @param string $name
+	 * 
 	 * @return void
 	 */
 	public function setLinkName($name) {
@@ -98,6 +100,7 @@ class EditPublicLinkPopup extends OwncloudPage {
 	/**
 	 * 
 	 * @param string $permissions
+	 * 
 	 * @return void
 	 */
 	public function setLinkPermissions($permissions) {
@@ -115,6 +118,7 @@ class EditPublicLinkPopup extends OwncloudPage {
 	/**
 	 *
 	 * @param string $password
+	 * 
 	 * @return void
 	 */
 	public function setLinkPassword($password) {
@@ -134,6 +138,7 @@ class EditPublicLinkPopup extends OwncloudPage {
 	/**
 	 *
 	 * @param string $date
+	 * 
 	 * @return void
 	 */
 	public function setLinkExpirationDate($date) {
@@ -165,6 +170,7 @@ class EditPublicLinkPopup extends OwncloudPage {
 	/**
 	 *
 	 * @param string $email
+	 * 
 	 * @return void
 	 */
 	public function setLinkEmail($email) {

--- a/tests/ui/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/ui/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -74,6 +74,7 @@ class PublicLinkTab extends OwncloudPage {
 	 * @param string $password
 	 * @param string $expirationDate
 	 * @param string $email
+	 *
 	 * @return string the name of the created public link
 	 */
 	public function createLink(
@@ -134,6 +135,7 @@ class PublicLinkTab extends OwncloudPage {
 	 * @param string $password
 	 * @param string $expirationDate
 	 * @param string $email
+	 *
 	 * @return void
 	 */
 	public function editLink(
@@ -150,6 +152,7 @@ class PublicLinkTab extends OwncloudPage {
 	/**
 	 * 
 	 * @param string $name
+	 *
 	 * @throws ElementNotFoundException
 	 * @return string
 	 */
@@ -177,6 +180,7 @@ class PublicLinkTab extends OwncloudPage {
 	/**
 	 * 
 	 * @param string $name
+	 *
 	 * @return void
 	 */
 	public function deleteLink($name) {
@@ -187,6 +191,7 @@ class PublicLinkTab extends OwncloudPage {
 	 * 
 	 * @param string $name
 	 * @param string $service
+	 *
 	 * @return void
 	 */
 	public function shareLink($name, $service) {
@@ -196,6 +201,7 @@ class PublicLinkTab extends OwncloudPage {
 	/**
 	 * 
 	 * @param string $name
+	 *
 	 * @return void
 	 */
 	public function copyLinkToClipboard($name) {
@@ -205,6 +211,7 @@ class PublicLinkTab extends OwncloudPage {
 	/**
 	 * 
 	 * @param string $name
+	 *
 	 * @throws ElementNotFoundException
 	 * @return NodeElement
 	 */

--- a/tests/ui/features/lib/LoginPage.php
+++ b/tests/ui/features/lib/LoginPage.php
@@ -43,6 +43,7 @@ class LoginPage extends OwncloudPage {
 	 * @param string $username
 	 * @param string $password
 	 * @param string $target
+	 *
 	 * @throws ElementNotFoundException
 	 * @return Page
 	 */
@@ -70,6 +71,7 @@ class LoginPage extends OwncloudPage {
 	 *
 	 * @param Session $session
 	 * @param int $timeout_msec
+	 *
 	 * @return void
 	 * @throws \Exception
 	 */

--- a/tests/ui/features/lib/OwncloudPage.php
+++ b/tests/ui/features/lib/OwncloudPage.php
@@ -50,6 +50,7 @@ class OwncloudPage extends Page {
 	/**
 	 * @param Session $session
 	 * @param int $timeout_msec
+	 * 
 	 * @return void
 	 */
 	public function waitTillPageIsLoaded(
@@ -85,6 +86,7 @@ class OwncloudPage extends Page {
 	 *
 	 * @param string $xpath
 	 * @param int $timeout_msec
+	 * 
 	 * @return void
 	 */
 	public function waitTillElementIsNull(
@@ -111,6 +113,7 @@ class OwncloudPage extends Page {
 	 *
 	 * @param string $xpath
 	 * @param int $timeout_msec
+	 * 
 	 * @return NodeElement|null
 	 */
 	public function waitTillElementIsNotNull(
@@ -247,6 +250,7 @@ class OwncloudPage extends Page {
 	/**
 	 *
 	 * @param string $path
+	 * 
 	 * @return void
 	 */
 	public function setPagePath($path) {
@@ -274,6 +278,7 @@ class OwncloudPage extends Page {
 	 *
 	 * @param Session $session
 	 * @param NodeElement $element
+	 * 
 	 * @return array
 	 */
 	public function getCoordinatesOfElement($session, $element) {
@@ -291,6 +296,7 @@ class OwncloudPage extends Page {
 	 * Gets the Window Height
 	 *
 	 * @param Session $session
+	 * 
 	 * @return int
 	 */
 	public function getWindowHeight($session) {
@@ -305,6 +311,7 @@ class OwncloudPage extends Page {
 	 * @param string $jQuerySelector e.g. "#app-content"
 	 * @param int|string $position number or JS function that returns a number
 	 * @param Session $session
+	 * 
 	 * @return void
 	 */
 	public function scrollToPosition($jQuerySelector, $position, Session $session) {
@@ -318,6 +325,7 @@ class OwncloudPage extends Page {
 	 *
 	 * @param Session $session
 	 * @param int $timeout_msec
+	 * 
 	 * @return void
 	 */
 	public function waitForOutstandingAjaxCalls(
@@ -371,6 +379,7 @@ class OwncloudPage extends Page {
 	 *
 	 * @param Session $session
 	 * @param int $timeout_msec
+	 * 
 	 * @return void
 	 */
 	public function waitForAjaxCallsToStart(
@@ -411,6 +420,7 @@ class OwncloudPage extends Page {
 	 *
 	 * @param Session $session
 	 * @param int $timeout_msec
+	 * 
 	 * @return void
 	 */
 	public function waitForAjaxCallsToStartAndFinish(
@@ -431,6 +441,7 @@ class OwncloudPage extends Page {
 	 * counts the sum of ajax requests in window.sumStartedAjaxRequests
 	 * 
 	 * @param Session $session
+	 * 
 	 * @see resetSumStartedAjaxRequests()
 	 * @see getSumStartedAjaxRequests()
 	 * @return void
@@ -475,6 +486,7 @@ class OwncloudPage extends Page {
 	 * reset the sum ajax counter so that every function can start counting from 0
 	 * 
 	 * @param Session $session
+	 * 
 	 * @see initAjaxCounters()
 	 * @return void
 	 */
@@ -487,6 +499,7 @@ class OwncloudPage extends Page {
 	 * gets the sum of all started Ajax requests
 	 * 
 	 * @param Session $session
+	 * 
 	 * @see initAjaxCounters()
 	 * @return int
 	 */
@@ -498,6 +511,7 @@ class OwncloudPage extends Page {
 	/**
 	 * 
 	 * @param Session $session
+	 * 
 	 * @see initAjaxCounters()
 	 * @throws \Exception
 	 * @return void
@@ -553,6 +567,7 @@ class OwncloudPage extends Page {
 	 * @param Session $session
 	 * @param string $scrolledElement jQuery identifier for the element that get scrolled
 	 * @param int $timeout_msec
+	 * 
 	 * @return void
 	 */
 	public function waitForScrollingToFinish(
@@ -594,6 +609,7 @@ class OwncloudPage extends Page {
 	 *
 	 * @param NodeElement $inputField
 	 * @param string $value
+	 * 
 	 * @throws \Exception
 	 * @return void
 	 */
@@ -617,6 +633,7 @@ class OwncloudPage extends Page {
 	 * before using it in tests.
 	 *
 	 * @param NodeElement $element
+	 * 
 	 * @throws \Exception
 	 * @return string text of the element with any whitespace trimmed
 	 */
@@ -635,6 +652,7 @@ class OwncloudPage extends Page {
 	 * both single and double quotes.
 	 *
 	 * @param string $text
+	 * 
 	 * @return string the text surrounded by single or double quotes
 	 * @throws \InvalidArgumentException
 	 */

--- a/tests/ui/features/lib/OwncloudPageElement/OCDialog.php
+++ b/tests/ui/features/lib/OwncloudPageElement/OCDialog.php
@@ -55,6 +55,7 @@ class OCDialog extends OwncloudPage {
 	 * there is no real __construct() that can take arguments
 	 *
 	 * @param \Behat\Mink\Element\NodeElement $dialogElement
+	 *
 	 * @return void
 	 */
 	public function setElement(NodeElement $dialogElement) {
@@ -107,6 +108,7 @@ class OCDialog extends OwncloudPage {
 	 * clicks the accept (primary) button
 	 * 
 	 * @param Session $session
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -130,6 +132,7 @@ class OCDialog extends OwncloudPage {
 	 * 
 	 * @param Session $session
 	 * @param string $label
+	 *
 	 * @return void
 	 */
 	public function clickButton(Session $session, $label) {

--- a/tests/ui/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/ui/features/lib/PersonalGeneralSettingsPage.php
@@ -44,6 +44,7 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 
 	/**
 	 * @param string $language
+	 * 
 	 * @return void
 	 */
 	public function changeLanguage($language) {
@@ -56,6 +57,7 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	 *
 	 * @param Session $session
 	 * @param int $timeout_msec
+	 *
 	 * @return void
 	 */
 	public function waitTillPageIsLoaded(

--- a/tests/ui/features/lib/PersonalSecuritySettingsPage.php
+++ b/tests/ui/features/lib/PersonalSecuritySettingsPage.php
@@ -48,6 +48,7 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 	 * create a new app password for the app named $appName
 	 *
 	 * @param string $appName
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -94,6 +95,7 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 	 * throws Exception if App could not be found in the list
 	 *
 	 * @param string $appName
+	 *
 	 * @throws \Exception
 	 * @return NodeElement
 	 */
@@ -113,6 +115,7 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 	 * returns the NodeElement of the button if found, else NULL
 	 *
 	 * @param NodeElement $tr
+	 *
 	 * @return NodeElement|NULL
 	 */
 	public function getDisconnectButton(NodeElement $tr) {

--- a/tests/ui/features/lib/PublicLinkFilesPage.php
+++ b/tests/ui/features/lib/PublicLinkFilesPage.php
@@ -70,6 +70,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 * adding public share to particular server
 	 * 
 	 * @param string $server
+	 * 
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -108,6 +109,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 * If name is not given a random one is chosen
 	 *
 	 * @param string $name
+	 * 
 	 * @throws ElementNotFoundException
 	 * @return string name of the created file
 	 */
@@ -122,6 +124,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 * @param string|array $toFileName
 	 * @param Session $session
 	 * @param int $maxRetries
+	 * 
 	 * @return void
 	 */
 	public function renameFile(
@@ -140,6 +143,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 * @param string|array $destination
 	 * @param Session $session
 	 * @param int $maxRetries
+	 * 
 	 * @return void
 	 */
 	public function moveFileTo(
@@ -154,6 +158,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 *
 	 * @param string $fileName
 	 * @param Session $session
+	 * 
 	 * @return string
 	 * @throws \SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException
 	 */

--- a/tests/ui/features/lib/TrashbinPage.php
+++ b/tests/ui/features/lib/TrashbinPage.php
@@ -71,6 +71,7 @@ class TrashbinPage extends FilesPageBasic {
 	 * 
 	 * @param string $fname
 	 * @param Session $session
+	 *
 	 * @return void
 	 */
 	public function restore($fname, Session $session) {

--- a/tests/ui/features/lib/UserPageElement/GroupList.php
+++ b/tests/ui/features/lib/UserPageElement/GroupList.php
@@ -51,6 +51,7 @@ class GroupList extends OwncloudPage {
 	 * there is no real __construct() that can take arguments
 	 *
 	 * @param \Behat\Mink\Element\NodeElement $groupListElement
+	 *
 	 * @return void
 	 */
 	public function setElement(NodeElement $groupListElement) {
@@ -60,6 +61,7 @@ class GroupList extends OwncloudPage {
 	/**
 	 * 
 	 * @param string $name
+	 *
 	 * @throws ElementNotFoundException
 	 * @return \Behat\Mink\Element\NodeElement
 	 */
@@ -84,6 +86,7 @@ class GroupList extends OwncloudPage {
 	 * deletes a group in the UI
 	 * 
 	 * @param string $name
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -103,6 +106,7 @@ class GroupList extends OwncloudPage {
 	/**
 	 * 
 	 * @param string  $groupName
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */

--- a/tests/ui/features/lib/UsersPage.php
+++ b/tests/ui/features/lib/UsersPage.php
@@ -64,6 +64,7 @@ class UsersPage extends OwncloudPage {
 	protected $groupListId = "usergrouplist";
 	/**
 	 * @param string $username
+	 *
 	 * @return NodeElement for the requested user in the table
 	 * @throws \Exception
 	 */
@@ -81,6 +82,7 @@ class UsersPage extends OwncloudPage {
 
 	/**
 	 * @param string $username
+	 *
 	 * @throws ElementNotFoundException
 	 * @return string text describing the quota
 	 */
@@ -133,6 +135,7 @@ class UsersPage extends OwncloudPage {
 	 *
 	 * @param string $setting the human readable setting string
 	 * @param boolean $value
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -198,6 +201,7 @@ class UsersPage extends OwncloudPage {
 	 * @param string $password
 	 * @param string $email
 	 * @param string[] $groups
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -296,6 +300,7 @@ class UsersPage extends OwncloudPage {
 	 * @param string $username
 	 * @param string $quota text form of quota to be input
 	 * @param Session $session
+	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
@@ -382,6 +387,7 @@ class UsersPage extends OwncloudPage {
 	 *
 	 * @param string $name
 	 * @param Session $session
+	 *
 	 * @return void
 	 */
 	public function deleteGroup($name, Session $session) {
@@ -394,6 +400,7 @@ class UsersPage extends OwncloudPage {
 	 * 
 	 * @param string $groupName
 	 * @param Session $session
+	 *
 	 * @return void
 	 */
 	public function addGroup($groupName, Session $session) {


### PR DESCRIPTION
## Description
1) Fixup stuff the ``phpcs`` told me about.
2) Exclude the ``Generic.Commenting.DocComment.ParamNotFirst`` message from ``phpcs`` because we want to be able to write ``@Given-When-Then`` tags that come before the ``param`` block. Those gherkin tag lines are effectively the method comments, but ``phpcs`` sees they are tags and complains.
3) Separate the ``param`` tags from the other ``return`` ``throws`` etc tags, and re-enable ``Generic.Commenting.DocComment.NonParamGroup`` - this is a step closely to PSR-* doc-block "standards" and I think it looks better to read.
4) Make all the ``BeforeScenario`` ``AfterScenario`` tags be in the same format - comment text about the method, blank line, before/after tag, blank line, ``param`` tag(s), blank line, ``return`` tag.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
Get doc-block format standardized before next steps in refactoring UI and API tests togehter.

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

