### PR TITLE
webUI tests - use id to find Public Link Share Dialog permission buttons

### DIFF
--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
@@ -42,6 +42,11 @@ class EditPublicLinkPopup extends OwncloudPage {
 	private $expirationDateInputXpath = ".//input[contains(@class,'expirationDate')]";
 	private $emailInputXpath = ".//input[@type='email']";
 	private $shareButtonXpath = ".//button[contains(text(), 'Share')]";
+	private $permissionLabelXpath = [
+		'read' => ".//label[contains(@for, 'sharingDialogAllowPublicRead')]",
+		'read-write' => ".//label[contains(@for, 'sharingDialogAllowPublicReadWrite')]",
+		'upload' => ".//label[contains(@for, 'sharingDialogAllowPublicUpload')]"
+	];
 	
 
 	/**
@@ -104,15 +109,24 @@ class EditPublicLinkPopup extends OwncloudPage {
 	 * @return void
 	 */
 	public function setLinkPermissions($permissions) {
-		$permissionsCheckbox = $this->popupElement->findField($permissions);
-		if (is_null($permissionsCheckbox)) {
-			throw new ElementNotFoundException(
-				__METHOD__ .
-				" findField($permissions)" .
-				" could not find the permission checkbox"
+		$permissions = strtolower($permissions);
+		if (array_key_exists($permissions, $this->permissionLabelXpath)) {
+			$permissionsCheckbox = $this->popupElement->find(
+				"xpath", $this->permissionLabelXpath[$permissions]
+			);
+			if (is_null($permissionsCheckbox)) {
+				throw new ElementNotFoundException(
+					__METHOD__ .
+					" findField($permissions)" .
+					" could not find the permission checkbox"
+				);
+			}
+			$permissionsCheckbox->click();
+		} else {
+			throw new \InvalidArgumentException(
+				__METHOD__ . " $permissions is not a valid public link permission"
 			);
 		}
-		$permissionsCheckbox->click();
 	}
 
 	/**

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -23,7 +23,7 @@ So that public sharing is limited according to organization policy
 	@skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
 	Scenario: creating a public link with read & write permissions makes it possible to delete files via the link
 		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| permission | Download / View / Upload |
+		| permission | read-write |
 		And the public accesses the last created public link using the webUI
 		And the user deletes the following elements using the webUI
 		| name                                 |
@@ -37,7 +37,7 @@ So that public sharing is limited according to organization policy
 	@skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
 	Scenario: creating a public link with read permissions only makes it impossible to delete files via the link
 		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| permission | Download / View |
+		| permission | read |
 		And the public accesses the last created public link using the webUI
 		Then it should not be possible to delete the file "lorem.txt" using the webUI
 
@@ -63,7 +63,7 @@ So that public sharing is limited according to organization policy
 		|username|password|displayname|email       |
 		|user2   |1234    |User One   |u1@oc.com.np|
 		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| permission | Download / View / Upload |
+		| permission | read-write |
 		And the user logs out of the webUI
 		And the public accesses the last created public link using the webUI
 		And the public adds the public link to "%remote_server%" as user "user2" with the password "1234" using the webUI


### PR DESCRIPTION
## Description
Pass down "generic" public link permission names ``read`` ``read-write`` or ``upload`` from the test steps to the page object code.
"Translate" those into sub-strings of the ``id`` that is used for each of the permission buttons/labels.
Use that to select the desired button.

## Related Issue

## Motivation and Context
The text displayed for each permission button recently changed, and the matching change had to be made in the Behat Gherkin scenario steps. It would be better (?) to make the tests a bit more generic, and not dependent on exactly what the text is in the UI.

## How Has This Been Tested?
The 3 relevant tests have been run locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
