### PR TITLE
Adding a system configuration which allows to set global CORS domains.

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CorsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CorsPlugin.php
@@ -96,7 +96,10 @@ class CorsPlugin extends \Sabre\DAV\ServerPlugin {
 		if ($request->getHeader('origin') !== null && !is_null($this->userSession->getUser())) {
 			$requesterDomain = $request->getHeader('origin');
 			$userId = $this->userSession->getUser()->getUID();
-			$response = \OC_Response::setCorsHeaders($userId, $requesterDomain, $response, null, $this->getExtraHeaders($request));
+			$headers = \OC_Response::setCorsHeaders($userId, $requesterDomain, null, $this->getExtraHeaders($request));
+			foreach ($headers as $key => $value) {
+				$response->addHeader($key, implode(',', $value));
+			}
 		}
 	}
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -65,6 +65,13 @@ $CONFIG = array(
     'otherdomain.example.org',
   ),
 
+/**
+ * The global list of CORS domains. All users can use tools running CORS
+ * requests from the listed domains.
+ */
+'cors.allowed-domains' => [
+	'https://foo.example.org',
+],
 
 /**
  * Where user files are stored; this defaults to ``data/`` in the ownCloud

--- a/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/CORSMiddleware.php
@@ -103,7 +103,10 @@ class CORSMiddleware extends Middleware {
 
 			$requesterDomain = $this->request->getHeader("Origin");
 
-			\OC_Response::setCorsHeaders($userId, $requesterDomain, $response, $this->config);
+			$headers = \OC_Response::setCorsHeaders($userId, $requesterDomain, $this->config);
+			foreach ($headers as $key => $value) {
+				$response->addHeader($key, implode(',', $value));
+			}
 
 			// allow credentials headers must not be true or CSRF is possible
 			// otherwise

--- a/lib/private/legacy/api.php
+++ b/lib/private/legacy/api.php
@@ -187,7 +187,10 @@ class OC_API {
 			!is_null(\OC::$server->getRequest()->getHeader('Origin'))) {
 			$requesterDomain = \OC::$server->getRequest()->getHeader('Origin');
 			$userId = \OC::$server->getUserSession()->getUser()->getUID();
-			$response = \OC_Response::setCorsHeaders($userId, $requesterDomain, $response);
+			$headers = \OC_Response::setCorsHeaders($userId, $requesterDomain);
+			foreach ($headers as $key => $value) {
+				$response->addHeader($key, implode(',', $value));
+			}
 		}
 
 		$format = self::requestedFormat();


### PR DESCRIPTION
## Description
As of today CORS domains can only be setup by a user for their own access.
There are situations where a globally deployed tool from a different domain might also want to access
ownCloud using CORS requests.

This PR introduces this feature.

## Motivation and Context
Phoenix requires this ...

## How has this been tested?
Using the sample app https://github.com/noveens/staticOwncloudWebapp
requires #30836 as well

## Screenshots (if appropriate):
![screenshot from 2018-03-20 09-33-50](https://user-images.githubusercontent.com/1005065/37643758-d7f86ede-2c21-11e8-9efb-df11b4ac0e22.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

