### PR TITLE
Cleanup double-slash URLs in acceptance tests

### DIFF
--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -46,7 +46,11 @@ class OcsApiHelper {
 	public static function sendRequest(
 		$baseUrl, $user, $password, $method, $path, $body = [], $apiVersion = 2
 	) {
-		$fullUrl = $baseUrl . "/ocs/v{$apiVersion}.php" . $path;
+		$fullUrl = $baseUrl;
+		if (substr($fullUrl, -1) !== '/') {
+			$fullUrl .= '/';
+		}
+		$fullUrl .= "ocs/v{$apiVersion}.php" . $path;
 		$client = new Client();
 		$options = [];
 		if ($user !== null) {

--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -146,8 +146,11 @@ class SharingHelper {
 			);
 		}
 
-		$fullUrl = $baseUrl .
-			"/ocs/v{$apiVersion}.php/apps/files_sharing/api/v{$sharingApiVersion}/shares";
+		$fullUrl = $baseUrl;
+		if (substr($fullUrl, -1) !== '/') {
+			$fullUrl .= '/';
+		}
+		$fullUrl .= "ocs/v{$apiVersion}.php/apps/files_sharing/api/v{$sharingApiVersion}/shares";
 		$client = new GClient();
 		$options['auth'] = [$user, $password];
 		$fd['path'] = $path;

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -873,7 +873,11 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public static function useBigFileIDs(BeforeSuiteScope $scope) {
-		$fullUrl = getenv('TEST_SERVER_URL') . "/v1.php/apps/testing/api/v1/increasefileid";
+		$fullUrl = getenv('TEST_SERVER_URL');
+		if (substr($fullUrl, -1) !== '/') {
+			$fullUrl .= '/';
+		}
+		$fullUrl .= "v1.php/apps/testing/api/v1/increasefileid";
 		$client = new Client();
 		$options = [];
 		$suiteSettingsContexts = $scope->getSuite()->getSettings()['contexts'];


### PR DESCRIPTION
## Description
In places where the acceptance tests use ``baseURL`` and append stuff to it, add checks that put a ``/`` after ``baseURL`` only if ``baseURL`` does not already end in a ``/``

That makes it flexible to have ``baseURL`` passed in with or without a trailing slash, and to not get double-slash sent in API requests.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
When running acceptance tests, on the PHP server we see requests like:
```
[Thu Mar 22 10:00:06 2018] 127.0.0.1:45804 [200]: /ocs//v1.php/apps/testing/api/v1/increasefileid
[Thu Mar 22 10:00:06 2018] 127.0.0.1:45806 [200]: //ocs/v1.php/cloud/capabilities
[Thu Mar 22 10:00:06 2018] 127.0.0.1:45808 [200]: //ocs/v1.php/apps/testing/api/v1/apps
[Thu Mar 22 10:00:07 2018] 127.0.0.1:45810 [200]: //ocs/v1.php/apps/testing/api/v1/app/core/shareapi_enabled
[Thu Mar 22 10:00:07 2018] 127.0.0.1:45812 [200]: //ocs/v1.php/cloud/capabilities
[Thu Mar 22 10:00:07 2018] 127.0.0.1:45814 [200]: //ocs/v1.php/apps/testing/api/v1/app/core/shareapi_enabled
```
Nothing bad goes wrong, ownCloud copes with "random" double-slash in the URI. But it makes people ask questions when they notice this in acceptance test output. So it is good to clean it up.

## How Has This Been Tested?
Local runs of some API acceptance tests now give requests like:
```
[Thu Mar 22 09:53:57 2018] 127.0.0.1:45418 [200]: /ocs/v1.php/apps/testing/api/v1/increasefileid
[Thu Mar 22 09:53:57 2018] 127.0.0.1:45420 [200]: /ocs/v1.php/cloud/capabilities
[Thu Mar 22 09:53:57 2018] 127.0.0.1:45422 [200]: /ocs/v1.php/apps/testing/api/v1/apps
[Thu Mar 22 09:53:57 2018] 127.0.0.1:45424 [200]: /ocs/v1.php/apps/testing/api/v1/app/core/shareapi_enabled
[Thu Mar 22 09:53:57 2018] 127.0.0.1:45426 [200]: /ocs/v1.php/cloud/capabilities
[Thu Mar 22 09:53:57 2018] 127.0.0.1:45428 [200]: /ocs/v1.php/apps/testing/api/v1/app/core/shareapi_enabled
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test refactoring

## Checklist:
- [x My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

