### PR TITLE
Do not load disabled app-themes

### DIFF
--- a/lib/private/Helper/EnvironmentHelper.php
+++ b/lib/private/Helper/EnvironmentHelper.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Helper;
+
+/**
+ * This class provides non-static wrappers for the static OC class members
+ */
+class EnvironmentHelper {
+	/**
+	 * Get the ownCloud root path for http requests (e.g. owncloud/)
+	 *
+	 * @return string
+	 */
+	public function getWebRoot() {
+		return \OC::$WEBROOT;
+	}
+
+	/**
+	 * Get the installation path for owncloud on the server
+	 * (e.g. /srv/http/owncloud)
+	 *
+	 * @return string
+	 */
+	public function getServerRoot() {
+		return \OC::$SERVERROOT;
+	}
+
+	/**
+	 * Get the apps folders location on the server as an array of
+	 * arrays with 'path' and 'url' keys
+	 * where 'path' keys holds an absolute filesystem path to the folder
+	 * and 'url' key holds a web path relative to the ownCloud webroot
+	 *
+	 * @return string[][]
+	 */
+	public function getAppsRoots() {
+		return \OC::$APPSROOTS;
+	}
+}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -878,7 +878,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 		$this->registerService('ThemeService', function ($c) {
 			return new ThemeService(
 				$this->getSystemConfig()->getValue('theme'),
-				\OC::$SERVERROOT
+				$c->getAppManager(),
+				new \OC\Helper\EnvironmentHelper()
 			);
 		});
 		$this->registerAlias('OCP\Theme\IThemeService', 'ThemeService');

--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -19,8 +19,15 @@
  */
 namespace OC\Theme;
 
+use OCP\App\IAppManager;
 use OCP\Theme\IThemeService;
+use OC\Helper\EnvironmentHelper;
 
