### PR TITLE
[stable10] Add a config option to ignore missing signature

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1241,6 +1241,11 @@ $CONFIG = array(
 		'.user.ini',
 	),
 /**
+ * The list of apps that are allowed to have no signature.json
+ */
+'integrity.ignore.missing.app.signature' => [],
+
+/**
  * Define a default folder for shared files and folders other than root.
  */
 'share_folder' => '/',

--- a/lib/private/IntegrityCheck/Exceptions/MissingSignatureException.php
+++ b/lib/private/IntegrityCheck/Exceptions/MissingSignatureException.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\IntegrityCheck\Exceptions;
+
+/**
+ * Class MissingSignatureException
+ *
+ * @package OC\IntegrityCheck\Exceptions
+ */
+class MissingSignatureException extends InvalidSignatureException {
+}

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -138,20 +138,42 @@ class CheckerTest extends TestCase {
 		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $x509, $rsa);
 	}
 
+	public function testIgnoredAppSignatureWithoutSignatureData() {
+		$this->environmentHelper
+			->expects($this->once())
+			->method('getChannel')
+			->will($this->returnValue('stable'));
+		$configMap = [
+			['integrity.check.disabled', false, false],
+			['integrity.ignore.missing.app.signature', [], ['SomeApp']]
+		];
+		$this->config
+			->expects($this->any())
+			->method('getSystemValue')
+			->will($this->returnValueMap($configMap));
+
+		$expected = [];
+		$this->assertSame($expected, $this->checker->verifyAppSignature('SomeApp'));
+	}
+
+
 	public function testVerifyAppSignatureWithoutSignatureData() {
 		$this->environmentHelper
 				->expects($this->once())
 				->method('getChannel')
 				->will($this->returnValue('stable'));
+		$configMap = [
+			['integrity.check.disabled', false, false],
+			['integrity.ignore.missing.app.signature', [], []]
+		];
 		$this->config
-				->expects($this->any())
-				->method('getSystemValue')
-				->with('integrity.check.disabled', false)
-				->will($this->returnValue(false));
+			->expects($this->any())
+			->method('getSystemValue')
+			->will($this->returnValueMap($configMap));
 
 		$expected = [
 			'EXCEPTION' => [
-					'class' => 'OC\IntegrityCheck\Exceptions\InvalidSignatureException',
+					'class' => 'OC\IntegrityCheck\Exceptions\MissingSignatureException',
 					'message' => 'Signature data not found.',
 			],
 		];
@@ -626,7 +648,7 @@ class CheckerTest extends TestCase {
 
 		$expected = [
 			'EXCEPTION' => [
-				'class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException',
+				'class' => 'OC\\IntegrityCheck\\Exceptions\\MissingSignatureException',
 				'message' => 'Signature data not found.',
 			],
 		];


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/30819

## Description
Allows certain apps to have a missing signature

## Related Issue
https://github.com/owncloud/core/issues/29094

## Motivation and Context
Blocks developing custom inhouse app-themes for our community

## How Has This Been Tested?
By
1. uploading this patch to my `10.0.7.2` cloud, 
2. listing my  app-theme in config.php with
`'integrity.ignore.missing.app.signature' => ['theme-1'],`
3. clicking `Rescan`
UPD. I tested  it more with several apps and found that clicking `Rescan` rescans core only, for apps rescan is done when any app is disabled/reenabled (this PR still works nevertheless)

### Expected & Actual 
app-theme is no longer reported in integrity check

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

