### PR TITLE
run UI tests in drone on Firefox

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,7 +31,7 @@ pipeline:
       - php occ config:system:set trusted_domains 2 --value=federated
       - php occ log:manage --level 0
       - php occ config:list
-      - echo "export TEST_SERVER_FED_URL=https://federated" > /drone/saved-settings.sh
+      - echo "export TEST_SERVER_FED_URL=${SERVER_PROTOCOL}://federated" > /drone/saved-settings.sh
       - php occ security:certificates:import /drone/server.crt
       - php occ security:certificates:import /drone/federated.crt
       - php occ security:certificates
@@ -272,8 +272,8 @@ pipeline:
       - echo 'Sharing a folder ..'
       - OC_PASS=123456 php occ user:add --password-from-env user1
       - chown www-data /drone/src -R
-      - curl -k -s -u user1:123456 -X MKCOL 'https://server/remote.php/webdav/new_folder'
-      - curl -k -s -u user1:123456 "https://server/ocs/v2.php/apps/files_sharing/api/v1/shares" --data 'path=/new_folder&shareType=0&permissions=15&name=new_folder&shareWith=admin'
+      - curl -k -s -u user1:123456 -X MKCOL '${SERVER_PROTOCOL}://server/remote.php/webdav/new_folder'
+      - curl -k -s -u user1:123456 "${SERVER_PROTOCOL}://server/ocs/v2.php/apps/files_sharing/api/v1/shares" --data 'path=/new_folder&shareType=0&permissions=15&name=new_folder&shareWith=admin'
     when:
       matrix:
         TEST_SUITE: litmus
@@ -282,7 +282,7 @@ pipeline:
     image: owncloud/litmus
     pull: true
     environment:
-      - LITMUS_URL=https://server/remote.php/webdav
+      - LITMUS_URL=${SERVER_PROTOCOL}://server/remote.php/webdav
       - LITMUS_USERNAME=admin
       - LITMUS_PASSWORD=admin
     when:
@@ -293,7 +293,7 @@ pipeline:
     image: owncloud/litmus
     pull: true
     environment:
-    - LITMUS_URL=https://server/remote.php/dav/files/admin
+    - LITMUS_URL=${SERVER_PROTOCOL}://server/remote.php/dav/files/admin
     - LITMUS_USERNAME=admin
     - LITMUS_PASSWORD=admin
     when:
@@ -304,7 +304,7 @@ pipeline:
     image: owncloud/litmus
     pull: true
     environment:
-    - LITMUS_URL=https://server/remote.php/dav/files/admin/local_storage/
+    - LITMUS_URL=${SERVER_PROTOCOL}://server/remote.php/dav/files/admin/local_storage/
     - LITMUS_USERNAME=admin
     - LITMUS_PASSWORD=admin
     when:
@@ -315,7 +315,7 @@ pipeline:
     image: owncloud/litmus
     pull: true
     environment:
-    - LITMUS_URL=https://server/remote.php/webdav/local_storage/
+    - LITMUS_URL=${SERVER_PROTOCOL}://server/remote.php/webdav/local_storage/
     - LITMUS_USERNAME=admin
     - LITMUS_PASSWORD=admin
     when:
@@ -326,7 +326,7 @@ pipeline:
     image: owncloud/litmus
     pull: true
     environment:
-    - LITMUS_URL=https://server/remote.php/dav/files/admin/new_folder/
+    - LITMUS_URL=${SERVER_PROTOCOL}://server/remote.php/dav/files/admin/new_folder/
     - LITMUS_USERNAME=admin
     - LITMUS_PASSWORD=admin
     when:
@@ -337,7 +337,7 @@ pipeline:
     image: owncloud/litmus
     pull: true
     environment:
-    - LITMUS_URL=https://server/remote.php/webdav/new_folder/
+    - LITMUS_URL=${SERVER_PROTOCOL}://server/remote.php/webdav/new_folder/
     - LITMUS_USERNAME=admin
     - LITMUS_PASSWORD=admin
     when:
@@ -370,7 +370,7 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-      - TEST_SERVER_URL=https://server
+      - TEST_SERVER_URL=${SERVER_PROTOCOL}://server
     commands:
       - touch /drone/saved-settings.sh
       - . /drone/saved-settings.sh
