### PR TITLE
Correct addGroup.feature and add new text cases to other group tests

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -13,7 +13,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 		And the HTTP status code should be "200"
 		And group "<group_id>" should exist
 		Examples:
-			| group-id            | comment                                 |
+			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
 			| España              | special European characters             |
@@ -26,14 +26,11 @@ So that I can more easily manage access to resources by groups rather than indiv
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
-			| Mgmt/Sydney         | Slash (special escaping happens)        |
-			| Mgmt//NSW/Sydney    | Multiple slash                          |
 			| 50%pass             | Percent sign (special escaping happens) |
 			| 50%25=0             | %25 literal looks like an escaped "%"   |
 			| 50%2Eagle           | %2E literal looks like an escaped "."   |
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
-			| /                   | forward slash                           |
 
 	Scenario: Create a group that already exists
 		Given group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -24,10 +24,15 @@ So that I can give a user access to the resources of the group
 			| Finance (NP)        | Space and brackets                      |
 			| Admin&Finance       | Ampersand                               |
 			| admin:Pokhara@Nepal | Colon and @                             |
+			| maintenance#123     | Hash sign                               |
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
 			| 50%pass             | Percent sign (special escaping happens) |
+			| 50%25=0             | %25 literal looks like an escaped "%"   |
+			| 50%2Eagle           | %2E literal looks like an escaped "."   |
+			| 50%2Fix             | %2F literal looks like an escaped slash |
+			| staff?group         | Question mark                           |
 
 	Scenario: adding user to a group without privileges
 		Given user "brand-new-user" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -8,13 +8,13 @@ So that I can remove unnecessary groups
 		Given using API version "1"
 
 	Scenario Outline: Delete a group
-		Given group "<group-name>" has been created
-		When the administrator deletes group "<group-name>" using the API
+		Given group "<group_id>" has been created
+		When the administrator deletes group "<group_id>" using the API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And group "<group-name>" should not exist
+		And group "<group_id>" should not exist
 		Examples:
-			| group-name          | comment                                 |
+			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
 			| España              | special European characters             |
@@ -23,7 +23,12 @@ So that I can remove unnecessary groups
 			| Finance (NP)        | Space and brackets                      |
 			| Admin&Finance       | Ampersand                               |
 			| admin:Pokhara@Nepal | Colon and @                             |
+			| maintenance#123     | Hash sign                               |
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
 			| 50%pass             | Percent sign (special escaping happens) |
+			| 50%25=0             | %25 literal looks like an escaped "%"   |
+			| 50%2Eagle           | %2E literal looks like an escaped "."   |
+			| 50%2Fix             | %2F literal looks like an escaped slash |
+			| staff?group         | Question mark                           |

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -26,10 +26,15 @@ So that I can manage user access to group resources
 			| Finance (NP)        | Space and brackets                      |
 			| Admin&Finance       | Ampersand                               |
 			| admin:Pokhara@Nepal | Colon and @                             |
+			| maintenance#123     | Hash sign                               |
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
 			| 50%pass             | Percent sign (special escaping happens) |
+			| 50%25=0             | %25 literal looks like an escaped "%"   |
+			| 50%2Eagle           | %2E literal looks like an escaped "."   |
+			| 50%2Fix             | %2F literal looks like an escaped slash |
+			| staff?group         | Question mark                           |
 
 	Scenario: removing a user from a group which doesn't exist
 		Given user "brand-new-user" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -13,7 +13,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 		And the HTTP status code should be "200"
 		And group "<group_id>" should exist
 		Examples:
-			| group-id            | comment                                 |
+			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
 			| España              | special European characters             |
@@ -26,14 +26,11 @@ So that I can more easily manage access to resources by groups rather than indiv
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
-			| Mgmt/Sydney         | Slash (special escaping happens)        |
-			| Mgmt//NSW/Sydney    | Multiple slash                          |
 			| 50%pass             | Percent sign (special escaping happens) |
 			| 50%25=0             | %25 literal looks like an escaped "%"   |
 			| 50%2Eagle           | %2E literal looks like an escaped "."   |
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
-			| /                   | forward slash                           |
 
 	Scenario: Create a group that already exists
 		Given group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -24,10 +24,15 @@ So that I can give a user access to the resources of the group
 			| Finance (NP)        | Space and brackets                      |
 			| Admin&Finance       | Ampersand                               |
 			| admin:Pokhara@Nepal | Colon and @                             |
