### PR TITLE
Treat any unknown app version as 0.0.1

### DIFF
--- a/lib/private/App/CodeChecker/InfoChecker.php
+++ b/lib/private/App/CodeChecker/InfoChecker.php
@@ -40,6 +40,7 @@ class InfoChecker extends BasicEmitter {
 		'id',
 		'licence',
 		'name',
+		'version',
 	];
 	private $optionalFields = [
 		'bugs',
@@ -53,7 +54,6 @@ class InfoChecker extends BasicEmitter {
 		'remote',
 		'repository',
 		'types',
-		'version',
 		'website',
 	];
 	private $deprecatedFields = [

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -302,6 +302,13 @@ class AppConfig implements IAppConfig {
 				$this->cache[$row['appid']] = [];
 			}
 
+			// check if installed_version matches the pattern
+			// one_or_more_digits-dot-one_or_more_digits-any-other-characters
+			if ($row['configkey'] === 'installed_version'
+				&& preg_match('/\d+\.\d+.*$/', $row['configvalue']) !== 1
+			) {
+				$row['configvalue'] = '0.0.1';
+			}
 			$this->cache[$row['appid']][$row['configkey']] = $row['configvalue'];
 		}
 		$result->closeCursor();

--- a/tests/lib/App/CodeChecker/InfoCheckerTest.php
+++ b/tests/lib/App/CodeChecker/InfoCheckerTest.php
@@ -53,10 +53,10 @@ class InfoCheckerTest extends TestCase {
 	public function appInfoData() {
 		return [
 			['testapp-infoxml', []],
-			['testapp-version', []],
+			['testapp-version', [['type' => 'mandatoryFieldMissing', 'field' => 'version']]],
 			['testapp-infoxml-version', []],
 			['testapp-infoxml-version-different', [['type' => 'differentVersions', 'message' => 'appinfo/version: 1.2.4 - appinfo/info.xml: 1.2.3']]],
-			['testapp-version-missing', []],
+			['testapp-version-missing', [['type' => 'mandatoryFieldMissing', 'field' => 'version']]],
 			['testapp-name-missing', [['type' => 'mandatoryFieldMissing', 'field' => 'name']]],
 		];
 	}


### PR DESCRIPTION
## Description
Treat any app version that doesn't fit into 
**[one or more digits]dot[one or more digits][whatever else]**
to be 0.0.1
e.g. **55.12rc7** or **0.1.3beta** are valid versions
while  '', 'null', 'false' are not

## Related Issue
Fixes https://github.com/owncloud/core/issues/30724

## Motivation and Context
App is not upgradable when `installed_version` contains garbage. The most common reason for this is missing `version` entry in appinfo.xml

## How Has This Been Tested?
1. Create apps/shitapp/appinfo
2. add an info.xml
```
<?xml version="1.0"?>
<info>
        <id>shitapp</id>
        <name>Shitapp</name>
        <description>This App provides the shitapp</description>
        <licence>AGPL</licence>
        <author>Shitman</author>
        <types>
                                <filesystem/>
        </types>
        <dependencies>
                <owncloud min-version="10.1" max-version="11.1" />
        </dependencies>
        <namespace>Shitapp</namespace>
</info>
```
3. `php occ app:enable shitapp`
4. add version tag into info.xml:
`	<version>100.100.100</version>`
5. Reload the page

### Expected
App upgrade is triggered on page reload

### Actual
It is not

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