@@ -383,7 +383,7 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-      - TEST_SERVER_URL=https://server
+      - TEST_SERVER_URL=${SERVER_PROTOCOL}://server
       - MAILHOG_HOST=email
     commands:
       - touch /drone/saved-settings.sh
@@ -400,7 +400,7 @@ pipeline:
       - BROWSER=${BROWSER}
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
-      - TEST_SERVER_URL=https://server
+      - TEST_SERVER_URL=${SERVER_PROTOCOL}://server
       - PLATFORM=Linux
       - MAILHOG_HOST=email
     commands:
@@ -526,6 +526,18 @@ services:
     when:
       matrix:
         USE_SERVER: true
+        SERVER_PROTOCOL: https
+
+  server:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - APACHE_WEBROOT=/drone/src/
+    command: [ "/usr/local/bin/apachectl", "-e", "debug" , "-D", "FOREGROUND" ]
+    when:
+      matrix:
+        USE_SERVER: true
+        SERVER_PROTOCOL: http
 
   federated:
     image: owncloudci/php:${PHP_VERSION}
@@ -540,6 +552,18 @@ services:
     when:
       matrix:
         USE_FEDERATED_SERVER: true
+        SERVER_PROTOCOL: https
+
+  federated:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - APACHE_WEBROOT=/drone/fed-server/
+    command: [ "/usr/local/bin/apachectl", "-e", "debug" , "-D", "FOREGROUND" ]
+    when:
+      matrix:
+        USE_FEDERATED_SERVER: true
+        SERVER_PROTOCOL: http
 
   apache_webdav:
     image: owncloudci/php
@@ -613,6 +637,7 @@ matrix:
   # Litmus
     - PHP_VERSION: 7.1
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       TEST_SUITE: litmus
       INSTALL_SERVER: true
       OWNCLOUD_LOG: true
@@ -774,6 +799,7 @@ matrix:
       BEHAT_SUITE: apiMain
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -784,6 +810,7 @@ matrix:
       BEHAT_SUITE: apiCapabilities
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -794,6 +821,7 @@ matrix:
       BEHAT_SUITE: apiComments
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -804,6 +832,7 @@ matrix:
       BEHAT_SUITE: apiFavorites
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -814,6 +843,7 @@ matrix:
       BEHAT_SUITE: apiFederation
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       USE_FEDERATED_SERVER: true
       FEDERATION_OC_VERSION: daily-stable10-qa
       INSTALL_SERVER: true
@@ -826,6 +856,7 @@ matrix:
       BEHAT_SUITE: apiProvisioning-v1
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -836,6 +867,7 @@ matrix:
       BEHAT_SUITE: apiProvisioning-v2
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -846,6 +878,7 @@ matrix:
       BEHAT_SUITE: apiSharees
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -856,6 +889,7 @@ matrix:
       BEHAT_SUITE: apiShareManagement
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -866,6 +900,7 @@ matrix:
       BEHAT_SUITE: apiShareOperations
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -876,6 +911,7 @@ matrix:
       BEHAT_SUITE: apiSharingNotifications
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -887,6 +923,7 @@ matrix:
       BEHAT_SUITE: apiTags
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -897,6 +934,7 @@ matrix:
       BEHAT_SUITE: apiTrashbin
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -907,6 +945,7 @@ matrix:
       BEHAT_SUITE: apiVersions
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -917,6 +956,7 @@ matrix:
       BEHAT_SUITE: apiWebdavLocks
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -927,6 +967,7 @@ matrix:
       BEHAT_SUITE: apiWebdavMove
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -937,6 +978,7 @@ matrix:
       BEHAT_SUITE: apiWebdavOperations
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -947,6 +989,7 @@ matrix:
       BEHAT_SUITE: apiWebdavProperties
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -957,6 +1000,7 @@ matrix:
       BEHAT_SUITE: apiWebdavUpload
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -968,6 +1012,7 @@ matrix:
       BEHAT_SUITE: cliProvisioning
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -980,6 +1025,7 @@ matrix:
       BEHAT_SUITE: cliMain
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -991,6 +1037,7 @@ matrix:
       BEHAT_SUITE: cliBackground
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1002,6 +1049,7 @@ matrix:
       BEHAT_SUITE: cliTrashbin
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1015,6 +1063,7 @@ matrix:
       BEHAT_SUITE: webUIAdminSettings
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1027,6 +1076,7 @@ matrix:
       BEHAT_SUITE: webUIComments
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1038,6 +1088,7 @@ matrix:
       BEHAT_SUITE: webUICreateDelete
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1049,6 +1100,7 @@ matrix:
       BEHAT_SUITE: webUIFavorites
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1060,6 +1112,7 @@ matrix:
       BEHAT_SUITE: webUIFiles
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1071,6 +1124,7 @@ matrix:
       BEHAT_SUITE: webUILogin
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1083,6 +1137,7 @@ matrix:
       BEHAT_SUITE: webUIMoveFilesFolders
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1094,6 +1149,7 @@ matrix:
       BEHAT_SUITE: webUIPersonalSettings
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1106,6 +1162,7 @@ matrix:
       BEHAT_SUITE: webUIRenameFiles
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1117,6 +1174,7 @@ matrix:
       BEHAT_SUITE: webUIRenameFolders
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1128,6 +1186,7 @@ matrix:
       BEHAT_SUITE: webUIRestrictSharing
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1139,6 +1198,7 @@ matrix:
       BEHAT_SUITE: webUISharingAcceptShares
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1150,6 +1210,7 @@ matrix:
       BEHAT_SUITE: webUISharingExternal
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       USE_FEDERATED_SERVER: true
       FEDERATION_OC_VERSION: daily-stable10-qa
       INSTALL_SERVER: true
