### PR TITLE
In useBigFileIDs do not depend on FeatureContext being context 0

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -876,8 +876,23 @@ trait BasicStructure {
 		$fullUrl = getenv('TEST_SERVER_URL') . "/v1.php/apps/testing/api/v1/increasefileid";
 		$client = new Client();
 		$options = [];
-		$adminUsername = $scope->getSuite()->getSettings()['contexts'][0][__CLASS__]['adminUsername'];
-		$adminPassword = $scope->getSuite()->getSettings()['contexts'][0][__CLASS__]['adminPassword'];
+		$suiteSettingsContexts = $scope->getSuite()->getSettings()['contexts'];
+		$adminUsername = null;
+		$adminPassword = null;
+		foreach ($suiteSettingsContexts as $context) {
+			if (isset($context[__CLASS__])) {
+				$adminUsername = $context[__CLASS__]['adminUsername'];
+				$adminPassword = $context[__CLASS__]['adminPassword'];
+				break;
+			}
+		}
+
+		if (($adminUsername === null) || ($adminPassword === null)) {
+			throw new \Exception(
+				"Could not find adminUsername and/or adminPassword in useBigFileIDs"
+			);
+		}
+
 		$options['auth'] = [$adminUsername, $adminPassword];
 		$client->send($client->createRequest('POST', $fullUrl, $options));
 	}


### PR DESCRIPTION
## Description
Loop through the contexts in the suite, find the context in which ``useBigFileIDs`` is being used, get the ``adminUsername`` and ``adminPassword`` parameters from there.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
At the moment, ``FeatureContext`` has to be listed first in each test suite in every ``behat.yml`` because the code in ``useBigFileIDs`` expected to find the ``FeatureContext`` parameters at index ``0`` of the suite settings ``contexts`` array.

That is less than ideal. And when getting app acceptance tests working where I want to have a local app context like ``TextEditorContext``, I am finding that I need to put ``FeatureContext`` not at the top of the list of contexts.

## How Has This Been Tested?
Running ``files_texteditor`` webUI acceptance tests with this enhancement to core, and seeing that it works.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test code

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

