### PR TITLE
Reword UI test steps

### DIFF
--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -126,7 +126,8 @@ trait Logging {
 	}
 
 	/**
-	 * @Given owncloud log level is set to :logLevel
+	 * @When the owncloud log level is set to :logLevel
+	 * @Given the owncloud log level has been set to :logLevel
 	 *
 	 * @param string $logLevel (debug|info|warning|error)
 	 *
@@ -137,7 +138,8 @@ trait Logging {
 	}
 
 	/**
-	 * @Given owncloud log backend is set to :backend
+	 * @When the owncloud log backend is set to :backend
+	 * @Given the owncloud log backend has been set to :backend
 	 *
 	 * @param string $backend (owncloud|syslog|errorlog)
 	 *
@@ -148,7 +150,8 @@ trait Logging {
 	}
 
 	/**
-	 * @Given owncloud log timezone is set to :timezone
+	 * @When the owncloud log timezone is set to :timezone
+	 * @Given the owncloud log timezone has been set to :timezone
 	 *
 	 * @param string $timezone
 	 *
@@ -159,7 +162,8 @@ trait Logging {
 	}
 
 	/**
-	 * @Given the owncloud log is cleared
+	 * @When the owncloud log is cleared
+	 * @Given the owncloud log has been cleared
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/WebUIBasicStructure.php
+++ b/tests/acceptance/features/bootstrap/WebUIBasicStructure.php
@@ -49,21 +49,23 @@ trait WebUIBasicStructure {
 	private $createdGroupNames = array();
 
 	/**
-	 * @Given I am logged in as admin
+	 * @When user admin logs in using the webUI
+	 * @Given user admin has logged in using the webUI
 	 *
 	 * @return void
 	 */
