### PR TITLE
Remove hardcoded DEBUG OUTPUT from OCS endpoint

### DIFF
--- a/lib/private/legacy/api.php
+++ b/lib/private/legacy/api.php
@@ -560,7 +560,7 @@ class OC_API {
 	public static function notFound() {
 		$format = \OC::$server->getRequest()->getParam('format', 'xml');
 		$txt='Invalid query, please check the syntax. API specifications are here:'
-			.' http://www.freedesktop.org/wiki/Specifications/open-collaboration-services. DEBUG OUTPUT:'."\n";
+			.' http://www.freedesktop.org/wiki/Specifications/open-collaboration-services.';
 		OC_API::respond(new \OC\OCS\Result(null, API::RESPOND_UNKNOWN_ERROR, $txt), $format);
 	}
 }

--- a/lib/private/legacy/api.php
+++ b/lib/private/legacy/api.php
@@ -34,37 +34,6 @@
 use OCP\API;
 use OCP\AppFramework\Http;
 
-/**
- * @author Bart Visscher <bartv@thisnet.nl>
- * @author Bernhard Posselt <dev@bernhard-posselt.com>
- * @author Björn Schießle <schiessle@owncloud.com>
- * @author Joas Schilling <nickvergessen@owncloud.com>
- * @author Jörn Friedrich Dreyer <jfd@butonic.de>
- * @author Lukas Reschke <lukas@owncloud.com>
- * @author Michael Gapczynski <GapczynskiM@gmail.com>
- * @author Morris Jobke <hey@morrisjobke.de>
- * @author Robin Appelman <icewind@owncloud.com>
- * @author Thomas Müller <thomas.mueller@tmit.eu>
- * @author Tom Needham <tom@owncloud.com>
- * @author Vincent Petry <pvince81@owncloud.com>
- *
- * @copyright Copyright (c) 2018, ownCloud GmbH
- * @license AGPL-3.0
- *
- * This code is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License, version 3,
- * as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License, version 3,
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *
- */
-
 class OC_API {
 
 	/**


### PR DESCRIPTION
## Description
- Removed an ugly, _caps-locked_ `DEBUG OUTPUT: \n` message from OCS API
- Since it caught my eye when opening the file on the editor, also removed a duplicated license header

## Related Issue
N/A

## Motivation and Context
Desktop clients perform a request to `<server>/ocs/v1.php/cloud/activity` to fetch [server's activity](https://github.com/owncloud/activity) - when said app (or any other under ocs namespace) is not installed - like it happens with vanilla oC installation after its unbundling on 10.0 - the request is replied with: 

```
{
    "ocs": {
        "data": [],
        "meta": {
            "message": "Invalid query, please check the syntax. API specifications are here: http://www.freedesktop.org/wiki/Specifications/open-collaboration-services. DEBUG OUTPUT:\n",
            "status": "failure",
            "statuscode": 999
        }
    }
}
```

Of course, there's better ways to determine if Activity app is enabled (e.g. https://doc.owncloud.org/server/latest/admin_manual/configuration/user/user_provisioning_api.html#apps-getapps) - however, this part of the message should be removed. 

## How Has This Been Tested?
```
curl 'https://localhost/ocs/v1.php/cloud/activity?page=0&pagesize=100&format=json' \
    -H 'OCS-APIREQUEST:true' \
    -H 'Authorization:Basic YWRtaW46YWRtaW4=' \
    -H 'User-Agent:Mozilla/5.0 (Macintosh) mirall/2.5.0master (build 9622)' 
{"ocs":{"meta":{"status":"failure","statuscode":999,"message":"Invalid query, please check the syntax. API specifications are here: http:\/\/www.freedesktop.org\/wiki\/Specifications\/open-collaboration-services."},"data":[]}}%
```

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

