### PR TITLE
Remove regular user-group from UI tests

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -8,12 +8,11 @@ default:
       contexts:
         - FeatureContext:
             baseUrl:  http://localhost:8080/ocs/
-            admin:
-              - admin
-              - admin
-            regular_user_password: 123456
-            mailhog_url: http://127.0.0.1:8025/api/v2/messages
-            oc_path: ../../
+            adminUsername: admin
+            adminPassword: admin
+            regularUserPassword: 123456
+            mailhogUrl: http://127.0.0.1:8025/api/v2/messages
+            ocPath: ../../
         - CardDavContext:
             baseUrl: http://localhost:8080
         - CalDavContext:
@@ -25,36 +24,33 @@ default:
       contexts:
         - FederationContext:
             baseUrl:  http://localhost:8080/ocs/
-            admin:
-              - admin
-              - admin
-            regular_user_password: 123456
-            mailhog_url: http://127.0.0.1:8025/api/v2/messages
-            oc_path: ../../
+            adminUsername: admin
+            adminPassword: admin
+            regularUserPassword: 123456
+            mailhogUrl: http://127.0.0.1:8025/api/v2/messages
+            ocPath: ../../
     apiCapabilities:
       paths:
         - %paths.base%/../features/apiCapabilities
       contexts:
         - CapabilitiesContext:
             baseUrl:  http://localhost:8080/ocs/
-            admin:
-              - admin
-              - admin
-            regular_user_password: 123456
-            mailhog_url: http://127.0.0.1:8025/api/v2/messages
-            oc_path: ../../
+            adminUsername: admin
+            adminPassword: admin
+            regularUserPassword: 123456
+            mailhogUrl: http://127.0.0.1:8025/api/v2/messages
+            ocPath: ../../
     apiSharees:
       paths:
         - %paths.base%/../features/apiSharees
       contexts:
         - ShareesContext:
             baseUrl:  http://localhost:8080/ocs/
-            admin:
-              - admin
-              - admin
-            regular_user_password: 123456
-            mailhog_url: http://127.0.0.1:8025/api/v2/messages
-            oc_path: ../../
+            adminUsername: admin
+            adminPassword: admin
+            regularUserPassword: 123456
+            mailhogUrl: http://127.0.0.1:8025/api/v2/messages
+            ocPath: ../../
 
     webUIFiles:
       paths:
@@ -62,6 +58,7 @@ default:
       context: &common_webui_suite_context
         parameters:
           ocPath: apps/testing/api/v1/occ
+          adminUsername: admin
           adminPassword: admin
           regularUserPassword: 123456
       contexts:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -64,8 +64,6 @@ default:
           ocPath: apps/testing/api/v1/occ
           adminPassword: admin
           regularUserPassword: 123456
-          regularGroupName: regulargrp
-          regularGroupNames: grp1,grp2,grp3,grpuser
       contexts:
         - WebUIGeneralContext:
         - WebUILoginContext:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -64,8 +64,6 @@ default:
           ocPath: apps/testing/api/v1/occ
           adminPassword: admin
           regularUserPassword: 123456
-          regularUserName: regularuser
-          regularUserNames: user1,user2,user3,usergrp
           regularGroupName: regulargrp
           regularGroupNames: grp1,grp2,grp3,grpuser
       contexts:

