### PR TITLE
[stable10] Don't reset inEvent while skipping events

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -364,8 +364,8 @@ class Log implements ILogger {
 		];
 
 		// note: regardless of log level we let listeners receive messages
-		$this->inEvent = true;
 		if (!$skipEvents) {
+			$this->inEvent = true;
 			$event = new GenericEvent(null);
 			$event->setArguments($eventArgs);
 			$this->eventDispatcher->dispatch('log.beforewrite', $event);
@@ -384,9 +384,12 @@ class Log implements ILogger {
 		if (!$skipEvents) {
 			$event = new GenericEvent(null);
 			$event->setArguments($eventArgs);
-			$this->eventDispatcher->dispatch('log.afterwrite', $event);
+			try {
+				$this->eventDispatcher->dispatch('log.afterwrite', $event);
+			} finally {
+				$this->inEvent = false;
+			}
 		}
-		$this->inEvent = false;
 	}
 
 	/**


### PR DESCRIPTION
## Description
If a PHP warning happens within the event handler, it would cause a log
entry to be added. The log entry itself would skip the event but would
reset the inEvent flag to zero despite being already in the log.

If the log handler logs further entries after the error happened, these would
not skip the event handler correctly since the flag was reset.

This fix resets the handler only when it makes sense.

## Related Issue
None raised

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1) Register an event handler with "log.afterwrite"
2) Trigger an error in the handler like `$a = []; $x = $a['x'];` (invalid offset)
3) After the error log another message

Before the fix: the second message would be logged in an infinite recursion.
After the fix: no recursion

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

