### PR TITLE
[stable10] OneNote 2016 needs a different user agent string

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -114,6 +114,7 @@ class ServerFactory {
 		// we do not provide locking we emulate it using a fake locking plugin.
 		if($this->request->isUserAgent([
 			'/WebDAVFS/',
+			'/OneNote/',
 			'/Microsoft Office OneNote 2013/',
 			'/Microsoft-WebDAV-MiniRedir/',
 		])) {

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -173,6 +173,7 @@ class Server {
 		// we do not provide locking we emulate it using a fake locking plugin.
 		if($request->isUserAgent([
 			'/WebDAVFS/',
+			'/OneNote/',
 			'/Microsoft Office OneNote 2013/',
 			'/Microsoft-WebDAV-MiniRedir/',
 		])) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Backport of https://github.com/owncloud/core/pull/30964 to stable10

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#30962 (OneNote 2016 needs a different user agent string)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

