### PR TITLE
Put setUpExternalUserBackends inside setUpScenario

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -159,7 +159,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function overrideBaseUrlWithWebUIValue($newBaseUrl) {
-		// baseUrl in the API tests featureContext uses a form with '/ocs/'
+		// baseUrl in the API tests FeatureContext uses a form with '/ocs/'
 		// on the end so add that.
 		if (substr($newBaseUrl, -1) !== '/') {
 			$newBaseUrl .= '/';

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -77,7 +77,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 
 	/**
 	 *
-	 * @var featureContext
+	 * @var FeatureContext
 	 */
 	private $featureContext;
 

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -488,29 +488,6 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @BeforeScenario @webUI
-	 * @TestAlsoOnExternalUserBackend
-	 *
-	 * @return void
-	 */
-	public function setUpExternalUserBackends() {
-		//TODO make it smarter to be able also to work with other backends
-		if (getenv("TEST_EXTERNAL_USER_BACKENDS") === "true") {
-			$result = SetupHelper::runOcc(
-				["user:sync", "OCA\User_LDAP\User_Proxy", "-m remove"]
-			);
-			if ((int)$result['code'] !== 0) {
-				throw new Exception(
-					"could not sync users with LDAP. stdOut:\n" .
-					$result['stdOut'] . "\n" .
-					"stdErr:\n" .
-					$result['stdErr'] . "\n"
-				);
-			}
-		}
-	}
-
-	/**
 	 * Return the baseUrl in the form that the webUI tests use.
 	 *
 	 * @return string
@@ -526,7 +503,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function setUpSuite(BeforeScenarioScope $scope) {
+	public function setUpScenario(BeforeScenarioScope $scope) {
 		// Get the environment
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context
@@ -574,6 +551,21 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			]
 		);
 
+		//TODO make it smarter to be able also to work with other backends
+		if (getenv("TEST_EXTERNAL_USER_BACKENDS") === "true") {
+			$result = SetupHelper::runOcc(
+				["user:sync", "OCA\User_LDAP\User_Proxy", "-m remove"]
+			);
+			if ((int)$result['code'] !== 0) {
+				throw new Exception(
+					"could not sync users with LDAP. stdOut:\n" .
+					$result['stdOut'] . "\n" .
+					"stdErr:\n" .
+					$result['stdErr'] . "\n"
+				);
+			}
+		}
+
 		$this->featureContext->overrideBaseUrlWithWebUIValue(
 			$this->getBaseUrlInWebUITestFormat()
 		);
@@ -604,6 +596,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			]
 		);
 	}
+
 	/**
 	 * @return string
 	 */


### PR DESCRIPTION
## Description
Put ``setUpExternalUserBackends`` inside ``setUpScenario`` so that ``SetupHelper::init`` runs first.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
When running user_ldap acceptance tests, it complains:
```
  ┌─ @BeforeScenario @webUI # WebUIGeneralContext::setUpExternalUserBackends()
  │
  ╳  Exception: runOcc called before init in /var/www/owncloud/tests/TestHelpers/SetupHelper.php:278
  ╳  Stack trace:
╳ #0 /var/www/owncloud/tests/acceptance/features/bootstrap/WebUIGeneralContext.php(500): TestHelpers\SetupHelper::runOcc(Array)
```

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
