### PR TITLE
[stable10] Update public link share in transfer ownership command

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -299,35 +299,7 @@ class TransferOwnership extends Command {
 
 		foreach($this->shares as $share) {
 			try {
-				if ($share->getSharedWith() === $this->destinationUser) {
-					// Unmount the shares before deleting, so we don't try to get the storage later on.
-					$shareMountPoint = $this->mountManager->find('/' . $this->destinationUser . '/files' . $share->getTarget());
-					if ($shareMountPoint) {
-						$this->mountManager->removeMount($shareMountPoint->getMountPoint());
-					}
-					$this->shareManager->deleteShare($share);
-				} else {
-					if ($share->getShareOwner() === $this->sourceUser) {
-						$share->setShareOwner($this->destinationUser);
-					}
-					if ($share->getSharedBy() === $this->sourceUser) {
-						$share->setSharedBy($this->destinationUser);
-					}
-					/*
-					 * If the share is already moved then updateShare would cause exception
-					 * This can happen if the folder is shared and file(s) inside the folder
-					 * has shares, for example public link
-					 */
-					if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
-						$sharePath = ltrim($share->getNode()->getPath(), '/');
-						if (strpos($sharePath, $this->finalTarget) !== false) {
-							//The share is already moved
-							continue;
-						}
-					}
-
-					$this->shareManager->updateShare($share);
-				}
+				$this->shareManager->transferShare($share, $this->sourceUser, $this->destinationUser, $this->finalTarget);
 			} catch (\OCP\Files\NotFoundException $e) {
 				$output->writeln('<error>Share with id ' . $share->getId() . ' points at deleted file, skipping</error>');
 			} catch (\Exception $e) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -869,7 +869,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$factory,
 				$c->getUserManager(),
 				$c->getLazyRootFolder(),
-				$c->getEventDispatcher()
+				$c->getEventDispatcher(),
+				new View('/')
 			);
 
 			return $manager;

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -28,6 +28,7 @@ namespace OC\Share20;
 
 use OC\Cache\CappedMemoryCache;
 use OC\Files\Mount\MoveableMount;
+use OC\Files\View;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -42,8 +43,10 @@ use OCP\Security\IHasher;
 use OCP\Security\ISecureRandom;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\Exceptions\TransferSharesException;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
