### PR TITLE
fix phpdoc

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -532,7 +532,7 @@ class OC_App {
 	/**
 	 * Get the path where to install apps
 	 *
-	 * @return string|false
+	 * @return string|null
 	 */
 	public static function getInstallPath() {
 		foreach (OC::$APPSROOTS as $dir) {


### PR DESCRIPTION
## Description
phpDoc of `OC_App::getInstallPath()` says it returns string|false but it returns `null`

## Motivation and Context
“Documentation is a love letter that you write to your future self.” - Damian Conway

## How Has This Been Tested?
:thinking: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

