### PR TITLE
Refactor userShouldExist and groupShouldExist

### DIFF
--- a/tests/acceptance/features/apiMain/provisioning-v1.feature
+++ b/tests/acceptance/features/apiMain/provisioning-v1.feature
@@ -15,18 +15,14 @@ Feature: provisioning
 
 	Scenario: Create a user
 		Given user "brand-new-user" has been deleted
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users" with body
-			| userid   | brand-new-user |
-			| password | 456firstpwd    |
+		When the administrator sends a user creation request for user "brand-new-user" password "456firstpwd" using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "brand-new-user" should exist
 
 	Scenario: Create an existing user
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users" with body
-			| userid   | brand-new-user |
-			| password | 456newpwd      |
+		When the administrator sends a user creation request for user "brand-new-user" password "456newpwd" using the API
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
 
@@ -57,24 +53,21 @@ Feature: provisioning
 
 	Scenario: Create a group
 		Given group "new-group" has been deleted
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
-			| groupid | new-group |
+		When the administrator sends a group creation request for group "new-group" using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And group "new-group" should exist
 
 	Scenario: Create a group with special characters
 		Given group "España" has been deleted
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
-			| groupid | España |
+		When the administrator sends a group creation request for group "España" using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And group "España" should exist
 
 	Scenario: Create a group named "0"
 		Given group "0" has been deleted
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
-			| groupid | 0 |
+		When the administrator sends a group creation request for group "0" using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And group "0" should exist

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -20,6 +20,7 @@
  */
 
 use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
@@ -330,7 +331,7 @@ trait BasicStructure {
 	 *
 	 * @param string $verb
 	 * @param string $url
-	 * @param \Behat\Gherkin\Node\TableNode $body
+	 * @param TableNode $body
 	 *
 	 * @return void
 	 */
@@ -350,7 +351,7 @@ trait BasicStructure {
 	 * @param string $user
 	 * @param string $verb
 	 * @param string $url
-	 * @param \Behat\Gherkin\Node\TableNode $body
+	 * @param TableNode $body
 	 *
 	 * @return void
 	 */
@@ -365,7 +366,7 @@ trait BasicStructure {
 		 * @var array $bodyArray
 		 */
 		$bodyArray = [];
-		if ($body instanceof \Behat\Gherkin\Node\TableNode) {
+		if ($body instanceof TableNode) {
 			$bodyArray = $body->getRowsHash();
 		}
 
@@ -401,7 +402,7 @@ trait BasicStructure {
 	 * @param string $user
 	 * @param string $verb
 	 * @param string $url
-	 * @param \Behat\Gherkin\Node\TableNode $body
+	 * @param TableNode $body
 	 *
 	 * @return void
 	 */
@@ -415,7 +416,7 @@ trait BasicStructure {
 			$options['cookies'] = $this->cookieJar;
 		}
 
-		if ($body instanceof \Behat\Gherkin\Node\TableNode) {
+		if ($body instanceof TableNode) {
 			$fd = $body->getRowsHash();
 			$options['body'] = $fd;
 		}

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -145,7 +145,7 @@ trait Provisioning {
 	public function adminCreatesUserUsingTheAPI($user) {
 		if (!$this->userExists($user) ) {
 			$password = $this->getPasswordForUser($user);
-			$this->createUser($user, $password);
+			$this->createUser($user, $password, null, null, true, 'api');
 		}
 		PHPUnit_Framework_Assert::assertTrue($this->userExists($user));
 	}
@@ -184,6 +184,25 @@ trait Provisioning {
 	}
 
 	/**
+	 * @When /^the administrator sends a user creation request for user "([^"]*)" password "([^"]*)" using the API$/
+	 *
+	 * @param string $user
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function adminSendsUserCreationRequestUsingTheAPI($user, $password) {
+		$bodyTable = new TableNode([['userid', $user], ['password', $password]]);
+		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+			$this->getAdminUsername(),
+			"POST",
+			"/cloud/users",
+			$bodyTable
+		);
+		$this->addUserToCreatedUsersList($user, $password);
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" should exist$/
 	 *
 	 * @param string $user
@@ -192,7 +211,6 @@ trait Provisioning {
 	 */
 	public function userShouldExist($user) {
 		PHPUnit_Framework_Assert::assertTrue($this->userExists($user));
-		$this->addUserToCreatedUsersList($user, $this->getPasswordForUser($user));
 	}
 
 	/**
@@ -215,7 +233,6 @@ trait Provisioning {
 	 */
 	public function groupShouldExist($group) {
 		PHPUnit_Framework_Assert::assertTrue($this->groupExists($group));
-		$this->addGroupToCreatedGroupsList($group);
 	}
 
 	/**
@@ -619,7 +636,7 @@ trait Provisioning {
 	 */
 	public function adminCreatesGroupUsingTheAPI($group) {
 		if (!$this->groupExists($group)) {
-			$this->createTheGroup($group);
+			$this->createTheGroup($group, 'api');
 		}
 		PHPUnit_Framework_Assert::assertTrue($this->groupExists($group));
 	}
@@ -636,6 +653,24 @@ trait Provisioning {
 		foreach ($table as $row) {
 			$this->createTheGroup($row['groupname']);
 		}
+	}
+
+	/**
+	 * @When /^the administrator sends a group creation request for group "([^"]*)" using the API$/
+	 *
+	 * @param string $group
+	 *
+	 * @return void
+	 */
+	public function adminSendsGroupCreationRequestUsingTheAPI($group) {
+		$bodyTable = new TableNode([['groupid', $group]]);
+		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+			$this->getAdminUsername(),
+			"POST",
+			"/cloud/groups",
+			$bodyTable
+		);
+		$this->addGroupToCreatedGroupsList($group);
 	}
 
 	/**


### PR DESCRIPTION
## Description
1) Remove ``addUserToCreatedUsersList`` from ``userShouldExist`` and ``addGroupToCreatedGroupsList``` from ``groupShouldExist`` - those methods are ``Then`` steps that should just test something, and not need to change or remember anything.
2) Provide new steps ``adminSendsUserCreationRequestUsingTheAPI`` and ``adminSendsGroupCreationRequestUsingTheAPI`` that can do "raw" user creation, and in those steps the code can know and remember that a user/group is created.
3) Use the new steps instead of the (user "admin" sends HTTP method "POST" to API endpoint...) step.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
Various acceptance test scenarios are doing "direct/raw" HTTP requests to test thing like basic user and group creation. In those cases, the underlying test code cannot (easily) be aware that a user or group just got created. This makes it difficult to cleanup well at the end of each scenario.

Remove "direct/raw" HTTP request user/group creation from test scenarios. Replace it with steps that can have functional understanding about what user/group was created.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring for technical debt

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

