### PR TITLE
[stable10] Fix mail debug message recipient field

### DIFF
--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -98,9 +98,25 @@ class Mailer implements IMailer {
 
 		$mailer->send($message->getSwiftMessage(), $failedRecipients);
 
+		$allRecipients = [];
+		if (!empty($message->getTo())) {
+			$allRecipients = array_merge($allRecipients, $message->getTo());
+		}
+		if (!empty($message->getCc())) {
+			$allRecipients = array_merge($allRecipients, $message->getCc());
+		}
+		if (!empty($message->getBcc())) {
+			$allRecipients = array_merge($allRecipients, $message->getBcc());
+		}
+
 		// Debugging logging
-		$logMessage = sprintf('Sent mail to "%s" with subject "%s"', print_r($message->getTo(), true), $message->getSubject());
-		$this->logger->debug($logMessage, ['app' => 'core']);
+		$logMessage = 'Sent mail from "{from}" to "{recipients}" with subject "{subject}"';
+		$this->logger->debug($logMessage, [
+			'app' => 'core',
+			'from' => json_encode($message->getFrom()),
+			'recipients' => json_encode($allRecipients),
+			'subject' => $message->getSubject()
+		]);
 		if($debugMode && isset($mailLogger)) {
 			$this->logger->debug($mailLogger->dump(), ['app' => 'core']);
 		}


### PR DESCRIPTION
## Description
For public link shares we use the BCC field now, so this one isn't logged properly.
This PR logs all the recipients as taken from To, CC and BCC now.
Also it uses `json_encode()` for a nicer formatting that looks less shitty than `Array( ... )`

## Related Issue
None

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Set "loglevel" to 0 and observe log.
Allow users to send share emails.
- [x] TEST: public link email single recipient
- [x] TEST: public link email multiple recipients
- [x] TEST: internal share email single recipient
- [x] TEST: internal share email group recipient
- [x] TEST: email from notification
- [ ] TEST: email from activity app

Before the fix: shitty empty `Array()` in log for public link email.
After the fix: both email types have a proper array with all recipients

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

