### PR TITLE
systemtags are always DAV v2

### DIFF
--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -153,7 +153,7 @@ class TagsHelper {
 		$userVisible = true,
 		$userAssignable = true,
 		$groups = null,
-		$davPathVersionToUse = 1
+		$davPathVersionToUse = 2
 	) {
 		$tagsPath = '/systemtags/';
 		$body = [

--- a/tests/acceptance/features/apiMain/tags.feature
+++ b/tests/acceptance/features/apiMain/tags.feature
@@ -1,8 +1,6 @@
 @api
 Feature: tags
-  Background:
-    Given using new DAV path
-
+  
   Scenario Outline: Creating a normal tag as regular user should work
     Given user "user0" has been created
     When user "user0" creates a "normal" tag with name "<tag_name>" using the API

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -55,7 +55,7 @@ trait Tags {
 				$user,
 				$this->getPasswordForUser($user),
 				$name, $userVisible, $userAssignable, $groups,
-				$this->getDavPathVersion()
+				$this->getDavPathVersion('systemtags')
 			);
 			$lastTagId = $createdTag['lastTagId'];
 			$this->response = $createdTag['HTTPResponse'];
@@ -296,7 +296,7 @@ trait Tags {
 		$appPath = '/systemtags/';
 		$tagID = $this->findTagIdByName($tagDisplayName);
 		PHPUnit_Framework_Assert::assertNotNull($tagID, "Tag wasn't found");
-		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->davPath . $appPath . $tagID;
+		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->getDavPath('systemtags') . $appPath . $tagID;
 		try {
 			$response = $client->proppatch($fullUrl, $properties, 1);
 			$this->response = $response;
@@ -360,7 +360,7 @@ trait Tags {
 				$user,
 				$this->getPasswordForUser($user),
 				$tagID,
-				$this->getDavPathVersion()
+				$this->getDavPathVersion('systemtags')
 			);
 		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
@@ -383,7 +383,7 @@ trait Tags {
 				$this->baseUrlWithoutOCSAppendix(),
 				$taggingUser, 
 				$this->getPasswordForUser($taggingUser),
-				$tagName, $fileName, $fileOwner, $this->getDavPathVersion()
+				$tagName, $fileName, $fileOwner, $this->getDavPathVersion('systemtags')
 			);
 		} catch ( BadResponseException $e ) {
 			$this->response = $e->getResponse();
@@ -412,7 +412,7 @@ trait Tags {
 						'{http://owncloud.org/ns}can-assign'
 					  ];
 		$appPath = '/systemtags-relations/files/';
-		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->davPath . $appPath . $fileID;
+		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->getDavPath('systemtags') . $appPath . $fileID;
 		try {
 			$response = $client->propfind($fullUrl, $properties, 1);
 		} catch (Sabre\HTTP\ClientHttpException $e) {
@@ -510,7 +510,14 @@ trait Tags {
 		$path = '/systemtags-relations/files/' . $fileID . '/' . $tagID;
 		try {
 			$this->response = $this->makeDavRequest(
-				$untaggingUser, "DELETE", $path, null, null, "uploads"
+				$untaggingUser,
+				"DELETE",
+				$path,
+				null,
+				null,
+				"uploads",
+				null,
+				$this->getDavPathVersion('systemtags')
 			);
 		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -23,6 +23,7 @@ use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Client as GClient;
 use GuzzleHttp\Message\ResponseInterface;
+use GuzzleHttp\Stream\StreamInterface;
 use Sabre\DAV\Client as SClient;
 use Sabre\DAV\Xml\Property\ResourceType;
 use TestHelpers\WebDavHelper;
@@ -78,13 +79,21 @@ trait WebDav {
 		);
 	}
 
+	private function getOldDavPath() {
+		return "remote.php/webdav";
+	}
+
+	private function getNewDavPath() {
+		return "remote.php/dav";
+	}
+
 	/**
 	 * @Given /^using old (?:dav|DAV) path$/
 	 *
 	 * @return void
 	 */
 	public function usingOldDavPath() {
-		$this->davPath = "remote.php/webdav";
+		$this->davPath = $this->getOldDavPath();
 		$this->usingOldDavPath = true;
 		$this->customDavPath = null;
 	}
@@ -95,7 +104,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function usingNewDavPath() {
-		$this->davPath = "remote.php/dav";
+		$this->davPath = $this->getNewDavPath();
 		$this->usingOldDavPath = false;
 		$this->customDavPath = null;
 	}
@@ -114,14 +123,44 @@ trait WebDav {
 	}
 
 	/**
-	 * @return int DAV path version (1 or 2)
+	 * Select a suitable dav path version number.
+	 * Some endpoints have only existed since a certain point in time, so for
+	 * those make sure to return a DAV path version that works for that endpoint.
+	 * Otherwise return the currently selected DAV path version.
+	 *
+	 * @param string $for the category of endpoint that the dav path will be used for
+	 *
+	 * @return int DAV path version (1 or 2) selected, or appropriate for the endpoint
 	 */
-	private function getDavPathVersion() {
+	private function getDavPathVersion($for = null) {
+		if ($for === 'systemtags') {
+			// systemtags only exists since dav v2
+			return 2;
+		}
+
 		if ($this->usingOldDavPath === true) {
 			return 1;
 		} else {
 			return 2;
 		}
+	}
+
+	/**
+	 * Select a suitable dav path.
+	 * Some endpoints have only existed since a certain point in time, so for
+	 * those make sure to return a DAV path that works for that endpoint.
+	 * Otherwise return the currently selected DAV path.
+	 *
+	 * @param string $for the category of endpoint that the dav path will be used for
+	 *
+	 * @return string DAV path selected, or appropriate for the endpoint
+	 */
+	private function getDavPath($for = null) {
+		if ($this->getDavPathVersion($for) === 1) {
+			return $this->getOldDavPath();
+		}
+
+		return $this->getNewDavPath();
 	}
 
 	/**
@@ -132,27 +171,32 @@ trait WebDav {
 	 * @param StreamInterface $body
 	 * @param string $type
 	 * @param string|null $requestBody
+	 * @param string|null $davPathVersion
 	 *
 	 * @return \GuzzleHttp\Message\FutureResponse|ResponseInterface|NULL
 	 */
-	public function makeDavRequest($user,
+	public function makeDavRequest(
+		$user,
 		$method,
 		$path,
 		$headers,
 		$body = null,
 		$type = "files",
-		$requestBody = null
+		$requestBody = null,
+		$davPathVersion = null
 	) {
-	
-
 		if ($this->customDavPath !== null) {
 			$path = $this->customDavPath . $path;
+		}
+
+		if ($davPathVersion === null) {
+			$davPathVersion = $this->getDavPathVersion();
 		}
 
 		return WebDavHelper::makeDavRequest(
 			$this->baseUrlWithoutOCSAppendix(),
 			$user, $this->getPasswordForUser($user), $method,
-			$path, $headers, $body, $requestBody, $this->getDavPathVersion(),
+			$path, $headers, $body, $requestBody, $davPathVersion,
 			$type
 		);
 	}
@@ -890,7 +934,7 @@ trait WebDav {
 	 * @return string
 	 */
 	public function makeSabrePathNotForFiles($path) {
-		return $this->encodePath($this->davPath . $path);
+		return $this->encodePath($this->getDavPath() . $path);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Teach ``getDavPathVersion`` that ``systemtags`` is only available since DAV version 2.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
Today I was getting firewall acceptance tests to use core API acceptance test methods to set up the scenarios. Some scenarios needed to create system tags. The step did not work. Eventually I discovered that you have to have the step:
```
Given using new dav path
```
always before doing something like:
```
And user "admin" has created a "normal" tag with name "MyTagName"
```
It would be nice to not have this step dependency. It will save someone else some pain in the future.

## How Has This Been Tested?
Run tags acceptance tests locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