@@ -1164,6 +1225,7 @@ matrix:
       BEHAT_SUITE: webUISharingInternalGroups
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1175,6 +1237,7 @@ matrix:
       BEHAT_SUITE: webUISharingInternalUsers
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1186,6 +1249,7 @@ matrix:
       BEHAT_SUITE: webUISharingNotifications
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1199,6 +1263,7 @@ matrix:
       BEHAT_SUITE: webUISharingPublic
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1211,6 +1276,7 @@ matrix:
       BEHAT_SUITE: webUITags
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1222,6 +1288,7 @@ matrix:
       BEHAT_SUITE: webUITrashbin
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1233,6 +1300,7 @@ matrix:
       BEHAT_SUITE: webUIUpload
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1244,6 +1312,7 @@ matrix:
       BEHAT_SUITE: webUIWebdavLocks
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1255,19 +1324,20 @@ matrix:
       BEHAT_SUITE: webUIWebdavLockProtection
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
 
-  ## Firefox
+    ## Firefox
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUIAdminSettings
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1277,10 +1347,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUIComments
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1289,10 +1359,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUICreateDelete
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1301,10 +1371,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUIFavorites
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1313,10 +1383,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUIFiles
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1325,10 +1395,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUILogin
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1338,10 +1408,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUIMoveFilesFolders
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1350,10 +1420,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUIPersonalSettings
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1363,10 +1433,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUIRenameFiles
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1375,10 +1445,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUIRenameFolders
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1387,10 +1457,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUIRestrictSharing
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1399,10 +1469,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUISharingAcceptShares
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1411,10 +1481,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUISharingExternal
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       USE_FEDERATED_SERVER: true
       FEDERATION_OC_VERSION: daily-stable10-qa
       INSTALL_SERVER: true
@@ -1426,10 +1496,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUISharingInternalGroups
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1438,10 +1508,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUISharingInternalUsers
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1450,10 +1520,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUISharingNotifications
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1464,10 +1534,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUISharingPublic
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1477,10 +1547,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUITags
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1489,10 +1559,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUITrashbin
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1501,10 +1571,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUIUpload
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1513,10 +1583,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUIWebdavLocks
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1525,10 +1595,10 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BROWSER_VERSION: 58
       BEHAT_SUITE: webUIWebdavLockProtection
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: http
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1539,6 +1609,7 @@ matrix:
       TEST_SUITE: caldav
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1549,6 +1620,7 @@ matrix:
       TEST_SUITE: carddav
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1559,6 +1631,7 @@ matrix:
       TEST_SUITE: caldav-old-endpoint
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -1569,6 +1642,7 @@ matrix:
       TEST_SUITE: carddav-old-endpoint
       DB_TYPE: mariadb
       USE_SERVER: true
