### PR TITLE
[stable10] Remove unused ldapUserCleanupInterval

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -860,20 +860,6 @@ $CONFIG = array(
 ),
 
 /**
- * LDAP
- *
- * Global settings used by LDAP User and Group Backend
- */
-
-/**
- * defines the interval in minutes for the background job that checks user
- * existence and marks them as ready to be cleaned up. The number is always
- * minutes. Setting it to 0 disables the feature.
- * See command line (occ) methods ldap:show-remnants and user:delete
- */
-'ldapUserCleanupInterval' => 51,
-
-/**
  * Comments
  *
  * Global settings for the Comments infrastructure


### PR DESCRIPTION
Backport #30805 

``ldapUserCleanupInterval`` is not used in ``stable10`` either.