### PR TITLE
Tidy error messages in acceptance tests run.sh

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -29,7 +29,7 @@ function env_encryption_enable {
 }
 
 function env_encryption_enable_master_key {
-	env_encryption_enable || { echo "Unable to enable user-keys encryption" >&2; exit 1; }
+	env_encryption_enable || { echo "Unable to enable masterkey encryption" >&2; exit 1; }
 	$OCC encryption:select-encryption-type masterkey --yes
 }
 
@@ -44,12 +44,12 @@ function env_encryption_disable {
 }
 
 function env_encryption_disable_master_key {
-	env_encryption_disable || { echo "Unable to disable encryption" >&2; exit 1; }
+	env_encryption_disable || { echo "Unable to disable masterkey encryption" >&2; exit 1; }
 	$OCC config:app:delete encryption useMasterKey
 }
 
-function env_encryption_disable_users_key {
-	env_encryption_disable || { echo "Unable to disable encryption" >&2; exit 1; }
+function env_encryption_disable_user_keys {
+	env_encryption_disable || { echo "Unable to disable user-keys encryption" >&2; exit 1; }
 	$OCC config:app:delete encryption userSpecificKey
 }
 
@@ -170,7 +170,7 @@ if test "$OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED" = "1"; then
 fi
 
 if test "$OC_TEST_ENCRYPTION_USER_KEYS_ENABLED" = "1"; then
-	env_encryption_disable_users_key
+	env_encryption_disable_user_keys
 fi
 
 if [ -z $HIDE_OC_LOGS ]; then


### PR DESCRIPTION
## Description
Make each error message about "could not enable/disable..." unique and with text reflecting which function it happened in.

## Related Issue
https://github.com/owncloud/QA/issues/517
Followup of #30412 to tidy up bits I just noticed.

## Motivation and Context
Make debugging easier when something goes wrong.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

