### PR TITLE
Revise wording of trashbin_retention_obligation auto setting

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -492,9 +492,9 @@ $CONFIG = array(
  * Available values:
  *
  * * ``auto``
- *     default setting. keeps files and folders in the trash bin for 30 days
- *     and automatically deletes anytime after that if space is needed (note:
- *     files may not be deleted if space is not needed).
+ *     default setting. Keeps files and folders in the deleted files for up to
+ *     30 days, automatically deleting them (at any time) if space is needed.
+ *     Note: files may not be removed if space is not required.
  * * ``D, auto``
  *     keeps files and folders in the trash bin for D+ days, delete anytime if
  *     space needed (note: files may not be deleted if space is not needed)


### PR DESCRIPTION
## Description

This PR corrects the wording for the `trashbin_retention_obligation` `auto` setting, in `config/config.sample.php` so that is neither ambiguous nor misleading. 

## Related Issue

https://github.com/owncloud/documentation/issues/4058.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

