### PR TITLE
Fix extractRequestTokenFromResponse method name

### DIFF
--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -183,7 +183,7 @@ trait Auth {
 			'cookies' => $this->cookieJar,
 			]
 		);
-		$this->extracRequestTokenFromResponse($response);
+		$this->extractRequestTokenFromResponse($response);
 
 		// Login and extract new token
 		$client = new Client();
@@ -197,7 +197,7 @@ trait Auth {
 				'cookies' => $this->cookieJar,
 			]
 		);
-		$this->extracRequestTokenFromResponse($response);
+		$this->extractRequestTokenFromResponse($response);
 	}
 
 }

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -604,7 +604,7 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	private function extracRequestTokenFromResponse(ResponseInterface $response) {
+	private function extractRequestTokenFromResponse(ResponseInterface $response) {
 		$this->requestToken = substr(
 			preg_replace(
 				'/(.*)data-requesttoken="(.*)">(.*)/sm', '\2',
@@ -633,7 +633,7 @@ trait BasicStructure {
 				'cookies' => $this->cookieJar,
 			]
 		);
-		$this->extracRequestTokenFromResponse($response);
+		$this->extractRequestTokenFromResponse($response);
 
 		// Login and extract new token
 		$password = $this->getPasswordForUser($user);
@@ -649,7 +649,7 @@ trait BasicStructure {
 				'cookies' => $this->cookieJar,
 			]
 		);
-		$this->extracRequestTokenFromResponse($response);
+		$this->extractRequestTokenFromResponse($response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -422,8 +422,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * has rows of files.
 	 *
 	 * @param string $name
-	 *
 	 * @param bool $expectToDeleteFile if true, then the caller expects that the file can be deleted
+	 *
 	 * @return void
 	 * @throws Exception
 	 */
@@ -1375,8 +1375,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @param string $localFile
 	 * @param bool $shouldBeSame (default true) if true then check that the file contents are the same
 	 *                           otherwise check that the file contents are different
-	 *
 	 * @param bool $checkOnRemoteServer if true, then use the remote server to download the file
+	 *
 	 * @return void
 	 * @throws Exception
 	 */

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -270,6 +270,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	 *
 	 * @param string|array $name
 	 * @param Session $session
+	 * @param bool $expectToDeleteFile
 	 * @param int $maxRetries
 	 *
 	 * @return void
@@ -461,9 +462,12 @@ abstract class FilesPageBasic extends OwncloudPage {
 
 	/**
 	 *
+	 * @param Session $session
+	 *
 	 * @return boolean
+	 * @throws \Exception
 	 */
-	public function isFolderEmpty($session) {
+	public function isFolderEmpty(Session $session) {
 		$this->waitTillPageIsLoaded($session);
 		$emptyContentElement = $this->find(
 			"xpath",


### PR DESCRIPTION
I have noticed this typo in the method name before, it has zero impact on functionality. But now I noticed it again when modifying code. So let's "fix" it so my brain is not impacted by it ever again.

And a few PHP docblock things that ``phpcs`` was complaining about.