### PR TITLE
Bugfix/calendarchanges limit 1000

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -1152,12 +1152,9 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		if ($syncToken) {
 
 			$query = 'SELECT `uri`, `operation` FROM `*PREFIX*calendarchanges` WHERE `synctoken` >= ? AND `synctoken` < ? AND `calendarid` = ? ORDER BY `synctoken`';
-			if ($limit>0) {
-				$query.= ' `LIMIT` ' . (int)$limit;
-			}
 
 			// Fetching all changes
-			$stmt = $this->db->prepare($query);
+			$stmt = $this->db->prepare($query, $limit ?: null, $limit ? 0 : null);
 			$stmt->execute([$syncToken, $currentToken, $calendarId]);
 
 			$changes = [];

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -722,12 +722,9 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		if ($syncToken) {
 
 			$query = 'SELECT `uri`, `operation` FROM `*PREFIX*addressbookchanges` WHERE `synctoken` >= ? AND `synctoken` < ? AND `addressbookid` = ? ORDER BY `synctoken`';
-			if ($limit>0) {
-				$query .= ' `LIMIT` ' . (int)$limit;
-			}
 
 			// Fetching all changes
-			$stmt = $this->db->prepare($query);
+			$stmt = $this->db->prepare($query, $limit ?: null, $limit ? 0 : null);
 			$stmt->execute([$syncToken, $currentToken, $addressBookId]);
 
 			$changes = [];

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -417,14 +417,14 @@ EOD;
 		$calendarId = $this->createTestCalendar();
 
 		// fist call without synctoken
-		$changes = $this->backend->getChangesForCalendar($calendarId, '', 1);
+		$changes = $this->backend->getChangesForCalendar($calendarId, '', 1, 1000);
 		$syncToken = $changes['syncToken'];
 
 		// add a change
 		$event = $this->createEvent($calendarId, '20130912T130000Z', '20130912T140000Z');
 
 		// look for changes
-		$changes = $this->backend->getChangesForCalendar($calendarId, $syncToken, 1);
+		$changes = $this->backend->getChangesForCalendar($calendarId, $syncToken, 1, 1000);
 		$this->assertEquals($event, $changes['added'][0]);
 	}
 

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -321,7 +321,7 @@ class CardDavBackendTest extends TestCase {
 		$bookId = $books[0]['id'];
 
 		// fist call without synctoken
-		$changes = $this->backend->getChangesForAddressBook($bookId, '', 1);
+		$changes = $this->backend->getChangesForAddressBook($bookId, '', 1, 1000);
 		$syncToken = $changes['syncToken'];
 
 		// add a change
@@ -329,7 +329,7 @@ class CardDavBackendTest extends TestCase {
 		$this->backend->createCard($bookId, $uri0, '');
 
 		// look for changes
-		$changes = $this->backend->getChangesForAddressBook($bookId, $syncToken, 1);
+		$changes = $this->backend->getChangesForAddressBook($bookId, $syncToken, 1, 1000);
 		$this->assertEquals($uri0, $changes['added'][0]);
 	}
 


### PR DESCRIPTION
## Description
LIMIT is wrongly used in CalDAV and CardDAV implementation of syncing

## Related Issue
fixes https://central.owncloud.org/t/internal-server-error-500/12405?u=deepdiver1975

## How Has This Been Tested?
- manual unit tests with sqlite
- other dbs will be tested on drone

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