-	public function iAmLoggedInAsAdmin() {
+	public function adminLogsInUsingTheWebUI() {
 		$this->loginPage->open();
 		$this->loginAs("admin", $this->getUserPassword("admin"));
 	}
 
 	/**
-	 * @Given I am logged in as a regular user
+	 * @When the regular user logs in using the webUI
+	 * @Given the regular user has logged in using the webUI
 	 *
 	 * @return void
 	 */
-	public function iAmLoggedInAsARegularUser() {
+	public function theRegularUserLogsInUsingTheWebUI() {
 		$this->loginPage->open();
 		$this->loginAsARegularUser();
 	}
@@ -100,11 +102,12 @@ trait WebUIBasicStructure {
 	}
 
 	/**
-	 * @When I logout
+	 * @When the user/administrator logs out of the webUI
+	 * @Given the user/administrator has logged out of the webUI
 	 *
 	 * @return void
 	 */
-	public function iLogout() {
+	public function theUserLogsOutOfTheWebUI() {
 		$settingsMenu = $this->owncloudPage->openSettingsMenu();
 		$settingsMenu->logout();
 		$this->loginPage->waitTillPageIsLoaded($this->getSession());
@@ -114,13 +117,13 @@ trait WebUIBasicStructure {
 	}
 
 	/**
-	 * @Given /^a regular user exists\s?(but is not initialized|)$/
+	 * @Given /^a regular user has been created\s?(but not initialized|)$/
 	 *
 	 * @param string $doNotInitialize just create the user, do not trigger creating skeleton files etc
 	 *
 	 * @return void
 	 */
-	public function aRegularUserExists($doNotInitialize = "") {
+	public function aRegularUserHasBeenCreated($doNotInitialize = "") {
 		$this->createUser(
 			$this->getRegularUserName(),
 			$this->getRegularUserPassword(),
@@ -131,13 +134,13 @@ trait WebUIBasicStructure {
 	}
 
 	/**
-	 * @Given /^regular users exist\s?(but are not initialized|)$/
+	 * @Given /^regular users have been created\s?(but not initialized|)$/
 	 *
 	 * @param string $doNotInitialize just create the user, do not trigger creating skeleton files etc
 	 *
 	 * @return void
 	 */
-	public function regularUsersExist($doNotInitialize) {
+	public function regularUsersHaveBeenCreated($doNotInitialize) {
 		foreach ($this->getRegularUserNames() as $user) {
 			$this->createUser(
 				$user,
@@ -150,7 +153,7 @@ trait WebUIBasicStructure {
 	}
 
 	/**
-	 * @Given /^these users exist\s?(but are not initialized|):$/
+	 * @Given /^these users have been created\s?(but not initialized|):$/
 	 * expects a table of users with the heading
 	 * "|username|password|displayname|email|"
 	 * displayname & email are optional
@@ -160,7 +163,7 @@ trait WebUIBasicStructure {
 	 *
 	 * @return void
 	 */
-	public function theseUsersExist($doNotInitialize, TableNode $table) {
+	public function theseUsersHaveBeenCreated($doNotInitialize, TableNode $table) {
 		foreach ($table as $row) {
 			if (isset($row['displayname'])) {
 				$displayName = $row['displayname'];
@@ -183,7 +186,7 @@ trait WebUIBasicStructure {
 	}
 
 	/**
-	 * @Given these users are initialized:
+	 * @Given these users have been initialized:
 	 * expects a table of users with the heading
 	 * "|username|password|"
 	 *
@@ -191,7 +194,7 @@ trait WebUIBasicStructure {
 	 *
 	 * @return void
 	 */
-	public function theseUsersAreInitialized(TableNode $table) {
+	public function theseUsersHaveBeenInitialized(TableNode $table) {
 		foreach ($table as $row) {
 			$this->initializeUser(
 				$row ['username'],
@@ -287,34 +290,34 @@ trait WebUIBasicStructure {
 		);
 	}
 	/**
-	 * @Given these groups exist:
+	 * @Given these groups have been created:
 	 * expects a table of groups with the heading "groupname"
 	 *
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 */
-	public function theseGroupsExist(TableNode $table) {
+	public function theseGroupsHaveBeenCreated(TableNode $table) {
 		foreach ($table as $row) {
 			$this->createGroup($row['groupname']);
 		}
 	}
 
 	/**
-	 * @Given a regular group exists
+	 * @Given a regular group has been created
 	 *
 	 * @return void
 	 */
-	public function aRegularGroupExists() {
+	public function aRegularGroupHasBeenCreated() {
 		$this->createGroup($this->regularGroupName);
 	}
 
 	/**
-	 * @Given regular groups exist
+	 * @Given regular groups have been created
 	 *
 	 * @return void
 	 */
-	public function regularGroupsExist() {
+	public function regularGroupsHaveBeenCreated() {
 		foreach ($this->regularGroupNames as $group) {
 			$this->createGroup($group);
 		}
@@ -371,21 +374,21 @@ trait WebUIBasicStructure {
 		$this->addGroupToCreatedGroupsList($group);
 	}
 	/**
-	 * @Given a regular user is in a regular group
+	 * @Given the regular user has been added to the regular group
 	 *
 	 * @return void
 	 */
-	public function aRegularUserIsInARegularGroup() {
+	public function theRegularUserHasBeenAddedToTheRegularGroup() {
 		$group = $this->getRegularGroupName();
 		$user = $this->getRegularUserName();
 		if (!in_array($user, $this->getCreatedUserNames())) {
-			$this->aRegularUserExists();
+			$this->aRegularUserHasBeenCreated();
 		}
-		$this->theUserIsInTheGroup($user, $group);
+		$this->userHasBeenAddedToGroup($user, $group);
 	}
 
 	/**
-	 * @Given the user :user is in the group :group
+	 * @Given user :user has been added to group :group ready for use by the webUI
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -394,7 +397,7 @@ trait WebUIBasicStructure {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theUserIsInTheGroup($user, $group, $method = null) {
+	public function userHasBeenAddedToGroup($user, $group, $method = null) {
 		if ($method === null && getenv("TEST_EXTERNAL_USER_BACKENDS") === "true") {
 			//guess yourself
 			$method = "ldap";

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -132,11 +132,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given I am on the files page
+	 * @When the user browses to the files page
+	 * @Given the user has browsed to the files page
 	 *
 	 * @return void
 	 */
-	public function iAmOnTheFilesPage() {
+	public function theUserBrowsesToTheFilesPage() {
 		if (!$this->filesPage->isOpen()) {
 			$this->filesPage->open();
 			$this->filesPage->waitTillPageIsLoaded($this->getSession());
@@ -145,11 +146,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given I am on the trashbin page
+	 * @When the user browses to the trashbin page
+	 * @Given the user has browsed to the trashbin page
 	 *
 	 * @return void
 	 */
-	public function iAmOnTheTrashbinPage() {
+	public function theUserBrowsesToTheTrashbinPage() {
 		if (!$this->trashbinPage->isOpen()) {
 			$this->trashbinPage->open();
 			$this->trashbinPage->waitTillPageIsLoaded($this->getSession());
@@ -158,11 +160,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 	
 	/**
-	 * @Given I am on the favorites page
+	 * @When the user browses to the favorites page
+	 * @Given the user has browsed to the favorites page
 	 *
 	 * @return void
 	 */
-	public function iAmOnTheFavoritesPage() {
+	public function theUserBrowsesToTheFavoritesPage() {
 		if (!$this->favoritesPage->isOpen()) {
 			$this->favoritesPage->open();
 			$this->favoritesPage->waitTillPageIsLoaded($this->getSession());
@@ -171,18 +174,19 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the files/favorites page is reloaded
+	 * @When the user reloads the current page of the webUI
+	 * @Given the user has reloaded the current page of the webUI
 	 *
 	 * @return void
 	 */
-	public function theFilesPageIsReloaded() {
+	public function theUserReloadsTheCurrentPageOfTheWebUI() {
 		$this->getSession()->reload();
 		$pageObject = $this->getCurrentPageObject();
 		$pageObject->waitTillPageIsLoaded($this->getSession());
 	}
 
 	/**
-	 * @When /^I create a folder with the (invalid|)\s?name ((?:'[^']*')|(?:"[^"]*"))$/
+	 * @When /^the user creates a folder with the (invalid|)\s?name ((?:'[^']*')|(?:"[^"]*")) using the webUI$/
 	 *
 	 * @param string $invalid contains "invalid"
 	 * 						  if the folder creation is expected to fail
@@ -190,7 +194,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function iCreateAFolder($invalid, $name) {
+	public function theUserCreatesAFolderUsingTheWebUI($invalid, $name) {
 		// The capturing group of the regex always includes the quotes at each
 		// end of the captured string, so trim them.
 		$name = trim($name, $name[0]);
@@ -223,14 +227,16 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When I create a folder with the following name
+	 * @When the user creates a folder with the following name using the webUI
 	 *
 	 * @param TableNode $namePartsTable table of parts of the file name
 	 *                                  table headings: must be: |name-parts |
 	 *
 	 * @return void
 	 */
-	public function createTheFollowingFolder(TableNode $namePartsTable) {
+	public function theUserCreatesTheFollowingFolderUsingTheWebUI(
+		TableNode $namePartsTable
+	) {
 		$fileName = '';
 
 		foreach ($namePartsTable as $namePartsRow) {
@@ -241,11 +247,11 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then there are no files\/folders listed
+	 * @Then there should be no files\/folders listed on the webUI
 	 *
 	 * @return void
 	 */
-	public function thereAreNoFilesFoldersListed() {
+	public function thereShouldBeNoFilesFoldersListedOnTheWebUI() {
 		PHPUnit_Framework_Assert::assertEquals(
 			0,
 			$this->filesPage->getSizeOfFileFolderList()
@@ -253,7 +259,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given the list of files\/folders does not fit in one browser page
+	 * @When the user creates so many files\/folders that they do not fit in one browser page
+	 * @Given so many files\/folders have been created that they do not fit in one browser page
 	 *
 	 * @return void
 	 */
@@ -278,24 +285,28 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 				$this->filesPage->findFileActionsMenuBtnByNo($itemsCount)
 			);
 		}
-		$this->theFilesPageIsReloaded();
+		$this->theUserReloadsTheCurrentPageOfTheWebUI();
 	}
 
 	/**
-	 * @Given I rename the file/folder :fromName to :toName
+	 * @When the user renames the file/folder :fromName to :toName using the webUI
+	 * @Given the user has renamed the file/folder :fromName to :toName using the webUI
 	 *
 	 * @param string $fromName
 	 * @param string $toName
 	 *
 	 * @return void
 	 */
-	public function iRenameTheFileFolderTo($fromName, $toName) {
+	public function theUserRenamesTheFileFolderToUsingTheWebUI(
+		$fromName, $toName
+	) {
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
 		$this->filesPage->renameFile($fromName, $toName, $this->getSession());
 	}
 
 	/**
-	 * @Given I rename the following file/folder to
+	 * @When the user renames the following file/folder using the webUI
+	 * @Given the user has renamed the following file/folder using the webUI
 	 *
 	 * @param TableNode $namePartsTable table of parts of the from and to file names
 	 *                                  table headings: must be:
@@ -303,7 +314,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function iRenameTheFollowingFileFolderTo(TableNode $namePartsTable) {
+	public function theUserRenamesTheFollowingFileFolderToUsingTheWebUI(
+		TableNode $namePartsTable
+	) {
 		$fromNameParts = [];
 		$toNameParts = [];
 
@@ -320,14 +333,17 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When I rename the file/folder :fromName to one of these names
+	 * @When the user renames the file/folder :fromName to one of these names using the webUI
+	 * @Given the user has renamed the file/folder :fromName to one of these names using the webUI
 	 *
 	 * @param string $fromName
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 */
-	public function iRenameTheFileToOneOfThisNames($fromName, TableNode $table) {
+	public function theUserRenamesTheFileToOneOfTheseNamesUsingTheWebUI(
+		$fromName, TableNode $table
+	) {
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
 		foreach ($table->getRows() as $row) {
 			$this->filesPage->renameFile($fromName, $row[0], $this->getSession());
@@ -340,13 +356,14 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * has an "Unshare" entry in the file actions menu. Clicking it works just
 	 * like delete.
 	 *
-	 * @When I delete/unshare the file/folder :name
+	 * @When the user deletes/unshares the file/folder :name using the webUI
+	 * @Given the user has deleted/unshared the file/folder :name using the webUI
 	 *
 	 * @param string $name
 	 *
 	 * @return void
 	 */
-	public function iDeleteTheFile($name) {
+	public function theUserDeletesTheFileUsingTheWebUI($name) {
 		$pageObject = $this->getCurrentPageObject();
 		$session = $this->getSession();
 		$pageObject->waitTillPageIsLoaded($session);
@@ -354,14 +371,17 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When I delete the following file/folder
+	 * @When the user deletes the following file/folder using the webUI
+	 * @Given the user has deleted the following file/folder using the webUI
 	 *
 	 * @param TableNode $namePartsTable table of parts of the file name
 	 *                                  table headings: must be: |name-parts |
 	 *
 	 * @return void
 	 */
-	public function iDeleteTheFollowingFile(TableNode $namePartsTable) {
+	public function theUserDeletesTheFollowingFileUsingTheWebUI(
+		TableNode $namePartsTable
+	) {
 		$fileNameParts = [];
 
 		foreach ($namePartsTable as $namePartsRow) {
@@ -372,13 +392,13 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given the following files/folders are deleted
+	 * @Given the following files/folders have been deleted
 	 *
 	 * @param TableNode $filesTable table headings: must be: |name|
 	 *
 	 * @return void
 	 */
-	public function theFollowingFilesFoldersAreDeleted(TableNode $filesTable) {
+	public function theFollowingFilesFoldersHaveBeenDeleted(TableNode $filesTable) {
 		foreach ($filesTable as $file) {
 			$username = $this->webUIGeneralContext->getCurrentUser();
 			$currentTime = microtime(true);
@@ -418,34 +438,39 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When I delete the elements
+	 * @When the user deletes the following elements using the webUI
+	 * @Given the user has deleted the following elements using the webUI
 	 *
 	 * @param TableNode $table table of file names
 	 *                         table headings: must be: |name|
 	 *
 	 * @return void
 	 */
-	public function iDeleteTheElements(TableNode $table) {
+	public function theUserDeletesTheFollowingElementsUsingTheWebUI(
+		TableNode $table
+	) {
 		$this->deletedElementsTable = $table;
 		foreach ($this->deletedElementsTable as $file) {
-			$this->iDeleteTheFile($file['name']);
+			$this->theUserDeletesTheFileUsingTheWebUI($file['name']);
 		}
 	}
 
 	/**
-	 * @When I move the file/folder :name into the folder :destination
+	 * @When the user moves the file/folder :name into the folder :destination using the webUI
+	 * @Given the user has moved the file/folder :name into the folder :destination using the webUI
 	 *
 	 * @param string|array $name
 	 * @param string|array $destination
 	 *
 	 * @return void
 	 */
-	public function iMoveTheFileFolderTo($name, $destination) {
+	public function theUserMovesTheFileFolderToUsingTheWebUI($name, $destination) {
 		$this->filesPage->moveFileTo($name, $destination, $this->getSession());
 	}
 
 	/**
-	 * @When I move the following file/folder to
+	 * @When the user moves the following file/folder using the webUI
+	 * @Given the user has moved the following file/folder using the webUI
 	 *
 	 * @param TableNode $namePartsTable table of parts of the from and to file names
 	 *                                  table headings: must be:
@@ -453,7 +478,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function iMoveTheFollowingFileFolderTo(TableNode $namePartsTable) {
+	public function theUserMovesTheFollowingFileFolderUsingTheWebUI(
+		TableNode $namePartsTable
+	) {
 		$itemToMoveNameParts = [];
 		$destinationNameParts = [];
 
@@ -461,11 +488,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			$itemToMoveNameParts[] = $namePartsRow['item-to-move-name-parts'];
 			$destinationNameParts[] = $namePartsRow['destination-name-parts'];
 		}
-		$this->iMoveTheFileFolderTo($itemToMoveNameParts, $destinationNameParts);
+		$this->theUserMovesTheFileFolderToUsingTheWebUI($itemToMoveNameParts, $destinationNameParts);
 	}
 
 	/**
-	 * @When I batch move these files/folders into the folder :folderName
+	 * @When the user batch moves these files/folders into the folder :folderName using the webUI
+	 * @Given the user has batch moved these files/folders into the folder :folderName using the webUI
 	 *
 	 * @param string $folderName
 	 * @param TableNode $files table of file names
@@ -473,42 +501,44 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function iBatchMoveTheseFilesIntoTheFolder(
+	public function theUserBatchMovesTheseFilesIntoTheFolderUsingTheWebUI(
 		$folderName, TableNode $files
 	) {
-		$this->iMarkTheseFilesForBatchAction($files);
+		$this->theUserMarksTheseFilesForBatchActionUsingTheWebUI($files);
 		$firstFileName = $files->getRow(1)[0];
-		$this->iMoveTheFileFolderTo($firstFileName, $folderName);
+		$this->theUserMovesTheFileFolderToUsingTheWebUI($firstFileName, $folderName);
 		$this->movedElementsTable = $files;
 	}
 
 	/**
-	 * @When I upload overwriting the file :name
+	 * @When the user uploads overwriting the file :name using the webUI
+	 * @Given the user has uploaded overwriting the file :name using the webUI
 	 *
 	 * @param string $name
 	 *
 	 * @return void
 	 */
-	public function iUploadOverwritingTheFile($name) {
-		$this->iUploadTheFile($name);
-		$this->choiceInUploadConflict("new");
-		$this->iClickTheButton("Continue");
+	public function theUserUploadsOverwritingTheFileUsingTheWebUI($name) {
+		$this->theUserUploadsTheFileUsingTheWebUI($name);
+		$this->choiceInUploadConflictDialogWebUI("new");
+		$this->theUserChoosesToInTheUploadDialog("Continue");
 	}
 
 	/**
-	 * @When I upload overwriting the file :name and retry if the file is locked
+	 * @When the user uploads overwriting the file :name using the webUI and retries if the file is locked
+	 * @Given the user has uploaded overwriting the file :name using the webUI and retries if the file is locked
 	 *
 	 * @param string $name
 	 *
 	 * @return void
 	 */
-	public function iUploadOverwritingTheFileRetry($name) {
+	public function theUserUploadsOverwritingTheFileUsingTheWebUIRetry($name) {
 		$previousNotificationsCount = 0;
 
 		for ($retryCounter = 0;
 			 $retryCounter < STANDARDRETRYCOUNT;
 			 $retryCounter++) {
-			$this->iUploadOverwritingTheFile($name);
+			$this->theUserUploadsOverwritingTheFileUsingTheWebUI($name);
 
 			try {
 				$notifications = $this->filesPage->getNotifications();
@@ -543,38 +573,41 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When I upload the file :name keeping both new and existing files
+	 * @When the user uploads the file :name keeping both new and existing files using the webUI
+	 * @Given the user has uploaded the file :name keeping both new and existing files using the webUI
 	 *
 	 * @param string $name
 	 *
 	 * @return void
 	 */
-	public function iUploadTheFileKeepingNewExisting($name) {
-		$this->iUploadTheFile($name);
-		$this->choiceInUploadConflict("new");
-		$this->choiceInUploadConflict("existing");
-		$this->iClickTheButton("Continue");
+	public function theUserUploadsTheFileKeepingNewExistingUsingTheWebUI($name) {
+		$this->theUserUploadsTheFileUsingTheWebUI($name);
+		$this->choiceInUploadConflictDialogWebUI("new");
+		$this->choiceInUploadConflictDialogWebUI("existing");
+		$this->theUserChoosesToInTheUploadDialog("Continue");
 	}
 
 	/**
-	 * @When I upload the file :name
+	 * @When the user uploads the file :name using the webUI
+	 * @Given the user has uploaded the file :name using the webUI
 	 *
 	 * @param string $name
 	 *
 	 * @return void
 	 */
-	public function iUploadTheFile($name) {
+	public function theUserUploadsTheFileUsingTheWebUI($name) {
 		$this->filesPage->uploadFile($this->getSession(), $name);
 	}
 
 	/**
-	 * @When /^I choose to keep the (new|existing) files$/
+	 * @When /^the user chooses to keep the (new|existing) files in the upload dialog$/
+	 * @Given /^the user has chosen to keep the (new|existing) files in the upload dialog$/
 	 *
 	 * @param string $choice
 	 *
 	 * @return void
 	 */
-	public function choiceInUploadConflict($choice) {
+	public function choiceInUploadConflictDialogWebUI($choice) {
 		$dialogs = $this->filesPage->getOcDialogs();
 		$isConflictDialog = false;
 		foreach ($dialogs as $dialog) {
@@ -605,13 +638,14 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When the user chooses :label in the upload dialog
 	 * @When I click the :label button
 	 *
 	 * @param string $label
 	 *
 	 * @return void
 	 */
-	public function iClickTheButton($label) {
+	public function theUserChoosesToInTheUploadDialog($label) {
 		$dialogs = $this->filesPage->getOcDialogs();
 		$dialog = end($dialogs);
 		$this->conflictDialog->setElement($dialog->getOwnElement());
@@ -620,84 +654,89 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the (?:deleted|moved) elements should (not|)\s?be listed$/
+	 * @Then /^the (?:deleted|moved) elements should (not|)\s?be listed on the webUI$/
 	 *
 	 * @param string $shouldOrNot
 	 *
 	 * @return void
 	 */
-	public function theDeletedMovedElementsShouldBeListed($shouldOrNot) {
+	public function theDeletedMovedElementsShouldBeListedOnTheWebUI($shouldOrNot) {
 		if (!is_null($this->deletedElementsTable)) {
 			foreach ($this->deletedElementsTable as $file) {
-				$this->checkIfFileFolderIsListed($file['name'], $shouldOrNot);
+				$this->checkIfFileFolderIsListedOnTheWebUI($file['name'], $shouldOrNot);
 			}
 		}
 		if (!is_null($this->movedElementsTable)) {
 			foreach ($this->movedElementsTable as $file) {
-				$this->checkIfFileFolderIsListed($file['name'], $shouldOrNot);
+				$this->checkIfFileFolderIsListedOnTheWebUI($file['name'], $shouldOrNot);
 			}
 		}
 	}
 
 	/**
-	 * @Then /^the (?:deleted|moved) elements should (not|)\s?be listed after a page reload$/
+	 * @Then /^the (?:deleted|moved) elements should (not|)\s?be listed on the webUI after a page reload$/
 	 *
 	 * @param string $shouldOrNot
 	 *
 	 * @return void
 	 */
-	public function theDeletedMovedElementsShouldBeListedAfterPageReload(
+	public function theDeletedMovedElementsShouldBeListedOnTheWebUIAfterPageReload(
 		$shouldOrNot
 	) {
-		$this->theFilesPageIsReloaded();
-		$this->theDeletedMovedElementsShouldBeListed($shouldOrNot);
+		$this->theUserReloadsTheCurrentPageOfTheWebUI();
+		$this->theDeletedMovedElementsShouldBeListedOnTheWebUI($shouldOrNot);
 	}
 
 	/**
-	 * @Then the deleted elements should be listed in the trashbin
+	 * @Then the deleted elements should be listed in the trashbin on the webUI
 	 *
 	 * @return void
 	 */
-	public function theDeletedElementsShouldBeListedInTheTrashbin() {
-		$this->iAmOnTheTrashbinPage();
+	public function theDeletedElementsShouldBeListedInTheTrashbinOnTheWebUI() {
+		$this->theUserBrowsesToTheTrashbinPage();
 
 		foreach ($this->deletedElementsTable as $file) {
-			$this->checkIfFileFolderIsListed($file['name'], "", "trashbin");
+			$this->checkIfFileFolderIsListedOnTheWebUI($file['name'], "", "trashbin");
 		}
 	}
 
 	/**
-	 * @When I batch delete these files
+	 * @When the user batch deletes these files using the webUI
+	 * @Given the user has batch deleted these files using the webUI
 	 *
 	 * @param TableNode $files table of file names
 	 *                         table headings: must be: |name|
 	 *
 	 * @return void
 	 */
-	public function iBatchDeleteTheseFiles(TableNode $files) {
+	public function theUserBatchDeletesTheseFilesUsingTheWebUI(TableNode $files) {
 		$this->deletedElementsTable = $files;
-		$this->iMarkTheseFilesForBatchAction($files);
-		$this->iBatchDeleteTheMarkedFiles();
+		$this->theUserMarksTheseFilesForBatchActionUsingTheWebUI($files);
+		$this->theUserBatchDeletesTheMarkedFilesUsingTheWebUI();
 	}
 
 	/**
-	 * @When I batch delete the marked files
+	 * @When the user batch deletes the marked files using the webUI
+	 * @Given the user has batch deleted the marked files using the webUI
 	 *
 	 * @return void
 	 */
-	public function iBatchDeleteTheMarkedFiles() {
+	public function theUserBatchDeletesTheMarkedFilesUsingTheWebUI() {
 		$this->filesPage->deleteAllSelectedFiles($this->getSession());
 	}
 
 	/**
-	 * @When I mark these files for batch action
+	 * @When the user marks these files for batch action using the webUI
+	 * @Given the user has marked these files for batch action using the webUI
 	 *
 	 * @param TableNode $files table of file names
 	 *                         table headings: must be: |name|
 	 *
 	 * @return void
 	 */
-	public function iMarkTheseFilesForBatchAction(TableNode $files) {
+	public function theUserMarksTheseFilesForBatchActionUsingTheWebUI(
+		TableNode $files
+	) {
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
 		foreach ($files as $file) {
 			$this->filesPage->selectFileForBatchAction(
@@ -707,7 +746,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When /^I open the (trashbin|)\s?(file|folder) ((?:'[^']*')|(?:"[^"]*"))$/
+	 * @When /^the user opens the (trashbin|)\s?(file|folder) ((?:'[^']*')|(?:"[^"]*")) using the webUI$/
+	 * @Given /^the user has opened the (trashbin|)\s?(file|folder) ((?:'[^']*')|(?:"[^"]*")) using the webUI$/
 	 *
 	 * @param string $typeOfFilesPage
 	 * @param string $fileOrFolder 
@@ -715,10 +755,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function iOpenTheFolderNamed($typeOfFilesPage, $fileOrFolder, $name) {
+	public function theUserOpensTheFolderNamedUsingTheWebUI(
+		$typeOfFilesPage, $fileOrFolder, $name
+	) {
 		// The capturing groups of the regex include the quotes at each
 		// end of the captured string, so trim them.
-		$this->iOpenTheFolder($typeOfFilesPage, $fileOrFolder, trim($name, $name[0]));
+		$this->theUserOpensTheFolderUsingTheWebUI($typeOfFilesPage, $fileOrFolder, trim($name, $name[0]));
 	}
 
 	/**
@@ -728,9 +770,11 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function iOpenTheFolder($typeOfFilesPage, $fileOrFolder, $name) {
+	public function theUserOpensTheFolderUsingTheWebUI(
+		$typeOfFilesPage, $fileOrFolder, $name
+	) {
 		if ($typeOfFilesPage === "trashbin") {
-			$this->iAmOnTheTrashbinPage();
+			$this->theUserBrowsesToTheTrashbinPage();
 		}
 		if ($fileOrFolder === "folder") {
 			if (is_array($name)) {
@@ -747,7 +791,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	
 	
 	/**
-	 * @Then /^the (?:file|folder) ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(?:in the |)(trashbin|favorites page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))?$/
+	 * @Then /^the (?:file|folder) ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(?:in the |)(trashbin|favorites page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))? on the webUI$/
 	 *
 	 * @param string $name enclosed in single or double quotes
 	 * @param string $shouldOrNot
@@ -756,7 +800,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theFileFolderShouldBeListed(
+	public function theFileFolderShouldBeListedOnTheWebUI(
 		$name, $shouldOrNot, $typeOfFilesPage = "", $folder = ""
 	) {
 		// The capturing groups of the regex include the quotes at each
@@ -765,7 +809,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			$folder = trim($folder, $folder[0]);
 		}
 
-		$this->checkIfFileFolderIsListed(
+		$this->checkIfFileFolderIsListedOnTheWebUI(
 			trim($name, $name[0]),
 			$shouldOrNot,
 			$typeOfFilesPage,
@@ -781,21 +825,21 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function checkIfFileFolderIsListed(
+	public function checkIfFileFolderIsListedOnTheWebUI(
 		$name, $shouldOrNot, $typeOfFilesPage = "", $folder = ""
 	) {
 		$should = ($shouldOrNot !== "not");
 		$exceptionMessage = null;
 		if ($typeOfFilesPage === "trashbin") {
-			$this->iAmOnTheTrashbinPage();
+			$this->theUserBrowsesToTheTrashbinPage();
 		}
 		if ($typeOfFilesPage === "favorites page") {
-			$this->iAmOnTheFavoritesPage();
+			$this->theUserBrowsesToTheFavoritesPage();
 		}
 		$pageObject = $this->getCurrentPageObject();
 		$pageObject->waitTillPageIsLoaded($this->getSession());
 		if ($folder !== "") {
-			$this->iOpenTheFolder($typeOfFilesPage, "folder", $folder);
+			$this->theUserOpensTheFolderUsingTheWebUI($typeOfFilesPage, "folder", $folder);
 		}
 
 		try {
@@ -857,23 +901,23 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the moved elements should (not|)\s?be listed in the folder ['"](.*)['"]$/
+	 * @Then /^the moved elements should (not|)\s?be listed in the folder ['"](.*)['"] on the webUI$/
 	 *
 	 * @param string $shouldOrNot
 	 * @param string $folderName
 	 *
 	 * @return void
 	 */
-	public function theMovedElementsShouldBeListedInTheFolder(
+	public function theMovedElementsShouldBeListedInTheFolderOnTheWebUI(
 		$shouldOrNot, $folderName
 	) {
-		$this->iOpenTheFolder("", "folder", $folderName);
+		$this->theUserOpensTheFolderUsingTheWebUI("", "folder", $folderName);
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
-		$this->theDeletedMovedElementsShouldBeListed($shouldOrNot);
+		$this->theDeletedMovedElementsShouldBeListedOnTheWebUI($shouldOrNot);
 	}
 
 	/**
-	 * @Then /^the following (?:file|folder|item) should (not|)\s?be listed in the following folder$/
+	 * @Then /^the following (?:file|folder|item) should (not|)\s?be listed in the following folder on the webUI$/
 	 *
 	 * @param string $shouldOrNot
 	 * @param TableNode $namePartsTable table of parts of the file name
@@ -881,7 +925,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theFollowingFileFolderShouldBeListedInTheFollowingFolder(
+	public function theFollowingFileFolderShouldBeListedInTheFollowingFolderOnTheWebUI(
 		$shouldOrNot, TableNode $namePartsTable
 	) {
 		$toBeListedTableArray[] = ["name-parts"];
@@ -890,17 +934,17 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			$folderNameParts[] = $namePartsRow['folder-name-parts'];
 			$toBeListedTableArray[] = [$namePartsRow['item-name-parts']];
 		}
-		$this->iOpenTheFolder("", "folder", $folderNameParts);
+		$this->theUserOpensTheFolderUsingTheWebUI("", "folder", $folderNameParts);
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
 
 		$toBeListedTable = new TableNode($toBeListedTableArray);
-		$this->theFollowingFileFolderShouldBeListed(
+		$this->theFollowingFileFolderShouldBeListedOnTheWebUI(
 			$shouldOrNot, "", "", $toBeListedTable
 		);
 	}
 
 	/**
-	 * @Then /^the following (?:file|folder) should (not|)\s?be listed\s?(?:in the |)(trashbin|favorites page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))?$/
+	 * @Then /^the following (?:file|folder) should (not|)\s?be listed\s?(?:in the |)(trashbin|favorites page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))? on the webUI$/
 	 *
 	 * @param string $shouldOrNot
 	 * @param string $typeOfFilesPage
@@ -910,7 +954,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theFollowingFileFolderShouldBeListed(
+	public function theFollowingFileFolderShouldBeListedOnTheWebUI(
 		$shouldOrNot, $typeOfFilesPage, $folder = "", TableNode $namePartsTable = null
 	) {
 		$fileNameParts = [];
@@ -929,7 +973,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			$folder = trim($folder, $folder[0]);
 		}
 
-		$this->checkIfFileFolderIsListed(
+		$this->checkIfFileFolderIsListedOnTheWebUI(
 			$fileNameParts,
 			$shouldOrNot,
 			$typeOfFilesPage,
@@ -938,14 +982,14 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then near the file/folder :name a tooltip with the text :toolTipText should be displayed
+	 * @Then near the file/folder :name a tooltip with the text :toolTipText should be displayed on the webUI
 	 *
 	 * @param string $name
 	 * @param string $toolTipText
 	 *
 	 * @return void
 	 */
-	public function nearTheFileATooltipWithTheTextShouldBeDisplayed(
+	public function nearTheFileATooltipWithTheTextShouldBeDisplayedOnTheWebUI(
 		$name,
 		$toolTipText
 	) {
@@ -956,39 +1000,40 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 	
 	/**
-	 * @When I restore the file/folder :fname
+	 * @When the user restores the file/folder :fname from the trashbin using the webUI
+	 * @Given the user has restored the file/folder :fname from the trashbin using the webUI
 	 *
 	 * @param string $fname
 	 *
 	 * @return void
 	 */
-	public function restoreFileAndFolder($fname) {
+	public function restoreFileFolderFromTrashbinUsingTheWebUI($fname) {
 		$session = $this->getSession();
 		$this->trashbinPage->restore($fname, $session);
 	}
 
 	/**
-	 * @Then near the folder input field a tooltip with the text :tooltiptext should be displayed
+	 * @Then near the folder input field a tooltip with the text :tooltiptext should be displayed on the webUI
 	 *
 	 * @param string $tooltiptext
 	 *
 	 * @return void
 	 */
-	public function folderInputFieldTooltipTextShouldBe($tooltiptext) {
+	public function folderInputFieldTooltipTextShouldBeDisplayedOnTheWebUI($tooltiptext) {
 		$createFolderTooltip = $this->filesPage->getCreateFolderTooltip();
 		PHPUnit_Framework_Assert::assertSame($tooltiptext, $createFolderTooltip);
 	}
 
 	/**
-	 * @Then it should not be possible to delete the file/folder :name
+	 * @Then it should not be possible to delete the file/folder :name using the webUI
 	 *
 	 * @param string $name
 	 *
 	 * @return void
 	 */
-	public function itShouldNotBePossibleToDelete($name) {
+	public function itShouldNotBePossibleToDeleteUsingTheWebUI($name) {
 		try {
-			$this->iDeleteTheFile($name);
+			$this->theUserDeletesTheFileUsingTheWebUI($name);
 		} catch (ElementNotFoundException $e) {
 			PHPUnit_Framework_Assert::assertContains(
 				"could not find button 'Delete' in action Menu",
@@ -998,11 +1043,11 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the filesactionmenu should be completely visible after clicking on it
+	 * @Then the files action menu should be completely visible after opening it using the webUI
 	 *
 	 * @return void
 	 */
-	public function theFilesactionmenuShouldBeCompletelyVisibleAfterClickingOnIt() {
+	public function theFilesActionMenuShouldBeCompletelyVisibleAfterOpeningItUsingTheWebUI() {
 		for ($i = 1; $i <= $this->filesPage->getSizeOfFileFolderList(); $i++) {
 			$actionMenu = $this->filesPage->openFileActionsMenuByNo($i);
 			
@@ -1097,27 +1142,27 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When I mark the file/folder :fileOrFolderName as favorite
-	 * @Given the file/folder :fileOrFolderName is marked as favorite
+	 * @When the user marks the file/folder :fileOrFolderName as favorite using the webUI
+	 * @Given the user has marked the file/folder :fileOrFolderName as favorite using the webUI
 	 *
 	 * @param string $fileOrFolderName
 	 *
 	 * @return void
 	 */
-	public function iMarkTheFileAsFavorite($fileOrFolderName) {
+	public function theUserMarksTheFileAsFavoriteUsingTheWebUI($fileOrFolderName) {
 		$fileRow = $this->filesPage->findFileRowByName($fileOrFolderName, $this->getSession());
 		$fileRow->markAsFavorite();
 		$this->filesPage->waitTillFileRowsAreReady($this->getSession());
 	}
 	
 	/**
-	 * @Then the file/folder :fileOrFolderName should be marked as favorite
+	 * @Then the file/folder :fileOrFolderName should be marked as favorite on the webUI
 	 *
 	 * @param string $fileOrFolderName
 	 *
 	 * @return void
 	 */
-	public function theFileShouldBeMarkedAsFavorite($fileOrFolderName) {
+	public function theFileShouldBeMarkedAsFavoriteOnTheWebUI($fileOrFolderName) {
 		$fileRow = $this->filesPage->findFileRowByName($fileOrFolderName, $this->getSession());
 		if ($fileRow->isMarkedAsFavorite() === false) {
 			throw new Exception(
@@ -1128,26 +1173,27 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 	
 	/**
-	 * @When I unmark the file/folder :fileOrFolderName
+	 * @When the user unmarks the favorited file/folder :fileOrFolderName using the webUI
+	 * @Given the user has unmarked the favorited file/folder :fileOrFolderName using the webUI
 	 *
 	 * @param string $fileOrFolderName
 	 *
 	 * @return void
 	 */
-	public function iUnmarkTheFolder($fileOrFolderName) {
+	public function theUserUnmarksTheFavoritedFileUsingTheWebUI($fileOrFolderName) {
 		$fileRow = $this->getCurrentPageObject()->findFileRowByName($fileOrFolderName, $this->getSession());
 		$fileRow->unmarkFavorite();
 		$this->getCurrentPageObject()->waitTillFileRowsAreReady($this->getSession());
 	}
 	
 	/**
-	 * @Then the file/folder :fileOrFolderName should not be marked as favorite
+	 * @Then the file/folder :fileOrFolderName should not be marked as favorite on the webUI
 	 *
 	 * @param string $fileOrFolderName
 	 *
 	 * @return void
 	 */
-	public function theFolderShouldNotBeMarkedAsFavorite($fileOrFolderName) {
+	public function theFolderShouldNotBeMarkedAsFavoriteOnTheWebUI($fileOrFolderName) {
 		$fileRow = $this->filesPage->findFileRowByName($fileOrFolderName, $this->getSession());
 		if ($fileRow->isMarkedAsFavorite() === true) {
 			throw new Exception(
@@ -1208,10 +1254,10 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When I enable the setting to view hidden files/folders
+	 * @When the user enables the setting to view hidden files/folders on the webUI
 	 * @return void
 	 */
-	public function iEnableTheSettingToViewHiddenFolders() {
+	public function theUserEnablesTheSettingToViewHiddenFoldersOnTheWebUI() {
 		$this->filesPage->enableShowHiddenFilesSettings();
 	}
 }

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -181,11 +181,11 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then no notification should be displayed
+	 * @Then no notification should be displayed on the webUI
 	 *
 	 * @return void
 	 */
-	public function noNotificationShouldBeDisplayed() {
+	public function noNotificationShouldBeDisplayedOnTheWebUI() {
 		try {
 			$notificationText = $this->owncloudPage->getNotificationText();
 			PHPUnit_Framework_Assert::assertEquals(
@@ -199,20 +199,22 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then a notification should be displayed with the text :notificationText
+	 * @Then a notification should be displayed on the webUI with the text :notificationText
 	 *
 	 * @param string $notificationText expected notification text
 	 *
 	 * @return void
 	 */
-	public function aNotificationShouldBeDisplayedWithTheText($notificationText) {
+	public function aNotificationShouldBeDisplayedOnTheWebUIWithTheText(
+		$notificationText
+	) {
 		PHPUnit_Framework_Assert::assertEquals(
 			$notificationText, $this->owncloudPage->getNotificationText()
 		);
 	}
 
 	/**
-	 * @Then /^notifications should be displayed with the text\s?(matching|)$/
+	 * @Then /^notifications should be displayed on the webUI with the text\s?(matching|)$/
 	 *
 	 * @param string $matching contains "matching" when notification text
 	 *                         has to be checked against regular expression
@@ -221,7 +223,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function notificationsShouldBeDisplayedWithTheText($matching, TableNode $table) {
+	public function notificationsShouldBeDisplayedOnTheWebUIWithTheText($matching, TableNode $table) {
 		$actualNotifications = $this->owncloudPage->getNotifications();
 		$numActualNotifications = count($actualNotifications);
 		$expectedNotifications = $table->getRows();
@@ -254,7 +256,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^((?:\d)|no)?\s?dialog[s]? should be displayed$/
+	 * @Then /^((?:\d)|no)?\s?dialog[s]? should be displayed on the webUI$/
 	 *
 	 * @param int|string|null $count
 	 * @param TableNode|null $table of expected dialogs format must be:
@@ -262,7 +264,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function dialogsShouldBeDisplayed(
+	public function dialogsShouldBeDisplayedOnTheWebUI(
 		$count = null, TableNode $table = null
 	) {
 		$dialogs = $this->owncloudPage->getOcDialogs();
@@ -312,13 +314,13 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then I should be redirected to a page with the title :title
+	 * @Then the user should be redirected to a webUI page with the title :title
 	 *
 	 * @param string $title
 	 *
 	 * @return void
 	 */
-	public function iShouldBeRedirectedToAPageWithTheTitle($title) {
+	public function theUserShouldBeRedirectedToAWebUIPageWithTheTitle($title) {
 		$this->owncloudPage->waitForOutstandingAjaxCalls($this->getSession());
 		$actualTitle = $this->getSession()->getPage()->find(
 			'xpath', './/title'
@@ -369,7 +371,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given /^the setting "([^"]*)" in the section "([^"]*)" is (disabled|enabled)$/
+	 * @Given /^the setting "([^"]*)" in the section "([^"]*)" has been (disabled|enabled)$/
 	 *
 	 * @param string $setting
 	 * @param string $section
@@ -377,7 +379,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function settingInSectionIs($setting, $section, $value) {
+	public function settingInSectionHasBeen($setting, $section, $value) {
 		if ($value === "enabled") {
 			$value = true;
 		} elseif ($value === "disabled") {
@@ -403,7 +405,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given a file with the size of :size bytes and the name :name exists
+	 * @Given a file with the size of :size bytes and the name :name has been created locally
 	 *
 	 * @param int $size if not int given it will be cast to int
 	 * @param string $name
@@ -411,7 +413,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @throws InvalidArgumentException
 	 * @return void
 	 */
-	public function aFileWithSizeAndNameExists($size, $name) {
+	public function aFileWithSizeAndNameHasBeenCreatedLocally($size, $name) {
 		$fullPath = getenv("FILES_FOR_UPLOAD") . $name;
 		if (file_exists($fullPath)) {
 			throw new InvalidArgumentException(

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -53,41 +53,45 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given I am on the login page
+	 * @When the user browses to the login page
+	 * @Given the user has browsed to the login page
 	 *
 	 * @return void
 	 */
-	public function iAmOnTheLoginPage() {
+	public function theUserBrowsesToTheLoginPage() {
 		$this->loginPage->open();
 	}
 
 	/**
-	 * @When I relogin with username :username and password :password
+	 * @When the user re-logs in with username :username and password :password using the webUI
 	 *
 	 * @param string $username
 	 * @param string $password
 	 *
 	 * @return void
 	 */
-	public function iReloginWithUsernameAndPassword($username, $password) {
-		$this->webUIGeneralContext->iLogout();
-		$this->iLoginWithUsernameAndPassword($username, $password);
+	public function theUserRelogsInWithUsernameAndPasswordUsingTheWebUI(
+		$username, $password
+	) {
+		$this->webUIGeneralContext->theUserLogsOutOfTheWebUI();
+		$this->theUserLogsInWithUsernameAndPasswordUsingTheWebUI($username, $password);
 	}
 
 	/**
-	 * @When I login with username :username and password :password
+	 * @When the user logs in with username :username and password :password using the webUI
+	 * @Given the user has logged in with username :username and password :password using the webUI
 	 *
 	 * @param string $username
 	 * @param string $password
 	 *
 	 * @return void
 	 */
-	public function iLoginWithUsernameAndPassword($username, $password) {
+	public function theUserLogsInWithUsernameAndPasswordUsingTheWebUI($username, $password) {
 		$this->filesPage = $this->webUIGeneralContext->loginAs($username, $password);
 	}
 
 	/**
-	 * @When I relogin with username :username and password :password to :server
+	 * @When the user re-logs in with username :username and password :password to :server using the webUI
 	 *
 	 * @param string $username
 	 * @param string $password
@@ -95,15 +99,17 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function iReloginWithUsernameAndPasswordToSrv(
+	public function theUserRelogsInWithUsernameAndPasswordToUsingTheWebUI(
 		$username, $password, $server
 	) {
-		$this->webUIGeneralContext->iLogout();
-		$this->iLoginWithUsernameAndPasswordToSrv($username, $password, $server);
+		$this->webUIGeneralContext->theUserLogsOutOfTheWebUI();
+		$this->theUserLogsInWithUsernameAndPasswordToUsingTheWebUI(
+			$username, $password, $server
+		);
 	}
 
 	/**
-	 * @When I login with username :username and password :password to :server
+	 * @When the user logs in with username :username and password :password to :server using the webUI
 	 *
 	 * @param string $username
 	 * @param string $password
@@ -111,7 +117,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function iLoginWithUsernameAndPasswordToSrv(
+	public function theUserLogsInWithUsernameAndPasswordToUsingTheWebUI(
 		$username, $password, $server
 	) {
 		$server = $this->webUIGeneralContext->substituteInLineCodes($server);
@@ -119,27 +125,29 @@ class WebUILoginContext extends RawMinkContext implements Context {
 			$server . $this->loginPage->getOriginalPath()
 		);
 		$this->loginPage->open();
-		$this->iLoginWithUsernameAndPassword($username, $password);
+		$this->theUserLogsInWithUsernameAndPasswordUsingTheWebUI($username, $password);
 		$this->webUIGeneralContext->setCurrentServer($server);
 	}
 
 	/**
-	 * @When I login with username :username and invalid password :password
-	 * @When I login with invalid username :username and password :password
-	 * @When I login with invalid username :username and invalid password :password
+	 * @When the user logs in with username :username and invalid password :password using the webUI
+	 * @When the user logs with invalid username :username and password :password using the webUI
+	 * @When the user logs with invalid username :username and invalid password :password using the webUI
 	 *
 	 * @param string $username
 	 * @param string $password
 	 *
 	 * @return void
 	 */
-	public function iLoginWithUsernameAndInvalidPassword($username, $password) {
+	public function theUserLogsInWithUsernameAndInvalidPasswordUsingTheWebUI(
+		$username, $password
+	) {
 		$this->loginPage->loginAs($username, $password, 'LoginPage');
 		$this->loginPage->waitTillPageIsLoaded($this->getSession());
 	}
 
 	/**
-	 * @When I login with username :username and password :password after a redirect from the :page page
+	 * @When the user logs in with username :username and password :password using the webUI after a redirect from the :page page
 	 *
 	 * @param string $username
 	 * @param string $password
@@ -147,7 +155,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function iLoginWithUsernameAndPasswordAfterRedirectFromThePage(
+	public function theUserLogsInWithUsernameAndPasswordAfterRedirectFromThePage(
 		$username,
 		$password,
 		$page
@@ -160,16 +168,16 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When I login as a regular user with a correct password
+	 * @When the user logs in as a regular user with a correct password using the webUI
 	 *
 	 * @return void
 	 */
-	public function iLoginAsARegularUserWithACorrectPassword() {
+	public function theUserLogsInAsARegularUserWithACorrectPasswordUsingTheWebUI() {
 		$this->filesPage = $this->webUIGeneralContext->loginAsARegularUser();
 	}
 
 	/**
-	 * @Then /^it should (not|)\s?be possible to login with the username ((?:'[^']*')|(?:"[^"]*")) and password ((?:'[^']*')|(?:"[^"]*")) into the WebUI$/
+	 * @Then /^it should (not|)\s?be possible to login with the username ((?:'[^']*')|(?:"[^"]*")) and password ((?:'[^']*')|(?:"[^"]*")) using the WebUI$/
 	 * 
 	 * @param string $shouldOrNot
 	 * @param string $username
@@ -188,20 +196,21 @@ class WebUILoginContext extends RawMinkContext implements Context {
 		if ($password !== "") {
 			$password = trim($password, $password[0]);
 		}
-		$this->iAmOnTheLoginPage();
+		$this->theUserBrowsesToTheLoginPage();
 		if ($should) {
-			$this->iLoginWithUsernameAndPassword($username, $password);
-			$this->webUIGeneralContext->iShouldBeRedirectedToAPageWithTheTitle(
+			$this->theUserLogsInWithUsernameAndPasswordUsingTheWebUI($username, $password);
+			$this->webUIGeneralContext->theUserShouldBeRedirectedToAWebUIPageWithTheTitle(
 				$this->loginSuccessPageTitle
 			);
 		} else {
-			$this->iLoginWithUsernameAndInvalidPassword($username, $password);
-			$this->webUIGeneralContext->iShouldBeRedirectedToAPageWithTheTitle(
+			$this->theUserLogsInWithUsernameAndInvalidPasswordUsingTheWebUI($username, $password);
+			$this->webUIGeneralContext->theUserShouldBeRedirectedToAWebUIPageWithTheTitle(
 				$this->loginFailedPageTitle
 			);
 		}
 		
 	}
+	
 	/**
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -50,11 +50,12 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	}
 
 	/**
-	 * @Given I am on the personal general settings page
+	 * @When the user browses to the personal general settings page
+	 * @Given the user has browsed to the personal general settings page
 	 *
 	 * @return void
 	 */
-	public function iAmOnThePersonalGeneralSettingsPage() {
+	public function theUserBrowsesToThePersonalGeneralSettingsPage() {
 		$this->personalGeneralSettingsPage->open();
 		$this->personalGeneralSettingsPage->waitForOutstandingAjaxCalls(
 			$this->getSession()
@@ -62,22 +63,15 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	}
 
 	/**
-	 * @Given /^I (attempt to |)go to the personal general settings page$/
+	 * Browse to the personal general settings page, but do not test or fail
+	 * if the expected page is not actually reached.
 	 *
-	 * @param string $attemptTo
+	 * @When /^the user attempts to browse to the personal general settings page$/
 	 *
 	 * @return void
-	 * @throws Exception
 	 */
-	public function iGoToThePersonalGeneralSettingsPage($attemptTo) {
-		$pageIsExpectedToLoad = ($attemptTo === "");
+	public function theUserAttemptsToBrowseToThePersonalGeneralSettingsPage() {
 		$this->visitPath($this->personalGeneralSettingsPage->getPagePath());
-
-		if ($pageIsExpectedToLoad) {
-			$this->personalGeneralSettingsPage->waitTillPageIsLoaded(
-				$this->getSession()
-			);
-		}
 
 		$this->personalGeneralSettingsPage->waitForOutstandingAjaxCalls(
 			$this->getSession()
@@ -85,13 +79,13 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	}
 
 	/**
-	 * @When I change the language to :language
+	 * @When the user changes the language to :language using the webUI
 	 *
 	 * @param string $language
 	 *
 	 * @return void
 	 */
-	public function iChangeTheLanguageTo($language) {
+	public function theUserChangesTheLanguageToUsingTheWebUI($language) {
 		$this->personalGeneralSettingsPage->changeLanguage($language);
 		$this->personalGeneralSettingsPage->waitForOutstandingAjaxCalls(
 			$this->getSession()
@@ -99,13 +93,13 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	}
 	
 	/**
-	 * @When I change the password to :newPassword
+	 * @When the user changes the password to :newPassword using the webUI
 	 *
 	 * @param string $newPassword
 	 *
 	 * @return void
 	 */
-	public function iChangeThePasswordTo($newPassword) {
+	public function theUserChangesThePasswordToUsingTheWebUI($newPassword) {
 		$username = $this->webUIGeneralContext->getCurrentUser();
 		$oldPassword = trim($this->webUIGeneralContext->getUserPassword($username));
 		$this->personalGeneralSettingsPage->changePassword(
@@ -114,13 +108,15 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	}
 	
 	/**
-	 * @When I change the password to :newPassword using wrong current password
+	 * @When the user changes the password to :newPassword entering the wrong current password using the webUI
 	 *
 	 * @param string $newPassword
 	 *
 	 * @return void
 	 */
-	public function iChangeThePasswordToUsingWrongCurrentPassword($newPassword) {
+	public function theUserChangesThePasswordWrongCurrentPasswordUsingTheWebUI(
+		$newPassword
+	) {
 		$oldPassword = "thisisawrongpassword";
 		$this->personalGeneralSettingsPage->changePassword(
 			$oldPassword, $newPassword, $this->getSession()
@@ -128,13 +124,13 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	}
 	
 	/**
-	 * @Then a password error message should be displayed with the text :wrongPasswordmessageText
+	 * @Then a password error message should be displayed on the webUI with the text :wrongPasswordmessageText
 	 *
 	 * @param string $wrongPasswordmessageText
 	 *
 	 * @return void
 	 */
-	public function aPasswordErrorMessageShouldBeDisplayedWithTheText(
+	public function aPasswordErrorMessageShouldBeDisplayedOnTheWebUIWithTheText(
 		$wrongPasswordmessageText
 	) {
 		PHPUnit_Framework_Assert::assertEquals(

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
@@ -48,29 +48,31 @@ class WebUIPersonalSecuritySettingsContext extends RawMinkContext implements Con
 	}
 
 	/**
-	 * @Given I am on the personal security settings page
+	 * @When the user browses to the personal security settings page
+	 * @Given the user has browsed to the personal security settings page
 	 *
 	 * @return void
 	 */
-	public function iAmOnThePersonalSecuritySettingsPage() {
+	public function theUserBrowsesToThePersonalSecuritySettingsPage() {
 		$this->personalSecuritySettingsPage->open();
 	}
 
 	/**
-	 * @When I create a new App password
+	 * @When the user creates a new App password using the webUI
+	 * @Given the user has created a new App password using the webUI
 	 *
 	 * @return void
 	 */
-	public function iCreateANewAppPasswordForTheAppNamed() {
+	public function theUserCreatesANewAppPasswordUsingTheWebUI() {
 		$this->personalSecuritySettingsPage->createNewAppPassword($this->appName);
 	}
 
 	/**
-	 * @Then the new app should be listed in the App passwords list
+	 * @Then the new app should be listed in the App passwords list on the webUI
 	 *
 	 * @return void
 	 */
-	public function theAppShouldBeListedInTheAppPasswordsList() {
+	public function theAppShouldBeListedInTheAppPasswordsListOnTheWebUI() {
 		$appTr = $this->personalSecuritySettingsPage->getLinkedAppByName(
 			$this->appName
 		);
@@ -81,11 +83,11 @@ class WebUIPersonalSecuritySettingsContext extends RawMinkContext implements Con
 	}
 
 	/**
-	 * @Then my username and the app password should be displayed
+	 * @Then the user display name and the app password should be displayed on the webUI
 	 *
 	 * @return void
 	 */
-	public function myUsernameAndTheAppPasswordShouldBeDisplayed() {
+	public function theUserDisplayNameAndAppPasswordShouldBeDisplayedOnTheWebUI() {
 		$result = $this->personalSecuritySettingsPage->getAppPasswordResult();
 		PHPUnit_Framework_Assert::assertEquals(
 			$this->personalSecuritySettingsPage->getMyDisplayname(),

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -81,7 +81,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given /^the (?:file|folder) "([^"]*)" is shared with the (?:(remote|federated)\s)?user "([^"]*)"$/
+	 * @When /^the user shares the (?:file|folder) "([^"]*)" with the (?:(remote|federated)\s)?user "([^"]*)" using the webUI$/
+	 * @Given /^the user has shared the (?:file|folder) "([^"]*)" with the (?:(remote|federated)\s)?user "([^"]*)" using the webUI$/
 	 *
 	 * @param string $folder
 	 * @param string $remote
@@ -91,7 +92,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * 
 	 * @return void
 	 */
-	public function theFileFolderIsSharedWithTheUser(
+	public function theUserSharesTheFileFolderWithTheUserUsingTheWebUI(
 		$folder, $remote, $user, $maxRetries = STANDARDRETRYCOUNT, $quiet = false
 	) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());
@@ -113,18 +114,21 @@ class WebUISharingContext extends RawMinkContext implements Context {
 				$user, $this->getSession(), $maxRetries, $quiet
 			);
 		}
-		$this->iCloseTheShareDialog();
+		$this->theUserClosesTheShareDialog();
 	}
 
 	/**
-	 * @Given the file/folder :folder is shared with the group :group
+	 * @When the user shares the file/folder :folder with the group :group using the webUI
+	 * @Given the user has shared the file/folder :folder with the group :group using the webUI
 	 *
 	 * @param string $folder
 	 * @param string $group
 	 * 
 	 * @return void
 	 */
-	public function theFileFolderIsSharedWithTheGroup($folder, $group) {
+	public function theUserSharesTheFileFolderWithTheGroupUsingTheWebUI(
+		$folder, $group
+	) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());
 		try {
 			$this->filesPage->closeSharingDialog();
@@ -135,34 +139,40 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			$folder, $this->getSession()
 		);
 		$this->sharingDialog->shareWithGroup($group, $this->getSession());
-		$this->iCloseTheShareDialog();
+		$this->theUserClosesTheShareDialog();
 	}
 
 	/**
-	 * @Given the share dialog for the file/folder :name is open
+	 * @When the user opens the share dialog for the file/folder :name
+	 * @Given the user has opened the share dialog for the file/folder :name
 	 *
 	 * @param string $name
 	 * 
 	 * @return void
 	 */
-	public function theShareDialogForTheFileFolderIsOpen($name) {
+	public function theUserOpensTheShareDialogForTheFileFolder($name) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());
 		$this->sharingDialog = $this->filesPage->openSharingDialog(
 			$name, $this->getSession()
 		);
 	}
+
 	/**
-	 * @Given I create a new public link for the file/folder :name
+	 * @When the user creates a new public link for the file/folder :name using the webUI
+	 * @Given the user has created a new public link for the file/folder :name using the webUI
 	 *
 	 * @param string $name
 	 * 
 	 * @return void
 	 */
-	public function iCreateANewPublicLinkFor($name) {
-		$this->iCreateANewPublicLinkForWith($name);
+	public function theUserCreatesANewPublicLinkForUsingTheWebUI($name) {
+		$this->theUserCreatesANewPublicLinkForUsingTheWebUIWith($name);
 	}
+
 	/**
-	 * @Given I create a new public link for the file/folder :name with
+	 * @When the user creates a new public link for the file/folder :name using the webUI with
+	 * @Given the user has created a new public link for the file/folder :name using the webUI with
+	 *
 	 * @param string $name
 	 * @param TableNode $settings table with the settings and no header
 	 *                            possible settings: name, permission,
@@ -172,7 +182,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * 
 	 * @return void
 	 */
-	public function iCreateANewPublicLinkForWith(
+	public function theUserCreatesANewPublicLinkForUsingTheWebUIWith(
 		$name, TableNode $settings = null
 	) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());
@@ -226,27 +236,29 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 	
 	/**
-	 * @Given I close the share dialog
+	 * @When the user closes the share dialog
+	 * @Given the user has closed the share dialog
 	 *
 	 * @return void
 	 */
-	public function iCloseTheShareDialog() {
+	public function theUserClosesTheShareDialog() {
 		$this->sharingDialog->closeSharingDialog();
 	}
 
 	/**
-	 * @Given I type :input in the share-with-field
+	 * @When the user types :input in the share-with-field
 	 *
 	 * @param string $input
 	 * 
 	 * @return void
 	 */
-	public function iTypeInTheShareWithField($input) {
+	public function theUserTypesInTheShareWithField($input) {
 		$this->sharingDialog->fillShareWithField($input, $this->getSession());
 	}
 
 	/**
-	 * @Given the sharing permissions of :userName for :fileName are set to
+	 * @When the user sets the sharing permissions of :userName for :fileName using the webUI to
+	 * @Given the user has set the sharing permissions of :userName for :fileName using the webUI to
 	 *
 	 * @param string $userName
 	 * @param string $fileName
@@ -259,33 +271,34 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * 
 	 * @return void
 	 */
-	public function theSharingPermissionsOfAreSetTo(
+	public function theUserSetsTheSharingPermissionsOfForOnTheWebUI(
 		$userName, $fileName, TableNode $permissionsTable
 	) {
 		$userName = $this->webUIGeneralContext->substituteInLineCodes($userName);
-		$this->theShareDialogForTheFileFolderIsOpen($fileName);
+		$this->theUserOpensTheShareDialogForTheFileFolder($fileName);
 		$this->sharingDialog->setSharingPermissions(
 			$userName, $permissionsTable->getRowsHash()
 		);
 	}
 
 	/**
-	 * @When the offered remote shares are accepted
+	 * @When the user accepts the offered remote shares
+	 * @Given the user has accepted the offered remote shares
 	 *
 	 * @return void
 	 */
-	public function theOfferedRemoteSharesAreAccepted() {
+	public function theUserAcceptsTheOfferedRemoteShares() {
 		foreach (array_reverse($this->filesPage->getOcDialogs()) as $ocDialog) {
 			$ocDialog->accept($this->getSession());
 		}
 	}
 
 	/**
-	 * @When I access the last created public link
+	 * @When the public accesses the last created public link using the webUI
 	 *
 	 * @return void
 	 */
-	public function iAccessTheLastCreatedPublicLink() {
+	public function thePublicAccessesTheLastCreatedPublicLinkUsingTheWebUI() {
 		$lastCreatedLink = end($this->createdPublicLinks);
 		$path = str_replace(
 			$this->getMinkParameter('base_url'),
@@ -299,7 +312,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When I add the public link to :server as user :username with the password :password
+	 * @When the public adds the public link to :server as user :username with the password :password using the webUI
 	 *
 	 * @param string $server
 	 * @param string $username
@@ -308,18 +321,20 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function iAddThePublicLinkTo($server, $username, $password) {
+	public function thePublicAddsThePublicLinkToUsingTheWebUI($server, $username, $password) {
 		if (!$this->publicLinkFilesPage->isOpen()) {
 			throw new Exception('Not on public link page!');
 		}
 		$server = $this->webUIGeneralContext->substituteInLineCodes($server);
 		$this->publicLinkFilesPage->addToServer($server);
+		// addToServer takes us from the public link page to the login page
+		// of the remote server, waiting for us to login.
 		$this->webUIGeneralContext->loginAs($username, $password);
 		$this->webUIGeneralContext->setCurrentServer($server);
 	}
 
 	/**
-	 * @Then all users and groups that contain the string :requiredString in their name should be listed in the autocomplete list
+	 * @Then all users and groups that contain the string :requiredString in their name should be listed in the autocomplete list on the webUI
 	 *
 	 * @param string $requiredString
 	 * 
@@ -334,7 +349,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then all users and groups that contain the string :requiredString in their name should be listed in the autocomplete list except :userOrGroup :notToBeListed
+	 * @Then all users and groups that contain the string :requiredString in their name should be listed in the autocomplete list on the webUI except :userOrGroup :notToBeListed
 	 *
 	 * @param string $requiredString
 	 * @param string $userOrGroup
@@ -376,11 +391,11 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then my own name should not be listed in the autocomplete list
+	 * @Then the users own name should not be listed in the autocomplete list on the webUI
 	 *
 	 * @return void
 	 */
-	public function myOwnNameShouldNotBeListedInTheAutocompleteList() {
+	public function theUsersOwnNameShouldNotBeListedInTheAutocompleteList() {
 		PHPUnit_Framework_Assert::assertNotContains(
 			$this->regularUserName,
 			$this->sharingDialog->getAutocompleteItemsList()
@@ -388,7 +403,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then a tooltip with the text :text should be shown near the share-with-field
+	 * @Then a tooltip with the text :text should be shown near the share-with-field on the webUI
 	 *
 	 * @param string $text
 	 * 
@@ -402,7 +417,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the autocomplete list should not be displayed
+	 * @Then the autocomplete list should not be displayed on the webUI
 	 *
 	 * @return void
 	 */
@@ -413,7 +428,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the (file|folder) "([^"]*)" should be marked as shared(?: with "([^"]*)")? by "([^"]*)"$/
+	 * @Then /^the (file|folder) "([^"]*)" should be marked as shared(?: with "([^"]*)")? by "([^"]*)" on the webUI$/
 	 *
 	 * @param string $fileOrFolder
 	 * @param string $itemName
@@ -463,7 +478,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^it should not be possible to share the (?:file|folder) "([^"]*)"(?: with "([^"]*)")?$/
+	 * @Then /^it should not be possible to share the (?:file|folder) "([^"]*)"(?: with "([^"]*)")? using the webUI$/
 	 *
 	 * @param string $fileName
 	 * @param string|null $shareWith
@@ -471,10 +486,10 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function itShouldNotBePossibleToShare($fileName, $shareWith = null) {
+	public function itShouldNotBePossibleToShareUsingTheWebUI($fileName, $shareWith = null) {
 		$sharingWasPossible = false;
 		try {
-			$this->theFileFolderIsSharedWithTheUser($fileName, null, $shareWith, 2, true);
+			$this->theUserSharesTheFileFolderWithTheUserUsingTheWebUI($fileName, null, $shareWith, 2, true);
 			$sharingWasPossible = true;
 		} catch (ElementNotFoundException $e) {
 			$possibleMessages = [

--- a/tests/acceptance/features/bootstrap/WebUIUserContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUserContext.php
@@ -48,12 +48,12 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	}
 	
 	/**
-	 * @Then :displayname should be shown as the name of the current user in the WebUI
+	 * @Then :displayname should be shown as the name of the current user on the WebUI
 	 * 
 	 * @param string $displayname
 	 * @return void
 	 */
-	public function displayNameOfTheCurrentUserInTheWebUiShouldBe($displayname) {
+	public function displayNameOfTheCurrentUserOnTheWebUiShouldBe($displayname) {
 		$actualUserName = $this->owncloudPage->getMyDisplayname();
 		PHPUnit_Framework_Assert::assertSame(
 			$displayname, $actualUserName,
@@ -62,13 +62,15 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	}
 	
 	/**
-	 * @Then /^the display name should (not|)\s?be visible in the WebUI$/
+	 * @Then /^the display name should (not|)\s?be visible on the WebUI$/
 	 * 
 	 * @param string $shouldOrNot
 	 * 
 	 * @return void
 	 */
-	public function displayNameOfTheCurrentUserShouldBeVisible($shouldOrNot) {
+	public function displayNameOfTheCurrentUserShouldBeVisibleOnTheWebUI(
+		$shouldOrNot
+	) {
 		$should = ($shouldOrNot !== "not");
 		if ($should) {
 			PHPUnit_Framework_Assert::assertTrue(
@@ -84,13 +86,13 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^(no|an) avatar should be shown for the current user in the WebUI$/
+	 * @Then /^(no|an) avatar should be shown for the current user on the WebUI$/
 	 * 
 	 * @param string $shouldOrNot
 	 * 
 	 * @return void
 	 */
-	public function avatarShouldBeShownInTheWebUI($shouldOrNot) {
+	public function avatarShouldBeShownOnTheWebUI($shouldOrNot) {
 		$should = ($shouldOrNot !== "no");
 		if ($should) {
 			PHPUnit_Framework_Assert::assertTrue(

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -35,7 +35,6 @@ require_once 'bootstrap.php';
  */
 class WebUIUsersContext extends RawMinkContext implements Context {
 
-
 	private $usersPage;
 	/**
 	 *
@@ -53,11 +52,12 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given I am on the users page
+	 * @When the user/administrator browses to the users page
+	 * @Given the user/administrator has browsed to the users page
 	 *
 	 * @return void
 	 */
-	public function iAmOnTheUsersPage() {
+	public function theUserBrowsesToTheUsersPage() {
 		$this->usersPage->open();
 		$this->usersPage->waitTillPageIsLoaded($this->getSession());
 	}
@@ -75,14 +75,15 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given quota of user :username is set/changed to :quota
+	 * @When the administrator sets/changes the quota of user :username to :quota using the webUI
+	 * @Given the administrator has set/changed the quota of user :username to :quota using the webUI
 	 *
 	 * @param string $username
 	 * @param string $quota
 	 * 
 	 * @return void
 	 */
-	public function quotaOfUserIsSetTo($username, $quota) {
+	public function theAdministratorSetsTheQuotaOfUserUsingTheWebUI($username, $quota) {
 		$this->usersPage->setQuotaOfUserTo($username, $quota, $this->getSession());
 	}
 
@@ -121,7 +122,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When /^I (attempt to |)create a user with the name "([^"]*)" (?:and )?the password "([^"]*)"(?: and the email "([^"]*)")?(?: that is a member of these groups)?$/
+	 * @When /^the administrator (attempts to create|creates) a user with the name "([^"]*)" (?:and )?the password "([^"]*)"(?: and the email "([^"]*)")?(?: that is a member of these groups)? using the webUI$/
 	 *
 	 * @param string $attemptTo
 	 * @param string $username
@@ -131,7 +132,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * 
 	 * @return void
 	 */
-	public function iCreateAUserInTheGUI(
+	public function theAdminCreatesAUserUsingTheWebUI(
 		$attemptTo, $username, $password, $email=null, TableNode $groupsTable=null
 	) {
 		if (!is_null($groupsTable)) {
@@ -159,34 +160,34 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 
 	/**
 	 * 
-	 * @When I delete the group named :name
+	 * @When the administrator deletes the group named :name using the webUI
 	 *
 	 * @param string $name
 	 * 
 	 * @return void
 	 */
-	public function iDeleteTheGroupNamed($name) {
+	public function theAdminDeletesTheGroupUsingTheWebUI($name) {
 		$this->usersPage->deleteGroup($name, $this->getSession());
 		$this->webUIGeneralContext->deleteGroupFromCreatedGroupsList($name);
 	}
 
 	/**
-	 * @When I delete these groups:
+	 * @When the administrator deletes these groups using the webUI:
 	 * expects a table of groups with the heading "groupname"
 	 *
 	 * @param TableNode $table
 	 * 
 	 * @return void
 	 */
-	public function iDeleteTheseGroups(TableNode $table) {
+	public function theAdminDeletesTheseGroupsUsingTheWebUI(TableNode $table) {
 		foreach ($table as $row) {
-			$this->iDeleteTheGroupNamed($row['groupname']);
+			$this->theAdminDeletesTheGroupUsingTheWebUI($row['groupname']);
 		}
 	}
 
 	
 	/**
-	 * @Then The group name :groupName should be listed
+	 * @Then the group name :groupName should be listed on the webUI
 	 *
 	 * @param string $groupName
 	 * 
@@ -200,21 +201,21 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then the group named :name should not be listed
+	 * @Then the group name :name should not be listed on the webUI
 	 *
 	 * @param string $name
 	 * 
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theGroupNamedShouldNotBeListed($name) {
+	public function theGroupNamedShouldNotBeListedOnTheWebUI($name) {
 		if (in_array($name, $this->usersPage->getAllGroups(), true)) {
 			throw new Exception("group '" . $name . "' is listed but should not");
 		}
 	}
 
 	/**
-	 * @Then /^these groups should (not|)\s?be listed:$/
+	 * @Then /^these groups should (not|)\s?be listed on the webUI:$/
 	 * expects a table of groups with the heading "groupname"
 	 *
 	 * @param string $shouldOrNot (not|)
@@ -223,7 +224,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theseGroupsShouldBeListed($shouldOrNot, TableNode $table) {
+	public function theseGroupsShouldBeListedOnTheWebUI($shouldOrNot, TableNode $table) {
 		$should = ($shouldOrNot !== "not");
 		$groups = $this->usersPage->getAllGroups();
 		foreach ($table as $row) {
@@ -238,17 +239,18 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the users page is reloaded
+	 * @When the user/administrator reloads the users page
+	 * @Given the user/administrator has reloaded the users page
 	 *
 	 * @return void
 	 */
-	public function theUsersPageIsReloaded() {
+	public function theUserReloadsTheUsersPage() {
 		$this->getSession()->reload();
 		$this->usersPage->waitTillPageIsLoaded($this->getSession());
 	}
 
 	/**
-	 * @Then quota of user :username should be set to :quota
+	 * @Then the quota of user :username should be set to :quota on the webUI
 	 *
 	 * @param string $username
 	 * @param string $quota
@@ -256,7 +258,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * @return void
 	 * @throws ExpectationException
 	 */
-	public function quotaOfUserShouldBeSetTo($username, $quota) {
+	public function quotaOfUserShouldBeSetToOnTheWebUI($username, $quota) {
 		$setQuota = $this->usersPage->getQuotaOfUser($username);
 		if ($setQuota !== $quota) {
 			throw new ExpectationException(
@@ -283,13 +285,13 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given I add a group with the name :groupName
-	 * 
+	 * @When the administrator adds group :groupName using the webUI
+	 *
 	 * @param string $groupName
 	 * 
 	 * @return void
 	 */
-	public function iAddAGroupWithTheName($groupName) {
+	public function theAdminAddsGroupUsingTheWebUI($groupName) {
 		$this->usersPage->addGroup($groupName, $this->getSession());
 	}
 }

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -6,22 +6,22 @@ I would like to mark any file/folder as favorite
 So that I can find my favorite file/folder easily
 
 	Background:
-		Given a regular user exists
-		And I am logged in as a regular user
-		And I am on the files page
+		Given a regular user has been created
+		And the regular user has logged in using the webUI
+		And the user has browsed to the files page
 
 	Scenario: mark a file as favorite and list it in favorites page
-		When I mark the file "data.zip" as favorite 
-		Then the file "data.zip" should be marked as favorite
-		And the files page is reloaded
-		Then the file "data.zip" should be marked as favorite
-		And the file "data.zip" should be listed in the favorites page
-		And the file "lorem.txt" should not be listed in the favorites page
+		When the user marks the file "data.zip" as favorite using the webUI
+		Then the file "data.zip" should be marked as favorite on the webUI
+		When the user reloads the current page of the webUI
+		Then the file "data.zip" should be marked as favorite on the webUI
+		And the file "data.zip" should be listed in the favorites page on the webUI
+		And the file "lorem.txt" should not be listed in the favorites page on the webUI
 
 	Scenario: mark a folder as favorite and list it in favorites page
-		When I mark the folder "simple-folder" as favorite 
-		Then the folder "simple-folder" should be marked as favorite
-		And the files page is reloaded
-		Then the folder "simple-folder" should be marked as favorite
-		And the folder "simple-folder" should be listed in the favorites page
-		And the folder "simple-empty-folder" should not be listed in the favorites page
+		When the user marks the folder "simple-folder" as favorite using the webUI
+		Then the folder "simple-folder" should be marked as favorite on the webUI
+		When the user reloads the current page of the webUI
+		Then the folder "simple-folder" should be marked as favorite on the webUI
+		And the folder "simple-folder" should be listed in the favorites page on the webUI
+		And the folder "simple-empty-folder" should not be listed in the favorites page on the webUI

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -6,39 +6,39 @@ I would like to unmark any file/folder
 So that I can remove my favorite file/folder from favorite page
 
 	Background:
-		Given a regular user exists
-		And I am logged in as a regular user
-		And I am on the files page
+		Given a regular user has been created
+		And the regular user has logged in using the webUI
+		And the user has browsed to the files page
 
 	Scenario: unmark a file as favorite from files page 
-		Given the file "data.zip" is marked as favorite 
-		When I unmark the file "data.zip"
-		Then the file "data.zip" should not be marked as favorite
-		And I am on the favorites page
-		Then the file "data.zip" should not be listed in the favorites page
+		Given the user has marked the file "data.zip" as favorite using the webUI
+		When the user unmarks the favorited file "data.zip" using the webUI
+		Then the file "data.zip" should not be marked as favorite on the webUI
+		When the user browses to the favorites page
+		Then the file "data.zip" should not be listed in the favorites page on the webUI
 
 	Scenario: unmark a folder as favorite from files page 
-		Given the folder "simple-folder" is marked as favorite 
-		When I unmark the folder "simple-folder"
-		Then the folder "simple-folder" should not be marked as favorite
-		And I am on the favorites page
-		Then the folder "simple-folder" should not be listed in the favorites page
+		Given the user has marked the folder "simple-folder" as favorite using the webUI
+		When the user unmarks the favorited folder "simple-folder" using the webUI
+		Then the folder "simple-folder" should not be marked as favorite on the webUI
+		When the user browses to the favorites page
+		Then the folder "simple-folder" should not be listed in the favorites page on the webUI
 	
 	Scenario: unmark a file as favorite from favorite page 
-		Given the file "data.zip" is marked as favorite 
-		And I am on the favorites page
-		When I unmark the file "data.zip"
-		And the favorites page is reloaded
-		Then the file "data.zip" should not be listed in the favorites page
-		And I am on the files page
-		Then the file "data.zip" should not be marked as favorite
+		Given the user has marked the file "data.zip" as favorite using the webUI
+		And the user has browsed to the favorites page
+		When the user unmarks the favorited file "data.zip" using the webUI
+		And the user reloads the current page of the webUI
+		Then the file "data.zip" should not be listed in the favorites page on the webUI
+		When the user browses to the files page
+		Then the file "data.zip" should not be marked as favorite on the webUI
 	
 
 	Scenario: unmark a folder as favorite from files page 
-		Given the folder "simple-folder" is marked as favorite 
-		And I am on the favorites page
-		When I unmark the folder "simple-folder"
-		And the favorites page is reloaded
-		Then the folder "simple-folder" should not be listed in the favorites page
-		And I am on the files page
-		Then the folder "simple-folder" should not be marked as favorite
+		Given the user has marked the folder "simple-folder" as favorite using the webUI
+		And the user has browsed to the favorites page
+		When the user unmarks the favorited folder "simple-folder" using the webUI
+		And the user reloads the current page of the webUI
+		Then the folder "simple-folder" should not be listed in the favorites page on the webUI
+		When the user browses to the files page
+		Then the folder "simple-folder" should not be marked as favorite on the webUI

--- a/tests/acceptance/features/webUIFiles/createFolders.feature
+++ b/tests/acceptance/features/webUIFiles/createFolders.feature
@@ -5,23 +5,23 @@ I want to create folders
 So that I can organise my data structure
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
-		And I am on the login page
-		And I login with username "user1" and password "1234"
-		And I am on the files page
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has browsed to the files page
 
 	Scenario: Create a folder inside another folder
-		When I create a folder with the name "top-folder"
-		And I open the folder "top-folder"
-		Then there are no files/folders listed
-		When I create a folder with the name "sub-folder"
-		Then the folder "sub-folder" should be listed
-		And the files page is reloaded
-		Then the folder "sub-folder" should be listed
+		When the user creates a folder with the name "top-folder" using the webUI
+		And the user opens the folder "top-folder" using the webUI
+		Then there should be no files/folders listed on the webUI
+		When the user creates a folder with the name "sub-folder" using the webUI
+		Then the folder "sub-folder" should be listed on the webUI
+		When the user reloads the current page of the webUI
+		Then the folder "sub-folder" should be listed on the webUI
 
 	Scenario: Create a folder with existing name
-		When I create a folder with the invalid name "simple-folder"
-		Then near the folder input field a tooltip with the text 'simple-folder already exists' should be displayed
+		When the user creates a folder with the invalid name "simple-folder" using the webUI
+		Then near the folder input field a tooltip with the text 'simple-folder already exists' should be displayed on the webUI
 	

--- a/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
+++ b/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
@@ -5,17 +5,17 @@ I want to create folders
 So that I can organise my data structure
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
-		And I am on the login page
-		And I login with username "user1" and password "1234"
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 
 	Scenario Outline: Create a folder using special characters
-		When I create a folder with the name <folder_name>
-		Then the folder <folder_name> should be listed
-		And the files page is reloaded
-		Then the folder <folder_name> should be listed
+		When the user creates a folder with the name <folder_name> using the webUI
+		Then the folder <folder_name> should be listed on the webUI
+		When the user reloads the current page of the webUI
+		Then the folder <folder_name> should be listed on the webUI
 		Examples:
 		|folder_name    |
 		|'सिमप्ले फोल्देर $%#?&@'|
@@ -27,13 +27,13 @@ So that I can organise my data structure
 	Scenario Outline: Create a sub-folder inside a folder with problematic name
 	# First try and create a folder with problematic name
 	# Then try and create a sub-folder inside the folder with problematic name
-		When I create a folder with the name <folder>
-		And I open the folder <folder>
-		Then there are no files/folders listed
-		When I create a folder with the name "sub-folder"
-		Then the folder "sub-folder" should be listed
-		And the files page is reloaded
-		Then the folder "sub-folder" should be listed
+		When the user creates a folder with the name <folder> using the webUI
+		And the user opens the folder <folder> using the webUI
+		Then there should be no files/folders listed on the webUI
+		When the user creates a folder with the name "sub-folder" using the webUI
+		Then the folder "sub-folder" should be listed on the webUI
+		When the user reloads the current page of the webUI
+		Then the folder "sub-folder" should be listed on the webUI
 		Examples:
 		|folder|
 		|"?&%0"|
@@ -42,11 +42,11 @@ So that I can organise my data structure
 	Scenario Outline: Create a sub-folder inside an existing folder with problematic name
 	# Use an existing folder with problematic name to create a sub-folder
 	# Uses the folder created by skeleton
-		When I open the folder <folder>
-		And I create a folder with the name "sub-folder"
-		Then the folder "sub-folder" should be listed
-		And the files page is reloaded
-		Then the folder "sub-folder" should be listed
+		When the user opens the folder <folder> using the webUI
+		And the user creates a folder with the name "sub-folder" using the webUI
+		Then the folder "sub-folder" should be listed on the webUI
+		When the user reloads the current page of the webUI
+		Then the folder "sub-folder" should be listed on the webUI
 		Examples:
 		|folder|
 		|"0"|

--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -5,48 +5,48 @@ I want to delete files and folders
 So that I can keep my filing system clean and tidy
 
 	Background:
-		Given a regular user exists
-		And I am logged in as a regular user
-		And I am on the files page
+		Given a regular user has been created
+		And the regular user has logged in using the webUI
+		And the user has browsed to the files page
 
 	Scenario: Delete files & folders one by one and check its existence after page reload
-		When I delete the elements
+		When the user deletes the following elements using the webUI
 		| name                                |
 		| simple-folder                       |
 		| lorem.txt                           |
 		| strängé नेपाली folder                  |
 		| strängé filename (duplicate #2 &).txt |
-		Then the deleted elements should not be listed
-		And the deleted elements should not be listed after a page reload
+		Then the deleted elements should not be listed on the webUI
+		And the deleted elements should not be listed on the webUI after a page reload
 
 	Scenario: Delete a file with problematic characters
-		When I rename the following file to
+		When the user renames the following file using the webUI
 			| from-name-parts | to-name-parts   |
 			| lorem.txt       | 'single'        |
 			|                 | "double" quotes |
 			|                 | question?       |
 			|                 | &and#hash       |
-		And the files page is reloaded
-		Then the following file should be listed
+		And the user reloads the current page of the webUI
+		Then the following file should be listed on the webUI
 			| name-parts      |
 			| 'single'        |
 			| "double" quotes |
 			| question?       |
 			| &and#hash       |
-		And I delete the following file
+		And the user deletes the following file using the webUI
 			| name-parts      |
 			| 'single'        |
 			| "double" quotes |
 			| question?       |
 			| &and#hash       |
-		Then the following file should not be listed
+		Then the following file should not be listed on the webUI
 			| name-parts      |
 			| 'single'        |
 			| "double" quotes |
 			| question?       |
 			| &and#hash       |
-		And the files page is reloaded
-		Then the following file should not be listed
+		When the user reloads the current page of the webUI
+		Then the following file should not be listed on the webUI
 			| name-parts      |
 			| 'single'        |
 			| "double" quotes |
@@ -54,21 +54,21 @@ So that I can keep my filing system clean and tidy
 			| &and#hash       |
 
 	Scenario: Delete multiple files at once
-		When I batch delete these files
+		When the user batch deletes these files using the webUI
 		| name          |
 		| data.zip      |
 		| lorem.txt     |
 		| simple-folder |
-		Then the deleted elements should not be listed
-		And the deleted elements should not be listed after a page reload
+		Then the deleted elements should not be listed on the webUI
+		And the deleted elements should not be listed on the webUI after a page reload
 
 	Scenario: Delete an empty folder
-		When I create a folder with the name "my-empty-folder"
-		And I create a folder with the name "my-other-empty-folder"
-		And I delete the folder "my-empty-folder"
-		Then the folder "my-other-empty-folder" should be listed
-		But the folder "my-empty-folder" should not be listed
+		When the user creates a folder with the name "my-empty-folder" using the webUI
+		And the user creates a folder with the name "my-other-empty-folder" using the webUI
+		And the user deletes the folder "my-empty-folder" using the webUI
+		Then the folder "my-other-empty-folder" should be listed on the webUI
+		But the folder "my-empty-folder" should not be listed on the webUI
 
 	Scenario: Delete the last file in a folder
-		When I delete the file "zzzz-must-be-last-file-in-folder.txt"
-		Then the file "zzzz-must-be-last-file-in-folder.txt" should not be listed
+		When the user deletes the file "zzzz-must-be-last-file-in-folder.txt" using the webUI
+		Then the file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/hiddenFile.feature
+++ b/tests/acceptance/features/webUIFiles/hiddenFile.feature
@@ -6,12 +6,12 @@ I would like to display hidden files/folders
 So that I can choose to see the files that I want.
 
 	Background:
-		Given a regular user exists
-		And I am logged in as a regular user
-		And I am on the files page
+		Given a regular user has been created
+		And the regular user has logged in using the webUI
+		And the user has browsed to the files page
 
 	Scenario: create a hidden folder
-		When I create a folder with the name ".xyz"
-		Then the folder ".xyz" should not be listed
-		When I enable the setting to view hidden folders
-		Then the folder ".xyz" should be listed
+		When the user creates a folder with the name ".xyz" using the webUI
+		Then the folder ".xyz" should not be listed on the webUI
+		When the user enables the setting to view hidden folders on the webUI
+		Then the folder ".xyz" should be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
+++ b/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
@@ -5,11 +5,11 @@ I want to see the whole menu of actions that can be done on a file
 So that I can manage and work with my files
 
 	Background:
-		Given a regular user exists
-		And I am logged in as a regular user
-		And I am on the files page
+		Given a regular user has been created
+		And the regular user has logged in using the webUI
+		And the user has browsed to the files page
 
 	@skipOnINTERNETEXPLORER
 	Scenario: scroll the file actions menu into view
-		And the list of files/folders does not fit in one browser page
-		Then the filesactionmenu should be completely visible after clicking on it
+		When the user creates so many files/folders that they do not fit in one browser page
+		Then the files action menu should be completely visible after opening it using the webUI

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -5,15 +5,15 @@ I want to manage user quota
 So that users can only take up a certain amount of storage space
 
 	Background:
-		Given a regular user exists but is not initialized
-		And I am logged in as admin
-		And I am on the users page
+		Given a regular user has been created but not initialized
+		And user admin has logged in using the webUI
+		And the administrator has browsed to the users page
 
 	Scenario Outline: change quota to a valid value
-		And quota of user "%regularuser%" is set to "<start_quota>"
-		When quota of user "%regularuser%" is changed to "<wished_quota>"
-		And the users page is reloaded
-		Then quota of user "%regularuser%" should be set to "<expected_quota>"
+		Given the administrator has set the quota of user "%regularuser%" to "<start_quota>" using the webUI
+		When the administrator changes the quota of user "%regularuser%" to "<wished_quota>" using the webUI
+		And the administrator reloads the users page
+		Then the quota of user "%regularuser%" should be set to "<expected_quota>" on the webUI
 
 		Examples:
 		|start_quota|wished_quota|expected_quota|
@@ -28,15 +28,15 @@ So that users can only take up a certain amount of storage space
 
 	@skipOnOcV10.0.3
 	Scenario: change quota to a valid value that do not work on 10.0.3
-		And quota of user "%regularuser%" is set to "Unlimited"
-		When quota of user "%regularuser%" is changed to "0 Kb"
-		And the users page is reloaded
-		Then quota of user "%regularuser%" should be set to "0 B"
+		Given the administrator has set the quota of user "%regularuser%" to "Unlimited" using the webUI
+		When the administrator changes the quota of user "%regularuser%" to "0 Kb" using the webUI
+		And the administrator reloads the users page
+		Then the quota of user "%regularuser%" should be set to "0 B" on the webUI
 
 	Scenario Outline: change quota to an invalid value
-		When quota of user "%regularuser%" is changed to "<wished_quota>"
-		Then a notification should be displayed with the text 'Invalid quota value "<wished_quota>"'
-		And quota of user "%regularuser%" should be set to "Default"
+		When the administrator changes the quota of user "%regularuser%" to "<wished_quota>" using the webUI
+		Then a notification should be displayed on the webUI with the text 'Invalid quota value "<wished_quota>"'
+		And the quota of user "%regularuser%" should be set to "Default" on the webUI
 
 		Examples:
 		|wished_quota|

--- a/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
@@ -5,12 +5,12 @@ I would like to add a group
 So that I can share documents with other users
 
 	Background: 
-		Given I am logged in as admin
-		And I am on the users page
+		Given user admin has logged in using the webUI
+		And the administrator has browsed to the users page
 
 	Scenario Outline: Add group
-		When I add a group with the name <groupname>
-		Then The group name <groupname> should be listed
+		When the administrator adds group <groupname> using the webUI
+		Then the group name <groupname> should be listed on the webUI
 		Examples:
 		|groupname|
 		|"localuser" |

--- a/tests/acceptance/features/webUIManageUsersGroups/login.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/login.feature
@@ -10,31 +10,31 @@ So that unauthorised access is impossible
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: simple user login
-		Given a regular user exists but is not initialized
-		And I am on the login page
-		When I login as a regular user with a correct password
-		Then I should be redirected to a page with the title "Files - ownCloud"
+		Given a regular user has been created but not initialized
+		And the user has browsed to the login page
+		When the user logs in as a regular user with a correct password using the webUI
+		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
 	Scenario: admin login
-		Given I am on the login page
-		When I login with username "admin" and password "admin"
-		Then I should be redirected to a page with the title "Files - ownCloud"
+		Given the user has browsed to the login page
+		When the user logs in with username "admin" and password "admin" using the webUI
+		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
 	Scenario: admin login with invalid password
-		Given I am on the login page
-		When I login with username "admin" and invalid password "invalidpassword"
-		Then I should be redirected to a page with the title "ownCloud"
+		Given the user has browsed to the login page
+		When the user logs in with username "admin" and invalid password "invalidpassword" using the webUI
+		Then the user should be redirected to a webUI page with the title "ownCloud"
 
 	Scenario: access the personal general settings page when not logged in
-		Given I attempt to go to the personal general settings page
-		Then I should be redirected to a page with the title "ownCloud"
-		When I login with username "admin" and password "admin" after a redirect from the "personal general settings" page
-		Then I should be redirected to a page with the title "Settings - ownCloud"
+		When the user attempts to browse to the personal general settings page
+		Then the user should be redirected to a webUI page with the title "ownCloud"
+		When the user logs in with username "admin" and password "admin" using the webUI after a redirect from the "personal general settings" page
+		Then the user should be redirected to a webUI page with the title "Settings - ownCloud"
 
 	Scenario: access the personal general settings page when not logged in using incorrect then correct password
-		Given I attempt to go to the personal general settings page
-		Then I should be redirected to a page with the title "ownCloud"
-		When I login with username "admin" and invalid password "qwerty"
-		Then I should be redirected to a page with the title "ownCloud"
-		When I login with username "admin" and password "admin" after a redirect from the "personal general settings" page
-		Then I should be redirected to a page with the title "Settings - ownCloud"
+		When the user attempts to browse to the personal general settings page
+		Then the user should be redirected to a webUI page with the title "ownCloud"
+		When the user logs in with username "admin" and invalid password "qwerty" using the webUI
+		Then the user should be redirected to a webUI page with the title "ownCloud"
+		When the user logs in with username "admin" and password "admin" using the webUI after a redirect from the "personal general settings" page
+		Then the user should be redirected to a webUI page with the title "Settings - ownCloud"

--- a/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
@@ -5,29 +5,29 @@ I want to manage groups
 So that access to resources can be controlled more effectively
 
 	Background:
-		Given a regular user exists but is not initialized
-		And I am logged in as admin
-		And I am on the users page
+		Given a regular user has been created but not initialized
+		And user admin has logged in using the webUI
+		And the administrator has browsed to the users page
 
 	@skipOnOcV10.0.3
 	Scenario: delete group called "0" and "false"
-		And these groups exist:
+		Given these groups have been created:
 		|groupname     |
 		|do-not-delete |
 		|0             |
 		|false         |
 		|do-not-delete2|
-		And I am on the users page
-		When I delete these groups:
+		And the administrator has browsed to the users page
+		When the administrator deletes these groups using the webUI:
 		|groupname|
 		|0        |
 		|false    |
-		And the users page is reloaded
-		Then these groups should be listed:
+		And the administrator reloads the users page
+		Then these groups should be listed on the webUI:
 		|groupname     |
 		|do-not-delete |
 		|do-not-delete2|
-		But these groups should not be listed:
+		But these groups should not be listed on the webUI:
 		|groupname|
 		|0        |
 		|false    |
@@ -42,7 +42,7 @@ So that access to resources can be controlled more effectively
 
 	@skipOnOcV10.0.3 @skipOnOcV10.0.4 @skipOnOcV10.0.5
 	Scenario: delete groups with special characters that appear in URLs
-		And these groups exist:
+		Given these groups have been created:
 		|groupname     |
 		|do-not-delete |
 		|a/slash       |
@@ -50,19 +50,19 @@ So that access to resources can be controlled more effectively
 		|hash#char     |
 		|q?mark        |
 		|do-not-delete2|
-		And I am on the users page
-		When I delete these groups:
+		And the administrator has browsed to the users page
+		When the administrator deletes these groups using the webUI:
 		|groupname     |
 		|a/slash       |
 		|per%cent      |
 		|hash#char     |
 		|q?mark        |
-		And the users page is reloaded
-		Then these groups should be listed:
+		And the administrator reloads the users page
+		Then these groups should be listed on the webUI:
 		|groupname     |
 		|do-not-delete |
 		|do-not-delete2|
-		But these groups should not be listed:
+		But these groups should not be listed on the webUI:
 		|groupname     |
 		|a/slash       |
 		|per%cent      |
@@ -80,25 +80,25 @@ So that access to resources can be controlled more effectively
 		|q?mark        |
 
 	Scenario: delete groups with problematic names
-		And these groups exist:
+		Given these groups have been created:
 		|groupname     |
 		|do-not-delete |
 		|grp1          |
 		|quotes'       |
 		|quotes"       |
 		|do-not-delete2|
-		And I am on the users page
-		When I delete these groups:
+		And the administrator has browsed to the users page
+		When the administrator deletes these groups using the webUI:
 		|groupname|
 		|grp1     |
 		|quotes'  |
 		|quotes"  |
-		And the users page is reloaded
-		Then these groups should be listed:
+		And the administrator reloads the users page
+		Then these groups should be listed on the webUI:
 		|groupname     |
 		|do-not-delete |
 		|do-not-delete2|
-		But these groups should not be listed:
+		But these groups should not be listed on the webUI:
 		|groupname|
 		|grp1     |
 		|quotes'  |

--- a/tests/acceptance/features/webUIManageUsersGroups/manageUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/manageUsers.feature
@@ -4,29 +4,27 @@ Feature: manage users
   I want to manage users
   So that unauthorised access is impossible
 
+  Background:
+    Given user admin has logged in using the webUI
+    And the administrator has browsed to the users page
+
   Scenario: use the webUI to create a simple user
-    Given I am logged in as admin
-    And I am on the users page
-    When I create a user with the name "guiusr1" and the password "pwd"
-    And I logout
-    And I login with username "guiusr1" and password "pwd"
-    Then I should be redirected to a page with the title "Files - ownCloud"
+    When the administrator creates a user with the name "guiusr1" and the password "pwd" using the webUI
+    And the administrator logs out of the webUI
+    And the user logs in with username "guiusr1" and password "pwd" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
   Scenario: use the webUI to create a user with special valid characters
-    Given I am logged in as admin
-    And I am on the users page
-    When I create a user with the name "@-_.'" and the password "pwd"
-    And I logout
-    And I login with username "@-_.'" and password "pwd"
-    Then I should be redirected to a page with the title "Files - ownCloud"
+    When the administrator creates a user with the name "@-_.'" and the password "pwd" using the webUI
+    And the administrator logs out of the webUI
+    And the user logs in with username "@-_.'" and password "pwd" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
   Scenario Outline: use the webUI to create a user with special invalid characters
-    Given I am logged in as admin
-    And I am on the users page
-    When I attempt to create a user with the name <user> and the password <pwd>
-    Then notifications should be displayed with the text
+    When the administrator attempts to create a user with the name <user> and the password <pwd> using the webUI
+    Then notifications should be displayed on the webUI with the text
       |Error creating user: Only the following characters are allowed in a username: "a-z", "A-Z", "0-9", and "_.@-'"|
-    And I should be redirected to a page with the title "Users - ownCloud"
+    And the user should be redirected to a webUI page with the title "Users - ownCloud"
     Examples:
       | user | pwd |
       |"a#%"|"pwd1"|
@@ -36,18 +34,14 @@ Feature: manage users
       |"a`*^"|"pwd2"|
 
   Scenario: use the webUI to create a user with empty password
-    Given I am logged in as admin
-    And I am on the users page
-    When I attempt to create a user with the name "bijay" and the password ""
-    Then notifications should be displayed with the text
+    When the administrator attempts to create a user with the name "bijay" and the password "" using the webUI
+    Then notifications should be displayed on the webUI with the text
       |Error creating user: A valid password must be provided|
-    And I should be redirected to a page with the title "Users - ownCloud"
+    And the user should be redirected to a webUI page with the title "Users - ownCloud"
 
   Scenario Outline: use the webUI to create a user with less than 3 characters
-    Given I am logged in as admin
-    And I am on the users page
-    When I attempt to create a user with the name <user> and the password <pwd>
-    Then notifications should be displayed with the text
+    When the administrator attempts to create a user with the name <user> and the password <pwd> using the webUI
+    Then notifications should be displayed on the webUI with the text
       |Error creating user: The username must be at least 3 characters long|
     Examples:
       |user|  pwd |

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -5,76 +5,76 @@ I want to move files
 So that I can organise my data structure
 
 	Background:
-		Given a regular user exists
-		And I am logged in as a regular user
-		And I am on the files page
+		Given a regular user has been created
+		And the regular user has logged in using the webUI
+		And the user has browsed to the files page
 
 	Scenario: An attempt to move a file into a sub-folder using rename is not allowed
-		When I rename the file "data.zip" to "simple-folder/data.zip"
-		Then near the file "data.zip" a tooltip with the text 'File name cannot contain "/".' should be displayed
+		When the user renames the file "data.zip" to "simple-folder/data.zip" using the webUI
+		Then near the file "data.zip" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
 
 	@skipOnFIREFOX47+
 	Scenario: move a file into a folder
-		When I move the file "data.zip" into the folder "simple-empty-folder"
-		Then the file "data.zip" should not be listed
-		But the file "data.zip" should be listed in the folder "simple-empty-folder"
-		When I am on the files page
-		And I move the file "data.tar.gz" into the folder "strängé नेपाली folder empty"
-		Then the file "data.tar.gz" should not be listed
-		But the file "data.tar.gz" should be listed in the folder "strängé नेपाली folder empty"
-		When I am on the files page
-		And I move the file "strängé filename (duplicate #2 &).txt" into the folder "strängé नेपाली folder empty"
-		Then the file "strängé filename (duplicate #2 &).txt" should not be listed
-		But the file "strängé filename (duplicate #2 &).txt" should be listed in the folder "strängé नेपाली folder empty"
+		When the user moves the file "data.zip" into the folder "simple-empty-folder" using the webUI
+		Then the file "data.zip" should not be listed on the webUI
+		But the file "data.zip" should be listed in the folder "simple-empty-folder" on the webUI
+		When the user browses to the files page
+		And the user moves the file "data.tar.gz" into the folder "strängé नेपाली folder empty" using the webUI
+		Then the file "data.tar.gz" should not be listed on the webUI
+		But the file "data.tar.gz" should be listed in the folder "strängé नेपाली folder empty" on the webUI
+		When the user browses to the files page
+		And the user moves the file "strängé filename (duplicate #2 &).txt" into the folder "strängé नेपाली folder empty" using the webUI
+		Then the file "strängé filename (duplicate #2 &).txt" should not be listed on the webUI
+		But the file "strängé filename (duplicate #2 &).txt" should be listed in the folder "strängé नेपाली folder empty" on the webUI
 
 	@skipOnFIREFOX47+
 	Scenario: move a file into a folder where a file with the same name already exists
-		When I move the file "data.zip" into the folder "simple-folder"
-		And I move the file "data.zip" into the folder "strängé नेपाली folder"
-		Then notifications should be displayed with the text
+		When the user moves the file "data.zip" into the folder "simple-folder" using the webUI
+		And the user moves the file "data.zip" into the folder "strängé नेपाली folder" using the webUI
+		Then notifications should be displayed on the webUI with the text
 			|Could not move "data.zip", target exists|
 			|Could not move "data.zip", target exists|
-		And the file "data.zip" should be listed
+		And the file "data.zip" should be listed on the webUI
 
 	@skipOnFIREFOX47+
 	Scenario: move a file into a folder where a file with the same name already exists
-		When I move the file "strängé filename (duplicate #2 &).txt" into the folder "strängé नेपाली folder"
-		Then notifications should be displayed with the text
+		When the user moves the file "strängé filename (duplicate #2 &).txt" into the folder "strängé नेपाली folder" using the webUI
+		Then notifications should be displayed on the webUI with the text
 			|Could not move "strängé filename (duplicate #2 &).txt", target exists|
-		And the file "strängé filename (duplicate #2 &).txt" should be listed
+		And the file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
 
 	@skipOnFIREFOX47+
 	Scenario: Move multiple files at once
-		When I batch move these files into the folder "simple-empty-folder"
+		When the user batch moves these files into the folder "simple-empty-folder" using the webUI
 		| name        |
 		| data.zip    |
 		| lorem.txt   |
 		| testapp.zip |
-		Then the moved elements should not be listed
-		And the moved elements should not be listed after a page reload
-		But the moved elements should be listed in the folder "simple-empty-folder"
+		Then the moved elements should not be listed on the webUI
+		And the moved elements should not be listed on the webUI after a page reload
+		But the moved elements should be listed in the folder "simple-empty-folder" on the webUI
 
 	@skipOnFIREFOX47+
 	Scenario: move a file into a folder (problematic characters)
-		When I rename the following file to
+		When the user renames the following file using the webUI
 			| from-name-parts         | to-name-parts          |
 			| lorem.txt               | 'single'               |
 			|                         | "double" quotes        |
 			|                         | question?              |
 			|                         | &and#hash              |
-		And I rename the following folder to
+		And the user renames the following folder using the webUI
 			| from-name-parts         |to-name-parts           |
 			| simple-empty-folder     | folder-with'single'    |
 			|                         | "double" quotes        |
 			|                         | question?              |
 			|                         | &and#hash              |
-		And I move the following file to
+		And the user moves the following file using the webUI
 			| item-to-move-name-parts | destination-name-parts |
 			| 'single'                | folder-with'single'    |
 			| "double" quotes         | "double" quotes        |
 			| question?               | question?              |
 			| &and#hash               | &and#hash              |
-		Then the following item should be listed in the following folder
+		Then the following item should be listed in the following folder on the webUI
 			| item-name-parts         | folder-name-parts      |
 			| 'single'                | folder-with'single'    |
 			| "double" quotes         | "double" quotes        |

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -5,62 +5,62 @@ I want to move folders
 So that I can organise my data structure
 
 	Background:
-		Given a regular user exists
-		And I am logged in as a regular user
-		And I am on the files page
+		Given a regular user has been created
+		And the regular user has logged in using the webUI
+		And the user has browsed to the files page
 
 	Scenario: An attempt to move a folder into a sub-folder using rename is not allowed
-		When I rename the folder "simple-empty-folder" to "simple-folder/simple-empty-folder"
-		Then near the folder "simple-empty-folder" a tooltip with the text 'File name cannot contain "/".' should be displayed
+		When the user renames the folder "simple-empty-folder" to "simple-folder/simple-empty-folder" using the webUI
+		Then near the folder "simple-empty-folder" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
 
 	@skipOnFIREFOX47+
 	Scenario: move a folder into another folder
-		When I move the folder "simple-folder" into the folder "simple-empty-folder"
-		Then the folder "simple-folder" should not be listed
-		But the folder "simple-folder" should be listed in the folder "simple-empty-folder"
-		When I am on the files page
-		And I move the folder "strängé नेपाली folder" into the folder "strängé नेपाली folder empty"
-		Then the folder "strängé नेपाली folder" should not be listed
-		But the folder "strängé नेपाली folder" should be listed in the folder "strängé नेपाली folder empty"
+		When the user moves the folder "simple-folder" into the folder "simple-empty-folder" using the webUI
+		Then the folder "simple-folder" should not be listed on the webUI
+		But the folder "simple-folder" should be listed in the folder "simple-empty-folder" on the webUI
+		When the user browses to the files page
+		And the user moves the folder "strängé नेपाली folder" into the folder "strängé नेपाली folder empty" using the webUI
+		Then the folder "strängé नेपाली folder" should not be listed on the webUI
+		But the folder "strängé नेपाली folder" should be listed in the folder "strängé नेपाली folder empty" on the webUI
 
 	@skipOnFIREFOX47+
 	Scenario: move a folder into another folder where a folder with the same name already exists
-		When I move the folder "simple-empty-folder" into the folder "simple-folder"
-		Then notifications should be displayed with the text
+		When the user moves the folder "simple-empty-folder" into the folder "simple-folder" using the webUI
+		Then notifications should be displayed on the webUI with the text
 			|Could not move "simple-empty-folder", target exists|
-		And the folder "simple-empty-folder" should be listed
+		And the folder "simple-empty-folder" should be listed on the webUI
 
 	@skipOnFIREFOX47+
 	Scenario: Move multiple folders at once
-		When I batch move these folders into the folder "simple-empty-folder"
+		When the user batch moves these folders into the folder "simple-empty-folder" using the webUI
 		| name               |
 		| simple-folder      |
 		| strängé नेपाली folder |
-		Then the moved elements should not be listed
-		And the moved elements should not be listed after a page reload
-		But the moved elements should be listed in the folder "simple-empty-folder"
+		Then the moved elements should not be listed on the webUI
+		And the moved elements should not be listed on the webUI after a page reload
+		But the moved elements should be listed in the folder "simple-empty-folder" on the webUI
 
 	@skipOnFIREFOX47+
 	Scenario: move a folder into another folder (problematic characters)
-		When I rename the following folder to
+		When the user renames the following folder using the webUI
 			| from-name-parts         | to-name-parts          |
 			| simple-folder           | 'single'               |
 			|                         | "double" quotes        |
 			|                         | question?              |
 			|                         | &and#hash              |
-		And I rename the following folder to
+		And the user renames the following folder using the webUI
 			| from-name-parts         |to-name-parts           |
 			| simple-empty-folder     | folder-with'single'    |
 			|                         | "double" quotes        |
 			|                         | question?              |
 			|                         | &and#hash              |
-		And I move the following folder to
+		And the user moves the following folder using the webUI
 			| item-to-move-name-parts | destination-name-parts |
 			| 'single'                | folder-with'single'    |
 			| "double" quotes         | "double" quotes        |
 			| question?               | question?              |
 			| &and#hash               | &and#hash              |
-		Then the following item should be listed in the following folder
+		Then the following item should be listed in the following folder on the webUI
 			| item-name-parts         | folder-name-parts      |
 			| 'single'                | folder-with'single'    |
 			| "double" quotes         | "double" quotes        |

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -5,22 +5,22 @@ I would like to change my login password
 So that I can login with my new password
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
-		And I am on the login page
-		And I login with username "user1" and password "1234"
-		And I go to the personal general settings page
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has browsed to the personal general settings page
 
 	Scenario: Change password 
-		When I change the password to "passcode"
-		And I relogin with username "user1" and password "passcode"
-		Then I should be redirected to a page with the title "Files - ownCloud"
+		When the user changes the password to "passcode" using the webUI
+		And the user re-logs in with username "user1" and password "passcode" using the webUI
+		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
 	Scenario: Password change with wrong current password
-		When I change the password to "passcode" using wrong current password
-		Then a password error message should be displayed with the text "Wrong password"
+		When the user changes the password to "passcode" entering the wrong current password using the webUI
+		Then a password error message should be displayed on the webUI with the text "Wrong password"
 
 	Scenario: New password is same as current password
-		When I change the password to "1234"
-		Then a password error message should be displayed with the text "The new password can not be the same as the previous one"
+		When the user changes the password to "1234" using the webUI
+		Then a password error message should be displayed on the webUI with the text "The new password can not be the same as the previous one"

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -5,8 +5,8 @@ I want to change the ownCloud User Interface to my preferred settings
 So that I can personalise the User Interface
 
 	Scenario: change language
-		Given a regular user exists
-		And I am logged in as a regular user
-		And I am on the personal general settings page
-		When I change the language to "Русский"
-		Then I should be redirected to a page with the title "Настройки - ownCloud"
+		Given a regular user has been created
+		And the regular user has logged in using the webUI
+		And the user has browsed to the personal general settings page
+		When the user changes the language to "Русский" using the webUI
+		Then the user should be redirected to a webUI page with the title "Настройки - ownCloud"

--- a/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
@@ -5,8 +5,8 @@ I want to be able to manage security settings for my account
 So that I can enable, allow and deny access to and from other storage systems or resources
 
 	Scenario: create new app password
-		Given I am logged in as admin
-		And I am on the personal security settings page
-		When I create a new App password
-		Then the new app should be listed in the App passwords list
-		And my username and the app password should be displayed
+		Given user admin has logged in using the webUI
+		And the user has browsed to the personal security settings page
+		When the user creates a new App password using the webUI
+		Then the new app should be listed in the App passwords list on the webUI
+		And the user display name and the app password should be displayed on the webUI

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -5,15 +5,15 @@ I want to rename files
 So that I can organise my data structure
 
 	Background:
-		Given a regular user exists
-		And I am logged in as a regular user
-		And I am on the files page
+		Given a regular user has been created
+		And the regular user has logged in using the webUI
+		And the user has browsed to the files page
 
 	Scenario Outline: Rename a file using special characters
-		When I rename the file "lorem.txt" to <to_file_name>
-		Then the file <to_file_name> should be listed
-		And the files page is reloaded
-		Then the file <to_file_name> should be listed
+		When the user renames the file "lorem.txt" to <to_file_name> using the webUI
+		Then the file <to_file_name> should be listed on the webUI
+		When the user reloads the current page of the webUI
+		Then the file <to_file_name> should be listed on the webUI
 		Examples:
 		|to_file_name |
 		|'लोरेम।तयक्स्त? $%#&@' |
@@ -21,102 +21,102 @@ So that I can organise my data structure
 		|"'quotes2'"  |
 
 	Scenario Outline: Rename a file that has special characters in its name
-		When I rename the file <from_name> to <to_name>
-		Then the file <to_name> should be listed
-		And the files page is reloaded
-		Then the file <to_name> should be listed
+		When the user renames the file <from_name> to <to_name> using the webUI
+		Then the file <to_name> should be listed on the webUI
+		When the user reloads the current page of the webUI
+		Then the file <to_name> should be listed on the webUI
 		Examples:
 		|from_name                            |to_name                              |
 		|"strängé filename (duplicate #2 &).txt"|"strängé filename (duplicate #3).txt"|
 		|"'single'quotes.txt"                 |"single-quotes.txt"                  |
 
 	Scenario: Rename a file using special characters and check its existence after page reload
-		When I rename the file "lorem.txt" to "लोरेम।तयक्स्त $%&"
-		And the files page is reloaded
-		Then the file "लोरेम।तयक्स्त $%&" should be listed
-		When I rename the file "लोरेम।तयक्स्त $%&" to '"double"quotes.txt'
-		And the files page is reloaded
-		Then the file '"double"quotes.txt' should be listed
-		When I rename the file '"double"quotes.txt' to "no-double-quotes.txt"
-		And the files page is reloaded
-		Then the file "no-double-quotes.txt" should be listed
-		When I rename the file 'no-double-quotes.txt' to "hash#And&QuestionMark?At@Filename.txt"
-		And the files page is reloaded
-		Then the file "hash#And&QuestionMark?At@Filename.txt" should be listed
-		When I rename the file 'zzzz-must-be-last-file-in-folder.txt' to "aaaaaa.txt"
-		And the files page is reloaded
-		Then the file "aaaaaa.txt" should be listed
+		When the user renames the file "lorem.txt" to "लोरेम।तयक्स्त $%&" using the webUI
+		And the user reloads the current page of the webUI
+		Then the file "लोरेम।तयक्स्त $%&" should be listed on the webUI
+		When the user renames the file "लोरेम।तयक्स्त $%&" to '"double"quotes.txt' using the webUI
+		And the user reloads the current page of the webUI
+		Then the file '"double"quotes.txt' should be listed on the webUI
+		When the user renames the file '"double"quotes.txt' to "no-double-quotes.txt" using the webUI
+		And the user reloads the current page of the webUI
+		Then the file "no-double-quotes.txt" should be listed on the webUI
+		When the user renames the file 'no-double-quotes.txt' to "hash#And&QuestionMark?At@Filename.txt" using the webUI
+		And the user reloads the current page of the webUI
+		Then the file "hash#And&QuestionMark?At@Filename.txt" should be listed on the webUI
+		When the user renames the file 'zzzz-must-be-last-file-in-folder.txt' to "aaaaaa.txt" using the webUI
+		And the user reloads the current page of the webUI
+		Then the file "aaaaaa.txt" should be listed on the webUI
 
 	Scenario: Rename a file using spaces at front and/or back of file name and type
-		When I rename the file "lorem.txt" to " space at start"
-		And the files page is reloaded
-		Then the file " space at start" should be listed
-		When I rename the file " space at start" to "space at end "
-		And the files page is reloaded
-		Then the file "space at end " should be listed
-		When I rename the file "space at end " to "space at end .txt"
-		And the files page is reloaded
-		Then the file "space at end .txt" should be listed
-		When I rename the file "space at end .txt" to "space at end. lis"
-		And the files page is reloaded
-		Then the file "space at end. lis" should be listed
-		When I rename the file "space at end. lis" to "space at end.log "
-		And the files page is reloaded
-		Then the file "space at end.log " should be listed
-		When I rename the file "space at end.log " to "  multiple   space    all     over   .  dat  "
-		And the files page is reloaded
-		Then the file "  multiple   space    all     over   .  dat  " should be listed
+		When the user renames the file "lorem.txt" to " space at start" using the webUI
+		And the user reloads the current page of the webUI
+		Then the file " space at start" should be listed on the webUI
+		When the user renames the file " space at start" to "space at end " using the webUI
+		And the user reloads the current page of the webUI
+		Then the file "space at end " should be listed on the webUI
+		When the user renames the file "space at end " to "space at end .txt" using the webUI
+		And the user reloads the current page of the webUI
+		Then the file "space at end .txt" should be listed on the webUI
+		When the user renames the file "space at end .txt" to "space at end. lis" using the webUI
+		And the user reloads the current page of the webUI
+		Then the file "space at end. lis" should be listed on the webUI
+		When the user renames the file "space at end. lis" to "space at end.log " using the webUI
+		And the user reloads the current page of the webUI
+		Then the file "space at end.log " should be listed on the webUI
+		When the user renames the file "space at end.log " to "  multiple   space    all     over   .  dat  " using the webUI
+		And the user reloads the current page of the webUI
+		Then the file "  multiple   space    all     over   .  dat  " should be listed on the webUI
 
 	Scenario: Rename a file using both double and single quotes
-		When I rename the following file to
+		When the user renames the following file using the webUI
 			|from-name-parts |to-name-parts         |
 			|lorem.txt       |First 'single' quotes |
 			|                |-then "double".txt    |
-		And the files page is reloaded
-		Then the following file should be listed
+		And the user reloads the current page of the webUI
+		Then the following file should be listed on the webUI
 			|name-parts            |
 			|First 'single' quotes |
 			|-then "double".txt    |
-		When I rename the following file to
+		When the user renames the following file using the webUI
 			|from-name-parts       |to-name-parts |
 			|First 'single' quotes |loremz.dat    |
 			|-then "double".txt    |              |
-		And the files page is reloaded
-		Then the file "loremz.dat" should be listed
+		And the user reloads the current page of the webUI
+		Then the file "loremz.dat" should be listed on the webUI
 
 	Scenario: Rename a file using forbidden characters
-		When I rename the file "data.zip" to one of these names
+		When the user renames the file "data.zip" to one of these names using the webUI
 		|lorem\txt  |
 		|\\.txt     |
 		|.htaccess  |
-		Then notifications should be displayed with the text
+		Then notifications should be displayed on the webUI with the text
 		|Could not rename "data.zip"|
 		|Could not rename "data.zip"|
 		|Could not rename "data.zip"|
-		And the file "data.zip" should be listed
+		And the file "data.zip" should be listed on the webUI
 
 	Scenario: Rename the last file in a folder
-		When I rename the file "zzzz-must-be-last-file-in-folder.txt" to "a-file.txt"
-		And the files page is reloaded
-		Then the file "a-file.txt" should be listed
+		When the user renames the file "zzzz-must-be-last-file-in-folder.txt" to "a-file.txt" using the webUI
+		And the user reloads the current page of the webUI
+		Then the file "a-file.txt" should be listed on the webUI
 
 	Scenario: Rename a file to become the last file in a folder
-		When I rename the file "lorem.txt" to "zzzz-z-this-is-now-the-last-file.txt"
-		And the files page is reloaded
-		Then the file "zzzz-z-this-is-now-the-last-file.txt" should be listed
+		When the user renames the file "lorem.txt" to "zzzz-z-this-is-now-the-last-file.txt" using the webUI
+		And the user reloads the current page of the webUI
+		Then the file "zzzz-z-this-is-now-the-last-file.txt" should be listed on the webUI
 
 	Scenario: Rename a file putting a name of a file which already exists
-		When I rename the file "data.zip" to "lorem.txt"
-		Then near the file "data.zip" a tooltip with the text 'lorem.txt already exists' should be displayed
+		When the user renames the file "data.zip" to "lorem.txt" using the webUI
+		Then near the file "data.zip" a tooltip with the text 'lorem.txt already exists' should be displayed on the webUI
 
 	Scenario: Rename a file to ..
-		When I rename the file "data.zip" to ".."
-		Then near the file "data.zip" a tooltip with the text '".." is an invalid file name.' should be displayed
+		When the user renames the file "data.zip" to ".." using the webUI
+		Then near the file "data.zip" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
 
 	Scenario: Rename a file to .
-		When I rename the file "data.zip" to "."
-		Then near the file "data.zip" a tooltip with the text '"." is an invalid file name.' should be displayed
+		When the user renames the file "data.zip" to "." using the webUI
+		Then near the file "data.zip" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
 
 	Scenario: Rename a file to .part
-		When I rename the file "data.zip" to "data.part"
-		Then near the file "data.zip" a tooltip with the text '"data.part" has a forbidden file type/extension.' should be displayed
+		When the user renames the file "data.zip" to "data.part" using the webUI
+		Then near the file "data.zip" a tooltip with the text '"data.part" has a forbidden file type/extension.' should be displayed on the webUI

--- a/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
@@ -5,18 +5,18 @@ I want to rename a file
 So that I can recognize my file easily
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
-		And I am on the login page
-		And I login with username "user1" and password "1234"
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 
 	Scenario Outline: Rename the existing file inside a problematic folder
-		When I open the folder <folder>
-		And I rename the file "lorem.txt" to "???.txt"
-		Then the file "???.txt" should be listed
-		And the files page is reloaded
-		Then the file "???.txt" should be listed
+		When the user opens the folder <folder> using the webUI
+		And the user renames the file "lorem.txt" to "???.txt" using the webUI
+		Then the file "???.txt" should be listed on the webUI
+		When the user reloads the current page of the webUI
+		Then the file "???.txt" should be listed on the webUI
 		Examples:
 		|       folder       |
 		|         "0"        |

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -5,15 +5,15 @@ I want to rename folders
 So that I can organise my data structure
 
 	Background:
-		Given a regular user exists
-		And I am logged in as a regular user
-		And I am on the files page
+		Given a regular user has been created
+		And the regular user has logged in using the webUI
+		And the user has browsed to the files page
 
 	Scenario Outline: Rename a folder using special characters
-		When I rename the folder "simple-folder" to <to_folder_name>
-		Then the folder <to_folder_name> should be listed
-		And the files page is reloaded
-		Then the folder <to_folder_name> should be listed
+		When the user renames the folder "simple-folder" to <to_folder_name> using the webUI
+		Then the folder <to_folder_name> should be listed on the webUI
+		When the user reloads the current page of the webUI
+		Then the folder <to_folder_name> should be listed on the webUI
 		Examples:
 		|to_folder_name |
 		|'सिमप्ले फोल्देर$%#?&@' |
@@ -21,80 +21,80 @@ So that I can organise my data structure
 		|"'quotes2'"    |
 
 	Scenario Outline: Rename a folder that has special characters in its name
-		When I rename the folder <from_name> to <to_name>
-		Then the folder <to_name> should be listed
-		And the files page is reloaded
-		Then the folder <to_name> should be listed
+		When the user renames the folder <from_name> to <to_name> using the webUI
+		Then the folder <to_name> should be listed on the webUI
+		When the user reloads the current page of the webUI
+		Then the folder <to_name> should be listed on the webUI
 		Examples:
 		|from_name           |to_name                 |
 		|"strängé नेपाली folder"|"strängé नेपाली folder-#?2"|
 		|"'single'quotes"    |"single-quotes"         |
 
 	Scenario: Rename a folder using special characters and check its existence after page reload
-		When I rename the folder "simple-folder" to "लोरेम।तयक्स्त $%&"
-		And the files page is reloaded
-		Then the folder "लोरेम।तयक्स्त $%&" should be listed
-		When I rename the folder "लोरेम।तयक्स्त $%&" to '"double"quotes'
-		And the files page is reloaded
-		Then the folder '"double"quotes' should be listed
-		When I rename the folder '"double"quotes' to "no-double-quotes"
-		And the files page is reloaded
-		Then the folder "no-double-quotes" should be listed
-		When I rename the folder 'no-double-quotes' to "hash#And&QuestionMark?At@FolderName"
-		And the files page is reloaded
-		Then the folder "hash#And&QuestionMark?At@FolderName" should be listed
+		When the user renames the folder "simple-folder" to "लोरेम।तयक्स्त $%&" using the webUI
+		And the user reloads the current page of the webUI
+		Then the folder "लोरेम।तयक्स्त $%&" should be listed on the webUI
+		When the user renames the folder "लोरेम।तयक्स्त $%&" to '"double"quotes' using the webUI
+		And the user reloads the current page of the webUI
+		Then the folder '"double"quotes' should be listed on the webUI
+		When the user renames the folder '"double"quotes' to "no-double-quotes" using the webUI
+		And the user reloads the current page of the webUI
+		Then the folder "no-double-quotes" should be listed on the webUI
+		When the user renames the folder 'no-double-quotes' to "hash#And&QuestionMark?At@FolderName" using the webUI
+		And the user reloads the current page of the webUI
+		Then the folder "hash#And&QuestionMark?At@FolderName" should be listed on the webUI
 
 	Scenario: Rename a folder using spaces at front and/or back of the name
-		When I rename the folder "simple-folder" to " space at start"
-		And the files page is reloaded
-		Then the folder " space at start" should be listed
-		When I rename the folder " space at start" to "space at end "
-		And the files page is reloaded
-		Then the folder "space at end " should be listed
-		When I rename the folder "space at end " to "  multiple   spaces    all     over   "
-		And the files page is reloaded
-		Then the folder "  multiple   spaces    all     over   " should be listed
+		When the user renames the folder "simple-folder" to " space at start" using the webUI
+		And the user reloads the current page of the webUI
+		Then the folder " space at start" should be listed on the webUI
+		When the user renames the folder " space at start" to "space at end " using the webUI
+		And the user reloads the current page of the webUI
+		Then the folder "space at end " should be listed on the webUI
+		When the user renames the folder "space at end " to "  multiple   spaces    all     over   " using the webUI
+		And the user reloads the current page of the webUI
+		Then the folder "  multiple   spaces    all     over   " should be listed on the webUI
 
 	Scenario: Rename a folder using both double and single quotes
-		When I rename the following folder to
+		When the user renames the following folder using the webUI
 			|from-name-parts |to-name-parts        |
 			|simple-folder  |First 'single' quotes |
 			|               |-then "double"        |
-		And the files page is reloaded
-		Then the following folder should be listed
+		And the user reloads the current page of the webUI
+		Then the following folder should be listed on the webUI
 			|name-parts            |
 			|First 'single' quotes |
 			|-then "double"        |
-		When I rename the following folder to
+		When the user renames the following folder using the webUI
 			|from-name-parts       |to-name-parts   |
 			|First 'single' quotes |a normal folder |
 			|-then "double"        |                |
-		And the files page is reloaded
-		Then the folder "a normal folder" should be listed
+		And the user reloads the current page of the webUI
+		Then the folder "a normal folder" should be listed on the webUI
 
 	Scenario: Rename a folder using forbidden characters
-		When I rename the folder "simple-folder" to one of these names
+		When the user renames the folder "simple-folder" to one of these names using the webUI
 		|simple\folder   |
 		|\\simple-folder |
 		|.htaccess       |
-		Then notifications should be displayed with the text
+		Then notifications should be displayed on the webUI with the text
 		|Could not rename "simple-folder"|
 		|Could not rename "simple-folder"|
 		|Could not rename "simple-folder"|
-		And the folder "simple-folder" should be listed
+		And the folder "simple-folder" should be listed on the webUI
 
 	Scenario: Rename a folder putting a name of a file which already exists
-		When I rename the folder "simple-folder" to "lorem.txt"
-		Then near the folder "simple-folder" a tooltip with the text 'lorem.txt already exists' should be displayed
+		When the user renames the folder "simple-folder" to "lorem.txt" using the webUI
+		Then near the folder "simple-folder" a tooltip with the text 'lorem.txt already exists' should be displayed on the webUI
 
 	Scenario: Rename a folder to ..
-		When I rename the folder "simple-folder" to ".."
-		Then near the folder "simple-folder" a tooltip with the text '".." is an invalid file name.' should be displayed
+		When the user renames the folder "simple-folder" to ".." using the webUI
+		Then near the folder "simple-folder" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
 
 	Scenario: Rename a folder to .
-		When I rename the folder "simple-folder" to "."
-		Then near the folder "simple-folder" a tooltip with the text '"." is an invalid file name.' should be displayed
+		When the user renames the folder "simple-folder" to "." using the webUI
+		Then near the folder "simple-folder" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
 
 	Scenario: Rename a folder to .part
-		When I rename the folder "simple-folder" to "simple.part"
-		Then near the folder "simple-folder" a tooltip with the text '"simple.part" has a forbidden file type/extension.' should be displayed
+		When the user renames the folder "simple-folder" to "simple.part" using the webUI
+		Then near the folder "simple-folder" a tooltip with the text '"simple.part" has a forbidden file type/extension.' should be displayed on the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
@@ -5,13 +5,13 @@ I want to be able to disable the sharing function
 So that users cannot share files
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
 		
 	@TestAlsoOnExternalUserBackend
 	Scenario: Users tries to share via WebUI when Sharing is disabled
-		When the setting "Allow apps to use the Share API" in the section "Sharing" is disabled
-		And I am on the login page
-		And I login with username "user1" and password "1234"
-		Then it should not be possible to share the folder "simple-folder"
+		Given the setting "Allow apps to use the Share API" in the section "Sharing" has been disabled
+		And the user has browsed to the login page
+		When the user logs in with username "user1" and password "1234" using the webUI
+		Then it should not be possible to share the folder "simple-folder" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -6,33 +6,33 @@ As a user
 I want to be able to forbid a user that received a share from me to share it further
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
 		|user2   |1234    |User Two   |u2@oc.com.np|
 		|user3   |1234    |User Three |u2@oc.com.np|
-		And these groups exist:
+		And these groups have been created:
 		|groupname|
 		|grp1     |
-		And the user "user1" is in the group "grp1"
-		And the user "user2" is in the group "grp1"
-		And I am on the login page
-		And I login with username "user2" and password "1234"
+		And user "user1" has been added to group "grp1" ready for use by the webUI
+		And user "user2" has been added to group "grp1" ready for use by the webUI
+		And the user has browsed to the login page
+		And the user has logged in with username "user2" and password "1234" using the webUI
 
 	@skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
 	Scenario: share a folder with another internal user and prohibit resharing
-		And the setting "Allow resharing" in the section "Sharing" is enabled
-		And I am on the files page
-		When the folder "simple-folder" is shared with the user "User One"
-		And the sharing permissions of "User One" for "simple-folder" are set to
+		Given the setting "Allow resharing" in the section "Sharing" has been enabled
+		And the user has browsed to the files page
+		When the user shares the folder "simple-folder" with the user "User One" using the webUI
+		And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
 		| share | no |
-		And I relogin with username "user1" and password "1234"
-		Then it should not be possible to share the folder "simple-folder (2)"
+		And the user re-logs in with username "user1" and password "1234" using the webUI
+		Then it should not be possible to share the folder "simple-folder (2)" using the webUI
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: forbid resharing globally
-		When the setting "Allow resharing" in the section "Sharing" is disabled
-		And I am on the files page
-		And the folder "simple-folder" is shared with the user "User One"
-		And I relogin with username "user1" and password "1234"
-		Then it should not be possible to share the folder "simple-folder (2)"
+		Given the setting "Allow resharing" in the section "Sharing" has been disabled
+		And the user has browsed to the files page
+		When the user shares the folder "simple-folder" with the user "User One" using the webUI
+		And the user re-logs in with username "user1" and password "1234" using the webUI
+		Then it should not be possible to share the folder "simple-folder (2)" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -5,53 +5,53 @@ I want to be able to restrict the sharing function
 So that users can only share files with specific users and groups
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
 		|user2   |1234    |User Two   |u2@oc.com.np|
 		|user3   |1234    |User Three |u2@oc.com.np|
-		And these groups exist:
+		And these groups have been created:
 		|groupname|
 		|grp1     |
 		|grp2     |
-		And the user "user1" is in the group "grp1"
-		And the user "user2" is in the group "grp1"
-		And the user "user3" is in the group "grp2"
-		And I am on the login page
-		And I login with username "user2" and password "1234"
+		And user "user1" has been added to group "grp1" ready for use by the webUI
+		And user "user2" has been added to group "grp1" ready for use by the webUI
+		And user "user3" has been added to group "grp2" ready for use by the webUI
+		And the user has browsed to the login page
+		And the user has logged in with username "user2" and password "1234" using the webUI
 	
 	@TestAlsoOnExternalUserBackend
 	Scenario: Restrict users to only share with users in their groups
-		When the setting "Restrict users to only share with users in their groups" in the section "Sharing" is enabled
-		And I am on the files page
-		Then it should not be possible to share the folder "simple-folder" with "User Three"
-		When the folder "simple-folder" is shared with the user "User One"
-		And I relogin with username "user1" and password "1234"
-		Then the folder "simple-folder (2)" should be listed
+		Given the setting "Restrict users to only share with users in their groups" in the section "Sharing" has been enabled
+		When the user browses to the files page
+		Then it should not be possible to share the folder "simple-folder" with "User Three" using the webUI
+		When the user shares the folder "simple-folder" with the user "User One" using the webUI
+		And the user re-logs in with username "user1" and password "1234" using the webUI
+		Then the folder "simple-folder (2)" should be listed on the webUI
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: Restrict users to only share with groups they are member of
-		When the setting "Restrict users to only share with groups they are member of" in the section "Sharing" is enabled
-		And I am on the files page
-		Then it should not be possible to share the folder "simple-folder" with "grp2"
-		When the folder "simple-folder" is shared with the group "grp1"
-		And I relogin with username "user1" and password "1234"
-		Then the folder "simple-folder (2)" should be listed
+		Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been enabled
+		When the user browses to the files page
+		Then it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
+		When the user shares the folder "simple-folder" with the group "grp1" using the webUI
+		And the user re-logs in with username "user1" and password "1234" using the webUI
+		Then the folder "simple-folder (2)" should be listed on the webUI
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: Do not restrict users to only share with groups they are member of
-		When the setting "Restrict users to only share with groups they are member of" in the section "Sharing" is disabled
-		And I am on the files page
-		When the folder "simple-folder" is shared with the group "grp2"
-		And I relogin with username "user3" and password "1234"
-		Then the folder "simple-folder (2)" should be listed
+		Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been disabled
+		And the user browses to the files page
+		When the user shares the folder "simple-folder" with the group "grp2" using the webUI
+		And the user re-logs in with username "user3" and password "1234" using the webUI
+		Then the folder "simple-folder (2)" should be listed on the webUI
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: Forbid sharing with groups
-		When the setting "Allow sharing with groups" in the section "Sharing" is disabled
-		And I am on the files page
-		Then it should not be possible to share the folder "simple-folder" with "grp1"
-		And it should not be possible to share the folder "simple-folder" with "grp2"
-		When the folder "simple-folder" is shared with the user "User One"
-		And I relogin with username "user1" and password "1234"
-		Then the folder "simple-folder (2)" should be listed
+		Given the setting "Allow sharing with groups" in the section "Sharing" has been disabled
+		When the user browses to the files page
+		Then it should not be possible to share the folder "simple-folder" with "grp1" using the webUI
+		And it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
+		When the user shares the folder "simple-folder" with the user "User One" using the webUI
+		And the user re-logs in with username "user1" and password "1234" using the webUI
+		Then the folder "simple-folder (2)" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -5,77 +5,77 @@ I want to share files with any users on other cloud storages
 So that other users have access to these files
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
 		|user2   |1234    |User Two   |u2@oc.com.np|
-		And I am on the login page
-		And I login with username "user2" and password "1234"
+		And the user has browsed to the login page
+		And the user has logged in with username "user2" and password "1234" using the webUI
 
 	Scenario: test the single steps of federation sharing
-		When the folder "simple-folder" is shared with the remote user "user1@%remote_server%"
-		And the folder "simple-empty-folder" is shared with the remote user "user1@%remote_server%"
-		And I relogin with username "user1" and password "1234" to "http://%remote_server%"
-		Then dialogs should be displayed
+		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server%" using the webUI
+		And the user shares the folder "simple-empty-folder" with the remote user "user1@%remote_server%" using the webUI
+		And the user re-logs in with username "user1" and password "1234" to "http://%remote_server%" using the webUI
+		Then dialogs should be displayed on the webUI
 		| title        | content                                                                              |
 		| Remote share | Do you want to add the remote share /simple-folder from user2@%local_server%/?       |
 		| Remote share | Do you want to add the remote share /simple-empty-folder from user2@%local_server%/? |
-		When the offered remote shares are accepted
-		Then the folder "simple-folder (2)" should be listed
-		When I open the folder "simple-folder (2)"
-		Then the file "lorem.txt" should be listed
+		When the user accepts the offered remote shares
+		Then the folder "simple-folder (2)" should be listed on the webUI
+		When the user opens the folder "simple-folder (2)" using the webUI
+		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 
 	@skipOnMICROSOFTEDGE
 	Scenario: share a folder with an remote user and prohibit deleting
-		When the folder "simple-folder" is shared with the remote user "user1@%remote_server%"
-		And the sharing permissions of "user1@%remote_server% (federated)" for "simple-folder" are set to
+		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server%" using the webUI
+		And the user sets the sharing permissions of "user1@%remote_server% (federated)" for "simple-folder" using the webUI to
 		| delete | no |
-		And I relogin with username "user1" and password "1234" to "http://%remote_server%"
-		And the offered remote shares are accepted
-		And I open the folder "simple-folder (2)"
-		Then it should not be possible to delete the file "lorem.txt"
+		And the user re-logs in with username "user1" and password "1234" to "http://%remote_server%" using the webUI
+		And the user accepts the offered remote shares
+		And the user opens the folder "simple-folder (2)" using the webUI
+		Then it should not be possible to delete the file "lorem.txt" using the webUI
 
 	Scenario: overwrite a file in a received share
-		When the folder "simple-folder" is shared with the remote user "user1@%remote_server%"
-		And I relogin with username "user1" and password "1234" to "http://%remote_server%"
-		And the offered remote shares are accepted
-		And I open the folder "simple-folder (2)"
-		And I upload overwriting the file "lorem.txt" and retry if the file is locked
-		And I relogin with username "user2" and password "1234" to "%base_url%"
-		And I open the folder "simple-folder"
-		Then the file "lorem.txt" should be listed
+		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server%" using the webUI
+		And the user re-logs in with username "user1" and password "1234" to "http://%remote_server%" using the webUI
+		And the user accepts the offered remote shares
+		And the user opens the folder "simple-folder (2)" using the webUI
+		And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+		And the user re-logs in with username "user2" and password "1234" to "%base_url%" using the webUI
+		And the user opens the folder "simple-folder" using the webUI
+		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"
 
 	Scenario: upload a new file in a received share
-		When the folder "simple-folder" is shared with the remote user "user1@%remote_server%"
-		And I relogin with username "user1" and password "1234" to "http://%remote_server%"
-		And the offered remote shares are accepted
-		And I open the folder "simple-folder (2)"
-		And I upload the file "new-lorem.txt"
-		And I relogin with username "user2" and password "1234" to "%base_url%"
-		And I open the folder "simple-folder"
-		And the file "new-lorem.txt" should be listed
+		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server%" using the webUI
+		And the user re-logs in with username "user1" and password "1234" to "http://%remote_server%" using the webUI
+		And the user accepts the offered remote shares
+		And the user opens the folder "simple-folder (2)" using the webUI
+		And the user uploads the file "new-lorem.txt" using the webUI
+		And the user re-logs in with username "user2" and password "1234" to "%base_url%" using the webUI
+		And the user opens the folder "simple-folder" using the webUI
+		Then the file "new-lorem.txt" should be listed on the webUI
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
 	Scenario: rename a file in a received share
-		When the folder "simple-folder" is shared with the remote user "user1@%remote_server%"
-		And I relogin with username "user1" and password "1234" to "http://%remote_server%"
-		And the offered remote shares are accepted
-		And I open the folder "simple-folder (2)"
-		And I rename the file "lorem-big.txt" to "renamed file.txt"
-		And I relogin with username "user2" and password "1234" to "%base_url%"
-		And I open the folder "simple-folder"
-		And the file "renamed file.txt" should be listed
+		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server%" using the webUI
+		And the user re-logs in with username "user1" and password "1234" to "http://%remote_server%" using the webUI
+		And the user accepts the offered remote shares
+		And the user opens the folder "simple-folder (2)" using the webUI
+		And the user renames the file "lorem-big.txt" to "renamed file.txt" using the webUI
+		And the user re-logs in with username "user2" and password "1234" to "%base_url%" using the webUI
+		And the user opens the folder "simple-folder" using the webUI
+		Then the file "renamed file.txt" should be listed on the webUI
 		And the content of "renamed file.txt" should be the same as the original "simple-folder/lorem-big.txt"
-		But the file "lorem-big.txt" should not be listed
+		But the file "lorem-big.txt" should not be listed on the webUI
 
 	Scenario: delete a file in a received share
-		When the folder "simple-folder" is shared with the remote user "user1@%remote_server%"
-		And I relogin with username "user1" and password "1234" to "http://%remote_server%"
-		And the offered remote shares are accepted
-		And I open the folder "simple-folder (2)"
-		And I delete the file "data.zip"
-		And I relogin with username "user2" and password "1234" to "%base_url%"
-		And I open the folder "simple-folder"
-		And the file "data.zip" should not be listed
+		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server%" using the webUI
+		And the user re-logs in with username "user1" and password "1234" to "http://%remote_server%" using the webUI
+		And the user accepts the offered remote shares
+		And the user opens the folder "simple-folder (2)" using the webUI
+		And the user deletes the file "data.zip" using the webUI
+		And the user re-logs in with username "user2" and password "1234" to "%base_url%" using the webUI
+		And the user opens the folder "simple-folder" using the webUI
+		Then the file "data.zip" should not be listed on the webUI

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -9,69 +9,69 @@ I want to limit the ability of a user to share files/folders through a publicly 
 So that public sharing is limited according to organization policy
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
-		And I am on the login page
-		And I login with username "user1" and password "1234"
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 
 	Scenario: simple sharing by public link
-		When I create a new public link for the folder "simple-folder"
-		And I access the last created public link
-		Then the file "lorem.txt" should be listed
+		When the user creates a new public link for the folder "simple-folder" using the webUI
+		And the public accesses the last created public link using the webUI
+		Then the file "lorem.txt" should be listed on the webUI
 
 	@skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
 	Scenario: creating a public link with read & write permissions makes it possible to delete files via the link
-		When I create a new public link for the folder "simple-folder" with
+		When the user creates a new public link for the folder "simple-folder" using the webUI with
 		| permission | Read & Write |
-		And I access the last created public link
-		And I delete the elements
+		And the public accesses the last created public link using the webUI
+		And the user deletes the following elements using the webUI
 		| name                                 |
 		| simple-empty-folder                  |
 		| lorem.txt                            |
 		| strängé filename (duplicate #2 &).txt  |
 		| zzzz-must-be-last-file-in-folder.txt |
-		Then the deleted elements should not be listed
-		And the deleted elements should not be listed after a page reload
+		Then the deleted elements should not be listed on the webUI
+		And the deleted elements should not be listed on the webUI after a page reload
 
 	@skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
 	Scenario: creating a public link with read permissions only makes it impossible to delete files via the link
-		When I create a new public link for the folder "simple-folder" with
+		When the user creates a new public link for the folder "simple-folder" using the webUI with
 		| permission | Read |
-		And I access the last created public link
-		Then it should not be possible to delete the file "lorem.txt"
+		And the public accesses the last created public link using the webUI
+		Then it should not be possible to delete the file "lorem.txt" using the webUI
 
 	@skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue_30392
 	Scenario: mount public link
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user2   |1234    |User One   |u1@oc.com.np|
-		When I create a new public link for the folder "simple-folder"
-		And I logout
-		And I access the last created public link
-		And I add the public link to "http://%remote_server%" as user "user2" with the password "1234"
-		And the offered remote shares are accepted
-		Then the folder "simple-folder (2)" should be listed
-		When I open the folder "simple-folder (2)"
-		Then the file "lorem.txt" should be listed
+		When the user creates a new public link for the folder "simple-folder" using the webUI
+		And the user logs out of the webUI
+		And the public accesses the last created public link using the webUI
+		And the public adds the public link to "http://%remote_server%" as user "user2" with the password "1234" using the webUI
+		And the user accepts the offered remote shares
+		Then the folder "simple-folder (2)" should be listed on the webUI
+		When the user opens the folder "simple-folder (2)" using the webUI
+		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
-		And it should not be possible to delete the file "lorem.txt"
+		And it should not be possible to delete the file "lorem.txt" using the webUI
 
 	@skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue_30392
 	Scenario: mount public link and overwrite file
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user2   |1234    |User One   |u1@oc.com.np|
-		When I create a new public link for the folder "simple-folder" with
+		When the user creates a new public link for the folder "simple-folder" using the webUI with
 		| permission | Read & Write |
-		And I logout
-		And I access the last created public link
-		And I add the public link to "http://%remote_server%" as user "user2" with the password "1234"
-		And the offered remote shares are accepted
-		Then the folder "simple-folder (2)" should be listed
-		When I open the folder "simple-folder (2)"
-		Then the file "lorem.txt" should be listed
+		And the user logs out of the webUI
+		And the public accesses the last created public link using the webUI
+		And the public adds the public link to "http://%remote_server%" as user "user2" with the password "1234" using the webUI
+		And the user accepts the offered remote shares
+		Then the folder "simple-folder (2)" should be listed on the webUI
+		When the user opens the folder "simple-folder (2)" using the webUI
+		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
-		When I upload overwriting the file "lorem.txt" and retry if the file is locked
-		Then the file "lorem.txt" should be listed
+		When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -5,101 +5,101 @@ I want to share files and folders with groups
 So that those groups can access the files and folders
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 			|username|password|displayname|email       |
 			|user1   |1234    |User One   |u1@oc.com.np|
 			|user2   |1234    |User Two   |u2@oc.com.np|
 			|user3   |1234    |User Three |u2@oc.com.np|
-		And these groups exist:
+		And these groups have been created:
 			|groupname|
 			|grp1     |
-		And the user "user1" is in the group "grp1"
-		And the user "user2" is in the group "grp1"
-		And I am on the login page
-		And I login with username "user3" and password "1234"
+		And user "user1" has been added to group "grp1" ready for use by the webUI
+		And user "user2" has been added to group "grp1" ready for use by the webUI
+		And the user has browsed to the login page
+		And the user has logged in with username "user3" and password "1234" using the webUI
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: share a folder with an internal group
-		When the folder "simple-folder" is shared with the group "grp1"
-		And the file "testimage.jpg" is shared with the group "grp1"
-		And I relogin with username "user1" and password "1234"
-		Then the folder "simple-folder (2)" should be listed
-		And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three"
-		And the file "testimage (2).jpg" should be listed
-		And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three"
-		When I relogin with username "user2" and password "1234"
-		Then the folder "simple-folder (2)" should be listed
-		And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three"
-		And the file "testimage (2).jpg" should be listed
-		And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three"
+		When the user shares the folder "simple-folder" with the group "grp1" using the webUI
+		And the user shares the file "testimage.jpg" with the group "grp1" using the webUI
+		And the user re-logs in with username "user1" and password "1234" using the webUI
+		Then the folder "simple-folder (2)" should be listed on the webUI
+		And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
+		And the file "testimage (2).jpg" should be listed on the webUI
+		And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
+		When the user re-logs in with username "user2" and password "1234" using the webUI
+		Then the folder "simple-folder (2)" should be listed on the webUI
+		And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
+		And the file "testimage (2).jpg" should be listed on the webUI
+		And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: share a file with an internal group a member overwrites and unshares the file
-		When I rename the file "lorem.txt" to "new-lorem.txt"
-		And the file "new-lorem.txt" is shared with the group "grp1"
-		And I relogin with username "user1" and password "1234"
+		When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
+		And the user shares the file "new-lorem.txt" with the group "grp1" using the webUI
+		And the user re-logs in with username "user1" and password "1234" using the webUI
 		Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
-		When I upload overwriting the file "new-lorem.txt" and retry if the file is locked
-		Then the file "new-lorem.txt" should be listed
+		When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
+		Then the file "new-lorem.txt" should be listed on the webUI
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# unshare the received shared file
-		When I unshare the file "new-lorem.txt"
-		Then the file "new-lorem.txt" should not be listed
+		When the user unshares the file "new-lorem.txt" using the webUI
+		Then the file "new-lorem.txt" should not be listed on the webUI
 		# check that another group member can still see the file
-		When I relogin with username "user2" and password "1234"
+		When the user re-logs in with username "user2" and password "1234" using the webUI
 		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# check that the original file owner can still see the file
-		When I relogin with username "user2" and password "1234"
+		When the user re-logs in with username "user2" and password "1234" using the webUI
 		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: share a folder with an internal group and a member uploads, overwrites and deletes files
-		When I rename the folder "simple-folder" to "new-simple-folder"
-		And the folder "new-simple-folder" is shared with the group "grp1"
-		And I relogin with username "user1" and password "1234"
-		And I open the folder "new-simple-folder"
+		When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
+		And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
+		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user opens the folder "new-simple-folder" using the webUI
 		Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
-		When I upload overwriting the file "lorem.txt" and retry if the file is locked
-		Then the file "lorem.txt" should be listed
+		When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"
 		# upload a new file into the received share
-		When I upload the file "new-lorem.txt"
+		When the user uploads the file "new-lorem.txt" using the webUI
 		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# delete a file in the received share
-		When I delete the file "data.zip"
-		Then the file "data.zip" should not be listed
+		When the user deletes the file "data.zip" using the webUI
+		Then the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible to another group member
-		When I relogin with username "user2" and password "1234"
-		And I open the folder "new-simple-folder"
+		When the user re-logs in with username "user2" and password "1234" using the webUI
+		And the user opens the folder "new-simple-folder" using the webUI
 		Then the content of "lorem.txt" should be the same as the local "lorem.txt"
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
-		And the file "data.zip" should not be listed
+		And the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
-		When I relogin with username "user3" and password "1234"
-		And I open the folder "new-simple-folder"
+		When the user re-logs in with username "user3" and password "1234" using the webUI
+		And the user opens the folder "new-simple-folder" using the webUI
 		Then the content of "lorem.txt" should be the same as the local "lorem.txt"
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
-		And the file "data.zip" should not be listed
+		And the file "data.zip" should not be listed on the webUI
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: share a folder with an internal group and a member unshares the folder
-		When I rename the folder "simple-folder" to "new-simple-folder"
-		And the folder "new-simple-folder" is shared with the group "grp1"
+		When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
+		And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
 		# unshare the received shared folder and check it is gone
-		And I relogin with username "user1" and password "1234"
-		And I unshare the folder "new-simple-folder"
-		Then the folder "new-simple-folder" should not be listed
+		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user unshares the folder "new-simple-folder" using the webUI
+		Then the folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible to another group member
-		When I relogin with username "user2" and password "1234"
-		Then the folder "new-simple-folder" should be listed
-		When I open the folder "new-simple-folder"
-		Then the file "lorem.txt" should be listed
-		Then the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
+		When the user re-logs in with username "user2" and password "1234" using the webUI
+		Then the folder "new-simple-folder" should be listed on the webUI
+		When the user opens the folder "new-simple-folder" using the webUI
+		Then the file "lorem.txt" should be listed on the webUI
+		And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 		# check that the folder is still visible for the share owner
-		When I relogin with username "user3" and password "1234"
-		Then the folder "new-simple-folder" should be listed
-		When I open the folder "new-simple-folder"
-		Then the file "lorem.txt" should be listed
-		Then the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
+		When the user re-logs in with username "user3" and password "1234" using the webUI
+		Then the folder "new-simple-folder" should be listed on the webUI
+		When the user opens the folder "new-simple-folder" using the webUI
+		Then the file "lorem.txt" should be listed on the webUI
+		And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
@@ -5,30 +5,30 @@ I want to share files and folders with groups
 So that those groups can access the files and folders
 
 	Scenario Outline: sharing  files and folder with an internal problematic group name
-		Given these users exist:
+		Given these users have been created:
 			|username|password|displayname|email       |
 			|user1   |1234    |User One   |u1@oc.com.np|
 			|user2   |1234    |User Two   |u2@oc.com.np|
 			|user3   |1234    |User Three |u2@oc.com.np|
-		And these groups exist:
+		And these groups have been created:
 			|groupname|
 			|<group>  |
-		And the user "user1" is in the group "<group>"
-		And the user "user2" is in the group "<group>"
-		And I am on the login page
-		And I login with username "user3" and password "1234"
-		When the folder "simple-folder" is shared with the group "<group>"
-		And the file "testimage.jpg" is shared with the group "<group>"
-		And I relogin with username "user1" and password "1234"
-		Then the folder "simple-folder (2)" should be listed
-		And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three"
-		And the file "testimage (2).jpg" should be listed
-		And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three"
-		When I relogin with username "user2" and password "1234"
-		Then the folder "simple-folder (2)" should be listed
-		And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three"
-		And the file "testimage (2).jpg" should be listed
-		And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three"
+		And user "user1" has been added to group "<group>" ready for use by the webUI
+		And user "user2" has been added to group "<group>" ready for use by the webUI
+		And the user has browsed to the login page
+		And the user has logged in with username "user3" and password "1234" using the webUI
+		When the user shares the folder "simple-folder" with the group "<group>" using the webUI
+		And the user shares the file "testimage.jpg" with the group "<group>" using the webUI
+		And the user re-logs in with username "user1" and password "1234" using the webUI
+		Then the folder "simple-folder (2)" should be listed on the webUI
+		And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
+		And the file "testimage (2).jpg" should be listed on the webUI
+		And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
+		When the user re-logs in with username "user2" and password "1234" using the webUI
+		Then the folder "simple-folder (2)" should be listed on the webUI
+		And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
+		And the file "testimage (2).jpg" should be listed on the webUI
+		And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
 		Examples:
 		|group    |
 		|?\?@#%@,;|

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -5,61 +5,61 @@ I want to share files, with minimal typing, to the right people or groups
 So that I can efficiently share my files with other users or groups
 
 	Background:
-		Given these users exist but are not initialized:
+		Given these users have been created but not initialized:
 			|username|password|displayname|email       |
 			|user1   |1234    |User One   |u1@oc.com.np|
 			|user2   |1234    |User Two   |u2@oc.com.np|
 			|user3   |1234    |User Three |u2@oc.com.np|
 			|usergrp |1234    |User Grp   |u@oc.com.np |
-		And a regular user exists
-		And regular groups exist
-		And I am logged in as a regular user
-		And I am on the files page
+		And a regular user has been created
+		And regular groups have been created
+		And the regular user has logged in using the webUI
+		And the user has browsed to the files page
 	@skipOnLDAP @user_ldap#175
 	Scenario: autocompletion of regular existing users
-		And the share dialog for the folder "simple-folder" is open
-		When I type "user" in the share-with-field
-		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list
-		And my own name should not be listed in the autocomplete list
+		Given the user has opened the share dialog for the folder "simple-folder"
+		When the user types "user" in the share-with-field
+		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI
+		And the users own name should not be listed in the autocomplete list on the webUI
 		
 	Scenario: autocompletion of regular existing groups
-		And the share dialog for the folder "simple-folder" is open
-		When I type "grp" in the share-with-field
-		Then all users and groups that contain the string "grp" in their name should be listed in the autocomplete list
-		And my own name should not be listed in the autocomplete list
+		Given the user has opened the share dialog for the folder "simple-folder"
+		When the user types "grp" in the share-with-field
+		Then all users and groups that contain the string "grp" in their name should be listed in the autocomplete list on the webUI
+		And the users own name should not be listed in the autocomplete list on the webUI
 		
 	Scenario: autocompletion for a pattern that does not match any user or group
-		And the share dialog for the folder "simple-folder" is open
-		When I type "doesnotexist" in the share-with-field
-		Then a tooltip with the text "No users or groups found for doesnotexist" should be shown near the share-with-field
-		And the autocomplete list should not be displayed
+		Given the user has opened the share dialog for the folder "simple-folder"
+		When the user types "doesnotexist" in the share-with-field
+		Then a tooltip with the text "No users or groups found for doesnotexist" should be shown near the share-with-field on the webUI
+		And the autocomplete list should not be displayed on the webUI
 		
 	@skipOnLDAP @user_ldap#175
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
-		And the folder "simple-folder" is shared with the user "User One"
-		And the share dialog for the folder "simple-folder" is open
-		When I type "user" in the share-with-field
-		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list except user "User One"
-		And my own name should not be listed in the autocomplete list
+		Given the user has shared the folder "simple-folder" with the user "User One" using the webUI
+		And the user has opened the share dialog for the folder "simple-folder"
+		When the user types "user" in the share-with-field
+		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User One"
+		And the users own name should not be listed in the autocomplete list on the webUI
 
 	@skipOnLDAP @user_ldap#175
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user whith whom the item is already shared (file)
-		And the file "data.zip" is shared with the user "User Grp"
-		And the share dialog for the file "data.zip" is open
-		When I type "user" in the share-with-field
-		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list except user "User Grp"
-		And my own name should not be listed in the autocomplete list
+		Given the user has shared the file "data.zip" with the user "User Grp" using the webUI
+		And the user has opened the share dialog for the file "data.zip"
+		When the user types "user" in the share-with-field
+		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Grp"
+		And the users own name should not be listed in the autocomplete list on the webUI
 	
 	Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
-		And the folder "simple-folder" is shared with the group "grp1"
-		And the share dialog for the folder "simple-folder" is open
-		When I type "grp" in the share-with-field
-		Then all users and groups that contain the string "grp" in their name should be listed in the autocomplete list except group "grp1"
-		And my own name should not be listed in the autocomplete list
+		Given the user shares the folder "simple-folder" with the group "grp1" using the webUI
+		And the user has opened the share dialog for the folder "simple-folder"
+		When the user types "grp" in the share-with-field
+		Then all users and groups that contain the string "grp" in their name should be listed in the autocomplete list on the webUI except group "grp1"
+		And the users own name should not be listed in the autocomplete list on the webUI
 
 	Scenario: autocompletion of a pattern that matches regular existing groups but also a group whith whom the item is already shared (file)
-		And the file "data.zip" is shared with the group "grpuser"
-		And the share dialog for the file "data.zip" is open
-		When I type "grp" in the share-with-field
-		Then all users and groups that contain the string "grp" in their name should be listed in the autocomplete list except group "grpuser"
-		And my own name should not be listed in the autocomplete list
+		Given the user shares the file "data.zip" with the group "grpuser" using the webUI
+		And the user has opened the share dialog for the file "data.zip"
+		When the user types "grp" in the share-with-field
+		Then all users and groups that contain the string "grp" in their name should be listed in the autocomplete list on the webUI except group "grpuser"
+		And the users own name should not be listed in the autocomplete list on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -5,89 +5,89 @@ I want to share files and folders with other users
 So that those users can access the files and folders
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 			|username|password|displayname|email       |
 			|user1   |1234    |User One   |u1@oc.com.np|
 			|user2   |1234    |User Two   |u2@oc.com.np|
-		And I am on the login page
-		And I login with username "user2" and password "1234"
+		And the user has browsed to the login page
+		And the user has logged in with username "user2" and password "1234" using the webUI
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: share a file & folder with another internal user
-		When the folder "simple-folder" is shared with the user "User One"
-		And the file "testimage.jpg" is shared with the user "User One"
-		And I relogin with username "user1" and password "1234"
-		Then the folder "simple-folder (2)" should be listed
-		And the folder "simple-folder (2)" should be marked as shared by "User Two"
-		And the file "testimage (2).jpg" should be listed
-		And the file "testimage (2).jpg" should be marked as shared by "User Two"
-		When I open the folder "simple-folder (2)"
-		Then the file "lorem.txt" should be listed
-		But the folder "simple-folder (2)" should not be listed
+		When the user shares the folder "simple-folder" with the user "User One" using the webUI
+		And the user shares the file "testimage.jpg" with the user "User One" using the webUI
+		And the user re-logs in with username "user1" and password "1234" using the webUI
+		Then the folder "simple-folder (2)" should be listed on the webUI
+		And the folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
+		And the file "testimage (2).jpg" should be listed on the webUI
+		And the file "testimage (2).jpg" should be marked as shared by "User Two" on the webUI
+		When the user opens the folder "simple-folder (2)" using the webUI
+		Then the file "lorem.txt" should be listed on the webUI
+		But the folder "simple-folder (2)" should not be listed on the webUI
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: share a file with another internal user who overwrites and unshares the file
-		When I rename the file "lorem.txt" to "new-lorem.txt"
-		And the file "new-lorem.txt" is shared with the user "User One"
-		And I relogin with username "user1" and password "1234"
+		When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
+		And the user shares the file "new-lorem.txt" with the user "User One" using the webUI
+		And the user re-logs in with username "user1" and password "1234" using the webUI
 		Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
-		When I upload overwriting the file "new-lorem.txt" and retry if the file is locked
-		Then the file "new-lorem.txt" should be listed
+		When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
+		Then the file "new-lorem.txt" should be listed on the webUI
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# unshare the received shared file
-		When I unshare the file "new-lorem.txt"
-		Then the file "new-lorem.txt" should not be listed
+		When the user unshares the file "new-lorem.txt" using the webUI
+		Then the file "new-lorem.txt" should not be listed on the webUI
 		# check that the original file owner can still see the file
-		When I relogin with username "user2" and password "1234"
+		When the user re-logs in with username "user2" and password "1234" using the webUI
 		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: share a folder with another internal user who uploads, overwrites and deletes files
-		When I rename the folder "simple-folder" to "new-simple-folder"
-		And the folder "new-simple-folder" is shared with the user "User One"
-		And I relogin with username "user1" and password "1234"
-		And I open the folder "new-simple-folder"
+		When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
+		And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
+		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user opens the folder "new-simple-folder" using the webUI
 		Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
-		When I upload overwriting the file "lorem.txt" and retry if the file is locked
-		Then the file "lorem.txt" should be listed
+		When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"
 		# upload a new file into the received share
-		When I upload the file "new-lorem.txt"
+		When the user uploads the file "new-lorem.txt" using the webUI
 		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# delete a file in the received share
-		When I delete the file "data.zip"
-		Then the file "data.zip" should not be listed
+		When the user deletes the file "data.zip" using the webUI
+		Then the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
-		When I relogin with username "user2" and password "1234"
-		And I open the folder "new-simple-folder"
-		Then the file "lorem.txt" should be listed
+		When the user re-logs in with username "user2" and password "1234" using the webUI
+		And the user opens the folder "new-simple-folder" using the webUI
+		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"
-		And the file "new-lorem.txt" should be listed
+		And the file "new-lorem.txt" should be listed on the webUI
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
-		And the file "data.zip" should not be listed
+		But the file "data.zip" should not be listed on the webUI
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: share a folder with another internal user who unshares the folder
-		When I rename the folder "simple-folder" to "new-simple-folder"
-		And the folder "new-simple-folder" is shared with the user "User One"
+		When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
+		And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
 		# unshare the received shared folder and check it is gone
-		And I relogin with username "user1" and password "1234"
-		And I unshare the folder "new-simple-folder"
-		Then the folder "new-simple-folder" should not be listed
+		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user unshares the folder "new-simple-folder" using the webUI
+		Then the folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible for the share owner
-		When I relogin with username "user2" and password "1234"
-		Then the folder "new-simple-folder" should be listed
-		When I open the folder "new-simple-folder"
-		Then the file "lorem.txt" should be listed
-		Then the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
+		When the user re-logs in with username "user2" and password "1234" using the webUI
+		Then the folder "new-simple-folder" should be listed on the webUI
+		When the user opens the folder "new-simple-folder" using the webUI
+		Then the file "lorem.txt" should be listed on the webUI
+		And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 
 	@skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
 	Scenario: share a folder with another internal user and prohibit deleting
-		When the folder "simple-folder" is shared with the user "User One"
-		And the sharing permissions of "User One" for "simple-folder" are set to
+		When the user shares the folder "simple-folder" with the user "User One" using the webUI
+		And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
 		| delete | no |
-		And I relogin with username "user1" and password "1234"
-		And I open the folder "simple-folder (2)"
-		Then it should not be possible to delete the file "lorem.txt"
+		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user opens the folder "simple-folder (2)" using the webUI
+		Then it should not be possible to delete the file "lorem.txt" using the webUI

--- a/tests/acceptance/features/webUITrashbin/restore.feature
+++ b/tests/acceptance/features/webUITrashbin/restore.feature
@@ -5,25 +5,25 @@ I would like to restore files/folders
 So that I can recover accidentally deleted files/folders in ownCloud
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
-		And I am on the login page
-		And I login with username "user1" and password "1234"
-		And I am on the files page
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has browsed to the files page
 
 	Scenario: Restore files
-		When I delete the file "data.zip" 
-		Then the file "data.zip" should be listed in the trashbin
-		When I restore the file "data.zip"
-		Then the file "data.zip" should not be listed 
-		When I am on the files page
-		Then the file "data.zip" should be listed 
+		When the user deletes the file "data.zip" using the webUI
+		Then the file "data.zip" should be listed in the trashbin on the webUI
+		When the user restores the file "data.zip" from the trashbin using the webUI
+		Then the file "data.zip" should not be listed on the webUI
+		When the user browses to the files page
+		Then the file "data.zip" should be listed on the webUI
 
 	Scenario: Restore folder
-		When I delete the folder "folder with space" 
-		Then the folder "folder with space" should be listed in the trashbin 
-		When I restore the folder "folder with space"
-		Then the file "folder with space" should not be listed 
-		When I am on the files page
-		Then the folder "folder with space" should be listed 
+		When the user deletes the folder "folder with space" using the webUI
+		Then the folder "folder with space" should be listed in the trashbin on the webUI
+		When the user restores the folder "folder with space" from the trashbin using the webUI
+		Then the file "folder with space" should not be listed on the webUI
+		When the user browses to the files page
+		Then the folder "folder with space" should be listed on the webUI

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -5,24 +5,24 @@ Feature: files and folders can be deleted from the trashbin
   So that I can control my trashbin space and which files are kept in that space
 
   Background:
-    Given a regular user exists
-    And I am logged in as a regular user
-    And the following files are deleted
+    Given a regular user has been created
+    And the regular user has logged in using the webUI
+    And the following files have been deleted
       | name          |
       | lorem.txt     |
       | lorem-big.txt |
       | simple-folder |
-    And I am on the trashbin page
+    And the user has browsed to the trashbin page
 
   Scenario: Delete files and check that they are gone
-    When I delete the file "lorem.txt"
-    And I open the folder "simple-folder"
-    And I delete the file "lorem-big.txt"
-    Then the file "lorem.txt" should not be listed in the trashbin
-    But the file "lorem.txt" should be listed in the trashbin folder "simple-folder"
-    And the file "lorem-big.txt" should not be listed in the trashbin folder "simple-folder"
-    But the file "lorem-big.txt" should be listed in the trashbin
+    When the user deletes the file "lorem.txt" using the webUI
+    And the user opens the folder "simple-folder" using the webUI
+    And the user deletes the file "lorem-big.txt" using the webUI
+    Then the file "lorem.txt" should not be listed in the trashbin on the webUI
+    But the file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
+    And the file "lorem-big.txt" should not be listed in the trashbin folder "simple-folder" on the webUI
+    But the file "lorem-big.txt" should be listed in the trashbin on the webUI
 
   Scenario: Delete folders and check that they are gone
-    When I delete the folder "simple-folder"
-    Then the folder "simple-folder" should not be listed in the trashbin
+    When the user deletes the folder "simple-folder" using the webUI
+    Then the folder "simple-folder" should not be listed in the trashbin on the webUI

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -5,34 +5,34 @@ Feature: files and folders exist in the trashbin after being deleted
   So that I can recover data easily
 
   Background:
-    Given a regular user exists
-    And I am logged in as a regular user
-    And I am on the files page
+    Given a regular user has been created
+    And the regular user has logged in using the webUI
+    And the user has browsed to the files page
 
   Scenario: Delete files & folders one by one and check that they are all in the trashbin
-    When I delete the elements
+    When the user deletes the following elements using the webUI
       | name                                |
       | simple-folder                       |
       | lorem.txt                           |
       | strängé नेपाली folder                  |
       | strängé filename (duplicate #2 &).txt |
-    Then the deleted elements should be listed in the trashbin
-    And the file "lorem.txt" should be listed in the trashbin folder "simple-folder"
+    Then the deleted elements should be listed in the trashbin on the webUI
+    And the file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
 
   Scenario: Delete a file with problematic characters and check it is in the trashbin
-    When I rename the following file to
+    When the user renames the following file using the webUI
       | from-name-parts | to-name-parts   |
       | lorem.txt       | 'single'        |
       |                 | "double" quotes |
       |                 | question?       |
       |                 | &and#hash       |
-    And I delete the following file
+    And the user deletes the following file using the webUI
       | name-parts      |
       | 'single'        |
       | "double" quotes |
       | question?       |
       | &and#hash       |
-    Then the following file should be listed in the trashbin
+    Then the following file should be listed in the trashbin on the webUI
       | name-parts      |
       | 'single'        |
       | "double" quotes |
@@ -40,19 +40,19 @@ Feature: files and folders exist in the trashbin after being deleted
       | &and#hash       |
 
   Scenario: Delete multiple files at once and check that they are all in the trashbin
-    When I batch delete these files
+    When the user batch deletes these files using the webUI
       | name          |
       | data.zip      |
       | lorem.txt     |
       | simple-folder |
-    Then the deleted elements should be listed in the trashbin
-    And the file "lorem.txt" should be listed in the trashbin folder "simple-folder"
+    Then the deleted elements should be listed in the trashbin on the webUI
+    And the file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
 
   Scenario: Delete an empty folder and check it is in the trashbin
-    When I create a folder with the name "my-empty-folder"
-    And I create a folder with the name "my-other-empty-folder"
-    And I delete the folder "my-empty-folder"
-    Then the folder "my-empty-folder" should be listed in the trashbin
-    But the folder "my-other-empty-folder" should not be listed in the trashbin
-    When I open the trashbin folder "my-empty-folder"
-    Then there are no files/folders listed
+    When the user creates a folder with the name "my-empty-folder" using the webUI
+    And the user creates a folder with the name "my-other-empty-folder" using the webUI
+    And the user deletes the folder "my-empty-folder" using the webUI
+    Then the folder "my-empty-folder" should be listed in the trashbin on the webUI
+    But the folder "my-other-empty-folder" should not be listed in the trashbin on the webUI
+    When the user opens the trashbin folder "my-empty-folder" using the webUI
+    Then there should be no files/folders listed on the webUI

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -6,82 +6,82 @@ I would like to be able to upload files via the WebUI
 So that I can store files in ownCloud
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
-		And I am on the login page
-		And I login with username "user1" and password "1234"
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 
 	Scenario: simple upload of a file that does not exist before
-		When I upload the file "new-lorem.txt"
-		Then no notification should be displayed
-		And the file "new-lorem.txt" should be listed
+		When the user uploads the file "new-lorem.txt" using the webUI
+		Then no notification should be displayed on the webUI
+		And the file "new-lorem.txt" should be listed on the webUI
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
 	Scenario: chunking upload
-		And a file with the size of "30000000" bytes and the name "big-video.mp4" exists
-		When I upload the file "big-video.mp4"
-		Then no notification should be displayed
-		And the file "big-video.mp4" should be listed
+		Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
+		When the user uploads the file "big-video.mp4" using the webUI
+		Then no notification should be displayed on the webUI
+		And the file "big-video.mp4" should be listed on the webUI
 		And the content of "big-video.mp4" should be the same as the local "big-video.mp4"
 
 	Scenario: conflict with a chunked file
-		And a file with the size of "30000000" bytes and the name "big-video.mp4" exists
-		When I rename the file "lorem.txt" to "big-video.mp4"
-		And I upload overwriting the file "big-video.mp4" and retry if the file is locked
-		Then the file "big-video.mp4" should be listed
+		Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
+		When the user renames the file "lorem.txt" to "big-video.mp4" using the webUI
+		And the user uploads overwriting the file "big-video.mp4" using the webUI and retries if the file is locked
+		Then the file "big-video.mp4" should be listed on the webUI
 		And the content of "big-video.mp4" should be the same as the local "big-video.mp4"
 
 	Scenario: upload a new file into a sub folder
-		When I open the folder "simple-folder"
-		And I upload the file "new-lorem.txt"
-		Then no notification should be displayed
-		And the file "new-lorem.txt" should be listed
+		When the user opens the folder "simple-folder" using the webUI
+		And the user uploads the file "new-lorem.txt" using the webUI
+		Then no notification should be displayed on the webUI
+		And the file "new-lorem.txt" should be listed on the webUI
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
 	Scenario: overwrite an existing file
-		When I upload overwriting the file "lorem.txt" and retry if the file is locked
-		Then no dialog should be displayed
-		And the file "lorem.txt" should be listed
+		When the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+		Then no dialog should be displayed on the webUI
+		And the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"
-		But the file "lorem (2).txt" should not be listed
+		But the file "lorem (2).txt" should not be listed on the webUI
 
 	Scenario: keep new and existing file
-		When I upload the file "lorem.txt"
-		And I choose to keep the new files
-		And I choose to keep the existing files
-		And I click the "Continue" button
-		Then no dialog should be displayed
-		And no notification should be displayed
-		And the file "lorem.txt" should be listed
+		When the user uploads the file "lorem.txt" using the webUI
+		And the user chooses to keep the new files in the upload dialog
+		And the user chooses to keep the existing files in the upload dialog
+		And the user chooses "Continue" in the upload dialog
+		Then no dialog should be displayed on the webUI
+		And no notification should be displayed on the webUI
+		And the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should not have changed
-		And the file "lorem (2).txt" should be listed
+		And the file "lorem (2).txt" should be listed on the webUI
 		And the content of "lorem (2).txt" should be the same as the local "lorem.txt"
 		
 	Scenario: cancel conflict dialog
-		When I upload the file "lorem.txt"
-		And I click the "Cancel" button
-		Then no dialog should be displayed
-		And no notification should be displayed
-		And the file "lorem.txt" should be listed
+		When the user uploads the file "lorem.txt" using the webUI
+		And the user chooses "Cancel" in the upload dialog
+		Then no dialog should be displayed on the webUI
+		And no notification should be displayed on the webUI
+		And the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should not have changed
-		And the file "lorem (2).txt" should not be listed
+		And the file "lorem (2).txt" should not be listed on the webUI
 
 	Scenario: overwrite an existing file in a sub-folder
-		When I open the folder "simple-folder"
-		And I upload overwriting the file "lorem.txt" and retry if the file is locked
-		Then the file "lorem.txt" should be listed
+		When the user opens the folder "simple-folder" using the webUI
+		And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"
 
 	Scenario: keep new and existing file in a sub-folder
-		When I open the folder "simple-folder"
-		And I upload the file "lorem.txt"
-		And I choose to keep the new files
-		And I choose to keep the existing files
-		And I click the "Continue" button
-		Then no dialog should be displayed
-		And no notification should be displayed
-		And the file "lorem.txt" should be listed
+		When the user opens the folder "simple-folder" using the webUI
+		And the user uploads the file "lorem.txt" using the webUI
+		And the user chooses to keep the new files in the upload dialog
+		And the user chooses to keep the existing files in the upload dialog
+		And the user chooses "Continue" in the upload dialog
+		Then no dialog should be displayed on the webUI
+		And no notification should be displayed on the webUI
+		And the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should not have changed
-		And the file "lorem (2).txt" should be listed
+		And the file "lorem (2).txt" should be listed on the webUI
 		And the content of "lorem (2).txt" should be the same as the local "lorem.txt"

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -8,42 +8,42 @@ These tests are written in a way that multiple file names are tested in one scen
 that is not academically correct but saves a lot of time
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
-		And I am on the login page
-		And I login with username "user1" and password "1234"
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 
 	Scenario: simple upload of a file that does not exist before
-		When I upload the file "new-'single'quotes.txt"
-		Then the file "new-'single'quotes.txt" should be listed
+		When the user uploads the file "new-'single'quotes.txt" using the webUI
+		Then the file "new-'single'quotes.txt" should be listed on the webUI
 		And the content of "new-'single'quotes.txt" should be the same as the local "new-'single'quotes.txt"
 
-		When I upload the file "new-strängé filename (duplicate #2 &).txt"
-		Then the file "new-strängé filename (duplicate #2 &).txt" should be listed
+		When the user uploads the file "new-strängé filename (duplicate #2 &).txt" using the webUI
+		Then the file "new-strängé filename (duplicate #2 &).txt" should be listed on the webUI
 		And the content of "new-strängé filename (duplicate #2 &).txt" should be the same as the local "new-strängé filename (duplicate #2 &).txt"
 
-		When I upload the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt"
-		Then the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed
+		When the user uploads the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" using the webUI
+		Then the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed on the webUI
 		And the content of "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be the same as the local "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt"
 
 	Scenario Outline: upload a new file into a sub folder
-		And a file with the size of "3000" bytes and the name "0" exists
-		When I open the folder <folder-to-upload-to>
-		And I upload the file "0"
-		Then the file "0" should be listed
+		Given a file with the size of "3000" bytes and the name "0" has been created locally
+		When the user opens the folder <folder-to-upload-to> using the webUI
+		And the user uploads the file "0" using the webUI
+		Then the file "0" should be listed on the webUI
 		And the content of "0" should be the same as the local "0"
 
-		When I upload the file "new-'single'quotes.txt"
-		Then the file "new-'single'quotes.txt" should be listed
+		When the user uploads the file "new-'single'quotes.txt" using the webUI
+		Then the file "new-'single'quotes.txt" should be listed on the webUI
 		And the content of "new-'single'quotes.txt" should be the same as the local "new-'single'quotes.txt"
 
-		When I upload the file "new-strängé filename (duplicate #2 &).txt"
-		Then the file "new-strängé filename (duplicate #2 &).txt" should be listed
+		When the user uploads the file "new-strängé filename (duplicate #2 &).txt" using the webUI
+		Then the file "new-strängé filename (duplicate #2 &).txt" should be listed on the webUI
 		And the content of "new-strängé filename (duplicate #2 &).txt" should be the same as the local "new-strängé filename (duplicate #2 &).txt"
 
-		When I upload the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt"
-		Then the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed
+		When the user uploads the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" using the webUI
+		Then the file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed on the webUI
 		And the content of "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be the same as the local "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt"
 		Examples:
 		| folder-to-upload-to  |
@@ -52,41 +52,41 @@ that is not academically correct but saves a lot of time
 		| "strängé नेपाली folder" |
 
 	Scenario: overwrite an existing file
-		When I upload overwriting the file "'single'quotes.txt" and retry if the file is locked
-		Then the file "'single'quotes.txt" should be listed
+		When the user uploads overwriting the file "'single'quotes.txt" using the webUI and retries if the file is locked
+		Then the file "'single'quotes.txt" should be listed on the webUI
 		And the content of "'single'quotes.txt" should be the same as the local "'single'quotes.txt"
 
-		When I upload overwriting the file "strängé filename (duplicate #2 &).txt" and retry if the file is locked
-		Then the file "strängé filename (duplicate #2 &).txt" should be listed
+		When the user uploads overwriting the file "strängé filename (duplicate #2 &).txt" using the webUI and retries if the file is locked
+		Then the file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
 		And the content of "strängé filename (duplicate #2 &).txt" should be the same as the local "strängé filename (duplicate #2 &).txt"
 
-		When I upload overwriting the file "zzzz-must-be-last-file-in-folder.txt" and retry if the file is locked
-		Then the file "zzzz-must-be-last-file-in-folder.txt" should be listed
+		When the user uploads overwriting the file "zzzz-must-be-last-file-in-folder.txt" using the webUI and retries if the file is locked
+		Then the file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
 		And the content of "zzzz-must-be-last-file-in-folder.txt" should be the same as the local "zzzz-must-be-last-file-in-folder.txt"
 
 	Scenario: keep new and existing file
-		When I upload the file "'single'quotes.txt" keeping both new and existing files
-		Then the file "'single'quotes.txt" should be listed
+		When the user uploads the file "'single'quotes.txt" keeping both new and existing files using the webUI
+		Then the file "'single'quotes.txt" should be listed on the webUI
 		And the content of "'single'quotes.txt" should not have changed
-		And the file "'single'quotes (2).txt" should be listed
+		And the file "'single'quotes (2).txt" should be listed on the webUI
 		And the content of "'single'quotes (2).txt" should be the same as the local "'single'quotes.txt"
 
-		When I upload the file "strängé filename (duplicate #2 &).txt" keeping both new and existing files
-		Then the file "strängé filename (duplicate #2 &).txt" should be listed
+		When the user uploads the file "strängé filename (duplicate #2 &).txt" keeping both new and existing files using the webUI
+		Then the file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
 		And the content of "strängé filename (duplicate #2 &).txt" should not have changed
-		And the file "strängé filename (duplicate #2 &) (2).txt" should be listed
+		And the file "strängé filename (duplicate #2 &) (2).txt" should be listed on the webUI
 		And the content of "strängé filename (duplicate #2 &) (2).txt" should be the same as the local "strängé filename (duplicate #2 &).txt"
 
-		When I upload the file "zzzz-must-be-last-file-in-folder.txt" keeping both new and existing files
-		Then the file "zzzz-must-be-last-file-in-folder.txt" should be listed
+		When the user uploads the file "zzzz-must-be-last-file-in-folder.txt" keeping both new and existing files using the webUI
+		Then the file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
 		And the content of "zzzz-must-be-last-file-in-folder.txt" should not have changed
-		And the file "zzzz-must-be-last-file-in-folder (2).txt" should be listed
+		And the file "zzzz-must-be-last-file-in-folder (2).txt" should be listed on the webUI
 		And the content of "zzzz-must-be-last-file-in-folder (2).txt" should be the same as the local "zzzz-must-be-last-file-in-folder.txt"
 
 	Scenario Outline: chunking upload using difficult names
-		And a file with the size of "30000000" bytes and the name <file-name> exists
-		When I upload the file <file-name>
-		Then the file <file-name> should be listed
+		Given a file with the size of "30000000" bytes and the name <file-name> has been created locally
+		When the user uploads the file <file-name> using the webUI
+		Then the file <file-name> should be listed on the webUI
 		And the content of <file-name> should be the same as the local <file-name>
 		Examples:
 		|file-name|
@@ -97,8 +97,8 @@ that is not academically correct but saves a lot of time
 	#uploading into "simple-folder" because there is a folder called "0" in the root
 	@skip @issue-29599
 	Scenario: Upload a file called "0" using chunking
-		And a file with the size of "30000000" bytes and the name "0" exists
-		When I open the folder "simple-folder"
-		And I upload the file "0"
-		Then the file "0" should be listed
+		Given a file with the size of "30000000" bytes and the name "0" has been created locally
+		When the user opens the folder "simple-folder" using the webUI
+		And the user uploads the file "0" using the webUI
+		Then the file "0" should be listed on the webUI
 		And the content of "0" should be the same as the local "0"

--- a/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
+++ b/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
@@ -6,18 +6,17 @@ I would like to upload a file
 So that I can store it in owncloud
 
 	Background:
-		Given these users exist:
+		Given these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
 
 	Scenario: simple upload of a file with the size greater than the size of quota
 		Given the quota of user "user1" has been set to "10 MB"
-		And I am on the login page
-		And I login with username "user1" and password "1234"
-		And I am on the files page
-		And a file with the size of "30000000" bytes and the name "big-video.mp4" exists
-		When I upload the file "big-video.mp4"
-		Then the file "big-video.mp4" should not be listed
-		And notifications should be displayed with the text matching
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has browsed to the files page
+		And a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
+		When the user uploads the file "big-video.mp4" using the webUI
+		Then the file "big-video.mp4" should not be listed on the webUI
+		And notifications should be displayed on the webUI with the text matching
 		|/^Not enough free space, you are uploading (\d+(.\d+)?) MB but only (\d+(.\d+)?) MB is left$/|
-


### PR DESCRIPTION
## Description
Changes wording of UI gherkin test steps.

Major points:
1) for most steps, mention ``using the webUI`` when the step is supposed to use the webUI to do the thing (vs "really background setup" that can/could create users/gorups... via any means like API, occ.

2) for `Then`` steps that test something that should be observed on the UI, mention ``on the webUI`` (vs when we are happy to test if a file exists or... by doing it "underneath" with the API)

3) when a step uses words like ``browse`` or ``redirected to page`` etc, then that is a webUI-specific word, so we do not have to always explicitly say ``using the webUI``

4) In ``Given`` steps that set the scene, use "present perfect" tense - ``the user has done xyz``

5) In ``When`` steps that perform the action(s) under test, use present tense - ``the user does xyz``

6) In ``Then`` steps that test some outcome, put the word ``should`` in the sentence - ``Then the folder "sub-folder" should be listed on the webUI``

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
Use a "standard" from of words in UI test steps so it is clear that they apply to the ``webUI`` and which steps are "setup" steps ``Given``, which are for ``When`` and which are for ``Then`` testing outcomes.

Make it like what was done to the API acceptance tests.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Doc PR https://github.com/owncloud/documentation/issues/3829