### PR TITLE
[stable10] Ability to log extra fields + trigger event when logging

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -236,6 +236,11 @@ class Log implements ILogger {
 		}
 		$logConditionFile = null;
 
+		$extraFields = [];
+		if (isset($context['extraFields'])) {
+			$extraFields = $context['extraFields'];
+			unset($context['extraFields']);
+		}
 		array_walk($context, [$this->normalizer, 'format']);
 
 		if (isset($context['app'])) {
@@ -321,7 +326,12 @@ class Log implements ILogger {
 
 		if ($level >= $minLevel) {
 			$logger = $this->logger;
-			call_user_func([$logger, 'write'], $app, $message, $level, $logConditionFile);
+			// check if logger supports extra fields
+			if (!empty($extraFields) && is_callable($logger, 'writeExtra')) {
+				call_user_func([$logger, 'writeExtra'], $app, $message, $level, $logConditionFile, $extraFields);
+			} else {
+				call_user_func([$logger, 'write'], $app, $message, $level, $logConditionFile);
+			}
 		}
 	}
 

--- a/lib/private/Log/Owncloud.php
+++ b/lib/private/Log/Owncloud.php
@@ -70,6 +70,10 @@ class Owncloud {
 	 * @param string conditionalLogFile
 	 */
 	public static function write($app, $message, $level, $conditionalLogFile = null) {
+		return self::writeExtra($app, $message, $level, $conditionalLogFile, []);
+	}
+
+	public static function writeExtra($app, $message, $level, $conditionalLogFile, $extraFields = []) {
 		$config = \OC::$server->getSystemConfig();
 
 		// default to ISO8601
@@ -110,6 +114,12 @@ class Owncloud {
 			'url',
 			'message'
 		);
+
+		if (!empty($extraFields)) {
+			// augment with additional fields
+			$entry = array_merge($entry, $extraFields);
+		}
+
 		$entry = json_encode($entry);
 		if (!is_null($conditionalLogFile)) {
 			if ($conditionalLogFile[0] !== '/') {

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -107,6 +107,11 @@ class LoggerTest extends TestCase {
 		self::$logs[]= "$level $message";
 	}
 
+	public static function writeExtra($app, $message, $level, $logConditionFile, $extraFields) {
+		$encodedFields = json_encode($extraFields);
+		self::$logs[]= "$level $message fields=$encodedFields";
+	}
+
 	public function userAndPasswordData() {
 		return [
 			['abc', 'def'],
@@ -197,4 +202,26 @@ class LoggerTest extends TestCase {
 		}
 	}
 
+	public function testExtraFields() {
+		$extraFields = [
+			'one' => 'un',
+			'two' => 'deux',
+			'three' => 'trois',
+		];
+
+		// with fields calls "writeExtra"
+		$this->logger->info(
+			'extra fields test', [
+				'extraFields' => $extraFields
+			]
+		);
+
+		// without fields calls "write"
+		$this->logger->info('no fields');
+
+		$logLines = $this->getLogs();
+
+		$this->assertEquals('1 extra fields test fields={"one":"un","two":"deux","three":"trois"}', $logLines[0]);
+		$this->assertEquals('1 no fields', $logLines[1]);
+	}
 }

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -12,6 +12,9 @@ use OC\Log;
 use OCP\IConfig;
 use OCP\IUserSession;
 use OCP\Util;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 class LoggerTest extends TestCase {
 	/** @var \OCP\ILogger */
@@ -21,6 +24,9 @@ class LoggerTest extends TestCase {
 	/** @var IConfig | \PHPUnit_Framework_MockObject_MockObject */
 	private $config;
 
+	/** @var EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject */
+	private $eventDispatcher;
+
 	protected function setUp() {
 		parent::setUp();
 
@@ -29,7 +35,8 @@ class LoggerTest extends TestCase {
 			'\OC\SystemConfig')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->logger = new Log('Test\LoggerTest', $this->config);
+		$this->eventDispatcher = new EventDispatcher();
+		$this->logger = new Log('Test\LoggerTest', $this->config, null, $this->eventDispatcher);
 	}
 
 	public function testInterpolation() {
@@ -223,5 +230,54 @@ class LoggerTest extends TestCase {
 
 		$this->assertEquals('1 extra fields test fields={"one":"un","two":"deux","three":"trois"}', $logLines[0]);
 		$this->assertEquals('1 no fields', $logLines[1]);
+	}
+
+	public function testEvents() {
+		$this->config->expects($this->any())
+			->method('getValue')
+			->will(($this->returnValueMap([
+				['loglevel', Util::WARN, Util::WARN],
+			])));
+
+		$beforeWriteEvent = null;
+		$this->eventDispatcher->addListener(
+			'log.beforewrite',
+			function(GenericEvent $event) use (&$beforeWriteEvent) {
+				$beforeWriteEvent = $event;
+			}
+		);
+		$afterWriteEvent = null;
+		$this->eventDispatcher->addListener(
+			'log.afterwrite',
+			function(GenericEvent $event) use (&$afterWriteEvent) {
+				$afterWriteEvent = $event;
+			}
+		);
+
+		$this->logger->debug(
+			'some {test} message', [
+				'app' => 'testapp',
+				'test' => 'replaced',
+				'extraFields' => ['extra' => 'one'],
+			]
+		);
+
+		$this->assertNotNull($beforeWriteEvent, 'before event was triggered');
+		$this->assertNotNull($afterWriteEvent, 'before event was triggered');
+
+		$expectedArgs = [
+			'app' => 'testapp',
+			'loglevel' => Util::DEBUG,
+			'message' => 'some {test} message',
+			'formattedMessage' => 'some replaced message',
+			'context' => [
+				'app' => 'testapp',
+				'test' => 'replaced',
+			],
+			'extraFields' => ['extra' => 'one'],
+		];
+
+		$this->assertEquals($expectedArgs, $beforeWriteEvent->getArguments(), 'before event arguments match');
+		$this->assertEquals($expectedArgs, $afterWriteEvent->getArguments(), 'after event arguments match');
 	}
 }


### PR DESCRIPTION
## Description
1) If a logger supports it like the default logger, additional fields can
now be added to the base JSON object.

Built to still support old loggers so this shouldn't break any API contracts.

2) Trigger an event before and after logging an entry, independently from log level

This makes it possible for apps to react on log events.
Could also help with the testing app to capture log entries.

## Related Issue
None

## Motivation and Context
Some log analyzers prefer to have the fields directly appearing in the base JSON object instead of serialized into strings.

## How Has This Been Tested?
Add `\OC::$server->getLogger()->error("Test extra fields", ['app' => 'test', 'extraFields' => ['hello' => 'field', 'another' => 'field']]);` to Sabre\Directory constructor and open the web UI.
Then check the logs:
```
{"reqId":"S9ulvAzpHQcTLEtVRMPf","level":3,"time":"2018-04-13T13:22:51+00:00","remoteAddr":"127.0.0.1","user":"admin","app":"test","method":"PROPFIND","url":"\/owncloud\/remote.php\/webdav\/","message":"Test extra fields","hello":"field","another":"field"}
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

