### PR TITLE
Remove api tags

### DIFF
--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -36,7 +36,7 @@ class AppManagementContext implements  Context {
 	private $cmdOutput;
 	
 	/**
-	 * @BeforeScenario @api
+	 * @BeforeScenario
 	 *
 	 * Remember the config values before each scenario
 	 *
@@ -50,7 +50,7 @@ class AppManagementContext implements  Context {
 	}
 	
 	/**
-	 * @AfterScenario @api
+	 * @AfterScenario
 	 *
 	 * Reset the config values after each scenario
 	 *

--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -32,7 +32,7 @@ trait Auth {
 	private $clientToken;
 
 	/**
-	 * @BeforeScenario @api
+	 * @BeforeScenario
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -824,7 +824,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @BeforeScenario @api&&@local_storage
+	 * @BeforeScenario @local_storage
 	 *
 	 * @return void
 	 */
@@ -838,7 +838,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @AfterScenario @api&&@local_storage
+	 * @AfterScenario @local_storage
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -149,15 +149,22 @@ trait BasicStructure {
 	/**
 	 * Override the baseUrl that came via the behat.yml and context constructor.
 	 * Use this when running in an environment that passes the baseUrl from some
-	 * external script. For example, the UI acceptance tests build up the baseUrl
-	 * from environment variables and the script passes the value in as a Mink
-	 * Extension parameter.
+	 * external script. For example, the webUI acceptance tests build up the
+	 * baseUrl from environment variables and the script passes the value in as
+	 * a Mink parameter.
 	 *
-	 * @param string $newBaseUrl
+	 * @param string $newBaseUrl in the format that the webUI tests use
 	 *
 	 * @return void
 	 */
-	public function overrideBaseUrl($newBaseUrl) {
+	public function overrideBaseUrlWithWebUIValue($newBaseUrl) {
+		// baseUrl in the API tests featureContext uses a form with '/ocs/'
+		// on the end so add that.
+		if (substr($newBaseUrl, -1) !== '/') {
+			$newBaseUrl .= '/';
+		}
+
+		$newBaseUrl .= 'ocs/';
 		$this->baseUrl = $newBaseUrl;
 		$this->localBaseUrl = $this->baseUrl;
 		$this->remoteBaseUrl = $this->baseUrl;

--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -68,7 +68,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @BeforeScenario @api&&@caldav
+	 * @BeforeScenario @caldav
 	 *
 	 * @param BeforeScenarioScope $scope
 	 *
@@ -84,7 +84,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @AfterScenario @api&&@caldav
+	 * @AfterScenario @caldav
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/CardDavContext.php
+++ b/tests/acceptance/features/bootstrap/CardDavContext.php
@@ -68,7 +68,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @BeforeScenario @api&&@carddav
+	 * @BeforeScenario @carddav
 	 *
 	 * @param BeforeScenarioScope $scope
 	 *
@@ -84,7 +84,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @AfterScenario @api&&@carddav
+	 * @AfterScenario @carddav
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -535,8 +535,8 @@ trait Tags {
 	}
 
 	/**
-	 * @BeforeScenario @api
-	 * @AfterScenario @api
+	 * @BeforeScenario
+	 * @AfterScenario
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -511,6 +511,15 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * Return the baseUrl in the form that the webUI tests use.
+	 *
+	 * @return string
+	 */
+	public function getBaseUrlInWebUITestFormat() {
+		return $this->getMinkParameter("base_url");
+	}
+
+	/**
 	 * @BeforeScenario @webUI
 	 *
 	 * @param BeforeScenarioScope $scope
@@ -565,20 +574,9 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			]
 		);
 
-		// The webUI tests get the base URL of the server-under-test via a
-		// Mink parameter. Tell that to featureContext, which normally gets
-		// baseUrl passed in from behat.yml via its constructor.
-		$baseUrl = $this->getMinkParameter("base_url");
-
-		// baseUrl in featureContext uses a form with '/ocs/' on the end
-		// so tell that to featureContext.
-		if (substr($baseUrl, -1) !== '/') {
-			$baseUrl .= '/';
-		}
-
-		$baseUrl .= 'ocs/';
-
-		$this->featureContext->overrideBaseUrl($baseUrl);
+		$this->featureContext->overrideBaseUrlWithWebUIValue(
+			$this->getBaseUrlInWebUITestFormat()
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
1) Remove ``api`` tags.
2) There is an issue with the order of execution of ``BeforeScenario`` methods. So when ``AppConfiguration.php`` wants to set sharing... settings, and it is running in a ``webUI`` scenario, make sure to get the base URL that the ``webUI`` has set. Then the code will find the server correctly to make the settings.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
Some ``BeforeScenario`` and ``AfterScenario`` methods in the API acceptance tests are only running for scenarios that are tagged ``api``. This could be a problem if a webUI scenario makes use of a related step. e.g. if a webUI scenario uses a step to add a tag on file, then the ``Tags.php`` ``AfterScenario`` is not going to run, so the file tag will not get cleaned up at the end f the scenario.

We should remove the ``api`` tag from as many ``BeforeScenario`` and ``AfterScenario`` methods as we can.

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

