### PR TITLE
[stable10] Use proper booleans in apps_paths in config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -754,13 +754,13 @@ $CONFIG = array(
       array (
         'path' => OC::$SERVERROOT.'/apps',
         'url' => '/apps',
-        'writable' => 'false',
+        'writable' => false,
       ),
       1 => 
       array (
         'path' => OC::$SERVERROOT.'/apps-external',
         'url' => '/apps-external',
-        'writable' => 'true',
+        'writable' => true,
       ),
     ),
 


### PR DESCRIPTION
I tried installing apps with `occ market:install` but it complained because I had `writable => "true"` instead of `writable => true`
