### PR TITLE
move notifications testing app to main testing app

### DIFF
--- a/apps/testing/appinfo/app.php
+++ b/apps/testing/appinfo/app.php
@@ -19,5 +19,17 @@
  *
  */
 
+namespace OCA\Testing;
+
 $app = new \OCA\Testing\Application();
 
+\OC::$server->getNotificationManager()->registerNotifier(
+	function () {
+		return new Notifier();
+	}, function () {
+		return [
+		'id' => 'testing',
+		'name' => 'testing',
+		];
+	}
+);

--- a/apps/testing/appinfo/routes.php
+++ b/apps/testing/appinfo/routes.php
@@ -25,6 +25,7 @@ use OCA\Testing\BigFileID;
 use OCA\Testing\Config;
 use OCA\Testing\Locking\Provisioning;
 use OCA\Testing\Occ;
+use OCA\Testing\Notifications;
 use OCP\API;
 
 $config = new Config(
@@ -114,4 +115,22 @@ API::register(
 	[$occ, 'execute'],
 	'testing',
 	API::ADMIN_AUTH
+);
+
+$notifications = new Notifications(
+	'notificationsacceptancetesting',
+	\OC::$server->getRequest(),
+	\OC::$server->getNotificationManager()
+);
+\OCP\API::register(
+	'delete',
+	'/apps/testing/api/v1/notifications',
+	[$notifications, 'deleteNotifications'],
+	'notifications'
+);
+\OCP\API::register(
+	'post',
+	'/apps/testing/api/v1/notifications',
+	[$notifications, 'addNotification'],
+	'notifications'
 );

--- a/apps/testing/lib/Notifications.php
+++ b/apps/testing/lib/Notifications.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use OCP\IRequest;
+use OCP\Notification\IManager;
+
+/**
+ * controller for Notification testing
+ *
+ */
+class Notifications extends \OCP\AppFramework\Controller {
+
+	/**
+	 * @var IManager 
+	 */
+	private $manager;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IManager $manager
+	 */
+	public function __construct($appName, IRequest $request, IManager $manager) {
+		parent::__construct($appName, $request);
+
+		$this->manager = $manager;
+	}
+
+	/**
+	 * @NoCSRFRequired
+	 *
+	 * @return \OC_OCS_Result
+	 */
+	public function addNotification() {
+		$notification = $this->manager->createNotification();
+		$app = $this->request->getParam('app', 'notificationsacceptancetesting');
+		$date = \DateTime::createFromFormat(
+			'U', $this->request->getParam('timestamp', 1449585176)
+		); // 2015-12-08T14:32:56+00:00
+		$user = $this->request->getParam('user', 'test1');
+		$subject = $this->request->getParam('subject', 'testing');
+		$link = $this->request->getParam('link', 'https://www.owncloud.org/');
+		$message = $this->request->getParam('message', 'message');
+		$objectType = $this->request->getParam('object_type', 'object');
+		$objectId = $this->request->getParam('object_id', 23);
+		$notification->setApp($app)
+			->setDateTime($date)
+			->setUser($user)
+			->setSubject($subject)
+			->setLink($link)
+			->setMessage($message)
+			->setObject($objectType, $objectId);
+
+		$this->manager->notify($notification);
+
+		return new \OC_OCS_Result();
+	}
+
+	/**
+	 * @NoCSRFRequired
+	 *
+	 * @return \OC_OCS_Result
+	 */
+	public function deleteNotifications() {
+		$notification = $this->manager->createNotification();
+		$this->manager->markProcessed($notification);
+
+		return new \OC_OCS_Result();
+	}
+}

--- a/apps/testing/lib/notifier.php
+++ b/apps/testing/lib/notifier.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use OCP\Notification\INotification;
+use OCP\Notification\INotifier;
+
+/**
+ * INotifier implementation for notification testing
+ *
+ */
+class Notifier implements INotifier {
+
+	/**
+	 * @param INotification $notification
+	 * @param string $languageCode The code of the language that should be used to prepare the notification
+	 * @return INotification
+	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
+	 */
+	public function prepare(INotification $notification, $languageCode) {
+		if ($notification->getApp() === 'notificationsacceptancetesting') {
+			$notification->setParsedSubject($notification->getSubject());
+			$notification->setParsedMessage($notification->getMessage());
+			return $notification;
+		}
+
+		throw new \InvalidArgumentException();
+	}
+}


### PR DESCRIPTION
## Description
The notification app has an own testing-app to create and delete notifications in acceptance tests. This PR brings that functionality into the main testing-app

## Motivation and Context
1. no need to enable an extra app (`notificationsacceptancetesting`) during test-runs 
2. easier to test remote system
3. make test-setup uniform across core and various apps

## How Has This Been Tested?
run notifications acceptance tests locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

