### PR TITLE
Fix error when reading empty authtoken names from db

### DIFF
--- a/lib/private/Authentication/Token/DefaultToken.php
+++ b/lib/private/Authentication/Token/DefaultToken.php
@@ -136,7 +136,7 @@ class DefaultToken extends Entity implements IToken {
 	 */
 	public function setName($name) {
 		if (strlen($name) < 1) {
-			throw new \InvalidArgumentException();
+			$name = '(none)';
 		}
 		parent::setName($name);
 	}


### PR DESCRIPTION
Issue: #30792

