### PR TITLE
Fix repair constructor for single user repair

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -182,7 +182,8 @@ class Scan extends Base {
 				try {
 					$repairStep = new RepairMismatchFileCachePath(
 						$connection,
-						$this->mimeTypeLoader
+						$this->mimeTypeLoader,
+						$this->logger
 					);
 					$repairStep->setStorageNumericId($storage->getCache()->getNumericStorageId());
 					$repairStep->setCountOnly(false);

--- a/apps/files/tests/Command/ScanTest.php
+++ b/apps/files/tests/Command/ScanTest.php
@@ -389,5 +389,18 @@ class ScanTest extends TestCase {
 		$storageId = $this->getStorageId('home::' . $this->scanUser1->getUID());
 		$this->assertFalse($this->getFileCacheEntry($storageId, 'files/toscan'));
 	}
+
+	/**
+	 * Scan and repair a single user
+	 */
+	public function testRepairOne() {
+		@mkdir($this->dataDir . '/' . $this->scanUser2->getUID() . '/files/toscan3', 0777, true);
+		$input = [
+			'user_id' => [$this->scanUser2->getUID()],
+			'--repair' => true,
+		];
+		$result = $this->commandTester->execute($input);
+		$this->assertEquals(0, $result);
+	}
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Repair for a single user was broken. Missing logging instance in the constructor.

## Related Issue
Tried it and it was broken.

## Motivation and Context
Would be nice if it worked. 

## How Has This Been Tested?
`occ files:scan --repair testuser`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

