### PR TITLE
Check basic auth credentials periodically after a timeout instead of …

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -85,6 +85,7 @@ use OC\Tagging\TagMapper;
 use OC\Theme\ThemeService;
 use OC\User\AccountMapper;
 use OC\User\AccountTermMapper;
+use OC\User\Session;
 use OC\User\SyncService;
 use OCP\App\IServiceLoader;
 use OCP\AppFramework\QueryException;
@@ -317,8 +318,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 
 			$userSyncService = new SyncService($c->getConfig(), $c->getLogger(), $c->getAccountMapper());
 
-			$userSession = new \OC\User\Session($manager, $session, $timeFactory,
-				$defaultTokenProvider, $c->getConfig(), $this, $userSyncService);
+			$userSession = new Session($manager, $session, $timeFactory,
+				$defaultTokenProvider, $c->getConfig(), $c->getLogger(), $this, $userSyncService);
 			$userSession->listen('\OC\User', 'preCreateUser', function ($uid, $password) {
 				\OC_Hook::emit('OC_User', 'pre_createUser', ['run' => true, 'uid' => $uid, 'password' => $password]);
 			});

--- a/tests/lib/User/BasicAuthModuleTest.php
+++ b/tests/lib/User/BasicAuthModuleTest.php
@@ -1,5 +1,6 @@
 <?php
 /**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
  * @copyright Copyright (c) 2018, ownCloud GmbH
@@ -24,6 +25,9 @@ namespace Test\User;
 
 
 use OC\User\BasicAuthModule;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use OCP\ILogger;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
@@ -32,10 +36,16 @@ use Test\TestCase;
 
 class BasicAuthModuleTest extends TestCase {
 
+	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
 	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
 	private $manager;
 	/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject */
 	private $request;
+	/** @var ITimeFactory | \PHPUnit_Framework_MockObject_MockObject */
+	private $timeFactory;
 	/** @var IUser | \PHPUnit_Framework_MockObject_MockObject */
 	private $user;
 	/** @var ISession | \PHPUnit_Framework_MockObject_MockObject */
@@ -43,9 +53,12 @@ class BasicAuthModuleTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
+		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(ILogger::class);
 		$this->manager = $this->createMock(IUserManager::class);
 		$this->request = $this->createMock(IRequest::class);
 		$this->session = $this->createMock(ISession::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 
 		$this->user = $this->createMock(IUser::class);
 		$this->user->expects($this->any())->method('getUID')->willReturn('user1');
@@ -66,6 +79,9 @@ class BasicAuthModuleTest extends TestCase {
 				['user2', []]
 			]);
 
