### PR TITLE
[stable10] catch possible 500 server exception when cleaning up groups in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -490,14 +490,34 @@ trait Provisioning {
 	}
 
 	/**
+	 * Try to delete the group, catching anything bad that might happen.
+	 * Use this method only in places where you want to try as best you
+	 * can to delete the group, but do not want to error if there is a problem.
+	 *
 	 * @param string $group
 	 *
 	 * @return void
 	 */
-	public function deleteGroup($group) {
-		$this->deleteTheGroupUsingTheAPI($group);
-		if ($this->theGroupShouldBeAbleToBeDeleted($group)) {
-			PHPUnit_Framework_Assert::assertFalse($this->groupExists($group));
+	public function cleanupGroup($group) {
+		try {
+			$this->deleteTheGroupUsingTheAPI($group);
+		} catch (BadResponseException $e) {
+			$this->response = $e->getResponse();
+			error_log(
+				"INFORMATION: There was an unexpected problem trying to delete group '" .
+				$group . "' status code " . $this->response->getStatusCode() .
+				" message `" . $e->getMessage() . "'"
+			);
+		}
+
+		if ($this->theGroupShouldBeAbleToBeDeleted($group)
+			&& $this->groupExists($group)
+		) {
+			error_log(
+				"INFORMATION: tried to delete group '" . $group .
+				"' at the end of the scenario but it seems to still exist. " .
+				"There might be problems with later scenarios."
+			);
 		}
 	}
 
@@ -1319,11 +1339,11 @@ trait Provisioning {
 		$previousServer = $this->currentServer;
 		$this->usingServer('LOCAL');
 		foreach ($this->createdGroups as $group => $groupData) {
-			$this->deleteGroup($group);
+			$this->cleanupGroup($group);
 		}
 		$this->usingServer('REMOTE');
 		foreach ($this->createdRemoteGroups as $remoteGroup => $groupData) {
-			$this->deleteGroup($remoteGroup);
+			$this->cleanupGroup($remoteGroup);
 		}
 		$this->usingServer($previousServer);
 	}


### PR DESCRIPTION
## Description
When doing ``cleanupGroups()`` at the end of a scenario, if "something bad" happens (e.g. a 500 "internal server error" server exception) then catch that. Because we want to go on and try to delete other groups, or do other ``AfterScenario`` actions to try as hard as we can to cleanup ready for the next scenario.

There is of course the possibility that the environment for later scenarios will not be as expected, so emit a message in the log so that if the next scenario fails, then someone can see that there was a previous cleanup problem and look into it more.

## Related Issue

## Motivation and Context
There is a problem deleting groups that have "a/slash" in their name using the provisioning API. In those cases Apache returns a 4nn error code, claiming the group does not exist, and that is already caught and handled in the acceptance tests - so the tests pass on drone with Apache.

On Travis, which uses PHP dev server, a "500 Internal server error" is returned. That resulted in the test itself failing on the Travis nightly cron job that runs tests for all browsers.

An example fail is:
```
  Scenario: delete groups with special characters that appear in URLs # /home/[secure]/build/owncloud/core/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature:43
    Given these groups have been created:                             # FeatureContext::theseGroupsHaveBeenCreated()
      | groupname      |
      | do-not-delete  |
      | a/slash        |
      | per%cent       |
      | hash#char      |
      | q?mark         |
      | do-not-delete2 |
    And the administrator has browsed to the users page               # WebUIUsersContext::theUserBrowsesToTheUsersPage()
    When the administrator deletes these groups using the webUI:      # WebUIUsersContext::theAdminDeletesTheseGroupsUsingTheWebUI()
      | groupname |
      | a/slash   |
      | per%cent  |
      | hash#char |
      | q?mark    |
    And the administrator reloads the users page                      # WebUIUsersContext::theUserReloadsTheUsersPage()
    Then these groups should be listed on the webUI:                  # WebUIUsersContext::theseGroupsShouldBeListedOnTheWebUI()
      | groupname      |
      | do-not-delete  |
      | do-not-delete2 |
    But these groups should not be listed on the webUI:               # WebUIUsersContext::theseGroupsShouldBeListedOnTheWebUI()
      | groupname |
      | a/slash   |
      | per%cent  |
      | hash#char |
      | q?mark    |
    And these groups should exist:                                    # FeatureContext::theseGroupsShouldNotExist()
      | groupname      |
      | do-not-delete  |
      | do-not-delete2 |
    But these groups should not exist:                                # FeatureContext::theseGroupsShouldNotExist()
      | groupname |
      | a/slash   |
      | per%cent  |
      | hash#char |
      | q?mark    |
SAUCELABS RESULT: (pass) https://saucelabs.com/jobs/4101487c8dfc41319f12453478d60a9b
  │
  ╳  exception 'GuzzleHttp\Exception\ServerException' with message 'Server error response [url] http://owncloud:8889/ocs/v2.php/cloud/groups/a%2Fslash [status code] 500 [reason phrase] Internal Server Error' in /home/[secure]/build/owncloud/core/lib/composer/guzzlehttp/guzzle/src/Exception/RequestException.php:89
  ╳  Stack trace:
  ╳  #0 /home/[secure]/build/owncloud/core/lib/composer/guzzlehttp/guzzle/src/Subscriber/HttpError.php(33): GuzzleHttp\Exception\RequestException::create(Object(GuzzleHttp\Message\Request), Object(GuzzleHttp\Message\Response))
  ╳  #1 /home/[secure]/build/owncloud/core/lib/composer/guzzlehttp/guzzle/src/Event/Emitter.php(108): GuzzleHttp\Subscriber\HttpError->onComplete(Object(GuzzleHttp\Event\CompleteEvent), 'complete')
 ```

And that leaves any other groups not cleaned up, and any other cleanup not done. So other test fails happen later because, for example, the group ``do-not-delete2`` is left behind.

## How Has This Been Tested?
Run locally using PHP dev server.
```
bash tests/travis/start_ui_tests.sh --feature tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
```
see it fail

Make this fix, run again, see it pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test fix

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

