### PR TITLE
Standardize case of OwncloudPage

### DIFF
--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -24,7 +24,7 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 $classLoader = new \Composer\Autoload\ClassLoader();
 $classLoader->addPsr4("Page\\", __DIR__ . "/../lib", true);
-$classLoader->addPsr4("TestHelpers\\", __DIR__ . "/../../../TestHelpers/", true);
+$classLoader->addPsr4("TestHelpers\\", __DIR__ . "/../../../TestHelpers", true);
 
 $classLoader->register();
 

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -32,7 +32,7 @@ use WebDriver\Exception\StaleElementReference;
 /**
  * Common elements/methods for all Files Pages
  */
-abstract class FilesPageBasic extends OwnCloudPage {
+abstract class FilesPageBasic extends OwncloudPage {
 
 	protected $fileActionMenuBtnXpathByNo = ".//*[@id='fileList']/tr[%d]//a[@data-action='menu']";
 	protected $fileActionMenuBtnXpath = "//a[@data-action='menu']";

--- a/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
@@ -31,7 +31,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundExc
  * Object for files action Menu on the FilesPage
  * containing actions like Rename, Delete, etc
  */
-class FileActionsMenu extends OwnCloudPage {
+class FileActionsMenu extends OwncloudPage {
 	/**
 	 * @var NodeElement of this action menu
 	 */

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -31,7 +31,7 @@ use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundExc
 /**
  * Object of a row on the FilesPage
  */
-class FileRow extends OwnCloudPage {
+class FileRow extends OwncloudPage {
 	/**
 	 * @var NodeElement of this row
 	 */


### PR DESCRIPTION
## Description
Spell ``OwncloudPage`` the same everywhere.
While we are here, make the directory reference in ``addPSR4`` not end in a ``/`` - we might as well be consistent in all usages, even though it does not seem to matter.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
I was struggling to work out why there needed to be a special ``require`` for ``OwncloudPage`` in the ``bootstrap.php`` of the ``files_texteditor`` app acceptance tests. Finally I discovered this case issue in the spelling in core.

## How Has This Been Tested?
Run some core and files_texteditor webUI acceptance tests locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix to acceptance tests

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
