### PR TITLE
API acceptance tests deduce suite from feature

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -149,6 +149,13 @@ if test "$BEHAT_FILTER_TAGS"; then
 	}'
 fi
 
+# If a feature file has been specified but no suite, then deduce the suite
+if test -n "$SCENARIO_TO_RUN" && test -z "$BEHAT_SUITE"
+then
+    FEATURE_PATH=`dirname $SCENARIO_TO_RUN`
+    BEHAT_SUITE=`basename $FEATURE_PATH`
+fi
+
 if test "$BEHAT_SUITE"; then
 	BEHAT_SUITE_OPTION="--suite=$BEHAT_SUITE"
 else


### PR DESCRIPTION
## Description
If a specific feature file is given when running API acceptance tests, and the suite has not been specified, then set the suite based on the name of the parent directory of the feature file.

## Motivation and Context
When I run a specific API acceptance test feature, but do not specify the suite that the feature is in:
```
./run.sh features/apiCapabilities/capabilities.feature
```
then lots of repeated lines spew out:
```
[Thu May  3 14:18:22 2018] Inserting dummy entry with fileid bigger than max int of 32 bits for testing
[Thu May  3 14:18:22 2018] 127.0.0.1:53482 [200]: /ocs/v1.php/apps/testing/api/v1/increasefileid
[Thu May  3 14:18:22 2018] Inserting dummy entry with fileid bigger than max int of 32 bits for testing
[Thu May  3 14:18:22 2018] 127.0.0.1:53484 [200]: /ocs/v1.php/apps/testing/api/v1/increasefileid
[Thu May  3 14:18:22 2018] Inserting dummy entry with fileid bigger than max int of 32 bits for testing
[Thu May  3 14:18:22 2018] 127.0.0.1:53486 [200]: /ocs/v1.php/apps/testing/api/v1/increasefileid
[Thu May  3 14:18:22 2018] Inserting dummy entry with fileid bigger than max int of 32 bits for testing
[Thu May  3 14:18:22 2018] 127.0.0.1:53488 [200]: /ocs/v1.php/apps/testing/api/v1/increasefileid
...
```
That is because ``behat`` is looking through every suite, running the suite setup, then running any feature/scenarios for that suite. But actually the requested feature file is only in 1 of those suites.

We can be smarter - the suite name is just the name of the parent folder of the feature file. We can work it out on-the-fly.

## How Has This Been Tested?
Local API acceptance test runs specifying a feature.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test enhancement

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
