### PR TITLE
[Stable10] Protect themes against enabling for groups

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -56,6 +56,7 @@ class AppManager implements IAppManager {
 		'authentication',
 		'logging',
 		'prevent_group_restriction',
+		'theme',
 	];
 
 	/** @var \OCP\IUserSession */

--- a/settings/js/admin-apps.js
+++ b/settings/js/admin-apps.js
@@ -181,9 +181,7 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		}
 
 		// set group select properly
-		if(OC.Settings.Apps.isType(app, 'filesystem') || OC.Settings.Apps.isType(app, 'prelogin') ||
-			OC.Settings.Apps.isType(app, 'authentication') || OC.Settings.Apps.isType(app, 'logging') ||
-			OC.Settings.Apps.isType(app, 'prevent_group_restriction')) {
+		if (OC.Settings.Apps.isProtected(app)) {
 			page.find(".groups-enable").hide();
 			page.find(".groups-enable__checkbox").prop('checked', false);
 		} else {
@@ -226,6 +224,28 @@ OC.Settings.Apps = OC.Settings.Apps || {
 		}
 
 		return author;
+	},
+
+	/**
+	 * Checks if enable for groups should be hidden
+	 * @param app
+	 * @returns {boolean}
+	 */
+	isProtected: function(app) {
+		var protectedTypes = [
+			'filesystem',
+			'prelogin',
+			'authentication',
+			'logging',
+			'prevent_group_restriction',
+			'theme'
+		];
+		for (var i=0;i<protectedTypes.length;i++) {
+			if (OC.Settings.Apps.isType(app, protectedTypes[i])) {
+				return true;
+			}
+		}
+		return false;
 	},
 
 	isType: function(app, type) {

--- a/settings/tests/js/apps/appSettingsSpec.js
+++ b/settings/tests/js/apps/appSettingsSpec.js
@@ -22,6 +22,7 @@
 describe('App Settings tests', function() {
 	var apps = [
 		{
+			"id" : "app1",
 			"author": "Author 1, Author 2",
 			"types": [
 				"logging",
@@ -29,6 +30,7 @@ describe('App Settings tests', function() {
 			]
 		},
 		{
+			"id" : "app2",
 			"author": [
 				"Author 1",
 				"Author 2",
@@ -41,6 +43,13 @@ describe('App Settings tests', function() {
 			],
 			"types": [
 				"filesystem"
+			]
+		},
+		{
+			"id" : "theme-custom",
+			"author": "Front End",
+			"types": [
+				"theme"
 			]
 		}
 	];
@@ -59,5 +68,10 @@ describe('App Settings tests', function() {
 
 		isFilesystem = OC.Settings.Apps.isType(apps[1], 'filesystem');
 		expect(isFilesystem).toEqual(true);
+	});
+
+	it('should protect app themes from enabling for groups', function () {
+		var isProtected = OC.Settings.Apps.isProtected(apps[2]);
+		expect(isProtected).toEqual(true);
 	});
 });

--- a/tests/Core/Command/Apps/AppsEnableTest.php
+++ b/tests/Core/Command/Apps/AppsEnableTest.php
@@ -64,7 +64,7 @@ class AppsEnableTest extends TestCase {
 		return [
 			['testing', 'testing enabled'],
 			['hui-buh', 'hui-buh not found'],
-			['theme-example', 'theme-example enabled for groups: admin', 'admin'],
+			['updatenotification', 'updatenotification enabled for groups: admin', 'admin'],
 			['hui-buh', 'hui-buh not found', 'admin'],
 		];
 	}


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/30926

## Description
it's not possible anyway

## Related Issue
https://github.com/owncloud/core/issues/30887

## Motivation and Context
Inconsistent UI

## How Has This Been Tested?
1. By revising apps management section and checking that `Enable only for groups` checkbox is gone for themes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

