### PR TITLE
fix changing own email address and fullname

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -992,7 +992,7 @@ OC.msg = {
 	 * is displayed as an error/success
 	 */
 	finishedAction: function (selector, response) {
-		if (response.status === "success") {
+		if (response.status === "success" || response.status === "ok") {
 			this.finishedSuccess(selector, response.data.message);
 		} else {
 			this.finishedError(selector, response.data.message);

--- a/settings/js/panels/profile.js
+++ b/settings/js/panels/profile.js
@@ -8,20 +8,23 @@ function changeEmailAddress () {
 	}
 	emailInfo.defaultValue = emailInfo.val();
 	OC.msg.startSaving('#lostpassword .msg');
-	var post = $("#lostpassword").serializeArray();
 	$.ajax({
 		type: 'PUT',
-		url: OC.generateUrl('/settings/users/{id}/mailAddress', {id: OC.currentUser}),
-		data: {
-			mailAddress: post[0].value
-		}
+		url: OC.linkToOCS('cloud/users', 2) + encodeURIComponent(OC.currentUser) +
+			 "?format=json",
+		data: "key=email&value=" + encodeURIComponent(emailInfo.val()),
 	}).done(function(result){
-		// I know the following 4 lines look weird, but that is how it works
 		// in jQuery -  for success the first parameter is the result
 		//              for failure the first parameter is the result object
+		result.status = result.ocs.meta.status;
+		result.data = new Object();
+		result.data.message = t('settings', 'Email has been changed successfully.');
 		OC.msg.finishedSaving('#lostpassword .msg', result);
 	}).fail(function(result){
-		OC.msg.finishedSaving('#lostpassword .msg', result.responseJSON);
+		result.status = result.responseJSON.ocs.meta.status;
+		result.data = new Object();
+		result.data.message = t('settings', 'Unable to change mail address');
+		OC.msg.finishedSaving('#lostpassword .msg', result);
 	});
 }
 
@@ -31,23 +34,31 @@ function changeEmailAddress () {
 function changeDisplayName () {
 	if ($('#displayName').val() !== '') {
 		OC.msg.startSaving('#displaynameform .msg');
-		// Serialize the data
-		var post = $("#displaynameform").serialize();
 		// Ajax foo
-		$.post(OC.generateUrl('/settings/users/{id}/displayName', {id: OC.currentUser}), post, function (data) {
-			if (data.status === "success") {
-				$('#oldDisplayName').val($('#displayName').val());
-				// update displayName on the top right expand button
-				$('#expandDisplayName').text($('#displayName').val());
-				// update avatar if avatar is available
-				if(!$('#removeavatar').hasClass('hidden')) {
-					updateAvatar();
-				}
+		$.ajax({
+			type: 'PUT',
+			url: OC.linkToOCS('cloud/users', 2) +
+				 encodeURIComponent(OC.currentUser) +
+				 "?format=json",
+			data: "key=display&value=" + encodeURIComponent($('#displayName').val())
+		}).done(function(result){
+			$('#oldDisplayName').val($('#displayName').val());
+			// update displayName on the top right expand button
+			$('#expandDisplayName').text($('#displayName').val());
+			// update avatar if avatar is available
+			if(!$('#removeavatar').hasClass('hidden')) {
+				updateAvatar();
 			}
-			else {
-				$('#newdisplayname').val(data.data.displayName);
-			}
-			OC.msg.finishedSaving('#displaynameform .msg', data);
+			result.status = result.ocs.meta.status;
+			result.data = new Object();
+			result.data.message = t('settings', 'Your full name has been changed.');
+			OC.msg.finishedSaving('#displaynameform .msg', result);
+		}).fail(function(result){
+			$('#displayName').val($('#oldDisplayName').val());
+			result.status = result.responseJSON.ocs.meta.status;
+			result.data = new Object();
+			result.data.message = result.responseJSON.ocs.meta.message;
+			OC.msg.finishedSaving('#displaynameform .msg', result);
 		});
 	}
 }

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -200,6 +200,7 @@ default:
         - WebUIFilesContext:
         - WebUIPersonalSecuritySettingsContext:
         - WebUIPersonalGeneralSettingsContext:
+        - WebUIUserContext:
 
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1338,6 +1338,22 @@ trait Provisioning {
 	}
 
 	/**
+	 * @Then the attributes of user :user returned by the API should include
+	 *
+	 * @param string $user
+	 * @param \Behat\Gherkin\Node\TableNode $body
+	 *
+	 * @return void
+	 */
+	public function checkAttributesForUser($user, $body) {
+		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+			$this->getAdminUsername(), "GET", "/cloud/users/$user",
+			null
+		);
+		$this->checkUserAttributes($body);
+	}
+
+	/**
 	 * @BeforeScenario
 	 * @AfterScenario
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -41,6 +41,12 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	private $featureContext;
 
 	/**
+	 *
+	 * @var WebUIGeneralContext
+	 */
+	private $webUIGeneralContext;
+
+	/**
 	 * WebUIPersonalGeneralSettingsContext constructor.
 	 *
 	 * @param PersonalGeneralSettingsPage $personalGeneralSettingsPage
@@ -61,6 +67,9 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 		$this->personalGeneralSettingsPage->open();
 		$this->personalGeneralSettingsPage->waitForOutstandingAjaxCalls(
 			$this->getSession()
+		);
+		$this->webUIGeneralContext->setCurrentPageObject(
+			$this->personalGeneralSettingsPage
 		);
 	}
 
@@ -124,7 +133,33 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 			$oldPassword, $newPassword, $this->getSession()
 		);
 	}
-	
+
+	/**
+	 * @When the user changes the full name to :newFullname using the webUI
+	 *
+	 * @param string $newFullname
+	 *
+	 * @return void
+	 */
+	public function theUserChangesTheFullnameToUsingTheWebUI($newFullname) {
+		$this->personalGeneralSettingsPage->changeFullname(
+			$newFullname, $this->getSession()
+		);
+	}
+
+	/**
+	 * @When the user changes the email address to :emailAddress using the webUI
+	 *
+	 * @param string $emailAddress
+	 *
+	 * @return void
+	 */
+	public function theUserChangesTheEmailAddressToUsingTheWebUI($emailAddress) {
+		$this->personalGeneralSettingsPage->changeEmailAddress(
+			$emailAddress, $this->getSession()
+		);
+	}
+
 	/**
 	 * @Then a password error message should be displayed on the webUI with the text :wrongPasswordmessageText
 	 *
@@ -156,5 +191,6 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
+		$this->webUIGeneralContext = $environment->getContext('WebUIGeneralContext');
 	}
 }

--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -39,6 +39,9 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	protected $personalProfilePanelId = "OC\Settings\Panels\Personal\Profile";
 	protected $oldPasswordInputID = "pass1";
 	protected $newPasswordInputID = "pass2";
+	protected $fullNameInputID = "displayName";
+	protected $emailAddressInputID = "email";
+	protected $changeEmailButtonID = "emailbutton";
 	protected $changePasswordButtonID = "passwordbutton";
 	protected $passwordErrorMessageID = "password-error";
 
@@ -104,6 +107,39 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 		$changePasswordButton->click();
 		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
+
+	/**
+	 *
+	 * @param string $newFullname
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function changeFullname($newFullname, Session $session) {
+		$this->fillField($this->fullNameInputID, $newFullname);
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
+	 *
+	 * @param string $newEmailAddress
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function changeEmailAddress($newEmailAddress, Session $session) {
+		$this->fillField($this->emailAddressInputID, $newEmailAddress);
+		$changeEmailButton = $this->findById($this->changeEmailButtonID);
+		if (is_null($changeEmailButton)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" could not find element with id $this->changePasswordButtonID"
+			);
+		}
+		$changeEmailButton->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
 	/**
 	 *
 	 * @throws ElementNotFoundException

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
@@ -1,0 +1,18 @@
+@webUI @insulated
+Feature: Change own email address on the personal settings page
+As a user
+I would like to change my own email address
+So that I can be reached by the owncloud server
+
+	Background:
+		Given these users have been created:
+		|username|password|displayname|email       |
+		|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has browsed to the personal general settings page
+
+	Scenario: Change full name 
+		When the user changes the email address to "new-address@owncloud.com" using the webUI
+		Then the attributes of user "user1" returned by the API should include
+			| email | new-address@owncloud.com |

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
@@ -1,0 +1,20 @@
+@webUI @insulated
+Feature: Change own full name on the personal settings page
+As a user
+I would like to change my own full name
+So that other users can recognize me by it
+
+	Background:
+		Given these users have been created:
+		|username|password|displayname|email       |
+		|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has browsed to the personal general settings page
+
+	Scenario: Change full name 
+		When the user changes the full name to "my#very&weird?नेपालि%name" using the webUI
+		And the user reloads the current page of the webUI
+		Then "my#very&weird?नेपालि%name" should be shown as the name of the current user on the WebUI
+		And the attributes of user "user1" returned by the API should include
+			| displayname | my#very&weird?नेपालि%name |


### PR DESCRIPTION
## Description
set personal email  and full name by using the ocs provisioning api

## Related Issue
#30915

## Motivation and Context
make it possible to change this values again and do not require the user management app to be enabled

## How Has This Been Tested?
manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

