### PR TITLE
Changes updated by rewriting config.php should sent events

### DIFF
--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -120,6 +120,18 @@ class ConfigTest extends TestCase {
 		$this->assertAttributeEquals($this->initialConfig, 'cache', $this->config);
 		$this->assertStringEqualsFile($this->configFile, self::TESTCONTENT);
 
+		$calledBeforeUpdate = [];
+		\OC::$server->getEventDispatcher()->addListener('config.beforesetvalue',
+			function (GenericEvent $event) use (&$calledBeforeUpdate) {
+				$calledBeforeUpdate[] = 'config.beforesetvalue';
+				$calledBeforeUpdate[] = $event;
+			});
+		$calledAfterUpdate = [];
+		\OC::$server->getEventDispatcher()->addListener('config.aftersetvalue',
+			function (GenericEvent $event) use (&$calledAfterUpdate) {
+				$calledAfterUpdate[] = 'config.aftersetvalue';
+				$calledAfterUpdate[] = $event;
+			});
 		$this->config->setValues([
 			'foo'			=> 'moo',
 			'alcohol_free'	=> null,
@@ -128,10 +140,55 @@ class ConfigTest extends TestCase {
 		$expectedConfig['foo'] = 'moo';
 		unset($expectedConfig['alcohol_free']);
 		$this->assertAttributeEquals($expectedConfig, 'cache', $this->config);
+		$this->assertInstanceOf(GenericEvent::class, $calledBeforeUpdate[1]);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterUpdate[1]);
+		$this->assertEquals('config.beforesetvalue', $calledBeforeUpdate[0]);
+		$this->assertEquals('config.aftersetvalue', $calledAfterUpdate[0]);
+		$this->assertArrayHasKey('key', $calledBeforeUpdate[1]);
+		$this->assertEquals('foo', $calledBeforeUpdate[1]->getArgument('key'));
+		$this->assertArrayHasKey('value', $calledBeforeUpdate[1]);
+		$this->assertEquals('moo', $calledBeforeUpdate[1]->getArgument('value'));
+		$this->assertArrayHasKey('key', $calledAfterUpdate[1]);
+		$this->assertEquals('foo', $calledAfterUpdate[1]->getArgument('key'));
+		$this->assertArrayHasKey('value', $calledAfterUpdate[1]);
+		$this->assertEquals('moo', $calledAfterUpdate[1]->getArgument('value'));
+		$this->assertArrayHasKey('update', $calledAfterUpdate[1]);
+		$this->assertTrue($calledAfterUpdate[1]->getArgument('update'));
+		$this->assertArrayHasKey('oldvalue', $calledAfterUpdate[1]);
+		$this->assertEquals('bar', $calledAfterUpdate[1]->getArgument('oldvalue'));
 
 		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
 			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n);\n";
 		$this->assertStringEqualsFile($this->configFile, $expected);
+
+		$calledBeforeDelete = [];
+		\OC::$server->getEventDispatcher()->addListener('config.beforedeletevalue',
+			function (GenericEvent $event) use (&$calledBeforeDelete) {
+				$calledBeforeDelete[] = 'config.beforedeletevalue';
+				$calledBeforeDelete[] = $event;
+			});
+		$calledAfterDelete = [];
+		\OC::$server->getEventDispatcher()->addListener('config.afterdeletevalue',
+			function (GenericEvent $event) use (&$calledAfterDelete) {
+				$calledAfterDelete[] = 'config.afterdeletevalue';
+				$calledAfterDelete[] = $event;
+			});
+
+		$this->config->setValues([
+			'foo' => null
+		]);
+		$this->assertInstanceOf(GenericEvent::class, $calledBeforeDelete[1]);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterDelete[1]);
+		$this->assertEquals('config.beforedeletevalue', $calledBeforeDelete[0]);
+		$this->assertEquals('config.afterdeletevalue', $calledAfterDelete[0]);
+		$this->assertArrayHasKey('key', $calledBeforeDelete[1]);
+		$this->assertEquals('foo', $calledBeforeDelete[1]->getArgument('key'));
+		$this->assertArrayHasKey('value', $calledBeforeDelete[1]);
+		$this->assertNull($calledBeforeDelete[1]->getArgument('value'));
+		$this->assertArrayHasKey('key', $calledAfterDelete[1]);
+		$this->assertEquals('foo', $calledAfterDelete[1]->getArgument('key'));
+		$this->assertArrayHasKey('value', $calledAfterDelete[1]);
+		$this->assertEquals('moo', $calledAfterDelete[1]->getArgument('value'));
 	}
 
 	public function testDeleteKey() {


### PR DESCRIPTION
When changes updated by rewriting config.php, for example
using method writeData() should also be logged. This change
would help to log these data. An example is updating
email settings from UI.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
When config rewrite happens with `setValues()`, the symfony events are not triggered for config changes. The config.php rewrite happens. Events should be triggered for the changes that happened.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When config rewrite happens with `setValues()`, the symfony events are not triggered for config changes. The config.php rewrite happens. Events should be triggered for the changes that happened.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Try to update the config say email
- [x] Verify the events are triggered by using debugger.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