+		// make config return default last_check_timeout
+		$this->config->method('getAppValue')->with('core', 'last_check_timeout', 5)->willReturn(5);
+
 	}
 
 	/**
@@ -75,12 +91,20 @@ class BasicAuthModuleTest extends TestCase {
 	 */
 	public function testAuth($expectedResult, $userId) {
 
-		$this->session
-			->method('exists')
-			->with('app_password')
-			->willReturn(false);
+		$this->session->method('exists')->will($this->returnValueMap([
+			['app_password', false],
+			['last_check_timeout', true]
+		]));
 
-		$module = new BasicAuthModule($this->manager, $this->session);
+		// check auth
+		$time = time();
+		$this->session->method('get')->will($this->returnValueMap([
+			['user_id', $userId],
+			['last_check_timeout', $time - 60 * 5]
+		]));
+		$this->timeFactory->method('getTime')->willReturn($time);
+
+		$module = new BasicAuthModule($this->config, $this->logger, $this->manager, $this->session, $this->timeFactory);
 		$this->request->server = [
 			'PHP_AUTH_USER' => $userId,
 			'PHP_AUTH_PW' => '123456',
@@ -94,17 +118,24 @@ class BasicAuthModuleTest extends TestCase {
 
 	public function testAppPassword() {
 
-		$this->session
-			->expects($this->once())
-			->method('exists')
-			->with('app_password')
-			->willReturn(true);
+		$this->session->method('exists')->will($this->returnValueMap([
+			['app_password', true],
+			['last_check_timeout', true]
+		]));
+
+		// check auth
+		$time = time();
+		$this->session->method('get')->will($this->returnValueMap([
+			['user_id', 'user'],
+			['last_check_timeout', $time - 60 * 5]
+		]));
+		$this->timeFactory->method('getTime')->willReturn($time);
 
 		$this->manager
 			->expects($this->never())
 			->method('checkPassword');
 
-		$module = new BasicAuthModule($this->manager, $this->session);
+		$module = new BasicAuthModule($this->config, $this->logger, $this->manager, $this->session, $this->timeFactory);
 		$this->request->server = [
 			'PHP_AUTH_USER' => 'user',
 			'PHP_AUTH_PW' => 'app-pass-word',
@@ -113,7 +144,7 @@ class BasicAuthModuleTest extends TestCase {
 	}
 
 	public function testGetUserPassword() {
-		$module = new BasicAuthModule($this->manager, $this->session);
+		$module = new BasicAuthModule($this->config, $this->logger, $this->manager, $this->session, $this->timeFactory);
 		$this->request->server = [
 			'PHP_AUTH_USER' => 'user1',
 			'PHP_AUTH_PW' => '123456',
@@ -134,5 +165,81 @@ class BasicAuthModuleTest extends TestCase {
 			'not unique email can not login' => [new \Exception('Invalid credentials'), 'not-unique@example.com'],
 			'user2 is not known' => [new \Exception('Invalid credentials'), 'user2'],
 		];
+	}
+
+
+	public function testTimeout() {
+
+		$this->session->method('exists')->will($this->returnValueMap([
+			['app_password', false],
+			['last_check_timeout', true]
+		]));
+
+		$time = time();
+		$this->session->method('get')->will($this->returnValueMap([
+			['last_check_timeout', $time - 60 * 4],
+			['user_id', 'user1']
+		]));
+
+		$this->timeFactory->method('getTime')->willReturn($time);
+
+		$this->manager
+			->expects($this->never())
+			->method('checkPassword');
+
+		$this->manager->expects($this->once())->method('get')
+			->with('user1')->willReturn($this->user);
+
+		$module = new BasicAuthModule($this->config, $this->logger, $this->manager, $this->session, $this->timeFactory);
+
+		$this->request->server = [
+			'PHP_AUTH_USER' => 'user1',
+			'PHP_AUTH_PW' => '123456',
+		];
+
+		$this->assertEquals($this->user, $module->auth($this->request));
+	}
+
+	public function invalidUserIdProvider () {
+		return [
+			[''], [null],
+		];
+	}
+
+	/**
+	 * @dataProvider invalidUserIdProvider
+	 * @expectedException \UnexpectedValueException
+	 */
+	public function testInvalidUserId($userId) {
+
+		$this->session->method('exists')->will($this->returnValueMap([
+			['app_password', false],
+			['last_check_timeout', true]
+		]));
+
+		$time = time();
+		$this->session->method('get')->will($this->returnValueMap([
+			['last_check_timeout', $time - 60 * 4],
+			['user_id', $userId]
+		]));
+
+		$this->timeFactory->method('getTime')->willReturn($time);
+
+		$this->manager
+			->expects($this->never())
+			->method('checkPassword');
+
+		$this->manager
+			->expects($this->never())
+			->method('get');
+
+		$module = new BasicAuthModule($this->config, $this->logger, $this->manager, $this->session, $this->timeFactory);
+
+		$this->request->server = [
+			'PHP_AUTH_USER' => 'user1',
+			'PHP_AUTH_PW' => '123456',
+		];
+
+		$module->auth($this->request);
 	}
 }

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -24,6 +24,7 @@ use OCP\App\IServiceLoader;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\IAuthModule;
 use OCP\IConfig;
+use OCP\ILogger;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
@@ -50,6 +51,8 @@ class SessionTest extends TestCase {
 
 	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
 	private $config;
+	/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
 	/** @var IServiceLoader */
 	private $serviceLoader;
 	/** @var \OC\User\SyncService */
@@ -64,6 +67,7 @@ class SessionTest extends TestCase {
 			->will($this->returnValue(10000));
 		$this->tokenProvider = $this->createMock(IProvider::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(ILogger::class);
 		$this->serviceLoader = $this->createMock(IServiceLoader::class);
 		$this->userSyncService = $this->createMock(\OC\User\SyncService::class);
 	}
@@ -123,7 +127,7 @@ class SessionTest extends TestCase {
 			->will($this->returnValue($expectedUser));
 
 		$userSession = new Session($manager, $session, $this->timeFactory,
-			$this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 		$user = $userSession->getUser();
 		$this->assertSame($expectedUser, $user);
 		$userSession->validateSession();
@@ -149,7 +153,7 @@ class SessionTest extends TestCase {
 
 		/** @var \PHPUnit_Framework_MockObject_MockObject | Session $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
-			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService])
 			->setMethods([
 				'getUser'
 			])
@@ -179,7 +183,7 @@ class SessionTest extends TestCase {
 			->will($this->returnValue('foo'));
 
 		$userSession = new Session($manager, $session, $this->timeFactory,
-			$this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 		$userSession->setUser($user);
 	}
 
@@ -237,7 +241,7 @@ class SessionTest extends TestCase {
 
 		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
-			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService])
 			->setMethods([
 				'prepareUserLogin'
 			])
@@ -287,7 +291,7 @@ class SessionTest extends TestCase {
 			->will($this->returnValue($user));
 
 		$userSession = new Session($manager, $session, $this->timeFactory,
-			$this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 		$userSession->login('foo', 'bar');
 	}
 
@@ -297,7 +301,7 @@ class SessionTest extends TestCase {
 		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $manager */
 		$manager = $this->createMock(Manager::class);
 		$userSession = new Session($manager, $session, $this->timeFactory,
-			$this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 
 		$user = $this->createMock(IUser::class);
 
@@ -329,7 +333,7 @@ class SessionTest extends TestCase {
 		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $manager */
 		$manager = $this->createMock(Manager::class);
 		$userSession = new Session($manager, $session, $this->timeFactory,
-			$this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 
 		$session->expects($this->never())
 			->method('set');
@@ -358,7 +362,7 @@ class SessionTest extends TestCase {
 		/** @var Manager | \PHPUnit_Framework_MockObject_MockObject $manager */
 		$manager = $this->createMock(Manager::class);
 		$userSession = new Session($manager, $session, $this->timeFactory,
-			$this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 		$username = 'user123';
 		$token = new DefaultToken();
 		$token->setLoginName($username);
@@ -393,7 +397,7 @@ class SessionTest extends TestCase {
 
 		/** @var Session $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
-			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService])
 			->setMethods(['login', 'supportsCookies', 'createSessionToken', 'getUser'])
 			->getMock();
 
@@ -419,7 +423,7 @@ class SessionTest extends TestCase {
 
 		/** @var Session $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
-			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService])
 			->setMethods(['login', 'supportsCookies', 'createSessionToken', 'getUser'])
 			->getMock();
 
@@ -448,7 +452,7 @@ class SessionTest extends TestCase {
 
 		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
-			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService])
 			->setMethods(['isTokenPassword', 'login', 'supportsCookies', 'createSessionToken', 'getUser'])
 			->getMock();
 
@@ -480,7 +484,7 @@ class SessionTest extends TestCase {
 
 		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
-			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService])
 			->setMethods(['login', 'isTwoFactorEnforced'])
 			->getMock();
 
@@ -538,7 +542,7 @@ class SessionTest extends TestCase {
 			//override, otherwise tests will fail because of setcookie()
 			->setMethods(['setMagicInCookie'])
 			//there  are passed as parameters to the constructor
-			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService])
 			->getMock();
 
 		$granted = $userSession->loginWithCookie('foo', $token);
@@ -573,7 +577,7 @@ class SessionTest extends TestCase {
 		\OC::$server->getConfig()->setUserValue('foo', 'login_token', $token, time());
 
 		$userSession = new Session($manager, $session, $this->timeFactory,
-			$this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 		$granted = $userSession->loginWithCookie('foo', 'badToken');
 
 		$this->assertFalse($granted);
@@ -606,7 +610,7 @@ class SessionTest extends TestCase {
 		\OC::$server->getConfig()->setUserValue('foo', 'login_token', $token, time());
 
 		$userSession = new Session($manager, $session, $this->timeFactory,
-			$this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 		$granted = $userSession->loginWithCookie('foo', $token);
 
 		$this->assertFalse($granted);
@@ -634,7 +638,7 @@ class SessionTest extends TestCase {
 		$session->set('user_id', 'foo');
 		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
-			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService])
 			->setMethods([
 				'validateSession'
 			])
@@ -657,7 +661,7 @@ class SessionTest extends TestCase {
 		$session = $this->createMock(ISession::class);
 		$user = $this->createMock(IUser::class);
 		$userSession = new Session($manager, $session, $this->timeFactory,
-			$this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 
 		$random = $this->createMock(ISecureRandom::class);
 		$config = $this->createMock(IConfig::class);
@@ -705,7 +709,7 @@ class SessionTest extends TestCase {
 		$token = $this->createMock(IToken::class);
 		$user = $this->createMock(IUser::class);
 		$userSession = new Session($manager, $session, $this->timeFactory,
-			$this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 
 		$random = $this->createMock(ISecureRandom::class);
 		$config = $this->createMock(IConfig::class);
@@ -755,7 +759,7 @@ class SessionTest extends TestCase {
 		/** @var ISession | \PHPUnit_Framework_MockObject_MockObject $session */
 		$session = $this->createMock(ISession::class);
 		$userSession = new Session($manager, $session, $this->timeFactory,
-			$this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 		/** @var IRequest $request */
 		$request = $this->createMock(IRequest::class);
 
@@ -787,7 +791,7 @@ class SessionTest extends TestCase {
 		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
 			->setMethods(['logout'])
-			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService])
 			->getMock();
 		/** @var IRequest | \PHPUnit_Framework_MockObject_MockObject $request */
 		$request = $this->createMock(IRequest::class);
@@ -819,7 +823,7 @@ class SessionTest extends TestCase {
 
 		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
-			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService])
 			->setMethods(['logout'])
 			->getMock();
 
@@ -868,7 +872,7 @@ class SessionTest extends TestCase {
 		$tokenProvider = $this->createMock(IProvider::class);
 		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
-			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService])
 			->setMethods(['logout'])
 			->getMock();
 
@@ -915,7 +919,7 @@ class SessionTest extends TestCase {
 		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
-			$tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 
 		$password = '123456';
 		$sessionId ='session1234';
@@ -945,7 +949,7 @@ class SessionTest extends TestCase {
 		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
-			$tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 
 		$session->expects($this->once())
 			->method('getId')
@@ -964,7 +968,7 @@ class SessionTest extends TestCase {
 		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
-			$tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 
 		$password = '123456';
 		$sessionId ='session1234';
@@ -1002,7 +1006,7 @@ class SessionTest extends TestCase {
 			->will($this->returnValue('foo'));
 
 		$userSession = new Session($manager, $session, $this->timeFactory,
-			$this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 		$userSession->setUser($user);
 
 
@@ -1044,7 +1048,7 @@ class SessionTest extends TestCase {
 			->will($this->returnValue('foo'));
 
 		$userSession = new Session($manager, $session, $this->timeFactory,
-			$this->tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$this->tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 		$userSession->setUser($user);
 
 		$this->assertTrue($userSession->logout());
@@ -1079,7 +1083,7 @@ class SessionTest extends TestCase {
 		/** @var IProvider | \PHPUnit_Framework_MockObject_MockObject $tokenProvider */
 		$tokenProvider = $this->createMock(IProvider::class);
 		$userSession = new Session($userManager, $session, $timeFactory,
-			$tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService);
+			$tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService);
 
 		// Fail if not userid returned
 		$apacheBackend = $this->createMock(IApacheBackend::class);
@@ -1136,7 +1140,7 @@ class SessionTest extends TestCase {
 
 		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $session */
 		$session = $this->getMockBuilder(Session::class)
-			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService])
 			->setMethods(['getAuthModules', 'logout', 'isLoggedIn', 'getUser'])
 			->getMock();
 		$session->expects($this->any())->method('getAuthModules')->willReturn($modules);
@@ -1184,7 +1188,7 @@ class SessionTest extends TestCase {
 
 		/** @var Session | \PHPUnit_Framework_MockObject_MockObject $session */
 		$session = $this->getMockBuilder(Session::class)
-			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->serviceLoader, $this->userSyncService])
+			->setConstructorArgs([$userManager, $session, $timeFactory, $tokenProvider, $this->config, $this->logger, $this->serviceLoader, $this->userSyncService])
 			->setMethods(['getAuthModules', 'createSessionToken', 'loginUser', 'getUser'])
 			->getMock();
 		$session->expects($this->any())->method('getAuthModules')->willReturn($modules);


### PR DESCRIPTION
…every request to stop hammering ldap servers if client uses basic auth