+      SERVER_PROTOCOL: https
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -1334,154 +1334,6 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BEHAT_SUITE: webUIAdminSettings
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUIComments
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUICreateDelete
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUIFavorites
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUIFiles
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUILogin
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUIMoveFilesFolders
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUIPersonalSettings
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-      USE_EMAIL: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUIRenameFiles
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUIRenameFolders
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUIRestrictSharing
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUISharingAcceptShares
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUISharingExternal
       DB_TYPE: mariadb
       USE_SERVER: true
       SERVER_PROTOCOL: http
@@ -1492,117 +1344,43 @@ matrix:
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
       USE_EMAIL: true
+      BEHAT_FILTER_TAGS: '@smokeTest&&~@notifications-app-required'
+      DIVIDE_INTO_NUM_PARTS: 3
+      RUN_PART: 1
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BEHAT_SUITE: webUISharingInternalGroups
       DB_TYPE: mariadb
       USE_SERVER: true
       SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUISharingInternalUsers
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUISharingNotifications
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
       USE_EMAIL: true
-      INSTALL_NOTIFICATIONS_APP: true
+      BEHAT_FILTER_TAGS: '@smokeTest&&~@notifications-app-required'
+      DIVIDE_INTO_NUM_PARTS: 3
+      RUN_PART: 2
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BROWSER: firefox
-      BEHAT_SUITE: webUISharingPublic
       DB_TYPE: mariadb
       USE_SERVER: true
       SERVER_PROTOCOL: http
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
       INSTALL_TESTING_APP: true
       USE_EMAIL: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUITags
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUITrashbin
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUIUpload
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUIWebdavLocks
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
-
-    - PHP_VERSION: 7.1
-      TEST_SUITE: selenium
-      BROWSER: firefox
-      BEHAT_SUITE: webUIWebdavLockProtection
-      DB_TYPE: mariadb
-      USE_SERVER: true
-      SERVER_PROTOCOL: http
-      INSTALL_SERVER: true
-      CHOWN_SERVER: true
-      OWNCLOUD_LOG: true
-      INSTALL_TESTING_APP: true
+      BEHAT_FILTER_TAGS: '@smokeTest&&~@notifications-app-required'
+      DIVIDE_INTO_NUM_PARTS: 3
+      RUN_PART: 3
 
     # caldav test
     - PHP_VERSION: 7.1

--- a/.drone.yml
+++ b/.drone.yml
@@ -397,7 +397,7 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-      - BROWSER=chrome
+      - BROWSER=${BROWSER}
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
       - TEST_SERVER_URL=https://server
@@ -501,6 +501,17 @@ services:
     when:
       matrix:
         TEST_SUITE: selenium
+        BROWSER: chrome
+
+  selenium:
+    image: selenium/standalone-firefox-debug:3.8.1
+    pull: true
+    environment:
+      - SE_OPTS=-enablePassThrough false
+    when:
+      matrix:
+        TEST_SUITE: selenium
+        BROWSER: firefox
 
   server:
     image: owncloudci/php:${PHP_VERSION}
@@ -997,8 +1008,10 @@ matrix:
       INSTALL_TESTING_APP: true
 
   # UI Acceptance tests
+  ## Chrome
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUIAdminSettings
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1010,6 +1023,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUIComments
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1020,6 +1034,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUICreateDelete
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1030,6 +1045,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUIFavorites
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1040,6 +1056,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUIFiles
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1050,6 +1067,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUILogin
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1061,6 +1079,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUIMoveFilesFolders
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1071,6 +1090,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUIPersonalSettings
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1082,6 +1102,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUIRenameFiles
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1092,6 +1113,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUIRenameFolders
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1102,6 +1124,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUIRestrictSharing
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1112,6 +1135,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUISharingAcceptShares
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1122,6 +1146,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUISharingExternal
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1135,6 +1160,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUISharingInternalGroups
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1145,6 +1171,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUISharingInternalUsers
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1155,6 +1182,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUISharingNotifications
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1167,6 +1195,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUISharingPublic
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1178,6 +1207,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUITags
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1188,6 +1218,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUITrashbin
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1198,6 +1229,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUIUpload
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1208,6 +1240,7 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
       BEHAT_SUITE: webUIWebdavLocks
       DB_TYPE: mariadb
       USE_SERVER: true
