### PR TITLE
remove , preventing install on oracle12

### DIFF
--- a/lib/private/Setup/OCI.php
+++ b/lib/private/Setup/OCI.php
@@ -99,7 +99,7 @@ class OCI extends AbstractDatabase {
 		                'CREATE SESSION',
 		                'CREATE TABLE',
 		                'CREATE SEQUENCE',
-		                'CREATE TRIGGER',
+		                'CREATE TRIGGER'
 		                ) AND a2.admin_option = 'YES')";
 		$stmt = \oci_parse($connection, $query);
 		if (!$stmt) {


### PR DESCRIPTION
oracle 12c at least choked on the superflous comma, when trying to check the permissions:
```json
{"reqId":"xFkaCsSEQaeF9xItLDNX","level":0,"time":"2018-04-27T22:09:01+02:00","remoteAddr":"","user":"--","app":"PHP","method":"--","url":"--","message":"oci_execute(): ORA-00936: missing expression at \/home\/jfd\/www\/core\/lib\/private\/Setup\/OCI.php#110"}
```

How to test:
use the SYSTEM user in the installation dialog. ownCloud will try to create a new user. 
As a result of the failed query the db user with limited credentials is not created an SYSTEM is used.

I used https://github.com/oracle/docker-images/tree/master/OracleDatabase/SingleInstance to first test with oc 12 ... installation failed and I fixed this bug. Had to switch to oracle11 XE because with v12 I ran into https://github.com/oracle/docker-images/issues/601#issuecomment-336660964

oracle 11 was smoother ... well .. installation still took 7:30 min ... but that is another issue ... might retry  after [**disabling** async io](https://github.com/oracle/docker-images/issues/601#issuecomment-384560247). oh that brings me down to 2:36 min. nice. An order of magnitude slower than other dbs ... but still