### PR TITLE
Return the quota setting as defined for the user.

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -32,6 +32,7 @@ namespace OCA\Provisioning_API;
 use OC\OCS\Result;
 use OC_Helper;
 use OCP\API;
+use OCP\Files\FileInfo;
 use OCP\Files\NotFoundException;
 use OCP\IGroup;
 use OCP\IGroupManager;
@@ -211,6 +212,7 @@ class Users {
 
 		// Find the data
 		$data['quota'] = $this->fillStorageInfo($userId);
+		$data['quota']['definition'] = $targetUserObject->getQuota();
 		$data['email'] = $targetUserObject->getEMailAddress();
 		$data['displayname'] = $targetUserObject->getDisplayName();
 		$data['home'] = $targetUserObject->getHome();
@@ -668,6 +670,7 @@ class Users {
 		} catch (NotFoundException $ex) {
 			$data = [];
 		}
+
 		return $data;
 	}
 }

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -727,7 +727,7 @@ class UsersTest extends OriginalTest {
 		$expected = new Result(
 			[
 				'enabled' => 'true',
-				'quota' => ['DummyValue'],
+				'quota' => ['DummyValue', 'definition' => null],
 				'email' => 'demo@owncloud.org',
 				'displayname' => 'Demo User',
 				'home' => '/var/ocdata/UserToGet',
@@ -794,7 +794,7 @@ class UsersTest extends OriginalTest {
 		$expected = new Result(
 			[
 				'enabled' => 'true',
-				'quota' => ['DummyValue'],
+				'quota' => ['DummyValue', 'definition' => null],
 				'email' => 'demo@owncloud.org',
 				'home' => '/var/ocdata/UserToGet',
 				'displayname' => 'Demo User',
@@ -893,7 +893,7 @@ class UsersTest extends OriginalTest {
 			->will($this->returnValue('subadmin@owncloud.org'));
 
 		$expected = new Result([
-			'quota' => ['DummyValue'],
+			'quota' => ['DummyValue', 'definition' => null],
 			'email' => 'subadmin@owncloud.org',
 			'displayname' => 'Subadmin User',
 			'home' => '/var/ocdata/UserToGet',


### PR DESCRIPTION
## Description
The quota setting of a user is not part of the response via the provisioning api.

## Related Issue
Fixes #19810

## How Has This Been Tested?
With curl ...

```sh
$ curl -uadmin:admin http://localhost:8080/ocs/v1.php/cloud/users/test?format=jn | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   322    0   322    0     0    117      0 --:--:--  0:00:02 --:--:--   117
{
   "ocs" : {
      "meta" : {
         "statuscode" : 100,
         "message" : null,
         "status" : "ok"
      },
      "data" : {
         "quota" : {
            "definition" : "5 GB",
            "relative" : 0,
            "used" : 0,
            "total" : 5368709120,
            "free" : 5368709120
         },
         "home" : "/home/deepdiver/Development/owncloud/core/data/test",
         "displayname" : "test",
         "enabled" : "true",
         "two_factor_auth_enabled" : "false",
         "email" : "a@foo.bar"
      }
   }
}
```
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

