### PR TITLE
Add symfony events for delete and create share

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -469,13 +469,6 @@ class Share20OCS {
 		$share->setShareType($shareType);
 		$share->setSharedBy($this->currentUser->getUID());
 
-
-
-
-		$beforeEvent->setArgument('share', $this->formatShare($share));
-
-		$this->eventDispatcher->dispatch('share.beforeCreate', $beforeEvent);
-
 		try {
 			$share = $this->shareManager->createShare($share);
 		} catch (GenericShareException $e) {
@@ -492,10 +485,6 @@ class Share20OCS {
 		$share->getNode()->unlock(\OCP\Lock\ILockingProvider::LOCK_SHARED);
 
 		$formattedShareAfterCreate = $this->formatShare($share);
-		$afterEvent = new GenericEvent(null, []);
-		$afterEvent->setArgument('share', $formattedShareAfterCreate);
-		$afterEvent->setArgument('result', 'success');
-		$this->eventDispatcher->dispatch('share.afterCreate', $afterEvent);
 		return new \OC\OCS\Result($formattedShareAfterCreate);
 	}
 

--- a/apps/files_sharing/tests/API/Share20OCSTest.php
+++ b/apps/files_sharing/tests/API/Share20OCSTest.php
@@ -24,7 +24,6 @@
  */
 namespace OCA\Files_Sharing\Tests\API;
 
-use JMS\Serializer\EventDispatcher\EventDispatcher;
 use OCA\Files_Sharing\API\Share20OCS;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -38,6 +37,7 @@ use OCP\IUserManager;
 use OCP\Lock\LockedException;
 use OCP\Share;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\TestCase;
 
 /**
@@ -108,7 +108,7 @@ class Share20OCSTest extends TestCase {
 				['core', 'shareapi_default_permissions', \OCP\Constants::PERMISSION_ALL, \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE]
 			]));
 
-		$this->eventDispatcher = \OC::$server->getEventDispatcher();
+		$this->eventDispatcher = new EventDispatcher();
 
 		$this->ocs = new Share20OCS(
 			$this->shareManager,
@@ -831,20 +831,11 @@ class Share20OCSTest extends TestCase {
 			}))
 			->will($this->returnArgument(0));
 
-		$calledAfterCreate = [];
-		\OC::$server->getEventDispatcher()->addListener('share.afterCreate', function (GenericEvent $event) use (&$calledAfterCreate) {
-			$calledAfterCreate[] = 'share.afterCreate';
-			$calledAfterCreate[] = $event;
-		});
 		$expected = new \OC\OCS\Result();
 		$result = $ocs->createShare();
 
 		$this->assertEquals($expected->getMeta(), $result->getMeta());
 		$this->assertEquals($expected->getData(), $result->getData());
-		$this->assertEquals('share.afterCreate', $calledAfterCreate[0]);
-		$this->assertInstanceOf(GenericEvent::class, $calledAfterCreate[1]);
-		$this->assertEquals('success', $calledAfterCreate[1]->getArgument('result'));
-		$this->assertArrayHasKey('share', $calledAfterCreate[1]);
 	}
 
 	public function testCreateShareGroupNoValidShareWith() {
@@ -2850,69 +2841,6 @@ class Share20OCSTest extends TestCase {
 		$result = $this->invokePrivate($ocs, 'formatShare', [$share]);
 
 		$this->assertEquals($expectedInfo, $result['share_with_additional_info']);
-	}
-
-	public function testBeforeAndAfterCreateHooksAreCalled() {
-		$ocs = $this->mockFormatShare();
-		$share = $this->newShare();
-		$this->shareManager->method('newShare')->willReturn($share);
-
-		$storage = $this->createMock('OCP\Files\Storage');
-		$storage->method('instanceOfStorage')
-			->with('OCA\Files_Sharing\External\Storage')
-			->willReturn(false);
-		$path = $this->createMock('\OCP\Files\File');
-		$path->method('getStorage')
-			->willReturn($storage);
-
-		$userFolder = $this->createMock('\OCP\Files\Folder');
-		$node = $this->createMock('\OCP\Files\Node');
-		$node->method('getStorage')
-			->willReturn($storage);
-		$userFolder->method('get')->willReturn($node);
-		$this->request
-			->method('getParam')
-			->will($this->returnValueMap([
-				['path', null, 'valid-path'],
-				['permissions', null, \OCP\Constants::PERMISSION_ALL],
-				['shareType', $this->any(), Share::SHARE_TYPE_USER],
-				['shareWith', null, 'validUser'],
-			]));
-
-		$this->rootFolder
-			->method('getUserFolder')
-			->with('currentUser')
-			->willReturn($userFolder);
-		$this->userManager->method('userExists')
-			->withAnyParameters()
-			->willReturn(true);
-		$this->shareManager
-			->method('createShare')
-			->willReturn($share);
-
-		$shareBeforeCreateCalled = false;
-
-		\OC::$server->getEventDispatcher()->addListener('share.beforeCreate', function (GenericEvent $event) use (&$shareBeforeCreateCalled) {
-			$shareBeforeCreateCalled = true;
-			$this->assertInstanceOf('Symfony\Component\EventDispatcher\GenericEvent', $event);
-			$args = $event->getArguments();
-			$this->assertArrayHasKey('share', $args);
-			$this->assertArrayHasKey('run', $args);
-		});
-
-		$shareAfterCreateCalled = false;
-
-		\OC::$server->getEventDispatcher()->addListener('share.afterCreate', function (GenericEvent $event) use (&$shareAfterCreateCalled) {
-			$shareAfterCreateCalled = true;
-			$this->assertInstanceOf('Symfony\Component\EventDispatcher\GenericEvent', $event);
-			$args = $event->getArguments();
-			$this->assertArrayHasKey('share', $args);
-		});
-
-		$ocs->createShare();
-
-		$this->assertTrue($shareBeforeCreateCalled, 'share.beforeCreate not called');
-		$this->assertTrue($shareAfterCreateCalled, 'share.afterCreate not called');
 	}
 }
 

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -150,7 +150,7 @@ class ApiTest extends TestCase {
 
 		$this->assertEquals('share.beforeCreate', $calledBeforeCreate[0]);
 		$this->assertInstanceOf(GenericEvent::class, $calledBeforeCreate[1]);
-		$this->assertTrue($calledBeforeCreate[1]->getArgument('run'));
+		$this->assertTrue($calledBeforeCreate[1]->getArgument('shareData')['run']);
 		$this->assertTrue($result->succeeded());
 		$data = $result->getData();
 		$this->assertEquals(19, $data['permissions']);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -863,7 +863,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$c->getL10N('core'),
 				$factory,
 				$c->getUserManager(),
-				$c->getLazyRootFolder()
+				$c->getLazyRootFolder(),
+				$c->getEventDispatcher()
 			);
 
 			return $manager;


### PR DESCRIPTION
Add symfony events for delete share.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Adding symfony events for delete share. This was missing in the code base.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding symfony events for delete share. This was missing in the codebase.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

