### PR TITLE
Remove /ocs/ from end of acceptance tests baseUrl

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -169,8 +169,8 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-      - TEST_SERVER_URL=http://server/ocs/
-      - TEST_SERVER_FED_URL=http://federated/ocs/
+      - TEST_SERVER_URL=http://server
+      - TEST_SERVER_FED_URL=http://federated
     commands:
     - ./tests/drone/test-api-acceptance.sh
     when:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -7,16 +7,14 @@ default:
         - %paths.base%/../features/apiMain
       contexts:
         - FeatureContext: &common_feature_context_params
-            baseUrl:  http://localhost:8080/ocs/
+            baseUrl:  http://localhost:8080
             adminUsername: admin
             adminPassword: admin
             regularUserPassword: 123456
             mailhogUrl: http://127.0.0.1:8025/api/v2/messages
             ocPath: ../../
         - CardDavContext:
-            baseUrl: http://localhost:8080
         - CalDavContext:
-            baseUrl: http://localhost:8080
         - AppManagementContext:
 
     apiCapabilities:

--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -212,7 +212,7 @@ trait AppConfiguration {
 	 */
 	public function setCapabilities($capabilitiesArray) {
 		$savedCapabilitiesChanges = AppConfigHelper::setCapabilities(
-			$this->baseUrlWithoutOCSAppendix(),
+			$this->getBaseUrl(),
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
 			$capabilitiesArray,
@@ -234,7 +234,7 @@ trait AppConfiguration {
 	 */
 	protected function modifyServerConfig($app, $parameter, $value) {
 		AppConfigHelper::modifyServerConfig(
-			$this->baseUrlWithoutOCSAppendix(),
+			$this->getBaseUrl(),
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
 			$app,
@@ -251,7 +251,7 @@ trait AppConfiguration {
 	 */
 	protected function modifyServerConfigs($appParameterValues) {
 		AppConfigHelper::modifyServerConfigs(
-			$this->baseUrlWithoutOCSAppendix(),
+			$this->getBaseUrl(),
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
 			$appParameterValues,
@@ -302,18 +302,6 @@ trait AppConfiguration {
 	 * @return void
 	 */
 	public function prepareParametersBeforeScenario(BeforeScenarioScope $scope) {
-		// If we are running a webUI scenario, then make sure to use the base URL
-		// that the webUI has configured.
-		// Because the order of BeforeScenario method execution is not guaranteed,
-		// we need to be sure this happens here, before calling resetAppConfigs(),
-		// which will need to access the server API.
-		if ($scope->getScenario()->hasTag("webUI") || $scope->getFeature()->hasTag("webUI")) {
-			$environment = $scope->getEnvironment();
-			$this->webUIGeneralContext = $environment->getContext('WebUIGeneralContext');
-			$baseUrl = $this->webUIGeneralContext->getBaseUrlInWebUITestFormat();
-			$this->overrideBaseUrlWithWebUIValue($baseUrl);
-		}
-
 		$user = $this->currentUser;
 		$this->currentUser = $this->getAdminUsername();
 		$this->resetAppConfigs();

--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -65,7 +65,7 @@ trait Auth {
 	private function sendRequest(
 		$url, $method, $authHeader = null, $useCookies = false
 	) {
-		$fullUrl = substr($this->baseUrl, 0, -5) . $url;
+		$fullUrl = $this->getBaseUrl() . $url;
 		try {
 			if ($useCookies) {
 				$request = $this->client->createRequest(
@@ -98,7 +98,7 @@ trait Auth {
 	public function aNewClientTokenHasBeenGenerated($user) {
 		$client = new Client();
 		$resp = $client->post(
-			substr($this->baseUrl, 0, -5) . '/token/generate', [
+			$this->getBaseUrl() . '/token/generate', [
 			'json' => [
 					'user' => $user,
 					'password' => $this->getPasswordForUser($user),
@@ -175,7 +175,7 @@ trait Auth {
 	 * @return void
 	 */
 	public function aNewBrowserSessionForHasBeenStarted($user) {
-		$loginUrl = substr($this->baseUrl, 0, -5) . '/login';
+		$loginUrl = $this->getBaseUrl() . '/login';
 		// Request a new session and extract CSRF token
 		$client = new Client();
 		$response = $client->get(

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -72,16 +72,28 @@ trait BasicStructure {
 	private $currentServer = '';
 
 	/**
-	 * @var string 
+	 * The base URL of the current server under test,
+	 * without any terminating slash
+	 * e.g. http://localhost:8080
+	 *
+	 * @var string
 	 */
 	private $baseUrl = '';
 
 	/**
+	 * The base URL of the local server under test,
+	 * without any terminating slash
+	 * e.g. http://localhost:8080
+	 *
 	 * @var string
 	 */
 	private $localBaseUrl = '';
 
 	/**
+	 * The base URL of the remote (federated) server under test,
+	 * without any terminating slash
+	 * e.g. http://localhost:8180
+	 *
 	 * @var string
 	 */
 	private $remoteBaseUrl = '';
@@ -122,7 +134,7 @@ trait BasicStructure {
 	) {
 
 		// Initialize your context here
-		$this->baseUrl = $baseUrl;
+		$this->baseUrl = rtrim($baseUrl, '/');
 		$this->adminUsername = $adminUsername;
 		$this->adminPassword = $adminPassword;
 		$this->regularUserPassword = $regularUserPassword;
@@ -136,48 +148,42 @@ trait BasicStructure {
 		// in case of CI deployment we take the server url from the environment
 		$testServerUrl = getenv('TEST_SERVER_URL');
 		if ($testServerUrl !== false) {
-			$this->baseUrl = $testServerUrl;
-			$this->localBaseUrl = $testServerUrl;
+			$this->baseUrl = rtrim($testServerUrl, '/');
+			$this->localBaseUrl = $this->baseUrl;
 		}
 
 		// federated server url from the environment
 		$testRemoteServerUrl = getenv('TEST_SERVER_FED_URL');
 		if ($testRemoteServerUrl !== false) {
-			$this->remoteBaseUrl = $testRemoteServerUrl;
+			$this->remoteBaseUrl = rtrim($testRemoteServerUrl, '/');
 		}
 	}
 
 	/**
-	 * Override the baseUrl that came via the behat.yml and context constructor.
-	 * Use this when running in an environment that passes the baseUrl from some
-	 * external script. For example, the webUI acceptance tests build up the
-	 * baseUrl from environment variables and the script passes the value in as
-	 * a Mink parameter.
-	 *
-	 * @param string $newBaseUrl in the format that the webUI tests use
-	 *
-	 * @return void
-	 */
-	public function overrideBaseUrlWithWebUIValue($newBaseUrl) {
-		// baseUrl in the API tests FeatureContext uses a form with '/ocs/'
-		// on the end so add that.
-		if (substr($newBaseUrl, -1) !== '/') {
-			$newBaseUrl .= '/';
-		}
-
-		$newBaseUrl .= 'ocs/';
-		$this->baseUrl = $newBaseUrl;
-		$this->localBaseUrl = $this->baseUrl;
-		$this->remoteBaseUrl = $this->baseUrl;
-	}
-
-	/**
-	 * returns the base URL without the /ocs part
+	 * returns the base URL (which is without a slash at the end)
 	 *
 	 * @return string
 	 */
-	public function baseUrlWithoutOCSAppendix() {
-		return substr($this->baseUrl, 0, -4);
+	public function getBaseUrl() {
+		return $this->baseUrl;
+	}
+
+	/**
+	 * returns the local base URL (which is without a slash at the end)
+	 *
+	 * @return string
+	 */
+	public function getLocalBaseUrl() {
+		return $this->localBaseUrl;
+	}
+
+	/**
+	 * returns the remote base URL (which is without a slash at the end)
+	 *
+	 * @return string
+	 */
+	public function getRemoteBaseUrl() {
+		return $this->remoteBaseUrl;
 	}
 
 	/**
@@ -395,7 +401,7 @@ trait BasicStructure {
 		}
 
 		$this->response = OcsApiHelper::sendRequest(
-			$this->baseUrlWithoutOCSAppendix(),
+			$this->getBaseUrl(),
 			$user, $password, $verb, $url, $bodyArray, $this->apiVersion
 		);
 
@@ -424,7 +430,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function sendingToWithDirectUrl($user, $verb, $url, $body) {
-		$fullUrl = substr($this->baseUrl, 0, -5) . $url;
+		$fullUrl = $this->getBaseUrl() . $url;
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser($user);
@@ -455,8 +461,7 @@ trait BasicStructure {
 	 * @return bool
 	 */
 	public function isAPublicLinkUrl($url) {
-		$baseUrlChopped = $this->baseUrlWithoutOCSAppendix();
-		$urlEnding = substr($url, strlen($baseUrlChopped));
+		$urlEnding = substr($url, strlen($this->getBaseUrl() . '/'));
 		return preg_match("%^(index.php/)?s/([a-zA-Z0-9]{15})$%", $urlEnding);
 	}
 
@@ -566,7 +571,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function userHasLoggedInToAWebStyleSessionUsingTheAPI($user) {
-		$loginUrl = substr($this->baseUrl, 0, -5) . '/login';
+		$loginUrl = $this->getBaseUrl() . '/login';
 		// Request a new session and extract CSRF token
 		$client = new Client();
 		$response = $client->get(
@@ -604,12 +609,10 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function sendingAToWithRequesttoken($method, $url) {
-		$baseUrl = substr($this->baseUrl, 0, -5);
-
 		$client = new Client();
 		$request = $client->createRequest(
 			$method,
-			$baseUrl . $url,
+			$this->getBaseUrl() . $url,
 			[
 				'cookies' => $this->cookieJar,
 			]
@@ -632,12 +635,10 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function sendingAToWithoutRequesttoken($method, $url) {
-		$baseUrl = substr($this->baseUrl, 0, -5);
-
 		$client = new Client();
 		$request = $client->createRequest(
 			$method,
-			$baseUrl . $url,
+			$this->getBaseUrl() . $url,
 			[
 				'cookies' => $this->cookieJar,
 			]
@@ -793,7 +794,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function getStatusPhp() {
-		$fullUrl = $this->baseUrlWithoutOCSAppendix() . "status.php";
+		$fullUrl = $this->getBaseUrl() . "/status.php";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser('admin');
@@ -886,7 +887,7 @@ trait BasicStructure {
 		if (substr($fullUrl, -1) !== '/') {
 			$fullUrl .= '/';
 		}
-		$fullUrl .= "v1.php/apps/testing/api/v1/increasefileid";
+		$fullUrl .= "ocs/v1.php/apps/testing/api/v1/increasefileid";
 		$client = new Client();
 		$options = [];
 		$suiteSettingsContexts = $scope->getSuite()->getSettings()['contexts'];

--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -31,10 +31,6 @@ use GuzzleHttp\Message\ResponseInterface;
  */
 class CalDavContext implements \Behat\Behat\Context\Context {
 	/**
-	 * @var string  
-	 */
-	private $baseUrl;
-	/**
 	 * @var Client 
 	 */
 	private $client;
@@ -51,21 +47,6 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 * @var FeatureContext
 	 */
 	private $featureContext;
-
-	/**
-	 * @param string $baseUrl
-	 *
-	 * @return void
-	 */
-	public function __construct($baseUrl) {
-		$this->baseUrl = $baseUrl;
-
-		// in case of ci deployment we take the server url from the environment
-		$testServerUrl = getenv('TEST_SERVER_URL');
-		if ($testServerUrl !== false) {
-			$this->baseUrl = substr($testServerUrl, 0, -5);
-		}
-	}
 
 	/**
 	 * @BeforeScenario @caldav
@@ -89,7 +70,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 * @return void
 	 */
 	public function afterScenario() {
-		$davUrl = $this->baseUrl . '/remote.php/dav/calendars/admin/MyCalendar';
+		$davUrl = $this->featureContext->getBaseUrl() . '/remote.php/dav/calendars/admin/MyCalendar';
 		try {
 			$this->client->delete(
 				$davUrl,
@@ -110,7 +91,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 * @return void
 	 */
 	public function userRequestsCalendarUsingTheAPI($user, $calendar) {
-		$davUrl = $this->baseUrl . '/remote.php/dav/calendars/' . $calendar;
+		$davUrl = $this->featureContext->getBaseUrl() . '/remote.php/dav/calendars/' . $calendar;
 
 		try {
 			$this->response = $this->client->get(
@@ -204,7 +185,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 * @return void
 	 */
 	public function userHasCreatedACalendarNamed($user, $name) {
-		$davUrl = $this->baseUrl . '/remote.php/dav/calendars/' . $user . '/' . $name;
+		$davUrl = $this->featureContext->getBaseUrl() . '/remote.php/dav/calendars/' . $user . '/' . $name;
 
 		$request = $this->client->createRequest(
 			'MKCALENDAR',

--- a/tests/acceptance/features/bootstrap/CardDavContext.php
+++ b/tests/acceptance/features/bootstrap/CardDavContext.php
@@ -31,10 +31,6 @@ use GuzzleHttp\Message\ResponseInterface;
  */
 class CardDavContext implements \Behat\Behat\Context\Context {
 	/**
-	 * @var string  
-	 */
-	private $baseUrl;
-	/**
 	 * @var Client 
 	 */
 	private $client;
@@ -51,21 +47,6 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	 * @var FeatureContext
 	 */
 	private $featureContext;
-
-	/**
-	 * @param string $baseUrl
-	 *
-	 * @return void
-	 */
-	public function __construct($baseUrl) {
-		$this->baseUrl = $baseUrl;
-
-		// in case of CI deployment we take the server url from the environment
-		$testServerUrl = getenv('TEST_SERVER_URL');
-		if ($testServerUrl !== false) {
-			$this->baseUrl = substr($testServerUrl, 0, -5);
-		}
-	}
 
 	/**
 	 * @BeforeScenario @carddav
@@ -89,7 +70,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	 * @return void
 	 */
 	public function afterScenario() {
-		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/admin/MyAddressbook';
+		$davUrl = $this->featureContext->getBaseUrl() . '/remote.php/dav/addressbooks/users/admin/MyAddressbook';
 		try {
 			$this->client->delete(
 				$davUrl,
@@ -111,7 +92,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	 * @throws \Exception
 	 */
 	public function userRequestsAddressbookUsingTheAPI($user, $addressBook) {
-		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/' . $addressBook;
+		$davUrl = $this->featureContext->getBaseUrl() . '/remote.php/dav/addressbooks/users/' . $addressBook;
 
 		try {
 			$this->response = $this->client->get(
@@ -135,7 +116,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	 * @throws \Exception
 	 */
 	public function userHasCreatedAnAddressbookNamed($user, $addressBook) {
-		$davUrl = $this->baseUrl . '/remote.php/dav/addressbooks/users/' . $user . '/' . $addressBook;
+		$davUrl = $this->featureContext->getBaseUrl() . '/remote.php/dav/addressbooks/users/' . $user . '/' . $addressBook;
 
 		$request = $this->client->createRequest(
 			'MKCOL',

--- a/tests/acceptance/features/bootstrap/Checksums.php
+++ b/tests/acceptance/features/bootstrap/Checksums.php
@@ -81,7 +81,7 @@ trait Checksums {
 		$client = new Client();
 		$request = $client->createRequest(
 			'PROPFIND',
-			substr($this->baseUrl, 0, -4) . $this->getDavFilesPath($user) . $path,
+			$this->getBaseUrl() . '/' . $this->getDavFilesPath($user) . $path,
 			[
 				'body' => '<?xml version="1.0"?>
 <d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">

--- a/tests/acceptance/features/bootstrap/Federation.php
+++ b/tests/acceptance/features/bootstrap/Federation.php
@@ -42,9 +42,9 @@ trait Federation {
 		$sharerUser, $sharerServer, $sharerPath, $shareeUser, $shareeServer
 	) {
 		if ($shareeServer == "REMOTE") {
-			$shareWith = "$shareeUser@" . substr($this->remoteBaseUrl, 0, -4);
+			$shareWith = "$shareeUser@" . $this->getRemoteBaseUrl() . '/';
 		} else {
-			$shareWith = "$shareeUser@" . substr($this->localBaseUrl, 0, -4);
+			$shareWith = "$shareeUser@" . $this->getLocalBaseUrl() . '/';
 		}
 		$previous = $this->usingServer($sharerServer);
 		$this->createShare(

--- a/tests/acceptance/features/bootstrap/Ip.php
+++ b/tests/acceptance/features/bootstrap/Ip.php
@@ -90,7 +90,7 @@ trait Ip {
 	public function setUpScenarioGetIpUrls() {
 		$this->ipv4Url = getenv('IPV4_URL');
 		$this->ipv6Url = getenv('IPV6_URL');
-		$this->baseUrl = $this->getMinkParameter("base_url");
+		$this->baseUrl = $this->featureContext->getBaseUrl();
 		$this->baseUrlForSourceIp = $this->baseUrl;
 	}
 }

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -313,7 +313,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function initializeUser($user, $password) {
-		$url = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/" . $user;
+		$url = $this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/cloud/users/" . $user;
 		$client = new Client();
 		$options = [
 			'auth' => [$user, $password],
@@ -376,12 +376,13 @@ trait Provisioning {
 		}
 		$user = trim($user);
 		$method = trim(strtolower($method));
-		$baseUrl = $this->baseUrlWithoutOCSAppendix();
 		$userWasCreated = false;
 		switch ($method) {
 			case "api":
 				$results = UserHelper::createUser(
-					$baseUrl, $user, $password,
+					$this->getBaseUrl(),
+					$user,
+					$password,
 					$this->getAdminUsername(),
 					$this->getAdminPassword(),
 					$displayName, $email
@@ -449,7 +450,7 @@ trait Provisioning {
 	 * @return bool
 	 */
 	public function userExists($user) {
-		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
@@ -471,7 +472,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userShouldBelongToGroup($user, $group) {
-		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/users/$user/groups";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
@@ -494,7 +495,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userShouldNotBelongToGroup($user, $group) {
-		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/users/$user/groups";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
@@ -515,7 +516,7 @@ trait Provisioning {
 	 * @return bool
 	 */
 	public function userBelongsToGroup($user, $group) {
-		$fullUrl = $this->baseUrl . "v2.php/cloud/users/$user/groups";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/users/$user/groups";
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === $this->getAdminUsername()) {
@@ -569,7 +570,7 @@ trait Provisioning {
 		switch ($method) {
 			case "api":
 				$result = UserHelper::addUserToGroup(
-					$this->baseUrlWithoutOCSAppendix(),
+					$this->getBaseUrl(),
 					$user, $group,
 					$this->getAdminUsername(),
 					$this->getAdminPassword()
@@ -703,7 +704,7 @@ trait Provisioning {
 		switch ($method) {
 			case "api":
 				$result = UserHelper::createGroup(
-					$this->baseUrlWithoutOCSAppendix(),
+					$this->getBaseUrl(),
 					$group,
 					$this->getAdminUsername(),
 					$this->getAdminPassword()
@@ -749,7 +750,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function adminDisablesUserUsingTheAPI($user) {
-		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/disable";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/cloud/users/$user/disable";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
@@ -767,7 +768,7 @@ trait Provisioning {
 	public function deleteTheUserUsingTheAPI($user) {
 		// Always try to delete the user
 		$this->response = UserHelper::deleteUser(
-			$this->baseUrlWithoutOCSAppendix(),
+			$this->getBaseUrl(),
 			$user,
 			$this->getAdminUsername(),
 			$this->getAdminPassword()
@@ -807,7 +808,7 @@ trait Provisioning {
 	 */
 	public function deleteTheGroupUsingTheAPI($group) {
 		$this->response = UserHelper::deleteGroup(
-			$this->baseUrlWithoutOCSAppendix(),
+			$this->getBaseUrl(),
 			$group,
 			$this->getAdminUsername(),
 			$this->getAdminPassword()
@@ -827,7 +828,7 @@ trait Provisioning {
 	 * @return bool
 	 */
 	public function groupExists($group) {
-		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/groups/$group";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
@@ -849,7 +850,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userShouldBeSubadminOfGroup($user, $group) {
-		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group/subadmins";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/groups/$group/subadmins";
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === $this->getAdminUsername()) {
@@ -875,7 +876,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function adminMakesUserSubadminOfGroupUsingTheAPI($user, $group) {
-		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user/subadmins";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/cloud/users/$user/subadmins";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
@@ -900,7 +901,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function adminMakesUserNotSubadminOfGroupUsingTheAPI($user, $group) {
-		$fullUrl = $this->baseUrl . "v2.php/cloud/groups/$group/subadmins";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/groups/$group/subadmins";
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === $this->getAdminUsername()) {
@@ -1066,7 +1067,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function appShouldBeDisabled($app) {
-		$fullUrl = $this->baseUrl . "v2.php/cloud/apps?filter=disabled";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/apps?filter=disabled";
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === $this->getAdminUsername()) {
@@ -1089,7 +1090,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function appShouldBeEnabled($app) {
-		$fullUrl = $this->baseUrl . "v2.php/cloud/apps?filter=enabled";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/apps?filter=enabled";
 		$client = new Client();
 		$options = [];
 		if ($this->currentUser === $this->getAdminUsername()) {
@@ -1112,7 +1113,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userShouldBeDisabled($user) {
-		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
@@ -1131,7 +1132,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function useShouldBeEnabled($user) {
-		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
@@ -1159,7 +1160,7 @@ trait Provisioning {
 			];
 
 		$this->response = OcsApiHelper::sendRequest(
-			$this->baseUrlWithoutOCSAppendix(),
+			$this->getBaseUrl(),
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
 			"PUT",
@@ -1193,7 +1194,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function getUserHome($user) {
-		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/cloud/users/$user";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -63,7 +63,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function userCreatesAShareWithSettings($user, $body) {
-		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser($user);
@@ -125,7 +125,7 @@ trait Sharing {
 		$user, $path, $publicUpload = false, $sharePassword = null, $permissions = null
 	) {
 		$this->response = SharingHelper::createShare(
-			$this->baseUrlWithoutOCSAppendix(),
+			$this->getBaseUrl(),
 			$user,
 			$this->getPasswordForUser($user),
 			$path,
@@ -207,7 +207,7 @@ trait Sharing {
 	 */
 	public function publicSharedFileCannotBeDownloaded($path) {
 		$token = $this->getLastShareToken();
-		$fullUrl = substr($this->baseUrl, 0, -4) . "public.php/webdav/" . rawurlencode(ltrim($path, '/'));
+		$fullUrl = $this->getBaseUrl() . "/public.php/webdav/" . rawurlencode(ltrim($path, '/'));
 
 		$client = new Client();
 		$options = [];
@@ -251,7 +251,7 @@ trait Sharing {
 	 */
 	public function checkLastPublicSharedFileWithPasswordDownload($password) {
 		$token = $this->getLastShareToken();
-		$fullUrl = substr($this->baseUrl, 0, -4) . "public.php/webdav";
+		$fullUrl = $this->getBaseUrl() . "/public.php/webdav";
 		$this->checkDownload($fullUrl, [$token, $password], 'text/plain');
 	}
 
@@ -377,7 +377,7 @@ trait Sharing {
 	private function publicUploadContent(
 		$filename, $password = '', $body = 'test', $autorename = false, $overwriting = false
 	) {
-		$url = substr($this->baseUrl, 0, -4) . "public.php/webdav/";
+		$url = $this->getBaseUrl() . "/public.php/webdav/";
 		$url .= rawurlencode(ltrim($filename, '/'));
 		$token = $this->getLastShareToken();
 		$options['auth'] = [$token, $password];
@@ -412,7 +412,7 @@ trait Sharing {
 	 */
 	public function theUserAddsExpirationDateToLastShare() {
 		$share_id = (string) $this->lastShareData->data[0]->id;
-		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser($this->currentUser);
@@ -450,7 +450,7 @@ trait Sharing {
 	 */
 	public function userUpdatesTheLastShareWith($user, $body) {
 		$share_id = (string) $this->lastShareData->data[0]->id;
-		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser($user);
@@ -503,7 +503,7 @@ trait Sharing {
 
 		try {
 			$this->response = SharingHelper::createShare(
-				$this->baseUrlWithoutOCSAppendix(),
+				$this->getBaseUrl(),
 				$user,
 				$this->getPasswordForUser($user),
 				$path,
@@ -685,7 +685,7 @@ trait Sharing {
 	public function userSharesFileWithUserUsingTheAPI(
 		$user1, $entry, $filepath, $user2, $withPerms = null, $permissions = null
 	) {
-		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser($user1);
@@ -748,7 +748,7 @@ trait Sharing {
 	public function userSharesFileWithGroupUsingTheAPI(
 		$user, $entry, $filepath, $group, $withPerms = null, $permissions = null
 	) {
-		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser($user);
@@ -868,23 +868,24 @@ trait Sharing {
 				if (substr($field, 0, 10) === "share_with") {
 					$value = str_replace(
 						"REMOTE",
-						substr($this->remoteBaseUrl, 0, -5),
+						$this->getRemoteBaseUrl(),
 						$value
 					);
 					$value = str_replace(
-						"LOCAL", substr($this->localBaseUrl, 0, -5),
+						"LOCAL",
+						$this->getLocalBaseUrl(),
 						$value
 					);
 				}
 				if (substr($field, 0, 6) === "remote") {
 					$value = str_replace(
 						"REMOTE",
-						substr($this->remoteBaseUrl, 0, -4),
+						$this->getRemoteBaseUrl() . '/',
 						$value
 					);
 					$value = str_replace(
 						"LOCAL",
-						substr($this->localBaseUrl, 0, -4),
+						$this->getLocalBaseUrl() . '/',
 						$value
 					);
 				}
@@ -908,7 +909,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function userRemovesAllSharesFromTheFileNamed($user, $fileName) {
-		$url = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares?format=json";
+		$url = $this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares?format=json";
 		$client = new \GuzzleHttp\Client();
 		$res = $client->get(
 			$url,
@@ -925,7 +926,7 @@ trait Sharing {
 			if (stripslashes($data['path']) === $fileName) {
 				$id = $data['id'];
 				$client->delete(
-					$this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/{$id}",
+					$this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/{$id}",
 					[
 						'auth' => $this->getAuthOptionForUser($user),
 						'headers' => [
@@ -973,7 +974,7 @@ trait Sharing {
 	 * @return array
 	 */
 	public function getShares($user, $path) {
-		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
+		$fullUrl = $this->getBaseUrl() . "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
 		$fullUrl = $fullUrl . '?path=' . $path;
 
 		$client = new Client();

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -51,7 +51,7 @@ trait Tags {
 	) {
 		try {
 			$createdTag = TagsHelper::createTag(
-				$this->baseUrlWithoutOCSAppendix(),
+				$this->getBaseUrl(),
 				$user,
 				$this->getPasswordForUser($user),
 				$name, $userVisible, $userAssignable, $groups,
@@ -135,7 +135,7 @@ trait Tags {
 	 */
 	public function requestTagsForUser($user, $withGroups = false) {
 		$this->response = TagsHelper:: requestTagsForUser(
-			$this->baseUrlWithoutOCSAppendix(),
+			$this->getBaseUrl(),
 			$user,
 			$this->getPasswordForUser($user),
 			$withGroups
@@ -296,7 +296,7 @@ trait Tags {
 		$appPath = '/systemtags/';
 		$tagID = $this->findTagIdByName($tagDisplayName);
 		PHPUnit_Framework_Assert::assertNotNull($tagID, "Tag wasn't found");
-		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->getDavPath('systemtags') . $appPath . $tagID;
+		$fullUrl = $this->getBaseUrl() . '/' . $this->getDavPath('systemtags') . $appPath . $tagID;
 		try {
 			$response = $client->proppatch($fullUrl, $properties, 1);
 			$this->response = $response;
@@ -356,7 +356,7 @@ trait Tags {
 		$tagID = $this->findTagIdByName($name);
 		try {
 			$this->response = TagsHelper::deleteTag(
-				$this->baseUrlWithoutOCSAppendix(),
+				$this->getBaseUrl(),
 				$user,
 				$this->getPasswordForUser($user),
 				$tagID,
@@ -380,7 +380,7 @@ trait Tags {
 	private function tag($taggingUser, $tagName, $fileName, $fileOwner) {
 		try {
 			$this->response = TagsHelper::tag(
-				$this->baseUrlWithoutOCSAppendix(),
+				$this->getBaseUrl(),
 				$taggingUser, 
 				$this->getPasswordForUser($taggingUser),
 				$tagName, $fileName, $fileOwner, $this->getDavPathVersion('systemtags')
@@ -412,7 +412,7 @@ trait Tags {
 						'{http://owncloud.org/ns}can-assign'
 					  ];
 		$appPath = '/systemtags-relations/files/';
-		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->getDavPath('systemtags') . $appPath . $fileID;
+		$fullUrl = $this->getBaseUrl() . '/' . $this->getDavPath('systemtags') . $appPath . $fileID;
 		try {
 			$response = $client->propfind($fullUrl, $properties, 1);
 		} catch (Sabre\HTTP\ClientHttpException $e) {
@@ -551,7 +551,7 @@ trait Tags {
 		foreach ($this->createdTags as $tagID) {
 			try {
 				$this->response = TagsHelper::deleteTag(
-					$this->baseUrlWithoutOCSAppendix(),
+					$this->getBaseUrl(),
 					$this->getAdminUsername(),
 					$this->getAdminPassword(),
 					$tagID,

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -79,10 +79,16 @@ trait WebDav {
 		);
 	}
 
+	/**
+	 * @return string
+	 */
 	private function getOldDavPath() {
 		return "remote.php/webdav";
 	}
 
+	/**
+	 * @return string
+	 */
 	private function getNewDavPath() {
 		return "remote.php/dav";
 	}
@@ -194,7 +200,7 @@ trait WebDav {
 		}
 
 		return WebDavHelper::makeDavRequest(
-			$this->baseUrlWithoutOCSAppendix(),
+			$this->getBaseUrl(),
 			$user, $this->getPasswordForUser($user), $method,
 			$path, $headers, $body, $requestBody, $davPathVersion,
 			$type
@@ -212,7 +218,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function userHasMovedFile($user, $entry, $fileSource, $fileDestination) {
-		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->getDavFilesPath($user);
+		$fullUrl = $this->getBaseUrl() . '/' . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		$this->response = $this->makeDavRequest($user, "MOVE", $fileSource, $headers);
 		PHPUnit_Framework_Assert::assertEquals(
@@ -233,7 +239,7 @@ trait WebDav {
 	public function userMovesFileUsingTheAPI(
 		$user, $entry, $fileSource, $fileDestination
 	) {
-		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->getDavFilesPath($user);
+		$fullUrl = $this->getBaseUrl() . '/' . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		try {
 			$this->response = $this->makeDavRequest(
@@ -255,7 +261,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function userCopiesFileUsingTheAPI($user, $fileSource, $fileDestination) {
-		$fullUrl = $this->baseUrlWithoutOCSAppendix() . $this->getDavFilesPath($user);
+		$fullUrl = $this->getBaseUrl() . '/' . $this->getDavFilesPath($user);
 		$headers['Destination'] = $fullUrl . $fileDestination;
 		try {
 			$this->response = $this->makeDavRequest(
@@ -301,7 +307,7 @@ trait WebDav {
 	 */
 	public function downloadPublicFileWithRange($range) {
 		$token = $this->lastShareData->data->token;
-		$fullUrl = $this->baseUrlWithoutOCSAppendix() . "public.php/webdav";
+		$fullUrl = $this->getBaseUrl() . "/public.php/webdav";
 
 		$client = new GClient();
 		$options = [];
@@ -324,7 +330,7 @@ trait WebDav {
 	 */
 	public function downloadPublicFileInsideAFolderWithRange($path, $range) {
 		$token = $this->lastShareData->data->token;
-		$fullUrl = $this->baseUrlWithoutOCSAppendix() . "public.php/webdav" . "$path";
+		$fullUrl = $this->getBaseUrl() . "/public.php/webdav" . "$path";
 
 		$client = new GClient();
 		$options = [];
@@ -946,7 +952,7 @@ trait WebDav {
 	 */
 	public function getSabreClient($user) {
 		return WebDavHelper::getSabreClient(
-			$this->baseUrlWithoutOCSAppendix(),
+			$this->getBaseUrl(),
 			$user,
 			$this->getPasswordForUser($user)
 		);
@@ -1509,7 +1515,7 @@ trait WebDav {
 	 */
 	private function moveNewDavChunkToFinalFile($user, $id, $dest, $headers) {
 		$source = '/uploads/' . $user . '/' . $id . '/.file';
-		$destination = $this->baseUrlWithoutOCSAppendix() . $this->getDavFilesPath($user) . $dest;
+		$destination = $this->getBaseUrl() . '/' . $this->getDavFilesPath($user) . $dest;
 
 		$headers['Destination'] = $destination;
 
@@ -1575,7 +1581,7 @@ trait WebDav {
 		$user, $path, $favOrUnfav, $folderDepth, $properties = null
 	) {
 		$settings = [
-			'baseUri' => $this->baseUrlWithoutOCSAppendix(),
+			'baseUri' => $this->getBaseUrl() . '/',
 			'userName' => $user,
 			'password' => $this->getPasswordForUser($user),
 			'authType' => SClient::AUTH_BASIC
@@ -1754,8 +1760,10 @@ trait WebDav {
 	private function getFileIdForPath($user, $path) {
 		try {
 			return WebDavHelper::getFileIdForPath(
-				$this->baseUrlWithoutOCSAppendix(), $user,
-				$this->getPasswordForUser($user), $path
+				$this->getBaseUrl(),
+				$user,
+				$this->getPasswordForUser($user),
+				$path
 			);
 		} catch ( Exception $e ) {
 			return null;

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -414,7 +414,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			while ($currentTime <= $end) {
 				try {
 					DeleteHelper::delete(
-						$this->featureContext->baseUrlWithoutOCSAppendix(),
+						$this->featureContext->getBaseUrl(),
 						$username,
 						$this->featureContext->getUserPassword($username),
 						$file['name']
@@ -1227,7 +1227,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	) {
 		$username = $this->featureContext->getCurrentUser();
 		$result = DownloadHelper::download(
-			$this->featureContext->baseUrlWithoutOCSAppendix(),
+			$this->featureContext->getBaseUrl(),
 			$username,
 			$this->featureContext->getUserPassword($username),
 			$remoteFile

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -176,7 +176,6 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		);
 		$nextPage->waitTillPageIsLoaded($session);
 		$this->featureContext->asUser($username);
-		$this->featureContext->usingServer('LOCAL');
 		return $nextPage;
 	}
 
@@ -363,7 +362,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		
 		$capability = $this->capabilities[strtolower($section)][$setting];
 		$change = AppConfigHelper::setCapability(
-			$this->getMinkParameter('base_url'),
+			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword(),
 			$capability['capabilitiesApp'],
@@ -404,7 +403,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 */
 	public function getBaseUrlWithoutScheme() {
 		return preg_replace(
-			"(^https?://)", "", $this->getMinkParameter('base_url')
+			"(^https?://)", "", $this->featureContext->getBaseUrl()
 		);
 	}
 
@@ -422,12 +421,10 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			[
 				"code" => "%base_url%",
 				"function" => [
-					$this,
-					"getMinkParameter"
+					$this->featureContext,
+					"getBaseUrl"
 				],
-				"parameter" => [
-					"base_url"
-				]
+				"parameter" => []
 			],
 			[
 				"code" => "%remote_server%",
@@ -442,7 +439,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 					$this,
 					"getBaseUrlWithoutScheme"
 				],
-				"parameter" => [ ]
+				"parameter" => []
 			]
 		];
 		foreach ($substitutions as $substitution) {
@@ -488,15 +485,6 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * Return the baseUrl in the form that the webUI tests use.
-	 *
-	 * @return string
-	 */
-	public function getBaseUrlInWebUITestFormat() {
-		return $this->getMinkParameter("base_url");
-	}
-
-	/**
 	 * @BeforeScenario @webUI
 	 *
 	 * @param BeforeScenarioScope $scope
@@ -522,12 +510,12 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		SetupHelper::init(
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword(),
-			$this->getMinkParameter('base_url'),
+			$this->featureContext->getBaseUrl(),
 			$suiteParameters['ocPath']
 		);
 		
 		$response = AppConfigHelper::getCapabilities(
-			$this->getMinkParameter('base_url'),
+			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword()
 		);
@@ -565,10 +553,6 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 				);
 			}
 		}
-
-		$this->featureContext->overrideBaseUrlWithWebUIValue(
-			$this->getBaseUrlInWebUITestFormat()
-		);
 	}
 
 	/**
@@ -616,7 +600,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 */
 	public function tearDownSuite() {
 		AppConfigHelper::modifyServerConfigs(
-			$this->getMinkParameter('base_url'),
+			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword(),
 			$this->savedCapabilitiesChanges
@@ -666,7 +650,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 */
 	public function clearFileLocks() {
 		$response = OcsApiHelper::sendRequest(
-			$this->getMinkParameter('base_url'),
+			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword(),
 			'delete',

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -133,7 +133,6 @@ class WebUILoginContext extends RawMinkContext implements Context {
 		);
 		$this->loginPage->open();
 		$this->theUserLogsInWithUsernameAndPasswordUsingTheWebUI($username, $password);
-		$this->featureContext->usingServer($server);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -304,7 +304,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	public function thePublicAccessesTheLastCreatedPublicLinkUsingTheWebUI() {
 		$lastCreatedLink = end($this->createdPublicLinks);
 		$path = str_replace(
-			$this->getMinkParameter('base_url'),
+			$this->featureContext->getBaseUrl(),
 			"",
 			$lastCreatedLink['url']
 		);
@@ -333,7 +333,6 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		// addToServer takes us from the public link page to the login page
 		// of the remote server, waiting for us to login.
 		$this->webUIGeneralContext->loginAs($username, $password);
-		$this->featureContext->usingServer($server);
 	}
 
 	/**
@@ -618,7 +617,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		];
 
 		$change = AppConfigHelper::setCapabilities(
-			$this->getMinkParameter('base_url'),
+			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword(),
 			$settings,

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -82,8 +82,8 @@ else
     PHPPID_FED=$!
     echo $PHPPID_FED
 
-    export TEST_SERVER_URL="http://localhost:$PORT/ocs/"
-    export TEST_SERVER_FED_URL="http://localhost:$PORT_FED/ocs/"
+    export TEST_SERVER_URL="http://localhost:$PORT"
+    export TEST_SERVER_FED_URL="http://localhost:$PORT_FED"
 fi
 
 #Set up personalized skeleton

--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -339,8 +339,8 @@ export REMOTE_FED_BASE_URL
 export FILES_FOR_UPLOAD="$(pwd)/tests/acceptance/filesForUpload/"
 
 # Provide TEST_SERVER* env vars. Some API acceptance test code uses these.
-export TEST_SERVER_URL="$BASE_URL/ocs/"
-export TEST_SERVER_FED_URL="$REMOTE_FED_BASE_URL/ocs/"
+export TEST_SERVER_URL="$BASE_URL"
+export TEST_SERVER_FED_URL="$REMOTE_FED_BASE_URL"
 
 if [ ! -w $FILES_FOR_UPLOAD ]
 then


### PR DESCRIPTION
## Description
1) Set ``baseUrl`` in the API acceptance tests to no longer have ``/ocs/`` on the end of it.
2) Provide convenience methods to return the ``baseUrl`` with an without a trailing slash.
3) Everywhere that used to do stuff like ``substr($this->baseUrl, 0, -5)`` now use the method to get ``baseUrl``
4) Update webUI test code so it consistently uses ``baseUrl`` from the API ``FeatureContext`` and does not keep trying to get it from ``getMinkParameter("base_url")``

## Related Issue
#30879 
https://github.com/owncloud/QA/issues/517

## Motivation and Context
Bring API and UI acceptance tests even closer together. By using a common format for ``baseUrl`` it will be easier to make a common script for running any acceptance test.

## How Has This Been Tested?
Locally and CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