+			| maintenance#123     | Hash sign                               |
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
 			| 50%pass             | Percent sign (special escaping happens) |
+			| 50%25=0             | %25 literal looks like an escaped "%"   |
+			| 50%2Eagle           | %2E literal looks like an escaped "."   |
+			| 50%2Fix             | %2F literal looks like an escaped slash |
+			| staff?group         | Question mark                           |
 
 	@skip @issue-31276
 	Scenario: adding user to a group without privileges

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -8,13 +8,13 @@ So that I can remove unnecessary groups
 		Given using API version "2"
 
 	Scenario Outline: Delete a group
-		Given group "<group-name>" has been created
-		When the administrator deletes group "<group-name>" using the API
+		Given group "<group_id>" has been created
+		When the administrator deletes group "<group_id>" using the API
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
-		And group "<group-name>" should not exist
+		And group "<group_id>" should not exist
 		Examples:
-			| group-name          | comment                                 |
+			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
 			| España              | special European characters             |
@@ -23,7 +23,12 @@ So that I can remove unnecessary groups
 			| Finance (NP)        | Space and brackets                      |
 			| Admin&Finance       | Ampersand                               |
 			| admin:Pokhara@Nepal | Colon and @                             |
+			| maintenance#123     | Hash sign                               |
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
 			| 50%pass             | Percent sign (special escaping happens) |
+			| 50%25=0             | %25 literal looks like an escaped "%"   |
+			| 50%2Eagle           | %2E literal looks like an escaped "."   |
+			| 50%2Fix             | %2F literal looks like an escaped slash |
+			| staff?group         | Question mark                           |

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -26,10 +26,15 @@ So that I can manage user access to group resources
 			| Finance (NP)        | Space and brackets                      |
 			| Admin&Finance       | Ampersand                               |
 			| admin:Pokhara@Nepal | Colon and @                             |
+			| maintenance#123     | Hash sign                               |
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
 			| 50%pass             | Percent sign (special escaping happens) |
+			| 50%25=0             | %25 literal looks like an escaped "%"   |
+			| 50%2Eagle           | %2E literal looks like an escaped "."   |
+			| 50%2Fix             | %2F literal looks like an escaped slash |
+			| staff?group         | Question mark                           |
 
 		Scenario: removing a user from a group which doesn't exist
 		Given user "brand-new-user" has been created

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -929,6 +929,7 @@ trait Provisioning {
 	 * @return bool
 	 */
 	public function groupExists($group) {
+		$group = \rawurlencode($group);
 		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/groups/$group";
 		$client = new Client();
 		$options = [];


### PR DESCRIPTION
## Description
1) Fix error in column name in ``addGroup.feature`` - ``group-id`` -> ``group_id``
2) URL-encode the group name when testing to see if a group exists - this allows ``groupExists()`` to correctly test for groups that have unusual characters in their name.
3) Remove test cases for groups that have slash in their name - fix for those will be in another PR
4) Add test cases for other ``#`` ``?`` ``%`` in group names to all the places where groups are manipulated - ``addToGroup`` ``deleteGroup`` ``removeFromGroup`` - for both API v1 and v2

Now we have a full range of test cases for group names that do work properly with the existing Provisioning API v1 and v2. This will help to ensure there are no regressions when we fix the "slash in group name" case.

## Motivation and Context
I wondered why the ``addGroup.feature`` test cases for group names containing a slash were passing. Because actually there is a problem with that - see issue #31015 and PR #31017 

I discovered that there was a typo in the column name of the examples table. Actually the scenario outline was running over-and-over and repeatedly testing adding a group with the literal name ``<group_id>`` instead of substituting in the group id in each example table row.

When I make that fix, then a lot of the group creations fail, because the group should be URL-encoded when the group name needs to be sent in the URL (e.g. when checking if the group exists).

After fixing that, I still have to remove the entries from the examples table that have a slash in the group name, because those really do fail. The other PR addresses fixing that problem.

## How Has This Been Tested?
Local acceptance test runs of group tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test fixes

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
