### PR TITLE
Quote var in if test in start_ui_tests.sh

### DIFF
--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -369,7 +369,7 @@ fi
 
 SUITE_FEATURE_TEXT="$BEHAT_SUITE"
 
-if [ -n $BEHAT_FEATURE ]
+if [ -n "$BEHAT_FEATURE" ]
 then
     # If running a whole feature, it will be something like login.feature
     # If running just a single scenario, it will also have the line number


### PR DESCRIPTION
## Description
Quote the var that is used in the ``bash`` ``if`` test.
The quotes were missed in the initial PR.

## Motivation and Context
The ``start_ui_tests.sh`` script gets a ``basename: missing operand`` message.
Nothing breaks, it is just an error in trying to assemble some info text output.
```
+ bash tests/travis/start_ui_tests.sh --remote
basename: missing operand
Try 'basename --help' for more information.
Running webUILogin  tests on 'chrome' () on Linux
@webUI @insulated @disablePreviews
Feature: login users
```

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