+/**
+ * Class ThemeService
+ *
+ * @package OC\Theme
+ */
 class ThemeService implements IThemeService {
 	const DEFAULT_THEME_PATH = '/themes/default';
 
@@ -28,23 +35,29 @@ class ThemeService implements IThemeService {
 	 * @var Theme
 	 */
 	private $theme;
-	
-	/** @var string */
-	private $serverRoot;
 
-	/** @var string */
-	private $defaultThemeDirectory;
+	/**
+	 * @var IAppManager
+	 */
+	private $appManager;
+
+	/**
+	 * @var EnvironmentHelper
+	 */
+	private $environmentHelper;
 
 	/**
 	 * ThemeService constructor.
 	 *
 	 * @param string $themeName
-	 * @param string $serverRoot
+	 * @param IAppManager $appManager
+	 * @param EnvironmentHelper $environmentHelper
 	 */
-	public function __construct($themeName, $serverRoot) {
-		$this->serverRoot = $serverRoot;
-		$this->defaultThemeDirectory = $this->serverRoot . self::DEFAULT_THEME_PATH;
-
+	public function __construct($themeName,
+		IAppManager $appManager, EnvironmentHelper $environmentHelper
+	) {
+		$this->appManager = $appManager;
+		$this->environmentHelper = $environmentHelper;
 		if ($themeName === '' && $this->defaultThemeExists()) {
 			$themeName = 'default';
 		}
@@ -56,7 +69,9 @@ class ThemeService implements IThemeService {
 	 * @return bool
 	 */
 	public function defaultThemeExists() {
-		return \is_dir($this->defaultThemeDirectory);
+		$defaultThemePath = $this->environmentHelper->getServerRoot()
+			. self::DEFAULT_THEME_PATH;
+		return \is_dir($defaultThemePath);
 	}
 
 	/**
@@ -68,6 +83,8 @@ class ThemeService implements IThemeService {
 
 	/**
 	 * @param string $themeName
+	 *
+	 * @return void
 	 */
 	public function setAppTheme($themeName = '') {
 		$this->theme = $this->makeTheme($themeName, true);
@@ -76,46 +93,51 @@ class ThemeService implements IThemeService {
 	/**
 	 * @param string $themeName
 	 * @param bool $appTheme
+	 *
 	 * @return Theme
 	 */
 	private function makeTheme($themeName, $appTheme = true) {
-		$baseDirectory = $this->serverRoot;
+		$serverRoot = $this->environmentHelper->getServerRoot();
+		$baseDirectory = $serverRoot;
 		$directory = '';
 		$webPath = '';
 		if ($themeName !== '') {
 			if ($appTheme) {
-				$themeDirectory = \OC_App::getAppPath($themeName);
-				// Use OC server root as a theme base directory if theme is located below it
-				// Use path to an app root as a theme base directory otherwise
-				// in any case theme directory is relative to theme base directory
-				if (\strpos($themeDirectory, $this->serverRoot)===0) {
-					$directory = \substr($themeDirectory, \strlen($this->serverRoot) + 1);
+				$themeDirectory = $this->appManager->getAppPath($themeName);
+				// If theme is located below OC server root
+				//   Theme base directory is OC server root
+				//
+				// if theme is located outside OC server root
+				//   Theme base directory is a path to the appsRoot containing
+				//   this theme
+				//
+				// In any case theme directory is relative to theme base directory
+				if (\strpos($themeDirectory, $serverRoot) === 0) {
+					$directory = \substr($themeDirectory, \strlen($serverRoot) + 1);
 				} else {
-					foreach (\OC::$APPSROOTS as $appRoot) {
-						if (\strpos($themeDirectory, $appRoot['path'])===0) {
-							$baseDirectory = $appRoot['path'];
-							$directory = \substr($themeDirectory, \strlen($appRoot['path']) + 1);
+					$appsRoots = $this->environmentHelper->getAppsRoots();
+					foreach ($appsRoots as $appsRoot) {
+						if (\strpos($themeDirectory, $appsRoot['path']) === 0) {
+							$baseDirectory = $appsRoot['path'];
+							$directory = \substr(
+								$themeDirectory,
+								\strlen($appsRoot['path']) + 1
+							);
 						}
 					}
 				}
 
-				$webPath = \OC_App::getAppWebPath($themeName);
+				$webPath = $this->appManager->getAppWebPath($themeName);
 			} else {
 				$directory = 'themes/' . $themeName;
 				$webPath = '/themes/' . $themeName;
 			}
 		}
 
-		if ($this->theme === null) {
-			$this->theme = new Theme($themeName, $directory, $webPath);
-		} else {
-			$this->theme->setName($themeName);
-			$this->theme->setDirectory($directory);
-			$this->theme->setWebPath($webPath);
-		}
-		$this->theme->setBaseDirectory($baseDirectory);
+		$theme = new Theme($themeName, $directory, $webPath);
+		$theme->setBaseDirectory($baseDirectory);
 
-		return $this->theme;
+		return $theme;
 	}
 
 	/**
@@ -130,7 +152,7 @@ class ThemeService implements IThemeService {
 	 */
 	private function getAllAppThemes() {
 		$themes = [];
-		foreach (\OC::$server->getAppManager()->getAllApps() as $app) {
+		foreach ($this->appManager->getInstalledApps() as $app) {
 			if (\OC_App::isType($app, 'theme')) {
 				$themes[$app] = $this->makeTheme($app);
 			}
@@ -142,14 +164,15 @@ class ThemeService implements IThemeService {
 	 * @return Theme[]
 	 */
 	private function getAllLegacyThemes() {
+		$serverRoot = $this->environmentHelper->getServerRoot();
 		$themes = [];
-		if (\is_dir($this->serverRoot . '/themes')) {
-			if ($handle = \opendir($this->serverRoot . '/themes')) {
+		if (\is_dir($serverRoot . '/themes')) {
+			if ($handle = \opendir($serverRoot . '/themes')) {
 				while (($entry = \readdir($handle)) !== false) {
 					if ($entry === '.' || $entry === '..') {
 						continue;
 					}
-					if (\is_dir($this->serverRoot . '/themes/' . $entry)) {
+					if (\is_dir($serverRoot . '/themes/' . $entry)) {
 						$themes[$entry] = $this->makeTheme($entry, false);
 					}
 				}

--- a/tests/lib/Theme/ThemeServiceTest.php
+++ b/tests/lib/Theme/ThemeServiceTest.php
@@ -3,10 +3,34 @@
 namespace Test\Theme;
 
 use OC\Theme\ThemeService;
+use OC\Helper\EnvironmentHelper;
+use OCP\App\IAppManager;
 
 class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
+	/**
+	 * @var IAppManager | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $appManager;
+
+	/**
+	 * @var EnvironmentHelper |  \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $environmentHelper;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->appManager = $this->getMockBuilder(IAppManager::class)
+			->getMock();
+		$this->environmentHelper = $this->getMockBuilder(EnvironmentHelper::class)
+			->getMock();
+	}
+
 	public function testCreatesThemeByGivenName() {
-		$themeService = new ThemeService('theme-name', \OC::$SERVERROOT);
+		$themeService = new ThemeService(
+			'theme-name',
+			$this->appManager,
+			$this->environmentHelper
+		);
 		$theme = $themeService->getTheme();
 		$this->assertEquals('theme-name', $theme->getName());
 		$this->assertEquals('themes/theme-name', $theme->getDirectory());
@@ -22,7 +46,11 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 			->method('defaultThemeExists')
 			->willReturn(false);
 
-		$themeService->__construct('', \OC::$SERVERROOT);
+		$themeService->__construct(
+			'',
+			$this->appManager,
+			$this->environmentHelper
+		);
 		$theme = $themeService->getTheme();
 
 		$this->assertEquals('', $theme->getName());
@@ -39,7 +67,11 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 			->method('defaultThemeExists')
 			->willReturn(true);
 
-		$themeService->__construct('', \OC::$SERVERROOT);
+		$themeService->__construct(
+			'',
+			$this->appManager,
+			$this->environmentHelper
+		);
 		$theme = $themeService->getTheme();
 
 		$this->assertEquals('default', $theme->getName());
@@ -47,9 +79,52 @@ class ThemeServiceTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testSetAppThemeSetsName() {
-		$themeService = new ThemeService('', \OC::$SERVERROOT);
+		$appThemeName = 'some-app-theme';
+		$this->appManager->expects($this->once())
+			->method('getAppPath')
+			->willReturn("/srv/www/apps/$appThemeName");
+		$this->environmentHelper->expects($this->any())
+			->method('getServerRoot')
+			->willReturn("/srv/www");
+
+		$themeService = new ThemeService(
+			'',
+			$this->appManager,
+			$this->environmentHelper
+		);
 		$this->assertEmpty($themeService->getTheme()->getName());
-		$themeService->setAppTheme('some-app-theme');
-		$this->assertEquals('some-app-theme', $themeService->getTheme()->getName());
+		$themeService->setAppTheme($appThemeName);
+		$this->assertEquals($appThemeName, $themeService->getTheme()->getName());
+	}
+
+	public function testThemeDirAboveOcRoot() {
+		$appThemeName = 'some-app-theme';
+		$this->appManager->expects($this->once())
+			->method('getAppPath')
+			->willReturn("/srv/www/apps/$appThemeName");
+
+		$this->environmentHelper->expects($this->any())
+			->method('getServerRoot')
+			->willReturn("/srv/www/owncloud");
+		$this->environmentHelper->expects($this->once())
+			->method('getAppsRoots')
+			->willReturn(
+				[
+					[
+						'path' => "/srv/www/apps",
+						'url' => '../apps',
+						'writable' => true,
+					]
+				]
+			);
+
+		$themeService = new ThemeService(
+			'',
+			$this->appManager,
+			$this->environmentHelper
+		);
+		$this->assertEmpty($themeService->getTheme()->getName());
+		$themeService->setAppTheme($appThemeName);
+		$this->assertEquals($appThemeName, $themeService->getTheme()->getName());
 	}
 }


### PR DESCRIPTION
## Description
Do not load disabled app-themes

## Related Issue
https://github.com/owncloud/core/issues/31134

## Motivation and Context
Inactive app-themes are applied to the page when they are loaded and this leads to broken or wrong page layout if `OC\Theme\ThemeService::getAllThemes` is called

## How Has This Been Tested?
https://github.com/owncloud/core/issues/31134#issue-314567249

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



