### PR TITLE
primary is deprecated, remove from params

### DIFF
--- a/lib/private/DB/MDB2SchemaReader.php
+++ b/lib/private/DB/MDB2SchemaReader.php
@@ -145,6 +145,7 @@ class MDB2SchemaReader {
 	 */
 	private function loadField($table, $xml) {
 		$options = ['notnull' => false];
+		$primary = null;
 		foreach ($xml->children() as $child) {
 			/**
 			 * @var \SimpleXMLElement $child
@@ -197,7 +198,6 @@ class MDB2SchemaReader {
 					break;
 				case 'primary':
 					$primary = $this->asBool($child);
-					$options['primary'] = $primary;
 					break;
 				case 'precision':
 					$precision = (string)$child;
@@ -246,11 +246,12 @@ class MDB2SchemaReader {
 			if (!empty($options['autoincrement'])
 				&& !empty($options['notnull'])
 			) {
-				$options['primary'] = true;
+				$primary = true;
 			}
 
+
 			$table->addColumn($name, $type, $options);
-			if (!empty($options['primary']) && $options['primary']) {
+			if ($primary) {
 				$table->setPrimaryKey([$name]);
 			}
 		}


### PR DESCRIPTION
got debug log during installation
```
{"reqId":"6WuMXs7qEttq4lFSGJT0","level":0,"time":"2018-04-27T13:49:02+02:00","remoteAddr":"","user":"--","app":"PHP","method":"--","url":"--","message":"The \"primary\" column option is not supported, setting it is deprecated and will cause an error in Doctrine 3.0 at \/home\/jfd\/www\/core\/lib\/composer\/doctrine\/dbal\/lib\/Doctrine\/DBAL\/Schema\/Column.php#133"}
```