### PR TITLE
[stable10] Cleanup double-slash URLs in acceptance tests

### DIFF
--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -46,7 +46,11 @@ class OcsApiHelper {
 	public static function sendRequest(
 		$baseUrl, $user, $password, $method, $path, $body = [], $apiVersion = 2
 	) {
-		$fullUrl = $baseUrl . "/ocs/v{$apiVersion}.php" . $path;
+		$fullUrl = $baseUrl;
+		if (substr($fullUrl, -1) !== '/') {
+			$fullUrl .= '/';
+		}
+		$fullUrl .= "ocs/v{$apiVersion}.php" . $path;
 		$client = new Client();
 		$options = [];
 		if ($user !== null) {

--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -146,8 +146,11 @@ class SharingHelper {
 			);
 		}
 
-		$fullUrl = $baseUrl .
-			"/ocs/v{$apiVersion}.php/apps/files_sharing/api/v{$sharingApiVersion}/shares";
+		$fullUrl = $baseUrl;
+		if (substr($fullUrl, -1) !== '/') {
+			$fullUrl .= '/';
+		}
+		$fullUrl .= "ocs/v{$apiVersion}.php/apps/files_sharing/api/v{$sharingApiVersion}/shares";
 		$client = new GClient();
 		$options['auth'] = [$user, $password];
 		$fd['path'] = $path;

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -873,7 +873,11 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public static function useBigFileIDs(BeforeSuiteScope $scope) {
-		$fullUrl = getenv('TEST_SERVER_URL') . "/v1.php/apps/testing/api/v1/increasefileid";
+		$fullUrl = getenv('TEST_SERVER_URL');
+		if (substr($fullUrl, -1) !== '/') {
+			$fullUrl .= '/';
+		}
+		$fullUrl .= "v1.php/apps/testing/api/v1/increasefileid";
 		$client = new Client();
 		$options = [];
 		$suiteSettingsContexts = $scope->getSuite()->getSettings()['contexts'];


### PR DESCRIPTION
Backport #30863 