### PR TITLE
Handle groups with slash and percent in provisioning API

### DIFF
--- a/apps/provisioning_api/lib/Groups.php
+++ b/apps/provisioning_api/lib/Groups.php
@@ -54,6 +54,17 @@ class Groups {
 	}
 
 	/**
+	 * unencode any encoded "/" or "%" that are intended to be literally part
+	 * of the group name.
+	 *
+	 * @param string $groupId
+	 * @return string
+	 */
+	private function unencodeGroupId($groupId) {
+		return \strtr($groupId, ['%25' => '%', '%2F' => '/']);
+	}
+
+	/**
 	 * returns a list of groups
 	 *
 	 * @param array $parameters
@@ -93,7 +104,7 @@ class Groups {
 			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED);
 		}
 
-		$groupId = $parameters['groupid'];
+		$groupId = $this->unencodeGroupId($parameters['groupid']);
 
 		// Check the group exists
 		if (!$this->groupManager->groupExists($groupId)) {
@@ -155,12 +166,13 @@ class Groups {
 	 * @return OC_OCS_Result
 	 */
 	public function deleteGroup($parameters) {
+		$groupId = $this->unencodeGroupId($parameters['groupid']);
 		// Check it exists
-		if (!$this->groupManager->groupExists($parameters['groupid'])) {
+		if (!$this->groupManager->groupExists($groupId)) {
 			return new OC_OCS_Result(null, 101);
 		}
 
-		if ($parameters['groupid'] === 'admin' || !$this->groupManager->get($parameters['groupid'])->delete()) {
+		if ($groupId === 'admin' || !$this->groupManager->get($groupId)->delete()) {
 			// Cannot delete admin group
 			return new OC_OCS_Result(null, 102);
 		}
@@ -173,7 +185,7 @@ class Groups {
 	 * @return OC_OCS_Result
 	 */
 	public function getSubAdminsOfGroup($parameters) {
-		$group = $parameters['groupid'];
+		$group = $this->unencodeGroupId($parameters['groupid']);
 		// Check group exists
 		$targetGroup = $this->groupManager->get($group);
 		if ($targetGroup === null) {

--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -182,6 +182,7 @@ class UserHelper {
 	public static function deleteGroup(
 		$baseUrl, $group, $adminUser, $adminPassword, $ocsApiVersion = 2
 	) {
+		$group = \strtr($group, ['%' => '%25', '/' => '%2F']);
 		$group = \rawurlencode($group);
 		return OcsApiHelper::sendRequest(
 			$baseUrl, $adminUser, $adminPassword,

--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -52,13 +52,7 @@ Feature: add groups
     When the administrator sends a group creation request for group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    # After fixing issue-31015, change the following step to "should exist"
-    And group "<group_id>" should not exist
-    #And group "<group_id>" should exist
-    #
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
+    And group "<group_id>" should exist
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |
@@ -72,14 +66,9 @@ Feature: add groups
   Scenario: admin tries to create a group with name ending in "/subadmins"
     Given group "new-group" has been created
     When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
-    # After fixing issue-31015, change the expected status to "101"
-    Then the OCS status code should be "100"
-    #Then the OCS status code should be "101"
+    Then the OCS status code should be "101"
     And the HTTP status code should be "200"
     And group "priv/subadmins" should not exist
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "priv/subadmins" using the occ command
 
   Scenario: admin tries to create a group that already exists
     Given group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -48,15 +48,10 @@ Feature: add users to group
   @issue-31015
   Scenario Outline: adding a user to a group that has a forward-slash in the group name
     Given user "brand-new-user" has been created with default attributes
-    # After fixing issue-31015, change the following step to "has been created"
-    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
-    #And group "<group_id>" has been created
+    And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -47,18 +47,11 @@ Feature: delete groups
 
   @issue-31015
   Scenario Outline: admin deletes a group that has a forward-slash in the group name
-    # After fixing issue-31015, change the following step to "has been created"
-    Given the administrator sends a group creation request for group "<group_id>" using the provisioning API
-    #Given group "<group_id>" has been created
+    Given group "<group_id>" has been created
     When the administrator deletes group "<group_id>" using the provisioning API
-    # After fixing issue-31015, change the expected status to "100"
-    #Then the OCS status code should be "100"
-    And the HTTP status code should be "404"
-    #And the HTTP status code should be "200"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
     And group "<group_id>" should not exist
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
@@ -31,7 +31,6 @@ Feature: get user groups
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
 
-	# Note: when the issue is fixed, use this scenario and delete the scenario above.
   @issue-31015
   Scenario: admin gets groups of an user, including groups containing a slash
     Given user "brand-new-user" has been created with default attributes
@@ -41,13 +40,9 @@ Feature: get user groups
     And group "Admin & Finance (NP)" has been created
     And group "admin:Pokhara@Nepal" has been created
     And group "नेपाली" has been created
-    # After fixing issue-31015, change the following steps to "has been created"
-    And the administrator sends a group creation request for group "Mgmt/Sydney" using the provisioning API
-    And the administrator sends a group creation request for group "var/../etc" using the provisioning API
-    And the administrator sends a group creation request for group "priv/subadmins/1" using the provisioning API
-    #And group "Mgmt/Sydney" has been created
-    #And group "var/../etc" has been created
-    #And group "priv/subadmins/1" has been created
+    And group "Mgmt/Sydney" has been created
+    And group "var/../etc" has been created
+    And group "priv/subadmins/1" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "brand-new-user" has been added to group "0"
     And user "brand-new-user" has been added to group "Admin & Finance (NP)"
@@ -68,11 +63,6 @@ Feature: get user groups
       | priv/subadmins/1     |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
-    # The following steps are needed so that the groups do get cleaned up.
-    # After fixing issue-31015, remove the following steps:
-    And the administrator deletes group "Mgmt/Sydney" using the occ command
-    And the administrator deletes group "var/../etc" using the occ command
-    And the administrator deletes group "priv/subadmins/1" using the occ command
 
   @smokeTest
   Scenario: subadmin tries to get other groups of a user in their group

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -52,17 +52,12 @@ Feature: remove a user from a group
   @issue-31015
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
     Given user "brand-new-user" has been created with default attributes
-    # After fixing issue-31015, change the following step to "has been created"
-    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
-    #And group "<group_id>" has been created
+    And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -43,22 +43,12 @@ Feature: add groups
       | 50%2Fix             | %2F literal looks like an escaped slash |
       | staff?group         | Question mark                           |
 
-    # Note: these groups do get created OK, but:
-    # 1) the "should exist" step fails because the API to check their existence does not work.
-    # 2) the ordinary group deletion in AfterScenario does not work, because the
-    #    that group-delete API does not work for groups with a slash in the name
   @issue-31015
   Scenario Outline: admin creates a group with a forward-slash in the group name
     When the administrator sends a group creation request for group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    # After fixing issue-31015, change the following step to "should exist"
-    And group "<group_id>" should not exist
-    #And group "<group_id>" should exist
-    #
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
+    And group "<group_id>" should exist
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |
@@ -66,21 +56,15 @@ Feature: add groups
       | var/../etc       | using slash-dot-dot                |
       | priv/subadmins/1 | Subadmins mentioned not at the end |
 
-	# A group name must not end in "/subadmins" because that would create ambiguity
-	# with the endpoint for getting the subadmins of a group
+  # A group name must not end in "/subadmins" because that would create ambiguity
+  # with the endpoint for getting the subadmins of a group
   @issue-31015
   Scenario: admin tries to create a group with name ending in "/subadmins"
     Given group "new-group" has been created
     When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
-    # After fixing issue-31015, change the expected status to "400"
-    Then the OCS status code should be "200"
-    #Then the OCS status code should be "400"
-    And the HTTP status code should be "200"
-    #And the HTTP status code should be "400"
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
     And group "priv/subadmins" should not exist
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "priv/subadmins" using the occ command
 
   Scenario: admin tries to create a group that already exists
     Given group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -48,15 +48,10 @@ Feature: add users to group
   @issue-31015
   Scenario Outline: adding a user to a group that has a forward-slash in the group name
     Given user "brand-new-user" has been created with default attributes
-    # After fixing issue-31015, change the following step to "has been created"
-    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
-    #And group "<group_id>" has been created
+    And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -47,18 +47,11 @@ Feature: delete groups
 
   @issue-31015
   Scenario Outline: admin deletes a group that has a forward-slash in the group name
-    # After fixing issue-31015, change the following step to "has been created"
-    Given the administrator sends a group creation request for group "<group_id>" using the provisioning API
-    #Given group "<group_id>" has been created
+    Given group "<group_id>" has been created
     When the administrator deletes group "<group_id>" using the provisioning API
-    # After fixing issue-31015, change the expected status to "200"
-    #Then the OCS status code should be "200"
-    And the HTTP status code should be "404"
-    #And the HTTP status code should be "200"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
     And group "<group_id>" should not exist
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
@@ -31,7 +31,6 @@ Feature: get user groups
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
 
-	# Note: when the issue is fixed, use this scenario and delete the scenario above.
   @issue-31015
   Scenario: admin gets groups of an user, including groups containing a slash
     Given user "brand-new-user" has been created with default attributes
@@ -41,13 +40,9 @@ Feature: get user groups
     And group "Admin & Finance (NP)" has been created
     And group "admin:Pokhara@Nepal" has been created
     And group "नेपाली" has been created
-    # After fixing issue-31015, change the following steps to "has been created"
-    And the administrator sends a group creation request for group "Mgmt/Sydney" using the provisioning API
-    And the administrator sends a group creation request for group "var/../etc" using the provisioning API
-    And the administrator sends a group creation request for group "priv/subadmins/1" using the provisioning API
-    #And group "Mgmt/Sydney" has been created
-    #And group "var/../etc" has been created
-    #And group "priv/subadmins/1" has been created
+    And group "Mgmt/Sydney" has been created
+    And group "var/../etc" has been created
+    And group "priv/subadmins/1" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "brand-new-user" has been added to group "0"
     And user "brand-new-user" has been added to group "Admin & Finance (NP)"
@@ -68,11 +63,6 @@ Feature: get user groups
       | priv/subadmins/1     |
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
-    # The following steps are needed so that the groups do get cleaned up.
-    # After fixing issue-31015, remove the following steps:
-    And the administrator deletes group "Mgmt/Sydney" using the occ command
-    And the administrator deletes group "var/../etc" using the occ command
-    And the administrator deletes group "priv/subadmins/1" using the occ command
 
   @smokeTest
   Scenario: subadmin tries to get other groups of a user in their group

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -52,17 +52,12 @@ Feature: remove a user from a group
   @issue-31015
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
     Given user "brand-new-user" has been created with default attributes
-      # After fixing issue-31015, change the following step to "has been created"
-    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
-    #And group "<group_id>" has been created
+    And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1923,6 +1923,11 @@ trait Provisioning {
 	 * @return bool
 	 */
 	public function groupExists($group) {
+		// First turn any "/" into "%2F"
+		$group = \strtr($group, ['%' => '%25', '/' => '%2F']);
+		// Now encode anything special. This will include any "/" that has
+		// become a "%2F" which will now become "%252F" or other literal "%"
+		// that has become "%25" above, and will now become "%2525"
 		$group = \rawurlencode($group);
 		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/groups/$group";
 		$this->response = HttpRequestHelper::get(


### PR DESCRIPTION
## Description
1) Add a range of test cases to the ``apiProvisioning`` acceptance test suite covering various group name combinations, including with ``/`` ``%`` ``?`` etc.
2) Modify ``apps/provisioning_api/lib/Groups.php`` so it will turn a literal ``%2F`` into a ``/`` - that provides a way to pass a ``/`` in a group name. (from outside you pass in ``%252F`` and the ``%25`` turns into a ``%`` by the time it gets through the server and is delivered to ``Groups.php``)
3) Similarly turn a literal ``%25`` into a ``%`` - you need that so you can always escape a ``%`` if you want to construct a literal group like ``my%25group`` or ``my%2Fgroup``


## Related Issue
#31015 

## Motivation and Context
It is nice to be able to use all group names in the Provisioning API.

## How Has This Been Tested?
Local API acceptance test runs.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
