### PR TITLE
[stable10] Convert FileContentNotAllowedException into DAVForbiddenException to …

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -644,7 +644,7 @@ class File extends Node implements IFile {
 	private function convertToSabreException(\Exception $e) {
 		if ($e instanceof FileContentNotAllowedException) {
 			// the file content is not permitted
-			throw new FileContentNotAllowedException($e->getMessage(), $e->getRetry(), $e);
+			throw new DAVForbiddenException($e->getMessage(), $e->getRetry(), $e);
 		}
 		if ($e instanceof \Sabre\DAV\Exception) {
 			throw $e;


### PR DESCRIPTION
…properly return HTTP 403

Backport of https://github.com/owncloud/core/pull/31190

## Description
After https://github.com/owncloud/core/pull/30771 uploading infected files leads to HTTP status 500 instead of 403

## Motivation and Context
wrong HTTP status in response

## How Has This Been Tested?
0. setup owncloud with files_antivirus@36bae7bb78a753e38e16b89bb413cddd7134ff77
1. Upload eicar
2. Look at the response HTTP status


### Expected
HTTP/1.1 403 Forbidden


### Actual
HTTP/1.1 500 Internal Server Error

Regression check:
3. tail data/owncloud.log - there should be no dav exceptions logged ()

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

