### PR TITLE
[stable10] getUser of the backend mock needs to return an array

### DIFF
--- a/tests/lib/Command/User/SyncBackendTest.php
+++ b/tests/lib/Command/User/SyncBackendTest.php
@@ -231,6 +231,10 @@ class SyncBackendTest extends TestCase {
 			->method('hasUserListings')
 			->will($this->returnValue(true));
 
+		$this->dummyBackend
+			->method('getUsers')
+			->willReturn([]);
+
 		$inputInterface
 			->expects($this->at(2))
 			->method('getOption')


### PR DESCRIPTION
backport of #31063 