### PR TITLE
During chunking process the after file creation not triggered

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -588,9 +588,43 @@ class FileTest extends TestCase {
 
 		$_SERVER['HTTP_OC_CHUNKED'] = true;
 		$file = 'foo.txt';
+
+		$calledBeforeCreateFile = [];
+		\OC::$server->getEventDispatcher()->addListener('file.beforecreate',
+			function (GenericEvent $event) use (&$calledBeforeCreateFile) {
+				$calledBeforeCreateFile[] = 'file.beforecreate';
+				$calledBeforeCreateFile[] = $event;
+			});
+		$calledAfterCreateFile = [];
+		\OC::$server->getEventDispatcher()->addListener('file.aftercreate',
+			function (GenericEvent $event) use (&$calledAfterCreateFile) {
+				$calledAfterCreateFile[] = 'file.aftercreate';
+				$calledAfterCreateFile[] = $event;
+			});
+		$calledAfterUpdateFile = [];
+		\OC::$server->getEventDispatcher()->addListener('file.afterupdate',
+			function (GenericEvent $event) use (&$calledAfterUpdateFile) {
+				$calledAfterUpdateFile[] = 'file.afterupdate';
+				$calledAfterUpdateFile[] = $event;
+			});
 		$this->doPut($file.'-chunking-12345-2-0', null, $request);
 		$this->doPut($file.'-chunking-12345-2-1', null, $request);
 		$this->assertEquals($resultMtime, $this->getFileInfos($file)['mtime']);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterCreateFile[1]);
+		$this->assertInstanceOf(GenericEvent::class, $calledBeforeCreateFile[1]);
+		$this->assertEquals('file.aftercreate', $calledAfterCreateFile[0]);
+		$this->assertEquals('file.beforecreate', $calledBeforeCreateFile[0]);
+		$this->assertEquals('file.afterupdate', $calledAfterUpdateFile[0]);
+		$this->assertArrayHasKey('path', $calledAfterCreateFile[1]);
+		$this->assertArrayHasKey('path', $calledBeforeCreateFile[1]);
+		//Internally it even tries to call mkdir to create cache dir So lets test what ever
+		// is there in the arrays. We will test all the indices.
+		$this->assertEquals('/'.$this->user.'/cache', $calledBeforeCreateFile[1]->getArgument('path'));
+		$this->assertEquals('/'.$this->user.'/files/'.$file, $calledBeforeCreateFile[3]->getArgument('path'));
+		$this->assertEquals('/'.$this->user.'/cache', $calledAfterCreateFile[1]->getArgument('path'));
+		//The indices 1 and 3 have part files.
+		$this->assertNotFalse(\strpos($calledAfterUpdateFile[1]->getArgument('path'), '/'.$this->user.'/cache/'. $file.'-chunking-12345-0'));
+		$this->assertNotFalse(\strpos($calledAfterUpdateFile[3]->getArgument('path'), '/'.$this->user.'/cache/'. $file.'-chunking-12345-1'));
 	}
 
 	/**
@@ -1141,6 +1175,74 @@ class FileTest extends TestCase {
 			$hookPath,
 			$params[Filesystem::signal_param_path]
 		);
+	}
+
+	/**
+	 * Testing update of file when put method is called repeatedly on same file.
+	 * This test also verifies the hooks being called.
+	 */
+	public function testUpdateFileWithPut() {
+		$view = new View('/' . $this->user . '/files/');
+
+		$path = 'test-update.txt';
+		$info = new FileInfo(
+			'/' . $this->user . '/files/' . $path,
+			$this->getMockStorage(),
+			null,
+			['permissions' => Constants::PERMISSION_ALL],
+			null
+		);
+
+		$file = new File($view, $info);
+
+		$calledBeforeCreate = [];
+		\OC::$server->getEventDispatcher()->addListener('file.beforecreate',
+			function (GenericEvent $event) use (&$calledBeforeCreate) {
+				$calledBeforeCreate[] = 'file.beforecreate';
+				$calledBeforeCreate[] = $event;
+			});
+		$calledAfterCreate = [];
+		\OC::$server->getEventDispatcher()->addListener('file.aftercreate',
+			function (GenericEvent $event) use (&$calledAfterCreate) {
+				$calledAfterCreate[] = 'file.aftercreate';
+				$calledAfterCreate[] = $event;
+			});
+		$view->lockFile($path, ILockingProvider::LOCK_SHARED);
+		$file->put($this->getStream('hello'));
+		$view->unlockFile($path, ILockingProvider::LOCK_SHARED);
+
+		$this->assertInstanceOf(GenericEvent::class, $calledBeforeCreate[1]);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterCreate[1]);
+		$this->assertEquals('file.beforecreate', $calledBeforeCreate[0]);
+		$this->assertEquals('file.aftercreate', $calledAfterCreate[0]);
+		$this->assertArrayHasKey('path', $calledBeforeCreate[1]);
+		$this->assertEquals('/'.$this->user.'/files//test-update.txt', $calledBeforeCreate[1]->getArgument('path'));
+		$this->assertArrayHasKey('path', $calledAfterCreate[1]);
+		$this->assertEquals('/'.$this->user.'/files//test-update.txt', $calledAfterCreate[1]->getArgument('path'));
+
+		$calledBeforeUpdate = [];
+		\OC::$server->getEventDispatcher()->addListener('file.beforeupdate',
+			function (GenericEvent $event) use (&$calledBeforeUpdate) {
+				$calledBeforeUpdate[] = 'file.beforeupdate';
+				$calledBeforeUpdate[] = $event;
+			});
+		$calledAfterUpdte = [];
+		\OC::$server->getEventDispatcher()->addListener('file.afterupdate',
+			function (GenericEvent $event) use (&$calledAfterUpdte) {
+				$calledAfterUpdte[] = 'file.afterupdate';
+				$calledAfterUpdte[] = $event;
+			});
+		$view->lockFile($path, ILockingProvider::LOCK_SHARED);
+		$file->put($this->getStream('world'));
+		$view->unlockFile($path, ILockingProvider::LOCK_SHARED);
+		$this->assertInstanceOf(GenericEvent::class, $calledBeforeUpdate[1]);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterUpdte[1]);
+		$this->assertEquals('file.beforeupdate', $calledBeforeUpdate[0]);
+		$this->assertEquals('file.afterupdate', $calledAfterUpdte[0]);
+		$this->assertArrayHasKey('path', $calledBeforeUpdate[1]);
+		$this->assertEquals('/'.$this->user.'/files//'.$path, $calledBeforeUpdate[1]->getArgument('path'));
+		$this->assertArrayHasKey('path', $calledAfterUpdte[1]);
+		$this->assertEquals('/'.$this->user.'/files//'.$path, $calledAfterUpdte[1]->getArgument('path'));
 	}
 
 	/**


### PR DESCRIPTION
In the clients like android, where chunking happens for files
greater than 1MB. Under such conditions the after file creation
symfony event is not triggered. This change helps to fix the
issue.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
When clients try to upload files and chunking is enabled. Then the after file creation symfony event is not triggered. This change addresses the issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When clients try to upload files and chunking is enabled. Then the after file creation symfony event is not triggered. This change addresses the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Upload a file using android app.
- [x] The after event triggered is listened using a test app.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

