### PR TITLE
fix repair orphaned shares sql and loop condition

### DIFF
--- a/lib/private/Repair/RepairOrphanedSubshare.php
+++ b/lib/private/Repair/RepairOrphanedSubshare.php
@@ -31,12 +31,6 @@ class RepairOrphanedSubshare implements IRepairStep {
 	/** @var IDBConnection  */
 	private $connection;
 
-	/** @var  IQueryBuilder */
-	private $missingParents;
-
-	/** @var  IQueryBuilder */
-	private $deleteOrphanReshares;
-
 	/**
 	 * RepairOrphanedSubshare constructor.
 	 *
@@ -44,27 +38,6 @@ class RepairOrphanedSubshare implements IRepairStep {
 	 */
 	public function __construct(IDBConnection $connection) {
 		$this->connection = $connection;
-
-		//This delete query deletes orphan shares whose parents are missing
-		$this->deleteOrphanReshares = $this->connection->getQueryBuilder();
-		$this->deleteOrphanReshares
-			->delete('share')
-			->where(
-				$this->deleteOrphanReshares->expr()->eq('parent',
-					$this->deleteOrphanReshares->createParameter('parentId')));
-
-
-		//Set the query to get the parent id's missing from the table.
-		$this->missingParents = $this->connection->getQueryBuilder();
-		$qb = $this->connection->getQueryBuilder();
-
-		$qb->select('id')
-			->from('share');
-		$this->missingParents->select('parent')
-			->from('share');
-		$this->missingParents->where($this->missingParents->expr()->isNotNull('parent'));
-		$this->missingParents->andWhere($this->missingParents->expr()->notIn('parent', $this->missingParents->createFunction($qb->getSQL())));
-		$this->missingParents->groupBy('parent');
 	}
 
 	/**
@@ -84,24 +57,34 @@ class RepairOrphanedSubshare implements IRepairStep {
 	 * @throws \Exception in case of failure
 	 */
 	public function run(IOutput $output) {
-		$pageLimit = 1000;
-		$paginationOffset = 0;
-		$deleteParents = [];
 
-		/** A one time call to get missing parents from oc_share table */
-		do {
-			$this->missingParents->setMaxResults($pageLimit);
-			$this->missingParents->setFirstResult($paginationOffset);
-			$results = $this->missingParents->execute();
-			$rows = $results->fetchAll();
-			$results->closeCursor();
-			if (count($rows) > 0) {
-				$paginationOffset += $pageLimit;
-				foreach ($rows as $row) {
-					$this->deleteOrphanReshares->setParameter('parentId', $row['parent'])->execute();
-				}
-			}
+		/**
+			DELETE FROM share
+			WHERE parent NOT IN (
+				SELECT id FROM (
+					SELECT id FROM share
+					ORDER BY id -- to prevent derived table merge
+				) mysqlerr1093hack
+			)
+		 */
 
-		} while (empty($rows));
+		// subselect for all share ids
+		$allShares = $this->connection->getQueryBuilder()
+			->select('id')
+			->from('share')
+			->orderBy('id'); // to prevent derived table merge, see https://mariadb.com/kb/en/library/derived-table-merge-optimization/#factsheet
+
+		// TODO this subquery currently cannot be built with our doctrine wrapper
+		// TODO make the mysql hack optional? might also be needed for oracle
+		$subquery = "SELECT `id` FROM ({$allShares->getSQL()}) mysqlerr1093hack";
+
+		//This delete query deletes orphan shares whose parents are missing
+		$deleteOrphanReshares = $this->connection->getQueryBuilder();
+		$deleteOrphanReshares
+			->delete('share')
+			->where($deleteOrphanReshares->expr()->notIn('parent',
+				$deleteOrphanReshares->createFunction($subquery)));
+
+		$deleteOrphanReshares->execute();
 	}
 }


### PR DESCRIPTION
Just ran into an out of memory error while upgrading the activity app on master ... caused by a never ending loop in the RepairOrphanedShares step: https://github.com/owncloud/core/pull/30653/files#diff-e37c59ae9672d3ba539a69df6838eed1R105

```json
{"reqId":"0nsq06yuhdWacDyMhNOe","level":0,"time":"2018-04-05T10:14:28+02:00","remoteAddr":"127.0.0.1","user":"--","app":"core","method":"GET","url":"\/core\/ajax\/update.php?requesttoken=IF9acipFDy0yA3sDCVlyOF0tJBkNWwwmZyI5dXxzNzo%3D%3Akik0ojaLKDHoO8FjdfGCYkEgHlCG57YsYO3oPlGlhRI%3D","message":"starting upgrade from 10.1.0.0 to 10.1.0.0"}
{"reqId":"0nsq06yuhdWacDyMhNOe","level":3,"time":"2018-04-05T10:21:59+02:00","remoteAddr":"127.0.0.1","user":"--","app":"PHP","method":"GET","url":"\/core\/ajax\/update.php?requesttoken=IF9acipFDy0yA3sDCVlyOF0tJBkNWwwmZyI5dXxzNzo%3D%3Akik0ojaLKDHoO8FjdfGCYkEgHlCG57YsYO3oPlGlhRI%3D","message":"Allowed memory size of 536870912 bytes exhausted (tried to allocate 16384 bytes) at \/var\/www\/html\/core\/lib\/composer\/doctrine\/dbal\/lib\/Doctrine\/DBAL\/Driver\/PDOConnection.php#104"}
```

This PR moves all the logic to the sql server instead of iterating over all shares and deleting them one by one.

Requires the mysql hack because we are deleting shares from a table we do a subselect on. 