### PR TITLE
Set empty authtoken names to 'none'

### DIFF
--- a/core/Migrations/Version20180319102121.php
+++ b/core/Migrations/Version20180319102121.php
@@ -1,0 +1,22 @@
+<?php
+namespace OC\Migrations;
+
+use OCP\IDBConnection;
+use OCP\Migration\ISqlMigration;
+
+/**
+ * Sets empty authtoken names to '(none)'
+ * https://github.com/owncloud/core/issues/30792
+ */
+class Version20180319102121 implements ISqlMigration {
+
+	public function sql(IDBConnection $connection) {
+		$q = $connection->getQueryBuilder();
+		$q->update('authtoken')
+			->set('name', $q->expr()->literal('(none)'))
+			->where($q->expr()->eq('name', $q->expr()->literal('')))
+			->orWhere($q->expr()->isNull('name'));
+		return [$q->getSQL()];
+    }
+}
+


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Empty authtokens names were allowed in earlier versions, but are now disallowed. This results in a crash during login when empty authokens are encountered from previous version

This migration sets all empty authtoken names to 'none'.

## Related Issue
#30792


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

