### PR TITLE
Remove unused config parameters

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -554,26 +554,11 @@ $CONFIG = array(
 'has_internet_connection' => true,
 
 /**
- * Allows ownCloud to verify a working WebDAV connection. This is done by
- * attempting to make a WebDAV request from PHP.
- */
-'check_for_working_webdav' => true,
-
-/**
  * Allows ownCloud to verify a working .well-known URL redirects. This is done
  * by attempting to make a request from JS to
  * https://your-domain.com/.well-known/caldav/
  */
 'check_for_working_wellknown_setup' => true,
-
-/**
- * This is a crucial security check on Apache servers that should always be set
- * to ``true``. This verifies that the ``.htaccess`` file is writable and works.
- * If it is not, then any options controlled by ``.htaccess``, such as large
- * file uploads, will not work. It also runs checks on the ``data/`` directory,
- * which verifies that it can't be accessed directly through the Web server.
- */
-'check_for_working_htaccess' => true,
 
 /**
  * In certain environments it is desired to have a read-only configuration file.
@@ -897,18 +882,6 @@ $CONFIG = array(
  * who are not in the ``admin`` group.
  */
 'singleuser' => false,
-
-
-/**
- * SSL
- */
-
-/**
- * Extra SSL options to be used for configuration.
- */
-'openssl' => array(
-	'config' => '/absolute/location/of/openssl.cnf',
-),
 
 /**
  * Allow the configuration of system wide trusted certificates


### PR DESCRIPTION
## Description
Remove config parameters:
``check_for_working_webdav``
``check_for_working_wellknown_setup``
``openssl`` 



## Related Issue

## Motivation and Context
Remove stuff that is not used anywhere.

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

