### PR TITLE
[stable10] Only reset checksum if metadata differs

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Checksum.php
+++ b/lib/private/Files/Storage/Wrapper/Checksum.php
@@ -190,7 +190,12 @@ class Checksum extends Wrapper {
 				return null;
 			}
 		}
-		$parentMetaData['checksum'] = self::getChecksumsInDbFormat($path);
+
+		$checksums = self::getChecksumsInDbFormat($path);
+
+		if (!empty($checksums)) {
+			$parentMetaData['checksum'] = $checksums;
+		}
 
 		if (!isset($parentMetaData['mimetype'])) {
 			$parentMetaData['mimetype'] = 'application/octet-stream';

--- a/tests/lib/Files/Storage/Wrapper/ChecksumTest.php
+++ b/tests/lib/Files/Storage/Wrapper/ChecksumTest.php
@@ -96,7 +96,7 @@ class ChecksumTest extends \Test\TestCase
 
 		$this->assertEquals(
 			$metaData,
-			['checksum' => '', 'mimetype' => 'application/octet-stream']
+			['mimetype' => 'application/octet-stream']
 		);
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
During a cache-scan, cache metadata and file(system) metadata is compared. As the files-system has
no checksum info the  checksum field is empty thus the scanner code wrongly assumes that the checksum has changed and resets the checksum field in file-cache.


## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



