### PR TITLE
Remove core test leftovers webUIManageUsersGroups webUIManageQuota

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,20 +65,6 @@ matrix:
         sauce_connect: true
     - php: 7.1
       if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="webUIManageUsersGroups" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 7.1
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="webUIManageQuota" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 7.1
-      if: type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest" BEHAT_SUITE="webUIPersonalSettings" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
@@ -157,20 +143,6 @@ matrix:
     - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="webUIFavorites" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 7.1
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="webUIManageUsersGroups" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 7.1
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="firefox" BROWSER_VERSION="57.0" BEHAT_SUITE="webUIManageQuota" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts
@@ -271,20 +243,6 @@ matrix:
         sauce_connect: true
     - php: 7.1
       if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="webUIManageUsersGroups" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 7.1
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="webUIManageQuota" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 7.1
-      if: type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="webUIPersonalSettings" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
@@ -369,20 +327,6 @@ matrix:
         sauce_connect: true
     - php: 7.1
       if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="webUIManageUsersGroups" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 7.1
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="webUIManageQuota" PLATFORM="Windows 10" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 7.1
-      if: type = cron
       env: DB=pgsql TC=selenium BROWSER="MicrosoftEdge" BROWSER_VERSION="latest" BEHAT_SUITE="webUIPersonalSettings" PLATFORM="Windows 10" TEST_DAV=0
       addons:
         apt: *common_apt
@@ -461,20 +405,6 @@ matrix:
     - php: 7.1
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="webUIFavorites" PLATFORM="Windows 7" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 7.1
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="webUIManageUsersGroups" PLATFORM="Windows 7" TEST_DAV=0
-      addons:
-        apt: *common_apt
-        hosts: *common_hosts
-        sauce_connect: true
-    - php: 7.1
-      if: type = cron
-      env: DB=pgsql TC=selenium BROWSER="internet explorer" BROWSER_VERSION="11.0" BEHAT_SUITE="webUIManageQuota" PLATFORM="Windows 7" TEST_DAV=0
       addons:
         apt: *common_apt
         hosts: *common_hosts

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -167,29 +167,6 @@ default:
         - WebUIUsersContext:
         - WebUIFilesContext:
 
-    webUIManageUsersGroups:
-      paths:
-        - %paths.base%/../features/webUIManageUsersGroups
-      context: *common_webui_suite_context
-      contexts:
-        - FeatureContext: *common_feature_context_params
-        - WebUIGeneralContext:
-        - WebUILoginContext:
-        - WebUIUsersContext:
-        - WebUIFilesContext:
-        - WebUIPersonalGeneralSettingsContext:
-
-    webUIManageQuota:
-      paths:
-        - %paths.base%/../features/webUIManageQuota
-      context: *common_webui_suite_context
-      contexts:
-        - FeatureContext: *common_feature_context_params
-        - WebUIGeneralContext:
-        - WebUILoginContext:
-        - WebUIUsersContext:
-        - WebUIFilesContext:
-
     webUIPersonalSettings:
       paths:
         - %paths.base%/../features/webUIPersonalSettings


### PR DESCRIPTION
## Description
Remove no longer existing webUI test suites.

## Related Issue
PR #30673 removed the code and tests

## Motivation and Context
The Travis nightly cron job is going to fail trying to run the UI acceptance test suites ``webUIManageUsersGroups`` and ``webUIManageQuota`` because those no longer exist.

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring test infrastructure

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

