### PR TITLE
Properly remember groups that have been deleted using the webUI

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -120,7 +120,7 @@ trait Provisioning {
 	 * @return boolean
 	 * @throws Exception
 	 */
-	public function theUserShouldHaveBeenCreated($username) {
+	public function theUserShouldExist($username) {
 		if (array_key_exists($username, $this->createdUsers)) {
 			return $this->createdUsers[$username]['shouldHaveBeenCreated'];
 		}
@@ -131,6 +131,27 @@ trait Provisioning {
 
 		throw new Exception(
 			"user '$username' was not created by this test run"
+		);
+	}
+
+	/**
+	 *
+	 * @param string $groupname
+	 *
+	 * @return boolean
+	 * @throws Exception
+	 */
+	public function theGroupShouldExist($groupname) {
+		if (array_key_exists($groupname, $this->createdGroups)) {
+			return $this->createdGroups[$groupname]['shouldHaveBeenCreated'];
+		}
+
+		if (array_key_exists($groupname, $this->createdRemoteGroups)) {
+			return $this->createdRemoteGroups[$groupname]['shouldHaveBeenCreated'];
+		}
+
+		throw new Exception(
+			"group '$groupname' was not created by this test run"
 		);
 	}
 
@@ -778,7 +799,7 @@ trait Provisioning {
 		// successfully created (i.e. the delete is expected to work) and
 		// there was a problem deleting the user. Because in this case there
 		// might be an effect on later tests.
-		if ($this->theUserShouldHaveBeenCreated($user) && ($this->response->getStatusCode() !== 200)) {
+		if ($this->theUserShouldExist($user) && ($this->response->getStatusCode() !== 200)) {
 			error_log(
 				"INFORMATION: could not delete user '" . $user . "' "
 				. $this->response->getStatusCode() . " " . $this->response->getBody()
@@ -814,7 +835,7 @@ trait Provisioning {
 			$this->getAdminPassword()
 		);
 
-		if ($this->response->getStatusCode() !== 200) {
+		if ($this->theGroupShouldExist($group) && ($this->response->getStatusCode() !== 200)) {
 			error_log(
 				"INFORMATION: could not delete group. '" . $group . "'"
 				. $this->response->getStatusCode() . " " . $this->response->getBody()
@@ -1250,15 +1271,11 @@ trait Provisioning {
 		$previousServer = $this->currentServer;
 		$this->usingServer('LOCAL');
 		foreach ($this->createdGroups as $group => $groupData) {
-			if ($groupData['shouldHaveBeenCreated']) {
-				$this->deleteGroup($group);
-			}
+			$this->deleteGroup($group);
 		}
 		$this->usingServer('REMOTE');
 		foreach ($this->createdRemoteGroups as $remoteGroup => $groupData) {
-			if ($groupData['shouldHaveBeenCreated']) {
-				$this->deleteGroup($remoteGroup);
-			}
+			$this->deleteGroup($remoteGroup);
 		}
 		$this->usingServer($previousServer);
 	}

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -630,8 +630,8 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function deleteGroupFromCreatedGroupsList($group) {
-		if (($key = array_search($group, $this->createdGroups, true)) !== false) {
-			unset($this->createdGroups[$key]);
+		if (array_key_exists($group, $this->createdGroups)) {
+			$this->createdGroups[$group]['shouldHaveBeenCreated'] = false;
 		}
 	}
 


### PR DESCRIPTION
## Description
``createdGroups`` array is actually keyed on the group name, so use ``array_key_exists()`` to see if the entry exists. If it does, then when a group has been deleted, mark it ``shouldHaveBeenCreated`` ``false`` - that stops the ``AfterScenario`` code from complaining when/if it cannot delete the group.

## Related Issue
#30897 

## Motivation and Context
webUI tests that delete groups on the webUI users page, they are not properly realizing that the group has been deleted. So in the ``AfterScenario`` that cleans up created groups, they complain with output like:
```
INFORMATION: could not delete group. '0'400 <?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>400</statuscode>
  <message/>
 </meta>
 <data/>
</ocs>
```
There is actually nothing wrong.
It would be good to stop such distracting noise in acceptance test output.
This accidentally got "broken" when the structure of the ``createdGroups`` array was changed recently.

## How Has This Been Tested?
Run the scenario:
```
bash tests/travis/start_ui_tests.sh --feature tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature:12
```
from ``stable10`` (this scenario is in ``core`` ``stable10`` and in ``user_management`` ``master``)
and confirm that the information message(s) are no longer emitted.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

