### PR TITLE
Tag API test BeforeSuite method

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -812,7 +812,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @BeforeSuite
+	 * @BeforeSuite @api
 	 *
 	 * @param BeforeSuiteScope $scope
 	 *


### PR DESCRIPTION
## Description
Tag ``BeforeSuite`` methods in the API tests with the ``api`` tag.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
Setup related to API tests should only be run for API test jobs, not webUI test jobs.

When running webUI tests locally, this was emitting noise like:
```
┌─ @BeforeSuite # ShareesContext::useBigFileIDs()
│
╳  GuzzleHttp\Ring\Exception\RingException: cURL error 3: <url> malformed in /home/phil/ownCloud/core/lib/composer/guzzlehttp/ringphp/src/Client/CurlFactory.php:127
╳  Stack trace:
╳  #0 /home/phil/ownCloud/core/lib/composer/guzzlehttp/ringphp/src/Client/CurlFactory.php(91): GuzzleHttp\Ring\Client\CurlFactory::createErrorResponse(Array, Array, Array)
╳  #1 /home/phil/ownCloud/core/lib/composer/guzzlehttp/ringphp/src/Client/CurlHandler.php(96): GuzzleHttp\Ring\Client\CurlFactory::createResponse(Array, Array, Array, Array, Resource id #727)

```
The ``webUI`` tests do not currently have an environment where that setup step works. That will come, but not right now.

## How Has This Been Tested?
Local run of UI tests passes without the noise.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

