### PR TITLE
Fix apps_paths config sample typo

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -735,7 +735,7 @@ $CONFIG = array(
  * ``OC::$SERVERROOT`` points to the web root of your instance.
  * Please see the Apps Management description on how to move custom apps properly.
  */
- 'apps_path' => 
+'apps_paths' =>
     array (
       0 => 
       array (
@@ -746,11 +746,10 @@ $CONFIG = array(
       1 => 
       array (
         'path' => OC::$SERVERROOT.'/apps-external',
-        'url' => '/apps--external',
+        'url' => '/apps-external',
         'writable' => 'true',
       ),
     ),
-
 
 /**
  * Previews


### PR DESCRIPTION
I've tested this by copy-pasting and adjusting the paths using the "apps_path" from config.sample.php of 10.0.8 RC2 and it failed due to the missing "s".

Please review @mmattel 