### PR TITLE
Make error origin distinguishable

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -696,9 +696,11 @@ class Storage {
 		if($config->getSystemValue('files_versions', Storage::DEFAULTENABLED)=='true' && $expiration->isEnabled()) {
 			// get available disk space for user
 			$user = \OC::$server->getUserManager()->get($uid);
-			if (is_null($user)) {
-				\OCP\Util::writeLog('files_versions', 'Backends provided no user object for ' . $uid, \OCP\Util::ERROR);
-				throw new \OC\User\NoUserException('Backends provided no user object for ' . $uid);
+
+			if ($user === null) {
+				$msg = "Backends provided no user object for $uid";
+				\OC::$server->getLogger()->error($msg, ['app' => __CLASS__]);
+				throw new \OC\User\NoUserException($msg);
 			}
 
 			\OC_Util::setupFS($uid);

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -407,11 +407,12 @@ class Filesystem {
 		$userManager = \OC::$server->getUserManager();
 		$userObject = $userManager->get($user);
 
-		if (is_null($userObject)) {
-			\OCP\Util::writeLog('files', ' Backends provided no user object for ' . $user, \OCP\Util::ERROR);
+		if ($userObject === null) {
+			$msg = "Backends provided no user object for $user";
+			\OC::$server->getLogger()->error($msg, ['app' => __CLASS__]);
 			// reset flag, this will make it possible to rethrow the exception if called again
 			unset(self::$usersSetup[$user]);
-			throw new \OC\User\NoUserException('Backends provided no user object for ' . $user);
+			throw new \OC\User\NoUserException($msg);
 		}
 
 		$realUid = $userObject->getUID();

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -345,9 +345,10 @@ class Root extends Folder implements IRootFolder {
 	public function getUserFolder($userId) {
 		$userObject = \OC::$server->getUserManager()->get($userId);
 
-		if (is_null($userObject)) {
-			\OCP\Util::writeLog('files', 'Backends provided no user object for ' . $userId, \OCP\Util::ERROR);
-			throw new NoUserException('Backends provided no user object for ' . $userId);
+		if ($userObject === null) {
+			$msg = "Backends provided no user object for $userId";
+			\OC::$server->getLogger()->error($msg, ['app' => __CLASS__]);
+			throw new NoUserException($msg);
 		}
 
 		$userId = $userObject->getUID();

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -145,10 +145,12 @@ class Share extends Constants {
 		$userManager = \OC::$server->getUserManager();
 		$userObject = $userManager->get($ownerUser);
 
-		if (is_null($ownerUser)) {
-			\OCP\Util::writeLog('files', ' Backends provided no user object for ' . $ownerUser, \OCP\Util::ERROR);
-			throw new \OC\User\NoUserException('Backends provided no user object for ' . $ownerUser);
+		if ($userObject === null) {
+			$msg = "Backends provided no user object for $ownerUser";
+			\OC::$server->getLogger()->error($msg, ['app' => __CLASS__]);
+			throw new \OC\User\NoUserException($msg);
 		}
+
 
 		$ownerUser = $userObject->getUID();
 


### PR DESCRIPTION
If you encounter sth like
```json
{
  "reqId":"uRCT44e115c4cbGoE4fI",
  "level":3,
  "time":"2018-02-27T15:23:22+01:00",
  "remoteAddr":"192.168.254.10",
  "user":"foo",
  "app":"files",
  "method":"PUT",
  "url":"\/remote.php\/webdav\/test0r\/wurstbr0t.txt",
  "message":" Backends provided no user object for bar"
}
```

three of the four possible origins in code are undistinguishable.

This PR uses `__CLASS__` as app to make it debuggable.

