### PR TITLE
[stable10] Prevent background scan to scan non-ready homes

### DIFF
--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -92,6 +92,7 @@ class MountPoint implements IMountPoint {
 
 		$mountpoint = $this->formatPath($mountpoint);
 		$this->mountPoint = $mountpoint;
+		// FIXME: this should also check for IStorage, and the public Storage interface
 		if ($storage instanceof Storage) {
 			$this->class = get_class($storage);
 			$this->storage = $this->loader->wrap($this, $storage);


### PR DESCRIPTION
## Description
Whenever a user has never logged in, their home is not setup yet.
In this case the background scan should not go there.

It turns out that the check already existed for regular scan but not background scan.
This PR refactors some of the storage checks into a common method to avoid discrepancies in the future.

## Related Issue
Fixes https://github.com/owncloud/core/issues/31188

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
See https://github.com/owncloud/core/issues/31188#issuecomment-382441610

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