--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -83,7 +83,7 @@ trait AppConfiguration {
 	 */
 	public function adminSetsServerParameterToUsingAPI($parameter, $app, $value) {
 		$user = $this->currentUser;
-		$this->currentUser = $this->getAdminUserName();
+		$this->currentUser = $this->getAdminUsername();
 
 		$this->modifyServerConfig($app, $parameter, $value);
 
@@ -207,7 +207,7 @@ trait AppConfiguration {
 	public function setCapabilities($capabilitiesArray) {
 		$savedCapabilitiesChanges = AppConfigHelper::setCapabilities(
 			$this->baseUrlWithoutOCSAppendix(),
-			$this->getAdminUserName(),
+			$this->getAdminUsername(),
 			$this->getAdminPassword(),
 			$capabilitiesArray,
 			$this->savedCapabilitiesXml
@@ -229,7 +229,7 @@ trait AppConfiguration {
 	protected function modifyServerConfig($app, $parameter, $value) {
 		AppConfigHelper::modifyServerConfig(
 			$this->baseUrlWithoutOCSAppendix(),
-			$this->getAdminUserName(),
+			$this->getAdminUsername(),
 			$this->getAdminPassword(),
 			$app,
 			$parameter,
@@ -246,7 +246,7 @@ trait AppConfiguration {
 	protected function modifyServerConfigs($appParameterValues) {
 		AppConfigHelper::modifyServerConfigs(
 			$this->baseUrlWithoutOCSAppendix(),
-			$this->getAdminUserName(),
+			$this->getAdminUsername(),
 			$this->getAdminPassword(),
 			$appParameterValues,
 			$this->apiVersion
@@ -296,7 +296,7 @@ trait AppConfiguration {
 	 */
 	public function prepareParametersBeforeScenario() {
 		$user = $this->currentUser;
-		$this->currentUser = $this->getAdminUserName();
+		$this->currentUser = $this->getAdminUsername();
 		$this->resetAppConfigs();
 		$this->currentUser = $user;
 	}
@@ -308,7 +308,7 @@ trait AppConfiguration {
 	 */
 	public function restoreParametersAfterScenario() {
 		$user = $this->currentUser;
-		$this->currentUser = $this->getAdminUserName();
+		$this->currentUser = $this->getAdminUsername();
 		$this->modifyServerConfigs($this->savedCapabilitiesChanges);
 		$this->currentUser = $user;
 	}

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -48,7 +48,12 @@ trait BasicStructure {
 	/**
 	 * @var array 
 	 */
-	private $adminUser = [];
+	private $adminUsername = '';
+
+	/**
+	 * @var array
+	 */
+	private $adminPassword = '';
 
 	/**
 	 * @var string
@@ -93,28 +98,29 @@ trait BasicStructure {
 	/**
 	 * BasicStructure constructor.
 	 *
-	 * @param  string $baseUrl
-	 * @param string $admin
-	 * @param string $regular_user_password
-	 * @param string $mailhog_url
-	 * @param string $oc_path
+	 * @param string $baseUrl
+	 * @param string $adminUsername
+	 * @param string $adminPassword
+	 * @param string $regularUserPassword
+	 * @param string $mailhogUrl
+	 * @param string $ocPath
 	 *
-	 * @return void
 	 */
 	public function __construct(
-		$baseUrl, $admin, $regular_user_password, $mailhog_url, $oc_path
+		$baseUrl, $adminUsername, $adminPassword, $regularUserPassword, $mailhogUrl, $ocPath
 	) {
 
 		// Initialize your context here
 		$this->baseUrl = $baseUrl;
-		$this->adminUser = $admin;
-		$this->regularUserPassword = $regular_user_password;
-		$this->mailhogUrl = $mailhog_url;
+		$this->adminUsername = $adminUsername;
+		$this->adminPassword = $adminPassword;
+		$this->regularUserPassword = $regularUserPassword;
+		$this->mailhogUrl = $mailhogUrl;
 		$this->localBaseUrl = $this->baseUrl;
 		$this->remoteBaseUrl = $this->baseUrl;
 		$this->currentServer = 'LOCAL';
 		$this->cookieJar = new \GuzzleHttp\Cookie\CookieJar();
-		$this->ocPath = $oc_path;
+		$this->ocPath = $ocPath;
 
 		// in case of CI deployment we take the server url from the environment
 		$testServerUrl = getenv('TEST_SERVER_URL');
@@ -684,15 +690,15 @@ trait BasicStructure {
 	/**
 	 * @return string
 	 */
-	public function getAdminUserName() {
-		return (string) $this->adminUser[0];
+	public function getAdminUsername() {
+		return (string) $this->adminUsername;
 	}
 
 	/**
 	 * @return string
 	 */
 	public function getAdminPassword() {
-		return (string) $this->adminUser[1];
+		return (string) $this->adminPassword;
 	}
 
 	/**
@@ -701,7 +707,7 @@ trait BasicStructure {
 	 * @return string
 	 */
 	public function getPasswordForUser($userName) {
-		if ($userName === $this->getAdminUserName()) {
+		if ($userName === $this->getAdminUsername()) {
 			return (string) $this->getAdminPassword();
 		} else {
 			return (string) $this->regularUserPassword;
@@ -721,7 +727,7 @@ trait BasicStructure {
 	 * @return array
 	 */
 	public function getAuthOptionForAdmin() {
-		return $this->getAuthOptionForUser($this->getAdminUserName());
+		return $this->getAuthOptionForUser($this->getAdminUsername());
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -61,7 +61,7 @@ trait Provisioning {
 	public function adminCreatesUserUsingTheAPI($user) {
 		if (!$this->userExists($user) ) {
 			$previous_user = $this->currentUser;
-			$this->currentUser = $this->getAdminUserName();
+			$this->currentUser = $this->getAdminUsername();
 			$this->createTheUserUsingTheAPI($user);
 			$this->currentUser = $previous_user;
 		}
@@ -125,7 +125,7 @@ trait Provisioning {
 	public function adminDeletesUserUsingTheAPI($user) {
 		if ($this->userExists($user)) {
 			$previous_user = $this->currentUser;
-			$this->currentUser = $this->getAdminUserName();
+			$this->currentUser = $this->getAdminUsername();
 			$this->deleteTheUserUsingTheAPI($user);
 			$this->currentUser = $previous_user;
 		}
@@ -154,7 +154,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
+		if ($this->currentUser === $this->getAdminUsername()) {
 			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
@@ -184,7 +184,7 @@ trait Provisioning {
 	 */
 	public function createUser($user) {
 		$previous_user = $this->currentUser;
-		$this->currentUser = $this->getAdminUserName();
+		$this->currentUser = $this->getAdminUsername();
 		$this->createTheUserUsingTheAPI($user);
 		PHPUnit_Framework_Assert::assertTrue($this->userExists($user));
 		$this->currentUser = $previous_user;
@@ -197,7 +197,7 @@ trait Provisioning {
 	 */
 	public function deleteUser($user) {
 		$previous_user = $this->currentUser;
-		$this->currentUser = $this->getAdminUserName();
+		$this->currentUser = $this->getAdminUsername();
 		$this->deleteTheUserUsingTheAPI($user);
 		PHPUnit_Framework_Assert::assertFalse($this->userExists($user));
 		$this->currentUser = $previous_user;
@@ -210,7 +210,7 @@ trait Provisioning {
 	 */
 	public function createGroup($group) {
 		$previous_user = $this->currentUser;
-		$this->currentUser = $this->getAdminUserName();
+		$this->currentUser = $this->getAdminUsername();
 		$this->createTheGroup($group);
 		PHPUnit_Framework_Assert::assertTrue($this->groupExists($group));
 		$this->currentUser = $previous_user;
@@ -223,7 +223,7 @@ trait Provisioning {
 	 */
 	public function deleteGroup($group) {
 		$previous_user = $this->currentUser;
-		$this->currentUser = $this->getAdminUserName();
+		$this->currentUser = $this->getAdminUsername();
 		$this->deleteTheGroupUsingTheAPI($group);
 		PHPUnit_Framework_Assert::assertFalse($this->groupExists($group));
 		$this->currentUser = $previous_user;
@@ -304,7 +304,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
+		if ($this->currentUser === $this->getAdminUsername()) {
 			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
@@ -329,7 +329,7 @@ trait Provisioning {
 	 */
 	public function adminAddsUserToGroupUsingTheAPI($user, $group) {
 		$previous_user = $this->currentUser;
-		$this->currentUser = $this->getAdminUserName();
+		$this->currentUser = $this->getAdminUsername();
 
 		if (!$this->userBelongsToGroup($user, $group)) {
 			$this->addUserToGroupUsingTheAPI($user, $group);
@@ -363,7 +363,7 @@ trait Provisioning {
 	public function adminCreatesGroupUsingTheAPI($group) {
 		if (!$this->groupExists($group)) {
 			$previous_user = $this->currentUser;
-			$this->currentUser = $this->getAdminUserName();
+			$this->currentUser = $this->getAdminUsername();
 			$this->createTheGroup($group);
 			$this->currentUser = $previous_user;
 		}
@@ -379,7 +379,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/groups";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
+		if ($this->currentUser === $this->getAdminUsername()) {
 			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
@@ -421,7 +421,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
+		if ($this->currentUser === $this->getAdminUsername()) {
 			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
@@ -441,7 +441,7 @@ trait Provisioning {
 	public function adminDeletesGroupUsingTheAPI($group) {
 		if ($this->groupExists($group)) {
 			$previous_user = $this->currentUser;
-			$this->currentUser = $this->getAdminUserName();
+			$this->currentUser = $this->getAdminUsername();
 			$this->deleteTheGroupUsingTheAPI($group);
 			$this->currentUser = $previous_user;
 		}
@@ -457,7 +457,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/groups/$group";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
+		if ($this->currentUser === $this->getAdminUsername()) {
 			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
@@ -476,7 +476,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/groups";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
+		if ($this->currentUser === $this->getAdminUsername()) {
 			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
@@ -520,7 +520,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group/subadmins";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
+		if ($this->currentUser === $this->getAdminUsername()) {
 			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
@@ -571,7 +571,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group/subadmins";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
+		if ($this->currentUser === $this->getAdminUsername()) {
 			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
@@ -737,7 +737,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/apps?filter=disabled";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
+		if ($this->currentUser === $this->getAdminUsername()) {
 			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
@@ -760,7 +760,7 @@ trait Provisioning {
 		$fullUrl = $this->baseUrl . "v2.php/cloud/apps?filter=enabled";
 		$client = new Client();
 		$options = [];
-		if ($this->currentUser === $this->getAdminUserName()) {
+		if ($this->currentUser === $this->getAdminUsername()) {
 			$options['auth'] = $this->getAuthOptionForAdmin();
 		}
 
@@ -828,7 +828,7 @@ trait Provisioning {
 		);
 
 		$previous_user = $this->currentUser;
-		$this->currentUser = "admin";
+		$this->currentUser = $this->getAdminUsername();
 		// method used from BasicStructure trait
 		$this->sendingToWith("PUT", "/cloud/users/" . $user, $body);
 		$this->currentUser = $previous_user;

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -242,7 +242,7 @@ trait Tags {
 	 */
 	public function theTagHasGroup($type, $tagName, $groups) {
 		$tagData = $this->requestTagByDisplayName(
-			$this->getAdminUserName(), $tagName, true
+			$this->getAdminUsername(), $tagName, true
 		);
 		PHPUnit_Framework_Assert::assertNotNull(
 			$tagData, "Tag $tagName wasn't found for admin user"
@@ -277,7 +277,7 @@ trait Tags {
 	 * @return int
 	 */
 	private function findTagIdByName($name) {
-		$tagData = $this->requestTagByDisplayName($this->getAdminUserName(), $name);
+		$tagData = $this->requestTagByDisplayName($this->getAdminUsername(), $name);
 		return (int)$tagData['{http://owncloud.org/ns}id'];
 	}
 
@@ -545,7 +545,7 @@ trait Tags {
 			try {
 				$this->response = TagsHelper::deleteTag(
 					$this->baseUrlWithoutOCSAppendix(),
-					$this->getAdminUserName(),
+					$this->getAdminUsername(),
 					$this->getAdminPassword(),
 					$tagID,
 					2

--- a/tests/acceptance/features/bootstrap/WebUIBasicStructure.php
+++ b/tests/acceptance/features/bootstrap/WebUIBasicStructure.php
@@ -42,8 +42,6 @@ trait WebUIBasicStructure {
 	 * @var array
 	 */
 	private $createdUsers = array();
-	private $regularGroupName;
-	private $regularGroupNames = array();
 	private $createdGroupNames = array();
 
 	/**
@@ -245,26 +243,6 @@ trait WebUIBasicStructure {
 	}
 
 	/**
-	 * @Given a regular group has been created
-	 *
-	 * @return void
-	 */
-	public function aRegularGroupHasBeenCreated() {
-		$this->createGroup($this->regularGroupName);
-	}
-
-	/**
-	 * @Given regular groups have been created
-	 *
-	 * @return void
-	 */
-	public function regularGroupsHaveBeenCreated() {
-		foreach ($this->regularGroupNames as $group) {
-			$this->createGroup($group);
-		}
-	}
-
-	/**
 	 * creates a single group
 	 *
 	 * @param string $group
@@ -401,11 +379,6 @@ trait WebUIBasicStructure {
 	) {
 		$suiteParameters = SetupHelper::getSuiteParameters($scope);
 		$this->regularUserPassword = (string)$suiteParameters['regularUserPassword'];
-		$this->regularGroupNames = explode(
-			",",
-			$suiteParameters['regularGroupNames']
-		);
-		$this->regularGroupName = (string)$suiteParameters['regularGroupName'];
 	}
 
 	/**
@@ -486,20 +459,6 @@ trait WebUIBasicStructure {
 			}
 		}
 		return $result;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getRegularGroupName() {
-		return $this->regularGroupName;
-	}
-
-	/**
-	 * @return array
-	 */
-	public function getRegularGroupNames() {
-		return $this->regularGroupNames;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIBasicStructure.php
+++ b/tests/acceptance/features/bootstrap/WebUIBasicStructure.php
@@ -52,7 +52,10 @@ trait WebUIBasicStructure {
 	 */
 	public function adminLogsInUsingTheWebUI() {
 		$this->loginPage->open();
-		$this->loginAs("admin", $this->getUserPassword("admin"));
+		$this->loginAs(
+			$this->getAdminUsername(),
+			$this->getAdminPassword()
+		);
 	}
 
 	/**
@@ -171,8 +174,9 @@ trait WebUIBasicStructure {
 		switch ($method) {
 			case "api":
 				$results = UserHelper::createUser(
-					$baseUrl, $user, $password, "admin",
-					$this->getUserPassword("admin"),
+					$baseUrl, $user, $password,
+					$this->getAdminUsername(),
+					$this->getAdminPassword(),
 					$displayName, $email
 				);
 				foreach ($results as $result) {
@@ -264,7 +268,9 @@ trait WebUIBasicStructure {
 			case "api":
 				$result = UserHelper::createGroup(
 					$this->getMinkParameter("base_url"),
-					$group, "admin", $this->getUserPassword("admin")
+					$group,
+					$this->getAdminUsername(),
+					$this->getAdminPassword()
 				);
 				if ($result->getStatusCode() !== 200) {
 					throw new Exception(
@@ -315,7 +321,9 @@ trait WebUIBasicStructure {
 			case "api":
 				$result = UserHelper::addUserToGroup(
 					$this->getMinkParameter("base_url"), 
-					$user, $group, "admin", $this->getUserPassword("admin")
+					$user, $group,
+					$this->getAdminUsername(),
+					$this->getAdminPassword()
 				);
 				if ($result->getStatusCode() !== 200) {
 					throw new Exception(
@@ -393,8 +401,8 @@ trait WebUIBasicStructure {
 			$result = UserHelper::deleteUser(
 				$baseUrl,
 				$username,
-				"admin",
-				$this->getUserPassword("admin")
+				$this->getAdminUsername(),
+				$this->getAdminPassword()
 			);
 			
 			if ($user['shouldHaveBeenCreated'] && ($result->getStatusCode() !== 200)) {
@@ -409,8 +417,8 @@ trait WebUIBasicStructure {
 			$result = UserHelper::deleteGroup(
 				$baseUrl,
 				$group,
-				"admin",
-				$this->getUserPassword("admin")
+				$this->getAdminUsername(),
+				$this->getAdminPassword()
 			);
 			
 			if ($result->getStatusCode() !== 200) {
@@ -523,6 +531,20 @@ trait WebUIBasicStructure {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getAdminUsername() {
+		return (string) $this->adminUsername;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getAdminPassword() {
+		return (string) $this->adminPassword;
+	}
+
+	/**
 	 *
 	 * @param string $username
 	 *
@@ -530,8 +552,8 @@ trait WebUIBasicStructure {
 	 * @throws Exception
 	 */
 	public function getUserPassword($username) {
-		if ($username === 'admin') {
-			$password = $this->adminPassword;
+		if ($username === $this->getAdminUsername()) {
+			$password = $this->getAdminPassword();
 		} else {
 			if (!array_key_exists($username, $this->createdUsers)) {
 				throw new Exception(

--- a/tests/acceptance/features/bootstrap/WebUIBasicStructure.php
+++ b/tests/acceptance/features/bootstrap/WebUIBasicStructure.php
@@ -34,9 +34,7 @@ require_once 'bootstrap.php';
 trait WebUIBasicStructure {
 
 	private $regularUserPassword;
-	private $regularUserName;
-	private $regularUserNames = array();
-	
+
 	/**
 	 * list of users that were created during test runs
 	 * key is the username value is an array of user attributes
@@ -57,27 +55,6 @@ trait WebUIBasicStructure {
 	public function adminLogsInUsingTheWebUI() {
 		$this->loginPage->open();
 		$this->loginAs("admin", $this->getUserPassword("admin"));
-	}
-
-	/**
-	 * @When the regular user logs in using the webUI
-	 * @Given the regular user has logged in using the webUI
-	 *
-	 * @return void
-	 */
-	public function theRegularUserLogsInUsingTheWebUI() {
-		$this->loginPage->open();
-		$this->loginAsARegularUser();
-	}
-
-	/**
-	 * @return Page\OwncloudPage
-	 */
-	public function loginAsARegularUser() {
-		return $this->loginAs(
-			$this->getRegularUserName(),
-			$this->getRegularUserPassword()
-		);
 	}
 
 	/**
@@ -113,42 +90,6 @@ trait WebUIBasicStructure {
 		$this->loginPage->waitTillPageIsLoaded($this->getSession());
 		if ($this->webUIFilesContext !== null) {
 			$this->webUIFilesContext->resetFilesContext();
-		}
-	}
-
-	/**
-	 * @Given /^a regular user has been created\s?(but not initialized|)$/
-	 *
-	 * @param string $doNotInitialize just create the user, do not trigger creating skeleton files etc
-	 *
-	 * @return void
-	 */
-	public function aRegularUserHasBeenCreated($doNotInitialize = "") {
-		$this->createUser(
-			$this->getRegularUserName(),
-			$this->getRegularUserPassword(),
-			null,
-			null,
-			($doNotInitialize === "")
-		);
-	}
-
-	/**
-	 * @Given /^regular users have been created\s?(but not initialized|)$/
-	 *
-	 * @param string $doNotInitialize just create the user, do not trigger creating skeleton files etc
-	 *
-	 * @return void
-	 */
-	public function regularUsersHaveBeenCreated($doNotInitialize) {
-		foreach ($this->getRegularUserNames() as $user) {
-			$this->createUser(
-				$user,
-				$this->getRegularUserPassword(),
-				null,
-				null,
-				($doNotInitialize === "")
-			);
 		}
 	}
 
@@ -373,19 +314,6 @@ trait WebUIBasicStructure {
 		}
 		$this->addGroupToCreatedGroupsList($group);
 	}
-	/**
-	 * @Given the regular user has been added to the regular group
-	 *
-	 * @return void
-	 */
-	public function theRegularUserHasBeenAddedToTheRegularGroup() {
-		$group = $this->getRegularGroupName();
-		$user = $this->getRegularUserName();
-		if (!in_array($user, $this->getCreatedUserNames())) {
-			$this->aRegularUserHasBeenCreated();
-		}
-		$this->userHasBeenAddedToGroup($user, $group);
-	}
 
 	/**
 	 * @Given user :user has been added to group :group ready for use by the webUI
@@ -472,11 +400,6 @@ trait WebUIBasicStructure {
 		BeforeScenarioScope $scope
 	) {
 		$suiteParameters = SetupHelper::getSuiteParameters($scope);
-		$this->regularUserNames = explode(
-			",",
-			$suiteParameters['regularUserNames']
-		);
-		$this->regularUserName = (string)$suiteParameters['regularUserName'];
 		$this->regularUserPassword = (string)$suiteParameters['regularUserPassword'];
 		$this->regularGroupNames = explode(
 			",",
@@ -531,20 +454,6 @@ trait WebUIBasicStructure {
 	 */
 	public function getRegularUserPassword() {
 		return $this->regularUserPassword;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getRegularUserName() {
-		return $this->regularUserName;
-	}
-
-	/**
-	 * @return array
-	 */
-	public function getRegularUserNames() {
-		return $this->regularUserNames;
 	}
 
 	/**
@@ -720,14 +629,6 @@ trait WebUIBasicStructure {
 				"function" => [
 					$this,
 					"getBaseUrlWithoutScheme"
-				],
-				"parameter" => [ ]
-			],
-			[
-				"code" => "%regularuser%",
-				"function" => [
-					$this,
-					"getRegularUserName"
 				],
 				"parameter" => [ ]
 			]

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -43,6 +43,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 
 	use WebUIBasicStructure;
 
+	private $adminUsername;
 	private $adminPassword;
 	private $owncloudPage;
 	private $loginPage;
@@ -338,8 +339,9 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 */
 	public function theGroupNamedShouldNotExist($name) {
 		$groups = UserHelper::getGroupsAsArray(
-			$this->getMinkParameter("base_url"), "admin",
-			$this->getUserPassword("admin")
+			$this->getMinkParameter("base_url"),
+			$this->getAdminUsername(),
+			$this->getAdminPassword()
 		);
 		if (in_array($name, $groups, true)) {
 			throw new Exception("group '" . $name . "' exists but should not");
@@ -391,8 +393,8 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		$capability = $this->capabilities[strtolower($section)][$setting];
 		$change = AppConfigHelper::setCapability(
 			$this->getMinkParameter('base_url'),
-			"admin",
-			$this->getUserPassword("admin"),
+			$this->getAdminUsername(),
+			$this->getAdminPassword(),
 			$capability['capabilitiesApp'],
 			$capability['capabilitiesParameter'],
 			$capability['testingApp'],
@@ -474,14 +476,19 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		}
 
 		$suiteParameters = SetupHelper::getSuiteParameters($scope);
+		$this->adminUsername = (string)$suiteParameters['adminUsername'];
 		$this->adminPassword = (string)$suiteParameters['adminPassword'];
 		SetupHelper::init(
-			"admin", $this->getUserPassword("admin"),
-			$this->getMinkParameter('base_url'), $suiteParameters['ocPath']
+			$this->getAdminUsername(),
+			$this->getAdminPassword(),
+			$this->getMinkParameter('base_url'),
+			$suiteParameters['ocPath']
 		);
 		
 		$response = AppConfigHelper::getCapabilities(
-			$this->getMinkParameter('base_url'), "admin", $this->getUserPassword("admin")
+			$this->getMinkParameter('base_url'),
+			$this->getAdminUsername(),
+			$this->getAdminPassword()
 		);
 		$this->savedCapabilitiesXml = AppConfigHelper::getCapabilitiesXml(
 			$response
@@ -549,8 +556,8 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	public function tearDownSuite() {
 		AppConfigHelper::modifyServerConfigs(
 			$this->getMinkParameter('base_url'),
-			"admin",
-			$this->getUserPassword("admin"),
+			$this->getAdminUsername(),
+			$this->getAdminPassword(),
 			$this->savedCapabilitiesChanges
 		);
 
@@ -599,8 +606,8 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	public function clearFileLocks() {
 		$response = OcsApiHelper::sendRequest(
 			$this->getMinkParameter('base_url'),
-			"admin",
-			$this->getUserPassword("admin"),
+			$this->getAdminUsername(),
+			$this->getAdminPassword(),
 			'delete',
 			"/apps/testing/api/v1/lockprovisioning",
 			["global" => "true"]

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -168,15 +168,6 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user logs in as a regular user with a correct password using the webUI
-	 *
-	 * @return void
-	 */
-	public function theUserLogsInAsARegularUserWithACorrectPasswordUsingTheWebUI() {
-		$this->filesPage = $this->webUIGeneralContext->loginAsARegularUser();
-	}
-
-	/**
 	 * @Then /^it should (not|)\s?be possible to login with the username ((?:'[^']*')|(?:"[^"]*")) and password ((?:'[^']*')|(?:"[^"]*")) using the WebUI$/
 	 * 
 	 * @param string $shouldOrNot

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -39,8 +39,6 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	private $filesPage;
 	private $publicLinkFilesPage;
 	private $sharingDialog;
-	private $regularGroupName;
-	private $regularGroupNames;
 	/**
 	 * 
 	 * @var WebUIGeneralContext
@@ -531,8 +529,6 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		// Get all the contexts you need in this context
 		$this->webUIGeneralContext = $environment->getContext('WebUIGeneralContext');
 		$this->webUIFilesContext = $environment->getContext('WebUIFilesContext');
-		$this->regularGroupNames = $this->webUIGeneralContext->getRegularGroupNames();
-		$this->regularGroupName = $this->webUIGeneralContext->getRegularGroupName();
 		$this->setupSharingConfigs();
 	}
 	

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -611,8 +611,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 
 		$change = AppConfigHelper::setCapabilities(
 			$this->getMinkParameter('base_url'),
-			"admin",
-			$this->webUIGeneralContext->getUserPassword("admin"),
+			$this->webUIGeneralContext->getAdminUsername(),
+			$this->webUIGeneralContext->getAdminPassword(),
 			$settings,
 			$this->webUIGeneralContext->getSavedCapabilitiesXml()
 		);

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -39,8 +39,6 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	private $filesPage;
 	private $publicLinkFilesPage;
 	private $sharingDialog;
-	private $regularUserName;
-	private $regularUserNames;
 	private $regularGroupName;
 	private $regularGroupNames;
 	/**
@@ -397,7 +395,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function theUsersOwnNameShouldNotBeListedInTheAutocompleteList() {
 		PHPUnit_Framework_Assert::assertNotContains(
-			$this->regularUserName,
+			$this->filesPage->getMyDisplayname(),
 			$this->sharingDialog->getAutocompleteItemsList()
 		);
 	}
@@ -533,8 +531,6 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		// Get all the contexts you need in this context
 		$this->webUIGeneralContext = $environment->getContext('WebUIGeneralContext');
 		$this->webUIFilesContext = $environment->getContext('WebUIFilesContext');
-		$this->regularUserNames = $this->webUIGeneralContext->getRegularUserNames();
-		$this->regularUserName = $this->webUIGeneralContext->getRegularUserName();
 		$this->regularGroupNames = $this->webUIGeneralContext->getRegularGroupNames();
 		$this->regularGroupName = $this->webUIGeneralContext->getRegularGroupName();
 		$this->setupSharingConfigs();

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -96,8 +96,8 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 
 		$this->response = OcsApiHelper::sendRequest(
 			$this->getMinkParameter('base_url'),
-			"admin",
-			$this->webUIGeneralContext->getUserPassword("admin"),
+			$this->webUIGeneralContext->getAdminUsername(),
+			$this->webUIGeneralContext->getAdminPassword(),
 			"PUT",
 			"/cloud/users/" . $user,
 			$body,

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -63,18 +63,6 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * substitute codes like "%regularuser%" with the actual name of the user
-	 *
-	 * @param string $username
-	 * 
-	 * @return string
-	 * @Transform :username
-	 */
-	public function checkUsername($username) {
-		return $this->webUIGeneralContext->substituteInLineCodes($username);
-	}
-
-	/**
 	 * @When the administrator sets/changes the quota of user :username to :quota using the webUI
 	 * @Given the administrator has set/changed the quota of user :username to :quota using the webUI
 	 *

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -6,8 +6,11 @@ I would like to mark any file/folder as favorite
 So that I can find my favorite file/folder easily
 
 	Background:
-		Given a regular user has been created
-		And the regular user has logged in using the webUI
+		Given these users have been created:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 		And the user has browsed to the files page
 
 	Scenario: mark a file as favorite and list it in favorites page

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -6,8 +6,11 @@ I would like to unmark any file/folder
 So that I can remove my favorite file/folder from favorite page
 
 	Background:
-		Given a regular user has been created
-		And the regular user has logged in using the webUI
+		Given these users have been created:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 		And the user has browsed to the files page
 
 	Scenario: unmark a file as favorite from files page 

--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -5,8 +5,11 @@ I want to delete files and folders
 So that I can keep my filing system clean and tidy
 
 	Background:
-		Given a regular user has been created
-		And the regular user has logged in using the webUI
+		Given these users have been created:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 		And the user has browsed to the files page
 
 	Scenario: Delete files & folders one by one and check its existence after page reload

--- a/tests/acceptance/features/webUIFiles/hiddenFile.feature
+++ b/tests/acceptance/features/webUIFiles/hiddenFile.feature
@@ -6,8 +6,11 @@ I would like to display hidden files/folders
 So that I can choose to see the files that I want.
 
 	Background:
-		Given a regular user has been created
-		And the regular user has logged in using the webUI
+		Given these users have been created:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 		And the user has browsed to the files page
 
 	Scenario: create a hidden folder

--- a/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
+++ b/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
@@ -5,8 +5,11 @@ I want to see the whole menu of actions that can be done on a file
 So that I can manage and work with my files
 
 	Background:
-		Given a regular user has been created
-		And the regular user has logged in using the webUI
+		Given these users have been created:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 		And the user has browsed to the files page
 
 	@skipOnINTERNETEXPLORER

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -5,15 +5,17 @@ I want to manage user quota
 So that users can only take up a certain amount of storage space
 
 	Background:
-		Given a regular user has been created but not initialized
+		Given these users have been created but not initialized:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
 		And user admin has logged in using the webUI
 		And the administrator has browsed to the users page
 
 	Scenario Outline: change quota to a valid value
-		Given the administrator has set the quota of user "%regularuser%" to "<start_quota>" using the webUI
-		When the administrator changes the quota of user "%regularuser%" to "<wished_quota>" using the webUI
+		Given the administrator has set the quota of user "user1" to "<start_quota>" using the webUI
+		When the administrator changes the quota of user "user1" to "<wished_quota>" using the webUI
 		And the administrator reloads the users page
-		Then the quota of user "%regularuser%" should be set to "<expected_quota>" on the webUI
+		Then the quota of user "user1" should be set to "<expected_quota>" on the webUI
 
 		Examples:
 		|start_quota|wished_quota|expected_quota|
@@ -28,15 +30,15 @@ So that users can only take up a certain amount of storage space
 
 	@skipOnOcV10.0.3
 	Scenario: change quota to a valid value that do not work on 10.0.3
-		Given the administrator has set the quota of user "%regularuser%" to "Unlimited" using the webUI
-		When the administrator changes the quota of user "%regularuser%" to "0 Kb" using the webUI
+		Given the administrator has set the quota of user "user1" to "Unlimited" using the webUI
+		When the administrator changes the quota of user "user1" to "0 Kb" using the webUI
 		And the administrator reloads the users page
-		Then the quota of user "%regularuser%" should be set to "0 B" on the webUI
+		Then the quota of user "user1" should be set to "0 B" on the webUI
 
 	Scenario Outline: change quota to an invalid value
-		When the administrator changes the quota of user "%regularuser%" to "<wished_quota>" using the webUI
+		When the administrator changes the quota of user "user1" to "<wished_quota>" using the webUI
 		Then a notification should be displayed on the webUI with the text 'Invalid quota value "<wished_quota>"'
-		And the quota of user "%regularuser%" should be set to "Default" on the webUI
+		And the quota of user "user1" should be set to "Default" on the webUI
 
 		Examples:
 		|wished_quota|

--- a/tests/acceptance/features/webUIManageUsersGroups/login.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/login.feature
@@ -10,9 +10,11 @@ So that unauthorised access is impossible
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: simple user login
-		Given a regular user has been created but not initialized
+		Given these users have been created but not initialized:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
 		And the user has browsed to the login page
-		When the user logs in as a regular user with a correct password using the webUI
+		When the user logs in with username "user1" and password "1234" using the webUI
 		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
 	Scenario: admin login

--- a/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
@@ -5,8 +5,7 @@ I want to manage groups
 So that access to resources can be controlled more effectively
 
 	Background:
-		Given a regular user has been created but not initialized
-		And user admin has logged in using the webUI
+		Given user admin has logged in using the webUI
 		And the administrator has browsed to the users page
 
 	@skipOnOcV10.0.3

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -5,8 +5,11 @@ I want to move files
 So that I can organise my data structure
 
 	Background:
-		Given a regular user has been created
-		And the regular user has logged in using the webUI
+		Given these users have been created:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 		And the user has browsed to the files page
 
 	Scenario: An attempt to move a file into a sub-folder using rename is not allowed

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -5,8 +5,11 @@ I want to move folders
 So that I can organise my data structure
 
 	Background:
-		Given a regular user has been created
-		And the regular user has logged in using the webUI
+		Given these users have been created:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 		And the user has browsed to the files page
 
 	Scenario: An attempt to move a folder into a sub-folder using rename is not allowed

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -5,8 +5,11 @@ I want to change the ownCloud User Interface to my preferred settings
 So that I can personalise the User Interface
 
 	Scenario: change language
-		Given a regular user has been created
-		And the regular user has logged in using the webUI
+		Given these users have been created:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 		And the user has browsed to the personal general settings page
 		When the user changes the language to "Русский" using the webUI
 		Then the user should be redirected to a webUI page with the title "Настройки - ownCloud"

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -5,8 +5,11 @@ I want to rename files
 So that I can organise my data structure
 
 	Background:
-		Given a regular user has been created
-		And the regular user has logged in using the webUI
+		Given these users have been created:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 		And the user has browsed to the files page
 
 	Scenario Outline: Rename a file using special characters

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -5,8 +5,11 @@ I want to rename folders
 So that I can organise my data structure
 
 	Background:
-		Given a regular user has been created
-		And the regular user has logged in using the webUI
+		Given these users have been created:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
 		And the user has browsed to the files page
 
 	Scenario Outline: Rename a folder using special characters

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -12,7 +12,12 @@ So that I can efficiently share my files with other users or groups
 			| user3       | 1234     | User Three   | u2@oc.com.np          |
 			| usergrp     | 1234     | User Grp     | u@oc.com.np           |
 			| regularuser | 1234     | User Regular | regularuser@oc.com.np |
-		And regular groups have been created
+		And these groups have been created:
+			|groupname|
+			|grp1     |
+			|grp2     |
+			|grp3     |
+			|grpuser  |
 		And the user has browsed to the login page
 		And the user has logged in with username "regularuser" and password "1234" using the webUI
 		And the user has browsed to the files page

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -6,15 +6,17 @@ So that I can efficiently share my files with other users or groups
 
 	Background:
 		Given these users have been created but not initialized:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
-			|user2   |1234    |User Two   |u2@oc.com.np|
-			|user3   |1234    |User Three |u2@oc.com.np|
-			|usergrp |1234    |User Grp   |u@oc.com.np |
-		And a regular user has been created
+			| username    | password | displayname  | email                 |
+			| user1       | 1234     | User One     | u1@oc.com.np          |
+			| user2       | 1234     | User Two     | u2@oc.com.np          |
+			| user3       | 1234     | User Three   | u2@oc.com.np          |
+			| usergrp     | 1234     | User Grp     | u@oc.com.np           |
+			| regularuser | 1234     | User Regular | regularuser@oc.com.np |
 		And regular groups have been created
-		And the regular user has logged in using the webUI
+		And the user has browsed to the login page
+		And the user has logged in with username "regularuser" and password "1234" using the webUI
 		And the user has browsed to the files page
+
 	@skipOnLDAP @user_ldap#175
 	Scenario: autocompletion of regular existing users
 		Given the user has opened the share dialog for the folder "simple-folder"

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -5,8 +5,11 @@ Feature: files and folders can be deleted from the trashbin
   So that I can control my trashbin space and which files are kept in that space
 
   Background:
-    Given a regular user has been created
-    And the regular user has logged in using the webUI
+    Given these users have been created:
+      |username|password|displayname|email       |
+      |user1   |1234    |User One   |u1@oc.com.np|
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "1234" using the webUI
     And the following files have been deleted
       | name          |
       | lorem.txt     |

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -5,8 +5,11 @@ Feature: files and folders exist in the trashbin after being deleted
   So that I can recover data easily
 
   Background:
-    Given a regular user has been created
-    And the regular user has logged in using the webUI
+    Given these users have been created:
+      |username|password|displayname|email       |
+      |user1   |1234    |User One   |u1@oc.com.np|
+    And the user has browsed to the login page
+    And the user has logged in with username "user1" and password "1234" using the webUI
     And the user has browsed to the files page
 
   Scenario: Delete files & folders one by one and check that they are all in the trashbin


### PR DESCRIPTION
## Description
Remove now-unwanted/unneeded "extras" from the UI tests, making them ever closer to the API tests:
1) Remove use of ``RegularUserName`` and ``RegularUserNames``
2) Remove use of ``regularGroupName`` and ``regularGroupNames`` 
3) Standardize the parameters sent from ``behat.yml`` for both UI and API tests (``adminUsername`` ``adminPassword`` ``regularUserPassword`` ...)

This will make it easy in the next step, to "switch on" availability of each others step definitions.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
Bring the UI tests to a point where they can "just use" API acceptance test steps.

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

