### PR TITLE
Better UX in files sidebar for image previews

### DIFF
--- a/apps/files/js/mainfileinfodetailview.js
+++ b/apps/files/js/mainfileinfodetailview.js
@@ -217,14 +217,18 @@
 				}
 			};
 
+			var height = isImage ? maxImageHeight : smallPreviewSize;
+			$iconDiv.css('height', height + 'px');
+			$iconDiv.css('width', '100%');
+
 			this._fileList.lazyLoadPreview({
 				path: path,
 				mime: mime,
 				etag: etag,
-				y: isImage ? maxImageHeight : smallPreviewSize,
+				y: height,
 				x: isImage ? maxImageWidth : smallPreviewSize,
-				a: isImage ? 1 : null,
-				mode: isImage ? 'cover' : null,
+				// a: isImage ? 1 : null,
+				// mode: isImage ? 'cover' : null,
 				callback: function (previewUrl, img) {
 					$iconDiv.previewImg = previewUrl;
 


### PR DESCRIPTION
## Description
- center image load spinner in files sidebar
- use fixed heights to prevent sidebar content to hop around
- use image previews which fill the whole preview area in the sidebar

Before:
![screencast_27-03-18_17_04_02](https://user-images.githubusercontent.com/1005065/37976629-342cb910-31e2-11e8-94ef-15342de19357.gif)

After:
![screencast_27-03-18_17_04_58](https://user-images.githubusercontent.com/1005065/37976759-81847cca-31e2-11e8-8fc9-e35f49499dda.gif)


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

