### PR TITLE
Fix appwebpath detection when OC installed into the subdir and approot is a sibling of oc root dir

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -531,7 +531,9 @@ class AppManager implements IAppManager {
 				$appRoot['url'] = substr($appRoot['url'], 3);
 				$ocWebRoot = dirname($ocWebRoot);
 			}
-			return $ocWebRoot . '/' . ltrim($appRoot['url'], '/');
+			$trimmedOcWebRoot = rtrim($ocWebRoot, '/');
+			$trimmedAppRoot = ltrim($appRoot['url'], '/');
+			return "$trimmedOcWebRoot/$trimmedAppRoot";
 		}
 		return false;
 	}

--- a/tests/lib/App/ManagerTest.php
+++ b/tests/lib/App/ManagerTest.php
@@ -530,7 +530,15 @@ class ManagerTest extends TestCase {
 		$this->assertFalse($appPath);
 	}
 
-	public function testAppWebRootAboveOcWebroot() {
+	/**
+	 * @dataProvider appAboveWebRootDataProvider
+	 *
+	 * @param string $ocWebRoot
+	 * @param string[] $appData
+	 * @param string $expectedAppWebPath
+	 */
+	public function testAppWebRootAboveOcWebRoot($ocWebRoot, $appData,
+		$expectedAppWebPath) {
 		$appId = 'notexistingapp';
 
 		$appManager = $this->getMockBuilder(AppManager::class)
@@ -540,17 +548,51 @@ class ManagerTest extends TestCase {
 
 		$appManager->expects($this->any())
 			->method('getOcWebRoot')
-			->willReturn('some/host/path');
+			->willReturn($ocWebRoot);
 
 		$appManager->expects($this->any())
 			->method('findAppInDirectories')
 			->with($appId)
-			->willReturn([
-				'path' => '/not/essential',
-				'url' => '../../relative',
-			]);
+			->willReturn($appData);
 
 		$appWebPath = $appManager->getAppWebPath($appId);
-		$this->assertEquals('some/relative', $appWebPath);
+		$this->assertEquals($expectedAppWebPath, $appWebPath);
+	}
+
+	public function appAboveWebRootDataProvider(){
+		return [
+			[
+				'/some/host/path',
+				[
+					'path' => '/not/essential',
+					'url' => '../../relative',
+				],
+				'/some/relative'
+			],
+			[
+				'/some/host/path',
+				[
+					'path' => '/not/essential',
+					'url' => '../relative',
+				],
+				'/some/host/relative'
+			],
+			[
+				'/some/hostPath',
+				[
+					'path' => '/not/essential',
+					'url' => '../relative',
+				],
+				'/some/relative'
+			],
+			[
+				'/someHostPath',
+				[
+					'path' => '/not/essential',
+					'url' => '../relative',
+				],
+				'/relative'
+			],
+		];
 	}
 }


### PR DESCRIPTION
## Description
Fixes css/js resolution for a case when owncloud installed into the first descendant of the server root directory and app-theme is located outside owncloud root directory.

## Related Issue
Fixes #31170 

## Motivation and Context
rewritten code produced double slash in the case described above and this broke proper URL generation for themes

## How Has This Been Tested?
Steps are listed in the issue https://github.com/owncloud/core/issues/31170#issue-315066079

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.