@@ -1218,6 +1251,281 @@ matrix:
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
+      BROWSER: chrome
+      BEHAT_SUITE: webUIWebdavLockProtection
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+  ## Firefox
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUIAdminSettings
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+      USE_EMAIL: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUIComments
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUICreateDelete
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUIFavorites
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUIFiles
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUILogin
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+      USE_EMAIL: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUIMoveFilesFolders
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUIPersonalSettings
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+      USE_EMAIL: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUIRenameFiles
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUIRenameFolders
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUIRestrictSharing
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUISharingAcceptShares
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUISharingExternal
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+      USE_EMAIL: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUISharingInternalGroups
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUISharingInternalUsers
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUISharingNotifications
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+      USE_EMAIL: true
+      INSTALL_NOTIFICATIONS_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUISharingPublic
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+      USE_EMAIL: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUITags
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUITrashbin
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUIUpload
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
+      BEHAT_SUITE: webUIWebdavLocks
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      INSTALL_TESTING_APP: true
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: selenium
+      BROWSER: firefox
+      BROWSER_VERSION: 58
       BEHAT_SUITE: webUIWebdavLockProtection
       DB_TYPE: mariadb
       USE_SERVER: true

--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -131,13 +131,13 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	 */
 	public function changeEmailAddress($newEmailAddress, Session $session) {
 		$emailField = $this->findById($this->emailAddressInputID);
-		if (\is_null($emailField)) {
+		if ($emailField === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" could not find email field with id $this->emailAddressInputID"
 			);
 		}
-		$this->cleanInputAndSetValue($emailField, $newEmailAddress);
+		$emailField->setValue($newEmailAddress);
 		$changeEmailButton = $this->findById($this->changeEmailButtonID);
 		$this->assertElementNotNull(
 			$changeEmailButton,

--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -130,7 +130,14 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	 * @return void
 	 */
 	public function changeEmailAddress($newEmailAddress, Session $session) {
-		$this->fillField($this->emailAddressInputID, $newEmailAddress);
+		$emailField = $this->findById($this->emailAddressInputID);
+		if (\is_null($emailField)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" could not find email field with id $this->emailAddressInputID"
+			);
+		}
+		$this->cleanInputAndSetValue($emailField, $newEmailAddress);
 		$changeEmailButton = $this->findById($this->changeEmailButtonID);
 		$this->assertElementNotNull(
 			$changeEmailButton,

--- a/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
@@ -45,7 +45,7 @@ Feature: admin general settings
     And the administrator sets the value of update channel to "daily" using the webUI
     Then the update channel should be "daily"
 
-  @smokeTest
+  @smokeTest @skipOnFIREFOX
   Scenario: administrator changes the cron job
     Given the administrator has invoked occ command "config:app:set core backgroundjobs_mode --value ajax"
     When the user reloads the current page of the webUI

--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -25,6 +25,7 @@ Feature: Add, delete and edit comments in files and folders
       | 😀 🤖       |
       | नेपालि      |
 
+  @skipOnFIREFOX
   Scenario Outline: Add comment on a shared file and check it is shown in other user's UI
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user browses directly to display the "comments" details of file "new-lorem.txt" in folder "/"

--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -27,6 +27,7 @@ Feature: deleting files and folders
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
+  @skipOnFIREFOX
   Scenario: Delete a file with problematic characters
     When the user renames the following file using the webUI
       | from-name-parts | to-name-parts   |
@@ -169,6 +170,7 @@ Feature: deleting files and folders
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
+  @skipOnFIREFOX
   Scenario: delete a file on a public share with problematic characters
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -97,6 +97,7 @@ Feature: Search
     And the user searches for "simple" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
+  @skipOnFIREFOX
   Scenario: Search for a file after name is changed
     When the user renames file "lorem.txt" to "torem.txt" using the webUI
     And the user searches for "torem" using the webUI

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -13,7 +13,6 @@ Feature: move files
     When the user renames file "data.zip" to "simple-folder/data.zip" using the webUI
     Then near file "data.zip" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
 
-  @skipOnFIREFOX
   @smokeTest
   Scenario: move a file into a folder
     When the user moves file "data.zip" into folder "simple-empty-folder" using the webUI
@@ -28,7 +27,6 @@ Feature: move files
     Then file "strängé filename (duplicate #2 &).txt" should not be listed on the webUI
     But file "strängé filename (duplicate #2 &).txt" should be listed in folder "strängé नेपाली folder empty" on the webUI
 
-  @skipOnFIREFOX
   Scenario: move a file into a folder where a file with the same name already exists
     When the user moves file "data.zip" into folder "simple-folder" using the webUI
     And the user moves file "data.zip" into folder "strängé नेपाली folder" using the webUI
@@ -37,14 +35,12 @@ Feature: move files
       | Could not move "data.zip", target exists |
     And file "data.zip" should be listed on the webUI
 
-  @skipOnFIREFOX
   Scenario: move a file into a folder where a file with the same name already exists
     When the user moves file "strängé filename (duplicate #2 &).txt" into folder "strängé नेपाली folder" using the webUI
     Then notifications should be displayed on the webUI with the text
       | Could not move "strängé filename (duplicate #2 &).txt", target exists |
     And file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
 
-  @skipOnFIREFOX
   @smokeTest
   Scenario: Move multiple files at once
     When the user batch moves these files into folder "simple-empty-folder" using the webUI
@@ -56,7 +52,6 @@ Feature: move files
     And the moved elements should not be listed on the webUI after a page reload
     But the moved elements should be listed in folder "simple-empty-folder" on the webUI
 
-  @skipOnFIREFOX
   Scenario: move a file into a folder (problematic characters)
     When the user renames the following file using the webUI
       | from-name-parts | to-name-parts   |
@@ -83,7 +78,6 @@ Feature: move files
       | question?       | question?           |
       | &and#hash       | &and#hash           |
 
-  @skipOnFIREFOX
   Scenario: move files on a public share
     Given the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -35,6 +35,7 @@ Feature: move files
       | Could not move "data.zip", target exists |
     And file "data.zip" should be listed on the webUI
 
+  @skipOnFIREFOX
   Scenario: move a file into a folder where a file with the same name already exists
     When the user moves file "strängé filename (duplicate #2 &).txt" into folder "strängé नेपाली folder" using the webUI
     Then notifications should be displayed on the webUI with the text
@@ -52,6 +53,7 @@ Feature: move files
     And the moved elements should not be listed on the webUI after a page reload
     But the moved elements should be listed in folder "simple-empty-folder" on the webUI
 
+  @skipOnFIREFOX
   Scenario: move a file into a folder (problematic characters)
     When the user renames the following file using the webUI
       | from-name-parts | to-name-parts   |

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
@@ -11,6 +11,7 @@ Feature: Change own email address on the personal settings page
 
   @issue-32385
   @smokeTest
+  @skipOnFIREFOX
   Scenario: Change email address
     When the user changes the email address to "new-address@owncloud.com" using the webUI
     # When the issue is fixed, remove the following step and replace with the commented-out step

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @skipOnFIREFOX
 Feature: rename files
   As a user
   I want to rename files

--- a/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @skipOnFIREFOX
 Feature: Renaming files inside a folder with problematic name
   As a user
   I want to rename a file

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -136,6 +136,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     But file "lorem-big.txt" should not be listed on the webUI
     And the content of "renamed file.txt" on the local server should be the same as the original "simple-folder/lorem-big.txt"
 
+  @skipOnFIREFOX
   Scenario: rename a file in a received share - remote server shares - local server receives
     Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
     And the user has reloaded the current page of the webUI
@@ -278,6 +279,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And using server "LOCAL"
     Then as "user1" file "simple-folder/simple-empty-folder/lorem.txt" should exist
 
+  @skipOnFIREFOX
   Scenario: rename a file in a folder inside a shared folder
     Given user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
     And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -33,7 +33,7 @@ Feature: Sharing files and folders with internal groups
     And file "testimage (2).jpg" should be listed on the webUI
     And file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
 
-  @TestAlsoOnExternalUserBackend
+  @TestAlsoOnExternalUserBackend @skipOnFIREFOX
   Scenario: share a file with an internal group a member overwrites and unshares the file
     Given user "user3" has logged in using the webUI
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -25,7 +25,7 @@ Feature: Sharing files and folders with internal users
     Then file "lorem.txt" should be listed on the webUI
     But folder "simple-folder (2)" should not be listed on the webUI
 
-  @TestAlsoOnExternalUserBackend
+  @TestAlsoOnExternalUserBackend @skipOnFIREFOX
   Scenario: share a file with another internal user who overwrites and unshares the file
     Given user "user2" has logged in using the webUI
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
@@ -96,6 +96,7 @@ Feature: Sharing files and folders with internal users
     And the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
+  @skipOnFIREFOX
   Scenario: share a folder with other user and then it should be listed on Shared with You for other user
     Given user "user2" has logged in using the webUI
     And the user has renamed folder "simple-folder" to "new-simple-folder" using the webUI

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -45,6 +45,7 @@ Feature: Creation of tags for the files and folders
     And the user toggles a tag "lorem" on the file using the webUI
     Then file "simple-folder/lorem.txt" should have no tags for user "user1"
 
+  @skipOnFIREFOX
   Scenario: Create and add tag on a shared file
     When the user renames file "lorem.txt" to "coolnewfile.txt" using the webUI
     And the user browses directly to display the details of file "coolnewfile.txt" in folder ""
@@ -60,6 +61,7 @@ Feature: Creation of tags for the files and folders
       | tag1 | normal |
       | tag2 | normal |
 
+  @skipOnFIREFOX
   Scenario: Delete a tag in a shared file
     When the user renames file "lorem.txt" to "coolnewfile.txt" using the webUI
     And the user browses directly to display the details of file "coolnewfile.txt" in folder ""

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -24,6 +24,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And the deleted elements should be listed in the trashbin on the webUI
     And file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
 
+  @skipOnFIREFOX
   Scenario: Delete a file with problematic characters and check it is in the trashbin
     When the user renames the following file using the webUI
       | from-name-parts | to-name-parts   |

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -24,6 +24,7 @@ Feature: File Upload
     And file "big-video.mp4" should be listed on the webUI
     And the content of "big-video.mp4" should be the same as the local "big-video.mp4"
 
+  @skipOnFIREFOX
   Scenario: conflict with a chunked file
     Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
     When the user renames file "lorem.txt" to "big-video.mp4" using the webUI

--- a/tests/acceptance/features/webUIWebdavLocks/unlock.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/unlock.feature
@@ -106,6 +106,7 @@ Feature: Unlock locked files and folders
       | exclusive |
       | shared    |
 
+  @skipOnFIREFOX
   Scenario: deleting the first one of multiple shared locks on the webUI
     Given these users have been created:
       | username  |
@@ -144,6 +145,7 @@ Feature: Unlock locked files and folders
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver1" by the WebDAV API
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver2" by the WebDAV API
 
+  @skipOnFIREFOX
   Scenario: deleting the second one of multiple shared locks on the webUI
     Given these users have been created:
       | username  |
@@ -182,6 +184,7 @@ Feature: Unlock locked files and folders
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver1" by the WebDAV API
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver2" by the WebDAV API
 
+  @skipOnFIREFOX
   Scenario: deleting the last one of multiple shared locks on the webUI
     Given these users have been created:
       | username  |


### PR DESCRIPTION
## Description
run UI tests in drone on Firefox without using saucelabs

by using the selenium docker containers we are able to run tests in Firefox same as we do in Chrome. This PR
1. sets the environment for it
2. un-skips a couple of tests that actually do run in this version of selenium and firefox
3. fixes one input. setting the Email  address didn't work correctly in Firefox if the field was pre-filled 

Limitations:
1. this might break FF tests in travis, because it un-skips some tests. Question: do we need the travis runs with FF if we run them in drone
2. currently we are limited to selenium 3.8.1, because 3.9.0 removed the `enablePassThrough` option. So without changing the docker container we are limited to Firefox 58.0

## Motivation and Context
get more independent of travis & saucelabs

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

