### PR TITLE
Remember which groups and users were really created

### DIFF
--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -124,7 +124,7 @@ class SharingDialog extends OwncloudPage {
 	public function groupStringsToMatchAutoComplete($groupNames) {
 		if (is_array($groupNames)) {
 			$autocompleteStrings = array();
-			foreach ($groupNames as $groupName) {
+			foreach ($groupNames as $groupName => $groupData) {
 				$autocompleteStrings[] = $groupName . $this->suffixToIdentifyGroups;
 			}
 		} else {


### PR DESCRIPTION
## Description
When processing user and group creation in the acceptance tests, keep track of which users and groups were actually created. 

And then only delete the things that were actually created "locally".
i.e. do not try to delete users and groups that come from LDAP.

## Related Issue
https://github.com/owncloud/QA/issues/517

## Motivation and Context
After recent refactorings in core, ``user_ldap`` acceptance tests fail because they try to cleanup users and groups at the end of a scenario. Actually the code should not do that - the users and groups are in the LDAP server and it is not relevant to try to "delete" them locally.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

