### PR TITLE
Fix ApiContoller initialization

### DIFF
--- a/apps/files/lib/AppInfo/Application.php
+++ b/apps/files/lib/AppInfo/Application.php
@@ -75,15 +75,11 @@ class Application extends App {
 		/**
 		 * Services
 		 */
-		$container->registerService('Tagger', function(IContainer $c)  {
-			return $c->query('ServerContainer')->getTagManager()->load('files');
-		});
 		$container->registerService('TagService', function(IContainer $c)  {
-			$homeFolder = $c->query('ServerContainer')->getUserFolder();
 			return new TagService(
 				$c->query('ServerContainer')->getUserSession(),
-				$c->query('Tagger'),
-				$homeFolder
+				$c->query('ServerContainer')->getTagManager(),
+				$c->query('ServerContainer')->getLazyRootFolder()
 			);
 		});
 

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -26,11 +26,16 @@
  */
 namespace OC;
 
+use OC\AppFramework\Middleware\Security\Exceptions\NotLoggedInException;
+use OCP\Files\IRootFolder;
+use OCP\IConfig;
+use OCP\IImage;
 use OCP\IPreview;
+use OCP\IUserSession;
 use OCP\Preview\IProvider;
 
 class PreviewManager implements IPreview {
-	/** @var \OCP\IConfig */
+	/** @var IConfig */
 	protected $config;
 
 	/** @var bool */
@@ -48,13 +53,23 @@ class PreviewManager implements IPreview {
 	/** @var array */
 	protected $defaultProviders;
 
+	/** @var IRootFolder */
+	private $rootFolder;
+
+	/** @var IUserSession */
+	private $userSession;
+
 	/**
 	 * Constructor
 	 *
-	 * @param \OCP\IConfig $config
+	 * @param IConfig $config
+	 * @param IRootFolder $rootFolder
+	 * @param IUserSession $userSession
 	 */
-	public function __construct(\OCP\IConfig $config) {
+	public function __construct(IConfig $config, IRootFolder $rootFolder, IUserSession $userSession) {
 		$this->config = $config;
+		$this->rootFolder = $rootFolder;
+		$this->userSession = $userSession;
 	}
 
 	/**
@@ -114,10 +129,18 @@ class PreviewManager implements IPreview {
 	 * @param int $maxX The maximum X size of the thumbnail. It can be smaller depending on the shape of the image
 	 * @param int $maxY The maximum Y size of the thumbnail. It can be smaller depending on the shape of the image
 	 * @param boolean $scaleUp Scale smaller images up to the thumbnail size or not. Might look ugly
-	 * @return \OCP\IImage
+	 * @return IImage
+	 * @throws NotLoggedInException
+	 * @throws \OCP\Files\NotFoundException
+	 * @throws \Exception
 	 */
 	public function createPreview($file, $maxX = 100, $maxY = 75, $scaleUp = false) {
-		$preview = new \OC\Preview('', '/', $file, $maxX, $maxY, $scaleUp);
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new NotLoggedInException();
+		}
+		$file = $this->rootFolder->getUserFolder($user->getUID())->get($file);
+		$preview = new Preview('', '/', $file, $maxX, $maxY, $scaleUp);
 		return $preview->getPreview();
 	}
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -159,7 +159,9 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 		});
 
 		$this->registerService('PreviewManager', function (Server $c) {
-			return new PreviewManager($c->getConfig());
+			return new PreviewManager($c->getConfig(),
+				$c->getLazyRootFolder(),
+				$c->getUserSession());
 		});
 
 		$this->registerService('EncryptionManager', function (Server $c) {

--- a/tests/lib/PreviewTest.php
+++ b/tests/lib/PreviewTest.php
@@ -27,6 +27,7 @@ use OC\Files\Storage\Temporary;
 use OC\Files\View;
 use OC\Preview;
 use OC\PreviewManager;
+use OC\Server;
 use Test\Traits\MountProviderTrait;
 use Test\Traits\UserTrait;
 
@@ -111,7 +112,8 @@ class PreviewTest extends TestCase {
 		//re-initialize the preview manager due to config change above
 		unset(\OC::$server['PreviewManager']);
 		\OC::$server->registerService('PreviewManager', function ($c) {
-			return new PreviewManager($c->getConfig());
+			/** @var Server $c */
+			return new PreviewManager($c->getConfig(), $c->getLazyRootFolder(), $c->getUserSession());
 		});
 
 		// Sample is 1680x1050 JPEG


### PR DESCRIPTION
## Description
The ApiController and its depending services rely on information about the logged in user.
At the time of initializing the services the authentication information is not evaluated.

This PR postpones some initialization logic.

# ToDo
- unit tests for tag service requires refactoring -> tomorrow

## Related Issue
 - refs #29914

## How Has This Been Tested?
curl command as described in the ticket #29914 with basic auth as well as with bearer

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

