### PR TITLE
API acceptance add group name combinations

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -15,9 +15,19 @@ So that I can give a user access to the resources of the group
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		Examples:
-			| group_id  |
-			| new-group |
-			| 0         |
+			| group_id            | comment                                 |
+			| new-group           | dash                                    |
+			| the.group           | dot                                     |
+			| España              | special European characters             |
+			| नेपाली              | Unicode group name                      |
+			| 0                   | The "false" group                       |
+			| Finance (NP)        | Space and brackets                      |
+			| Admin&Finance       | Ampersand                               |
+			| admin:Pokhara@Nepal | Colon and @                             |
+			| maint+eng           | Plus sign                               |
+			| $x<=>[y*z^2]!       | Maths symbols                           |
+			| Mgmt\Middle         | Backslash                               |
+			| 50%pass             | Percent sign (special escaping happens) |
 
 	Scenario: adding user to a group without privileges
 		Given user "brand-new-user" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -7,16 +7,23 @@ So that I can remove unnecessary groups
 	Background:
 		Given using API version "1"
 
-	Scenario: Delete a group
-		Given group "new-group" has been created
-		When the administrator deletes group "new-group" using the API
+	Scenario Outline: Delete a group
+		Given group "<group-name>" has been created
+		When the administrator deletes group "<group-name>" using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And group "new-group" should not exist
-
-	Scenario: Delete a group with special characters
-		Given group "España" has been created
-		When the administrator deletes group "España" using the API
-		Then the OCS status code should be "100"
-		And the HTTP status code should be "200"
-		And group "España" should not exist
+		And group "<group-name>" should not exist
+		Examples:
+			| group-name          | comment                                 |
+			| new-group           | dash                                    |
+			| the.group           | dot                                     |
+			| España              | special European characters             |
+			| नेपाली              | Unicode group name                      |
+			| 0                   | The "false" group                       |
+			| Finance (NP)        | Space and brackets                      |
+			| Admin&Finance       | Ampersand                               |
+			| admin:Pokhara@Nepal | Colon and @                             |
+			| maint+eng           | Plus sign                               |
+			| $x<=>[y*z^2]!       | Maths symbols                           |
+			| Mgmt\Middle         | Backslash                               |
+			| 50%pass             | Percent sign (special escaping happens) |

--- a/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
@@ -9,13 +9,23 @@ So that I can manage group membership
 
 	Scenario: getting groups of an user
 		Given user "brand-new-user" has been created
+		And group "unused-group" has been created
 		And group "new-group" has been created
 		And group "0" has been created
+		And group "Admin & Finance (NP)" has been created
+		And group "admin:Pokhara@Nepal" has been created
+		And group "नेपाली" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "brand-new-user" has been added to group "0"
+		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
+		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
+		And user "brand-new-user" has been added to group "नेपाली"
 		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user/groups"
 		Then the groups returned by the API should be
-			| new-group |
-			| 0         |
+			| new-group            |
+			| 0                    |
+			| Admin & Finance (NP) |
+			| admin:Pokhara@Nepal  |
+			| नेपाली               |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200" 

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -17,11 +17,21 @@ So that I can manage user access to group resources
 		And the HTTP status code should be "200" 
 		And user "brand-new-user" should not belong to group "<group_id>"
 		Examples:
-			| group_id  |
-			| new-group |
-			| 0         |
+			| group_id            | comment                                 |
+			| new-group           | dash                                    |
+			| the.group           | dot                                     |
+			| España              | special European characters             |
+			| नेपाली              | Unicode group name                      |
+			| 0                   | The "false" group                       |
+			| Finance (NP)        | Space and brackets                      |
+			| Admin&Finance       | Ampersand                               |
+			| admin:Pokhara@Nepal | Colon and @                             |
+			| maint+eng           | Plus sign                               |
+			| $x<=>[y*z^2]!       | Maths symbols                           |
+			| Mgmt\Middle         | Backslash                               |
+			| 50%pass             | Percent sign (special escaping happens) |
 
