### PR TITLE
Don't check for existence twice if we know it is not a part file (objectstorage only)

### DIFF
--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -243,7 +243,7 @@ class Util {
 	}
 
 	/**
-	 * Remove .path extension from a file path
+	 * Remove .part extension from a file path
 	 * @param string $path Path that may identify a .part file
 	 * @return string File path without .part extension
 	 * @note this is needed for reusing keys


### PR DESCRIPTION
### Description

Don't check for existence in the storage (e.g. objectstorage) twice if we know it is not a part file. 

In that section of the code, we were checking for file existence in the storage twice for the same path. In case of part file we indeed need to check twice, but otherwise not. 

There is no difference for Filesystem storage, but Objectstorage/Files_primary_s3 is affected.

- [x] Requires unit tests adjustments due to changed function

### How did I test

<img width="1301" alt="perf-obj-part" src="https://user-images.githubusercontent.com/13368647/42127724-fe6c9802-7c9d-11e8-8e3a-01ebb1e4c1bb.png">
