### PR TITLE
[stable10] Remove cache data from the symfony events

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -132,9 +132,21 @@ class Config {
 	 * @param mixed $value value
 	 */
 	public function setValue($key, $value) {
+		/**
+		 * update and oldvalue help the after event listeners to know
+		 * if its an update or not. If update then get the old value.
+		 */
+		$update = false;
+		$oldValue = null;
 		if ($this->isReadOnly()) {
 			throw new \Exception('Config file is read only.');
 		}
+
+		if (isset($this->cache[$key])) {
+			$update = true;
+			$oldValue = $this->cache[$key];
+		}
+
 		$this->emittingCall(function () use (&$key, &$value) {
 			if ($this->set($key, $value)) {
 				// Write changes
@@ -142,8 +154,8 @@ class Config {
 			}
 			return true;
 		}, [
-			'before' => ['key' => $key, 'value' => $value, 'cache' => $this->cache],
-			'after' => ['key' => $key, 'value' => $value, 'cache' => $this->cache]
+			'before' => ['key' => $key, 'value' => $value],
+			'after' => ['key' => $key, 'value' => $value, 'update' => $update, 'oldvalue' => $oldValue]
 		], 'config', 'setvalue');
 	}
 
@@ -179,8 +191,8 @@ class Config {
 			}
 			return true;
 		}, [
-			'before' => ['key' => $key, 'cache' => $this->cache],
-			'after' => ['key' => $key, 'cache' => $this->cache]
+			'before' => ['key' => $key],
+			'after' => ['key' => $key]
 		], 'config', 'deletevalue');
 	}
 

--- a/lib/public/Events/EventEmitterTrait.php
+++ b/lib/public/Events/EventEmitterTrait.php
@@ -44,12 +44,12 @@ trait EventEmitterTrait {
 	 * @since 10.0.5
 	 */
 	public function emittingCall(\Closure $fn, $arguments ,$class, $eventName) {
-		if (isset($arguments['before']) and count($arguments['before']) > 0) {
+		if (isset($arguments['before']) && count($arguments['before']) > 0) {
 			\OC::$server->getEventDispatcher()->dispatch("$class.before$eventName", new GenericEvent(null, $arguments['before']));
 		}
-		$result = $fn();
-		if (($result !== false) && ($result !== null) and
-			(isset($arguments['after']) and count($arguments['after']) > 0)) {
+		$result = isset($arguments['after']) ? $fn($arguments['after']) : $fn([]);
+		if (($result !== false) && ($result !== null) &&
+			(isset($arguments['after']) && count($arguments['after']) > 0)) {
 			\OC::$server->getEventDispatcher()->dispatch("$class.after$eventName", new GenericEvent(null, $arguments['after']));
 		}
 		return $result;

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -227,11 +227,11 @@ class AppConfigTest extends TestCase {
 		$this->assertArrayHasKey('key', $calledBeforeSetValue[1]);
 		$this->assertArrayHasKey('value', $calledBeforeSetValue[1]);
 		$this->assertArrayHasKey('app', $calledBeforeSetValue[1]);
-		$this->assertArrayHasKey('appcache', $calledBeforeSetValue[1]);
 		$this->assertArrayHasKey('key', $calledAfterSetValue[1]);
 		$this->assertArrayHasKey('value', $calledAfterSetValue[1]);
 		$this->assertArrayHasKey('app', $calledAfterSetValue[1]);
-		$this->assertArrayHasKey('appcache', $calledAfterSetValue[1]);
+		$this->assertArrayHasKey('update', $calledAfterSetValue[1]);
+		$this->assertArrayHasKey('oldvalue', $calledAfterSetValue[1]);
 
 		$this->assertEquals('1.33.7', $config->getValue('testapp', 'installed_version'));
 		$this->assertConfigKey('testapp', 'installed_version', '1.33.7');
@@ -268,11 +268,11 @@ class AppConfigTest extends TestCase {
 		$this->assertArrayHasKey('key', $calledBeforeSetValue[1]);
 		$this->assertArrayHasKey('value', $calledBeforeSetValue[1]);
 		$this->assertArrayHasKey('app', $calledBeforeSetValue[1]);
-		$this->assertArrayHasKey('appcache', $calledBeforeSetValue[1]);
 		$this->assertArrayHasKey('key', $calledAfterSetValue[1]);
 		$this->assertArrayHasKey('value', $calledAfterSetValue[1]);
 		$this->assertArrayHasKey('app', $calledAfterSetValue[1]);
-		$this->assertArrayHasKey('appcache', $calledAfterSetValue[1]);
+		$this->assertArrayHasKey('update', $calledAfterSetValue[1]);
+		$this->assertArrayHasKey('oldvalue', $calledAfterSetValue[1]);
 
 		$this->assertTrue($config->hasKey('someapp', 'somekey'));
 		$this->assertEquals('somevalue', $config->getValue('someapp', 'somekey'));

--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -96,10 +96,10 @@ class ConfigTest extends TestCase {
 		$this->assertEquals('config.aftersetvalue', $calledAfterSetValue[0]);
 		$this->assertArrayHasKey('key', $calledBeforeSetValue[1]);
 		$this->assertArrayHasKey('value', $calledBeforeSetValue[1]);
-		$this->assertArrayHasKey('cache', $calledBeforeSetValue[1]);
 		$this->assertArrayHasKey('key', $calledAfterSetValue[1]);
 		$this->assertArrayHasKey('value', $calledAfterSetValue[1]);
-		$this->assertArrayHasKey('cache', $calledAfterSetValue[1]);
+		$this->assertArrayHasKey('update', $calledAfterSetValue[1]);
+		$this->assertArrayHasKey('oldvalue', $calledAfterSetValue[1]);
 
 		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
 			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n  'bar' => 'red',\n  'apps' => \n " .
@@ -157,9 +157,7 @@ class ConfigTest extends TestCase {
 		$this->assertEquals('config.beforedeletevalue', $calledBeforeDeleteValue[0]);
 		$this->assertEquals('config.afterdeletevalue', $calledAfterDeleteValue[0]);
 		$this->assertArrayHasKey('key', $calledBeforeDeleteValue[1]);
-		$this->assertArrayHasKey('cache', $calledBeforeDeleteValue[1]);
 		$this->assertArrayHasKey('key', $calledAfterDeleteValue[1]);
-		$this->assertArrayHasKey('cache', $calledAfterDeleteValue[1]);
 
 		$expected = "<?php\n\$CONFIG = array (\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
 			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n);\n";


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Remove cache data from the symfony event dispatcher.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove cache data from the symfony event dispatcher. Its not ideal to expose too much information.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

