### PR TITLE
Properly use error exit code when php version or platform is not supp…

### DIFF
--- a/console.php
+++ b/console.php
@@ -38,21 +38,21 @@ define('OC_CONSOLE', 1);
 if (version_compare(PHP_VERSION, '7.1.0') === -1) {
 	echo 'This version of ownCloud requires at least PHP 7.1.0'.PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.'.PHP_EOL;
-	return;
+	exit(1);
 }
 
 // Show warning if PHP 7.3 is used as ownCloud is not compatible with PHP 7.3
 if (version_compare(PHP_VERSION, '7.3.0alpha1') !== -1) {
 	echo 'This version of ownCloud is not compatible with PHP 7.3' . PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '.' . PHP_EOL;
-	return;
+	exit(1);
 }
 
 // running oC on Windows is unsupported since 8.1, this has to happen here because
 // is seems that the autoloader on Windows fails later and just throws an exception.
 if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 	echo 'ownCloud Server does not support Microsoft Windows.';
-	return;
+	exit(1);
 }
 
 function exceptionHandler($exception) {


### PR DESCRIPTION
…orted
## Description
In case occ cannot be used because the platform (windows) or the php version is wrong we shall exit 1 to indicate the calling script that something went wrong

## Related Issue
https://github.com/owncloud/contacts/pull/636#issuecomment-368633323

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

