### PR TITLE
Remove pagination from the repair step

### DIFF
--- a/tests/lib/Repair/RepairOrphanedSubshareTest.php
+++ b/tests/lib/Repair/RepairOrphanedSubshareTest.php
@@ -288,12 +288,16 @@ class RepairOrphanedSubshareTest extends TestCase {
 	}
 
 	/**
-	 * A new approach
+	 * This is a test to verify if there are lets say 3000 parents which got reshared
+	 * to subsequent users. And lets say 2500 parent entries got deleted, then
+	 * users who had these parents shared would become orphans. And this test
+	 * is a proof that all the 2500 orphaned shares in the users will be removed.
+	 * And hence no further issues would be caused in the UI.
 	 */
-	public function testOrphanSharesNoMorePagination() {
+	public function testLargeOrphanSharesDistributedAmongUsers() {
 		$qb = $this->connection->getQueryBuilder();
 		$totalUsers[] = 'admin';
-		//Create 4 users. admin, user1, user2
+		//Create 4 users. admin, user1, user2, user3
 		$user = 'user';
 		for ($i = 1; $i <= 3; $i++) {
 			$this->createUser($user . $i);
@@ -387,20 +391,16 @@ class RepairOrphanedSubshareTest extends TestCase {
 			}
 		}
 
-		//Lets check range of 2900 to 2910
-		foreach (range(2900, 2910) as $adminIndex) {
-			$row = $checkQuery->select('parent')
-				->from('share')->where($checkQuery->expr()->eq('id', $checkQuery->createNamedParameter($getAllIdsPerUser['admin'][$adminIndex])))
-				->execute()->fetchAll();
-			$this->assertEquals(1, count($row));
-		}
-
-		//Lets check rance of 1 to 9
-		foreach (range(1, 9) as $adminIndex) {
-			$row = $checkQuery->select('parent')
-				->from('share')->where($checkQuery->expr()->eq('id', $checkQuery->createNamedParameter($getAllIdsPerUser['admin'][$adminIndex])))
-				->execute()->fetchAll();
-			$this->assertEquals(1, count($row));
+		//Lets check range of 2900 to 2910 and 1 to 9
+		$checkRandomAvailableEntries[] = range(2900, 2910);
+		$checkRandomAvailableEntries[] = range(1, 9);
+		foreach ($checkRandomAvailableEntries as $checkRandomAvailableEntry) {
+			foreach ($checkRandomAvailableEntry as $adminIndex) {
+				$row = $checkQuery->select('parent')
+					->from('share')->where($checkQuery->expr()->eq('id', $checkQuery->createNamedParameter($getAllIdsPerUser['admin'][$adminIndex])))
+					->execute()->fetchAll();
+				$this->assertEquals(1, count($row));
+			}
 		}
 	}
 


### PR DESCRIPTION
The pagination is not required as the
rows are deleted during the operation.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
The pagination should be removed from this repair step. Because if the pagination is there, then the changes will not be taken after the first removal in the loop. The second iteration might omit changes which have broken links.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/pull/30653#issuecomment-378194758

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the rows are deleted on the fly, then its better to avoid pagination and use the pagelimit .

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

