### PR TITLE
correctly handle exceptions for getByUid, properly cache not existing user

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -36,14 +36,12 @@ namespace OC\User;
 use OC\Cache\CappedMemoryCache;
 use OC\Hooks\PublicEmitter;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\Events\EventEmitterTrait;
 use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IConfig;
-use OCP\User\IProvidesExtendedSearchBackend;
-use OCP\User\IProvidesEMailBackend;
-use OCP\User\IProvidesQuotaBackend;
 use OCP\UserInterface;
 use OCP\Util\UserSearch;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -177,16 +175,28 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return \OC\User\User|null Either the user or null if the specified user does not exist
 	 */
 	public function get($uid) {
-		if (\is_null($uid) || (!\is_string($uid) && !\is_numeric($uid))) {
+		// fix numeric uid that was cast by storing it in an array key
+		if (\is_numeric($uid)) {
+			$uid = (string)$uid;
+		}
+		if (!\is_string($uid)) {
 			return null;
 		}
-		if ($this->cachedUsers->hasKey($uid)) { //check the cache first to prevent having to loop over the backends
+		//check the cache first to prevent having to loop over the backends
+		if ($this->cachedUsers->hasKey($uid)) {
 			return $this->cachedUsers->get($uid);
 		}
 		try {
 			$account = $this->accountMapper->getByUid($uid);
 			return $this->getUserObject($account);
 		} catch (DoesNotExistException $ex) {
+			$this->cachedUsers->set($uid, null);
+			return null;
+		} catch (MultipleObjectsReturnedException $ex) {
+			$this->logger->error(
+				"More than one user found for $uid, treating as not existing.",
+				['app' => __CLASS__]
+			);
 			$this->cachedUsers->set($uid, null);
 			return null;
 		}

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -16,6 +16,7 @@ use OC\User\Database;
 use OC\User\Manager;
 use OC\User\SyncService;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\IConfig;
 use OCP\ILogger;
 use OCP\IUser;
@@ -147,6 +148,11 @@ class ManagerTest extends TestCase {
 
 	public function testGetAccountNotExists() {
 		$this->accountMapper->expects($this->once())->method('getByUid')->with('foo')->willThrowException(new DoesNotExistException(''));
+		$this->assertNull($this->manager->get('foo'));
+	}
+
+	public function testGetDuplicateAccountNotExists() {
+		$this->accountMapper->expects($this->once())->method('getByUid')->with('foo')->willThrowException(new MultipleObjectsReturnedException(''));
 		$this->assertNull($this->manager->get('foo'));
 	}
 


### PR DESCRIPTION
getByUID cannot return null. Need to properly handle the exceptions.

@tomneedham didn't we fix this already?