### PR TITLE
Set minimum php version to 5.6 im composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "jarnaiz/behat-junit-formatter": "^1.3"
     },
     "require": {
-        "php": ">=5.4.1",
+        "php": ">=5.6",
         "doctrine/dbal": "^2.5",
         "phpseclib/phpseclib": "^2.0",
         "rackspace/php-opencloud": "v1.9.2",


### PR DESCRIPTION
## Description
Set minimum php version to 5.6 - 5.4 was set which reflects the old defintion of 9.1 ...

## Motivation and Context
PHPStorm uses the min php version in composer.json while inspecting the code base.
Using the wrong version will result in wrong inspections.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

