### PR TITLE
[stable10] Fix repair constructor for single user repair

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -182,7 +182,8 @@ class Scan extends Base {
 				try {
 					$repairStep = new RepairMismatchFileCachePath(
 						$connection,
-						$this->mimeTypeLoader
+						$this->mimeTypeLoader,
+						$this->logger
 					);
 					$repairStep->setStorageNumericId($storage->getCache()->getNumericStorageId());
 					$repairStep->setCountOnly(false);

--- a/apps/files/tests/Command/ScanTest.php
+++ b/apps/files/tests/Command/ScanTest.php
@@ -389,5 +389,18 @@ class ScanTest extends TestCase {
 		$storageId = $this->getStorageId('home::' . $this->scanUser1->getUID());
 		$this->assertFalse($this->getFileCacheEntry($storageId, 'files/toscan'));
 	}
+
+	/**
+	 * Scan and repair a single user
+	 */
+	public function testRepairOne() {
+		@mkdir($this->dataDir . '/' . $this->scanUser2->getUID() . '/files/toscan3', 0777, true);
+		$input = [
+			'user_id' => [$this->scanUser2->getUID()],
+			'--repair' => true,
+		];
+		$result = $this->commandTester->execute($input);
+		$this->assertEquals(0, $result);
+	}
 }
 


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/30949 to stable10

Tested manually on `occ` and ran the unit test.