### PR TITLE
fixes objectstore#75 - use storage specific implementations of moveFr…

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -319,6 +319,24 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		return true;
 	}
 
+	public function moveFromStorage(\OCP\Files\Storage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+		if ($sourceStorage === $this) {
+			return $this->copy($sourceInternalPath, $targetInternalPath);
+		}
+		// cross storage moves need to perform a move operation
+		// TODO: there is some cache updating missing which requires bigger changes and is
+		//       subject to followup PRs
+		if (!$sourceStorage->instanceOfStorage(self::class)) {
+			return parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+		}
+
+		// source and target live on the same object store and we can simply rename
+		// which updates the cache properly
+		$this->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+		return true;
+	}
+
+
 	public function getMimeType($path) {
 		$path = $this->normalizePath($path);
 		$stat = $this->stat($path);

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -636,6 +636,9 @@ class Encryption extends Wrapper {
 			return false;
 		}
 
+		if (!$this->encryptionManager->isEnabled()) {
+			return $this->storage->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime);
+		}
 		$result = $this->copyBetweenStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime, true);
 		if ($result) {
 			if ($sourceStorage->is_dir($sourceInternalPath)) {


### PR DESCRIPTION
…omStorage

## Description

A move operation of files and folders needs it's special implementation on the objectstore level.

please note that this is only a partial fix. In the scenario where objectstore and encryption is enabled the bug will remain visible.

## Related Issue
owncloud/objectstore#75

## How Has This Been Tested?
Manually with scaility
Steps are listed in the ticket.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

