### PR TITLE
flush/rebuild cache only once per matrix on push to branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -47,6 +47,8 @@ pipeline:
     when:
       local: false
       event: [ push ]
+      matrix:
+        TEST_SUITE: javascript
 
   flush:
     image: plugins/s3-cache:1
@@ -57,6 +59,8 @@ pipeline:
     when:
       local: false
       event: [push]
+      matrix:
+        TEST_SUITE: javascript
 
   phplint:
     image: owncloudci/php:${PHP_VERSION}


### PR DESCRIPTION
## Description
Only flush/rebuild the cache in one permutation of drone

## Motivation and Context
When we merge a PR - for all permutations the cache would be flushed/rebuilt and pushed to minio -> waste of time/resources

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] CI improvements

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

