### PR TITLE
getUser of the backend mock needs to return an array

### DIFF
--- a/tests/lib/Command/User/SyncBackendTest.php
+++ b/tests/lib/Command/User/SyncBackendTest.php
@@ -231,6 +231,10 @@ class SyncBackendTest extends TestCase {
 			->method('hasUserListings')
 			->will($this->returnValue(true));
 
+		$this->dummyBackend
+			->method('getUsers')
+			->willReturn([]);
+
 		$inputInterface
 			->expects($this->at(2))
 			->method('getOption')


### PR DESCRIPTION
Unit tests fail on php 7.2

```
There was 1 error:

1) Test\Command\User\SyncBackendTest::testSingleUserSync
count(): Parameter must be an array or an object that implements Countable

/drone/server/core/Command/User/SyncBackend.php:235
/drone/server/core/Command/User/SyncBackend.php:159
/drone/server/tests/lib/TestCase.php:193
/drone/server/tests/lib/Command/User/SyncBackendTest.php:258
