### PR TITLE
Remember more created groups

### DIFF
--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -150,12 +150,12 @@ class UserHelper {
 	 * @return ResponseInterface
 	 */
 	public static function deleteGroup(
-		$baseUrl, $group, $adminUser, $adminPassword
+		$baseUrl, $group, $adminUser, $adminPassword, $apiVersion = 2
 	) {
 		$group = \rawurlencode($group);
 		return OcsApiHelper::sendRequest(
 			$baseUrl, $adminUser, $adminPassword,
-			"DELETE", "/cloud/groups/" . $group
+			"DELETE", "/cloud/groups/" . $group, [], $apiVersion
 		);
 	}
 

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -9,14 +9,14 @@ So that I can remove unnecessary groups
 
 	Scenario: Delete a group
 		Given group "new-group" has been created
-		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/groups/new-group"
+		When the administrator deletes group "new-group" using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And group "new-group" should not exist
 
 	Scenario: Delete a group with special characters
 		Given group "España" has been created
-		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/groups/España"
+		When the administrator deletes group "España" using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And group "España" should not exist

--- a/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
@@ -19,3 +19,9 @@ So that I can know which users are in a group
 		And the users returned by the API should be
 			| brand-new-user |
 			| 123            |
+
+	Scenario: getting users in an empty group
+		Given group "new-group" has been created
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
@@ -18,9 +18,3 @@ So that I can see all the groups in my ownCloud
 			| admin     |
 			| new-group |
 			| 0         |
-
-	Scenario: getting an empty group
-		Given group "new-group" has been created
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -9,14 +9,14 @@ So that I can remove unnecessary groups
 
 	Scenario: Delete a group
 		Given group "new-group" has been created
-		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/groups/new-group"
+		When the administrator deletes group "new-group" using the API
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And group "new-group" should not exist
 
 	Scenario: Delete a group with special characters
 		Given group "España" has been created
-		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/groups/España"
+		When the administrator deletes group "España" using the API
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And group "España" should not exist

--- a/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
@@ -19,3 +19,9 @@ So that I can know which users are in a group
 		And the users returned by the API should be
 			| brand-new-user |
 			| 123            |
+
+	Scenario: getting users in an empty group
+		Given group "new-group" has been created
+		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
+		Then the OCS status code should be "200"
+		And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
@@ -18,9 +18,3 @@ So that I can see all the groups in my ownCloud
 			| admin     |
 			| new-group |
 			| 0         |
-
-	Scenario: getting an empty group
-		Given group "new-group" has been created
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -871,14 +871,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator deletes group "([^"]*)" using the API$/
 	 * @Given /^group "([^"]*)" has been deleted$/
 	 *
 	 * @param string $group
 	 *
 	 * @return void
 	 */
-	public function adminDeletesGroupUsingTheAPI($group) {
+	public function groupHasBeenDeletedUsingTheAPI($group) {
 		if ($this->groupExists($group)) {
 			$this->deleteTheGroupUsingTheAPI($group);
 		}
@@ -886,6 +885,8 @@ trait Provisioning {
 	}
 
 	/**
+	 * @When /^the administrator deletes group "([^"]*)" using the API$/
+	 *
 	 * @param string $group
 	 *
 	 * @return void
@@ -895,7 +896,8 @@ trait Provisioning {
 			$this->getBaseUrl(),
 			$group,
 			$this->getAdminUsername(),
-			$this->getAdminPassword()
+			$this->getAdminPassword(),
+			$this->apiVersion
 		);
 
 		if ($this->theGroupShouldExist($group)


### PR DESCRIPTION
## Description
1) At the moment, when deleting groups in the acceptance tests, the specific step actually always uses API version 2. Make it use the currently selected API version so the step can properly be used in either v1 or v2 tests.
2) In the ``deleteGroups`` API acceptance tests, use the special steps for deleting a group (rather than the step that "sends HTTP method..."). This way the test code will be aware that the group should have been deleted, and so will not complain about it not being there in the ``AfterScenario`` cleanup.
3) The scenario about "getting an empty group" actually belongs in ``getGroup.feature`` because it is listing the contents of a single group. Move it there.

## Motivation and Context
Improve API acceptance tests for groups.

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test fixing


## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
