### PR TITLE
[stable10] Use correct expiration variable for link share mail

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -211,7 +211,7 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				null,
 				$filter->getFile(),
 				$filter->getLink(),
-				$filter->getExpirationDate(),
+				$expiration,
 				$filter->getPersonalNote(),
 				$options
 			);


### PR DESCRIPTION
## Description
The value is converted to another format in `$expiration` so we should use that as we did before the filters were added.

## Related Issue
None raised.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Create public link share, set expiration, set by email.

Before fix: no expiration in email.
After fix: expiration notice in email

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Not tests possible nor codecov due to the code being in the "bad zone"