### PR TITLE
doc improvement for integrity.ignore.missing.app.signature

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1165,9 +1165,16 @@ $CONFIG = array(
 		'.user.ini',
 	),
 /**
- * The list of apps that are allowed to have no signature.json
+ * The list of apps that are allowed to have no signature.json. Besides
+ * ownCloud apps, this is particularly useful when creating ownCloud themes,
+ * because themes are treated as apps.
+ * The following example allows theme-1 and theme-2 to have no signature.
  */
-'integrity.ignore.missing.app.signature' => [],
+'integrity.ignore.missing.app.signature' =>
+	array(
+		'theme-1',
+		'theme-2',
+	),
 
 /**
  * Define a default folder for shared files and folders other than root.


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
This is a documentation improvement for key: ``integrity.ignore.missing.app.signature``.
The example array made matches the way how we describe other arrays.

## Related Issue
The key was recently introduced in https://github.com/owncloud/core/pull/30819

## Motivation and Context
The usage description had room for improvement, especially in the context of own themes which are treated as apps

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

The documentation update will follow immediately after merging