-		Scenario: removing a user from a group which doesn't exist
+	Scenario: removing a user from a group which doesn't exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
 		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -15,9 +15,19 @@ So that I can give a user access to the resources of the group
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		Examples:
-			| group_id  |
-			| new-group |
-			| 0         |
+			| group_id            | comment                                 |
+			| new-group           | dash                                    |
+			| the.group           | dot                                     |
+			| España              | special European characters             |
+			| नेपाली              | Unicode group name                      |
+			| 0                   | The "false" group                       |
+			| Finance (NP)        | Space and brackets                      |
+			| Admin&Finance       | Ampersand                               |
+			| admin:Pokhara@Nepal | Colon and @                             |
+			| maint+eng           | Plus sign                               |
+			| $x<=>[y*z^2]!       | Maths symbols                           |
+			| Mgmt\Middle         | Backslash                               |
+			| 50%pass             | Percent sign (special escaping happens) |
 
 	@skip @issue-31276
 	Scenario: adding user to a group without privileges

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -7,16 +7,23 @@ So that I can remove unnecessary groups
 	Background:
 		Given using API version "2"
 
-	Scenario: Delete a group
-		Given group "new-group" has been created
-		When the administrator deletes group "new-group" using the API
+	Scenario Outline: Delete a group
+		Given group "<group-name>" has been created
+		When the administrator deletes group "<group-name>" using the API
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
-		And group "new-group" should not exist
-
-	Scenario: Delete a group with special characters
-		Given group "España" has been created
-		When the administrator deletes group "España" using the API
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And group "España" should not exist
+		And group "<group-name>" should not exist
+		Examples:
+			| group-name          | comment                                 |
+			| new-group           | dash                                    |
+			| the.group           | dot                                     |
+			| España              | special European characters             |
+			| नेपाली              | Unicode group name                      |
+			| 0                   | The "false" group                       |
+			| Finance (NP)        | Space and brackets                      |
+			| Admin&Finance       | Ampersand                               |
+			| admin:Pokhara@Nepal | Colon and @                             |
+			| maint+eng           | Plus sign                               |
+			| $x<=>[y*z^2]!       | Maths symbols                           |
+			| Mgmt\Middle         | Backslash                               |
+			| 50%pass             | Percent sign (special escaping happens) |

--- a/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
@@ -9,13 +9,23 @@ So that I can manage group membership
 
 	Scenario: getting groups of an user
 		Given user "brand-new-user" has been created
+		And group "unused-group" has been created
 		And group "new-group" has been created
 		And group "0" has been created
+		And group "Admin & Finance (NP)" has been created
+		And group "admin:Pokhara@Nepal" has been created
+		And group "नेपाली" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "brand-new-user" has been added to group "0"
+		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
+		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
+		And user "brand-new-user" has been added to group "नेपाली"
 		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user/groups"
 		Then the groups returned by the API should be
-			| new-group |
-			| 0         |
+			| new-group            |
+			| 0                    |
+			| Admin & Finance (NP) |
+			| admin:Pokhara@Nepal  |
+			| नेपाली               |
 		And the OCS status code should be "200"
 		And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -17,9 +17,19 @@ So that I can manage user access to group resources
 		And the HTTP status code should be "200"
 		And user "brand-new-user" should not belong to group "<group_id>"
 		Examples:
-			| group_id  |
-			| new-group |
-			| 0         |
+			| group_id            | comment                                 |
+			| new-group           | dash                                    |
+			| the.group           | dot                                     |
+			| España              | special European characters             |
+			| नेपाली              | Unicode group name                      |
+			| 0                   | The "false" group                       |
+			| Finance (NP)        | Space and brackets                      |
+			| Admin&Finance       | Ampersand                               |
+			| admin:Pokhara@Nepal | Colon and @                             |
+			| maint+eng           | Plus sign                               |
+			| $x<=>[y*z^2]!       | Maths symbols                           |
+			| Mgmt\Middle         | Backslash                               |
+			| 50%pass             | Percent sign (special escaping happens) |
 
 		Scenario: removing a user from a group which doesn't exist
 		Given user "brand-new-user" has been created

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -189,7 +189,7 @@ trait Provisioning {
 			$password = $this->getPasswordForUser($user);
 			$this->createUser($user, $password, null, null, true, 'api');
 		}
