### PR TITLE
Update lost password email to use HTML link

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -336,7 +336,8 @@ class LostController extends Controller {
 			$message = $this->mailer->createMessage();
 			$message->setTo([$email => $user]);
 			$message->setSubject($this->l10n->t('%s password reset', [$this->defaults->getName()]));
-			$message->setPlainBody($msg);
+			$message->setPlainBody(\strip_tags($msg));
+			$message->setHtmlBody($msg);
 			$message->setFrom([$this->from => $this->defaults->getName()]);
 			$this->mailer->send($message);
 		} catch (\Exception $e) {

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -331,12 +331,15 @@ class LostController extends Controller {
 		$tmpl = new \OC_Template('core', 'lostpassword/email');
 		$tmpl->assign('link', $link);
 		$msg = $tmpl->fetchPage();
+		$tmplAlt = new \OC_Template('core', 'lostpassword/altemail');
+		$tmplAlt->assign('link', $link);
+		$msgAlt = $tmplAlt->fetchPage();
 
 		try {
 			$message = $this->mailer->createMessage();
 			$message->setTo([$email => $user]);
 			$message->setSubject($this->l10n->t('%s password reset', [$this->defaults->getName()]));
-			$message->setPlainBody(\strip_tags($msg));
+			$message->setPlainBody($msgAlt);
 			$message->setHtmlBody($msg);
 			$message->setFrom([$this->from => $this->defaults->getName()]);
 			$this->mailer->send($message);

--- a/core/templates/lostpassword/altemail.php
+++ b/core/templates/lostpassword/altemail.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author Christopher Schäpers <kondou@ts.unde.re>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+print_unescaped(str_replace('{link}', $_['link'], $l->t('Use the following link to reset your password: {link}')));
+print_unescaped("\n\n");
+// TRANSLATORS term at the end of a mail
+p($l->t("Cheers!"));
+?>
+
+--
+<?php p($theme->getName() . ' - ' . $theme->getSlogan()); ?>
+<?php print_unescaped("\n".$theme->getBaseUrl());
+

--- a/core/templates/lostpassword/email.php
+++ b/core/templates/lostpassword/email.php
@@ -1,21 +1,36 @@
+<table cellspacing="0" cellpadding="0" border="0" width="100%">
+<tr><td>
+<table cellspacing="0" cellpadding="0" border="0" width="600px">
+<tr>
+<td bgcolor="<?php p($theme->getMailHeaderColor());?>" width="20px">&nbsp;</td>
+<td bgcolor="<?php p($theme->getMailHeaderColor());?>">
+<img src="<?php p(\OC::$server->getURLGenerator()->getAbsoluteURL(image_path('', 'logo-mail.gif'))); ?>" alt="<?php p($theme->getName()); ?>"/>
+</td>
+</tr>
+<tr><td colspan="2">&nbsp;</td></tr>
+<tr>
+<td width="20px">&nbsp;</td>
+<td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">
 <?php
-/**
- * @author Christopher Schäpers <kondou@ts.unde.re>
- *
- * @copyright Copyright (c) 2018, ownCloud GmbH
- * @license AGPL-3.0
- *
- * This code is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License, version 3,
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License, version 3,
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *
- */
-echo str_replace('{link}', "<a href=\"{$_['link']}\">{$_['link']}</a>", $l->t('Use the following link to reset your password: {link}'));
+print_unescaped(str_replace('{link}', "<a href=\"{$_['link']}\">{$_['link']}</a>", $l->t('Use the following link to reset your password: {link}')));
+print_unescaped("<br><br>");
+// TRANSLATORS term at the end of a mail
+p($l->t("Cheers!"));
+?>
+</td>
+</tr>
+<tr><td colspan="2">&nbsp;</td></tr>
+<tr>
+<td width="20px">&nbsp;</td>
+<td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">--<br>
+<?php p($theme->getName()); ?> -
+<?php p($theme->getSlogan()); ?>
+<br><a href="<?php p($theme->getBaseUrl()); ?>"><?php p($theme->getBaseUrl());?></a>
+</td>
+</tr>
+<tr>
+<td colspan="2">&nbsp;</td>
+</tr>
+</table>
+</td></tr>
+</table>

--- a/core/templates/lostpassword/email.php
+++ b/core/templates/lostpassword/email.php
@@ -18,4 +18,4 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-echo str_replace('{link}', $_['link'], $l->t('Use the following link to reset your password: {link}'));
+echo str_replace('{link}', "<a href=\"{$_['link']}\">{$_['link']}</a>", $l->t('Use the following link to reset your password: {link}'));

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -365,11 +365,11 @@ class LostControllerTest extends TestCase {
 		$message
 			->expects($this->at(2))
 			->method('setPlainBody')
-			->with('Use the following link to reset your password: https://ownCloud.com/index.php/lostpassword/');
+			->with($this->stringContains('Use the following link to reset your password: https://ownCloud.com/index.php/lostpassword/'));
 		$message
 			->expects($this->at(3))
 			->method('setHtmlBody')
-			->with('Use the following link to reset your password: <a href="https://ownCloud.com/index.php/lostpassword/">https://ownCloud.com/index.php/lostpassword/</a>');
+			->with($this->stringContains('Use the following link to reset your password: <a href="https://ownCloud.com/index.php/lostpassword/">https://ownCloud.com/index.php/lostpassword/</a>'));
 		$message
 			->expects($this->at(4))
 			->method('setFrom')
@@ -430,11 +430,11 @@ class LostControllerTest extends TestCase {
 		$message
 			->expects($this->at(2))
 			->method('setPlainBody')
-			->with('Use the following link to reset your password: https://ownCloud.com/index.php/lostpassword/');
+			->with($this->stringContains('Use the following link to reset your password: https://ownCloud.com/index.php/lostpassword/'));
 		$message
 			->expects($this->at(3))
 			->method('setHtmlBody')
-			->with('Use the following link to reset your password: <a href="https://ownCloud.com/index.php/lostpassword/">https://ownCloud.com/index.php/lostpassword/</a>');
+			->with($this->stringContains('Use the following link to reset your password: <a href="https://ownCloud.com/index.php/lostpassword/">https://ownCloud.com/index.php/lostpassword/</a>'));
 		$message
 			->expects($this->at(4))
 			->method('setFrom')

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -368,6 +368,10 @@ class LostControllerTest extends TestCase {
 			->with('Use the following link to reset your password: https://ownCloud.com/index.php/lostpassword/');
 		$message
 			->expects($this->at(3))
+			->method('setHtmlBody')
+			->with('Use the following link to reset your password: <a href="https://ownCloud.com/index.php/lostpassword/">https://ownCloud.com/index.php/lostpassword/</a>');
+		$message
+			->expects($this->at(4))
 			->method('setFrom')
 			->with(['lostpassword-noreply@localhost' => null]);
 		$this->mailer
@@ -429,6 +433,10 @@ class LostControllerTest extends TestCase {
 			->with('Use the following link to reset your password: https://ownCloud.com/index.php/lostpassword/');
 		$message
 			->expects($this->at(3))
+			->method('setHtmlBody')
+			->with('Use the following link to reset your password: <a href="https://ownCloud.com/index.php/lostpassword/">https://ownCloud.com/index.php/lostpassword/</a>');
+		$message
+			->expects($this->at(4))
 			->method('setFrom')
 			->with(['lostpassword-noreply@localhost' => null]);
 		$this->mailer


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Update the lost password email to send both HTML and plain text versions so that URL in email can be clicked.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/30742

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solve issue https://github.com/owncloud/core/issues/30742

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Update associated tests to add HTML support.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

