### PR TITLE
UI tests for sharing autocompletion with min-char setting

### DIFF
--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -40,7 +40,29 @@ So that I can efficiently share my files with other users or groups
 		When the user types "doesnotexist" in the share-with-field
 		Then a tooltip with the text "No users or groups found for doesnotexist" should be shown near the share-with-field on the webUI
 		And the autocomplete list should not be displayed on the webUI
-		
+
+	@skipOnLDAP
+	Scenario: autocomplete short user names when completely typed
+		Given these users have been created but not initialized:
+			| username  | password | displayname  | email                 |
+			| uu1       | 1234     | UU One       | uu1@oc.com.np         |
+		And the user has opened the share dialog for the folder "simple-folder"
+		When the user types "uu1" in the share-with-field
+		Then all users and groups that contain the string "uu1" in their name should be listed in the autocomplete list on the webUI
+
+	Scenario: autocompletion when not enough characters typed
+		Given the user has opened the share dialog for the folder "simple-folder"
+		When the user types "use" in the share-with-field
+		Then a tooltip with the text "No users or groups found for use" should be shown near the share-with-field on the webUI
+		And the autocomplete list should not be displayed on the webUI
+
+	Scenario: autocompletion when changing minimum characters for sharing autocomplete
+		Given the administrator has set the minimum characters for sharing autocomplete to "2"
+		And the user has opened the share dialog for the folder "simple-folder"
+		When the user types "us" in the share-with-field
+		Then all users and groups that contain the string "us" in their name should be listed in the autocomplete list on the webUI
+		And the users own name should not be listed in the autocomplete list on the webUI
+
 	@skipOnLDAP @user_ldap#175
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
 		Given the user has shared the folder "simple-folder" with the user "User One" using the webUI
@@ -70,3 +92,4 @@ So that I can efficiently share my files with other users or groups
 		When the user types "grou" in the share-with-field
 		Then all users and groups that contain the string "grou" in their name should be listed in the autocomplete list on the webUI except group "groupuser"
 		And the users own name should not be listed in the autocomplete list on the webUI
+


### PR DESCRIPTION
## Description
test to see if autocompletion works correctly with the new setting introduced in https://github.com/owncloud/core/pull/30798

## Related Issue
https://github.com/owncloud/core/issues/30313
https://github.com/owncloud/core/issues/31058

## How Has This Been Tested?
run tests locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.