### PR TITLE
Retry on stalled upload

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -94,7 +94,9 @@
 					},
 					config: this._filesConfig,
 					enableUpload: true,
-					maxChunkSize: OC.appConfig.files && OC.appConfig.files.max_chunk_size
+					maxChunkSize: OC.appConfig.files && OC.appConfig.files.max_chunk_size,
+					uploadStallTimeout: OC.appConfig.files && OC.appConfig.files.upload_stall_timeout,
+					uploadStallRetries: OC.appConfig.files && OC.appConfig.files.upload_stall_retries
 				}
 			);
 			this.files.initialize();

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -320,8 +320,17 @@ OC.FileUpload.prototype = {
 		if (this.data.isChunked) {
 			this._deleteChunkFolder();
 		}
+		this.data.stalled = false;
 		this.data.abort();
 		this.deleteUpload();
+	},
+
+	/**
+	 * retry the upload
+	 */
+	retry: function() {
+		this.data.stalled = true;
+		this.data.abort();
 	},
 
 	/**
@@ -472,6 +481,17 @@ OC.Uploader.prototype = _.extend({
 	 */
 	davClient: null,
 
+	/**
+	 * Upload progressbar element
+	 *
+	 * @type Object
+	 */
+	$uploadprogressbar: null,
+
+	/**
+	 * @type int
+	 */
+	_uploadStallTimeout: 60,
 	/**
 	 * Function that will allow us to know if Ajax uploads are supported
 	 * @link https://github.com/New-Bamboo/example-ajax-upload/blob/master/public/index.html
@@ -727,7 +747,7 @@ OC.Uploader.prototype = _.extend({
 		// resubmit upload
 		this.submitUploads([upload]);
 	},
-	_trace:false, //TODO implement log handler for JS per class?
+	_trace:true, //TODO implement log handler for JS per class?
 	log:function(caption, e, data) {
 		if (this._trace) {
 			console.log(caption);
@@ -794,34 +814,36 @@ OC.Uploader.prototype = _.extend({
 		var self = this;
 		window.clearInterval(this._progressBarInterval);
 		$('#uploadprogresswrapper .stop').fadeOut();
-		$('#uploadprogressbar').fadeOut(function() {
+		this.$uploadprogressbar.fadeOut(function() {
 			self.$uploadEl.trigger(new $.Event('resized'));
 		});
 	},
 
 	_showProgressBar: function() {
-		$('#uploadprogressbar').fadeIn();
+		this.$uploadprogressbar.fadeIn();
 		this.$uploadEl.trigger(new $.Event('resized'));
 		if (this._progressBarInterval) {
 			window.clearInterval(this._progressBarInterval);
 		}
 		this._progressBarInterval = window.setInterval(_.bind(this._updateProgressBar, this), 1000);
 		this._lastProgress = 0;
-		this._lastProgressStalledSeconds = 0;
 	},
 	
 	_updateProgressBar: function() {
-		var progress = parseInt($('#uploadprogressbar').attr('data-loaded'), 10);
-		var total = parseInt($('#uploadprogressbar').attr('data-total'), 10);
+		var progress = parseInt(this.$uploadprogressbar.attr('data-loaded'), 10);
+		var total = parseInt(this.$uploadprogressbar.attr('data-total'), 10);
 		if (progress !== this._lastProgress) {
 			this._lastProgress = progress;
-			this._lastProgressStalledSeconds = 0;
+			this._lastProgressTime = new Date().getTime();
 		} else {
-			if (this._lastProgressStalledSeconds < 1) {
-				this._lastProgressStalledSeconds++;
-			} else if (progress >= total) {
+			if (progress >= total) {
 				// change message if we stalled at 100%
-				$('#uploadprogressbar .label .desktop').text(t('core', 'Processing files...'));
+				this.$uploadprogressbar.find('.label .desktop').text(t('core', 'Processing files...'));
+			} else if (new Date().getTime() - this._lastProgressTime >= this._uploadStallTimeout * 1000 ) {
+				// stalling needs to be checked here because the file upload no longer triggers events
+				// restart upload
+				this.log('progress stalled'); // retry chunk (and prevent IE from dying)
+				$.each(this._uploads, function(i,e){ console.log(e.retry()) })
 			}
 		}
 	},
@@ -871,9 +893,14 @@ OC.Uploader.prototype = _.extend({
 		if (options.url) {
 			this.url = options.url;
 		}
+		if (options.uploadStallTimeout) {
+			this._uploadStallTimeout = options.uploadStallTimeout;
+		}
 
 		$uploadEl = $($uploadEl);
 		this.$uploadEl = $uploadEl;
+
+		this.$uploadprogressbar = $('#uploadprogressbar')
 
 		if ($uploadEl.exists()) {
 			$('#uploadprogresswrapper .stop').on('click', function() {
@@ -885,6 +912,8 @@ OC.Uploader.prototype = _.extend({
 				dropZone: options.dropZone, // restrict dropZone to content div
 				autoUpload: false,
 				sequentialUploads: true,
+				maxRetries: options.uploadStallRetries,
+				retryTimeout: 500,
 				//singleFileUploads is on by default, so the data.files array will always have length 1
 				/**
 				 * on first add of every selection
@@ -1049,6 +1078,53 @@ OC.Uploader.prototype = _.extend({
 				},
 				fail: function(e, data) {
 					var upload = self.getUpload(data);
+					if (upload.data.stalled) {
+						self.log('retry', e, upload);
+						// jQuery Widget Factory uses "namespace-widgetname" since version 1.10.0:
+						var fu = $(this).data('blueimp-fileupload') || $(this).data('fileupload'),
+							retries = upload.data.retries || 0,
+							retry = function () {
+								var uid = OC.getCurrentUser().uid;
+								upload.uploader.davClient.getFolderContents(
+									'uploads/' + uid + '/' + upload.getId()
+								)
+								.done(function (status, files) {
+									data.uploadedBytes = 0;
+									_.each(files, function(file) {
+										// only count numeric file names to omit .file and .file.zsync
+										if (!isNaN(parseFloat(file.name))
+											&& isFinite(file.name)
+											// only count full chunks
+											&& file.size === fu.options.maxChunkSize
+										) {
+											data.uploadedBytes += file.size;
+										}
+									});
+
+									// clear the previous data:
+									data.data = null;
+									// overwrite chunk
+									delete data.headers['If-None-Match'];
+									data.submit();
+								})
+								.fail(function (status, ex) {
+									self.log('failed to retry', status, ex);
+									fu._trigger('fail', e, data);
+								});
+							};
+						if (upload.data.stalled &&
+							data.uploadedBytes < data.files[0].size &&
+							retries < fu.options.maxRetries) {
+							retries += 1;
+							upload.data.retries = retries;
+							window.setTimeout(retry, retries * fu.options.retryTimeout);
+							return;
+						}
+						fu.prototype
+							.options.fail.call(this, e, data);
+						return;
+					}
+
 					var status = null;
 					if (upload) {
 						status = upload.getResponseStatus();
@@ -1146,14 +1222,14 @@ OC.Uploader.prototype = _.extend({
 					self.log('progress handle fileuploadstart', e, data);
 					$('#uploadprogresswrapper .stop').show();
 					$('#uploadprogresswrapper .label').show();
-					$('#uploadprogressbar').progressbar({value: 0});
-					$('#uploadprogressbar .ui-progressbar-value').
+					self.$uploadprogressbar.progressbar({value: 0});
+					self.$uploadprogressbar.find('.ui-progressbar-value').
 						html('<em class="label inner"><span class="desktop">'
 							+ t('files', 'Uploading...')
 							+ '</span><span class="mobile">'
 							+ t('files', '...')
 							+ '</span></em>');
-                    $('#uploadprogressbar').tipsy({gravity:'n', fade:true, live:true});
+					self.$uploadprogressbar.tipsy({gravity:'n', fade:true, live:true});
 					self._showProgressBar();
 					self.trigger('start', e, data);
 				});
@@ -1179,18 +1255,18 @@ OC.Uploader.prototype = _.extend({
 					}
 					var smoothRemainingSeconds = (bufferTotal / bufferSize); //seconds
 					var h = moment.duration(smoothRemainingSeconds, "seconds").humanize();
-					$('#uploadprogressbar').attr('data-loaded', data.loaded);
-					$('#uploadprogressbar').attr('data-total', data.total);
-					$('#uploadprogressbar .label .mobile').text(h);
-					$('#uploadprogressbar .label .desktop').text(h);
-					$('#uploadprogressbar').attr('original-title',
+					self.$uploadprogressbar.attr('data-loaded', data.loaded);
+					self.$uploadprogressbar.attr('data-total', data.total);
+					self.$uploadprogressbar.find('.label .mobile').text(h);
+					self.$uploadprogressbar.find('.label .desktop').text(h);
+					self.$uploadprogressbar.attr('original-title',
 						t('files', '{loadedSize} of {totalSize} ({bitrate})' , {
 							loadedSize: humanFileSize(data.loaded),
 							totalSize: humanFileSize(data.total),
 							bitrate: humanFileSize(data.bitrate) + '/s'
 						})
 					);
-					$('#uploadprogressbar').progressbar('value', progress);
+					self.$uploadprogressbar.progressbar('value', progress);
 					self.trigger('progressall', e, data);
 				});
 				fileupload.on('fileuploadstop', function(e, data) {

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -747,7 +747,7 @@ OC.Uploader.prototype = _.extend({
 		// resubmit upload
 		this.submitUploads([upload]);
 	},
-	_trace:true, //TODO implement log handler for JS per class?
+	_trace:false, //TODO implement log handler for JS per class?
 	log:function(caption, e, data) {
 		if (this._trace) {
 			console.log(caption);
@@ -1078,7 +1078,7 @@ OC.Uploader.prototype = _.extend({
 				},
 				fail: function(e, data) {
 					var upload = self.getUpload(data);
-					if (upload.data.stalled) {
+					if (upload && upload.data && upload.data.stalled) {
 						self.log('retry', e, upload);
 						// jQuery Widget Factory uses "namespace-widgetname" since version 1.10.0:
 						var fu = $(this).data('blueimp-fileupload') || $(this).data('fileupload'),
@@ -1112,7 +1112,7 @@ OC.Uploader.prototype = _.extend({
 									fu._trigger('fail', e, data);
 								});
 							};
-						if (upload.data.stalled &&
+						if (upload && upload.data && upload.data.stalled &&
 							data.uploadedBytes < data.files[0].size &&
 							retries < fu.options.maxRetries) {
 							retries += 1;

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1248,7 +1248,7 @@ OC.Uploader.prototype = _.extend({
 					lastSize = data.loaded;
 					diffSize = diffSize / diffUpdate; // apply timing factor, eg. 1mb/2s = 0.5mb/s
 					var remainingSeconds = ((data.total - data.loaded) / diffSize);
-					if(remainingSeconds >= 0) {
+					if (isFinite(remainingSeconds) && remainingSeconds >= 0) {
 						bufferTotal = bufferTotal - (buffer[bufferIndex]) + remainingSeconds;
 						buffer[bufferIndex] = remainingSeconds; //buffer to make it smoother
 						bufferIndex = (bufferIndex + 1) % bufferSize;
@@ -1296,6 +1296,11 @@ OC.Uploader.prototype = _.extend({
 						'/' + encodeURIComponent(chunkId);
 					delete data.contentRange;
 					delete data.headers['Content-Range'];
+				});
+				fileupload.on('fileuploadchunksend', function(e, data) {
+					var upload = self.getUpload(data);
+					// reset retries
+					upload.data.retries = 0;
 				});
 				fileupload.on('fileuploaddone', function(e, data) {
 					var upload = self.getUpload(data);

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -345,7 +345,9 @@
 						fileList: this,
 						filesClient: this.filesClient,
 						dropZone: $('#content'),
-						maxChunkSize: options.maxChunkSize
+						maxChunkSize: options.maxChunkSize,
+						uploadStallTimeout: options.uploadStallTimeout,
+						uploadStallRetries: options.uploadStallRetries
 					});
 
 					this.setupUploadEvents(this._uploader);

--- a/apps/files/lib/App.php
+++ b/apps/files/lib/App.php
@@ -46,8 +46,12 @@ class App {
 
 	public static function extendJsConfig($array) {
 		$maxChunkSize = (int)(\OC::$server->getConfig()->getAppValue('files', 'max_chunk_size', (10 * 1024 * 1024)));
+		$uploadStallTimeout = (int)(\OC::$server->getConfig()->getAppValue('files', 'upload_stall_timeout', 60)); // in seconds
+		$uploadStallRetries = (int)(\OC::$server->getConfig()->getAppValue('files', 'upload_stall_retries', 100));
 		$array['array']['oc_appconfig']['files'] = [
-			'max_chunk_size' => $maxChunkSize
+			'max_chunk_size' => $maxChunkSize,
+			'upload_stall_timeout' => $uploadStallTimeout,
+			'upload_stall_retries' => $uploadStallRetries
 		];
 	}
 }

--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -24,6 +24,8 @@ describe('OC.Upload tests', function() {
 	var testFile;
 	var uploader;
 	var failStub;
+	var currentUserStub;
+	var getFolderContentsStub;
 
 	beforeEach(function() {
 		testFile = {
@@ -37,6 +39,7 @@ describe('OC.Upload tests', function() {
 			'<input type="file" id="file_upload_start" name="files[]" multiple="multiple">' +
 			'<input type="hidden" id="free_space" name="free_space" value="50000000">' + // 50 MB
 			// TODO: handlebars!
+			'<div id="uploadprogressbar"></div>' +
 			'<div id="new">' +
 			'<a>New</a>' +
 			'<ul>' +
@@ -48,10 +51,17 @@ describe('OC.Upload tests', function() {
 		uploader = new OC.Uploader($dummyUploader);
 		failStub = sinon.stub();
 		uploader.on('fail', failStub);
+
+		currentUserStub = sinon.stub(OC, 'getCurrentUser').returns({uid: 'current@user'});
+		getFolderContentsStub = sinon.stub(OC.Files.Client.prototype, 'getFolderContents');
 	});
 	afterEach(function() {
 		$dummyUploader = undefined;
 		failStub = undefined;
+		currentUserStub.restore();
+		getFolderContentsStub.restore();
+		uploader.clear();
+		uploader = null;
 	});
 
 	/**
@@ -67,7 +77,8 @@ describe('OC.Upload tests', function() {
 				files: [file],
 				jqXHR: jqXHR,
 				response: sinon.stub.returns(jqXHR),
-				submit: sinon.stub()
+				submit: sinon.stub(),
+				abort: sinon.stub()
 			};
 			if (uploader.fileUploadParam.add.call(
 					$dummyUploader[0],
@@ -271,6 +282,137 @@ describe('OC.Upload tests', function() {
 			upload.submit();
 
 			expect(upload.data.headers['OC-Autorename']).toEqual('1');
+		});
+	});
+	describe('Chunked upload', function() {
+		it('rewires data url when uploading chunks', function() {
+			var result = addFiles(uploader, [testFile]);
+			var upload = uploader.getUpload(result[0]);
+			expect(result[0]).not.toEqual(null);
+			expect(result[0].submit.calledOnce).toEqual(true);
+
+			result[0].contentRange = 'bytes 100-250/150';
+			result[0].headers['Content-Range'] = 'bytes 100-250/150';
+			result[0].retries = 3;
+
+			$dummyUploader.trigger('fileuploadchunksend', result[0]);
+
+			expect(result[0].contentRange).not.toBeDefined();
+			expect(result[0].headers['Content-Range']).not.toBeDefined();
+			expect(result[0].url)
+				.toEqual(OC.getRootPath() + '/remote.php/dav/uploads/current%40user/' + upload.getId() + '/100');
+			expect(result[0].retries).toEqual(0);
+		});
+
+		it('retries stalled chunk on failure', function() {
+			var clock = sinon.useFakeTimers();
+
+			uploader = new OC.Uploader($dummyUploader, {
+				maxChunkSize: 150
+			});
+			uploader.on('fail', failStub);
+
+			var result = addFiles(uploader, [testFile]);
+			var upload = uploader.getUpload(result[0]);
+
+			// chunk upload doesn't call "submit" initially
+			expect(result[0].submit.notCalled).toEqual(true);
+
+			upload.data.stalled = true;
+
+			result[0].headers['If-None-Match'] = '*';
+
+			result[0].uploadedBytes = 300; // less than expected
+
+			uploader.fileUploadParam.fail.call($dummyUploader[0], {}, result[0]);
+
+			expect(upload.data.retries).toEqual(1);
+			expect(failStub.notCalled).toEqual(true);
+
+			expect(getFolderContentsStub.notCalled).toEqual(true);
+
+			var deferred = $.Deferred();
+			getFolderContentsStub.returns(deferred.promise());
+
+			// trigger retry
+			clock.tick(10000);
+
+			expect(getFolderContentsStub.calledOnce).toEqual(true);
+			expect(getFolderContentsStub.getCall(0).args[0]).toEqual('uploads/current@user/' + upload.getId());
+
+			deferred.resolve(207, [
+				{
+					name: '0',
+					size: 150
+				},
+				{
+					name: '150',
+					size: 150
+				},
+				// this chunk is smaller and needs to be retried
+				{
+					name: '300',
+					size: 100
+				},
+				// ignored
+				{
+					name: '.file',
+					size: 10000
+				}
+			]);
+
+			// uploaded bytes was set to the sum of all chunk sizes
+			expect(result[0].uploadedBytes).toEqual(300);
+			expect(result[0].data).toBeFalsy();
+
+			// header was cleared for overwriting
+			expect(result[0].headers['If-None-Match']).not.toBeDefined();
+
+			expect(result[0].submit.calledOnce).toEqual(true);
+
+			clock.restore();
+		});
+
+		it('stalled progress will set stalled flag after a while', function() {
+			var clock = sinon.useFakeTimers();
+
+			uploader = new OC.Uploader($dummyUploader, {
+				uploadStallTimeout: 10
+			});
+
+			var result = addFiles(uploader, [testFile]);
+			var upload = uploader.getUpload(result[0]);
+
+			$dummyUploader.trigger('fileuploadstart', result[0]);
+
+			result[0].uploadedBytes = 300;
+
+			expect(upload.data.stalled).toBeFalsy();
+
+			$dummyUploader.trigger('fileuploadprogressall', {loaded: 300, total: 5000});
+			clock.tick(5000);
+
+			expect(upload.data.stalled).toBeFalsy();
+
+			result[0].uploadedBytes = 400; // some progress, no stall
+
+			$dummyUploader.trigger('fileuploadprogressall', {loaded: 400, total: 5000});
+			clock.tick(10000);
+
+			expect(upload.data.stalled).toBeFalsy();
+
+			expect(result[0].abort.notCalled).toEqual(true);
+
+			// no progress, stalled
+			$dummyUploader.trigger('fileuploadprogressall', {loaded: 400, total: 5000});
+
+			clock.tick(10000);
+
+			expect(upload.data.stalled).toEqual(true);
+
+			expect(result[0].abort.calledOnce).toEqual(true);
+
+			clock.restore();
 		});
 	});
 });


### PR DESCRIPTION
fixes https://github.com/owncloud/core/issues/30770

# how to test
use this snippet to fake a bad connection:
```diff
diff --git a/apps/dav/lib/Connector/Sabre/Directory.php b/apps/dav/lib/Connector/Sabre/Directory.php
index d6650d575f..9dcccc3c27 100644
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -488,6 +488,17 @@ class Directory extends Node implements ICollection, IQuota, IMoveTarget {
         * @param resource $data data
         */
        public function createFileDirectly($name, $data) {
-               $this->fileView->file_put_contents($this->getPath() . '/' .  $name, $data);
+               $tgt = $this->fileView->fopen($this->getPath() . '/' .  $name, 'wb');
+
+               while(!feof($data)) {
+                       if (mt_rand(0,99) <= 10) {
+                               sleep(10);
+                               exit();
+                       }
+                       fwrite($tgt, fread($data, 512));
+               }
+               fclose($data);
+               fclose($tgt);
+               //$this->fileView->file_put_contents($this->getPath() . '/' .  $name, $data);
        }
 }
```

now set a lower max chunk size and upload stall timeout:
```
./occ config:app:set files max_chunk_size --value 1024
./occ config:app:set files upload_stall_timeout --value 3
```

you should see the uploads stall quite frequently. but now they get restarted an puck up where they left off.

- [ ] requires doc changes:
  introduces two new app config keys to control stalled uploads:
  - upload_stall_timeout (default 60) in seconds: when to consider an upload stalled
  - upload_stall_retries (default 100): how often to retry 100 because we really want to upload a file.