### PR TITLE
run files_external owncloud tests with owncloud 10

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -245,6 +245,13 @@ services:
       matrix:
         FILES_EXTERNAL_TYPE: webdav_apache
 
+  owncloud_external:
+    image: owncloud/server
+    pull: true
+    when:
+      matrix:
+        FILES_EXTERNAL_TYPE: webdav_owncloud
+
 matrix:
   include:
 
@@ -310,6 +317,11 @@ matrix:
       DB_TYPE: sqlite
       FILES_EXTERNAL_TYPE: webdav_apache
 
+    - PHP_VERSION: 7.1
+      TEST_SUITE: phpunit
+      COVERAGE: true
+      DB_TYPE: sqlite
+      FILES_EXTERNAL_TYPE: webdav_owncloud
 
   # Ui Acceptance tests
     - PHP_VERSION: 7.1

--- a/apps/files_external/tests/Storage/OwncloudTest.php
+++ b/apps/files_external/tests/Storage/OwncloudTest.php
@@ -42,12 +42,12 @@ class OwncloudTest extends \Test\Files\Storage\Storage {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$this->config = include('files_external/tests/config.php');
-		if ( ! is_array($this->config) or ! isset($this->config['owncloud']) or ! $this->config['owncloud']['run']) {
+		$this->config = include('files_external/tests/config.owncloud.php');
+		if (!is_array($this->config) or !$this->config['run']) {
 			$this->markTestSkipped('ownCloud backend not configured');
 		}
-		$this->config['owncloud']['root'] .= '/' . $id; //make sure we have an new empty folder to work in
-		$this->instance = new OwnCloud($this->config['owncloud']);
+		$this->config['root'] .= '/' . $id; //make sure we have an new empty folder to work in
+		$this->instance = new OwnCloud($this->config);
 		$this->instance->mkdir('/');
 	}
 
@@ -57,5 +57,9 @@ class OwncloudTest extends \Test\Files\Storage\Storage {
 		}
 
 		parent::tearDown();
+	}
+
+	public function testPartFile() {
+		$this->markTestSkipped('part files are not used when dealing with external owncloud');
 	}
 }

--- a/tests/drone/configs/config.files_external.webdav-oc.php
+++ b/tests/drone/configs/config.files_external.webdav-oc.php
@@ -1,0 +1,9 @@
+<?php
+return array(
+	'run'=>true,
+	'host'=>'owncloud_external:80',
+	'user'=>'admin',
+	'password'=>'admin',
+	'root'=>'',
+	'wait'=> 0
+);

--- a/tests/drone/test-phpunit.sh
+++ b/tests/drone/test-phpunit.sh
@@ -15,6 +15,11 @@ set_up_external_storage() {
       cp tests/drone/configs/config.files_external.webdav-apache.php apps/files_external/tests/config.webdav.php
       FILES_EXTERNAL_TEST_TO_RUN=WebdavTest.php
       ;;
+    webdav_owncloud)
+      wait-for-it -t 120 owncloud_external:80
+      cp tests/drone/configs/config.files_external.webdav-oc.php apps/files_external/tests/config.owncloud.php
+      FILES_EXTERNAL_TEST_TO_RUN=OwncloudTest.php
+      ;;
     *)
       echo "Unsupported files external type!"
       exit 1


### PR DESCRIPTION
## Description
Execute files_external tests with owncloud

This PR currently will fail for `testCheckUpdate` 

https://github.com/owncloud/core/blob/92b658a60e6c28ef9dd7594384180e0d73e96660/tests/lib/Files/Storage/Storage.php#L326-L336

Reason:
We compare local cached "permissions" with sharePermissions from remote:
```
return $sharePermissions !== $cachedData['permissions'];
```

https://github.com/owncloud/core/blob/master/lib/private/Files/Storage/DAV.php#L781

Screenshot from data tracked down in xdebug
![image](https://user-images.githubusercontent.com/6403243/37178889-195969fc-2324-11e8-9a21-ee68a1028429.png)


I am unsure how `{http://open-collaboration-services.org/ns}share-permissions` correlates with the cached `permissions` field.
But it seems we do not cache it anywhere? @PVince81 

## Motivation and Context
Jenkins 🔫 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

