### PR TITLE
Remove usage of create_function - refs https://travis-ci.org/owncloud…

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -518,8 +518,7 @@ class OC_App {
 
 		}
 
-		$navigation = self::proceedNavigation($settings);
-		return $navigation;
+		return self::proceedNavigation($settings);
 	}
 
 	// This is private as well. It simply works, so don't ask for more details
@@ -534,7 +533,17 @@ class OC_App {
 		}
 		unset($navEntry);
 
-		usort($list, create_function('$a, $b', 'if( $a["order"] == $b["order"] ) {return 0;}elseif( $a["order"] < $b["order"] ) {return -1;}else{return 1;}'));
+		usort($list, function($a, $b) {
+			if ($a["order"] == $b["order"]) {
+				return 0;
+			}
+
+			if($a["order"] < $b["order"]) {
+				return -1;
+			}
+
+			return 1;
+		});
 
 		return $list;
 	}
@@ -673,8 +682,7 @@ class OC_App {
 	 */
 	public static function getNavigation() {
 		$entries = OC::$server->getNavigationManager()->getAll();
-		$navigation = self::proceedNavigation($entries);
-		return $navigation;
+		return self::proceedNavigation($entries);
 	}
 
 	/**

--- a/tests/lib/legacy/AppTest.php
+++ b/tests/lib/legacy/AppTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+
+namespace Test\legacy;
+
+
+use OC\NavigationManager;
+use Test\TestCase;
+
+class AppTest extends TestCase {
+
+	/**
+	 * @dataProvider providesNavigation
+	 * @param array $expected
+	 * @param array $unorderedNavigation
+	 */
+	public function testNavigation($expected, $unorderedNavigation) {
+		$navigationManager = $this->createMock(NavigationManager::class);
+		$navigationManager->method('getAll')->willReturn($unorderedNavigation);
+		$this->overwriteService('NavigationManager', $navigationManager);
+		$navigation = \OC_App::getNavigation();
+		$this->assertEquals($expected, $navigation);
+	}
+
+	public function providesNavigation() {
+		return [
+			'one entry' => [[[
+				'id' => 'files',
+				'order' => 0,
+				'active' => false
+			]], [[
+				'id' => 'files',
+				'order' => 0
+			]]],
+			'two entries' => [[[
+				'id' => 'files',
+				'order' => 0,
+				'active' => false
+			],[
+			'id' => 'mail',
+				'order' => 1,
+				'active' => false
+			]], [[
+				'id' => 'mail',
+				'order' => 1
+			], [
+				'id' => 'files',
+				'order' => 0
+			]]]
+		];
+	}
+
+	protected function tearDown() {
+		$this->restoreService('NavigationManager');
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
…/activity/jobs/349712842#L946
## Description
php 7.2 deprecated create_function

```
1) OCA\Activity\Tests\Controller\ActivitiesTest::testShowList
Function create_function() is deprecated
/home/travis/build/owncloud/core/lib/private/legacy/app.php:537
/home/travis/build/owncloud/core/lib/private/legacy/app.php:676
/home/travis/build/owncloud/core/lib/private/TemplateLayout.php:76
/home/travis/build/owncloud/core/lib/private/legacy/template.php:234
/home/travis/build/owncloud/core/lib/public/AppFramework/Http/TemplateResponse.php:156
/home/travis/build/owncloud/core/apps/activity/tests/Controller/ActivitiesTest.php:126
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

