### PR TITLE
[stable10] Respect sharing.federation.allowHttpFallback in FederatedShareProvider

### DIFF
--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -57,7 +57,8 @@ class Application extends App {
 			$addressHandler,
 			\OC::$server->getHTTPClientService(),
 			$discoveryManager,
-			\OC::$server->getJobList()
+			\OC::$server->getJobList(),
+			\OC::$server->getConfig()
 		);
 		$tokenHandler = new \OCA\FederatedFileSharing\TokenHandler(
 			\OC::$server->getSecureRandom()

--- a/apps/federatedfilesharing/lib/BackgroundJob/RetryJob.php
+++ b/apps/federatedfilesharing/lib/BackgroundJob/RetryJob.php
@@ -74,7 +74,8 @@ class RetryJob extends Job {
 				$addressHandler,
 				\OC::$server->getHTTPClientService(),
 				$discoveryManager,
-				\OC::$server->getJobList()
+				\OC::$server->getJobList(),
+				\OC::$server->getConfig()
 			);
 		}
 

--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -29,6 +29,8 @@ use OCA\FederatedFileSharing\DiscoveryManager;
 use OCA\FederatedFileSharing\Notifications;
 use OCP\BackgroundJob\IJobList;
 use OCP\Http\Client\IClientService;
+use OCP\IConfig;
+use OCA\FederatedFileSharing\BackgroundJob\RetryJob;
 
 class NotificationsTest extends \Test\TestCase {
 
@@ -44,14 +46,18 @@ class NotificationsTest extends \Test\TestCase {
 	/** @var  IJobList | \PHPUnit_Framework_MockObject_MockObject */
 	private $jobList;
 
+	/** @var  IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+
 	public function setUp() {
 		parent::setUp();
 
-		$this->jobList = $this->createMock('OCP\BackgroundJob\IJobList');
-		$this->discoveryManager = $this->getMockBuilder('OCA\FederatedFileSharing\DiscoveryManager')
+		$this->jobList = $this->createMock(IJobList::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->discoveryManager = $this->getMockBuilder(DiscoveryManager::class)
 			->disableOriginalConstructor()->getMock();
-		$this->httpClientService = $this->createMock('OCP\Http\Client\IClientService');
-		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')
+		$this->httpClientService = $this->createMock(IClientService::class);
+		$this->addressHandler = $this->getMockBuilder(AddressHandler::class)
 			->disableOriginalConstructor()->getMock();
 
 	}
@@ -68,16 +74,18 @@ class NotificationsTest extends \Test\TestCase {
 				$this->addressHandler,
 				$this->httpClientService,
 				$this->discoveryManager,
-				$this->jobList
+				$this->jobList,
+				$this->config
 			);
 		} else {
-			$instance = $this->getMockBuilder('OCA\FederatedFileSharing\Notifications')
+			$instance = $this->getMockBuilder(Notifications::class)
 				->setConstructorArgs(
 					[
 						$this->addressHandler,
 						$this->httpClientService,
 						$this->discoveryManager,
-						$this->jobList
+						$this->jobList,
+						$this->config
 					]
 				)->setMethods($mockedMethods)->getMock();
 		}
@@ -113,7 +121,7 @@ class NotificationsTest extends \Test\TestCase {
 		if ($try === 0 && $expected === false) {
 			$this->jobList->expects($this->once())->method('add')
 				->with(
-					'OCA\FederatedFileSharing\BackgroundJob\RetryJob',
+					RetryJob::class,
 					[
 						'remote' => $remote,
 						'remoteId' => $id,

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -102,7 +102,8 @@ class ProviderFactory implements IProviderFactory {
 				$addressHandler,
 				$this->serverContainer->getHTTPClientService(),
 				$discoveryManager,
-				$this->serverContainer->getJobList()
+				$this->serverContainer->getJobList(),
+				$this->serverContainer->getConfig()
 			);
 			$tokenHandler = new TokenHandler(
 				$this->serverContainer->getSecureRandom()

--- a/ocs/routes.php
+++ b/ocs/routes.php
@@ -92,7 +92,8 @@ if (\OC::$server->getAppManager()->isEnabledForUser('files_sharing')) {
 		$addressHandler,
 		\OC::$server->getHTTPClientService(),
 		new \OCA\FederatedFileSharing\DiscoveryManager(\OC::$server->getMemCacheFactory(), \OC::$server->getHTTPClientService()),
-		\OC::$server->getJobList()
+		\OC::$server->getJobList(),
+		\OC::$server->getConfig()
 	);
 	$s2s = new OCA\FederatedFileSharing\RequestHandler(
 		$federatedSharingApp->getFederatedShareProvider(),

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -5,7 +5,8 @@ I want to share files with any users on other cloud storages
 So that other users have access to these files
 
 	Background:
-		Given these users have been created:
+		Given the administrator has allowed http fallback for federation sharing
+		And these users have been created:
 		|username|password|displayname|email       |
 		|user1   |1234    |User One   |u1@oc.com.np|
 		|user2   |1234    |User Two   |u2@oc.com.np|

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -90,6 +90,9 @@ fi
 PREVIOUS_SKELETON_DIR=$($OCC --no-warnings config:system:get skeletondirectory)
 $OCC config:system:set skeletondirectory --value="$(pwd)/skeleton"
 
+PREVIOUS_HTTP_FALLBACK_SETTING=$($OCC --no-warnings config:system:get sharing.federation.allowHttpFallback)
+$OCC config:system:set sharing.federation.allowHttpFallback --type boolean --value true
+
 #Enable external storage app
 $OCC config:app:set core enable_external_storage --value=yes
 $OCC config:system:set files_external_allow_create_new_local --value=true
@@ -175,6 +178,13 @@ if test "A$PREVIOUS_SKELETON_DIR" = "A"; then
 	$OCC config:system:delete skeletondirectory
 else
 	$OCC config:system:set skeletondirectory --value="$PREVIOUS_SKELETON_DIR"
+fi
+
+# Put back HTTP fallback setting
+if test "A$PREVIOUS_HTTP_FALLBACK_SETTING" = "A"; then
+	$OCC config:system:delete sharing.federation.allowHttpFallback
+else
+	$OCC config:system:set sharing.federation.allowHttpFallback --type boolean --value="$PREVIOUS_HTTP_FALLBACK_SETTING"
 fi
 
 # Clear storage folder


### PR DESCRIPTION
## Description
By default federated sharing should use https only - in selected cases a fallback to http is allowed.

## Related Issue
refs https://github.com/owncloud/core/issues/31194

## How Has This Been Tested?
1. have an owncloud instance available on http only
2. create federated share via https
3. falback to http is only allowed if the config switch is set to true

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

