### PR TITLE
[stable10] webUI tests - use id to find Public Link Share Dialog permission buttons

### DIFF
--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
@@ -42,6 +42,11 @@ class EditPublicLinkPopup extends OwncloudPage {
 	private $expirationDateInputXpath = ".//input[contains(@class,'expirationDate')]";
 	private $emailInputXpath = ".//input[@type='email']";
 	private $shareButtonXpath = ".//button[contains(text(), 'Share')]";
+	private $permissionLabelXpath = [
+		'read' => ".//label[contains(@for, 'sharingDialogAllowPublicRead')]",
+		'read-write' => ".//label[contains(@for, 'sharingDialogAllowPublicReadWrite')]",
+		'upload' => ".//label[contains(@for, 'sharingDialogAllowPublicUpload')]"
+	];
 	
 
 	/**
@@ -104,15 +109,24 @@ class EditPublicLinkPopup extends OwncloudPage {
 	 * @return void
 	 */
 	public function setLinkPermissions($permissions) {
-		$permissionsCheckbox = $this->popupElement->findField($permissions);
-		if (is_null($permissionsCheckbox)) {
-			throw new ElementNotFoundException(
-				__METHOD__ .
-				" findField($permissions)" .
-				" could not find the permission checkbox"
+		$permissions = strtolower($permissions);
+		if (array_key_exists($permissions, $this->permissionLabelXpath)) {
+			$permissionsCheckbox = $this->popupElement->find(
+				"xpath", $this->permissionLabelXpath[$permissions]
+			);
+			if (is_null($permissionsCheckbox)) {
+				throw new ElementNotFoundException(
+					__METHOD__ .
+					" findField($permissions)" .
+					" could not find the permission checkbox"
+				);
+			}
+			$permissionsCheckbox->click();
+		} else {
+			throw new \InvalidArgumentException(
+				__METHOD__ . " $permissions is not a valid public link permission"
 			);
 		}
-		$permissionsCheckbox->click();
 	}
 
 	/**

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -23,7 +23,7 @@ So that public sharing is limited according to organization policy
 	@skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
 	Scenario: creating a public link with read & write permissions makes it possible to delete files via the link
 		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| permission | Download / View / Upload |
+		| permission | read-write |
 		And the public accesses the last created public link using the webUI
 		And the user deletes the following elements using the webUI
 		| name                                 |
@@ -37,7 +37,7 @@ So that public sharing is limited according to organization policy
 	@skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
 	Scenario: creating a public link with read permissions only makes it impossible to delete files via the link
 		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| permission | Download / View |
+		| permission | read |
 		And the public accesses the last created public link using the webUI
 		Then it should not be possible to delete the file "lorem.txt" using the webUI
 
@@ -63,7 +63,7 @@ So that public sharing is limited according to organization policy
 		|username|password|displayname|email       |
 		|user2   |1234    |User One   |u1@oc.com.np|
 		When the user creates a new public link for the folder "simple-folder" using the webUI with
-		| permission | Download / View / Upload |
+		| permission | read-write |
 		And the user logs out of the webUI
 		And the public accesses the last created public link using the webUI
 		And the public adds the public link to "%remote_server%" as user "user2" with the password "1234" using the webUI


### PR DESCRIPTION
Backport #31037 