### PR TITLE
Fix for (redis) dev editions

### DIFF
--- a/settings/Panels/Admin/SecurityWarning.php
+++ b/settings/Panels/Admin/SecurityWarning.php
@@ -87,7 +87,7 @@ class SecurityWarning implements ISettings {
 		];
 		$outdatedCaches = [];
 		foreach ($caches as $php_module => $data) {
-			$isOutdated = extension_loaded($php_module) && version_compare(phpversion($php_module), $data['version'], '<');
+			$isOutdated = extension_loaded($php_module) && version_compare(phpversion($php_module), $data['version'], '<') && (strpos(phpversion($php_module), 'dev')===false);
 			if ($isOutdated) {
 				$outdatedCaches[$php_module] = $data;
 			}


### PR DESCRIPTION
## Description
It's very annoying that the admin panel throws a warning regarding the redis version.
I use the latest development version so the version string is "develop" and obviously greater then 2.2.5.
Another issue is that in ubuntu 16.04 php-redis is "2.2.8-devphp7".
With my fix all dev versions are accepted and the annoying warning disappears :)


## How Has This Been Tested?
Tested on php7/7.1 on ownCloud 10.0.7

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

