### PR TITLE
API tests code to phpcs-defined standard

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -26,6 +26,7 @@
 		<exclude name="Generic.Commenting.DocComment.TagValueIndent" />
 		<exclude name="Generic.Commenting.DocComment.ParamNotFirst" />
 		<exclude name="PEAR.Commenting.FileComment.IncompleteCopyright" />
+		<exclude name="PEAR.Commenting.FileComment.IncompleteLicense" />
 		<exclude name="PEAR.Commenting.FileComment.MissingVersion" />
 		<exclude name="PEAR.Commenting.FileComment.MissingCategoryTag" />
 		<exclude name="PEAR.Commenting.FileComment.MissingPackageTag" />

--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -44,6 +44,7 @@ trait AppConfiguration {
 	/**
 	 * @param string $verb
 	 * @param string $url
+	 *
 	 * @return void
 	 */
 	abstract public function sendingTo($verb, $url);
@@ -52,18 +53,21 @@ trait AppConfiguration {
 	 * @param string $verb
 	 * @param string $url
 	 * @param \Behat\Gherkin\Node\TableNode $body
+	 *
 	 * @return void
 	 */
 	abstract public function sendingToWith($verb, $url, $body);
 
 	/**
 	 * @param mixed $statusCode
+	 *
 	 * @return void
 	 */
 	abstract public function theOCSStatusCodeShouldBe($statusCode);
 
 	/**
 	 * @param mixed $statusCode
+	 *
 	 * @return void
 	 */
 	abstract public function theHTTPStatusCodeShouldBe($statusCode);
@@ -74,6 +78,7 @@ trait AppConfiguration {
 	 * @param string $parameter
 	 * @param string $app
 	 * @param string $value
+	 *
 	 * @return void
 	 */
 	public function adminSetsServerParameterToUsingAPI($parameter, $app, $value) {
@@ -91,6 +96,7 @@ trait AppConfiguration {
 	 * @param string $parameter
 	 * @param string $app
 	 * @param string $value
+	 *
 	 * @return void
 	 */
 	public function serverParameterHasBeenSetTo($parameter, $app, $value) {
@@ -104,9 +110,12 @@ trait AppConfiguration {
 	 * @param string $capabilitiesApp the "app" name in the capabilities response
 	 * @param string $capabilitiesPath the path to the element
 	 * @param string $expectedValue
+	 *
 	 * @return void
 	 */
-	public function theCapabilitiesSettingOfAppParameterShouldBe($capabilitiesApp, $capabilitiesPath, $expectedValue) {
+	public function theCapabilitiesSettingOfAppParameterShouldBe(
+		$capabilitiesApp, $capabilitiesPath, $expectedValue
+	) {
 		$this->getCapabilitiesCheckResponse();
 
 		PHPUnit_Framework_Assert::assertEquals(
@@ -118,6 +127,7 @@ trait AppConfiguration {
 	/**
 	 * @param string $capabilitiesApp the "app" name in the capabilities response
 	 * @param string $capabilitiesPath the path to the element
+	 *
 	 * @return string
 	 */
 	public function getAppParameter($capabilitiesApp, $capabilitiesPath) {
@@ -137,7 +147,9 @@ trait AppConfiguration {
 	 */
 	public function getCapabilitiesCheckResponse() {
 		$this->sendingTo('GET', '/cloud/capabilities');
-		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->response->getStatusCode()
+		);
 	}
 
 	/**
@@ -151,9 +163,12 @@ trait AppConfiguration {
 	 * @param string $xml of the capabilities
 	 * @param string $capabilitiesApp the "app" name in the capabilities response
 	 * @param string $capabilitiesPath the path to the element
+	 *
 	 * @return string
 	 */
-	public function getParameterValueFromXml($xml, $capabilitiesApp, $capabilitiesPath) {
+	public function getParameterValueFromXml(
+		$xml, $capabilitiesApp, $capabilitiesPath
+	) {
 		$path_to_element = explode('@@@', $capabilitiesPath);
 		$answeredValue = $xml->{$capabilitiesApp};
 
@@ -168,6 +183,7 @@ trait AppConfiguration {
 	 * @param string $capabilitiesApp the "app" name in the capabilities response
 	 * @param string $capabilitiesParameter the parameter name in the
 	 *                                      capabilities response
+	 *
 	 * @return boolean
 	 */
 	public function wasCapabilitySet($capabilitiesApp, $capabilitiesParameter) {
@@ -179,12 +195,13 @@ trait AppConfiguration {
 	}
 
 	/**
-	 * @param array $capabilitiesArray[] with each array entry containing keys for:
-	 *                                   ['capabilitiesApp'] the "app" name in the capabilities response
-	 *                                   ['capabilitiesParameter'] the parameter name in the capabilities response
-	 *                                   ['testingApp'] the "app" name as understood by "testing"
-	 *                                   ['testingParameter'] the parameter name as understood by "testing"
-	 *                                   ['testingState'] boolean state the parameter must be set to for the test
+	 * @param array $capabilitiesArray with each array entry containing keys for:
+	 *                                 ['capabilitiesApp'] the "app" name in the capabilities response
+	 *                                 ['capabilitiesParameter'] the parameter name in the capabilities response
+	 *                                 ['testingApp'] the "app" name as understood by "testing"
+	 *                                 ['testingParameter'] the parameter name as understood by "testing"
+	 *                                 ['testingState'] boolean state the parameter must be set to for the test
+	 *
 	 * @return void
 	 */
 	public function setCapabilities($capabilitiesArray) {
@@ -196,13 +213,17 @@ trait AppConfiguration {
 			$this->savedCapabilitiesXml
 		);
 
-		$this->savedCapabilitiesChanges = array_merge($this->savedCapabilitiesChanges, $savedCapabilitiesChanges);
+		$this->savedCapabilitiesChanges = array_merge(
+			$this->savedCapabilitiesChanges,
+			$savedCapabilitiesChanges
+		);
 	}
 
 	/**
 	 * @param string $app
 	 * @param string $parameter
 	 * @param string $value
+	 *
 	 * @return void
 	 */
 	protected function modifyServerConfig($app, $parameter, $value) {
@@ -219,6 +240,7 @@ trait AppConfiguration {
 
 	/**
 	 * @param string $appParameterValues
+	 *
 	 * @return void
 	 */
 	protected function modifyServerConfigs($appParameterValues) {
@@ -234,6 +256,7 @@ trait AppConfiguration {
 	/**
 	 * @param boolean $enabled if true, then enable the testing app
 	 *                         otherwise disable the testing app
+	 *
 	 * @return void
 	 */
 	protected function setStatusTestingApp($enabled) {
@@ -268,6 +291,7 @@ trait AppConfiguration {
 
 	/**
 	 * @BeforeScenario
+	 *
 	 * @return void
 	 */
 	public function prepareParametersBeforeScenario() {
@@ -279,6 +303,7 @@ trait AppConfiguration {
 
 	/**
 	 * @AfterScenario
+	 *
 	 * @return void
 	 */
 	public function restoreParametersAfterScenario() {

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -30,27 +30,37 @@ class AppManagementContext implements  Context {
 	
 	private $oldAppPath;
 	
-	/** @var string stdout of last command */
+	/**
+	 * @var string stdout of last command 
+	 */
 	private $cmdOutput;
 	
 	/**
 	 * @BeforeScenario
 	 *
 	 * Remember the config values before each scenario
+	 *
+	 * @return void
 	 */
 	public function prepareParameters() {
 		include_once __DIR__ . '/../../../../lib/base.php';
-		$this->oldAppPath = \OC::$server->getConfig()->getSystemValue('apps_paths', null);
+		$this->oldAppPath = \OC::$server->getConfig()->getSystemValue(
+			'apps_paths', null
+		);
 	}
 	
 	/**
 	 * @AfterScenario
 	 *
 	 * Reset the config values after each scenario
+	 *
+	 * @return void
 	 */
 	public function undoChangingParameters() {
 		if (!is_null($this->oldAppPath)) {
-			\OC::$server->getConfig()->setSystemValue('apps_paths', $this->oldAppPath);
+			\OC::$server->getConfig()->setSystemValue(
+				'apps_paths', $this->oldAppPath
+			);
 		} else {
 			\OC::$server->getConfig()->deleteSystemValue('apps_paths');
 		}
@@ -61,6 +71,8 @@ class AppManagementContext implements  Context {
 	 *
 	 * @param string $dir1
 	 * @param string $dir2
+	 *
+	 * @return void
 	 */
 	public function setAppDirectories($dir1, $dir2) {
 		$fullpath1 = \OC::$SERVERROOT . '/' . $dir1;
@@ -80,10 +92,13 @@ class AppManagementContext implements  Context {
 	 * @param string $appId app id
 	 * @param string $version app version
 	 * @param string $dir app directory
+	 *
+	 * @return void
 	 */
 	public function appHasBeenPutInDir($appId, $version, $dir) {
 		$ocVersion = \OC::$server->getConfig()->getSystemValue('version', '0.0.0');
-		$appInfo = sprintf('<?xml version="1.0"?>
+		$appInfo = sprintf(
+			'<?xml version="1.0"?>
 			<info>
 				<id>%s</id>
 				<name>%s</name>
@@ -128,12 +143,16 @@ class AppManagementContext implements  Context {
 	 * @Given the administrator has loaded app :appId using the console
 	 *
 	 * @param string $appId app id
+	 *
+	 * @return void
 	 */
 	public function loadApp($appId) {
 		$args = explode(' ', "app:getpath $appId");
-		$args = array_map(function($arg) {
-			return escapeshellarg($arg);
-		}, $args);
+		$args = array_map(
+			function ($arg) {
+				return escapeshellarg($arg);
+			}, $args
+		);
 		$args[] = '--no-ansi';
 		$args = implode(' ', $args);
 
@@ -142,7 +161,12 @@ class AppManagementContext implements  Context {
 			1 => ['pipe', 'w'],
 			2 => ['pipe', 'w'],
 		];
-		$process = proc_open('php console.php ' . $args, $descriptor, $pipes, \OC::$SERVERROOT);
+		$process = proc_open(
+			'php console.php ' . $args,
+			$descriptor,
+			$pipes,
+			\OC::$SERVERROOT
+		);
 		$this->cmdOutput = stream_get_contents($pipes[1]);
 		proc_close($process);
 	}
@@ -152,8 +176,13 @@ class AppManagementContext implements  Context {
 	 *
 	 * @param string $appId
 	 * @param string $dir
+	 *
+	 * @return void
 	 */
-	 public function appVersionIs($appId, $dir) {
-		PHPUnit_Framework_Assert::assertEquals(\OC::$SERVERROOT . '/' . $dir . '/' . $appId, trim($this->cmdOutput));
+	public function appVersionIs($appId, $dir) {
+		PHPUnit_Framework_Assert::assertEquals(
+			\OC::$SERVERROOT . '/' . $dir . '/' . $appId,
+			trim($this->cmdOutput)
+		);
 	}
 }

--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -1,15 +1,41 @@
 <?php
+/**
+ * @author Christoph Wurst <christoph@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
+/**
+ * Authentication functions
+ */
 trait Auth {
 
 	private $clientToken;
 
-	/** @BeforeScenario */
+	/**
+	 * @BeforeScenario
+	 *
+	 * @return void
+	 */
 	public function setUpScenario() {
 		$this->client = new Client();
 		$this->responseXml = '';
@@ -21,6 +47,8 @@ trait Auth {
 	 *
 	 * @param string $url
 	 * @param string $method
+	 *
+	 * @return void
 	 */
 	public function userRequestsURLWith($url, $method) {
 		$this->sendRequest($url, $method);
@@ -31,14 +59,20 @@ trait Auth {
 	 * @param string $method
 	 * @param string|null $authHeader
 	 * @param bool $useCookies
+	 *
+	 * @return void
 	 */
-	private function sendRequest($url, $method, $authHeader = null, $useCookies = false) {
+	private function sendRequest(
+		$url, $method, $authHeader = null, $useCookies = false
+	) {
 		$fullUrl = substr($this->baseUrl, 0, -5) . $url;
 		try {
 			if ($useCookies) {
-				$request = $this->client->createRequest($method, $fullUrl, [
-				    'cookies' => $this->cookieJar,
-				]);
+				$request = $this->client->createRequest(
+					$method, $fullUrl, [
+					'cookies' => $this->cookieJar,
+					]
+				);
 			} else {
 				$request = $this->client->createRequest($method, $fullUrl);
 			}
@@ -58,15 +92,19 @@ trait Auth {
 	 * @Given a new client token for :user has been generated
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function aNewClientTokenHasBeenGenerated($user) {
 		$client = new Client();
-		$resp = $client->post(substr($this->baseUrl, 0, -5) . '/token/generate', [
+		$resp = $client->post(
+			substr($this->baseUrl, 0, -5) . '/token/generate', [
 			'json' => [
 					'user' => $user,
 					'password' => $this->getPasswordForUser($user),
 			]
-		]);
+			]
+		);
 		$this->clientToken = json_decode($resp->getBody()->getContents())->token;
 	}
 
@@ -77,6 +115,8 @@ trait Auth {
 	 * @param string $user
 	 * @param string $url
 	 * @param string $method
+	 *
+	 * @return void
 	 */
 	public function userRequestsURLWithUsingBasicAuth($user, $url, $method) {
 		$authString = $user . ':' . $this->getPasswordForUser($user);
@@ -90,9 +130,15 @@ trait Auth {
 	 * @param string $user
 	 * @param string $url
 	 * @param string $method
+	 *
+	 * @return void
 	 */
 	public function userRequestsURLWithUsingBasicTokenAuth($user, $url, $method) {
-		$this->sendRequest($url, $method, 'basic ' . base64_encode($user . ':' . $this->clientToken));
+		$this->sendRequest(
+			$url,
+			$method,
+			'basic ' . base64_encode($user . ':' . $this->clientToken)
+		);
 	}
 
 	/**
@@ -101,6 +147,8 @@ trait Auth {
 	 *
 	 * @param string $url
 	 * @param string $method
+	 *
+	 * @return void
 	 */
 	public function userRequestsURLWithUsingAClientToken($url, $method) {
 		$this->sendRequest($url, $method, 'token ' . $this->clientToken);
@@ -112,6 +160,8 @@ trait Auth {
 	 *
 	 * @param string $url
 	 * @param string $method
+	 *
+	 * @return void
 	 */
 	public function userRequestsURLWithBrowserSession($url, $method) {
 		$this->sendRequest($url, $method, null, true);
@@ -121,6 +171,8 @@ trait Auth {
 	 * @Given a new browser session for :user has been started
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function aNewBrowserSessionForHasBeenStarted($user) {
 		$loginUrl = substr($this->baseUrl, 0, -5) . '/login';
@@ -128,7 +180,7 @@ trait Auth {
 		$client = new Client();
 		$response = $client->get(
 			$loginUrl, [
-		    'cookies' => $this->cookieJar,
+			'cookies' => $this->cookieJar,
 			]
 		);
 		$this->extracRequestTokenFromResponse($response);

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1,4 +1,23 @@
 <?php
+/**
+ * @author Sergio Bertolin <sbertolin@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
@@ -9,6 +28,9 @@ use TestHelpers\OcsApiHelper;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
+/**
+ * Basic functions needed by mostly everything
+ */
 trait BasicStructure {
 
 	use AppConfiguration;
@@ -23,7 +45,9 @@ trait BasicStructure {
 	use WebDav;
 	use CommandLine;
 
-	/** @var array */
+	/**
+	 * @var array 
+	 */
 	private $adminUser = [];
 
 	/**
@@ -31,28 +55,55 @@ trait BasicStructure {
 	 */
 	private $regularUserPassword = '';
 
-	/** @var string */
+	/**
+	 * @var string 
+	 */
 	private $currentUser = '';
 
-	/** @var string */
+	/**
+	 * @var string 
+	 */
 	private $currentServer = '';
 
-	/** @var string */
+	/**
+	 * @var string 
+	 */
 	private $baseUrl = '';
 
-	/** @var int */
+	/**
+	 * @var int 
+	 */
 	private $apiVersion = 1;
 
-	/** @var ResponseInterface */
+	/**
+	 * @var ResponseInterface 
+	 */
 	private $response = null;
 
-	/** @var \GuzzleHttp\Cookie\CookieJar */
+	/**
+	 * @var \GuzzleHttp\Cookie\CookieJar 
+	 */
 	private $cookieJar;
 
-	/** @var string */
+	/**
+	 * @var string 
+	 */
 	private $requestToken;
 
-	public function __construct($baseUrl, $admin, $regular_user_password, $mailhog_url, $oc_path) {
+	/**
+	 * BasicStructure constructor.
+	 *
+	 * @param  string $baseUrl
+	 * @param string $admin
+	 * @param string $regular_user_password
+	 * @param string $mailhog_url
+	 * @param string $oc_path
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		$baseUrl, $admin, $regular_user_password, $mailhog_url, $oc_path
+	) {
 
 		// Initialize your context here
 		$this->baseUrl = $baseUrl;
@@ -81,6 +132,8 @@ trait BasicStructure {
 
 	/**
 	 * returns the base URL without the /ocs part
+	 *
+	 * @return string
 	 */
 	private function baseUrlWithoutOCSAppendix() {
 		return substr($this->baseUrl, 0, -4);
@@ -90,6 +143,8 @@ trait BasicStructure {
 	 * @Given /^using (?:api|API) version "([^"]*)"$/
 	 *
 	 * @param string $version
+	 *
+	 * @return void
 	 */
 	public function usingApiVersion($version) {
 		$this->apiVersion = $version;
@@ -99,6 +154,8 @@ trait BasicStructure {
 	 * @Given /^as user "([^"]*)"$/
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function asUser($user) {
 		$this->currentUser = $user;
@@ -108,6 +165,7 @@ trait BasicStructure {
 	 * @Given /^using server "(LOCAL|REMOTE)"$/
 	 *
 	 * @param string $server
+	 *
 	 * @return string Previous used server
 	 */
 	public function usingServer($server) {
@@ -128,6 +186,8 @@ trait BasicStructure {
 	 *
 	 * @param string $verb
 	 * @param string $url
+	 *
+	 * @return void
 	 */
 	public function sendingTo($verb, $url) {
 		$this->sendingToWith($verb, $url, null);
@@ -140,6 +200,8 @@ trait BasicStructure {
 	 * @param string $user
 	 * @param string $verb
 	 * @param string $url
+	 *
+	 * @return void
 	 */
 	public function userSendingTo($user, $verb, $url) {
 		$this->userSendsHTTPMethodToAPIEndpointWithBody(
@@ -153,7 +215,9 @@ trait BasicStructure {
 	/**
 	 * Parses the xml answer to get ocs response which doesn't match with
 	 * http one in v1 of the api.
+	 *
 	 * @param ResponseInterface $response
+	 *
 	 * @return string
 	 */
 	public function getOCSResponseStatusCode($response) {
@@ -166,6 +230,7 @@ trait BasicStructure {
 	 * @param ResponseInterface $response
 	 * @param string $key1
 	 * @param string $key2
+	 *
 	 * @return string
 	 */
 	public function getXMLKey1Key2Value($response, $key1, $key2) {
@@ -179,6 +244,7 @@ trait BasicStructure {
 	 * @param string $key1
 	 * @param string $key2
 	 * @param string $key3
+	 *
 	 * @return string
 	 */
 	public function getXMLKey1Key2Key3Value($response, $key1, $key2, $key3) {
@@ -193,9 +259,12 @@ trait BasicStructure {
 	 * @param string $key2
 	 * @param string $key3
 	 * @param string $attribute
+	 *
 	 * @return string
 	 */
-	public function getXMLKey1Key2Key3AttributeValue($response, $key1, $key2, $key3, $attribute) {
+	public function getXMLKey1Key2Key3AttributeValue(
+		$response, $key1, $key2, $key3, $attribute
+	) {
 		return (string) $response->xml()->$key1->$key2->$key3->attributes()->$attribute;
 	}
 
@@ -203,10 +272,15 @@ trait BasicStructure {
 	 * This function is needed to use a vertical fashion in the gherkin tables.
 	 *
 	 * @param array $arrayOfArrays
+	 *
 	 * @return array
 	 */
 	public function simplifyArray($arrayOfArrays) {
-		$a = array_map(function($subArray) { return $subArray[0]; }, $arrayOfArrays);
+		$a = array_map(
+			function ($subArray) {
+				return $subArray[0]; 
+			}, $arrayOfArrays
+		);
 		return $a;
 	}
 
@@ -217,6 +291,8 @@ trait BasicStructure {
 	 * @param string $verb
 	 * @param string $url
 	 * @param \Behat\Gherkin\Node\TableNode $body
+	 *
+	 * @return void
 	 */
 	public function sendingToWith($verb, $url, $body) {
 		$this->userSendsHTTPMethodToAPIEndpointWithBody(
@@ -235,8 +311,12 @@ trait BasicStructure {
 	 * @param string $verb
 	 * @param string $url
 	 * @param \Behat\Gherkin\Node\TableNode $body
+	 *
+	 * @return void
 	 */
-	public function userSendsHTTPMethodToAPIEndpointWithBody($user, $verb, $url, $body) {
+	public function userSendsHTTPMethodToAPIEndpointWithBody(
+		$user, $verb, $url, $body
+	) {
 
 		/**
 		 * array of the data to be sent in the body.
@@ -270,6 +350,8 @@ trait BasicStructure {
 	 * @param string $user
 	 * @param string $verb
 	 * @param string $url
+	 *
+	 * @return void
 	 */
 	public function userSendsHTTPMethodToUrl($user, $verb, $url) {
 		$this->sendingToWithDirectUrl($user, $verb, $url, null);
@@ -280,6 +362,8 @@ trait BasicStructure {
 	 * @param string $verb
 	 * @param string $url
 	 * @param \Behat\Gherkin\Node\TableNode $body
+	 *
+	 * @return void
 	 */
 	public function sendingToWithDirectUrl($user, $verb, $url, $body) {
 		$fullUrl = substr($this->baseUrl, 0, -5) . $url;
@@ -310,30 +394,39 @@ trait BasicStructure {
 	/**
 	 * @param string $possibleUrl
 	 * @param string $finalPart
+	 *
 	 * @return bool
 	 */
 	public function isExpectedUrl($possibleUrl, $finalPart) {
 		$baseUrlChopped = $this->baseUrlWithoutOCSAppendix();
 		$endCharacter = strlen($baseUrlChopped) + strlen($finalPart);
-		return (substr($possibleUrl,0,$endCharacter) == "$baseUrlChopped" . "$finalPart");
+		return (substr($possibleUrl, 0, $endCharacter) == "$baseUrlChopped" . "$finalPart");
 	}
 
 	/**
 	 * @Then /^the OCS status code should be "([^"]*)"$/
 	 *
 	 * @param int $statusCode
+	 *
+	 * @return void
 	 */
 	public function theOCSStatusCodeShouldBe($statusCode) {
-		PHPUnit_Framework_Assert::assertEquals($statusCode, $this->getOCSResponseStatusCode($this->response));
+		PHPUnit_Framework_Assert::assertEquals(
+			$statusCode, $this->getOCSResponseStatusCode($this->response)
+		);
 	}
 
 	/**
 	 * @Then /^the HTTP status code should be "([^"]*)"$/
 	 *
 	 * @param int $statusCode
+	 *
+	 * @return void
 	 */
 	public function theHTTPStatusCodeShouldBe($statusCode) {
-		PHPUnit_Framework_Assert::assertEquals($statusCode, $this->response->getStatusCode());
+		PHPUnit_Framework_Assert::assertEquals(
+			$statusCode, $this->response->getStatusCode()
+		);
 	}
 
 	/**
@@ -342,6 +435,8 @@ trait BasicStructure {
 	 * @param string $key1
 	 * @param string $key2
 	 * @param string $idText
+	 *
+	 * @return void
 	 */
 	public function theXMLKey1Key2ValueShouldBe($key1, $key2, $idText) {
 		PHPUnit_Framework_Assert::assertEquals(
@@ -357,6 +452,8 @@ trait BasicStructure {
 	 * @param string $key2
 	 * @param string $key3
 	 * @param string $idText
+	 *
+	 * @return void
 	 */
 	public function theXMLKey1Key2Key3ValueShouldBe($key1, $key2, $key3, $idText) {
 		PHPUnit_Framework_Assert::assertEquals(
@@ -372,9 +469,15 @@ trait BasicStructure {
 	 * @param string $key2
 	 * @param string $key3
 	 * @param string $attribute
+	 *
+	 * @return void
 	 */
-	public function theXMLKey1Key2AttributeValueShouldBe($key1, $key2, $key3, $attribute) {
-		$value = $this->getXMLKey1Key2Key3AttributeValue($this->response, $key1, $key2, $key3, $attribute);
+	public function theXMLKey1Key2AttributeValueShouldBe(
+		$key1, $key2, $key3, $attribute
+	) {
+		$value = $this->getXMLKey1Key2Key3AttributeValue(
+			$this->response, $key1, $key2, $key3, $attribute
+		);
 		PHPUnit_Framework_Assert::assertTrue(
 			version_compare($value, '0.0.1') >= 0,
 			'attribute ' . $attribute . ' value ' . $value . ' is not a valid version string'
@@ -383,9 +486,18 @@ trait BasicStructure {
 
 	/**
 	 * @param ResponseInterface $response
+	 *
+	 * @return void
 	 */
 	private function extracRequestTokenFromResponse(ResponseInterface $response) {
-		$this->requestToken = substr(preg_replace('/(.*)data-requesttoken="(.*)">(.*)/sm', '\2', $response->getBody()->getContents()), 0, 89);
+		$this->requestToken = substr(
+			preg_replace(
+				'/(.*)data-requesttoken="(.*)">(.*)/sm', '\2',
+				$response->getBody()->getContents()
+			),
+			0,
+			89
+		);
 	}
 
 	/**
@@ -393,6 +505,8 @@ trait BasicStructure {
 	 * @Given /^user "([^"]*)" has logged in to a web-style session using the API$/
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function userHasLoggedInToAWebStyleSessionUsingTheAPI($user) {
 		$loginUrl = substr($this->baseUrl, 0, -5) . '/login';
@@ -429,6 +543,8 @@ trait BasicStructure {
 	 *
 	 * @param string $method
 	 * @param string $url
+	 *
+	 * @return void
 	 */
 	public function sendingAToWithRequesttoken($method, $url) {
 		$baseUrl = substr($this->baseUrl, 0, -5);
@@ -455,6 +571,8 @@ trait BasicStructure {
 	 *
 	 * @param string $method
 	 * @param string $url
+	 *
+	 * @return void
 	 */
 	public function sendingAToWithoutRequesttoken($method, $url) {
 		$baseUrl = substr($this->baseUrl, 0, -5);
@@ -477,6 +595,8 @@ trait BasicStructure {
 	/**
 	 * @param string $path
 	 * @param string $filename
+	 *
+	 * @return void
 	 */
 	public static function removeFile($path, $filename) {
 		if (file_exists("$path" . "$filename")) {
@@ -491,26 +611,34 @@ trait BasicStructure {
 	 * @param string $user
 	 * @param string $filename
 	 * @param string $text
+	 *
+	 * @return void
 	 */
 	public function modifyTextOfFile($user, $filename, $text) {
 		self::removeFile($this->getUserHome($user) . "/files", "$filename");
-		file_put_contents($this->getUserHome($user) . "/files" . "$filename", "$text");
+		file_put_contents(
+			$this->getUserHome($user) . "/files" . "$filename", "$text"
+		);
 	}
 
 	/**
 	 * @param string $name
 	 * @param string $size
+	 *
+	 * @return void
 	 */
 	public function createFileSpecificSize($name, $size) {
 		$file = fopen("work/" . "$name", 'w');
-		fseek($file, $size - 1 ,SEEK_CUR);
-		fwrite($file,'a'); // write a dummy char at SIZE position
+		fseek($file, $size - 1, SEEK_CUR);
+		fwrite($file, 'a'); // write a dummy char at SIZE position
 		fclose($file);
 	}
 
 	/**
 	 * @param string $name
 	 * @param string $text
+	 *
+	 * @return void
 	 */
 	public function createFileWithText($name, $text) {
 		$file = fopen("work/" . "$name", 'w');
@@ -523,6 +651,8 @@ trait BasicStructure {
 	 *
 	 * @param string $filename
 	 * @param string $size
+	 *
+	 * @return void
 	 */
 	public function fileHasBeenCreatedInLocalStorageWithSize($filename, $size) {
 		$this->createFileSpecificSize("local_storage/$filename", $size);
@@ -533,6 +663,8 @@ trait BasicStructure {
 	 *
 	 * @param string $filename
 	 * @param string $text
+	 *
+	 * @return void
 	 */
 	public function fileHasBeenCreatedInLocalStorageWithText($filename, $text) {
 		$this->createFileWithText("local_storage/$filename", $text);
@@ -542,6 +674,8 @@ trait BasicStructure {
 	 * @Given file :filename has been deleted in local storage
 	 *
 	 * @param string $filename
+	 *
+	 * @return void
 	 */
 	public function fileHasBeenDeletedInLocalStorage($filename) {
 		unlink("work/local_storage/$filename");
@@ -563,6 +697,7 @@ trait BasicStructure {
 
 	/**
 	 * @param string $userName
+	 *
 	 * @return string
 	 */
 	public function getPasswordForUser($userName) {
@@ -575,6 +710,7 @@ trait BasicStructure {
 
 	/**
 	 * @param string $userName
+	 *
 	 * @return array
 	 */
 	public function getAuthOptionForUser($userName) {
@@ -590,14 +726,18 @@ trait BasicStructure {
 
 	/**
 	 * @When the admin requests status.php using the API
+	 *
+	 * @return void
 	 */
-	public function getStatusPhp(){
+	public function getStatusPhp() {
 		$fullUrl = $this->baseUrlWithoutOCSAppendix() . "status.php";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser('admin');
 		try {
-			$this->response = $client->send($client->createRequest('GET', $fullUrl, $options));
+			$this->response = $client->send(
+				$client->createRequest('GET', $fullUrl, $options)
+			);
 		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
@@ -607,17 +747,23 @@ trait BasicStructure {
 	 * @Then the json responded should match with
 	 *
 	 * @param PyStringNode $jsonExpected
+	 *
+	 * @return void
 	 */
 	public function jsonRespondedShouldMatch(PyStringNode $jsonExpected) {
 		$jsonExpectedEncoded = json_encode($jsonExpected->getRaw());
 		$jsonRespondedEncoded = json_encode((string) $this->response->getBody());
-		PHPUnit\Framework\Assert::assertEquals($jsonExpectedEncoded, $jsonRespondedEncoded);
+		PHPUnit\Framework\Assert::assertEquals(
+			$jsonExpectedEncoded, $jsonRespondedEncoded
+		);
 	}
 
 	/**
 	 * @Then the status.php response should match with
 	 *
 	 * @param PyStringNode $jsonExpected
+	 *
+	 * @return void
 	 */
 	public function statusPhpRespondedShouldMatch(PyStringNode $jsonExpected) {
 		$jsonExpectedDecoded = json_decode($jsonExpected->getRaw(), true);
@@ -639,6 +785,8 @@ trait BasicStructure {
 
 	/**
 	 * @BeforeScenario @local_storage
+	 *
+	 * @return void
 	 */
 	public static function removeFilesFromLocalStorageBefore() {
 		$dir = "./work/local_storage/";
@@ -651,6 +799,8 @@ trait BasicStructure {
 
 	/**
 	 * @AfterScenario @local_storage
+	 *
+	 * @return void
 	 */
 	public static function removeFilesFromLocalStorageAfter() {
 		$dir = "./work/local_storage/";
@@ -663,7 +813,10 @@ trait BasicStructure {
 
 	/**
 	 * @BeforeSuite
+	 *
 	 * @param BeforeSuiteScope $scope
+	 *
+	 * @return void
 	 */
 	public static function useBigFileIDs(BeforeSuiteScope $scope) {
 		$fullUrl = getenv('TEST_SERVER_URL') . "/v1.php/apps/testing/api/v1/increasefileid";

--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -26,14 +26,25 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\ResponseInterface;
 
+/**
+ * CalDav functions
+ */
 class CalDavContext implements \Behat\Behat\Context\Context {
-	/** @var string  */
+	/**
+	 * @var string  
+	 */
 	private $baseUrl;
-	/** @var Client */
+	/**
+	 * @var Client 
+	 */
 	private $client;
-	/** @var ResponseInterface */
+	/**
+	 * @var ResponseInterface 
+	 */
 	private $response;
-	/** @var array */
+	/**
+	 * @var array 
+	 */
 	private $responseXml = '';
 
 	/**
@@ -43,6 +54,8 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @param string $baseUrl
+	 *
+	 * @return void
 	 */
 	public function __construct($baseUrl) {
 		$this->baseUrl = $baseUrl;
@@ -58,6 +71,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 * @BeforeScenario @caldav
 	 *
 	 * @param BeforeScenarioScope $scope
+	 *
 	 * @return void
 	 */
 	public function setUpScenario(BeforeScenarioScope $scope) {
@@ -71,9 +85,11 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @AfterScenario @caldav
+	 *
+	 * @return void
 	 */
 	public function afterScenario() {
-		$davUrl = $this->baseUrl. '/remote.php/dav/calendars/admin/MyCalendar';
+		$davUrl = $this->baseUrl . '/remote.php/dav/calendars/admin/MyCalendar';
 		try {
 			$this->client->delete(
 				$davUrl,
@@ -81,7 +97,8 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 					'auth' => $this->featureContext->getAuthOptionForAdmin()
 				]
 			);
-		} catch (BadResponseException $e) {}
+		} catch (BadResponseException $e) {
+		}
 	}
 
 	/**
@@ -89,9 +106,11 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 *
 	 * @param string $user
 	 * @param string $calendar
+	 *
+	 * @return void
 	 */
 	public function userRequestsCalendarUsingTheAPI($user, $calendar) {
-		$davUrl = $this->baseUrl . '/remote.php/dav/calendars/'.$calendar;
+		$davUrl = $this->baseUrl . '/remote.php/dav/calendars/' . $calendar;
 
 		try {
 			$this->response = $this->client->get(
@@ -109,6 +128,8 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 * @Then the CalDAV HTTP status code should be :code
 	 *
 	 * @param int $code
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function theCalDavHttpStatusCodeShouldBe($code) {
@@ -134,6 +155,8 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 * @Then the CalDAV exception should be :message
 	 *
 	 * @param string $message
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function theCalDavExceptionShouldBe($message) {
@@ -154,6 +177,8 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 * @Then the CalDAV error message should be :message
 	 *
 	 * @param string $message
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function theCalDavErrorMessageShouldBe($message) {
@@ -175,9 +200,11 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 *
 	 * @param string $user
 	 * @param string $name
+	 *
+	 * @return void
 	 */
 	public function userHasCreatedACalendarNamed($user, $name) {
-		$davUrl = $this->baseUrl . '/remote.php/dav/calendars/'.$user.'/'.$name;
+		$davUrl = $this->baseUrl . '/remote.php/dav/calendars/' . $user . '/' . $name;
 
 		$request = $this->client->createRequest(
 			'MKCALENDAR',

--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -24,6 +24,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Gherkin\Node\TableNode;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
@@ -37,10 +38,11 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 	/**
 	 * @Then the capabilities should contain
 	 *
-	 * @param \Behat\Gherkin\Node\TableNode|null $formData
+	 * @param TableNode|null $formData
+	 *
 	 * @return void
 	 */
-	public function checkCapabilitiesResponse(\Behat\Gherkin\Node\TableNode $formData) {
+	public function checkCapabilitiesResponse(TableNode $formData) {
 		$capabilitiesXML = $this->getCapabilitiesXml();
 
 		foreach ($formData->getHash() as $row) {
@@ -66,7 +68,9 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 		$this->savedCapabilitiesXml = $this->getCapabilitiesXml();
 		// Set the required starting values for testing
 		$capabilitiesArray = $this->getCommonSharingConfigs();
-		$capabilitiesArray = array_merge($capabilitiesArray, $this->getCommonFederationConfigs());
+		$capabilitiesArray = array_merge(
+			$capabilitiesArray, $this->getCommonFederationConfigs()
+		);
 		$capabilitiesArray = array_merge(
 			$capabilitiesArray,
 			[

--- a/tests/acceptance/features/bootstrap/CardDavContext.php
+++ b/tests/acceptance/features/bootstrap/CardDavContext.php
@@ -26,14 +26,25 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\ResponseInterface;
 
+/**
+ * CardDav functions
+ */
 class CardDavContext implements \Behat\Behat\Context\Context {
-	/** @var string  */
+	/**
+	 * @var string  
+	 */
 	private $baseUrl;
-	/** @var Client */
+	/**
+	 * @var Client 
+	 */
 	private $client;
-	/** @var ResponseInterface */
+	/**
+	 * @var ResponseInterface 
+	 */
 	private $response;
-	/** @var array */
+	/**
+	 * @var array 
+	 */
 	private $responseXml = '';
 
 	/**
@@ -43,6 +54,8 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @param string $baseUrl
+	 *
+	 * @return void
 	 */
 	public function __construct($baseUrl) {
 		$this->baseUrl = $baseUrl;
@@ -58,6 +71,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	 * @BeforeScenario @carddav
 	 *
 	 * @param BeforeScenarioScope $scope
+	 *
 	 * @return void
 	 */
 	public function setUpScenario(BeforeScenarioScope $scope) {
@@ -71,6 +85,8 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 
 	/**
 	 * @AfterScenario @carddav
+	 *
+	 * @return void
 	 */
 	public function afterScenario() {
 		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/admin/MyAddressbook';
@@ -81,7 +97,8 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 					'auth' => $this->featureContext->getAuthOptionForAdmin()
 				]
 			);
-		} catch (BadResponseException $e) {}
+		} catch (BadResponseException $e) {
+		}
 	}
 
 	/**
@@ -89,10 +106,12 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	 *
 	 * @param string $user
 	 * @param string $addressBook
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function userRequestsAddressbookUsingTheAPI($user, $addressBook) {
-		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/'.$addressBook;
+		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/' . $addressBook;
 
 		try {
 			$this->response = $this->client->get(
@@ -111,10 +130,12 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	 *
 	 * @param string $user
 	 * @param string $addressBook
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function userHasCreatedAnAddressbookNamed($user, $addressBook) {
-		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/'.$user.'/'.$addressBook;
+		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/' . $user . '/' . $addressBook;
 
 		$request = $this->client->createRequest(
 			'MKCOL',
@@ -126,7 +147,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
       <d:prop>
         <d:resourcetype>
             <d:collection />,<card:addressbook />
-          </d:resourcetype>,<d:displayname>'.$addressBook.'</d:displayname>
+          </d:resourcetype>,<d:displayname>' . $addressBook . '</d:displayname>
       </d:prop>
     </d:set>
   </d:mkcol>',
@@ -145,6 +166,8 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	 * @Then the CardDAV HTTP status code should be :code
 	 *
 	 * @param int $code
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function theCardDavHttpStatusCodeShouldBe($code) {
@@ -170,6 +193,8 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	 * @Then the CardDAV exception should be :message
 	 *
 	 * @param string $message
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function theCardDavExceptionShouldBe($message) {
@@ -190,6 +215,8 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	 * @Then the CardDAV error message should be :arg1
 	 *
 	 * @param string $message
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function theCardDavErrorMessageShouldBe($message) {

--- a/tests/acceptance/features/bootstrap/Checksums.php
+++ b/tests/acceptance/features/bootstrap/Checksums.php
@@ -1,9 +1,31 @@
 <?php
+/**
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 use GuzzleHttp\Client;
 
+/**
+ * Checksum functions
+ */
 trait Checksums {
 
 	/**
@@ -14,26 +36,36 @@ trait Checksums {
 	 * @param string $source
 	 * @param string $destination
 	 * @param string $checksum
+	 *
+	 * @return void
 	 */
-	public function userUploadsFileToWithChecksumUsingTheAPI($user, $source, $destination, $checksum) {
+	public function userUploadsFileToWithChecksumUsingTheAPI(
+		$user, $source, $destination, $checksum
+	) {
 		$file = \GuzzleHttp\Stream\Stream::factory(fopen($source, 'r'));
-		$this->response = $this->makeDavRequest($user,
-							  'PUT',
-							  $destination,
-							  ['OC-Checksum' => $checksum],
-							  $file,
-							  "files");
+		$this->response = $this->makeDavRequest(
+			$user,
+			'PUT',
+			$destination,
+			['OC-Checksum' => $checksum],
+			$file,
+			"files"
+		);
 	}
 
 	/**
 	 * @Then the webdav response should have a status code :statusCode
 	 *
 	 * @param int $statusCode
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function theWebdavResponseShouldHaveAStatusCode($statusCode) {
 		if ((int)$statusCode !== $this->response->getStatusCode()) {
-			throw new \Exception("Expected $statusCode, got ".$this->response->getStatusCode());
+			throw new \Exception(
+				"Expected $statusCode, got " . $this->response->getStatusCode()
+			);
 		}
 	}
 
@@ -42,6 +74,8 @@ trait Checksums {
 	 *
 	 * @param string $user
 	 * @param string $path
+	 *
+	 * @return void
 	 */
 	public function userRequestsTheChecksumOfViaPropfind($user, $path) {
 		$client = new Client();
@@ -65,10 +99,11 @@ trait Checksums {
 	 * @Then the webdav checksum should match :checksum
 	 *
 	 * @param string $checksum
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
-	public function theWebdavChecksumShouldMatch($checksum)
-	{
+	public function theWebdavChecksumShouldMatch($checksum) {
 		$service = new Sabre\Xml\Service();
 		$parsed = $service->parse($this->response->getBody()->getContents());
 
@@ -79,7 +114,9 @@ trait Checksums {
 		$checksums = $parsed[0]['value'][1]['value'][0]['value'][0];
 
 		if ($checksums['value'][0]['value'] !== $checksum) {
-			throw new \Exception("Expected $checksum, got ".$checksums['value'][0]['value']);
+			throw new \Exception(
+				"Expected $checksum, got " . $checksums['value'][0]['value']
+			);
 		}
 	}
 
@@ -87,20 +124,24 @@ trait Checksums {
 	 * @Then the header checksum should match :checksum
 	 *
 	 * @param string $checksum
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
-	public function theHeaderChecksumShouldMatch($checksum)
-	{
+	public function theHeaderChecksumShouldMatch($checksum) {
 		if ($this->response->getHeader('OC-Checksum') !== $checksum) {
-			throw new \Exception("Expected $checksum, got ".$this->response->getHeader('OC-Checksum'));
+			throw new \Exception(
+				"Expected $checksum, got " . $this->response->getHeader('OC-Checksum')
+			);
 		}
 	}
 
 	/**
 	 * @Then the webdav checksum should be empty
+	 *
+	 * @return void
 	 */
-	public function theWebdavChecksumShouldBeEmpty()
-	{
+	public function theWebdavChecksumShouldBeEmpty() {
 		$service = new Sabre\Xml\Service();
 		$parsed = $service->parse($this->response->getBody()->getContents());
 
@@ -111,17 +152,22 @@ trait Checksums {
 		$status = $parsed[0]['value'][1]['value'][1]['value'];
 
 		if ($status !== 'HTTP/1.1 404 Not Found') {
-			throw new \Exception("Expected 'HTTP/1.1 404 Not Found', got ".$status);
+			throw new \Exception(
+				"Expected 'HTTP/1.1 404 Not Found', got " . $status
+			);
 		}
 	}
 
 	/**
 	 * @Then the OC-Checksum header should not be there
+	 *
+	 * @return void
 	 */
-	public function theOcChecksumHeaderShouldNotBeThere()
-	{
+	public function theOcChecksumHeaderShouldNotBeThere() {
 		if ($this->response->hasHeader('OC-Checksum')) {
-			throw new \Exception("Expected no checksum header but got ".$this->response->getHeader('OC-Checksum'));
+			throw new \Exception(
+				"Expected no checksum header but got " . $this->response->getHeader('OC-Checksum')
+			);
 		}
 	}
 
@@ -135,18 +181,24 @@ trait Checksums {
 	 * @param string $data
 	 * @param string $destination
 	 * @param string $checksum
+	 *
+	 * @return void
 	 */
-	public function userUploadsChunkFileOfWithToWithChecksum($user, $num, $total, $data, $destination, $checksum) {
+	public function userUploadsChunkFileOfWithToWithChecksum(
+		$user, $num, $total, $data, $destination, $checksum
+	) {
 		try {
 			$num -= 1;
 			$data = \GuzzleHttp\Stream\Stream::factory($data);
 			$file = $destination . '-chunking-42-' . $total . '-' . $num;
-			$this->response = $this->makeDavRequest($user,
-								  'PUT',
-								  $file,
-								  ['OC-Checksum' => $checksum, 'OC-Chunked' => '1'],
-								  $data,
-								  "files");
+			$this->response = $this->makeDavRequest(
+				$user,
+				'PUT',
+				$file,
+				['OC-Checksum' => $checksum, 'OC-Chunked' => '1'],
+				$data,
+				"files"
+			);
 		} catch (\GuzzleHttp\Exception\RequestException $ex) {
 			$this->response = $ex->getResponse();
 		}

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -21,12 +21,21 @@
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
+/**
+ * Command line functions
+ */
 trait CommandLine {
-	/** @var int return code of last command */
+	/**
+	 * @var int return code of last command 
+	 */
 	private $lastCode;
-	/** @var string stdout of last command */
+	/**
+	 * @var string stdout of last command 
+	 */
 	private $lastStdOut;
-	/** @var string stderr of last command */
+	/**
+	 * @var string stderr of last command 
+	 */
 	private $lastStdErr;
 
 	/**
@@ -34,13 +43,16 @@ trait CommandLine {
 	 *
 	 * @param array $args of the occ command
 	 * @param bool $escaping
+	 *
 	 * @return int exit code
 	 */
 	public function runOcc($args = [], $escaping = true) {
 		if ($escaping === true) {
-			$args = array_map(function($arg) {
-				return escapeshellarg($arg);
-			}, $args);
+			$args = array_map(
+				function ($arg) {
+					return escapeshellarg($arg);
+				}, $args
+			);
 		}
 		$args[] = '--no-ansi';
 		$args = implode(' ', $args);
@@ -50,7 +62,9 @@ trait CommandLine {
 			1 => ['pipe', 'w'],
 			2 => ['pipe', 'w'],
 		];
-		$process = proc_open('php console.php ' . $args, $descriptor, $pipes, $this->ocPath);
+		$process = proc_open(
+			'php console.php ' . $args, $descriptor, $pipes, $this->ocPath
+		);
 		$this->lastStdOut = stream_get_contents($pipes[1]);
 		$this->lastStdErr = stream_get_contents($pipes[2]);
 		$this->lastCode = proc_close($process);
@@ -62,6 +76,8 @@ trait CommandLine {
 	 * @Given /^the administrator has invoked occ command "([^"]*)"$/
 	 *
 	 * @param string $cmd
+	 *
+	 * @return void
 	 */
 	public function invokingTheCommand($cmd) {
 		$args = explode(' ', $cmd);
@@ -70,6 +86,8 @@ trait CommandLine {
 
 	/**
 	 * Find exception texts in stderr
+	 *
+	 * @return array of exception texts
 	 */
 	public function findExceptions() {
 		$exceptions = [];
@@ -94,6 +112,7 @@ trait CommandLine {
 	 *
 	 * @param string $input stdout or stderr output
 	 * @param string $text text to search for
+	 *
 	 * @return array array of lines that matched
 	 */
 	public function findLines($input, $text) {
@@ -109,6 +128,8 @@ trait CommandLine {
 
 	/**
 	 * @Then /^the command should have been successful$/
+	 *
+	 * @return void
 	 */
 	public function theCommandShouldHaveBeenSuccessful() {
 		$exceptions = $this->findExceptions();
@@ -128,11 +149,15 @@ trait CommandLine {
 	 * @Then /^the command should have failed with exit code ([0-9]+)$/
 	 *
 	 * @param int $exitCode
+	 *
+	 * @return void
 	 * @throws Exception
 	 */
 	public function theCommandFailedWithExitCode($exitCode) {
 		if ($this->lastCode !== (int)$exitCode) {
-			throw new \Exception('The command was expected to fail with exit code ' . $exitCode . ' but got ' . $this->lastCode);
+			throw new \Exception(
+				'The command was expected to fail with exit code ' . $exitCode . ' but got ' . $this->lastCode
+			);
 		}
 	}
 
@@ -140,6 +165,8 @@ trait CommandLine {
 	 * @Then /^the command should have failed with exception text "([^"]*)"$/
 	 *
 	 * @param string $exceptionText
+	 *
+	 * @return void
 	 * @throws Exception
 	 */
 	public function theCommandFailedWithExceptionText($exceptionText) {
@@ -149,7 +176,9 @@ trait CommandLine {
 		}
 
 		if (!in_array($exceptionText, $exceptions)) {
-			throw new \Exception('The command did not throw any exception with the text "' . $exceptionText . '"');
+			throw new \Exception(
+				'The command did not throw any exception with the text "' . $exceptionText . '"'
+			);
 		}
 	}
 
@@ -157,12 +186,16 @@ trait CommandLine {
 	 * @Then /^the command output should contain the text "([^"]*)"$/
 	 *
 	 * @param string $text
+	 *
+	 * @return void
 	 * @throws Exception
 	 */
 	public function theCommandOutputContainsTheText($text) {
 		$lines = $this->findLines($this->lastStdOut, $text);
 		if (empty($lines)) {
-			throw new \Exception('The command did not output the expected text on stdout "' . $text . '"');
+			throw new \Exception(
+				'The command did not output the expected text on stdout "' . $text . '"'
+			);
 		}
 	}
 
@@ -170,12 +203,16 @@ trait CommandLine {
 	 * @Then /^the command error output should contain the text "([^"]*)"$/
 	 *
 	 * @param string $text
+	 *
+	 * @return void
 	 * @throws Exception
 	 */
 	public function theCommandErrorOutputContainsTheText($text) {
 		$lines = $this->findLines($this->lastStdErr, $text);
 		if (empty($lines)) {
-			throw new \Exception('The command did not output the expected text on stderr "' . $text . '"');
+			throw new \Exception(
+				'The command did not output the expected text on stderr "' . $text . '"'
+			);
 		}
 	}
 
@@ -184,6 +221,7 @@ trait CommandLine {
 	/**
 	 * @param string $sourceUser
 	 * @param string $targetUser
+	 *
 	 * @return string|null
 	 */
 	private function findLastTransferFolderForUser($sourceUser, $targetUser) {
@@ -208,9 +246,11 @@ trait CommandLine {
 			return null;
 		}
 
-		usort($foundPaths, function($a, $b) {
-			return $a['date'] - $b['date'];
-		});
+		usort(
+			$foundPaths, function ($a, $b) {
+				return $a['date'] - $b['date'];
+			}
+		);
 
 		$davPath = rtrim($this->getDavFilesPath($targetUser), '/');
 
@@ -225,6 +265,8 @@ trait CommandLine {
 	 *
 	 * @param string $user1
 	 * @param string $user2
+	 *
+	 * @return void
 	 */
 	public function transferringOwnership($user1, $user2) {
 		if ($this->runOcc(['files:transfer-ownership', $user1, $user2]) === 0) {
@@ -238,6 +280,8 @@ trait CommandLine {
 	/**
 	 * @When /^the administrator successfully recreates the encryption masterkey using the occ command$/
 	 * @Given /^the administrator has successfully recreated the encryption masterkey$/
+	 *
+	 * @return void
 	 */
 	public function recreateMasterKeyUsingOccCommand() {
 		$this->runOcc(['encryption:recreate-master-key', '-y']);
@@ -251,6 +295,8 @@ trait CommandLine {
 	 * @param string $path
 	 * @param string $user1
 	 * @param string $user2
+	 *
+	 * @return void
 	 */
 	public function transferringOwnershipPath($path, $user1, $user2) {
 		$path = '--path=' . $path;
@@ -266,6 +312,8 @@ trait CommandLine {
 	 * @Given /^using received transfer folder of "([^"]+)" as dav path$/
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function usingTransferFolderAsDavPath($user) {
 		$davPath = $this->getDavFilesPath($user);

--- a/tests/acceptance/features/bootstrap/Comments.php
+++ b/tests/acceptance/features/bootstrap/Comments.php
@@ -24,13 +24,18 @@ use GuzzleHttp\Exception\BadResponseException;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
-//class CommentsContext implements \Behat\Behat\Context\Context {
-
+/**
+ * Comments functions
+ */
 trait Comments {
 
-	/** @var int */
+	/**
+	 * @var int 
+	 */
 	private $lastCommentId;
-	/** @var int */
+	/**
+	 * @var int 
+	 */
 	private $lastFileId;
 
 	/**
@@ -41,6 +46,8 @@ trait Comments {
 	 * @param string $content
 	 * @param string $type
 	 * @param string $path
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function userCommentsWithContentOnEntry($user, $content, $type, $path) {
@@ -48,23 +55,25 @@ trait Comments {
 		$this->lastFileId = $fileId;
 		$commentsPath = '/comments/files/' . $fileId . '/';
 		try {
-			$this->response = $this->makeDavRequest($user,
-								  "POST",
-								  $commentsPath,
-								  ['Content-Type' => 'application/json',
+			$this->response = $this->makeDavRequest(
+				$user,
+				"POST",
+				$commentsPath,
+				['Content-Type' => 'application/json',
 								   ],
-								    null,
-								   "uploads",
-								   '{"actorId":"user0",
+				null,
+				"uploads",
+				'{"actorId":"user0",
 								    "actorDisplayName":"user0",
 								    "actorType":"users",
 								    "verb":"comment",
 								    "message":"' . $content . '",
 								    "creationDateTime":"Thu, 18 Feb 2016 17:04:18 GMT",
-								    "objectType":"files"}');
+								    "objectType":"files"}'
+			);
 			$responseHeaders =  $this->response->getHeaders();
 			$commentUrl = $responseHeaders['Content-Location'][0];
-			$this->lastCommentId = substr($commentUrl, strrpos($commentUrl,'/')+1);
+			$this->lastCommentId = substr($commentUrl, strrpos($commentUrl, '/') + 1);
 		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
@@ -77,13 +86,17 @@ trait Comments {
 	 * @param string $type
 	 * @param string $path
 	 * @param \Behat\Gherkin\Node\TableNode|null $expectedElements
+	 *
+	 * @return void
 	 */
 	public function checkComments($user, $type, $path, $expectedElements) {
 		$fileId = $this->getFileIdForPath($user, $path);
 		$commentsPath = '/comments/files/' . $fileId . '/';
 		$properties = '<oc:limit>200</oc:limit><oc:offset>0</oc:offset>';
 		try {
-			$elementList = $this->reportElementComments($user,$commentsPath,$properties);
+			$elementList = $this->reportElementComments(
+				$user, $commentsPath, $properties
+			);
 		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 			$statusCode = $this->response->getStatusCode();
@@ -97,13 +110,16 @@ trait Comments {
 			foreach ($elementRows as $expectedElement) {
 				$commentFound = false;
 				foreach ($elementList as $id => $answer) {
-					if  (($answer[200]['{http://owncloud.org/ns}actorDisplayName'] === $expectedElement[0]) and
-						($answer[200]['{http://owncloud.org/ns}message'] === $expectedElement[1])) {
+					if (($answer[200]['{http://owncloud.org/ns}actorDisplayName'] === $expectedElement[0])
+						and ($answer[200]['{http://owncloud.org/ns}message'] === $expectedElement[1])
+					) {
 						$commentFound = true;
 						break;
 					}
 				}
-				PHPUnit_Framework_Assert::assertTrue($commentFound, "Comment not found");
+				PHPUnit_Framework_Assert::assertTrue(
+					$commentFound, "Comment not found"
+				);
 			}
 		}
 	}
@@ -115,14 +131,20 @@ trait Comments {
 	 * @param string $numberOfComments
 	 * @param string $type
 	 * @param string $path
+	 *
+	 * @return void
 	 */
 	public function checkNumberOfComments($user, $numberOfComments, $type, $path) {
 		$fileId = $this->getFileIdForPath($user, $path);
 		$commentsPath = '/comments/files/' . $fileId . '/';
 		$properties = '<oc:limit>200</oc:limit><oc:offset>0</oc:offset>';
 		try {
-			$elementList = $this->reportElementComments($user,$commentsPath,$properties);
-			PHPUnit_Framework_Assert::assertCount((int) $numberOfComments, $elementList);
+			$elementList = $this->reportElementComments(
+				$user, $commentsPath, $properties
+			);
+			PHPUnit_Framework_Assert::assertCount(
+				(int) $numberOfComments, $elementList
+			);
 		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 			$statusCode = $this->response->getStatusCode();
@@ -136,17 +158,21 @@ trait Comments {
 	 * @param string $user
 	 * @param string $fileId
 	 * @param string $commentId
+	 *
+	 * @return void
 	 */
 	public function deleteComment($user, $fileId, $commentId) {
 		$commentsPath = '/comments/files/' . $fileId . '/' . $commentId;
 		try {
-			$this->response = $this->makeDavRequest($user,
-													"DELETE",
-													$commentsPath,
-													[],
-													null,
-													"uploads",
-													null);
+			$this->response = $this->makeDavRequest(
+				$user,
+				"DELETE",
+				$commentsPath,
+				[],
+				null,
+				"uploads",
+				null
+			);
 		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
@@ -157,6 +183,8 @@ trait Comments {
 	 * @Given user :user has deleted the last created comment
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function userDeletesLastComment($user) {
@@ -168,13 +196,15 @@ trait Comments {
 	 *
 	 * @param string $key
 	 * @param string $value
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function theResponseShouldContainAPropertyWithValue($key, $value) {
 		$keys = $this->response[0]['value'][2]['value'][0]['value'];
 		$found = false;
 		foreach ($keys as $singleKey) {
-			if ($singleKey['name'] === '{http://owncloud.org/ns}'.substr($key, 3)) {
+			if ($singleKey['name'] === '{http://owncloud.org/ns}' . substr($key, 3)) {
 				if ($singleKey['value'] === $value) {
 					$found = true;
 				}
@@ -189,11 +219,15 @@ trait Comments {
 	 * @Then the response should contain only :number comments
 	 *
 	 * @param int $number
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function theResponseShouldContainOnlyComments($number) {
 		if (count($this->response) !== (int)$number) {
-			throw new \Exception("Found more comments than $number (" . count($this->response) . ")");
+			throw new \Exception(
+				"Found more comments than $number (" . count($this->response) . ")"
+			);
 		}
 	}
 
@@ -202,24 +236,28 @@ trait Comments {
 	 * @param string $content
 	 * @param string $fileId
 	 * @param string $commentId
+	 *
+	 * @return void
 	 */
 	public function editAComment($user, $content, $fileId, $commentId) {
 		$commentsPath = '/comments/files/' . $fileId . '/' . $commentId;
 		try {
-			$this->response = $this->makeDavRequest($user,
-								  "PROPPATCH",
-								  $commentsPath,
-								  [],
-								  null,
-								  "uploads",
-								  '<?xml version="1.0"?>
+			$this->response = $this->makeDavRequest(
+				$user,
+				"PROPPATCH",
+				$commentsPath,
+				[],
+				null,
+				"uploads",
+				'<?xml version="1.0"?>
 									<d:propertyupdate  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
 										<d:set>
 											<d:prop>
 												<oc:message>' . htmlspecialchars($content, ENT_XML1, 'UTF-8') . '</oc:message>
 											</d:prop>
 										</d:set>
-									</d:propertyupdate>');
+									</d:propertyupdate>'
+			);
 		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();
 		}
@@ -231,10 +269,14 @@ trait Comments {
 	 *
 	 * @param string $user
 	 * @param string $content
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function userEditsLastCreatedComment($user, $content) {
-		$this->editAComment($user, $content, $this->lastFileId, $this->lastCommentId);
+		$this->editAComment(
+			$user, $content, $this->lastFileId, $this->lastCommentId
+		);
 	}
 
 }

--- a/tests/acceptance/features/bootstrap/Federation.php
+++ b/tests/acceptance/features/bootstrap/Federation.php
@@ -21,6 +21,9 @@
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
+/**
+ * Federated cloud functions
+ */
 trait Federation {
 
 	/**
@@ -32,6 +35,7 @@ trait Federation {
 	 * @param string $sharerPath
 	 * @param string $shareeUser
 	 * @param string $shareeServer "LOCAL" or "REMOTE"
+	 *
 	 * @return void
 	 */
 	public function federateSharing(
@@ -55,6 +59,7 @@ trait Federation {
 	 *
 	 * @param string $user
 	 * @param string $server
+	 *
 	 * @return void
 	 */
 	public function acceptLastPendingShare($user, $server) {

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -45,7 +45,10 @@ class FederationContext implements Context, SnippetAcceptingContext {
 		$this->savedCapabilitiesXml = $this->getCapabilitiesXml();
 		// Set the required starting values for testing
 		$capabilitiesArray = $this->getCommonSharingConfigs();
-		$capabilitiesArray = array_merge($capabilitiesArray, $this->getCommonFederationConfigs());
+		$capabilitiesArray = array_merge(
+			$capabilitiesArray,
+			$this->getCommonFederationConfigs()
+		);
 		$capabilitiesArray = array_merge(
 			$capabilitiesArray,
 			[

--- a/tests/acceptance/features/bootstrap/MailTool.php
+++ b/tests/acceptance/features/bootstrap/MailTool.php
@@ -24,13 +24,18 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 
+/**
+ * Mailhog-related functions
+ */
 trait MailTool {
 
-	/*
+	/**
 	 * Connects to an API in a docker container with mailhog,
 	 * retrieving the emails sent from it.
 	 * To use it the container should have previously been set up.
-	*/
+	 *
+	 * @return mixed JSON encoded contents
+	 */
 	public function getEmails() {
 		$fullUrl = $this->mailhogUrl;
 		$client = new Client();

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1,4 +1,23 @@
 <?php
+/**
+ * @author Sergio Bertolin <sbertolin@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
@@ -6,18 +25,29 @@ use GuzzleHttp\Message\ResponseInterface;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
+/**
+ * Functions for provisioning of users and groups
+ */
 trait Provisioning {
 
-	/** @var array */
+	/**
+	 * @var array 
+	 */
 	private $createdUsers = [];
 
-	/** @var array */
+	/**
+	 * @var array 
+	 */
 	private $createdRemoteUsers = [];
 
-	/** @var array */
+	/**
+	 * @var array 
+	 */
 	private $createdRemoteGroups = [];
 
-	/** @var array */
+	/**
+	 * @var array 
+	 */
 	private $createdGroups = [];
 
 	/**
@@ -25,9 +55,11 @@ trait Provisioning {
 	 * @Given /^user "([^"]*)" has been created$/
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function adminCreatesUserUsingTheAPI($user) {
-		if ( !$this->userExists($user) ) {
+		if (!$this->userExists($user) ) {
 			$previous_user = $this->currentUser;
 			$this->currentUser = $this->getAdminUserName();
 			$this->createTheUserUsingTheAPI($user);
@@ -40,6 +72,8 @@ trait Provisioning {
 	 * @Then /^user "([^"]*)" should exist$/
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function userShouldExist($user) {
 		PHPUnit_Framework_Assert::assertTrue($this->userExists($user));
@@ -50,6 +84,8 @@ trait Provisioning {
 	 * @Then /^user "([^"]*)" should not exist$/
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function userShouldNotExist($user) {
 		PHPUnit_Framework_Assert::assertFalse($this->userExists($user));
@@ -59,6 +95,8 @@ trait Provisioning {
 	 * @Then /^group "([^"]*)" should exist$/
 	 *
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function groupShouldExist($group) {
 		PHPUnit_Framework_Assert::assertTrue($this->groupExists($group));
@@ -69,6 +107,8 @@ trait Provisioning {
 	 * @Then /^group "([^"]*)" should not exist$/
 	 *
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function groupShouldNotExist($group) {
 		PHPUnit_Framework_Assert::assertFalse($this->groupExists($group));
@@ -79,6 +119,8 @@ trait Provisioning {
 	 * @Given /^user "([^"]*)" has been deleted$/
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function adminDeletesUserUsingTheAPI($user) {
 		if ($this->userExists($user)) {
@@ -92,6 +134,8 @@ trait Provisioning {
 
 	/**
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function rememberTheUser($user) {
 		if ($this->currentServer === 'LOCAL') {
@@ -103,6 +147,8 @@ trait Provisioning {
 
 	/**
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function createTheUserUsingTheAPI($user) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users";
@@ -118,19 +164,23 @@ trait Provisioning {
 							'password' => $password
 							];
 
-		$this->response = $client->send($client->createRequest("POST", $fullUrl, $options));
+		$this->response = $client->send(
+			$client->createRequest("POST", $fullUrl, $options)
+		);
 		$this->rememberTheUser($user);
 
 		//Quick hack to login once with the current user
 		$options2 = [
 			'auth' => [$user, $password],
 		];
-		$url = $fullUrl.'/'.$user;
+		$url = $fullUrl . '/' . $user;
 		$client->send($client->createRequest('GET', $url, $options2));
 	}
 
 	/**
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function createUser($user) {
 		$previous_user = $this->currentUser;
@@ -142,6 +192,8 @@ trait Provisioning {
 
 	/**
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function deleteUser($user) {
 		$previous_user = $this->currentUser;
@@ -153,6 +205,8 @@ trait Provisioning {
 
 	/**
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function createGroup($group) {
 		$previous_user = $this->currentUser;
@@ -164,6 +218,8 @@ trait Provisioning {
 
 	/**
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function deleteGroup($group) {
 		$previous_user = $this->currentUser;
@@ -175,6 +231,7 @@ trait Provisioning {
 
 	/**
 	 * @param string $user
+	 *
 	 * @return bool
 	 */
 	public function userExists($user) {
@@ -184,10 +241,10 @@ trait Provisioning {
 		$options['auth'] = $this->getAuthOptionForAdmin();
 		try {
 			$this->response = $client->get($fullUrl, $options);
-			return True;
+			return true;
 		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
-			return False;
+			return false;
 		}
 	}
 
@@ -196,6 +253,8 @@ trait Provisioning {
 	 *
 	 * @param string $user
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function userShouldBelongToGroup($user, $group) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
@@ -207,7 +266,9 @@ trait Provisioning {
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
 		sort($respondedArray);
 		PHPUnit_Framework_Assert::assertContains($group, $respondedArray);
-		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->response->getStatusCode()
+		);
 	}
 
 	/**
@@ -215,6 +276,8 @@ trait Provisioning {
 	 *
 	 * @param string $user
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function userShouldNotBelongToGroup($user, $group) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
@@ -226,12 +289,15 @@ trait Provisioning {
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
 		sort($respondedArray);
 		PHPUnit_Framework_Assert::assertNotContains($group, $respondedArray);
-		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->response->getStatusCode()
+		);
 	}
 
 	/**
 	 * @param string $user
 	 * @param string $group
+	 *
 	 * @return bool
 	 */
 	public function userBelongsToGroup($user, $group) {
@@ -246,9 +312,9 @@ trait Provisioning {
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
 
 		if (in_array($group, $respondedArray)) {
-			return True;
+			return true;
 		} else {
-			return False;
+			return false;
 		}
 	}
 
@@ -258,6 +324,8 @@ trait Provisioning {
 	 *
 	 * @param string $user
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function adminAddsUserToGroupUsingTheAPI($user, $group) {
 		$previous_user = $this->currentUser;
@@ -273,6 +341,8 @@ trait Provisioning {
 
 	/**
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function rememberTheGroup($group) {
 		if ($this->currentServer === 'LOCAL') {
@@ -287,6 +357,8 @@ trait Provisioning {
 	 * @Given /^group "([^"]*)" has been created$/
 	 *
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function adminCreatesGroupUsingTheAPI($group) {
 		if (!$this->groupExists($group)) {
@@ -300,6 +372,8 @@ trait Provisioning {
 
 	/**
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function createTheGroup($group) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/groups";
@@ -313,7 +387,9 @@ trait Provisioning {
 			'groupid' => $group,
 		];
 
-		$this->response = $client->send($client->createRequest("POST", $fullUrl, $options));
+		$this->response = $client->send(
+			$client->createRequest("POST", $fullUrl, $options)
+		);
 		$this->rememberTheGroup($group);
 	}
 
@@ -322,6 +398,8 @@ trait Provisioning {
 	 * @Given /^user "([^"]*)" has been disabled$/
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function adminDisablesUserUsingTheAPI($user) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/disable";
@@ -329,11 +407,15 @@ trait Provisioning {
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
 
-		$this->response = $client->send($client->createRequest("PUT", $fullUrl, $options));
+		$this->response = $client->send(
+			$client->createRequest("PUT", $fullUrl, $options)
+		);
 	}
 
 	/**
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function deleteTheUserUsingTheAPI($user) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
@@ -343,7 +425,9 @@ trait Provisioning {
 			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
-		$this->response = $client->send($client->createRequest("DELETE", $fullUrl, $options));
+		$this->response = $client->send(
+			$client->createRequest("DELETE", $fullUrl, $options)
+		);
 	}
 
 	/**
@@ -351,6 +435,8 @@ trait Provisioning {
 	 * @Given /^group "([^"]*)" has been deleted$/
 	 *
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function adminDeletesGroupUsingTheAPI($group) {
 		if ($this->groupExists($group)) {
@@ -364,6 +450,8 @@ trait Provisioning {
 
 	/**
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function deleteTheGroupUsingTheAPI($group) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/groups/$group";
@@ -373,12 +461,16 @@ trait Provisioning {
 			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
-		$this->response = $client->send($client->createRequest("DELETE", $fullUrl, $options));
+		$this->response = $client->send(
+			$client->createRequest("DELETE", $fullUrl, $options)
+		);
 	}
 
 	/**
 	 * @param string $user
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function addUserToGroupUsingTheAPI($user, $group) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/groups";
@@ -392,11 +484,14 @@ trait Provisioning {
 							'groupid' => $group,
 							];
 
-		$this->response = $client->send($client->createRequest("POST", $fullUrl, $options));
+		$this->response = $client->send(
+			$client->createRequest("POST", $fullUrl, $options)
+		);
 	}
 
 	/**
 	 * @param string $group
+	 *
 	 * @return bool
 	 */
 	public function groupExists($group) {
@@ -406,10 +501,10 @@ trait Provisioning {
 		$options['auth'] = $this->getAuthOptionForAdmin();
 		try {
 			$this->response = $client->get($fullUrl, $options);
-			return True;
+			return true;
 		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
-			return False;
+			return false;
 		}
 	}
 
@@ -418,6 +513,8 @@ trait Provisioning {
 	 *
 	 * @param string $user
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function userShouldBeSubadminOfGroup($user, $group) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group/subadmins";
@@ -431,7 +528,9 @@ trait Provisioning {
 		$respondedArray = $this->getArrayOfSubadminsResponded($this->response);
 		sort($respondedArray);
 		PHPUnit_Framework_Assert::assertContains($user, $respondedArray);
-		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->response->getStatusCode()
+		);
 	}
 
 	/**
@@ -440,6 +539,8 @@ trait Provisioning {
 	 *
 	 * @param string $user
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function adminMakesUserSubadminOfGroupUsingTheAPI($user, $group) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/subadmins";
@@ -449,8 +550,12 @@ trait Provisioning {
 		$options['body'] = [
 							'groupid' => $group
 							];
-		$this->response = $client->send($client->createRequest("POST", $fullUrl, $options));
-		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+		$this->response = $client->send(
+			$client->createRequest("POST", $fullUrl, $options)
+		);
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->response->getStatusCode()
+		);
 	}
 
 	/**
@@ -459,6 +564,8 @@ trait Provisioning {
 	 *
 	 * @param string $user
 	 * @param string $group
+	 *
+	 * @return void
 	 */
 	public function adminMakesUserNotSubadminOfGroupUsingTheAPI($user, $group) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group/subadmins";
@@ -472,20 +579,26 @@ trait Provisioning {
 		$respondedArray = $this->getArrayOfSubadminsResponded($this->response);
 		sort($respondedArray);
 		PHPUnit_Framework_Assert::assertNotContains($user, $respondedArray);
-		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->response->getStatusCode()
+		);
 	}
 
 	/**
 	 * @Then /^the users returned by the API should be$/
 	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $usersList
+	 *
+	 * @return void
 	 */
 	public function theUsersShouldBe($usersList) {
 		if ($usersList instanceof \Behat\Gherkin\Node\TableNode) {
 			$users = $usersList->getRows();
 			$usersSimplified = $this->simplifyArray($users);
 			$respondedArray = $this->getArrayOfUsersResponded($this->response);
-			PHPUnit_Framework_Assert::assertEquals($usersSimplified, $respondedArray, "", 0.0, 10, true);
+			PHPUnit_Framework_Assert::assertEquals(
+				$usersSimplified, $respondedArray, "", 0.0, 10, true
+			);
 		}
 
 	}
@@ -494,31 +607,41 @@ trait Provisioning {
 	 * @Then /^the groups returned by the API should be$/
 	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $groupsList
+	 *
+	 * @return void
 	 */
 	public function theGroupsShouldBe($groupsList) {
 		if ($groupsList instanceof \Behat\Gherkin\Node\TableNode) {
 			$groups = $groupsList->getRows();
 			$groupsSimplified = $this->simplifyArray($groups);
 			$respondedArray = $this->getArrayOfGroupsResponded($this->response);
-			PHPUnit_Framework_Assert::assertEquals($groupsSimplified, $respondedArray, "", 0.0, 10, true);
+			PHPUnit_Framework_Assert::assertEquals(
+				$groupsSimplified, $respondedArray, "", 0.0, 10, true
+			);
 		}
 
 	}
 
 	/**
 	 * @param \Behat\Gherkin\Node\TableNode|null $groupsOrUsersList
+	 *
+	 * @return void
 	 */
 	public function checkSubadminGroupsOrUsersTable($groupsOrUsersList) {
 		$tableRows = $groupsOrUsersList->getRows();
 		$simplifiedTableRows = $this->simplifyArray($tableRows);
 		$respondedArray = $this->getArrayOfSubadminsResponded($this->response);
-		PHPUnit_Framework_Assert::assertEquals($simplifiedTableRows, $respondedArray, "", 0.0, 10, true);
+		PHPUnit_Framework_Assert::assertEquals(
+			$simplifiedTableRows, $respondedArray, "", 0.0, 10, true
+		);
 	}
 
 	/**
 	 * @Then /^the subadmin groups returned by the API should be$/
 	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $groupsList
+	 *
+	 * @return void
 	 */
 	public function theSubadminGroupsShouldBe($groupsList) {
 		$this->checkSubadminGroupsOrUsersTable($groupsList);
@@ -528,6 +651,8 @@ trait Provisioning {
 	 * @Then /^the subadmin users returned by the API should be$/
 	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $usersList
+	 *
+	 * @return void
 	 */
 	public function theSubadminUsersShouldBe($usersList) {
 		$this->checkSubadminGroupsOrUsersTable($usersList);
@@ -537,6 +662,8 @@ trait Provisioning {
 	 * @Then /^the apps returned by the API should include$/
 	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $appList
+	 *
+	 * @return void
 	 */
 	public function theAppsShouldInclude($appList) {
 		$apps = $appList->getRows();
@@ -551,6 +678,7 @@ trait Provisioning {
 	 * Parses the xml answer to get the array of users returned.
 	 *
 	 * @param ResponseInterface $resp
+	 *
 	 * @return array
 	 */
 	public function getArrayOfUsersResponded($resp) {
@@ -563,6 +691,7 @@ trait Provisioning {
 	 * Parses the xml answer to get the array of groups returned.
 	 *
 	 * @param ResponseInterface $resp
+	 *
 	 * @return array
 	 */
 	public function getArrayOfGroupsResponded($resp) {
@@ -575,6 +704,7 @@ trait Provisioning {
 	 * Parses the xml answer to get the array of apps returned.
 	 *
 	 * @param ResponseInterface $resp
+	 *
 	 * @return array
 	 */
 	public function getArrayOfAppsResponded($resp) {
@@ -587,6 +717,7 @@ trait Provisioning {
 	 * Parses the xml answer to get the array of subadmins returned.
 	 *
 	 * @param ResponseInterface $resp
+	 *
 	 * @return array
 	 */
 	public function getArrayOfSubadminsResponded($resp) {
@@ -599,6 +730,8 @@ trait Provisioning {
 	 * @Then /^app "([^"]*)" should be disabled$/
 	 *
 	 * @param string $app
+	 *
+	 * @return void
 	 */
 	public function appShouldBeDisabled($app) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/apps?filter=disabled";
@@ -611,13 +744,17 @@ trait Provisioning {
 		$this->response = $client->get($fullUrl, $options);
 		$respondedArray = $this->getArrayOfAppsResponded($this->response);
 		PHPUnit_Framework_Assert::assertContains($app, $respondedArray);
-		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->response->getStatusCode()
+		);
 	}
 
 	/**
 	 * @Then /^app "([^"]*)" should be enabled$/
 	 *
 	 * @param string $app
+	 *
+	 * @return void
 	 */
 	public function appShouldBeEnabled($app) {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/apps?filter=enabled";
@@ -630,13 +767,17 @@ trait Provisioning {
 		$this->response = $client->get($fullUrl, $options);
 		$respondedArray = $this->getArrayOfAppsResponded($this->response);
 		PHPUnit_Framework_Assert::assertContains($app, $respondedArray);
-		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->response->getStatusCode()
+		);
 	}
 
 	/**
 	 * @Then /^user "([^"]*)" should be disabled$/
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function userShouldBeDisabled($user) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
@@ -645,13 +786,17 @@ trait Provisioning {
 		$options['auth'] = $this->getAuthOptionForAdmin();
 
 		$this->response = $client->get($fullUrl, $options);
-		PHPUnit_Framework_Assert::assertEquals("false", $this->response->xml()->data[0]->enabled);
+		PHPUnit_Framework_Assert::assertEquals(
+			"false", $this->response->xml()->data[0]->enabled
+		);
 	}
 
 	/**
 	 * @Then /^user "([^"]*)" should be enabled$/
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function useShouldBeEnabled($user) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
@@ -660,7 +805,9 @@ trait Provisioning {
 		$options['auth'] = $this->getAuthOptionForAdmin();
 
 		$this->response = $client->get($fullUrl, $options);
-		PHPUnit_Framework_Assert::assertEquals("true", $this->response->xml()->data[0]->enabled);
+		PHPUnit_Framework_Assert::assertEquals(
+			"true", $this->response->xml()->data[0]->enabled
+		);
 	}
 
 	/**
@@ -669,20 +816,25 @@ trait Provisioning {
 	 *
 	 * @param string $user
 	 * @param string $quota
+	 *
+	 * @return void
 	 */
-	public function adminSetsUserQuotaToUsingTheAPI($user, $quota)
-	{
-		$body = new \Behat\Gherkin\Node\TableNode([
+	public function adminSetsUserQuotaToUsingTheAPI($user, $quota) {
+		$body = new \Behat\Gherkin\Node\TableNode(
+			[
 			0 => ['key', 'quota'],
 			1 => ['value', $quota],
-		]);
+			]
+		);
 
 		$previous_user = $this->currentUser;
 		$this->currentUser = "admin";
 		// method used from BasicStructure trait
 		$this->sendingToWith("PUT", "/cloud/users/" . $user, $body);
 		$this->currentUser = $previous_user;
-		PHPUnit_Framework_Assert::assertEquals(200, $this->response->getStatusCode());
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->response->getStatusCode()
+		);
 	}
 
 	/**
@@ -690,9 +842,10 @@ trait Provisioning {
 	 * @Given user :user has been given unlimited quota
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
-	public function adminGivesUnlimitedQuotaToUserUsingTheAPI($user)
-	{
+	public function adminGivesUnlimitedQuotaToUserUsingTheAPI($user) {
 		$this->adminSetsUserQuotaToUsingTheAPI($user, 'none');
 	}
 
@@ -700,6 +853,8 @@ trait Provisioning {
 	 * Returns home path of the given user
 	 *
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function getUserHome($user) {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
@@ -714,13 +869,17 @@ trait Provisioning {
 	 * @Then /^the user attributes returned by the API should include$/
 	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 *
+	 * @return void
 	 */
 	public function checkUserAttributes($body) {
 		$data = $this->response->xml()->data[0];
 		$fd = $body->getRowsHash();
 		foreach ($fd as $field => $value) {
 			if ($data->$field != $value) {
-				PHPUnit_Framework_Assert::fail("$field" . " has value " . "$data->$field");
+				PHPUnit_Framework_Assert::fail(
+					"$field" . " has value " . "$data->$field"
+				);
 			}
 		}
 	}
@@ -728,9 +887,10 @@ trait Provisioning {
 	/**
 	 * @BeforeScenario
 	 * @AfterScenario
+	 *
+	 * @return void
 	 */
-	public function cleanupUsers()
-	{
+	public function cleanupUsers() {
 		$previousServer = $this->currentServer;
 		$this->usingServer('LOCAL');
 		foreach ($this->createdUsers as $user) {
@@ -746,9 +906,10 @@ trait Provisioning {
 	/**
 	 * @BeforeScenario
 	 * @AfterScenario
+	 *
+	 * @return void
 	 */
-	public function cleanupGroups()
-	{
+	public function cleanupGroups() {
 		$previousServer = $this->currentServer;
 		$this->usingServer('LOCAL');
 		foreach ($this->createdGroups as $group) {

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -38,6 +38,7 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 	 * @When /^the user gets the sharees using the API with parameters$/
 	 *
 	 * @param \Behat\Gherkin\Node\TableNode $body
+	 *
 	 * @return void
 	 */
 	public function theUserGetsTheShareesWithParameters($body) {
@@ -49,6 +50,7 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 	 *
 	 * @param string $user
 	 * @param \Behat\Gherkin\Node\TableNode $body
+	 *
 	 * @return void
 	 */
 	public function userGetsTheShareesWithParameters($user, $body) {
@@ -73,6 +75,7 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 	 *
 	 * @param string $shareeType
 	 * @param \Behat\Gherkin\Node\TableNode $shareesList
+	 *
 	 * @return void
 	 */
 	public function theShareesReturnedShouldBe($shareeType, $shareesList) {
@@ -87,6 +90,7 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 	 * @Then /^the "([^"]*)" sharees returned should be empty$/
 	 *
 	 * @param string $shareeType
+	 *
 	 * @return void
 	 */
 	public function theShareesReturnedShouldBeEmpty($shareeType) {
@@ -99,6 +103,7 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 	/**
 	 * @param ResponseInterface $response
 	 * @param string $shareeType
+	 *
 	 * @return array
 	 */
 	public function getArrayOfShareesResponded(
@@ -114,7 +119,8 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 		$sharees = [];
 		foreach ($elements[$shareeType] as $element) {
 			if (is_int(key($element))) {
-				// this is a list of elements instead of just one item, so return the list
+				// this is a list of elements instead of just one item,
+				// so return the list
 				foreach ($element as $innerItem) {
 					$sharees[] = [
 						$innerItem['label'],
@@ -142,7 +148,10 @@ class ShareesContext implements Context, SnippetAcceptingContext {
 		$this->savedCapabilitiesXml = $this->getCapabilitiesXml();
 		// Set the required starting values for testing
 		$capabilitiesArray = $this->getCommonSharingConfigs();
-		$capabilitiesArray = array_merge($capabilitiesArray, $this->getCommonFederationConfigs());
+		$capabilitiesArray = array_merge(
+			$capabilitiesArray,
+			$this->getCommonFederationConfigs()
+		);
 		$this->setCapabilities($capabilitiesArray);
 	}
 }

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -59,6 +59,7 @@ trait Sharing {
 	 *
 	 * @param string $user
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 *
 	 * @return void
 	 */
 	public function userCreatesAShareWithSettings($user, $body) {
@@ -91,6 +92,7 @@ trait Sharing {
 	 * @When /^the user creates a share using the API with settings$/
 	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 *
 	 * @return void
 	 */
 	public function theUserCreatesAShareWithSettings($body) {
@@ -101,6 +103,7 @@ trait Sharing {
 	 * @Given /^the user has created a share with settings$/
 	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 *
 	 * @return void
 	 */
 	public function theUserHasCreatedAShareWithSettings($body) {
@@ -115,6 +118,7 @@ trait Sharing {
 	 * @param boolean $publicUpload
 	 * @param string|null $sharePassword
 	 * @param string|int|string[]|int[]|null $permissions
+	 *
 	 * @return void
 	 */
 	public function createAPublicShare(
@@ -145,6 +149,7 @@ trait Sharing {
 	 *
 	 * @param string $user
 	 * @param string $path
+	 *
 	 * @return void
 	 */
 	public function userCreatesAPublicShareOf($user, $path) {
@@ -169,9 +174,12 @@ trait Sharing {
 	 * @param string $user
 	 * @param string $path
 	 * @param string|int|string[]|int[]|null $permissions
+	 *
 	 * @return void
 	 */
-	public function userCreatesAPublicShareOfWithPermission($user, $path, $permissions) {
+	public function userCreatesAPublicShareOfWithPermission(
+		$user, $path, $permissions
+	) {
 		$this->createAPublicShare($user, $path, true, null, $permissions);
 	}
 
@@ -181,16 +189,20 @@ trait Sharing {
 	 *
 	 * @param string $path
 	 * @param string|int|string[]|int[]|null $permissions
+	 *
 	 * @return void
 	 */
 	public function aPublicShareOfIsCreatedWithPermission($path, $permissions) {
-		$this->createAPublicShare($this->currentUser, $path, true, null, $permissions);
+		$this->createAPublicShare(
+			$this->currentUser, $path, true, null, $permissions
+		);
 	}
 
 	/**
 	 * @Then /^the public shared file "([^"]*)" should not be able to be downloaded$/
 	 *
 	 * @param string $path
+	 *
 	 * @return void
 	 */
 	public function publicSharedFileCannotBeDownloaded($path) {
@@ -232,8 +244,8 @@ trait Sharing {
 	/**
 	 * @Then /^the last public shared file should be able to be downloaded with password "([^"]*)"$/
 	 *
-	 * @param string $filename unused
 	 * @param string $password
+	 *
 	 * @return void
 	 */
 	public function checkLastPublicSharedFileWithPasswordDownload($password) {
@@ -246,6 +258,7 @@ trait Sharing {
 	 * @param string $url
 	 * @param string $auth
 	 * @param string $mimeType
+	 *
 	 * @return void
 	 */
 	private function checkDownload($url, $auth = null, $mimeType = null) {
@@ -284,6 +297,7 @@ trait Sharing {
 	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
+	 *
 	 * @return void
 	 */
 	public function publiclyUploadingContent($filename, $body = 'test') {
@@ -296,6 +310,7 @@ trait Sharing {
 	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
+	 *
 	 * @return void
 	 */
 	public function publiclyOverwritingContent($filename, $body = 'test') {
@@ -309,6 +324,7 @@ trait Sharing {
 	 * @param string $filename target file name
 	 * @param string $password
 	 * @param string $body content to upload
+	 *
 	 * @return void
 	 */
 	public function publiclyUploadingContentWithPassword(
@@ -323,6 +339,7 @@ trait Sharing {
 	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
+	 *
 	 * @return void
 	 */
 	public function publiclyUploadingContentAutorename($filename, $body = 'test') {
@@ -352,6 +369,7 @@ trait Sharing {
 	 * @param string $body
 	 * @param bool $autorename
 	 * @param bool $overwriting the upload is expected to overwrite an existing file
+	 *
 	 * @return void
 	 */
 	private function publicUploadContent(
@@ -411,6 +429,7 @@ trait Sharing {
 	 * @Given /^the user has updated the last share with$/
 	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 *
 	 * @return void
 	 */
 	public function theUserUpdatesTheLastShareWith($body) {
@@ -423,6 +442,7 @@ trait Sharing {
 	 *
 	 * @param string $user
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 *
 	 * @return void
 	 */
 	public function userUpdatesTheLastShareWith($user, $body) {
@@ -464,6 +484,7 @@ trait Sharing {
 	 * @param string $password
 	 * @param int $permissions
 	 * @param string $linkName
+	 *
 	 * @return void
 	 */
 	public function createShare(
@@ -501,6 +522,7 @@ trait Sharing {
 	/**
 	 * @param string $field
 	 * @param string $contentExpected
+	 *
 	 * @return bool
 	 */
 	public function isFieldInResponse($field, $contentExpected) {
@@ -515,7 +537,9 @@ trait Sharing {
 				} elseif ($contentExpected == "A_NUMBER") {
 					return is_numeric((string)$element->$field);
 				} elseif ($contentExpected == "AN_URL") {
-					return $this->isExpectedUrl((string)$element->$field, "index.php/s/");
+					return $this->isExpectedUrl(
+						(string)$element->$field, "index.php/s/"
+					);
 				} elseif ((string)$element->$field == $contentExpected) {
 					return true;
 				} else {
@@ -545,6 +569,7 @@ trait Sharing {
 	 * @Then /^file "([^"]*)" should be included in the response$/
 	 *
 	 * @param string $filename
+	 *
 	 * @return void
 	 */
 	public function checkSharedFileInResponse($filename) {
@@ -559,6 +584,7 @@ trait Sharing {
 	 * @Then /^file "([^"]*)" should not be included in the response$/
 	 *
 	 * @param string $filename
+	 *
 	 * @return void
 	 */
 	public function checkSharedFileNotInResponse($filename) {
@@ -573,6 +599,7 @@ trait Sharing {
 	 * @Then /^file "([^"]*)" should be included as path in the response$/
 	 *
 	 * @param string $filename
+	 *
 	 * @return void
 	 */
 	public function checkSharedFileAsPathInResponse($filename) {
@@ -587,6 +614,7 @@ trait Sharing {
 	 * @Then /^file "([^"]*)" should not be included as path in the response$/
 	 *
 	 * @param string $filename
+	 *
 	 * @return void
 	 */
 	public function checkSharedFileAsPathNotInResponse($filename) {
@@ -601,6 +629,7 @@ trait Sharing {
 	 * @Then /^user "([^"]*)" should be included in the response$/
 	 *
 	 * @param string $user
+	 *
 	 * @return void
 	 */
 	public function checkSharedUserInResponse($user) {
@@ -614,6 +643,7 @@ trait Sharing {
 	 * @Then /^user "([^"]*)" should not be included in the response$/
 	 *
 	 * @param string $user
+	 *
 	 * @return void
 	 */
 	public function checkSharedUserNotInResponse($user) {
@@ -626,12 +656,15 @@ trait Sharing {
 	/**
 	 * @param string $userOrGroup
 	 * @param int $permissions
+	 *
 	 * @return bool
 	 */
 	public function isUserOrGroupInSharedData($userOrGroup, $permissions = null) {
 		$data = $this->response->xml()->data[0];
 		foreach ($data as $element) {
-			if ($element->share_with == $userOrGroup && ($permissions === null || $permissions == $element->permissions)) {
+			if ($element->share_with == $userOrGroup
+				&& ($permissions === null || $permissions == $element->permissions)
+			) {
 				return true;
 			}
 		}
@@ -648,6 +681,7 @@ trait Sharing {
 	 * @param string $user2
 	 * @param null $withPerms unused
 	 * @param int $permissions
+	 *
 	 * @return void
 	 */
 	public function userSharesFileWithUserUsingTheAPI(
@@ -689,6 +723,7 @@ trait Sharing {
 	 * @param string $group
 	 * @param null $withPerms unused
 	 * @param int $permissions
+	 *
 	 * @return void
 	 */
 	public function theUserSharesFileWithGroupUsingTheAPI(
@@ -709,6 +744,7 @@ trait Sharing {
 	 * @param string $group
 	 * @param null $withPerms unused
 	 * @param int $permissions
+	 *
 	 * @return void
 	 */
 	public function userSharesFileWithGroupUsingTheAPI(
@@ -748,6 +784,7 @@ trait Sharing {
 	 * @Given /^user "([^"]*)" has deleted the last share$/
 	 *
 	 * @param string $user
+	 *
 	 * @return void
 	 */
 	public function userDeletesLastShareUsingTheAPI($user) {
@@ -769,6 +806,7 @@ trait Sharing {
 	 * @When /^user "([^"]*)" gets the info of the last share using the API$/
 	 *
 	 * @param string $user
+	 *
 	 * @return void
 	 */
 	public function userGetsInfoOfLastShareUsingTheAPI($user) {
@@ -809,6 +847,7 @@ trait Sharing {
 	 * @Then /^the response should contain ([0-9]+) entries$/
 	 *
 	 * @param int $count
+	 *
 	 * @return void
 	 */
 	public function checkingTheResponseEntriesCount($count) {
@@ -820,6 +859,7 @@ trait Sharing {
 	 * @Then /^the share fields of the last share should include$/
 	 *
 	 * @param \Behat\Gherkin\Node\TableNode|null $body
+	 *
 	 * @return void
 	 */
 	public function checkShareFields($body) {
@@ -865,6 +905,7 @@ trait Sharing {
 	 *
 	 * @param string $user
 	 * @param string $fileName
+	 *
 	 * @throws Exception
 	 * @return void
 	 */
@@ -899,7 +940,9 @@ trait Sharing {
 		}
 
 		if ($deleted === false) {
-			throw new \Exception("Could not delete shares for user $user file $fileName");
+			throw new \Exception(
+				"Could not delete shares for user $user file $fileName"
+			);
 		}
 	}
 
@@ -928,6 +971,7 @@ trait Sharing {
 	 *
 	 * @param string $user
 	 * @param string $path
+	 *
 	 * @return array
 	 */
 	public function getShares($user, $path) {
@@ -951,6 +995,7 @@ trait Sharing {
 	 * @param string $type
 	 * @param string $path
 	 * @param \Behat\Gherkin\Node\TableNode|null $TableNode
+	 *
 	 * @return int|void
 	 */
 	public function checkPublicShares($user, $type, $path, $TableNode) {
@@ -994,6 +1039,7 @@ trait Sharing {
 	 * @param string $user
 	 * @param string $path to share
 	 * @param string $name of share
+	 *
 	 * @return int|null
 	 */
 	public function getPublicShareIDByName($user, $path, $name) {
@@ -1014,9 +1060,12 @@ trait Sharing {
 	 * @param string $name
 	 * @param string $type unused
 	 * @param string $path
+	 *
 	 * @return void
 	 */
-	public function userDeletesPublicShareNamedUsingTheAPI($user, $name, $type, $path) {
+	public function userDeletesPublicShareNamedUsingTheAPI(
+		$user, $name, $type, $path
+	) {
 		$share_id = $this->getPublicShareIDByName($user, $path, $name);
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
 		$this->sendingToWith("DELETE", $url, null);

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -24,11 +24,17 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Message\ResponseInterface;
 use TestHelpers\TagsHelper;
 
+/**
+ * Tags functions
+ */
 trait Tags {
 
-	/** @var array */
+	/**
+	 * @var array 
+	 */
 	private $createdTags = array();
 
 	/**
@@ -37,8 +43,12 @@ trait Tags {
 	 * @param bool $userAssignable
 	 * @param string $name
 	 * @param string $groups
+	 *
+	 * @return void
 	 */
-	private function createTag($user, $userVisible, $userAssignable, $name, $groups = null) {
+	private function createTag(
+		$user, $userVisible, $userAssignable, $name, $groups = null
+	) {
 		try {
 			$createdTag = TagsHelper::createTag(
 				$this->baseUrlWithoutOCSAppendix(),
@@ -58,15 +68,20 @@ trait Tags {
 	/**
 	 * @param array $tagData
 	 * @param string $type
+	 *
+	 * @return void
 	 */
 	private function assertTypeOfTag($tagData, $type) {
 		$userAttributes = TagsHelper::validateTypeOfTag($type);
 		$tagDisplayName = $tagData['{http://owncloud.org/ns}display-name'];
 		$userVisible = ($userAttributes[0]) ? 'true' : 'false';
 		$userAssignable = ($userAttributes[1]) ? 'true' : 'false';
-		if (($tagData['{http://owncloud.org/ns}user-visible'] !== $userVisible) ||
-			($tagData['{http://owncloud.org/ns}user-assignable'] !== $userAssignable)) {
-				PHPUnit_Framework_Assert::fail("tag $tagDisplayName is not of type $type");
+		if (($tagData['{http://owncloud.org/ns}user-visible'] !== $userVisible) 
+			|| ($tagData['{http://owncloud.org/ns}user-assignable'] !== $userAssignable)
+		) {
+				PHPUnit_Framework_Assert::fail(
+					"tag $tagDisplayName is not of type $type"
+				);
 		}
 	}
 
@@ -77,10 +92,17 @@ trait Tags {
 	 * @param string $user
 	 * @param string $type
 	 * @param string $name
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function createsATagWithName($user, $type, $name) {
-		$this->createTag($user, TagsHelper::validateTypeOfTag($type)[0], TagsHelper::validateTypeOfTag($type)[1], $name);
+		$this->createTag(
+			$user,
+			TagsHelper::validateTypeOfTag($type)[0],
+			TagsHelper::validateTypeOfTag($type)[1],
+			$name
+		);
 	}
 
 	/**
@@ -91,15 +113,24 @@ trait Tags {
 	 * @param string $type
 	 * @param string $name
 	 * @param string $groups
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function createsATagWithNameAndGroups($user, $type, $name, $groups) {
-		$this->createTag($user, TagsHelper::validateTypeOfTag($type)[0], TagsHelper::validateTypeOfTag($type)[1], $name, $groups);
+		$this->createTag(
+			$user,
+			TagsHelper::validateTypeOfTag($type)[0],
+			TagsHelper::validateTypeOfTag($type)[1],
+			$name,
+			$groups
+		);
 	}
 
 	/**
 	 * @param string $user
 	 * @param bool $withGroups
+	 *
 	 * @return array
 	 */
 	public function requestTagsForUser($user, $withGroups = false) {
@@ -116,12 +147,17 @@ trait Tags {
 	 * @param string $user
 	 * @param string $tagDisplayName
 	 * @param bool $withGroups
+	 *
 	 * @return array|null
 	 */
-	public function requestTagByDisplayName($user, $tagDisplayName, $withGroups = false) {
+	public function requestTagByDisplayName(
+		$user, $tagDisplayName, $withGroups = false
+	) {
 		$tagList = $this->requestTagsForUser($user, $withGroups);
 		foreach ($tagList as $path => $tagData) {
-			if (!empty($tagData) && $tagData['{http://owncloud.org/ns}display-name'] === $tagDisplayName) {
+			if (!empty($tagData)
+				&& $tagData['{http://owncloud.org/ns}display-name'] === $tagDisplayName
+			) {
 				return $tagData;
 			}
 		}
@@ -133,13 +169,17 @@ trait Tags {
 	 *
 	 * @param string $user
 	 * @param TableNode $table
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function theFollowingTagsShouldExistFor($user, TableNode $table) {
 		foreach ($table->getRowsHash() as $rowDisplayName => $rowType) {
 			$tagData = $this->requestTagByDisplayName($user, $rowDisplayName);
 			if (is_null($tagData)) {
-				PHPUnit_Framework_Assert::fail("tag $rowDisplayName is not in propfind answer");
+				PHPUnit_Framework_Assert::fail(
+					"tag $rowDisplayName is not in propfind answer"
+				);
 			} else {
 				$this->assertTypeOfTag($tagData, $rowType);
 			}
@@ -151,10 +191,14 @@ trait Tags {
 	 *
 	 * @param string $tagDisplayName
 	 * @param string $user
+	 *
+	 * @return void
 	 */
 	public function tagShouldNotExistForUser($tagDisplayName, $user) {
 		$tagData = $this->requestTagByDisplayName($user, $tagDisplayName);
-		PHPUnit_Framework_Assert::assertNull($tagData, "tag $tagDisplayName is in propfind answer");
+		PHPUnit_Framework_Assert::assertNull(
+			$tagData, "tag $tagDisplayName is in propfind answer"
+		);
 	}
 
 	/**
@@ -164,9 +208,13 @@ trait Tags {
 	 * @param string $shouldOrNot should or should not
 	 * @param string $type
 	 * @param string $tagDisplayName
+	 *
+	 * @return void
 	 * @throws Exception
 	 */
-	public function theUserCanAssignTheTag($user, $shouldOrNot, $type, $tagDisplayName) {
+	public function theUserCanAssignTheTag(
+		$user, $shouldOrNot, $type, $tagDisplayName
+	) {
 		$tagData = $this->requestTagByDisplayName($user, $tagDisplayName);
 		$this->assertTypeOfTag($tagData, $type);
 		if ($shouldOrNot === 'should') {
@@ -174,7 +222,9 @@ trait Tags {
 		} else if ($shouldOrNot === 'should not') {
 			$expected = 'false';
 		} else {
-			throw new \Exception('Invalid condition, must be "should" or "should not"');
+			throw new \Exception(
+				'Invalid condition, must be "should" or "should not"'
+			);
 		}
 		if ($tagData['{http://owncloud.org/ns}can-assign'] !== $expected) {
 			throw new \Exception('Tag cannot be assigned by user');
@@ -187,13 +237,21 @@ trait Tags {
 	 * @param string $type
 	 * @param string $tagName
 	 * @param string $groups list of groups separated by "|"
+	 *
+	 * @return void
 	 */
 	public function theTagHasGroup($type, $tagName, $groups) {
-		$tagData = $this->requestTagByDisplayName($this->getAdminUserName(), $tagName, true);
-		PHPUnit_Framework_Assert::assertNotNull($tagData, "Tag $tagName wasn't found for admin user");
+		$tagData = $this->requestTagByDisplayName(
+			$this->getAdminUserName(), $tagName, true
+		);
+		PHPUnit_Framework_Assert::assertNotNull(
+			$tagData, "Tag $tagName wasn't found for admin user"
+		);
 		$this->assertTypeOfTag($tagData, $type);
-		PHPUnit_Framework_Assert::assertEquals($tagData['{http://owncloud.org/ns}groups'], $groups,
-			'Tag has groups "' . $tagData['{http://owncloud.org/ns}groups'] . '" instead of the expected "' . $groups . '"' );
+		PHPUnit_Framework_Assert::assertEquals(
+			$tagData['{http://owncloud.org/ns}groups'], $groups,
+			'Tag has groups "' . $tagData['{http://owncloud.org/ns}groups'] . '" instead of the expected "' . $groups . '"' 
+		);
 	}
 
 	/**
@@ -201,16 +259,21 @@ trait Tags {
 	 *
 	 * @param int $count
 	 * @param string $user
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function tagsShouldExistFor($count, $user) {
 		if ((int)$count !== count($this->requestTagsForUser($user))) {
-			throw new \Exception("Expected $count tags, got ".count($this->requestTagsForUser($user)));
+			throw new \Exception(
+				"Expected $count tags, got " . count($this->requestTagsForUser($user))
+			);
 		}
 	}
 
 	/**
 	 * @param string $name
+	 *
 	 * @return int
 	 */
 	private function findTagIdByName($name) {
@@ -222,8 +285,12 @@ trait Tags {
 	 * @param string $user
 	 * @param string $tagDisplayName
 	 * @param string $properties optional
+	 *
+	 * @return ResponseInterface|null
 	 */
-	private function sendProppatchToSystemtags($user, $tagDisplayName, $properties = null) {
+	private function sendProppatchToSystemtags(
+		$user, $tagDisplayName, $properties = null
+	) {
 		$client = $this->getSabreClient($user);
 		$client->setThrowExceptions(true);
 		$appPath = '/systemtags/';
@@ -247,6 +314,8 @@ trait Tags {
 	 * @param string $user
 	 * @param string $oldName
 	 * @param string $newName
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function editTagName($user, $oldName, $newName) {
@@ -263,6 +332,8 @@ trait Tags {
 	 * @param string $user
 	 * @param string $oldName
 	 * @param string $groups
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function editTagGroups($user, $oldName, $groups) {
@@ -278,6 +349,8 @@ trait Tags {
 	 *
 	 * @param string $user
 	 * @param string $name
+	 *
+	 * @return void
 	 */
 	public function userDeletesTag($user, $name) {
 		$tagID = $this->findTagIdByName($name);
@@ -301,6 +374,8 @@ trait Tags {
 	 * @param string $tagName
 	 * @param string $fileName
 	 * @param string $fileOwner
+	 *
+	 * @return void
 	 */
 	private function tag($taggingUser, $tagName, $fileName, $fileOwner) {
 		try {
@@ -309,7 +384,7 @@ trait Tags {
 				$taggingUser, 
 				$this->getPasswordForUser($taggingUser),
 				$tagName, $fileName, $fileOwner, $this->getDavPathVersion()
-				);
+			);
 		} catch ( BadResponseException $e ) {
 			$this->response = $e->getResponse();
 		}
@@ -319,6 +394,7 @@ trait Tags {
 	 * @param string $user
 	 * @param string $fileName
 	 * @param string|null $sharingUser
+	 *
 	 * @return \Sabre\HTTP\ResponseInterface
 	 */
 	private function requestTagsForFile($user, $fileName, $sharingUser = null) {
@@ -355,8 +431,12 @@ trait Tags {
 	 * @param string $fileName
 	 * @param string $sharedOrOwnedBy unused
 	 * @param string $sharingUser
+	 *
+	 * @return void
 	 */
-	public function addsTheTagToSharedBy($taggingUser, $tagName, $fileName, $sharedOrOwnedBy, $sharingUser) {
+	public function addsTheTagToSharedBy(
+		$taggingUser, $tagName, $fileName, $sharedOrOwnedBy, $sharingUser
+	) {
 		$this->tag($taggingUser, $tagName, $fileName, $sharingUser);
 	}
 
@@ -367,9 +447,12 @@ trait Tags {
 	 * @param string $sharedOrOwnedBy unused
 	 * @param string $sharingUser
 	 * @param TableNode $table
+	 *
 	 * @return bool
 	 */
-	public function sharedByHasTheFollowingTags($fileName, $sharedOrOwnedBy, $sharingUser, TableNode $table) {
+	public function sharedByHasTheFollowingTags(
+		$fileName, $sharedOrOwnedBy, $sharingUser, TableNode $table
+	) {
 		$tagList = $this->requestTagsForFile($sharingUser, $fileName);
 		//Check if we are looking for no tags
 		if ((!is_array($tagList)) && ($table->getRowAsString(0) === '|  |')) {
@@ -379,14 +462,18 @@ trait Tags {
 		$found = false;
 		foreach ($table->getRowsHash() as $rowDisplayName => $rowType) {
 			foreach ($tagList as $path => $tagData) {
-				if (!empty($tagData) && $tagData['{http://owncloud.org/ns}display-name'] === $rowDisplayName) {
+				if (!empty($tagData)
+					&& $tagData['{http://owncloud.org/ns}display-name'] === $rowDisplayName
+				) {
 					$found = true;
 					$this->assertTypeOfTag($tagData, $rowType);
 					break;
 				}
 			}
 			if ($found === false) {
-					PHPUnit_Framework_Assert::fail("tag $rowDisplayName is not in propfind answer");
+					PHPUnit_Framework_Assert::fail(
+						"tag $rowDisplayName is not in propfind answer"
+					);
 			}
 		}
 		return $found;
@@ -399,9 +486,13 @@ trait Tags {
 	 * @param string $sharingUser unused
 	 * @param string $user
 	 * @param TableNode $table
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
-	public function sharedByHasTheFollowingTagsFor($fileName, $sharingUser, $user, TableNode $table) {
+	public function sharedByHasTheFollowingTagsFor(
+		$fileName, $sharingUser, $user, TableNode $table
+	) {
 		$this->sharedByHasTheFollowingTags($fileName, 'shared', $user, $table);
 	}
 
@@ -410,13 +501,17 @@ trait Tags {
 	 * @param string $tagName
 	 * @param string $fileName
 	 * @param string $fileOwner
+	 *
+	 * @return void
 	 */
 	private function untag($untaggingUser, $tagName, $fileName, $fileOwner) {
 		$fileID = $this->getFileIdForPath($fileOwner, $fileName);
 		$tagID = $this->findTagIdByName($tagName);
 		$path = '/systemtags-relations/files/' . $fileID . '/' . $tagID;
 		try {
-			$this->response = $this->makeDavRequest($untaggingUser,"DELETE", $path, null, null, "uploads");
+			$this->response = $this->makeDavRequest(
+				$untaggingUser, "DELETE", $path, null, null, "uploads"
+			);
 		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 		}
@@ -430,17 +525,22 @@ trait Tags {
 	 * @param string $tagName
 	 * @param string $fileName
 	 * @param string $shareUser
+	 *
+	 * @return void
 	 */
-	public function removesTheTagFromSharedBy($user, $tagName, $fileName, $shareUser) {
+	public function removesTheTagFromSharedBy(
+		$user, $tagName, $fileName, $shareUser
+	) {
 		$this->untag($user, $tagName, $fileName, $shareUser);
 	}
 
 	/**
 	 * @BeforeScenario
 	 * @AfterScenario
+	 *
+	 * @return void
 	 */
-	public function cleanupTags()
-	{
+	public function cleanupTags() {
 		foreach ($this->createdTags as $tagID) {
 			try {
 				$this->response = TagsHelper::deleteTag(
@@ -448,7 +548,8 @@ trait Tags {
 					$this->getAdminUserName(),
 					$this->getAdminPassword(),
 					$tagID,
-					2);
+					2
+				);
 			} catch (BadResponseException  $e) {
 				$this->response = $e->getResponse();
 			}

--- a/tests/acceptance/features/bootstrap/Trashbin.php
+++ b/tests/acceptance/features/bootstrap/Trashbin.php
@@ -31,10 +31,16 @@ trait Trashbin {
 	 * @Given user :user has emptied the trashbin
 	 *
 	 * @param string $user user
+	 *
+	 * @return void
 	 */
 	public function emptyTrashbin($user) {
-		$body = new \Behat\Gherkin\Node\TableNode([['allfiles', 'true'], ['dir', '%2F']]);
-		$this->sendingToWithDirectUrl($user, 'POST', "/index.php/apps/files_trashbin/ajax/delete.php", $body);
+		$body = new \Behat\Gherkin\Node\TableNode(
+			[['allfiles', 'true'], ['dir', '%2F']]
+		);
+		$this->sendingToWithDirectUrl(
+			$user, 'POST', "/index.php/apps/files_trashbin/ajax/delete.php", $body
+		);
 		$this->theHTTPStatusCodeShouldBe('200');
 	}
 
@@ -43,11 +49,17 @@ trait Trashbin {
 	 *
 	 * @param string $user user
 	 * @param string $path path
+	 *
 	 * @return array response
 	 */
 	public function listTrashbinFolder($user, $path) {
 		$params = '?dir=' . rawurlencode('/' . trim($path, '/'));
-		$this->sendingToWithDirectUrl($user, 'GET', '/index.php/apps/files_trashbin/ajax/list.php' . $params, null);
+		$this->sendingToWithDirectUrl(
+			$user,
+			'GET',
+			'/index.php/apps/files_trashbin/ajax/list.php' . $params,
+			null
+		);
 		$this->theHTTPStatusCodeShouldBe('200');
 
 
@@ -62,6 +74,8 @@ trait Trashbin {
 	 * @param string $user
 	 * @param string $entryText unused
 	 * @param string $path
+	 *
+	 * @return void
 	 */
 	public function asTheFileOrFolderExistsInTrash($user, $entryText, $path) {
 		$path = trim($path, '/');
@@ -103,6 +117,7 @@ trait Trashbin {
 	 *
 	 * @param string $user
 	 * @param string $originalPath
+	 *
 	 * @return bool
 	 */
 	private function isInTrash($user, $originalPath) {
@@ -111,7 +126,7 @@ trait Trashbin {
 
 		$found = false;
 		foreach ($listing as $entry) {
-			if ( substr($entry['extraData'], 0, 2) === "./" ) {
+			if (substr($entry['extraData'], 0, 2) === "./" ) {
 				$entry['extraData'] = substr($entry['extraData'], 2);
 			}
 			if ($entry['extraData'] === $originalPath) {
@@ -125,27 +140,38 @@ trait Trashbin {
 	/**
 	 * @param string $user
 	 * @param string $elementTrashID
+	 *
+	 * @return void
 	 */
 	private function sendUndeleteRequest($user, $elementTrashID) {
-		$body = new \Behat\Gherkin\Node\TableNode([['files',  "[\"$elementTrashID\"]"], ['dir', '/']]);
-		$this->sendingToWithDirectUrl($user, 'POST', "/index.php/apps/files_trashbin/ajax/undelete.php", $body);
+		$body = new \Behat\Gherkin\Node\TableNode(
+			[['files',  "[\"$elementTrashID\"]"], ['dir', '/']]
+		);
+		$this->sendingToWithDirectUrl(
+			$user, 'POST', "/index.php/apps/files_trashbin/ajax/undelete.php", $body
+		);
 		$this->theHTTPStatusCodeShouldBe('200');
 	}
 
 	/**
 	 * @param string $user
 	 * @param string $originalPath
+	 *
+	 * @return void
 	 */
 	private function restoreElement($user, $originalPath) {
 		$listing = $this->listTrashbinFolder($user, null);
 		$originalPath = trim($originalPath, '/');
 
 		foreach ($listing as $entry) {
-			if ( substr($entry['extraData'], 0, 2) === "./" ) {
+			if (substr($entry['extraData'], 0, 2) === "./" ) {
 				$entry['extraData'] = substr($entry['extraData'], 2);
 			}
 			if ($entry['extraData'] === $originalPath) {
-				$this->sendUndeleteRequest($user, $entry['name'] . '.d' . floor((integer)$entry['mtime']/1000));
+				$this->sendUndeleteRequest(
+					$user,
+					$entry['name'] . '.d' . floor((integer)$entry['mtime'] / 1000)
+				);
 				break;
 			}
 		}
@@ -158,11 +184,15 @@ trait Trashbin {
 	 * @param string $user
 	 * @param string $entryText unused
 	 * @param string $originalPath
+	 *
+	 * @return void
 	 */
 	public function elementInTrashIsRestored($user, $entryText, $originalPath) {
 		$this->restoreElement($user, $originalPath);
-		PHPUnit_Framework_Assert::assertFalse($this->isInTrash($user, $originalPath),
-											"File previously located at $originalPath is still in the trashbin");
+		PHPUnit_Framework_Assert::assertFalse(
+			$this->isInTrash($user, $originalPath),
+			"File previously located at $originalPath is still in the trashbin"
+		);
 	}
 
 	/**
@@ -171,10 +201,16 @@ trait Trashbin {
 	 * @param string $user
 	 * @param string $entryText unused
 	 * @param string $originalPath
+	 *
+	 * @return void
 	 */
-	public function elementIsInTrashCheckingOriginalPath($user, $entryText, $originalPath) {
-		PHPUnit_Framework_Assert::assertTrue($this->isInTrash($user, $originalPath),
-											"File previously located at $originalPath wasn't found in the trashbin");
+	public function elementIsInTrashCheckingOriginalPath(
+		$user, $entryText, $originalPath
+	) {
+		PHPUnit_Framework_Assert::assertTrue(
+			$this->isInTrash($user, $originalPath),
+			"File previously located at $originalPath wasn't found in the trashbin"
+		);
 	}
 
 	/**
@@ -183,10 +219,16 @@ trait Trashbin {
 	 * @param string $user
 	 * @param string $entryText
 	 * @param string $originalPath
+	 *
+	 * @return void
 	 */
-	public function elementIsNotInTrashCheckingOriginalPath($user, $entryText, $originalPath) {
-		PHPUnit_Framework_Assert::assertFalse($this->isInTrash($user, $entryText, $originalPath), 
-											"File previously located at $originalPath was found in the trashbin");
+	public function elementIsNotInTrashCheckingOriginalPath(
+		$user, $entryText, $originalPath
+	) {
+		PHPUnit_Framework_Assert::assertFalse(
+			$this->isInTrash($user, $entryText, $originalPath), 
+			"File previously located at $originalPath was found in the trashbin"
+		);
 	}
 
 	/**
@@ -194,6 +236,7 @@ trait Trashbin {
 	 *
 	 * @param string $user
 	 * @param string $name
+	 *
 	 * @return string|null real entry name with timestamp suffix or null if not found
 	 */
 	private function findFirstTrashedEntry($user, $name) {

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
 $classLoader = new \Composer\Autoload\ClassLoader();
-$classLoader->addPsr4("TestHelpers\\", __DIR__. "/../../../../tests/TestHelpers/", true);
+$classLoader->addPsr4("TestHelpers\\", __DIR__ . "/../../../../tests/TestHelpers/", true);
 $classLoader->register();


### PR DESCRIPTION
## Description
Run the ``phpcs`` code-standard checker against the ``tests/acceptance`` code.
Format it according to that (which is the code-standard checker that the UI test code is currently formatted to).
Thankfully ``phpcs`` has related tools that can automatically do a lot of this.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
Get prepared for merging API and UI tests. If they both conform to the same code format standard, life will be easier in future.

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

