### PR TITLE
Text improvements in config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -57,7 +57,9 @@ $CONFIG = array(
 /**
  * Your list of trusted domains that users can log into. Specifying trusted
  * domains prevents host header poisoning. Do not remove this, as it performs
- * necessary security checks.
+ * necessary security checks. Please consider that for backend processes like 
+ * background jobs or occ commands, the url parameter in key ``overwrite.cli.url``
+ * is used. For more details please see that key.
  */
 'trusted_domains' =>
   array (
@@ -413,6 +415,10 @@ $CONFIG = array(
  * are generated within ownCloud using any kind of command line tools (cron or
  * occ). The value should contain the full base URL:
  * ``https://www.example.com/owncloud``
+ * As an example, alerts shown in the browser to upgrade an app are triggered by
+ * a cron background process and therefore uses the url of this key, even if the user
+ * has logged on via a different domain defined in key ``trusted_domains``. When the 
+ * user clicks an alert like this, he will be redirected to that URL and must logon again.
  */
 'overwrite.cli.url' => '',
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
If you get an alarm to upgrade an app and you have been logged on via a secondary domain used in ``trusted_domains``, you will get redirected to the doamin used in ``overwrite.cli.url`` because alerts are notifications created by background processes which use by design the url of ``overwrite.cli.url``.

## Related Issue
https://github.com/owncloud/core/issues/31081

## Motivation and Context
Better understanding why you might get redirected

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@settermjd we might add an additional description in the documentation. Location tbd.