### PR TITLE
Make getPasswordForUser know about individual user passwords

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -751,7 +751,13 @@ trait BasicStructure {
 	public function getPasswordForUser($userName) {
 		if ($userName === $this->getAdminUsername()) {
 			return (string) $this->getAdminPassword();
+		} else if (array_key_exists($userName, $this->createdUsers)) {
+			return (string) $this->createdUsers[$userName]['password'];
+		} else if (array_key_exists($userName, $this->createdRemoteUsers)) {
+			return (string) $this->createdRemoteUsers[$userName]['password'];
 		} else {
+			// The user has not been created yet, let the caller have the
+			// default password.
 			return (string) $this->regularUserPassword;
 		}
 	}


### PR DESCRIPTION
## Description
Make ``getPasswordForUser()`` lookup the specific password of created users, rather than just give back the default ``regularUserPassword``

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
In acceptance tests, if I create user and specify a password for them, like:
```
		Given these users have been created:
			|username|password|displayname|email       |
			|user1   |1234    |User One   |u1@oc.com.np|
```
then I use various API steps to setup other things for the user, like:
```
Given user "user1" has created a "normal" tag with name "newtag"
```
then the step fails, because it calls ``getPasswordForUser("user1")`` which returns just the default password. But it needs to be smarter and return the password that was specified when creating the user.

## How Has This Been Tested?
Create a scenario like described above and verify that the tag gets created.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

