### PR TITLE
Always set headers

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,23 +15,23 @@
 
   <IfModule mod_env.c>
     # Add security and privacy related headers
-    Header set X-Content-Type-Options "nosniff"
-    Header set X-XSS-Protection "1; mode=block"
-    Header set X-Robots-Tag "none"
-    Header set X-Frame-Options "SAMEORIGIN"
-    Header set X-Download-Options "noopen"
-    Header set X-Permitted-Cross-Domain-Policies "none"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-XSS-Protection "1; mode=block"
+    Header always set X-Robots-Tag "none"
+    Header always set X-Frame-Options "SAMEORIGIN"
+    Header always set X-Download-Options "noopen"
+    Header always set X-Permitted-Cross-Domain-Policies "none"
     SetEnv modHeadersAvailable true
   </IfModule>
 
   # Let browsers cache CSS, JS files for half a year
   <FilesMatch "\.(css|js)$">
-    Header set Cache-Control "max-age=15778463"
+    Header always set Cache-Control "max-age=15778463"
   </FilesMatch>
   
   # Let browsers cache WOFF files for a week
   <FilesMatch "\.woff$">
-    Header set Cache-Control "max-age=604800"
+    Header always set Cache-Control "max-age=604800"
   </FilesMatch>
 </IfModule>
 


### PR DESCRIPTION
Hi,

Headers may already be defined in Apache configuration.
This then leads to header values being defined twice, thus triggering such error message :
`The "X-Content-Type-Options" HTTP header is not configured to equal to "nosniff". This is a potential security or privacy risk and we recommend adjusting this setting.`

This PR then adds the `always` keyword to `Header` definitions, which solves the issue.

Thank you 👍 

Ben