### PR TITLE
webUI deleteFile() correction to information message

### DIFF
--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -312,6 +312,9 @@ abstract class FilesPageBasic extends OwncloudPage {
 			}
 		}
 		if ($expectToDeleteFile && ($counter > 0)) {
+			if (is_array($name)) {
+				$name = implode($name);
+			}
 			$message = "INFORMATION: retried to delete file '" . $name . "' " .
 					   $counter . " times";
 			echo $message;


### PR DESCRIPTION
## Description
Implode the name array into a string, if needed, before using it in the text message.

## Related Issue

## Motivation and Context
In webUI tests, if ``deleteFile()`` had a problem deleting a file, it emits an information message. But the file name passed in can be an array of parts of the file name. If that is the case, then a PHP message is emitted about "array to string conversion".

Noticed while running some tests locally for other reasons.

## How Has This Been Tested?
Run various webUI tests that delete files with obscure names. See that the "array to string conversion" is not emitted.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test minor adjustment

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