-		PHPUnit_Framework_Assert::assertTrue($this->userExists($user));
+		$this->userShouldExist($user);
 	}
 
 	/**
@@ -252,7 +252,10 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userShouldExist($user) {
-		PHPUnit_Framework_Assert::assertTrue($this->userExists($user));
+		PHPUnit_Framework_Assert::assertTrue(
+			$this->userExists($user),
+			"User '$user' should exist but does not exist"
+		);
 	}
 
 	/**
@@ -263,7 +266,10 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userShouldNotExist($user) {
-		PHPUnit_Framework_Assert::assertFalse($this->userExists($user));
+		PHPUnit_Framework_Assert::assertFalse(
+			$this->userExists($user),
+			"User '$user' should not exist but does exist"
+		);
 	}
 
 	/**
@@ -274,7 +280,10 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function groupShouldExist($group) {
-		PHPUnit_Framework_Assert::assertTrue($this->groupExists($group));
+		PHPUnit_Framework_Assert::assertTrue(
+			$this->groupExists($group),
+			"Group '$group' should exist but does not exist"
+		);
 	}
 
 	/**
@@ -285,7 +294,10 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function groupShouldNotExist($group) {
-		PHPUnit_Framework_Assert::assertFalse($this->groupExists($group));
+		PHPUnit_Framework_Assert::assertFalse(
+			$this->groupExists($group),
+			"Group '$group' should not exist but does exist"
+		);
 	}
 
 	/**
@@ -324,7 +336,7 @@ trait Provisioning {
 		if ($this->userExists($user)) {
 			$this->deleteTheUserUsingTheAPI($user);
 		}
-		PHPUnit_Framework_Assert::assertFalse($this->userExists($user));
+		$this->userShouldNotExist($user);
 	}
 
 	/**
@@ -486,7 +498,7 @@ trait Provisioning {
 	 */
 	public function deleteUser($user) {
 		$this->deleteTheUserUsingTheAPI($user);
-		PHPUnit_Framework_Assert::assertFalse($this->userExists($user));
+		$this->userShouldNotExist($user);
 	}
 
 	/**
@@ -729,7 +741,7 @@ trait Provisioning {
 		if (!$this->groupExists($group)) {
 			$this->createTheGroup($group, 'api');
 		}
-		PHPUnit_Framework_Assert::assertTrue($this->groupExists($group));
+		$this->groupShouldExist($group);
 	}
 
 	/**
@@ -881,7 +893,7 @@ trait Provisioning {
 		if ($this->groupExists($group)) {
 			$this->deleteTheGroupUsingTheAPI($group);
 		}
-		PHPUnit_Framework_Assert::assertFalse($this->groupExists($group));
+		$this->groupShouldNotExist($group);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
@@ -46,9 +46,11 @@ class WebUIPersonalSecuritySettingsContext extends RawMinkContext implements Con
 	 * WebUIPersonalSecuritySettingsContext constructor.
 	 *
 	 * @param PersonalSecuritySettingsPage $personalSecuritySettingsPage
+	 * @param LoginPage $loginPage
 	 */
 	public function __construct(
-		PersonalSecuritySettingsPage $personalSecuritySettingsPage, LoginPage $loginPage
+		PersonalSecuritySettingsPage $personalSecuritySettingsPage,
+		LoginPage $loginPage
 	) {
 		$this->personalSecuritySettingsPage = $personalSecuritySettingsPage;
 		$this->appName = \substr(\str_shuffle($this->strForAppName), 0, 8);


### PR DESCRIPTION
## Description
1) Make scenario outlines with more test cases for adding users to groups, removing users from groups, deleting groups... with unusual group names
2) Make better messages when a user or group is not in the expected state.

## Motivation and Context
1) There are only a few test cases for manipulating and deleting unusual group names. There is a PR to try and fix cases that do not work. But for now, it would be good to have test cases for group names that do work. That will avoid regressions, and make the diffs in the "fixing" PR smaller.

2) Messages that come out when a user or group is expected to exist but does not, are unhelpful
```
Failed asserting that false is true.
```
A better message would be good, so we have some idea where the problem might be.

## How Has This Been Tested?
Local Provisioning API acceptance test runs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test enahncements

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
