### PR TITLE
webUI acceptance tests for trashbin multi delete and restore

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -749,7 +749,18 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserBatchDeletesTheMarkedFilesUsingTheWebUI() {
-		$this->filesPage->deleteAllSelectedFiles($this->getSession());
+		$pageObject = $this->getCurrentPageObject();
+		$pageObject->deleteAllSelectedFiles($this->getSession());
+	}
+
+	/**
+	 * @When the user batch restores the marked files using the webUI
+	 * @Given the user has batch restored the marked files using the webUI
+	 *
+	 * @return void
+	 */
+	public function theUserBatchRestoresTheMarkedFilesUsingTheWebUI() {
+		$this->trashbinPage->restoreAllSelectedFiles($this->getSession());
 	}
 
 	/**
@@ -764,12 +775,25 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function theUserMarksTheseFilesForBatchActionUsingTheWebUI(
 		TableNode $files
 	) {
-		$this->filesPage->waitTillPageIsLoaded($this->getSession());
+		$pageObject = $this->getCurrentPageObject();
+		$session = $this->getSession();
+		$pageObject->waitTillPageIsLoaded($session);
 		foreach ($files as $file) {
-			$this->filesPage->selectFileForBatchAction(
-				$file['name'], $this->getSession()
+			$pageObject->selectFileForBatchAction(
+				$file['name'], $session
 			);
 		}
+	}
+
+	/**
+	 * @When the user marks all files for batch action using the webUI
+	 * @Given the user has selected all files for batch action using the webUI
+	 *
+	 * @return void
+	 */
+	public function theUserMarksAllFilesForBatchActionUsingTheWebUI() {
+		$pageObject = $this->getCurrentPageObject();
+		$pageObject->selectAllFilesForBatchAction();
 	}
 
 	/**
@@ -816,9 +840,33 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$pageObject->waitTillPageIsLoaded($this->getSession());
 	}
 	
-	
 	/**
-	 * @Then /^the (?:file|folder) ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(?:in the |)(trashbin|favorites page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))? on the webUI$/
+	 * @Then /^the folder should (not|)\s?be empty on the webUI$/
+	 *
+	 * @param string $shouldOrNot
+	 *
+	 * @return void
+	 */
+	public function theFolderShouldBeEmptyOnTheWebUI($shouldOrNot) {
+		$should = ($shouldOrNot !== "not");
+		$pageObject = $this->getCurrentPageObject();
+		$folderIsEmpty = $pageObject->isFolderEmpty();
+
+		if ($should) {
+			PHPUnit_Framework_Assert::assertTrue(
+				$folderIsEmpty,
+				"folder contains items but should be empty"
+			);
+		} else {
+			PHPUnit_Framework_Assert::assertFalse(
+				$folderIsEmpty,
+				"folder is empty but should contain items"
+			);
+		}
+	}
+
+	/**
+	 * @Then /^the (?:file|folder) ((?:'[^']*')|(?:"[^"]*")) should (not|)\s?be listed\s?(?:in the |)(trashbin|favorites page|files page|)\s?(?:folder ((?:'[^']*')|(?:"[^"]*")))? on the webUI$/
 	 *
 	 * @param string $name enclosed in single or double quotes
 	 * @param string $shouldOrNot
@@ -862,6 +910,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		}
 		if ($typeOfFilesPage === "favorites page") {
 			$this->theUserBrowsesToTheFavoritesPage();
+		}
+		if ($typeOfFilesPage === "files page") {
+			$this->theUserBrowsesToTheFilesPage();
 		}
 		$pageObject = $this->getCurrentPageObject();
 		$pageObject->waitTillPageIsLoaded($this->getSession());

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -870,7 +870,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function theFolderShouldBeEmptyOnTheWebUI($shouldOrNot) {
 		$should = ($shouldOrNot !== "not");
 		$pageObject = $this->getCurrentPageObject();
-		$folderIsEmpty = $pageObject->isFolderEmpty();
+		$folderIsEmpty = $pageObject->isFolderEmpty($this->getSession());
 
 		if ($should) {
 			PHPUnit_Framework_Assert::assertTrue(

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -266,6 +266,21 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then there should be exactly :count files\/folders listed on the webUI
+	 * @Then there should be exactly :count file/files listed on the webUI
+	 * @Then there should be exactly :count folder/folders listed on the webUI
+	 *
+	 * @param string $count that is numeric
+	 * @return void
+	 */
+	public function thereShouldBeCountFilesFoldersListedOnTheWebUI($count) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$count,
+			$this->filesPage->getSizeOfFileFolderList()
+		);
+	}
+
+	/**
 	 * @When the user creates so many files\/folders that they do not fit in one browser page
 	 * @Given so many files\/folders have been created that they do not fit in one browser page
 	 *
@@ -764,8 +779,11 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user marks these files for batch action using the webUI
-	 * @Given the user has marked these files for batch action using the webUI
+	 * mark a set of files ready for them to be included in a batch action
+	 * if any of the files are already marked, then they will be unmarked
+	 *
+	 * @When the user marks/unmarks these files for batch action using the webUI
+	 * @Given the user has marked/unmarked these files for batch action using the webUI
 	 *
 	 * @param TableNode $files table of file names
 	 *                         table headings: must be: |name|
@@ -863,6 +881,18 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 				"folder is empty but should contain items"
 			);
 		}
+	}
+
+	/**
+	 * @Then /^the folder should (not|)\s?be empty on the webUI after a page reload$/
+	 *
+	 * @param string $shouldOrNot
+	 *
+	 * @return void
+	 */
+	public function theFolderShouldBeEmptyOnTheWebUIAfterAPageReload($shouldOrNot) {
+		$this->theUserReloadsTheCurrentPageOfTheWebUI();
+		$this->theFolderShouldBeEmptyOnTheWebUI($shouldOrNot);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -259,9 +259,10 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function thereShouldBeNoFilesFoldersListedOnTheWebUI() {
+		$pageObject = $this->getCurrentPageObject();
 		PHPUnit_Framework_Assert::assertEquals(
 			0,
-			$this->filesPage->getSizeOfFileFolderList()
+			$pageObject->getSizeOfFileFolderList()
 		);
 	}
 
@@ -274,9 +275,10 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function thereShouldBeCountFilesFoldersListedOnTheWebUI($count) {
+		$pageObject = $this->getCurrentPageObject();
 		PHPUnit_Framework_Assert::assertEquals(
 			$count,
-			$this->filesPage->getSizeOfFileFolderList()
+			$pageObject->getSizeOfFileFolderList()
 		);
 	}
 

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -460,7 +460,8 @@ abstract class FilesPageBasic extends OwncloudPage {
 	 *
 	 * @return boolean
 	 */
-	public function isFolderEmpty() {
+	public function isFolderEmpty($session) {
+		$this->waitTillPageIsLoaded($session);
 		$emptyContentElement = $this->find(
 			"xpath",
 			$this->getEmptyContentXpath()

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -390,6 +390,8 @@ abstract class FilesPageBasic extends OwncloudPage {
 	}
 
 	/**
+	 * selects the given file, ready for it to be included in a batch action
+	 * if the row is already selected, then it will be unselected.
 	 *
 	 * @param string $name
 	 * @param Session $session

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -387,6 +387,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	public function deleteAllSelectedFiles(Session $session) {
 		$this->findDeleteAllSelectedFilesBtn()->click();
 		$this->waitForAjaxCallsToStartAndFinish($session);
+		$this->waitTillFileRowsAreReady($session);
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -22,6 +22,7 @@
 
 namespace Page;
 
+use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 use Page\FilesPageElement\FileActionsMenu;
 use Page\FilesPageElement\FileRow;
@@ -47,6 +48,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	protected $fileRowXpathFromActionMenu = "/../..";
 	protected $appSettingsXpath = "//div[@id='app-settings']";
 	protected $showHiddenFilesCheckboxXpath = "//label[@for='showhiddenfilesToggle']";
+	protected $selectAllFilesCheckboxXpath = "//label[@for='select_all_files']";
 	protected $appSettingsContentId = "app-settings-content";
 	protected $styleOfCheckboxWhenVisible = "display: block;";
 
@@ -88,7 +90,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	/**
 	 * @param int $number
 	 *
-	 * @return \Behat\Mink\Element\NodeElement|null
+	 * @return NodeElement|null
 	 */
 	public function findActionMenuByNo($number) {
 		$xpath = sprintf($this->fileActionMenuBtnXpathByNo, $number);
@@ -235,7 +237,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	 * Finds the open File Action Menu
 	 * the File Action Button must be clicked first
 	 *
-	 * @return \Behat\Mink\Element\NodeElement
+	 * @return NodeElement
 	 * @throws ElementNotFoundException
 	 */
 	public function findFileActionMenuElement() {
@@ -342,7 +344,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	/**
 	 *
 	 * @throws ElementNotFoundException
-	 * @return \Behat\Mink\Element\NodeElement
+	 * @return NodeElement
 	 */
 	public function findDeleteAllSelectedFilesBtn() {
 		$deleteAllSelectedBtn = $this->find(
@@ -356,6 +358,24 @@ abstract class FilesPageBasic extends OwncloudPage {
 			);
 		}
 		return $deleteAllSelectedBtn;
+	}
+
+	/**
+	 *
+	 * @throws ElementNotFoundException
+	 * @return NodeElement
+	 */
+	public function findSelectAllFilesBtn() {
+		$selectedAllFilesBtn = $this->find(
+			"xpath", $this->selectAllFilesCheckboxXpath
+		);
+		if (is_null($selectedAllFilesBtn)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				"could not find button $this->selectAllFilesCheckboxXpath to select all files"
+			);
+		}
+		return $selectedAllFilesBtn;
 	}
 
 	/**
@@ -383,10 +403,18 @@ abstract class FilesPageBasic extends OwncloudPage {
 
 	/**
 	 *
+	 * @return void
+	 */
+	public function selectAllFilesForBatchAction() {
+		$this->findSelectAllFilesBtn()->click();
+	}
+
+	/**
+	 *
 	 * @param int $number
 	 *
 	 * @throws ElementNotFoundException
-	 * @return \Behat\Mink\Element\NodeElement
+	 * @return NodeElement
 	 */
 	public function findFileActionsMenuBtnByNo($number) {
 		$xpathLocator = sprintf($this->fileActionMenuBtnXpathByNo, $number);
@@ -423,6 +451,23 @@ abstract class FilesPageBasic extends OwncloudPage {
 		$actionMenu = $this->getPage('FilesPageElement\\FileActionsMenu');
 		$actionMenu->setElement($actionMenuElement);
 		return $actionMenu;
+	}
+
+	/**
+	 *
+	 * @return boolean
+	 */
+	public function isFolderEmpty() {
+		$emptyContentElement = $this->find(
+			"xpath",
+			$this->getEmptyContentXpath()
+		);
+
+		if (!is_null($emptyContentElement)) {
+			return $emptyContentElement->isVisible();
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -272,6 +272,7 @@ class FileRow extends OwncloudPage {
 
 	/**
 	 * selects this row for batch action e.g. download or delete
+	 * if the row is already selected, then it will be unselected.
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/lib/TrashbinPage.php
+++ b/tests/acceptance/features/lib/TrashbinPage.php
@@ -99,6 +99,7 @@ class TrashbinPage extends FilesPageBasic {
 	public function restoreAllSelectedFiles(Session $session) {
 		$this->findRestoreAllSelectedFilesBtn()->click();
 		$this->waitForAjaxCallsToStartAndFinish($session);
+		$this->waitTillFileRowsAreReady($session);
 	}
 
 	/**

--- a/tests/acceptance/features/lib/TrashbinPage.php
+++ b/tests/acceptance/features/lib/TrashbinPage.php
@@ -22,7 +22,9 @@
 
 namespace Page;
 
+use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**
  * Trashbin page.
@@ -38,6 +40,9 @@ class TrashbinPage extends FilesPageBasic {
 	protected $fileNameMatchXpath = "//span[contains(@class,'nametext') and .=%s]";
 	protected $fileListXpath = ".//div[@id='app-content-trashbin']//tbody[@id='fileList']";
 	protected $emptyContentXpath = ".//div[@id='app-content-trashbin']//div[@id='emptycontent']";
+	protected $deleteAllSelectedBtnXpath = ".//*[@id='app-content-trashbin']//*[@class='delete-selected']";
+	protected $restoreAllSelectedBtnXpath = ".//*[@id='app-content-trashbin']//*[@class='undelete']";
+	protected $selectAllFilesCheckboxXpath = "//label[@for='select_all_trash']";
 
 	/**
 	 * @return string
@@ -65,6 +70,35 @@ class TrashbinPage extends FilesPageBasic {
 	 */
 	protected function getEmptyContentXpath() {
 		return $this->emptyContentXpath;
+	}
+
+	/**
+	 * @throws ElementNotFoundException
+	 * @return NodeElement
+	 */
+	public function findRestoreAllSelectedFilesBtn() {
+		$restoreAllSelectedBtn = $this->find(
+			"xpath", $this->restoreAllSelectedBtnXpath
+		);
+		if (is_null($restoreAllSelectedBtn)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->restoreAllSelectedBtnXpath " .
+				"could not find button to restore all selected files"
+			);
+		}
+		return $restoreAllSelectedBtn;
+	}
+
+	/**
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function restoreAllSelectedFiles(Session $session) {
+		$this->findRestoreAllSelectedFilesBtn()->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
 
 	/**

--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -65,6 +65,23 @@ So that I can keep my filing system clean and tidy
 		Then the deleted elements should not be listed on the webUI
 		And the deleted elements should not be listed on the webUI after a page reload
 
+	Scenario: Delete all files at once
+		When the user marks all files for batch action using the webUI
+		And the user batch deletes the marked files using the webUI
+		Then the folder should be empty on the webUI
+		And the folder should be empty on the webUI after a page reload
+
+	Scenario: Delete all except for a few files at once
+		When the user marks all files for batch action using the webUI
+		And the user unmarks these files for batch action using the webUI
+			| name          |
+			| lorem.txt     |
+			| simple-folder |
+		And the user batch deletes the marked files using the webUI
+		Then there should be exactly 2 files/folders listed on the webUI
+		And the folder "simple-folder" should be listed on the webUI
+		And the file "lorem.txt" should be listed on the webUI
+
 	Scenario: Delete an empty folder
 		When the user creates a folder with the name "my-empty-folder" using the webUI
 		And the user creates a folder with the name "my-other-empty-folder" using the webUI

--- a/tests/acceptance/features/webUITrashbin/restore.feature
+++ b/tests/acceptance/features/webUITrashbin/restore.feature
@@ -27,3 +27,42 @@ So that I can recover accidentally deleted files/folders in ownCloud
 		Then the file "folder with space" should not be listed on the webUI
 		When the user browses to the files page
 		Then the folder "folder with space" should be listed on the webUI
+
+	Scenario: Select some trashbin files and restore them in a batch
+		Given the following files have been deleted
+			| name          |
+			| data.zip      |
+			| lorem.txt     |
+			| lorem-big.txt |
+			| simple-folder |
+		And the user has browsed to the trashbin page
+		When the user marks these files for batch action using the webUI
+			| name          |
+			| lorem.txt     |
+			| lorem-big.txt |
+		And the user batch restores the marked files using the webUI
+		Then the file "data.zip" should be listed on the webUI
+		And the folder "simple-folder" should be listed on the webUI
+		But the file "lorem.txt" should not be listed on the webUI
+		And the file "lorem-big.txt" should not be listed on the webUI
+		And the file "lorem.txt" should be listed in the files page on the webUI
+		And the file "lorem-big.txt" should be listed in the files page on the webUI
+		But the file "data.zip" should not be listed in the files page on the webUI
+		And the folder "simple-folder" should not be listed in the files page on the webUI
+
+	Scenario: Select all trashbin files and restore them in a batch
+		Given the following files have been deleted
+			| name          |
+			| data.zip      |
+			| lorem.txt     |
+			| lorem-big.txt |
+			| simple-folder |
+		And the user has browsed to the trashbin page
+		And the user marks all files for batch action using the webUI
+		And the user batch restores the marked files using the webUI
+		Then the folder should be empty on the webUI
+		When the user browses to the files page
+		Then the file "lorem.txt" should be listed on the webUI
+		And the file "lorem-big.txt" should be listed on the webUI
+		And the file "data.zip" should be listed on the webUI
+		And the folder "simple-folder" should be listed on the webUI

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -12,6 +12,7 @@ Feature: files and folders can be deleted from the trashbin
     And the user has logged in with username "user1" and password "1234" using the webUI
     And the following files have been deleted
       | name          |
+      | data.zip      |
       | lorem.txt     |
       | lorem-big.txt |
       | simple-folder |
@@ -29,3 +30,21 @@ Feature: files and folders can be deleted from the trashbin
   Scenario: Delete folders and check that they are gone
     When the user deletes the folder "simple-folder" using the webUI
     Then the folder "simple-folder" should not be listed in the trashbin on the webUI
+
+  Scenario: Select some files and delete from trashbin in a batch
+    When the user batch deletes these files using the webUI
+      | name          |
+      | lorem.txt     |
+      | lorem-big.txt |
+    Then the deleted elements should not be listed on the webUI
+    And the deleted elements should not be listed on the webUI after a page reload
+    But the file "data.zip" should be listed on the webUI
+    And the folder "simple-folder" should be listed on the webUI
+    # make sure the delete button is not accidentally doing restore
+    And the file "lorem.txt" should not be listed in the files page on the webUI
+    And the file "lorem-big.txt" should not be listed in the files page on the webUI
+
+  Scenario: Select all files and delete from trashbin in a batch
+    When the user marks all files for batch action using the webUI
+    And the user batch deletes the marked files using the webUI
+    Then the folder should be empty on the webUI


### PR DESCRIPTION
## Description
1) Add webUI trashbin acceptance tests that select multiple files, or all files, and confirm that the selected files can be restored or deleted from the trashbin.

2) Add webUI files page tests that select multiple files, or all files, and confirm that the selected files can be deleted

3) Improve the waiting for cases where there is multiple file delete or restore - we need to ``waitTillFileRowsAreReady()`` to make sure all the file row actions have properly finished.

## Related Issue
#30942 
Note: this PR first adds tests for existing behavior that works. After this PR, it will be easy to add a couple more test scenarios for the more complex trashbin file selection combinations in the issue.

## Motivation and Context
There are not yet tests of the webUI behavior when selecting multiple files in the trashbin.

## How Has This Been Tested?
Run new tests locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New acceptance tests

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

