### PR TITLE
Fix legacy theme urls

### DIFF
--- a/lib/private/Theme/ThemeService.php
+++ b/lib/private/Theme/ThemeService.php
@@ -103,7 +103,7 @@ class ThemeService implements IThemeService {
 				$webPath = \OC_App::getAppWebPath($themeName);
 			} else {
 				$directory = 'themes/' . $themeName;
-				$webPath = '/themes/' . $themeName;
+				$webPath = \OC::$WEBROOT . "/themes/$themeName";
 			}
 		}
 


### PR DESCRIPTION
Without this legacy themes always assume `/`as the oc endpoint, causing failed image loads. Workaround: use a proper theme app.