### PR TITLE
Add symfony event for resolving private links by apps

### DIFF
--- a/apps/files_trashbin/appinfo/app.php
+++ b/apps/files_trashbin/appinfo/app.php
@@ -39,4 +39,7 @@ if (class_exists('OCA\Files\App')) {
 			'name' => $l->t('Deleted files'),
 		];
 	});
+
+	$app = new \OCA\Files_Trashbin\AppInfo\Application();
+	$app->registerListeners();
 }

--- a/apps/files_trashbin/lib/AppInfo/Application.php
+++ b/apps/files_trashbin/lib/AppInfo/Application.php
@@ -25,6 +25,7 @@ namespace OCA\Files_Trashbin\AppInfo;
 use OCA\Files_Trashbin\Expiration;
 use OCA\Files_Trashbin\Quota;
 use OCP\AppFramework\App;
+use OCA\Files_Trashbin\Trashbin;
 
 class Application extends App {
 	public function __construct (array $urlParams = []) {
@@ -55,5 +56,20 @@ class Application extends App {
 				$c->query('ServerContainer')->getConfig()
 			);
 		});
+
+		/*
+		 * Register trashbin service
+		 */
+		$container->registerService('Trashbin', function($c) {
+			return new Trashbin(
+				$c->getServer()->getLazyRootFolder(),
+				$c->getServer()->getUrlGenerator(),
+				$c->getServer()->getEventDispatcher()
+			);
+		});
+	}
+
+	public function registerListeners() {
+		$this->getContainer()->query('Trashbin')->registerListeners();
 	}
 }

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -187,7 +187,11 @@ abstract class TestCase extends BaseTestCase {
 
 			$method->setAccessible(true);
 
-			return $method->invokeArgs($object, $parameters);
+			if ($method->isStatic()) {
+				return $method->invokeArgs($reflection, $parameters);
+			} else {
+				return $method->invokeArgs($object, $parameters);
+			}
 		} elseif ($reflection->hasProperty($methodName)) {
 			$property = $reflection->getProperty($methodName);
 


### PR DESCRIPTION
## Description
Apps can now resolve private links whenever the link was not resolvable by the files app.
    
Currently only the trashbin is responding to this in case a file is in trash.

## Related Issue
Will be required for https://github.com/owncloud/core/pull/30106 to also resolve file id to pending share page URL

## Motivation and Context
Will be required for https://github.com/owncloud/core/pull/30106 to also resolve file id to pending share page URL.
Also decouples the ViewController from trashbin...

## How Has This Been Tested?
Manual test by opening a private link pointing at a trashed folder: the web UI opens in the trashed folder.
Unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

