### PR TITLE
move substituteInLineCodes() so it can be used in API tests

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -178,6 +178,17 @@ trait BasicStructure {
 	}
 
 	/**
+	 * gets the base url but without "http(s)://" in front of it
+	 *
+	 * @return string
+	 */
+	public function getBaseUrlWithoutScheme() {
+		return preg_replace(
+			"(^https?://)", "", $this->getBaseUrl()
+		);
+	}
+
+	/**
 	 * returns the remote base URL (which is without a slash at the end)
 	 *
 	 * @return string
@@ -845,6 +856,54 @@ trait BasicStructure {
 			PHPUnit_Framework_Assert::fail('Cannot get version variables from occ');
 		}
 		PHPUnit\Framework\Assert::assertEquals($jsonExpectedEncoded, $jsonRespondedEncoded);
+	}
+
+	/**
+	 * substitutes codes like %base_url% with the value
+	 * if the given value does not have anything to be substituted
+	 * then it is returned unmodified
+	 *
+	 * @param string $value
+	 *
+	 * @return string
+	 */
+	public function substituteInLineCodes($value) {
+		$substitutions = [
+			[
+				"code" => "%base_url%",
+				"function" => [
+					$this,
+					"getBaseUrl"
+				],
+				"parameter" => []
+			],
+			[
+				"code" => "%remote_server%",
+				"function" => "getenv",
+				"parameter" => [
+					"REMOTE_FED_BASE_URL"
+				]
+			],
+			[
+				"code" => "%local_server%",
+				"function" => [
+					$this,
+					"getBaseUrlWithoutScheme"
+				],
+				"parameter" => []
+			]
+		];
+		foreach ($substitutions as $substitution) {
+			$value = str_replace(
+				$substitution["code"],
+				call_user_func_array(
+					$substitution["function"],
+					$substitution["parameter"]
+				),
+				$value
+			);
+		}
+		return $value;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -60,7 +60,7 @@ trait Logging {
 			$logEntry = json_decode($logLines[$lineNo], true);
 			foreach (array_keys($expectedLogEntry) as $attribute) {
 				$expectedLogEntry [$attribute]
-					= $this->webUIGeneralContext->substituteInLineCodes(
+					= $this->featureContext->substituteInLineCodes(
 						$expectedLogEntry [$attribute]
 					);
 				PHPUnit_Framework_Assert::assertArrayHasKey(
@@ -104,7 +104,7 @@ trait Logging {
 			foreach ($logEntriesExpectedNotToExist as $logEntryExpectedNotToExist) {
 				foreach (array_keys($logEntryExpectedNotToExist) as $attribute) {
 					$logEntryExpectedNotToExist [$attribute]
-						= $this->webUIGeneralContext->substituteInLineCodes(
+						= $this->featureContext->substituteInLineCodes(
 							$logEntryExpectedNotToExist [$attribute]
 						);
 					if (isset($logEntries [$attribute])

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -306,9 +306,10 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 				$content = $dialog->getMessage();
 				$title = $dialog->getTitle();
 				for ($dialogI = 0; $dialogI < count($expectedDialogs); $dialogI++) {
-					$expectedDialogs[$dialogI]['content'] = $this->substituteInLineCodes(
-						$expectedDialogs[$dialogI]['content']
-					);
+					$expectedDialogs[$dialogI]['content']
+						= $this->featureContext->substituteInLineCodes(
+							$expectedDialogs[$dialogI]['content']
+						);
 					if ($expectedDialogs[$dialogI]['content'] === $content
 						&& $expectedDialogs[$dialogI]['title'] === $title
 					) {
@@ -394,65 +395,6 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		}
 		UploadHelper::createFileSpecificSize($fullPath, (int)$size);
 		$this->createdFiles[] = $fullPath;
-	}
-
-	/**
-	 * gets the base url but without "http(s)://" in front of it
-	 *
-	 * @return string
-	 */
-	public function getBaseUrlWithoutScheme() {
-		return preg_replace(
-			"(^https?://)", "", $this->featureContext->getBaseUrl()
-		);
-	}
-
-	/**
-	 * substitutes codes like %base_url% with the value
-	 * if the given value does not have anything to be substituted
-	 * then it is returned unmodified
-	 *
-	 * @param string $value
-	 *
-	 * @return string
-	 */
-	public function substituteInLineCodes($value) {
-		$substitutions = [
-			[
-				"code" => "%base_url%",
-				"function" => [
-					$this->featureContext,
-					"getBaseUrl"
-				],
-				"parameter" => []
-			],
-			[
-				"code" => "%remote_server%",
-				"function" => "getenv",
-				"parameter" => [
-					"REMOTE_FED_BASE_URL"
-				]
-			],
-			[
-				"code" => "%local_server%",
-				"function" => [
-					$this,
-					"getBaseUrlWithoutScheme"
-				],
-				"parameter" => []
-			]
-		];
-		foreach ($substitutions as $substitution) {
-			$value = str_replace(
-				$substitution["code"],
-				call_user_func_array(
-					$substitution["function"],
-					$substitution["parameter"]
-				),
-				$value
-			);
-		}
-		return $value;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -127,7 +127,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	public function theUserLogsInWithUsernameAndPasswordToUsingTheWebUI(
 		$username, $password, $server
 	) {
-		$server = $this->webUIGeneralContext->substituteInLineCodes($server);
+		$server = $this->featureContext->substituteInLineCodes($server);
 		$this->loginPage->setPagePath(
 			$server . $this->loginPage->getOriginalPath()
 		);

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -107,7 +107,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->sharingDialog = $this->filesPage->openSharingDialog(
 			$folder, $this->getSession()
 		);
-		$user = $this->webUIGeneralContext->substituteInLineCodes($user);
+		$user = $this->featureContext->substituteInLineCodes($user);
 		if ($remote === "remote") {
 			$this->sharingDialog->shareWithRemoteUser(
 				$user, $this->getSession(), $maxRetries, $quiet
@@ -277,7 +277,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	public function theUserSetsTheSharingPermissionsOfForOnTheWebUI(
 		$userName, $fileName, TableNode $permissionsTable
 	) {
-		$userName = $this->webUIGeneralContext->substituteInLineCodes($userName);
+		$userName = $this->featureContext->substituteInLineCodes($userName);
 		$this->theUserOpensTheShareDialogForTheFileFolder($fileName);
 		$this->sharingDialog->setSharingPermissions(
 			$userName, $permissionsTable->getRowsHash()
@@ -328,7 +328,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		if (!$this->publicLinkFilesPage->isOpen()) {
 			throw new Exception('Not on public link page!');
 		}
-		$server = $this->webUIGeneralContext->substituteInLineCodes($server);
+		$server = $this->featureContext->substituteInLineCodes($server);
 		$this->publicLinkFilesPage->addToServer($server);
 		// addToServer takes us from the public link page to the login page
 		// of the remote server, waiting for us to login.


### PR DESCRIPTION
## Description
move the function `substituteInLineCodes()` to a more appropriate place

## Motivation and Context
This function is also useful in API tests

## How Has This Been Tested?
:robot: will test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

