### PR TITLE
Tag before and after scenario with api or webUI

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -290,7 +290,7 @@ trait AppConfiguration {
 	abstract protected function resetAppConfigs();
 
 	/**
-	 * @BeforeScenario
+	 * @BeforeScenario @api
 	 *
 	 * @return void
 	 */
@@ -302,7 +302,7 @@ trait AppConfiguration {
 	}
 
 	/**
-	 * @AfterScenario
+	 * @AfterScenario @api
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -36,7 +36,7 @@ class AppManagementContext implements  Context {
 	private $cmdOutput;
 	
 	/**
-	 * @BeforeScenario
+	 * @BeforeScenario @api
 	 *
 	 * Remember the config values before each scenario
 	 *
@@ -50,7 +50,7 @@ class AppManagementContext implements  Context {
 	}
 	
 	/**
-	 * @AfterScenario
+	 * @AfterScenario @api
 	 *
 	 * Reset the config values after each scenario
 	 *

--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -32,7 +32,7 @@ trait Auth {
 	private $clientToken;
 
 	/**
-	 * @BeforeScenario
+	 * @BeforeScenario @api
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -784,7 +784,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @BeforeScenario @local_storage
+	 * @BeforeScenario @api&&@local_storage
 	 *
 	 * @return void
 	 */
@@ -798,7 +798,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @AfterScenario @local_storage
+	 * @AfterScenario @api&&@local_storage
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -68,7 +68,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @BeforeScenario @caldav
+	 * @BeforeScenario @api&&@caldav
 	 *
 	 * @param BeforeScenarioScope $scope
 	 *
@@ -84,7 +84,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @AfterScenario @caldav
+	 * @AfterScenario @api&&@caldav
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/CardDavContext.php
+++ b/tests/acceptance/features/bootstrap/CardDavContext.php
@@ -68,7 +68,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @BeforeScenario @carddav
+	 * @BeforeScenario @api&&@carddav
 	 *
 	 * @param BeforeScenarioScope $scope
 	 *
@@ -84,7 +84,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @AfterScenario @carddav
+	 * @AfterScenario @api&&@carddav
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -885,8 +885,8 @@ trait Provisioning {
 	}
 
 	/**
-	 * @BeforeScenario
-	 * @AfterScenario
+	 * @BeforeScenario @api
+	 * @AfterScenario @api
 	 *
 	 * @return void
 	 */
@@ -904,8 +904,8 @@ trait Provisioning {
 	}
 
 	/**
-	 * @BeforeScenario
-	 * @AfterScenario
+	 * @BeforeScenario @api
+	 * @AfterScenario @api
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -535,8 +535,8 @@ trait Tags {
 	}
 
 	/**
-	 * @BeforeScenario
-	 * @AfterScenario
+	 * @BeforeScenario @api
+	 * @AfterScenario @api
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/WebUIBasicStructure.php
+++ b/tests/acceptance/features/bootstrap/WebUIBasicStructure.php
@@ -436,7 +436,7 @@ trait WebUIBasicStructure {
 	}
 
 	/**
-	 * @BeforeScenario
+	 * @BeforeScenario @webUI
 	 * @TestAlsoOnExternalUserBackend
 	 *
 	 * @return void
@@ -459,7 +459,7 @@ trait WebUIBasicStructure {
 	}
 
 	/**
-	 * @BeforeScenario
+	 * @BeforeScenario @webUI
 	 *
 	 * @param BeforeScenarioScope $scope
 	 *
@@ -483,7 +483,7 @@ trait WebUIBasicStructure {
 	}
 
 	/**
-	 * @AfterScenario
+	 * @AfterScenario @webUI
 	 *
 	 * @return void
 	 * @throws Exception

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1194,7 +1194,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *
-	 * @BeforeScenario
+	 * @BeforeScenario @webUI
 	 *
 	 * @param BeforeScenarioScope $scope
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -452,7 +452,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @BeforeScenario
+	 * @BeforeScenario @webUI
 	 *
 	 * @param BeforeScenarioScope $scope
 	 *
@@ -505,7 +505,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	/**
 	 * disable the previews on all tests tagged with '@disablePreviews'
 	 * 
-	 * @BeforeScenario @disablePreviews
+	 * @BeforeScenario @webUI&&@disablePreviews
 	 *
 	 * @return void
 	 */
@@ -540,7 +540,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	/**
 	 * After Scenario. Sets back old settings
 	 *
-	 * @AfterScenario
+	 * @AfterScenario @webUI
 	 *
 	 * @return void
 	 */
@@ -590,7 +590,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	/**
 	 * After Scenario. clear file locks
 	 *
-	 * @AfterScenario
+	 * @AfterScenario @webUI
 	 *
 	 * @return void
 	 */
@@ -609,7 +609,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	/**
 	 * After Scenario. Report the pass/fail status to SauceLabs.
 	 *
-	 * @AfterScenario
+	 * @AfterScenario @webUI
 	 *
 	 * @param AfterScenarioScope $afterScenarioScope
 	 *

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -206,7 +206,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *
-	 * @BeforeScenario
+	 * @BeforeScenario @webUI
 	 *
 	 * @param BeforeScenarioScope $scope
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -147,7 +147,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *
-	 * @BeforeScenario
+	 * @BeforeScenario @webUI
 	 *
 	 * @param BeforeScenarioScope $scope
 	 *

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -506,7 +506,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *
-	 * @BeforeScenario
+	 * @BeforeScenario @webUI
 	 *
 	 * @param BeforeScenarioScope $scope
 	 * 

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -269,7 +269,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	/**
 	 * This will run before EVERY scenario.
 	 *
-	 * @BeforeScenario
+	 * @BeforeScenario @webUI
 	 *
 	 * @param BeforeScenarioScope $scope
 	 * 


### PR DESCRIPTION
## Description
Tag each ``BeforeScenario`` and ``AfterScenario`` method with ``api`` or ``webUI`` as appropriate.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
When running the whole content of the acceptance tests ``behat.yml``, the jobs are run with the tag ``api`` or ``webUI`` to run just the relevant scenarios. However, when that happens, ``behat`` is scanning the whole ``behat.yml`` for contexts, loading them, and running the ``BeforeScenario`` and ``AfterScenario`` of every context. At the moment, this could produce unexpected side-effects because both API and UI tests do some setup of settings etc (that will be resolved together "real soon now"). But for now we do not want them to potentially be interfering with the "default settings" set up by the other.

Similarly, API tests set the "big file id" stuff. In some webUI test environments (e.g. ``user_ldap``) that is not working cleanly. Better to not "inherit it all by default" at the moment.

## How Has This Been Tested?
CI knows

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

