### PR TITLE
Fix redis tests for phpredis 4.0.0

### DIFF
--- a/tests/lib/Memcache/RedisTest.php
+++ b/tests/lib/Memcache/RedisTest.php
@@ -16,10 +16,9 @@ class RedisTest extends Cache {
 		if (!\OC\Memcache\Redis::isAvailable()) {
 			self::markTestSkipped('The redis extension is not available.');
 		}
-
-		$instance = new \OC\Memcache\Redis(self::getUniqueID());
-
+		
 		try {
+			$instance = new \OC\Memcache\Redis(self::getUniqueID());
 			$instance->set(self::getUniqueID(), self::getUniqueID());
 		} catch(\RedisException $ex) {
 			self::markTestSkipped('redis server seems to be down.');


### PR DESCRIPTION
PHPREDIS 4.0.0 has a breaking change - it will now throw a RedisException when connection errors occured - ref: https://github.com/phpredis/phpredis/issues/1273#issuecomment-358737034

Todays update to the docker containers has bumped the phpredis version to 4.0.0 -> thus CI started to fail afterward.

In the Unit Tests we only catched the exception at a explicit check (required to work for redis < 4.0.0 ) - this PR moves the exception handling to a earlier point in time

## Motivation and Context
Make ci 💚 

## How Has This Been Tested?
locally in docker container with php-redis 4.0.0 -> :robot: will confirm

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. -> 🤖 

