### PR TITLE
Remove unused ldapUserCleanupInterval

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -842,20 +842,6 @@ $CONFIG = array(
 ),
 
 /**
- * LDAP
- *
- * Global settings used by LDAP User and Group Backend
- */
-
-/**
- * defines the interval in minutes for the background job that checks user
- * existence and marks them as ready to be cleaned up. The number is always
- * minutes. Setting it to 0 disables the feature.
- * See command line (occ) methods ldap:show-remnants and user:delete
- */
-'ldapUserCleanupInterval' => 51,
-
-/**
  * Comments
  *
  * Global settings for the Comments infrastructure


### PR DESCRIPTION
## Description
Remove unused ``ldapUserCleanupInterval``

## Related Issue
#30419 

## Motivation and Context
Reduce confusion

## How Has This Been Tested?
Search all code.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

