### PR TITLE
[stable10] During chunking process the after file creation not triggered

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -111,9 +111,6 @@ class File extends Node implements IFile {
 	 * @return string|null
 	 */
 	public function put($data) {
-		$path = $this->fileView->getAbsolutePath($this->path);
-		$beforeEvent = new GenericEvent(null, ['path' => $path]);
-		\OC::$server->getEventDispatcher()->dispatch('file.beforecreate', $beforeEvent);
 		try {
 			$exists = $this->fileView->file_exists($this->path);
 			if ($this->info && $exists && !$this->info->isUpdateable()) {
@@ -133,6 +130,16 @@ class File extends Node implements IFile {
 			} catch (\Exception $e) {
 				$this->convertToSabreException($e);
 			}
+		}
+
+		$newFile = false;
+		$path = $this->fileView->getAbsolutePath($this->path);
+		$beforeEvent = new GenericEvent(null, ['path' => $path]);
+		if (!$this->fileView->file_exists($this->path)) {
+			\OC::$server->getEventDispatcher()->dispatch('file.beforecreate', $beforeEvent);
+			$newFile = true;
+		} else {
+			\OC::$server->getEventDispatcher()->dispatch('file.beforeupdate', $beforeEvent);
 		}
 
 		list($partStorage) = $this->fileView->resolvePath($this->path);
@@ -265,7 +272,11 @@ class File extends Node implements IFile {
 		}
 
 		$afterEvent = new GenericEvent(null, ['path' => $path]);
-		\OC::$server->getEventDispatcher()->dispatch('file.aftercreate', $afterEvent);
+		if ($newFile === true) {
+			\OC::$server->getEventDispatcher()->dispatch('file.aftercreate', $afterEvent);
+		} else {
+			\OC::$server->getEventDispatcher()->dispatch('file.afterupdate', $afterEvent);
+		}
 		return '"' . $this->info->getEtag() . '"';
 	}
 
@@ -471,6 +482,16 @@ class File extends Node implements IFile {
 			$partFile = null;
 
 			$targetPath = $path . '/' . $info['name'];
+			$absPath = $this->fileView->getAbsolutePath($targetPath);
+			$beforeEvent = new GenericEvent(null, ['path' => $absPath]);
+			$newFile = false;
+			if (!$this->fileView->file_exists($targetPath)) {
+				\OC::$server->getEventDispatcher()->dispatch('file.beforecreate', $beforeEvent);
+				$newFile = true;
+			} else {
+				\OC::$server->getEventDispatcher()->dispatch('file.beforeupdate', $beforeEvent);
+			}
+
 			/** @var \OC\Files\Storage\Storage $targetStorage */
 			list($targetStorage, $targetInternalPath) = $this->fileView->resolvePath($targetPath);
 
@@ -553,7 +574,16 @@ class File extends Node implements IFile {
 
 				$this->fileView->unlockFile($targetPath, ILockingProvider::LOCK_SHARED);
 
-				return $info->getEtag();
+				$etag = $info->getEtag();
+				if ($etag !== null) {
+					$afterEvent = new GenericEvent(null, ['path' => $absPath]);
+					if ($newFile === true) {
+						\OC::$server->getEventDispatcher()->dispatch('file.aftercreate', $afterEvent);
+					} else {
+						\OC::$server->getEventDispatcher()->dispatch('file.afterupdate', $afterEvent);
+					}
+				}
+				return $etag;
 			} catch (\Exception $e) {
 				if ($partFile !== null) {
 					$targetStorage->unlink($targetInternalPath);


### PR DESCRIPTION
In the clients like android, where chunking happens for files
greater than 1MB. Under such conditions the after file creation
symfony event is not triggered. This change helps to fix the
issue.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
When clients try to upload files and chunking is enabled. Then the after file creation symfony event is not triggered. This change addresses the issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When clients try to upload files and chunking is enabled. Then the after file creation symfony event is not triggered. This change addresses the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Upload a file using android app.
- [x] The after event triggered is listened using a test app.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

