### PR TITLE
[stable10] Replace emittingCall with separate before and after events

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -111,162 +111,161 @@ class File extends Node implements IFile {
 	 */
 	public function put($data) {
 		$path = $this->fileView->getAbsolutePath($this->path);
-		return $this->emittingCall(function () use (&$data) {
+		$beforeEvent = new GenericEvent(null, ['path' => $path]);
+		\OC::$server->getEventDispatcher()->dispatch('file.beforecreate', $beforeEvent);
+		try {
+			$exists = $this->fileView->file_exists($this->path);
+			if ($this->info && $exists && !$this->info->isUpdateable()) {
+				throw new Forbidden();
+			}
+		} catch (StorageNotAvailableException $e) {
+			throw new ServiceUnavailable("File is not updatable: " . $e->getMessage());
+		}
+
+		// verify path of the target
+		$this->verifyPath();
+
+		// chunked handling
+		if (\OC_FileChunking::isWebdavChunk()) {
 			try {
-				$exists = $this->fileView->file_exists($this->path);
-				if ($this->info && $exists && !$this->info->isUpdateable()) {
-					throw new Forbidden();
-				}
-			} catch (StorageNotAvailableException $e) {
-				throw new ServiceUnavailable("File is not updatable: " . $e->getMessage());
+				return $this->createFileChunked($data);
+			} catch (\Exception $e) {
+				$this->convertToSabreException($e);
+			}
+		}
+
+		list($partStorage) = $this->fileView->resolvePath($this->path);
+		$needsPartFile = $this->needsPartFile($partStorage) && (strlen($this->path) > 1);
+
+		if ($needsPartFile) {
+			// mark file as partial while uploading (ignored by the scanner)
+			$partFilePath = $this->getPartFileBasePath($this->path) . '.ocTransferId' . rand() . '.part';
+		} else {
+			// upload file directly as the final path
+			$partFilePath = $this->path;
+		}
+
+		// the part file and target file might be on a different storage in case of a single file storage (e.g. single file share)
+		/** @var \OC\Files\Storage\Storage $partStorage */
+		list($partStorage, $internalPartPath) = $this->fileView->resolvePath($partFilePath);
+		/** @var \OC\Files\Storage\Storage $storage */
+		list($storage, $internalPath) = $this->fileView->resolvePath($this->path);
+		try {
+			$target = $partStorage->fopen($internalPartPath, 'wb');
+			if ($target === false) {
+				\OCP\Util::writeLog('webdav', '\OC\Files\Filesystem::fopen() failed', \OCP\Util::ERROR);
+				// because we have no clue about the cause we can only throw back a 500/Internal Server Error
+				throw new Exception('Could not write file contents');
+			}
+			list($count, $result) = \OC_Helper::streamCopy($data, $target);
+			fclose($target);
+
+			if (!self::isChecksumValid($partStorage, $internalPartPath)) {
+				throw new BadRequest('The computed checksum does not match the one received from the client.');
 			}
 
-			// verify path of the target
-			$this->verifyPath();
+			if ($result === false) {
+				$expected = -1;
+				if (isset($_SERVER['CONTENT_LENGTH'])) {
+					$expected = $_SERVER['CONTENT_LENGTH'];
+				}
+				throw new Exception('Error while copying file to target location (copied bytes: ' . $count . ', expected filesize: ' . $expected . ' )');
+			}
 
-			// chunked handling
-			if (\OC_FileChunking::isWebdavChunk()) {
+			// if content length is sent by client:
+			// double check if the file was fully received
+			// compare expected and actual size
+			if (isset($_SERVER['CONTENT_LENGTH']) && $_SERVER['REQUEST_METHOD'] === 'PUT') {
+				$expected = $_SERVER['CONTENT_LENGTH'];
+				if ($count != $expected) {
+					throw new BadRequest('expected filesize ' . $expected . ' got ' . $count);
+				}
+			}
+
+		} catch (\Exception $e) {
+			if ($needsPartFile) {
+				$partStorage->unlink($internalPartPath);
+			}
+			$this->convertToSabreException($e);
+		}
+
+		try {
+			$view = \OC\Files\Filesystem::getView();
+			if ($view) {
+				$run = $this->emitPreHooks($exists);
+			} else {
+				$run = true;
+			}
+
+			try {
+				$this->changeLock(ILockingProvider::LOCK_EXCLUSIVE);
+			} catch (LockedException $e) {
+				if ($needsPartFile) {
+					$partStorage->unlink($internalPartPath);
+				}
+				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
+			}
+
+			if ($needsPartFile) {
+				// rename to correct path
 				try {
-					return $this->createFileChunked($data);
+					if ($run) {
+						$renameOkay = $storage->moveFromStorage($partStorage, $internalPartPath, $internalPath);
+						$fileExists = $storage->file_exists($internalPath);
+					}
+					if (!$run || $renameOkay === false || $fileExists === false) {
+						\OCP\Util::writeLog('webdav', 'renaming part file to final file failed', \OCP\Util::ERROR);
+						throw new Exception('Could not rename part file to final file');
+					}
+				} catch (ForbiddenException $ex) {
+					throw new DAVForbiddenException($ex->getMessage(), $ex->getRetry());
 				} catch (\Exception $e) {
+					$partStorage->unlink($internalPartPath);
 					$this->convertToSabreException($e);
 				}
 			}
 
-			list($partStorage) = $this->fileView->resolvePath($this->path);
-			$needsPartFile = $this->needsPartFile($partStorage) && (strlen($this->path) > 1);
-
-			if ($needsPartFile) {
-				// mark file as partial while uploading (ignored by the scanner)
-				$partFilePath = $this->getPartFileBasePath($this->path) . '.ocTransferId' . rand() . '.part';
-			} else {
-				// upload file directly as the final path
-				$partFilePath = $this->path;
-			}
-
-			// the part file and target file might be on a different storage in case of a single file storage (e.g. single file share)
-			/** @var \OC\Files\Storage\Storage $partStorage */
-			list($partStorage, $internalPartPath) = $this->fileView->resolvePath($partFilePath);
-			/** @var \OC\Files\Storage\Storage $storage */
-			list($storage, $internalPath) = $this->fileView->resolvePath($this->path);
-			try {
-				$target = $partStorage->fopen($internalPartPath, 'wb');
-				if ($target === false) {
-					\OCP\Util::writeLog('webdav', '\OC\Files\Filesystem::fopen() failed', \OCP\Util::ERROR);
-					// because we have no clue about the cause we can only throw back a 500/Internal Server Error
-					throw new Exception('Could not write file contents');
-				}
-				list($count, $result) = \OC_Helper::streamCopy($data, $target);
-				fclose($target);
-
-				if (!self::isChecksumValid($partStorage, $internalPartPath)) {
-					throw new BadRequest('The computed checksum does not match the one received from the client.');
-				}
-
-				if ($result === false) {
-					$expected = -1;
-					if (isset($_SERVER['CONTENT_LENGTH'])) {
-						$expected = $_SERVER['CONTENT_LENGTH'];
-					}
-					throw new Exception('Error while copying file to target location (copied bytes: ' . $count . ', expected filesize: ' . $expected . ' )');
-				}
-
-				// if content length is sent by client:
-				// double check if the file was fully received
-				// compare expected and actual size
-				if (isset($_SERVER['CONTENT_LENGTH']) && $_SERVER['REQUEST_METHOD'] === 'PUT') {
-					$expected = $_SERVER['CONTENT_LENGTH'];
-					if ($count != $expected) {
-						throw new BadRequest('expected filesize ' . $expected . ' got ' . $count);
-					}
-				}
-
-			} catch (\Exception $e) {
-				if ($needsPartFile) {
-					$partStorage->unlink($internalPartPath);
-				}
-				$this->convertToSabreException($e);
-			}
+			// since we skipped the view we need to scan and emit the hooks ourselves
+			$storage->getUpdater()->update($internalPath);
 
 			try {
-				$view = \OC\Files\Filesystem::getView();
-				if ($view) {
-					$run = $this->emitPreHooks($exists);
-				} else {
-					$run = true;
-				}
-
-				try {
-					$this->changeLock(ILockingProvider::LOCK_EXCLUSIVE);
-				} catch (LockedException $e) {
-					if ($needsPartFile) {
-						$partStorage->unlink($internalPartPath);
-					}
-					throw new FileLocked($e->getMessage(), $e->getCode(), $e);
-				}
-
-				if ($needsPartFile) {
-					// rename to correct path
-					try {
-						if ($run) {
-							$renameOkay = $storage->moveFromStorage($partStorage, $internalPartPath, $internalPath);
-							$fileExists = $storage->file_exists($internalPath);
-						}
-						if (!$run || $renameOkay === false || $fileExists === false) {
-							\OCP\Util::writeLog('webdav', 'renaming part file to final file failed', \OCP\Util::ERROR);
-							throw new Exception('Could not rename part file to final file');
-						}
-					} catch (ForbiddenException $ex) {
-						throw new DAVForbiddenException($ex->getMessage(), $ex->getRetry());
-					} catch (\Exception $e) {
-						$partStorage->unlink($internalPartPath);
-						$this->convertToSabreException($e);
-					}
-				}
-
-				// since we skipped the view we need to scan and emit the hooks ourselves
-				$storage->getUpdater()->update($internalPath);
-
-				try {
-					$this->changeLock(ILockingProvider::LOCK_SHARED);
-				} catch (LockedException $e) {
-					throw new FileLocked($e->getMessage(), $e->getCode(), $e);
-				}
-
-				// allow sync clients to send the mtime along in a header
-				if (isset($this->request->server['HTTP_X_OC_MTIME'])) {
-					$mtime = $this->sanitizeMtime($this->request->server ['HTTP_X_OC_MTIME']);
-					if ($this->fileView->touch($this->path, $mtime)) {
-						$this->header('X-OC-MTime: accepted');
-					}
-				}
-
-				if ($view) {
-					$this->emitPostHooks($exists);
-				}
-
-				$this->refreshInfo();
-
-				$meta = $partStorage->getMetaData($internalPartPath);
-
-				if (isset($meta['checksum'])) {
-					$this->fileView->putFileInfo(
-						$this->path,
-						['checksum' => $meta['checksum']]
-					);
-				}
-
-				$this->refreshInfo();
-
-			} catch (StorageNotAvailableException $e) {
-				throw new ServiceUnavailable("Failed to check file size: " . $e->getMessage());
+				$this->changeLock(ILockingProvider::LOCK_SHARED);
+			} catch (LockedException $e) {
+				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 			}
 
-			return '"' . $this->info->getEtag() . '"';
-		},[
-			'before' => ['path' => $path],
-			'after' => ['path' => $path],
-		], 'file', 'create');
+			// allow sync clients to send the mtime along in a header
+			if (isset($this->request->server['HTTP_X_OC_MTIME'])) {
+				$mtime = $this->sanitizeMtime($this->request->server ['HTTP_X_OC_MTIME']);
+				if ($this->fileView->touch($this->path, $mtime)) {
+					$this->header('X-OC-MTime: accepted');
+				}
+			}
+
+			if ($view) {
+				$this->emitPostHooks($exists);
+			}
+
+			$this->refreshInfo();
+
+			$meta = $partStorage->getMetaData($internalPartPath);
+
+			if (isset($meta['checksum'])) {
+				$this->fileView->putFileInfo(
+					$this->path,
+					['checksum' => $meta['checksum']]
+				);
+			}
+
+			$this->refreshInfo();
+
+		} catch (StorageNotAvailableException $e) {
+			throw new ServiceUnavailable("Failed to check file size: " . $e->getMessage());
+		}
+
+		$afterEvent = new GenericEvent(null, ['path' => $path]);
+		\OC::$server->getEventDispatcher()->dispatch('file.aftercreate', $afterEvent);
+		return '"' . $this->info->getEtag() . '"';
 	}
 
 	private function getPartFileBasePath($path) {


### PR DESCRIPTION
The call to emittingCall was causing issues when
clients like android are trying to upload files.
Which were triggering after events even when the
upload operation was not completed. Replacing
emittingCall would explicitely call the before
and after events when required.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Remove emittingCall in this method. It was found that before completion of the upload, the after event was emitted. Which is not correct. Hence called the before and after events separately. To be specific the return https://github.com/owncloud/core/blob/955d0df3f552663aaff22fd10b95ee54d98bd6bd/apps/dav/lib/Connector/Sabre/File.php#L132 was the cause, to raise this PR.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove `emittingCall` in this method. It was found that before completion of the upload, the after event was emitted. Which is not correct. Hence called the before and after events separately.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

