### PR TITLE
Set quota via provisioning API in UI upload test

### DIFF
--- a/tests/ui/features/bootstrap/UsersContext.php
+++ b/tests/ui/features/bootstrap/UsersContext.php
@@ -26,6 +26,7 @@ use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\UsersPage;
+use TestHelpers\OcsApiHelper;
 
 require_once 'bootstrap.php';
 
@@ -83,6 +84,40 @@ class UsersContext extends RawMinkContext implements Context {
 	 */
 	public function quotaOfUserIsSetTo($username, $quota) {
 		$this->usersPage->setQuotaOfUserTo($username, $quota, $this->getSession());
+	}
+
+	/**
+	 * Taken from acceptance Provisioning.php and modified to suit current
+	 * UI test environment. This function should be removed when merging UI
+	 * and API acceptance tests, and the one from Provisioning.php used everywhere.
+	 *
+	 * @Given the quota of user :user has been set to :quota
+	 *
+	 * @param string $user
+	 * @param string $quota
+	 *
+	 * @return void
+	 */
+	public function theQuotaOfUserHasBeenSetTo($user, $quota) {
+		$body
+			= [
+				'key' => 'quota',
+				'value' => $quota,
+			];
+
+		$this->response = OcsApiHelper::sendRequest(
+			$this->getMinkParameter('base_url'),
+			"admin",
+			$this->featureContext->getUserPassword("admin"),
+			"PUT",
+			"/cloud/users/" . $user,
+			$body,
+			2
+		);
+
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->response->getStatusCode()
+		);
 	}
 
 	/**

--- a/tests/ui/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
+++ b/tests/ui/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
@@ -9,12 +9,11 @@ So that I can store it in owncloud
 		Given these users exist:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
-		And I am logged in as admin
-		And I am on the users page
 
 	Scenario: simple upload of a file with the size greater than the size of quota
-		When quota of user "user1" is set to "10 MB"
-		And I relogin with username "user1" and password "1234"
+		Given the quota of user "user1" has been set to "10 MB"
+		And I am on the login page
+		And I login with username "user1" and password "1234"
 		And I am on the files page
 		And a file with the size of "30000000" bytes and the name "big-video.mp4" exists
 		When I upload the file "big-video.mp4"


### PR DESCRIPTION
## Description
Take some code from the API acceptance test suite and use it in the UI test suite to set user quota.

## Related Issue
PR #30673 wants to move the users page UI out of core.

## Motivation and Context
There is an upload test in the UI tests that sets user quota prior to the upload. The scenario setup currently sets the quota using the UI logged in as admin. That ties the test (which is about upload) to the existence of the users page in the UI. We don't want such dependencies that complicate life.

## How Has This Been Tested?
CI will know,

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

