### PR TITLE
Improve use of baseUrl in Ip.php trait

### DIFF
--- a/tests/acceptance/features/bootstrap/Ip.php
+++ b/tests/acceptance/features/bootstrap/Ip.php
@@ -45,7 +45,21 @@ trait Ip {
 
 	private $ipv4Url;
 	private $ipv6Url;
-	private $baseUrl;
+
+	/**
+	 * returns the base URL that matches the currently selected source IP
+	 * address (which might be an IPv4 or IPv6 address)
+	 *
+	 * @return string
+	 */
+	public function getBaseUrlForSourceIp() {
+		// Lazy init so we know that featureContext has been setup
+		// by the time we need it here.
+		if ($this->baseUrlForSourceIp === null) {
+			$this->baseUrlForSourceIp = $this->featureContext->getBaseUrl();
+		}
+		return $this->baseUrlForSourceIp;
+	}
 
 	/**
 	 * @When the client accesses the server from a :networkScope :ipAddressFamily address
@@ -78,7 +92,7 @@ trait Ip {
 		} else if (filter_var($sourceIpAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
 			$this->baseUrlForSourceIp = $this->ipv6Url;
 		} else {
-			$this->baseUrlForSourceIp = $this->baseUrl;
+			$this->baseUrlForSourceIp = $this->featureContext->getBaseUrl();
 		}
 	}
 
@@ -90,7 +104,5 @@ trait Ip {
 	public function setUpScenarioGetIpUrls() {
 		$this->ipv4Url = getenv('IPV4_URL');
 		$this->ipv6Url = getenv('IPV6_URL');
-		$this->baseUrl = $this->featureContext->getBaseUrl();
-		$this->baseUrlForSourceIp = $this->baseUrl;
 	}
 }


### PR DESCRIPTION
## Description
1) Do not keep a separate copy of ``baseUrl`` variable in this trait.
2) Only init ``baseUrlForSourceIp`` when something asks for it. Previously it was setup in the ``BeforeScenario`` and that caused problems depending on the order in which ``BeforeScenario`` were run by Behat. (noticed in firewall, which uses this ``Ip.php`` trait)

## Related Issue
#30879 
https://github.com/owncloud/QA/issues/517

## Motivation and Context
Get rid of another copy of ``baseUrl``
Make firewall UI tests work with latest core changes.

## How Has This Been Tested?
Locally with firewall tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
