### PR TITLE
Handle frontend only apps directly in the navigation manager

### DIFF
--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -141,7 +141,8 @@ class NavigationManager implements INavigationManager {
 				continue;
 			}
 			$nav = $info['navigation'];
-			if (!isset($nav['route'])) {
+			// either a route or a static page must be defined
+			if (!isset($nav['route']) && !isset($nav['static'])) {
 				continue;
 			}
 			$role = isset($nav['@attributes']['role']) ? $nav['@attributes']['role'] : 'all';
@@ -153,7 +154,15 @@ class NavigationManager implements INavigationManager {
 			}
 			$l = $this->l10nFac->get($app);
 			$order = isset($nav['order']) ? $nav['order'] : 100;
-			$route = $this->urlGenerator->linkToRoute($nav['route']);
+			if (isset($nav['route'])) {
+				$route = $this->urlGenerator->linkToRoute($nav['route']);
+			} else {
+				$html = 'index.html';
+				if (isset($nav['static'])) {
+					$html = $nav['static'];
+				}
+				$route = $this->urlGenerator->linkTo($app, $html);
+			}
 			$name = isset($nav['name']) ? $nav['name'] : ucfirst($app);
 			$icon = isset($nav['icon']) ? $nav['icon'] : 'app.svg';
 			$iconPath = null;

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -186,9 +186,14 @@ class NavigationManagerTest extends TestCase {
 		$urlGenerator->expects($this->any())->method('imagePath')->willReturnCallback(function($appName, $file) {
 			return "/apps/$appName/img/$file";
 		});
-		$urlGenerator->expects($this->exactly(count($expected)))->method('linkToRoute')->willReturnCallback(function($route) {
-			return "/apps/test/";
-		});
+		if (isset($config['navigation']['static'])) {
+			$urlGenerator->expects($this->never())->method('linkToRoute')->willReturn('/apps/test/');
+			$urlGenerator->expects($this->once())->method('linkTo')->willReturn('link-to-static');
+		} else {
+			$urlGenerator->expects($this->exactly(count($expected)))->method('linkToRoute')->willReturn('/apps/test/');
+			$urlGenerator->expects($this->never())->method('linkTo')->willReturn('link-to-static');
+		}
+
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())->method('getUID')->willReturn('user001');
 		$userSession->expects($this->any())->method('getUser')->willReturn($user);
@@ -218,7 +223,15 @@ class NavigationManagerTest extends TestCase {
 				'name' => 'Test',
 				'active' => false
 			]], ['navigation' => ['@attributes' => ['role' => 'admin'], 'route' => 'test.page.index']], true],
-			'admin' => [[], ['navigation' => ['@attributes' => ['role' => 'admin'], 'route' => 'test.page.index']]]
+			'admin' => [[], ['navigation' => ['@attributes' => ['role' => 'admin'], 'route' => 'test.page.index']]],
+			'with static' => [[[
+				'id' => 'test',
+				'order' => 100,
+				'href' => 'link-to-static',
+				'icon' => '/apps/test/img/app.svg',
+				'name' => 'Test',
+				'active' => false
+			]], ['navigation' => ['static' => 'static.html']]],
 		];
 	}
 }


### PR DESCRIPTION
Following info.xml allows apps to simply deliver html+css+js app being natively integrated into the navigation menu

![screenshot from 2018-03-23 15-01-33](https://user-images.githubusercontent.com/1005065/37833257-205cf132-2eab-11e8-9b6c-217c734d18eb.png)

```xml
<?xml version="1.0"?>
<info>
	<id>static_web_app</id>
	<name>Static Demo</name>
	<summary>Static Demo</summary>
	<description>Static Demo</description>
	<licence>AGPL</licence>
	<author>Thomas Müller</author>
	<version>0.0.1</version>
	<category>tools</category>
	<dependencies>
		<owncloud min-version="10.0" max-version="10.1" />
	</dependencies>
	<navigation>
		<name>Static Demo</name>
                <static>index.html</static>
	</navigation>
	</frontend>
</info>



