### PR TITLE
Remove api tag in useBigFileIDs

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -860,7 +860,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @BeforeSuite @api
+	 * @BeforeSuite
 	 *
 	 * @param BeforeSuiteScope $scope
 	 *
@@ -870,9 +870,10 @@ trait BasicStructure {
 		$fullUrl = getenv('TEST_SERVER_URL') . "/v1.php/apps/testing/api/v1/increasefileid";
 		$client = new Client();
 		$options = [];
-		$adminCredentials = $scope->getSuite()->getSettings()['contexts'][0][__CLASS__]['admin'];
-		$options['auth'] = $adminCredentials;
-		$client->send($client->createRequest('post', $fullUrl, $options));
+		$adminUsername = $scope->getSuite()->getSettings()['contexts'][0][__CLASS__]['adminUsername'];
+		$adminPassword = $scope->getSuite()->getSettings()['contexts'][0][__CLASS__]['adminPassword'];
+		$options['auth'] = [$adminUsername, $adminPassword];
+		$client->send($client->createRequest('POST', $fullUrl, $options));
 	}
 }
 

--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -338,6 +338,10 @@ export IPV6_URL
 export REMOTE_FED_BASE_URL
 export FILES_FOR_UPLOAD="$(pwd)/tests/acceptance/filesForUpload/"
 
+# Provide TEST_SERVER* env vars. Some API acceptance test code uses these.
+export TEST_SERVER_URL="$BASE_URL/ocs/"
+export TEST_SERVER_FED_URL="$REMOTE_FED_BASE_URL/ocs/"
+
 if [ ! -w $FILES_FOR_UPLOAD ]
 then
 	echo "WARNING: cannot write to upload folder '$FILES_FOR_UPLOAD', some upload tests might fail"


### PR DESCRIPTION
##Description
Get the ``useBigFileIDs`` ``BeforeSuite`` method working with any acceptance test environment - API and webUI.

Actually I am not sure how it was working previous to this, because the code needed the ``adminUsername`` ``adminPassword`` separation changes.

Issue https://github.com/owncloud/QA/issues/517