### PR TITLE
Unified symfony event for updates happening in share

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -739,7 +739,19 @@ class Share20OCS {
 
 			// set name only if passed as parameter, empty string is allowed
 			if ($name !== null) {
+				$oldname = $share->getName();
 				$share->setName($name);
+
+				//Trigger update event for name change only if name differ
+				if ($name !== $oldname) {
+					$shareAfterNameUpdate = new GenericEvent(null);
+					$shareAfterNameUpdate->setArguments([
+						'sharenameupdated' => true,
+						'oldname' => $oldname,
+						'shareobject' => $share,
+					]);
+					$this->eventDispatcher->dispatch('share.afterupdate', $shareAfterNameUpdate);
+				}
 			}
 
 			if ($newPermissions !== null) {

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2724,7 +2724,23 @@ class ManagerTest extends \Test\TestCase {
 			'path' => '/myPath',
 		]);
 
+		$calledAfterUpdate = [];
+		$this->eventDispatcher->addListener('share.afterupdate',
+			function (GenericEvent $event) use (&$calledAfterUpdate) {
+				$calledAfterUpdate[] = 'share.afterupdate';
+				$calledAfterUpdate[] = $event;
+			});
+
 		$manager->updateShare($share);
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterUpdate[1]);
+		$this->assertEquals('share.afterupdate', $calledAfterUpdate[0]);
+		$this->assertArrayHasKey('permissionupdate', $calledAfterUpdate[1]);
+		$this->assertTrue($calledAfterUpdate[1]->getArgument('permissionupdate'));
+		$this->assertArrayHasKey('oldpermissions', $calledAfterUpdate[1]);
+		$this->assertEquals(1, $calledAfterUpdate[1]->getArgument('oldpermissions'));
+		$this->assertArrayHasKey('shareobject', $calledAfterUpdate[1]);
+		$this->assertInstanceOf(Share::class, $calledAfterUpdate[1]->getArgument('shareobject'));
+		$this->assertArrayHasKey('path', $calledAfterUpdate[1]);
 	}
 
 	public function testUpdateShareGroup() {
@@ -2831,7 +2847,22 @@ class ManagerTest extends \Test\TestCase {
 		$hookListner2->expects($this->never())->method('post');
 
 
+		$calledAfterUpdate = [];
+		$this->eventDispatcher->addListener('share.afterupdate',
+			function (GenericEvent $event) use (&$calledAfterUpdate) {
+				$calledAfterUpdate[] = 'share.afterupdate';
+				$calledAfterUpdate[] = $event;
+			});
 		$manager->updateShare($share);
+
+		$this->assertInstanceOf(GenericEvent::class, $calledAfterUpdate[1]);
+		$this->assertEquals('share.afterupdate', $calledAfterUpdate[0]);
+		$this->assertArrayHasKey('expirationdateupdated', $calledAfterUpdate[1]);
+		$this->assertTrue($calledAfterUpdate[1]->getArgument('expirationdateupdated'));
+		$this->assertArrayHasKey('oldexpirationdate', $calledAfterUpdate[1]);
+		$this->assertNull($calledAfterUpdate[1]->getArgument('oldexpirationdate'));
+		$this->assertArrayHasKey('shareobject', $calledAfterUpdate[1]);
+		$this->assertInstanceOf(Share::class, $calledAfterUpdate[1]->getArgument('shareobject'));
 	}
 
 	/**


### PR DESCRIPTION
A unified symfony event for updates happening in share.
This change covers the updates for updates in:
a) share name
b) password change
c) update in expiry date
d) update of permission

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
A unified event to handle updates in share, like:
a) share name update
b) share password update
c) update of expiry date
d) permissions

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A unified event to handle updates in share, like:
a) share name update
b) share password update
c) update of expiry date
d) permissions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

