### PR TITLE
[WIP] allow renaming usernames

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -156,6 +156,7 @@ class Users {
 		}
 
 		try {
+			// FIXME add username
 			$newUser = $this->userManager->createUser($userId, $password);
 			$this->logger->info('Successful addUser call with userid: '.$userId, ['app' => 'ocs_api']);
 

--- a/lib/private/User/Account.php
+++ b/lib/private/User/Account.php
@@ -28,6 +28,7 @@ use OCP\UserInterface;
  * Class Account
  *
  * @method string getUserId()
+ * @method void setUserId(string $userId)
  * @method string getDisplayName()
  * @method void setDisplayName(string $displayName)
  * @method string getEmail()
@@ -37,7 +38,7 @@ use OCP\UserInterface;
  * @method string getBackend()
  * @method void setBackend(string $backEnd)
  * @method int getState()
- * @method void setState(integer $state)
+ * @method void setState(int $state)
  * @method string getQuota()
  * @method void setQuota(string $quota)
  * @method string getHome()
@@ -70,11 +71,17 @@ class Account extends Entity {
 	}
 
 	/**
-	 * @param string $uid
+	 * @return string
 	 */
-	public function setUserId($uid) {
-		parent::setter('lowerUserId', [\strtolower($uid)]);
-		parent::setter('userId', [$uid]);
+	public function getUserName() {
+		return parent::getter('lowerUserId');
+	}
+
+	/**
+	 * @param string $userName
+	 */
+	public function setUserName($userName) {
+		parent::setter('lowerUserId', [$userName]);
 	}
 
 	/**

--- a/lib/private/User/AccountMapper.php
+++ b/lib/private/User/AccountMapper.php
@@ -113,7 +113,7 @@ class AccountMapper extends Mapper {
 		// it's the whole email
 		$qb->select('*')
 			->from($this->getTableName())
-			->where($qb->expr()->eq($qb->createFunction('LOWER(`email`)'), $qb->createFunction('LOWER(' . $qb->createNamedParameter($email) . ')')));
+			->where($qb->expr()->iLike('email', $qb->createNamedParameter($this->db->escapeLikeParameter($email))));
 
 		return $this->findEntities($qb->getSQL(), $qb->getParameters());
 	}
@@ -128,7 +128,22 @@ class AccountMapper extends Mapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
 			->from($this->getTableName())
-			->where($qb->expr()->eq('lower_user_id', $qb->createNamedParameter(\strtolower($uid))));
+			->where($qb->expr()->iLike('user_id', $qb->createNamedParameter($this->db->escapeLikeParameter($uid))));
+
+		return $this->findEntity($qb->getSQL(), $qb->getParameters());
+	}
+
+	/**
+	 * @param string $userName
+	 * @throws DoesNotExistException if the account does not exist
+	 * @throws MultipleObjectsReturnedException if more than one account exists
+	 * @return Account
+	 */
+	public function getByUserName($userName) {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->iLike('lower_user_id', $qb->createNamedParameter($this->db->escapeLikeParameter($userName))));
 
 		return $this->findEntity($qb->getSQL(), $qb->getParameters());
 	}
@@ -172,7 +187,8 @@ class AccountMapper extends Mapper {
 			->from($this->getTableName(), 'a')
 			->leftJoin('a', 'account_terms', 't', $qb->expr()->eq('a.id', 't.account_id'))
 			->orderBy('display_name')
-			->where($qb->expr()->like('lower_user_id', $qb->createNamedParameter($loweredParameter)))
+			->where($qb->expr()->iLike('lower_user_id', $qb->createNamedParameter($parameter)))
+			->orWhere($qb->expr()->iLike('user_id', $qb->createNamedParameter($parameter)))
 			->orWhere($qb->expr()->iLike('display_name', $qb->createNamedParameter($parameter)))
 			->orWhere($qb->expr()->iLike('email', $qb->createNamedParameter($parameter)))
 			->orWhere($qb->expr()->like('t.term', $qb->createNamedParameter($loweredParameter)));

--- a/lib/private/User/BasicAuthModule.php
+++ b/lib/private/User/BasicAuthModule.php
@@ -100,7 +100,7 @@ class BasicAuthModule implements IAuthModule {
 			$users = $this->manager->getByEmail($authUser);
 			$count = \count($users);
 			if ($count === 1) {
-				$user = $this->manager->checkPassword($users[0]->getUID(), $authPass);
+				$user = $this->manager->checkPassword($users[0]->getUserName(), $authPass);
 				if ($user instanceof IUser) {
 					// only update timeout on success
 					$this->session->set('last_check_timeout', $now);

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -216,21 +216,17 @@ class Database extends Backend implements IUserBackend, IProvidesHomeBackend, IP
 
 	/**
 	 * Check if the password is correct
+	 *
 	 * @param string $uid The username
 	 * @param string $password The password
-	 * @return string
+	 * @param string $login the username or email
+	 * @return string|false
 	 *
 	 * Check if the password is correct without logging in the user
 	 * returns the user id or false
+	 * @throws \OC\DatabaseException
 	 */
-	public function checkPassword($loginName, $password) {
-		try {
-			$account = \OC::$server->getAccountMapper()->getByUserName($loginName);
-		} catch (DoesNotExistException $ex) {
-			return false;
-		}
-		$uid = $account->getUserId();
-
+	public function checkPassword($uid, $password, $login = null) {
 		$query = \OC_DB::prepare('SELECT `uid`, `password` FROM `*PREFIX*users` WHERE LOWER(`uid`) = LOWER(?)');
 		$result = $query->execute([$uid]);
 
@@ -243,7 +239,7 @@ class Database extends Backend implements IUserBackend, IProvidesHomeBackend, IP
 					$this->setPassword($uid, $password);
 					unset($this->cache[$uid]); // invalidate cache
 				}
-				return $uid;
+				return $row['uid'];
 			}
 		}
 

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -94,6 +94,10 @@ class Database extends Backend implements IUserBackend, IProvidesHomeBackend, IP
 		// forbid that? might break existing users? force them to change their
 		// username on next login?
 
+		if ($userName === null) {
+			$userName = $uid;
+		}
+
 		unset($this->cache[$uid]); // make sure we are reading from the db
 		if (!$this->userExists($uid)) {
 			$query = \OC_DB::prepare('INSERT INTO `*PREFIX*users` ( `uid`, `password` ) VALUES( ?, ? )');

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -354,9 +354,9 @@ class Manager extends PublicEmitter implements IUserManager {
 	}
 
 	/**
-	 * @param string $uid
+	 * @param string $uid (optional) required if $userName is null
 	 * @param string $password
-	 * @param string $userName
+	 * @param string $userName (optional) if omitted uid will be used
 	 * @throws \Exception
 	 * @return bool|IUser the created user or false
 	 */
@@ -365,13 +365,12 @@ class Manager extends PublicEmitter implements IUserManager {
 			$l = \OC::$server->getL10N('lib');
 
 			if ($uid === null && $userName === null) {
-				throw new \Exception($l->t('A valid user name must be provided'));
+				throw new \Exception($l->t('A user id or user name must be provided'));
 			}
 
 			if ($uid !== null && $userName === null) {
-				// use uid as username, generate uid
+				// use uid as username
 				$userName = $uid;
-				$uid = null;
 			}
 
 			if ($uid === null) {

--- a/lib/private/User/RemoteUser.php
+++ b/lib/private/User/RemoteUser.php
@@ -33,6 +33,9 @@ class RemoteUser implements IUser {
 	/** @var string */
 	private $userId;
 
+	/** @var string */
+	private $userName;
+
 	/**
 	 * RemoteUser constructor.
 	 *
@@ -40,13 +43,34 @@ class RemoteUser implements IUser {
 	 */
 	public function __construct($userId) {
 		$this->userId = $userId;
+		// FIXME set username correctly
+		$this->userName = $userId;
+	}
+
+	/**
+	 * @inheritdoc
+	 * @deprecated
+	 */
+	public function getUID() {
+		return $this->getUserId();
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function getUID() {
+	public function getUserId() {
 		return $this->userId;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getUserName() {
+		return $this->userName;
+	}
+
+	public function setUserName($userName) {
+		$this->userName = \trim($userName);
 	}
 
 	/**
@@ -156,9 +180,18 @@ class RemoteUser implements IUser {
 	 * @inheritdoc
 	 */
 	public function getCloudId() {
-		$uid = $this->getUID();
+		$uid = $this->getUserId();
 		$server = \OC::$server->getURLGenerator()->getAbsoluteURL('/');
 		return $uid . '@' . \rtrim($this->removeProtocolFromUrl($server), '/');
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getCloudName() {
+		$name = $this->getUserName();
+		$server = \OC::$server->getURLGenerator()->getAbsoluteURL('/');
+		return $name . '@' . \rtrim($this->removeProtocolFromUrl($server), '/');
 	}
 
 	/**

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -307,13 +307,13 @@ class Session implements IUserSession, Emitter {
 	 * @return boolean|null
 	 * @throws LoginException
 	 */
-	public function login($uid, $password) {
+	public function login($loginName, $password) {
 		$this->session->regenerateId();
 
-		if ($this->validateToken($password, $uid)) {
+		if ($this->validateToken($password, $loginName)) {
 			return $this->loginWithToken($password);
 		}
-		return $this->loginWithPassword($uid, $password);
+		return $this->loginWithPassword($loginName, $password);
 	}
 
 	/**
@@ -322,7 +322,7 @@ class Session implements IUserSession, Emitter {
 	 * Checks token auth enforced
 	 * Checks 2FA enabled
 	 *
-	 * @param string $user
+	 * @param string $loginName
 	 * @param string $password
 	 * @param IRequest $request
 	 * @throws \InvalidArgumentException
@@ -344,7 +344,7 @@ class Session implements IUserSession, Emitter {
 		if (!$this->login($user, $password)) {
 			$users = $this->manager->getByEmail($user);
 			if (\count($users) === 1) {
-				return $this->login($users[0]->getUID(), $password);
+				return $this->login($users[0]->getUserName(), $password);
 			}
 			return false;
 		}
@@ -616,8 +616,10 @@ class Session implements IUserSession, Emitter {
 			return false;
 		}
 
+		$userName = $uid; // FIXME does apache auth return username or uid? auth actually only returns a login -> username
+
 		// Now we try to create the account or sync
-		$this->userSyncService->createOrSyncAccount($uid, $backend);
+		$this->userSyncService->createOrSyncAccount($uid, $backend, $userName);
 
 		$user = $this->manager->get($uid);
 		if ($user === null) {

--- a/lib/private/User/SyncService.php
+++ b/lib/private/User/SyncService.php
@@ -103,7 +103,7 @@ class SyncService {
 		// update existing and insert new users
 		foreach ($userIds as $uid) {
 			try {
-				$account = $this->createOrSyncAccount($uid, $backend);
+				$account = $this->createOrSyncAccount($uid, $backend, $uid);
 				$uid = $account->getUserId(); // get correct case
 				// clean the user's preferences
 				$this->cleanPreferences($uid);

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -118,11 +118,49 @@ class User implements IUser {
 	 * get the user id
 	 *
 	 * @return string
+	 * @deprecated use getUserId or getUserName to clarify code
 	 */
 	public function getUID() {
+		// TODO log deprecation warning
+		return $this->getUserId();
+	}
+
+	/**
+	 * get the user id
+	 *
+	 * @return string
+	 */
+	public function getUserId() {
 		return $this->account->getUserId();
 	}
 
+	/**
+	 * get the user name
+	 *
+	 * @return string
+	 * @since 10.0.9
+	 */
+	public function getUserName() {
+		return $this->account->getUserName();
+	}
+
+	/**
+	 * set the user name
+	 *
+	 * @param string|null $userName
+	 * @return void
+	 * @since 10.0.9
+	 */
+	public function setUserName($userName) {
+		// TODO add check if allowed?
+		$userName = \trim($userName);
+		if ($userName === $this->account->getUserName()) {
+			return;
+		}
+		$this->account->setUserName($userName);
+		$this->mapper->update($this->account);
+		$this->triggerChange('userName', $userName);
+	}
 	/**
 	 * get the display name for the user, if no specific display name is set it will fallback to the user id
 	 *
@@ -131,7 +169,7 @@ class User implements IUser {
 	public function getDisplayName() {
 		$displayName = $this->account->getDisplayName();
 		if (empty($displayName)) {
-			$displayName = $this->getUID();
+			$displayName = $this->getUserName();
 		}
 		return $displayName;
 	}

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -171,6 +171,9 @@ class User implements IUser {
 		if (empty($displayName)) {
 			$displayName = $this->getUserName();
 		}
+		if (empty($displayName)) {
+			$displayName = $this->getUserId();
+		}
 		return $displayName;
 	}
 
@@ -491,9 +494,18 @@ class User implements IUser {
 	 * @since 9.0.0
 	 */
 	public function getCloudId() {
-		$uid = $this->getUID();
+		$uid = $this->getUserId();
 		$server = $this->urlGenerator->getAbsoluteURL('/');
 		return $uid . '@' . \rtrim($this->removeProtocolFromUrl($server), '/');
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getCloudName() {
+		$name = $this->getUserName();
+		$server = $this->urlGenerator->getAbsoluteURL('/');
+		return $name . '@' . \rtrim($this->removeProtocolFromUrl($server), '/');
 	}
 
 	/**

--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -212,11 +212,8 @@ class OC_User {
 	public static function setUserId($uid) {
 		$userSession = \OC::$server->getUserSession();
 		$userManager = \OC::$server->getUserManager();
-		if ($user = $userManager->get($uid)) {
-			$userSession->setUser($user);
-		} else {
-			\OC::$server->getSession()->set('user_id', $uid);
-		}
+		$user = $userManager->get($uid);
+		$userSession->setUser($user);
 	}
 
 	/**

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -38,8 +38,32 @@ interface IUser {
 	 *
 	 * @return string
 	 * @since 8.0.0
+	 * @deprecated use getUserId or getUserName to clarify code
 	 */
 	public function getUID();
+	/**
+	 * get the user id
+	 *
+	 * @return string
+	 * @since 10.0.9
+	 */
+	public function getUserId();
+
+	/**
+	 * get the user name
+	 *
+	 * @return string
+	 * @since 10.0.9
+	 */
+	public function getUserName();
+
+	/**
+	 * set the user name
+	 *
+	 * @param string $userName
+	 * @since 10.0.9
+	 */
+	public function setUserName($userName);
 
 	/**
 	 * get the display name for the user, if no specific display name is set it will fallback to the user id

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -197,6 +197,14 @@ interface IUser {
 	public function getCloudId();
 
 	/**
+	 * get the federation cloud name
+	 *
+	 * @return string
+	 * @since 10.0.9
+	 */
+	public function getCloudName();
+
+	/**
 	 * set the email address of the user
 	 *
 	 * @param string|null $mailAddress

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -76,8 +76,27 @@ interface IUserManager {
 	 * @param string $uid
 	 * @return \OCP\IUser|null Either the user or null if the specified user does not exist
 	 * @since 8.0.0
+	 * @deprecated use getByUserId or getByUserName to clarify code
 	 */
 	public function get($uid);
+
+	/**
+	 * get a user by user id
+	 *
+	 * @param string $uid
+	 * @return \OCP\IUser|null Either the user or null if the specified user does not exist
+	 * @since 10.0.9
+	 */
+	public function getByUserId($uid);
+
+	/**
+	 * get a user by user name
+	 *
+	 * @param string $userName
+	 * @return \OCP\IUser|null Either the user or null if the specified user does not exist
+	 * @since 10.0.9
+	 */
+	public function getByUserName($userName);
 
 	/**
 	 * check if a user exists
@@ -134,11 +153,12 @@ interface IUserManager {
 	/**
 	 * @param string $uid
 	 * @param string $password
+	 * @param string $userName
 	 * @throws \Exception
 	 * @return bool|\OCP\IUser the created user of false
 	 * @since 8.0.0
 	 */
-	public function createUser($uid, $password);
+	public function createUser($uid = null, $password, $userName = null);
 
 	/**
 	 * returns how many users per backend exist (if supported by backend)
@@ -180,8 +200,9 @@ interface IUserManager {
 	 * @param string $uid
 	 * @param string $password
 	 * @param UserInterface $backend
+	 * @param string $userName
 	 * @return IUser | null
 	 * @since 10.0
 	 */
-	public function createUserFromBackend($uid, $password, $backend);
+	public function createUserFromBackend($uid, $password, $backend, $userName);
 }

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -393,7 +393,7 @@ class AppTest extends \Test\TestCase {
 	 *
 	 * @dataProvider appConfigValuesProvider
 	 */
-	public function testEnabledApps($user, $expectedApps, $forceAll) {
+	public function testEnabledApps($userName, $expectedApps, $forceAll) {
 		$groupManager = \OC::$server->getGroupManager();
 		$user1 = $this->createUser(self::TEST_USER1, self::TEST_USER1);
 		$user2 = $this->createUser(self::TEST_USER2, self::TEST_USER2);
@@ -406,7 +406,12 @@ class AppTest extends \Test\TestCase {
 		$group2->addUser($user2);
 		$group2->addUser($user3);
 
-		\OC_User::setUserId($user);
+		if ($userName !== null) {
+			$user = \OC::$server->getUserManager()->getByUserName($userName);
+			\OC_User::setUserId($user->getUserId());
+		} else {
+			\OC_User::setUserId(null);
+		}
 
 		$this->setupAppConfigMock()->expects($this->once())
 			->method('getValues')

--- a/tests/lib/Cache/FileCacheTest.php
+++ b/tests/lib/Cache/FileCacheTest.php
@@ -22,6 +22,7 @@
 
 namespace Test\Cache;
 
+use OCP\User;
 use Test\Traits\UserTrait;
 
 /**
@@ -38,6 +39,10 @@ class FileCacheTest extends TestCache {
 	 * @var string
 	 * */
 	private $user;
+	/**
+	 * @var User
+	 * */
+	private $testUser;
 	/**
 	 * @var string
 	 * */
@@ -68,14 +73,14 @@ class FileCacheTest extends TestCache {
 		$config->setSystemValue('cachedirectory', $datadir);
 
 		//login
-		$this->createUser('test', 'test');
+		$this->testUser = $this->createUser('test', 'test');
 
 		$this->user = \OC_User::getUser();
-		\OC_User::setUserId('test');
+		\OC_User::setUserId($this->testUser->getUserId());
 
 		//set up the users dir
 		$this->rootView = new \OC\Files\View('');
-		$this->rootView->mkdir('/test');
+		$this->rootView->mkdir("/{$this->testUser->getUserId()}");
 
 		$this->instance=new \OC\Cache\File();
 
@@ -104,7 +109,7 @@ class FileCacheTest extends TestCache {
 			->setConstructorArgs([['datadir' => \OC::$server->getTempManager()->getTemporaryFolder()]])
 			->getMock();
 
-		\OC\Files\Filesystem::mount($mockStorage, [], '/test/cache');
+		\OC\Files\Filesystem::mount($mockStorage, [], "/{$this->testUser->getUserId()}/cache");
 
 		return $mockStorage;
 	}

--- a/tests/lib/Files/Cache/HomeCacheTest.php
+++ b/tests/lib/Files/Cache/HomeCacheTest.php
@@ -38,7 +38,7 @@ class DummyUser extends \OC\User\User {
 	/**
 	 * @return string
 	 */
-	public function getUID() {
+	public function getUserId() {
 		return $this->uid;
 	}
 }

--- a/tests/lib/Files/Cache/UpdaterLegacyTest.php
+++ b/tests/lib/Files/Cache/UpdaterLegacyTest.php
@@ -56,7 +56,7 @@ class UpdaterLegacyTest extends \Test\TestCase {
 			self::$user = $this->getUniqueID();
 		}
 
-		\OC::$server->getUserManager()->createUser(self::$user, 'password');
+		\OC::$server->getUserManager()->createUser(self::$user, 'password', self::$user.'Name');
 		$this->loginAsUser(self::$user);
 
 		Filesystem::init(self::$user, '/' . self::$user . '/files');

--- a/tests/lib/Files/Storage/HomeTest.php
+++ b/tests/lib/Files/Storage/HomeTest.php
@@ -42,7 +42,7 @@ class DummyUser extends User {
 		return $this->home;
 	}
 
-	public function getUID() {
+	public function getUserId() {
 		return $this->uid;
 	}
 }

--- a/tests/lib/Traits/UserTrait.php
+++ b/tests/lib/Traits/UserTrait.php
@@ -34,7 +34,7 @@ trait UserTrait {
 
 		$userManager = \OC::$server->getUserManager();
 		if ($password === null) {
-			if ($userName) { // frefer username as password
+			if ($userName) { // prefer username as password
 				$password = $userName;
 			} else {
 				$password = $userId;

--- a/tests/lib/Traits/UserTrait.php
+++ b/tests/lib/Traits/UserTrait.php
@@ -26,15 +26,29 @@ trait UserTrait {
 
 	private $previousUserManagerInternals;
 
-	protected function createUser($name, $password = null) {
-		if ($password === null) {
-			$password = $name;
+	// FIXME add username
+	protected function createUser($userId = null, $password = null, $userName = null) {
+		if ($userId === null && $userName === null) {
+			throw new \Exception('A user id or user name must be provided');
 		}
+
 		$userManager = \OC::$server->getUserManager();
-		if ($userManager->userExists($name)) {
-			$userManager->get($name)->delete();
+		if ($password === null) {
+			if ($userName) { // frefer username as password
+				$password = $userName;
+			} else {
+				$password = $userId;
+			}
 		}
-		$user = $userManager->createUser($name, $password);
+
+		if ($user = $userManager->getByUserId($userId)) {
+			$user->delete();
+		}
+		if ($user = $userManager->getByUserName($userName)) {
+			$user->delete();
+		}
+
+		$user = $userManager->createUser($userId, $password, $userName);
 		$this->users[] = $user;
 		return $user;
 	}

--- a/tests/lib/User/AccountMapperTest.php
+++ b/tests/lib/User/AccountMapperTest.php
@@ -60,7 +60,8 @@ class AccountMapperTest extends TestCase {
 			}
 
 			$account = new Account();
-			$account->setUserId("TestFind$i");
+			$account->setUserId("TestId$i");
+			$account->setUserName("TestFind$i");
 			$account->setDisplayName("Test Find $i");
 			$account->setEmail("test$i@find.tld");
 			$account->setBackend(self::class);
@@ -95,7 +96,7 @@ class AccountMapperTest extends TestCase {
 	 * find all, use lower case
 	 */
 	public function testFindAll() {
-		$result = $this->mapper->find("testfind");
+		$result = $this->mapper->find('testfind');
 		$this->assertCount(4, $result);
 	}
 
@@ -103,9 +104,9 @@ class AccountMapperTest extends TestCase {
 	 * find by userid, use lower case
 	 */
 	public function testFindByUserId() {
-		$result = $this->mapper->find("testfind1");
+		$result = $this->mapper->find('testid1');
 		$this->assertCount(1, $result);
-		$this->assertEquals("TestFind1", \array_shift($result)->getUserId());
+		$this->assertEquals('TestId1', \array_shift($result)->getUserId());
 	}
 
 	/**
@@ -114,7 +115,7 @@ class AccountMapperTest extends TestCase {
 	public function testFindByDisplayName() {
 		$result = $this->mapper->find('test find 2');
 		$this->assertCount(1, $result);
-		$this->assertEquals("TestFind2", \array_shift($result)->getUserId());
+		$this->assertEquals('TestId2', \array_shift($result)->getUserId());
 	}
 
 	public function findByEmailDataProvider() {
@@ -133,7 +134,7 @@ class AccountMapperTest extends TestCase {
 	public function testFindByEmail($email) {
 		$result = $this->mapper->find($email);
 		$this->assertCount(1, $result);
-		$this->assertEquals("TestFind3", \array_shift($result)->getUserId());
+		$this->assertEquals('TestId3', \array_shift($result)->getUserId());
 	}
 
 	/**
@@ -144,7 +145,7 @@ class AccountMapperTest extends TestCase {
 	public function testGetByEmail($email) {
 		$result = $this->mapper->getByEmail($email);
 		$this->assertCount(1, $result);
-		$this->assertEquals("TestFind3", \array_shift($result)->getUserId());
+		$this->assertEquals('TestId3', \array_shift($result)->getUserId());
 	}
 
 	/**
@@ -153,7 +154,7 @@ class AccountMapperTest extends TestCase {
 	public function testFindBySearchTerm() {
 		$result = $this->mapper->find('term 4 b');
 		$this->assertCount(1, $result);
-		$this->assertEquals("TestFind4", \array_shift($result)->getUserId());
+		$this->assertEquals('TestId4', \array_shift($result)->getUserId());
 	}
 
 	/**
@@ -163,17 +164,17 @@ class AccountMapperTest extends TestCase {
 		$result = $this->mapper->find('Term', 2, 2);
 		$this->assertCount(2, $result);
 		//results are ordered by display name
-		$this->assertEquals("TestFind3", \array_shift($result)->getUserId());
-		$this->assertEquals("TestFind4", \array_shift($result)->getUserId());
+		$this->assertEquals('TestId3', \array_shift($result)->getUserId());
+		$this->assertEquals('TestId4', \array_shift($result)->getUserId());
 	}
 
 	public function findUserIdsDataProvider() {
 		return [
-			[self::class, null, null, ['TestFind1','TestFind2','TestFind3','TestFind4']],
+			[self::class, null, null, ['TestId1','TestId2','TestId3','TestId4']],
 			['not existing backend', null, null, []],
-			[self::class, 1, null, ['TestFind1']],
-			[self::class, 2, 2, ['TestFind3', 'TestFind4']],
-			[self::class, 1, 3, ['TestFind4']],
+			[self::class, 1, null, ['TestId1']],
+			[self::class, 2, 2, ['TestId3', 'TestId4']],
+			[self::class, 1, 3, ['TestId4']],
 		];
 	}
 
@@ -189,10 +190,10 @@ class AccountMapperTest extends TestCase {
 
 	public function findUserIdsLoggedInDataProvider() {
 		return [
-			[self::class, null, null, ['TestFind2','TestFind4']],
+			[self::class, null, null, ['TestId2','TestId4']],
 			['not existing backend', null, null, []],
-			[self::class, 1, null, ['TestFind2']],
-			[self::class, 1, 1, ['TestFind4']],
+			[self::class, 1, null, ['TestId2']],
+			[self::class, 1, 1, ['TestId4']],
 		];
 	}
 
@@ -202,10 +203,10 @@ class AccountMapperTest extends TestCase {
 	 * @dataProvider findUserIdsLoggedInDataProvider
 	 */
 	public function testFindUserIdsLoggedIn($backend, $limit, $offset, $expected) {
-		$accounts = $this->mapper->find("TestFind2");
+		$accounts = $this->mapper->find('TestFind2');
 		$accounts[0]->setLastLogin(\time());
 		$this->mapper->update($accounts[0]);
-		$accounts = $this->mapper->find("TestFind4");
+		$accounts = $this->mapper->find('TestFind4');
 		$accounts[0]->setLastLogin(\time());
 		$this->mapper->update($accounts[0]);
 

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -52,6 +52,8 @@ class ManagerTest extends TestCase {
 		/** @var ILogger | \PHPUnit_Framework_MockObject_MockObject $logger */
 		$logger = $this->createMock(ILogger::class);
 		$this->accountMapper = $this->createMock(AccountMapper::class);
+		$this->accountMapper->method('getByEmail')->willReturn([]);
+
 		$this->syncService = $this->createMock(SyncService::class);
 
 		$this->userSearch = $this->getMockBuilder(\OCP\Util\UserSearch::class)

--- a/tests/lib/User/SyncServiceTest.php
+++ b/tests/lib/User/SyncServiceTest.php
@@ -91,10 +91,10 @@ class SyncServiceTest extends TestCase {
 		$this->mapper->expects($this->once())->method('getByUid')->with($backendUids[0])->willThrowException(new DoesNotExistException('entity not found'));
 
 		// Lets provide some config for the user
-		$this->config->expects($this->at(0))->method('getUserKeys')->with($backendUids[0], 'core')->willReturn([]);
-		$this->config->expects($this->at(1))->method('getUserKeys')->with($backendUids[0], 'login')->willReturn([]);
-		$this->config->expects($this->at(2))->method('getUserKeys')->with($backendUids[0], 'settings')->willReturn([]);
-		$this->config->expects($this->at(3))->method('getUserKeys')->with($backendUids[0], 'files')->willReturn([]);
+		$this->config->expects($this->at(0))->method('getUserKeys')->with($this->anything(), 'core')->willReturn([]);
+		$this->config->expects($this->at(1))->method('getUserKeys')->with($this->anything(), 'login')->willReturn([]);
+		$this->config->expects($this->at(2))->method('getUserKeys')->with($this->anything(), 'settings')->willReturn([]);
+		$this->config->expects($this->at(3))->method('getUserKeys')->with($this->anything(), 'files')->willReturn([]);
 
 		// Pretend we dont update anything
 		$account->expects($this->any())->method('getUpdatedFields')->willReturn([]);

--- a/tests/lib/Util/User/MemoryAccountMapper.php
+++ b/tests/lib/Util/User/MemoryAccountMapper.php
@@ -67,6 +67,17 @@ class MemoryAccountMapper extends AccountMapper {
 		return \array_values($match)[0];
 	}
 
+	public function getByUserName($userName) {
+		$match = \array_filter(self::$accounts, function (Account $a) use ($userName) {
+			return \strtolower($a->getUserName()) === \strtolower($userName);
+		});
+		if (empty($match)) {
+			throw new DoesNotExistException('');
+		}
+
+		return \array_values($match)[0];
+	}
+
 	public function getUserCount($hasLoggedIn) {
 		return \count(self::$accounts);
 	}


### PR DESCRIPTION
## Description
This PR allows renaming usernames by
* treating the lower_user_id column as the user name 
* treading the user_id column as a generated user id
* existing code asking for the uid will get the user_id, making migration unneeded:
  * existing users will keep their user_id
  * new users will get a generated id, the username will be stored in the lower_user_id column

Requires https://github.com/owncloud/user_management/pull/27

# TODO
- [ ] rename lower_user_id column - deferred for now for easier testing
- [ ] introduce new Interfaces for username vs userid. adding new methods to the existing interface may break existing apps
  - IUser
  - IUserManager
- [ ] use proper uuids instead of `uniqid()`
- [ ] sync samaccountname to the lower_user_id column (separate PR)
- [ ] Work on the tests

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/core/issues/6984
- allows us to subsequently do https://github.com/owncloud/core/issues/29503
- deprecates https://github.com/owncloud/core/pull/30617

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
username != userid != display name

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manual testing, waiting for ci

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

