### PR TITLE
[stable10] run swift objectstorage tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -84,6 +84,7 @@ pipeline:
       - DB_TYPE=${DB_TYPE}
       - FILES_EXTERNAL_TYPE=${FILES_EXTERNAL_TYPE}
       - COVERAGE=${COVERAGE}
+      - PRIMARY_OBJECTSTORE=${PRIMARY_OBJECTSTORE}
     commands:
       - ./tests/drone/install-server.sh
       - ./tests/drone/test-phpunit.sh
@@ -194,6 +195,22 @@ pipeline:
         TEST_SUITE: selenium
 
 services:
+
+  ceph:
+    image: owncloudci/ceph
+    pull: true
+    environment:
+      - KEYSTONE_PUBLIC_PORT=5034
+      - KEYSTONE_ADMIN_USER=test
+      - KEYSTONE_ADMIN_PASS=testing
+      - KEYSTONE_ADMIN_TENANT=testtenant
+      - KEYSTONE_ENDPOINT_REGION=testregion
+      - KEYSTONE_SERVICE=testceph
+      - OSD_SIZE=500
+    when:
+      matrix:
+        OBJECTSTORE: swift
+
   mariadb:
     image: mariadb:10.2
     environment:
@@ -439,6 +456,20 @@ matrix:
       COVERAGE: true
       DB_TYPE: sqlite
       FILES_EXTERNAL_TYPE: swift
+
+  # Primary Objectstorage
+    - PHP_VERSION: 5.6
+      TEST_SUITE: phpunit
+      DB_TYPE: sqlite
+      OBJECTSTORE: swift
+      PRIMARY_OBJECTSTORE: swift
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: phpunit
+      COVERAGE: true
+      DB_TYPE: sqlite
+      OBJECTSTORE: swift
+      PRIMARY_OBJECTSTORE: swift
 
   # Ui Acceptance tests
     - PHP_VERSION: 7.1

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -755,7 +755,7 @@ public function testPutWithModifyRun() {
 		}
 
 		// objectstore does not use partfiles -> no move after upload -> no exception
-		if (getenv('RUN_OBJECTSTORE_TESTS')) {
+		if ($this->runsWithPrimaryObjectstorage()) {
 			$this->assertFalse($thrown);
 		} else {
 			$this->assertTrue($thrown);

--- a/apps/files/tests/Command/ScanTest.php
+++ b/apps/files/tests/Command/ScanTest.php
@@ -95,7 +95,7 @@ class ScanTest extends TestCase {
 	private $groupsCreated = [];
 
 	protected function setUp() {
-		if (getenv('RUN_OBJECTSTORE_TESTS')) {
+		if ($this->runsWithPrimaryObjectstorage()) {
 			$this->markTestSkipped('not testing scanner as it does not make sense for primary object store');
 		}
 		parent::setUp();

--- a/tests/drone/configs/config.primary_storage.swift.php
+++ b/tests/drone/configs/config.primary_storage.swift.php
@@ -1,0 +1,17 @@
+<?php
+$CONFIG = array (
+	'objectstore' => array(
+		'class' => 'OC\\Files\\ObjectStore\\Swift',
+		'arguments' => array(
+			'username' => 'test',
+			'password' => 'testing',
+			'container' => 'owncloud-autotest',
+			'objectPrefix' => 'autotest:oid:urn:',
+			'autocreate' => true,
+			'region' => 'testregion',
+			'url' => 'http://ceph:5034/v2.0',
+			'tenantName' => 'testtenant',
+			'serviceName' => 'testceph',
+		),
+	),
+);

--- a/tests/drone/install-server.sh
+++ b/tests/drone/install-server.sh
@@ -72,6 +72,20 @@ case "${DB_TYPE}" in
     ;;
 esac
 
+declare -x PRIMARY_OBJECTSTORE
+if [[ ! -z "${PRIMARY_OBJECTSTORE}" ]]; then
+  case "${PRIMARY_OBJECTSTORE}" in
+    swift)
+      wait-for-it -t 120 ceph:5034
+      cp tests/drone/configs/config.primary_storage.swift.php config/autotest-storage-swift.config.php
+      ;;
+    *)
+      echo "Unknown primary object storage!"
+      exit 1
+      ;;
+  esac
+fi
+
 install_cmd="maintenance:install -vvv \
       --database=${DB} \
       --database-name=${DB_NAME} \

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -428,7 +428,7 @@ class FilesystemTest extends TestCase {
 		$homeMount = Filesystem::getStorage('/' . $userId . '/');
 
 		$this->assertTrue($homeMount->instanceOfStorage('\OCP\Files\IHomeStorage'));
-		if (getenv('RUN_OBJECTSTORE_TESTS')) {
+		if ($this->runsWithPrimaryObjectstorage()) {
 			$this->assertTrue($homeMount->instanceOfStorage('\OC\Files\ObjectStore\HomeObjectStoreStorage'));
 			$this->assertEquals('object::user:' . $userId, $homeMount->getId());
 		} else {

--- a/tests/lib/Files/ObjectStore/SwiftTest.php
+++ b/tests/lib/Files/ObjectStore/SwiftTest.php
@@ -40,7 +40,7 @@ class SwiftTest extends \Test\Files\Storage\Storage {
 	protected function setUp() {
 		parent::setUp();
 
-		if (!getenv('RUN_OBJECTSTORE_TESTS')) {
+		if (!$this->runsWithPrimaryObjectstorage()) {
 			$this->markTestSkipped('objectstore tests are unreliable in some environments');
 		}
 

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -522,4 +522,11 @@ abstract class TestCase extends BaseTestCase {
 		return $processUser['name'];
 	}
 
+	public function runsWithPrimaryObjectstorage() {
+		if (getenv('RUN_OBJECTSTORE_TESTS')) {
+			return true;
+		}
+		return false;
+	}
+
 }

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -523,7 +523,8 @@ abstract class TestCase extends BaseTestCase {
 	}
 
 	public function runsWithPrimaryObjectstorage() {
-		if (getenv('RUN_OBJECTSTORE_TESTS')) {
+		$objectstoreConfiguration = \OC::$server->getConfig()->getSystemValue('objectstore', null);
+		if ($objectstoreConfiguration !== null) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
## Description
Run swift tests inside drone 

ref: https://github.com/owncloud/core/pull/30208

## Motivation and Context
In master we removed swift already - yet in stable10 the code still lives in core.
With moving from jenkins/travis to drone, this needs to run in drone now 

## How Has This Been Tested?
🤖 🏗 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

