### PR TITLE
TestHelpers code to phpcs-defined standard

### DIFF
--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -43,6 +43,7 @@ class AppConfigHelper {
 	 * @param boolean $testingState the on|off state the parameter must be set to for the test
 	 * @param string $savedCapabilitiesXml the original capabilities in XML format
 	 * @param int $apiVersion (1|2)
+	 *
 	 * @return array of the original state of the capability set
 	 */
 	public static function setCapability(
@@ -87,14 +88,15 @@ class AppConfigHelper {
 	 * @param string $baseUrl
 	 * @param string $user
 	 * @param string $password
-	 * @param array $capabilitiesArray[] with each array entry containing keys for:
-	 *                                   ['capabilitiesApp'] the "app" name in the capabilities response
-	 *                                   ['capabilitiesParameter'] the parameter name in the capabilities response
-	 *                                   ['testingApp'] the "app" name as understood by "testing"
-	 *                                   ['testingParameter'] the parameter name as understood by "testing"
-	 *                                   ['testingState'] boolean state the parameter must be set to for the test
+	 * @param array $capabilitiesArray with each array entry containing keys for:
+	 *                                 ['capabilitiesApp'] the "app" name in the capabilities response
+	 *                                 ['capabilitiesParameter'] the parameter name in the capabilities response
+	 *                                 ['testingApp'] the "app" name as understood by "testing"
+	 *                                 ['testingParameter'] the parameter name as understood by "testing"
+	 *                                 ['testingState'] boolean state the parameter must be set to for the test
 	 * @param string $savedCapabilitiesXml the original capabilities in XML format
 	 * @param int $apiVersion (1|2)
+	 *
 	 * @return array of the original state of each capability set
 	 */
 	public static function setCapabilities(
@@ -116,10 +118,10 @@ class AppConfigHelper {
 					$savedCapabilitiesXml
 				);
 
-				// Always set each config value, because sometimes enabling one config
-				// also changes some sub-settings. So the "interim" state as we set
-				// the config values could be unexpectedly different from the original
-				// saved state.
+				// Always set each config value, because sometimes enabling one
+				// config also changes some sub-settings. So the "interim" state
+				// as we set the config values could be unexpectedly different
+				// from the original saved state.
 				$appParameterValues[] = [
 					'appid' => $capabilityToSet['testingApp'],
 					'configkey' => $capabilityToSet['testingParameter'],
@@ -154,9 +156,12 @@ class AppConfigHelper {
 	 * @param string $xml of the capabilities
 	 * @param string $capabilitiesApp the "app" name in the capabilities response
 	 * @param string $capabilitiesPath the path to the element
+	 *
 	 * @return string
 	 */
-	public static function getParameterValueFromXml($xml, $capabilitiesApp, $capabilitiesPath) {
+	public static function getParameterValueFromXml(
+		$xml, $capabilitiesApp, $capabilitiesPath
+	) {
 		$pathToElement = explode('@@@', $capabilitiesPath);
 		$answeredValue = $xml->{$capabilitiesApp};
 		for ($i = 0; $i < count($pathToElement); $i++) {
@@ -170,6 +175,7 @@ class AppConfigHelper {
 	 * @param string $capabilitiesParameter the parameter name in the
 	 *                                      capabilities response
 	 * @param string $savedCapabilitiesXml the original capabilities in XML format
+	 *
 	 * @return boolean
 	 */
 	public static function wasCapabilitySet(
@@ -187,6 +193,7 @@ class AppConfigHelper {
 	 * http one in v1 of the api.
 	 * 
 	 * @param ResponseInterface $response
+	 *
 	 * @return string
 	 */
 	public static function getOCSResponse($response) {
@@ -199,6 +206,7 @@ class AppConfigHelper {
 	 * @param string $baseUrl
 	 * @param string $user
 	 * @param string $password
+	 *
 	 * @return ResponseInterface
 	 */
 	public static function getCapabilities($baseUrl, $user, $password) {
@@ -216,6 +224,7 @@ class AppConfigHelper {
 
 	/**
 	 * @param ResponseInterface $response
+	 *
 	 * @return string retrieved capabilities in XML format
 	 */
 	public static function getCapabilitiesXml($response) {
@@ -230,6 +239,7 @@ class AppConfigHelper {
 	 * @param string $parameter
 	 * @param string $value
 	 * @param int $apiVersion (1|2)
+	 *
 	 * @return void
 	 */
 	public static function modifyServerConfig(
@@ -249,7 +259,9 @@ class AppConfigHelper {
 		);
 		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
 		if ($apiVersion === 1) {
-			PHPUnit_Framework_Assert::assertEquals("100", self::getOCSResponse($response));
+			PHPUnit_Framework_Assert::assertEquals(
+				"100", self::getOCSResponse($response)
+			);
 		}
 	}
 
@@ -257,8 +269,9 @@ class AppConfigHelper {
 	 * @param string $baseUrl
 	 * @param string $user
 	 * @param string $password
-	 * @param array $appParameterValues[] 'appid' 'configkey' and 'value'
+	 * @param array $appParameterValues 'appid' 'configkey' and 'value'
 	 * @param int $apiVersion (1|2)
+	 *
 	 * @return void
 	 */
 	public static function modifyServerConfigs(
@@ -278,7 +291,9 @@ class AppConfigHelper {
 		);
 		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
 		if ($apiVersion === 1) {
-			PHPUnit_Framework_Assert::assertEquals("100", self::getOCSResponse($response));
+			PHPUnit_Framework_Assert::assertEquals(
+				"100", self::getOCSResponse($response)
+			);
 		}
 	}
 

--- a/tests/TestHelpers/DeleteHelper.php
+++ b/tests/TestHelpers/DeleteHelper.php
@@ -44,6 +44,7 @@ class DeleteHelper {
 	 * @param array  $headers
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
+	 *
 	 * @return FutureResponse|ResponseInterface|NULL
 	 */
 	public static function delete(

--- a/tests/TestHelpers/DownloadHelper.php
+++ b/tests/TestHelpers/DownloadHelper.php
@@ -44,6 +44,7 @@ class DownloadHelper {
 	 * @param array  $headers
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
+	 *
 	 * @return FutureResponse|ResponseInterface|NULL
 	 */
 	public static function download(

--- a/tests/TestHelpers/IpHelper.php
+++ b/tests/TestHelpers/IpHelper.php
@@ -44,6 +44,7 @@ class IpHelper {
 	 *
 	 * @param string $regex matching the desired text in the ifconfig output
 	 * @param string $except regex that matches devices not to be included
+	 *
 	 * @throws Exception
 	 * @return array of elements that match the inner part of the regex
 	 */
@@ -114,6 +115,7 @@ class IpHelper {
 	 *
 	 * @param string $ipv4Address with format like "192.168.1.1"
 	 * @param int $cidr the CIDR "mask" size for the subnet (0 to 32)
+	 *
 	 * @throws InvalidArgumentException
 	 * @return string IPv4 subnet base address
 	 */
@@ -143,6 +145,7 @@ class IpHelper {
 	 *
 	 * @param string $ipv6Address with format like "a:b:c::1"
 	 * @param int $cidr the CIDR "mask" size for the subnet (0 to 128)
+	 *
 	 * @throws InvalidArgumentException
 	 * @return string IPv6 subnet base address
 	 */
@@ -215,6 +218,7 @@ class IpHelper {
 	 * get a loopback address for the given IP address family
 	 *
 	 * @param string $ipAddressFamily IPv4 or IPv6 (not case sensitive)
+	 *
 	 * @throws InvalidArgumentException
 	 * @return string IP loopback address
 	 */
@@ -236,6 +240,7 @@ class IpHelper {
 	 * that contains the loopback address of the given IP address family
 	 *
 	 * @param string $ipAddressFamily IPv4 or IPv6 (not case sensitive)
+	 *
 	 * @throws InvalidArgumentException
 	 * @return string IP of loopback subnet base address
 	 */
@@ -298,6 +303,7 @@ class IpHelper {
 	 * i.e. a "real" routable IP address on some network interface
 	 *
 	 * @param string $ipAddressFamily IPv4 or IPv6 (not case sensitive)
+	 *
 	 * @throws InvalidArgumentException
 	 * @return string IP address
 	 */
@@ -319,6 +325,7 @@ class IpHelper {
 	 * that contains the IPv4 address of the first routable IPv4 subnet
 	 *
 	 * @param int $cidr the CIDR "mask" size for the subnet
+	 *
 	 * @return string IPv4 local subnet base address
 	 */
 	private static function routableIpv4AddressSubnet($cidr) {
@@ -330,6 +337,7 @@ class IpHelper {
 	 * that contains the IPv6 address of the first routable IPv6 subnet
 	 *
 	 * @param int $cidr the CIDR "mask" size for the subnet
+	 *
 	 * @return string IPv6 local subnet base address
 	 */
 	private static function routeableIpv6AddressSubnet($cidr) {
@@ -342,6 +350,7 @@ class IpHelper {
 	 *
 	 * @param string $ipAddressFamily IPv4 or IPv6 (not case sensitive)
 	 * @param int $cidr the CIDR "mask" size for the subnet
+	 *
 	 * @throws InvalidArgumentException
 	 * @return string IP of local subnet base address
 	 */
@@ -365,6 +374,7 @@ class IpHelper {
 	 * @param string $networkScope which type of address to return,
 	 *                             "routable" or "loopback"
 	 * @param string $ipAddressFamily IPv4 or IPv6 (not case sensitive)
+	 *
 	 * @throws InvalidArgumentException
 	 * @return string IP address
 	 */
@@ -393,6 +403,7 @@ class IpHelper {
 	 *                             "routable" or "loopback"
 	 * @param string $ipAddressFamily IPv4 or IPv6 (not case sensitive)
 	 * @param int $cidr the CIDR "mask" size for the subnet
+	 *
 	 * @throws InvalidArgumentException
 	 * @return string IP of base address
 	 */

--- a/tests/TestHelpers/LoggingHelper.php
+++ b/tests/TestHelpers/LoggingHelper.php
@@ -78,6 +78,7 @@ class LoggingHelper {
 	/**
 	 *
 	 * @param string $logLevel (debug|info|warning|error|fatal)
+	 *
 	 * @return void
 	 * @throws \InvalidArgumentException
 	 * @throws \Exception
@@ -122,6 +123,7 @@ class LoggingHelper {
 	/**
 	 *
 	 * @param string $backend (owncloud|syslog|errorlog)
+	 *
 	 * @return void
 	 * @throws \InvalidArgumentException
 	 * @throws \Exception
@@ -165,6 +167,7 @@ class LoggingHelper {
 	/**
 	 *
 	 * @param string $timezone
+	 *
 	 * @return void
 	 * @throws \Exception
 	 */
@@ -199,6 +202,7 @@ class LoggingHelper {
 	 * @param string $filepath file to read
 	 * @param int $noOfLinesToRead no of lines to read
 	 * @param bool $adaptive make the file buffer adaptive
+	 *
 	 * @return array lines of the file to read
 	 * @throws \Exception
 	 * @author Torleif Berger, Lorenzo Stanco

--- a/tests/TestHelpers/MoveCopyHelper.php
+++ b/tests/TestHelpers/MoveCopyHelper.php
@@ -43,6 +43,7 @@ class MoveCopyHelper {
 	 * @param array  $headers
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
+	 *
 	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
 	 */
 	public static function copy(
@@ -75,6 +76,7 @@ class MoveCopyHelper {
 	 * @param array  $headers
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
+	 *
 	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
 	 */
 	public static function move(
@@ -108,6 +110,7 @@ class MoveCopyHelper {
 	 * @param array  $headers
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
+	 *
 	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
 	 */
 	private static function copyOrMove(

--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -39,6 +39,7 @@ class OcsApiHelper {
 	 * @param string $path
 	 * @param array $body array of key, value pairs e.g ['value' => 'yes']
 	 * @param int $apiVersion (1|2) default 2
+	 *
 	 * @return ResponseInterface
 	 * @throws ClientException
 	 */

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -56,6 +56,7 @@ class SetupHelper {
 	 * @param string $password
 	 * @param string $displayName
 	 * @param string $email
+	 *
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
 	 */
 	public static function createUser(
@@ -79,6 +80,7 @@ class SetupHelper {
 	 * deletes a user
 	 *
 	 * @param string $userName
+	 *
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
 	 */
 	public static function deleteUser($userName) {
@@ -91,6 +93,7 @@ class SetupHelper {
 	 * @param string $app
 	 * @param string $key
 	 * @param string $value
+	 *
 	 * @return string[]
 	 */
 	public static function changeUserSetting(
@@ -105,6 +108,7 @@ class SetupHelper {
 	 * creates a group
 	 *
 	 * @param string $groupName
+	 *
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
 	 */
 	public static function createGroup($groupName) {
@@ -116,6 +120,7 @@ class SetupHelper {
 	 *
 	 * @param string $groupName
 	 * @param string $userName
+	 *
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
 	 */
 	public static function addUserToGroup($groupName, $userName) {
@@ -129,6 +134,7 @@ class SetupHelper {
 	 *
 	 * @param string $groupName
 	 * @param string $userName
+	 *
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
 	 */
 	public static function removeUserFromGroup($groupName, $userName) {
@@ -141,6 +147,7 @@ class SetupHelper {
 	 * deletes a group
 	 *
 	 * @param string $groupName
+	 *
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
 	 */
 	public static function deleteGroup($groupName) {
@@ -157,6 +164,7 @@ class SetupHelper {
 	/**
 	 *
 	 * @param HookScope $scope
+	 *
 	 * @return array of suite context parameters
 	 */
 	public static function getSuiteParameters(HookScope $scope) {
@@ -165,6 +173,11 @@ class SetupHelper {
 	}
 
 	/**
+	 *
+	 * @param string $adminUsername
+	 * @param string $adminPassword
+	 * @param string $baseUrl
+	 * @param string $ocPath
 	 *
 	 * @return void
 	 */
@@ -202,6 +215,7 @@ class SetupHelper {
 	 * enables an app
 	 *
 	 * @param string $appName
+	 *
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
 	 */
 	public static function enableApp($appName) {
@@ -212,6 +226,7 @@ class SetupHelper {
 	 * disables an app
 	 *
 	 * @param string $appName
+	 *
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
 	 */
 	public static function disableApp($appName) {
@@ -222,6 +237,7 @@ class SetupHelper {
 	 * checks if an app is currently enabled
 	 *
 	 * @param string $appName
+	 *
 	 * @return bool true if enabled, false if disabled or not existing
 	 */
 	public static function isAppEnabled($appName) {
@@ -233,6 +249,7 @@ class SetupHelper {
 	 * lists app status (enabled or disabled)
 	 *
 	 * @param string $appName
+	 *
 	 * @return bool true if the app needed to be enabled, false otherwise
 	 */
 	public static function enableAppIfNotEnabled($appName) {
@@ -249,6 +266,7 @@ class SetupHelper {
 	 *
 	 * @param array $args anything behind "occ".
 	 *                    For example: "files:transfer-ownership"
+	 *
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
 	 */
 	public static function runOcc($args) {

--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -47,13 +47,13 @@ class SharingHelper {
 	 * @param string|null $sharePassword The password to protect the public link
 	 *                                   share with.
 	 * @param string|int|string[]|int[]|null $permissions The permissions to set on the share.
-	 *                                      1 = read; 2 = update; 4 = create;
-	 *                                      8 = delete; 16 = share; 31 = all
-	 *                                      15 = change
-	 *                                      (default: 31, for public shares: 1)
-	 *                                      Pass either the (total) number,
-	 *                                      or the keyword,
-	 *                                      or an array of keywords or numbers.
+	 *                                                    1 = read; 2 = update; 4 = create;
+	 *                                                    8 = delete; 16 = share; 31 = all
+	 *                                                    15 = change
+	 *                                                    (default: 31, for public shares: 1)
+	 *                                                    Pass either the (total) number,
+	 *                                                    or the keyword,
+	 *                                                    or an array of keywords or numbers.
 	 * @param string|null $linkName A (human-readable) name for the share,
 	 *                              which can be up to 64 characters in length.
 	 * @param string|null $expireDate **NOT IMPLEMENTED**
@@ -62,6 +62,7 @@ class SharingHelper {
 	 *                                in the format 'YYYY-MM-DD'.
 	 * @param int $apiVersion
 	 * @param int $sharingApiVersion
+	 *
 	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
 	 */
 	public static function createShare(
@@ -91,7 +92,8 @@ class SharingHelper {
 			}
 		}
 
-		$validShareTypes = ['user' => 0, 'group' => 1, 'public' => 3, 'federated' => 6];
+		$validShareTypes
+			= ['user' => 0, 'group' => 1, 'public' => 3, 'federated' => 6];
 		if (isset($validShareTypes[$shareType])) {
 			$shareType = $validShareTypes[$shareType];
 		}
@@ -105,8 +107,8 @@ class SharingHelper {
 				if (!is_array($permissions)) {
 					$permissions = [$permissions];
 				}
-				$validPermissionTypes =
-					[
+				$validPermissionTypes
+					= [
 						'read' => 1,
 						'update' => 2,
 						'create' => 4,
@@ -122,7 +124,9 @@ class SharingHelper {
 					} elseif (in_array($permission, $validPermissionTypes)) {
 						$permissionSum += (int) $permission;
 					} else {
-						throw new \InvalidArgumentException("invalid permission type ($permission)");
+						throw new \InvalidArgumentException(
+							"invalid permission type ($permission)"
+						);
 					}
 				}
 			}

--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -38,6 +38,7 @@ class TagsHelper {
 	 * @param string $fileName
 	 * @param string $fileOwner
 	 * @param int $davPathVersionToUse (1|2)
+	 *
 	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
 	 */
 	public static function tag(
@@ -72,6 +73,7 @@ class TagsHelper {
 	 * @param string $user
 	 * @param string $password
 	 * @param bool $withGroups
+	 *
 	 * @return array
 	 */
 	public static function requestTagsForUser(
@@ -108,6 +110,7 @@ class TagsHelper {
 	 * @param string $password
 	 * @param string $tagDisplayName
 	 * @param bool $withGroups
+	 *
 	 * @return array
 	 */
 	public static function requestTagByDisplayName(
@@ -137,6 +140,7 @@ class TagsHelper {
 	 * @param bool $userAssignable
 	 * @param string $groups separated by "|"
 	 * @param int $davPathVersionToUse (1|2)
+	 *
 	 * @return array ['lastTagId', 'HTTPResponse']
 	 * @throws \GuzzleHttp\Exception\ClientException
 	 * @link self::makeDavRequest()
@@ -187,6 +191,7 @@ class TagsHelper {
 	 * @param string $password
 	 * @param int $tagID
 	 * @param int $davPathVersionToUse (1|2)
+	 *
 	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
 	 * @throws \GuzzleHttp\Exception\ClientException
 	 */
@@ -208,6 +213,7 @@ class TagsHelper {
 	/**
 	 *
 	 * @param string $type
+	 *
 	 * @throws \Exception
 	 * @return boolean[]
 	 */

--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -49,6 +49,7 @@ class UploadHelper {
 	 * @param int    $chunkingVersion     (1|2|null)
 	 *                                    if set to null chunking will not be used
 	 * @param int    $noOfChunks          how many chunks do we want to upload
+	 *
 	 * @return FutureResponse|ResponseInterface|NULL
 	 */
 	public static function upload(
@@ -151,6 +152,7 @@ class UploadHelper {
 	 *
 	 * @param string $file
 	 * @param int $noOfChunks
+	 *
 	 * @return array $string
 	 */
 	public static function chunkFile($file, $noOfChunks = 1) {
@@ -174,6 +176,7 @@ class UploadHelper {
 	 *
 	 * @param string $name full path of the file to create
 	 * @param int $size
+	 *
 	 * @return void
 	 */
 	public static function createFileSpecificSize($name, $size) {
@@ -199,6 +202,7 @@ class UploadHelper {
 	 *
 	 * @param string $name full path of the file to create
 	 * @param string $text
+	 *
 	 * @return void
 	 */
 	public static function createFileWithText($name, $text) {

--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -39,6 +39,7 @@ class UserHelper {
 	 * @param string $adminPassword
 	 * @param string $displayName
 	 * @param string $email
+	 *
 	 * @return ResponseInterface[]
 	 *          we need multiple requests to set $displayName and $email
 	 *          this array will contain the responses from all requests
@@ -84,6 +85,7 @@ class UserHelper {
 	 * @param string $value
 	 * @param string $adminUser
 	 * @param string $adminPassword
+	 *
 	 * @return ResponseInterface
 	 */
 	public static function editUser(
@@ -105,6 +107,7 @@ class UserHelper {
 	 * @param string $userName
 	 * @param string $adminUser
 	 * @param string $adminPassword
+	 *
 	 * @return ResponseInterface
 	 */
 	public static function deleteUser(
@@ -125,6 +128,7 @@ class UserHelper {
 	 * @param string $group
 	 * @param string $adminUser
 	 * @param string $adminPassword
+	 *
 	 * @return ResponseInterface
 	 */
 	public static function createGroup(
@@ -142,6 +146,7 @@ class UserHelper {
 	 * @param string $group
 	 * @param string $adminUser
 	 * @param string $adminPassword
+	 *
 	 * @return ResponseInterface
 	 */
 	public static function deleteGroup(
@@ -161,6 +166,7 @@ class UserHelper {
 	 * @param string $group
 	 * @param string $adminUser
 	 * @param string $adminPassword
+	 *
 	 * @return ResponseInterface
 	 */
 	public static function addUserToGroup(
@@ -178,6 +184,7 @@ class UserHelper {
 	 * @param string $adminUser
 	 * @param string $adminPassword
 	 * @param string $search
+	 *
 	 * @return ResponseInterface
 	 */
 	public static function getGroups(
@@ -195,6 +202,7 @@ class UserHelper {
 	 * @param string $adminUser
 	 * @param string $adminPassword
 	 * @param string $search
+	 *
 	 * @return string[]
 	 */
 	public static function getGroupsAsArray(

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -42,6 +42,7 @@ class WebDavHelper {
 	 * @param string $user
 	 * @param string $password
 	 * @param string $path
+	 *
 	 * @throws Exception
 	 * @return int
 	 */
@@ -85,6 +86,7 @@ class WebDavHelper {
 	 * @param int $davPathVersionToUse (1|2)
 	 * @param string $type of request
 	 * @param string $sourceIpAddress to initiate the request from
+	 *
 	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
 	 * @throws \GuzzleHttp\Exception\BadResponseException
 	 */
@@ -125,7 +127,9 @@ class WebDavHelper {
 			foreach ($headers as $key => $value) {
 				//? and # need to be encoded in the Destination URL
 				if ($key === "Destination") {
-					$value = str_replace($urlSpecialChar[0], $urlSpecialChar[1], $value);
+					$value = str_replace(
+						$urlSpecialChar[0], $urlSpecialChar[1], $value
+					);
 				}
 				if ($request->hasHeader($key) === true) {
 					$request->setHeader($key, $value);
@@ -147,6 +151,7 @@ class WebDavHelper {
 	 * @param string $user
 	 * @param int $davPathVersionToUse (1|2)
 	 * @param string $type
+	 *
 	 * @throws InvalidArgumentException
 	 * @return string
 	 */
@@ -174,6 +179,7 @@ class WebDavHelper {
 	 * @param string $baseUrl
 	 * @param string $user
 	 * @param string $password
+	 *
 	 * @return \Sabre\DAV\Client
 	 */
 	public static function getSabreClient($baseUrl, $user, $password) {
@@ -192,6 +198,7 @@ class WebDavHelper {
 	 * 
 	 * @param string $url
 	 * @param bool $trailingSlash forces a trailing slash
+	 *
 	 * @return string
 	 */
 	public static function sanitizeUrl($url, $trailingSlash = false) {


### PR DESCRIPTION
## Description
Refactor ``TestHelpers`` code so it meets the ``phpcs`` standards.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
Make all acceptance testing code conform to the same standard.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

