### PR TITLE
[stable10] API tests to create and use an app password

### DIFF
--- a/tests/acceptance/features/apiMain/auth.feature
+++ b/tests/acceptance/features/apiMain/auth.feature
@@ -28,6 +28,11 @@ Feature: auth
 		When the user requests "/index.php/apps/files" with "GET" using the browser session
 		Then the HTTP status code should be "200"
 
+	Scenario: access files app with an app password
+		Given a new browser session for "user0" has been started
+		And the user has generated a new app password named "my-client"
+		When the user requests "/index.php/apps/files" with "GET" using the generated app password
+		Then the HTTP status code should be "200"
 
 	# WebDAV
 
@@ -76,3 +81,9 @@ Feature: auth
 		Given a new browser session for "user0" has been started
 		When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using the browser session
 		Then the OCS status code should be "100"
+
+	Scenario: using OCS with an app password
+		Given a new browser session for "user0" has been started
+		And the user has generated a new app password named "my-client"
+		When the user requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using the generated app password
+		Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiMain/tokenAuth.feature
+++ b/tests/acceptance/features/apiMain/tokenAuth.feature
@@ -1,0 +1,39 @@
+@api
+Feature: tokenAuth
+
+	Background:
+		Given using API version "1"
+		And these users have been created:
+			| username    | password | displayname  | email                 |
+			| user1       | 1234     | User One     | u1@oc.com.np          |
+		And token auth has been enforced
+
+	Scenario: creating a user with basic auth should be blocked when token auth is enforced
+		Given user "brand-new-user" has been deleted
+		When the administrator sends a user creation request for user "brand-new-user" password "456firstpwd" using the API
+		Then the OCS status code should be "997"
+		And the HTTP status code should be "401"
+
+	Scenario: moving a file should be blocked when token auth is enforced
+		Given using new DAV path
+		When user "user1" moves file "/textfile0.txt" to "/renamed_textfile0.txt" using the API
+		Then the HTTP status code should be "401"
+
+	Scenario: can access files app with an app password when token auth is enforced
+		Given a new browser session for "user1" has been started
+		And the user has generated a new app password named "my-client"
+		When the user requests "/index.php/apps/files" with "GET" using the generated app password
+		Then the HTTP status code should be "200"
+
+	Scenario: cannot access files app with basic auth when token auth is enforced
+		When user "user1" requests "/index.php/apps/files" with "GET" using basic auth
+		Then the HTTP status code should be "401"
+
+	Scenario: using WebDAV with basic auth should be blocked when token auth is enforced
+		When user "user0" requests "/remote.php/webdav" with "PROPFIND" using basic auth
+		Then the HTTP status code should be "401"
+
+	Scenario: using OCS with basic auth should be blocked when token auth is enforced
+		When user "user0" requests "/ocs/v1.php/apps/files_sharing/api/v1/remote_shares" with "GET" using basic auth
+		Then the OCS status code should be "997"
+		And the HTTP status code should be "401"

--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -314,6 +314,7 @@ trait AppConfiguration {
 	 * @return void
 	 */
 	public function restoreParametersAfterScenario() {
+		$this->deleteTokenAuthEnforcedAfterScenario();
 		$user = $this->currentUser;
 		$this->currentUser = $this->getAdminUsername();
 		$this->modifyServerConfigs($this->savedCapabilitiesChanges);

--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -282,10 +282,6 @@ trait Auth {
 
 		// Remember that we set this value, so it can be removed after the scenario
 		$this->tokenAuthHasBeenSet = true;
-
-		// It takes some time for the change in config.php to really be
-		// recognised at the server.
-		sleep(5);
 	}
 
 	/**
@@ -304,7 +300,6 @@ trait Auth {
 				]
 			);
 			$this->tokenAuthHasBeenSet = false;
-			sleep(5);
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1344,6 +1344,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function cleanupUsers() {
+		$this->deleteTokenAuthEnforcedAfterScenario();
 		$previousServer = $this->currentServer;
 		$this->usingServer('LOCAL');
 		foreach ($this->createdUsers as $user => $userData) {
@@ -1363,6 +1364,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function cleanupGroups() {
+		$this->deleteTokenAuthEnforcedAfterScenario();
 		$previousServer = $this->currentServer;
 		$this->usingServer('LOCAL');
 		foreach ($this->createdGroups as $group => $groupData) {

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -548,6 +548,7 @@ trait Tags {
 	 * @return void
 	 */
 	public function cleanupTags() {
+		$this->deleteTokenAuthEnforcedAfterScenario();
 		foreach ($this->createdTags as $tagID) {
 			try {
 				$this->response = TagsHelper::deleteTag(


### PR DESCRIPTION
## Description
1) Add test steps that generate an app password and can use it to access API endpoints
2) Add scenarios to generate an app password and use it
3) Add test steps that can turn on token_auth_enforced
4) Add a few scenarios to check what can be done and what is blocked by token_auth_enforced

## Related Issue

## Motivation and Context
Have some automated tests that check that an app password can be created and used.

## How Has This Been Tested?
Local test runs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance tests

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
