### PR TITLE
Don`t apply checksum wrapper to mixed r/w streams

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Checksum.php
+++ b/lib/private/Files/Storage/Wrapper/Checksum.php
@@ -56,8 +56,8 @@ class Checksum extends Wrapper {
 	 */
 	public function fopen($path, $mode) {
 		$stream = $this->getWrapperStorage()->fopen($path, $mode);
-		if (!\is_resource($stream)) {
-			// don't wrap on error
+		if (!\is_resource($stream) || $this->isReadWriteStream($mode)) {
+			// don't wrap on error or mixed mode streams (could cause checksum corruption)
 			return $stream;
 		}
 
@@ -116,6 +116,14 @@ class Checksum extends Wrapper {
 		}
 
 		return self::NOT_REQUIRED;
+	}
+
+	/**
+	 * @param $mode
+	 * @return bool
+	 */
+	private function isReadWriteStream($mode) {
+		return \strpos($mode, '+') !== false;
 	}
 
 	/**

--- a/tests/lib/Files/Storage/Wrapper/ChecksumTest.php
+++ b/tests/lib/Files/Storage/Wrapper/ChecksumTest.php
@@ -36,6 +36,8 @@ class ChecksumTest extends \Test\TestCase {
 	 */
 	private $instance;
 
+	private $testFileName;
+
 	const TEST_DATA = 'somedata';
 	const EXPECTED_CHECKSUMS = 'SHA1:efaa311ae448a7374c122061bfed952d940e9e37 MD5:aefaf7502d52994c3b01957636a3cdd2 ADLER32:0f2c034f';
 
@@ -45,39 +47,43 @@ class ChecksumTest extends \Test\TestCase {
 		$this->instance = new \OC\Files\Storage\Wrapper\Checksum([
 			'storage' => $this->sourceStorage
 		]);
+
+		$this->testFileName = '/'. \bin2hex(\random_bytes(4)) . '.txt';
 	}
 
 	public function testFilePutContentsCalculatesChecksum() {
-		$this->instance->file_put_contents('/foo.txt', 'somedata');
-		$metaData = $this->instance->getMetaData('/foo.txt');
+		$this->instance->file_put_contents($this->testFileName, 'somedata');
+		$metaData = $this->instance->getMetaData($this->testFileName);
 
 		$this->assertArrayHasKey('checksum', $metaData);
 		$this->assertEquals(self::EXPECTED_CHECKSUMS, $metaData['checksum']);
 	}
 
 	public function testWriteToFileHandleCalculatesChecksum() {
-		$handle = $this->instance->fopen('/foo.txt', 'w+');
+		$handle = $this->instance->fopen($this->testFileName, 'w');
 
 		$this->assertInternalType('resource', $handle);
 		$this->assertNotFalse(\fwrite($handle, self::TEST_DATA));
 		$this->assertNotFalse(\fclose($handle));
 
-		$metaData = $this->instance->getMetaData('/foo.txt');
+		$metaData = $this->instance->getMetaData($this->testFileName);
 
 		$this->assertArrayHasKey('checksum', $metaData);
 		$this->assertEquals(self::EXPECTED_CHECKSUMS, $metaData['checksum']);
 	}
 
 	public function testReadFromFileHandleOnNewFileCalculatesChecksum() {
-		$this->sourceStorage->file_put_contents('/foo.txt', self::TEST_DATA);
+		$this->sourceStorage->file_put_contents($this->testFileName, self::TEST_DATA);
+		// Make file available in filecache (without checksum)
+		$this->sourceStorage->getScanner($this->testFileName)->scan($this->testFileName);
 
-		$handle = $this->instance->fopen('/foo.txt', "r");
-		$data = \fread($handle, $this->sourceStorage->filesize('/foo.txt'));
+		$handle = $this->instance->fopen($this->testFileName, 'r');
+		$data = \fread($handle, $this->sourceStorage->filesize($this->testFileName));
 		\fclose($handle);
 
 		$this->assertEquals(self::TEST_DATA, $data);
 
-		$metaData = $this->instance->getMetaData('/foo.txt');
+		$metaData = $this->instance->getMetaData($this->testFileName);
 
 		$this->assertArrayHasKey('checksum', $metaData);
 		$this->assertEquals(self::EXPECTED_CHECKSUMS, $metaData['checksum']);
@@ -97,13 +103,42 @@ class ChecksumTest extends \Test\TestCase {
 	 * @depends testFilePutContentsCalculatesChecksum
 	 */
 	public function testFileChangeChangesChecksum() {
-		$this->instance->file_put_contents('/foo.txt', self::TEST_DATA);
-		$this->instance->file_put_contents('/foo.txt', 'otherdata');
+		$this->instance->file_put_contents($this->testFileName, self::TEST_DATA);
+		$this->instance->file_put_contents($this->testFileName, 'otherdata');
 
-		$metaData = $this->instance->getMetaData('/foo.txt');
+		$metaData = $this->instance->getMetaData($this->testFileName);
 
 		$this->assertEquals(
 			"SHA1:693301c930b242611c005b00c151cc216259f1bd MD5:e4de345997131e5fa4421c3b2a9edddb ADLER32:12fc03bd",
+			$metaData['checksum']
+		);
+	}
+
+	public function testChecksumWrapperIsNotAppliedOnReadWriteStreams() {
+		$handle = $this->instance->fopen($this->testFileName, 'x+');
+		\fwrite($handle, self::TEST_DATA);
+		\fclose($handle);
+
+		$metaData = $this->instance->getMetaData($this->testFileName);
+
+		$this->assertEmpty($metaData['checksum']);
+	}
+
+	/**
+	 * @depends testFilePutContentsCalculatesChecksum
+	 */
+	public function testRewindDoesNotCorruptChecksum() {
+		$this->instance->file_put_contents($this->testFileName, self::TEST_DATA);
+		$handle = $this->instance->fopen($this->testFileName, 'r+');
+		\fread($handle, $this->sourceStorage->filesize($this->testFileName));
+		\rewind($handle);
+		\fread($handle, $this->sourceStorage->filesize($this->testFileName));
+		\fclose($handle);
+
+		$metaData = $this->instance->getMetaData($this->testFileName);
+
+		$this->assertEquals(
+			self::EXPECTED_CHECKSUMS,
 			$metaData['checksum']
 		);
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Don`t apply checksum wrapper on mixed read/write streams because this could corrupt the checksum context if the stream is for example seeked or rewinded.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Might be the potential source of checksum issues we are having. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

