### PR TITLE
Revert "[stable10] Fix failure of shares which are already moved with transfer-ownership

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -313,18 +313,6 @@ class TransferOwnership extends Command {
 					if ($share->getSharedBy() === $this->sourceUser) {
 						$share->setSharedBy($this->destinationUser);
 					}
-					/*
-					 * If the share is already moved then updateShare would cause exception
-					 * This can happen if the folder is shared and file(s) inside the folder
-					 * has shares, for example public link
-					 */
-					if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
-						$sharePath = ltrim($share->getNode()->getPath(), '/');
-						if (strpos($sharePath, $this->finalTarget) !== false) {
-							//The share is already moved
-							continue;
-						}
-					}
 
 					$this->shareManager->updateShare($share);
 				}

--- a/tests/acceptance/features/apiMain/transfer-ownership.feature
+++ b/tests/acceptance/features/apiMain/transfer-ownership.feature
@@ -178,21 +178,6 @@ Feature: transfer-ownership
 		And the downloaded content when downloading file "/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
 
 	@no_default_encryption
-	Scenario: transferring ownership of folder shares which has public link
-		Given user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
-		And user "user0" has created a folder "/test"
-		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt" using the API
-		And user "user0" has shared folder "/test" with user "user2" with permissions 31
-		And user "user1" creates a share using the API with settings
-			| path      | /test/somefile.txt |
-			| shareType | 3                  |
-		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
-		And the command should have been successful
-		Then the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
-
-	@no_default_encryption
 	Scenario: transferring ownership of folder shared with third user
 		Given user "user0" has been created
 		And user "user1" has been created


### PR DESCRIPTION
Reverts https://github.com/owncloud/core/pull/30161

Had to adjust the test reverting as the test file moved to a new location since the original PR