### PR TITLE
Specifically exclude anything other than the core bundled apps

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,9 +1,39 @@
 <?php
 
+$dirToParse = 'apps';
+$dirIterator = new DirectoryIterator(__DIR__ . '/' . $dirToParse);
+
+$bundledApps = [
+    'comments',
+    'dav',
+    'federatedfilesharing',
+    'federation',
+    'files',
+    'files_external',
+    'files_sharing',
+    'files_trashbin',
+    'files_versions',
+    'provisioning_api',
+    'systemtags',
+    'testing',
+    'updatenotification'
+];
+
+$excludeDirs = [
+    'lib/composer',
+    'build',
+    'apps/files_external/3rdparty'
+];
+
+foreach ($dirIterator as $fileinfo) {
+    $filename = $fileinfo->getFilename();
+    if ($fileinfo->isDir() && !$fileinfo->isDot() && !in_array($filename, $bundledApps)) {
+        $excludeDirs[] = $dirToParse . '/' . $filename;
+    }
+}
+
 $finder = PhpCsFixer\Finder::create()
-    ->exclude('lib/composer')
-    ->exclude('build')
-    ->exclude('apps/files_external/3rdparty')
+    ->exclude($excludeDirs)
     ->in(__DIR__)
 ;
 


### PR DESCRIPTION
## Description
Parse the apps directory and specifically exclude any apps that are not bundled with core.

## Related Issue
None

## Motivation and Context
When doing development in a git clone of ``core`` I often clone other apps into the ``apps`` folder.
This is causing ``make test-php-style`` to scan all those extra files in the apps, and report lots of errors.
This makes it difficult to see which are the few errors that are actually in the core branch I am fixing.

## How Has This Been Tested?
``make test-php-style``
and see that it has the same length list of files checked as when used with a new ``git clone`` of ``core``

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

