### PR TITLE
Silence retried to delete file messages

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -359,6 +359,29 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * Delete a file on the current page. The current page should be one that
+	 * has rows of files.
+	 *
+	 * @param string $name
+	 *
+	 * @param bool $expectToDeleteFile if true, then the caller expects that the file can be deleted
+	 * @return void
+	 * @throws Exception
+	 */
+	public function deleteTheFileUsingTheWebUI($name, $expectToDeleteFile = true) {
+		$pageObject = $this->getCurrentPageObject();
+		$session = $this->getSession();
+		$pageObject->waitTillPageIsLoaded($session);
+		if ($expectToDeleteFile) {
+			$pageObject->deleteFile($name, $session, $expectToDeleteFile);
+		} else {
+			// We do not expect to be able to delete the file,
+			// so do not waste time doing too many retries.
+			$pageObject->deleteFile($name, $session, $expectToDeleteFile, MINIMUMRETRYCOUNT);
+		}
+	}
+
+	/**
 	 * for a folder or individual file that is shared, the receiver of the share
 	 * has an "Unshare" entry in the file actions menu. Clicking it works just
 	 * like delete.
@@ -371,10 +394,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserDeletesTheFileUsingTheWebUI($name) {
-		$pageObject = $this->getCurrentPageObject();
-		$session = $this->getSession();
-		$pageObject->waitTillPageIsLoaded($session);
-		$pageObject->deleteFile($name, $session);
+		$this->deleteTheFileUsingTheWebUI($name);
 	}
 
 	/**
@@ -458,7 +478,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	) {
 		$this->deletedElementsTable = $table;
 		foreach ($this->deletedElementsTable as $file) {
-			$this->theUserDeletesTheFileUsingTheWebUI($file['name']);
+			$this->deleteTheFileUsingTheWebUI($file['name']);
 		}
 	}
 
@@ -1040,7 +1060,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function itShouldNotBePossibleToDeleteUsingTheWebUI($name) {
 		try {
-			$this->theUserDeletesTheFileUsingTheWebUI($name);
+			$this->deleteTheFileUsingTheWebUI($name, false);
 		} catch (ElementNotFoundException $e) {
 			PHPUnit_Framework_Assert::assertContains(
 				"could not find button 'Delete' in action Menu",

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -40,3 +40,5 @@ const STANDARDUIWAITTIMEOUTMILLISEC = 10000;
 const MINIMUMUIWAITTIMEOUTMILLISEC = 500;
 // Default number of times to retry where retries are useful
 const STANDARDRETRYCOUNT = 5;
+// Minimum number of times to retry where retries are useful
+const MINIMUMRETRYCOUNT = 2;

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -272,7 +272,12 @@ abstract class FilesPageBasic extends OwncloudPage {
 	 *
 	 * @return void
 	 */
-	public function deleteFile($name, Session $session, $maxRetries = STANDARDRETRYCOUNT) {
+	public function deleteFile(
+		$name,
+		Session $session,
+		$expectToDeleteFile = true,
+		$maxRetries = STANDARDRETRYCOUNT
+	) {
 		$this->initAjaxCounters($session);
 		$this->resetSumStartedAjaxRequests($session);
 		
@@ -285,22 +290,26 @@ abstract class FilesPageBasic extends OwncloudPage {
 				//if no XHR Request were fired we assume the delete action
 				//did not work and we retry
 				if ($countXHRRequests === 0) {
-					error_log("Error while deleting file");
+					if ($expectToDeleteFile) {
+						error_log("Error while deleting file");
+					}
 				} else {
 					break;
 				}
 			} catch (\Exception $e) {
 				$this->closeFileActionsMenu();
-				error_log(
-					"Error while deleting file"
-					. "\n-------------------------\n"
-					. $e->getMessage()
-					. "\n-------------------------\n"
-				);
+				if ($expectToDeleteFile) {
+					error_log(
+						"Error while deleting file"
+						. "\n-------------------------\n"
+						. $e->getMessage()
+						. "\n-------------------------\n"
+					);
+				}
 				usleep(STANDARDSLEEPTIMEMICROSEC);
 			}
 		}
-		if ($counter > 0) {
+		if ($expectToDeleteFile && ($counter > 0)) {
 			$message = "INFORMATION: retried to delete file '" . $name . "' " .
 					   $counter . " times";
 			echo $message;


### PR DESCRIPTION
## Description
If the scenario step does not expect the file to be able to be deleted, then do not emit messages about "retried to delete". In this case we know that we are supposed to retry a bit, and then it is expected that we will give up and not be able to delete the file.

In this case, reduce the number of retries so we do not waste so much time rechecking that a delete really cannot be done.

## Related Issue
#30897 
This "cleanup" is to reduce "noise" in the test output, so that people do not mis-understand what is "normal" and what is a problem.

## Motivation and Context
When a test tries to delete a file, and expects that it should not be possible to delete the file, then actually the "Delete" action does not exist in the file actions menu. That is expected and what is being tested for. But while doing the checks, the code emits messages like:
```
INFORMATION: retried to delete file
Error while deleting file
```
These are disturbing to read in the test output, and can send you off looking for problems in the wrong place, when actually this is expected to happen for these test scenario steps.

When we are doing this kind of "negative" "cannot delete" test, we should not emit this noise.

## How Has This Been Tested?
Run a full set of webUI tests on Travis. Inspect the logs and see that these ``INFORMATION:`` messages no longer appear.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

