### PR TITLE
no need to call EmailContext everywhere

### DIFF
--- a/tests/TestHelpers/EmailHelper.php
+++ b/tests/TestHelpers/EmailHelper.php
@@ -86,4 +86,20 @@ class EmailHelper {
 		$response = $client->send($request);
 		return $response;
 	}
+
+	/**
+	 * 
+	 * @return string
+	 */
+	public static function getMailhogUrl() {
+		$mailhogHost = getenv('MAILHOG_HOST');
+		if ($mailhogHost === false) {
+			$mailhogHost = "127.0.0.1";
+		}
+		$mailhogPort = getenv('MAILHOG_PORT');
+		if ($mailhogPort === false) {
+			$mailhogPort = "8025";
+		}
+		return "http://$mailhogHost:$mailhogPort";
+	}
 }

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -85,7 +85,6 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIFilesContext:
-        - EmailContext:
 
     webUIMoveFilesFolders:
       paths:
@@ -96,7 +95,6 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIFilesContext:
-        - EmailContext:
 
     webUIRenameFiles:
       paths:
@@ -107,7 +105,6 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIFilesContext:
-        - EmailContext:
 
     webUIRenameFolders:
       paths:
@@ -118,7 +115,6 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIFilesContext:
-        - EmailContext:
 
     webUITrashbin:
       paths:
@@ -129,7 +125,6 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIFilesContext:
-        - EmailContext:
 
     webUISharingInternalGroups:
       paths:
@@ -141,7 +136,6 @@ default:
         - WebUILoginContext:
         - WebUIFilesContext:
         - WebUISharingContext:
-        - EmailContext:
 
     webUISharingInternalUsers:
       paths:
@@ -153,7 +147,6 @@ default:
         - WebUILoginContext:
         - WebUIFilesContext:
         - WebUISharingContext:
-        - EmailContext:
 
     webUISharingExternal:
       paths:
@@ -166,7 +159,6 @@ default:
         - WebUIFilesContext:
         - WebUISharingContext:
         - FederationContext:
-        - EmailContext:
 
     webUIUpload:
       paths:
@@ -177,7 +169,6 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIFilesContext:
-        - EmailContext:
 
     webUIRestrictSharing:
       paths:
@@ -189,7 +180,6 @@ default:
         - WebUILoginContext:
         - WebUIFilesContext:
         - WebUISharingContext:
-        - EmailContext:
 
     webUIFavorites:
       paths:
@@ -200,7 +190,6 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIFilesContext:
-        - EmailContext:
 
     webUIPersonalSettings:
       paths:
@@ -213,7 +202,6 @@ default:
         - WebUIFilesContext:
         - WebUIPersonalSecuritySettingsContext:
         - WebUIPersonalGeneralSettingsContext:
-        - EmailContext:
 
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:

--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -40,7 +40,7 @@ class EmailContext implements Context, SnippetAcceptingContext {
 	public function getMailhogUrl() {
 		return $this->mailhogUrl;
 	}
-	
+
 	/**
 	 * @Then the email address :address should have received an email with the body containing
 	 * 
@@ -65,15 +65,7 @@ class EmailContext implements Context, SnippetAcceptingContext {
 	 * @return void
 	 */
 	public function setUpScenario(BeforeScenarioScope $scope) {
-		$mailhogHost = getenv('MAILHOG_HOST');
-		if ($mailhogHost === false) {
-			$mailhogHost = "127.0.0.1";
-		}
-		$mailhogPort = getenv('MAILHOG_PORT');
-		if ($mailhogPort === false) {
-			$mailhogPort = "8025";
-		}
-		$this->mailhogUrl = "http://$mailhogHost:$mailhogPort";
+		$this->mailhogUrl = EmailHelper::getMailhogUrl();
 		$this->clearMailHogMessages();
 	}
 

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -42,12 +42,6 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	
 	/**
 	 * 
-	 * @var EmailContext
-	 */
-	private $emailContext;
-
-	/**
-	 * 
 	 * @var FeatureContext
 	 */
 	private $featureContext;
@@ -250,10 +244,10 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 */
 	public function theUserFollowsThePasswordResetLinkFromTheirEmail($emailAddress) {
 		$content = EmailHelper::getBodyOfLastEmail(
-			$this->emailContext->getMailhogUrl(), $emailAddress
+			EmailHelper::getMailhogUrl(), $emailAddress
 		);
 		preg_match(
-			'/Use the following link to reset your password: (http.*user1)/',
+			'/Use the following link to reset your password: (http.*)/',
 			$content, $matches
 		);
 		PHPUnit_Framework_Assert::assertArrayHasKey(
@@ -292,6 +286,5 @@ class WebUILoginContext extends RawMinkContext implements Context {
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
 		$this->webUIGeneralContext = $environment->getContext('WebUIGeneralContext');
-		$this->emailContext = $environment->getContext('EmailContext');
 	}
 }

--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -443,7 +443,6 @@ if test "A$PREVIOUS_MAIL_DOMAIN" = "A"; then
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete mail_domain"
 else
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_domain --value=$PREVIOUS_MAIL_DOMAIN"
-	echo "config:system:set mail_domain --value=$PREVIOUS_MAIL_DOMAIN"
 fi
 if test "A$PREVIOUS_MAIL_FROM_ADDRESS" = "A"; then
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete mail_from_address"


### PR DESCRIPTION
## Description
small refactoring, so that the EmailContext is not needed everywhere we use LoginContext

## Related Issue
CI failing in other repos

## Motivation and Context
without that change we basically need EmailContext in every single UI test, because every test has to login somehow and LoginContext depends on EmailContext

## How Has This Been Tested?
:robot: did test for me

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

