### PR TITLE
Skip mailhog ui tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   - sh -c "if [ '$TEST_DAV' = '1' ]; then echo \"Testing DAV\"; fi"
 
   - sh -c "if [ '$TEST_DAV' = '1' ]; then bash apps/dav/tests/travis/$TC/script.sh; fi"
-  - sh -c "if [ '$TC' = 'selenium' ]; then bash tests/travis/start_ui_tests.sh; fi"
+  - sh -c "if [ '$TC' = 'selenium' ]; then bash tests/travis/start_ui_tests.sh --tags ~@mailhog; fi"
 
 matrix:
   include:

--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -58,7 +58,7 @@ class EmailContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
-	 * @BeforeScenario
+	 * @BeforeScenario @mailhog
 	 *
 	 * @param BeforeScenarioScope $scope
 	 *

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @mailhog
 
 Feature: reset the password
 As a user


### PR DESCRIPTION
## Description
skip UI tests that depend on mailhog on travis

## Motivation and Context
installing mailhog on travis would be harder, and I feel it is not needed to run email related tests on all browsers

## How Has This Been Tested?
webUILogin tests succeed here https://github.com/individual-it/owncloud-core/pull/82

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.