### PR TITLE
Fix webUI display of group containing numeric username

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -160,7 +160,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return \OC\User\User|null Either the user or null if the specified user does not exist
 	 */
 	public function get($uid) {
-		if (is_null($uid) || !is_string($uid)) {
+		if (is_null($uid) || (!is_string($uid) && !is_numeric($uid))) {
 			return null;
 		}
 		if ($this->cachedUsers->hasKey($uid)) { //check the cache first to prevent having to loop over the backends

--- a/tests/acceptance/features/apiMain/provisioning-v1.feature
+++ b/tests/acceptance/features/apiMain/provisioning-v1.feature
@@ -132,11 +132,24 @@ Feature: provisioning
 		Then the OCS status code should be "103"
 		And the HTTP status code should be "200"
 
-	Scenario: getting a group
+	Scenario: getting an empty group
 		Given group "new-group" has been created
 		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
+
+	Scenario: getting users in a group
+		Given user "brand-new-user" has been created
+		And user "123" has been created
+		And group "new-group" has been created
+		And user "brand-new-user" has been added to group "new-group"
+		And user "123" has been added to group "new-group"
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And the users returned by the API should be
+			| brand-new-user |
+			| 123            |
 
 	Scenario: Getting all groups
 		Given group "0" has been created


### PR DESCRIPTION
## Description
1) When looking up a user id allow the ``uid`` to be a number that "looks like a string" - allowing a number of any sort (which will always cast itself into a non-empty string later as required)

2) I went looking for an API test for this - there does not seem to be anything directly for ``settings/users/...`` - but I noticed that there is no provisioning test to make sure that endpoint provides a list of users in a group, so added one here. That passes with string and numeric usernames.

## Related Issue
#30727 

## Motivation and Context
"random" issues with numeric<=>string mixups are annoying. Fix them.

## How Has This Been Tested?
1) In the webUI, login as admin and add user ``123``
2) Add a group `aaa`
3) Add user ``123`` to group ``aaa``
4) Click on group ``aaa`` in the groups left-side panel
5) See that the group member ``123`` is displayed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

