### PR TITLE
Throw symfony events on group actions

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -260,8 +260,10 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$this->getUserManager(),
 				new UserSearch(
 					$c->getConfig()
-				)
+				),
+				$this->getEventDispatcher()
 			);
+
 			$groupManager->listen('\OC\Group', 'preCreate', function ($gid) {
 				\OC_Hook::emit('OC_Group', 'pre_createGroup', ['run' => true, 'gid' => $gid]);
 			});

--- a/tests/lib/App/ManagerTest.php
+++ b/tests/lib/App/ManagerTest.php
@@ -164,8 +164,8 @@ class ManagerTest extends TestCase {
 
 	public function testEnableAppForGroups() {
 		$groups = [
-			new Group('group1', [], null),
-			new Group('group2', [], null)
+			new Group('group1', [], null, $this->eventDispatcher),
+			new Group('group2', [], null, $this->eventDispatcher)
 		];
 		$this->expectClearCache();
 		$this->manager->enableAppForGroups('test', $groups);
@@ -191,8 +191,8 @@ class ManagerTest extends TestCase {
 	 */
 	public function testEnableAppForGroupsAllowedTypes(array $appInfo) {
 		$groups = [
-			new Group('group1', [], null),
-			new Group('group2', [], null)
+			new Group('group1', [], null, $this->eventDispatcher),
+			new Group('group2', [], null, $this->eventDispatcher)
 		];
 		$this->expectClearCache();
 
@@ -236,8 +236,8 @@ class ManagerTest extends TestCase {
 	 */
 	public function testEnableAppForGroupsForbiddenTypes($type) {
 		$groups = [
-			new Group('group1', [], null),
-			new Group('group2', [], null)
+			new Group('group1', [], null, $this->eventDispatcher),
+			new Group('group2', [], null, $this->eventDispatcher)
 		];
 
 		/** @var AppManager|\PHPUnit_Framework_MockObject_MockObject $manager */


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Required change for https://github.com/owncloud/core/pull/30106 to discard the notification when the user is removed from the group

## Related Issue
Required for https://github.com/owncloud/core/pull/30106

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unittests included

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
