### PR TITLE
[POC] Direct write

### DIFF
--- a/apps/dav/lib/Upload/AssemblyStream.php
+++ b/apps/dav/lib/Upload/AssemblyStream.php
@@ -277,4 +277,12 @@ class AssemblyStream implements \Icewind\Streams\File {
 
 		return \fopen('data://text/plain,' . $data, 'r');
 	}
+
+	public function getNodes() {
+		return $this->nodes;
+	}
+
+	public function getSize() {
+		return $this->size;
+	}
 }


### PR DESCRIPTION
## Description
We should not use the temp storage to store chunks (and regular files as well ?) but handle the stream directly to the objectstore implementation.

This should give us some performance boost.

Downside:
I don't see how any stream based operations can work in this scenario.
- preview
- encryption (well anyhow a bad idea ...)
- checksums
- workflow & firewall
- anti virus
- trash
- ransomware
- quota
- anything which uses our storage wrapper approach

## Motivation and Context
Bring some more speed to objectstore

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