+use OCP\Share\IShare;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -76,6 +79,8 @@ class Manager implements IManager {
 	private $sharingDisabledForUsersCache;
 	/** @var EventDispatcher  */
 	private $eventDispatcher;
+	/** @var  View */
+	private $view;
 
 
 	/**
@@ -103,7 +108,8 @@ class Manager implements IManager {
 			IProviderFactory $factory,
 			IUserManager $userManager,
 			IRootFolder $rootFolder,
-			EventDispatcher $eventDispatcher
+			EventDispatcher $eventDispatcher,
+			View $view
 	) {
 		$this->logger = $logger;
 		$this->config = $config;
@@ -117,6 +123,7 @@ class Manager implements IManager {
 		$this->rootFolder = $rootFolder;
 		$this->sharingDisabledForUsersCache = new CappedMemoryCache();
 		$this->eventDispatcher = $eventDispatcher;
+		$this->view = $view;
 	}
 
 	/**
@@ -673,6 +680,93 @@ class Manager implements IManager {
 		$this->eventDispatcher->dispatch('share.afterCreate', $afterEvent);
 
 		return $share;
+	}
+
+	/**
+	 * Transfer shares from oldOwner to newOwner. Both old and new owners are uid
+	 *
+	 * finalTarget is of the form "user1/files/transferred from admin on 20180509"
+	 *
+	 * TransferShareException would be thrown when:
+	 *  - oldOwner, newOwner does not exist.
+	 *  - oldOwner and newOwner are same
+	 * NotFoundException would be thrown when finalTarget does not exist in the file
+	 * system
+	 *
+	 * @param IShare $share
+	 * @param string $oldOwner
+	 * @param string $newOwner
+	 * @param string $finalTarget
+	 * @throws TransferSharesException
+	 * @throws NotFoundException
+	 */
+	public function transferShare(IShare $share, $oldOwner, $newOwner, $finalTarget) {
+		if ($this->userManager->get($oldOwner) === null) {
+			throw new TransferSharesException("The current owner of the share $oldOwner doesn't exist");
+		}
+		if ($this->userManager->get($newOwner) === null) {
+			throw new TransferSharesException("The future owner $newOwner, where the share has to be moved doesn't exist");
+		}
+
+		if ($oldOwner === $newOwner) {
+			throw new TransferSharesException("The current owner of the share and the future owner of the share are same");
+		}
+
+		//If the destination location, i.e finalTarget is not present, then
+		//throw an exception
+		if (!$this->view->file_exists($finalTarget)) {
+			throw new NotFoundException("The target location $finalTarget doesn't exist");
+		}
+
+		/**
+		 * If the share was already shared with new owner, then we can delete it
+		 */
+		if ($share->getSharedWith() === $newOwner) {
+			// Unmount the shares before deleting, so we don't try to get the storage later on.
+			$shareMountPoint = $this->mountManager->find('/' . $newOwner . '/files' . $share->getTarget());
+			if ($shareMountPoint) {
+				$this->mountManager->removeMount($shareMountPoint->getMountPoint());
+			}
+			$this->deleteShare($share);
+		} else {
+			$sharedWith = $share->getSharedWith();
+
+			$targetFile = '/' . rtrim(basename($finalTarget), '/') . '/' . ltrim(basename($share->getTarget()), '/');
+			/**
+			 * Scenario where share is made by old owner to a user different
+			 * from new owner
+			 */
+			if (($sharedWith !== null) && ($sharedWith !== $oldOwner) && ($sharedWith !== $newOwner)) {
+				$sharedBy = $share->getSharedBy();
+				$sharedOwner = $share->getShareOwner();
+				//The origin of the share now has to be the destination user.
+				if ($sharedBy === $oldOwner) {
+					$share->setSharedBy($newOwner);
+				}
+				if ($sharedOwner === $oldOwner) {
+					$share->setShareOwner($newOwner);
+				}
+				if (($sharedBy === $oldOwner) || ($sharedOwner === $oldOwner)) {
+					$share->setTarget($targetFile);
+				}
+			} else {
+				if ($share->getShareOwner() === $oldOwner) {
+					$share->setShareOwner($newOwner);
+				}
+				if ($share->getSharedBy() === $oldOwner) {
+					$share->setSharedBy($newOwner);
+				}
+			}
+
+			/**
+			 * Here we update the target when the share is link
+			 */
+			if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
+				$share->setTarget($targetFile);
+			}
+
+			$this->updateShare($share);
+		}
 	}
 
 	/**

--- a/lib/public/Share/Exceptions/TransferSharesException.php
+++ b/lib/public/Share/Exceptions/TransferSharesException.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCP\Share\Exceptions;
+
+/**
+ * Class TransferSharesException
+ *
+ * @package OCP\Share\Exceptions
+ * @since 10.0.9
+ */
+class TransferSharesException extends GenericShareException {
+
+	/**
+	 * TransferSharesException constructor.
+	 *
+	 * @param string $message
+	 * @param string $hint
+	 * @param int $code
+	 * @param \Exception|null $previous
+	 * @since 10.0.9
+	 */
+	public function __construct($message = '', $hint = '', $code = 0, \Exception $previous = null) {
+		parent::__construct($message, $hint, $code, $previous);
+	}
+}

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -21,9 +21,12 @@
 
 namespace OCP\Share;
 
+use OC\User\NoUserException;
 use OCP\Files\Node;
 
+use OCP\Files\NotFoundException;
 use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\Exceptions\TransferSharesException;
 
 /**
  * Interface IManager
@@ -112,6 +115,27 @@ interface IManager {
 	 */
 	public function getSharesBy($userId, $shareType, $path = null, $reshares = false, $limit = 50, $offset = 0);
 
+	/**
+	 * Transfer shares from oldOwner to newOwner. Both old and new owners are uid
+	 *
+	 * @param IShare $share
+	 * @param string $oldOwner - is the previous owner of the share, the uid string
+	 * @param string $newOwner - is the new owner of the share, the uid string
+	 * @param string $finalTarget - is the target folder where share has to be moved
+	 *
+	 * finalTarget is of the form "user1/files/transferred from admin on 20180509"
+	 *
+	 * TransferShareException would be thrown when:
+	 *  - oldOwner, newOwner does not exist.
+	 *  - oldOwner and newOwner are same
+	 * NotFoundException would be thrown when finalTarget does not exist in the file
+	 * system
+	 *
+	 * @throws TransferSharesException
+	 * @throws NotFoundException
+	 * @since 10.0.9
+	 */
+	public function transferShare(IShare $share, $oldOwner, $newOwner, $finalTarget);
 
 	/**
 	 * Get shares shared with $userId for specified share types.


### PR DESCRIPTION
The public link share wasn't updated in the command.
This resulted in failure, when the public links were
accessed after the files were transferred. This change
helps to update the share for public links. And hence
access to the links won't cause any failure.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
The public links were failing after transfer ownership command is executed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/31150

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change allows the public links to work even after the transfer ownership command is executed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

