### PR TITLE
changes to the acceptance tests needed for oauth tests

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -77,7 +77,7 @@ class WebDavHelper {
 	 * should include the subfolder if owncloud runs in a subfolder
 	 * e.g. http://localhost:8080/owncloud-core
 	 * @param string $user
-	 * @param string $password
+	 * @param string $password or token when bearer auth is used
 	 * @param string $method PUT, GET, DELETE, etc.
 	 * @param string $path
 	 * @param array $headers
@@ -86,6 +86,7 @@ class WebDavHelper {
 	 * @param int $davPathVersionToUse (1|2)
 	 * @param string $type of request
 	 * @param string $sourceIpAddress to initiate the request from
+	 * @param string $authType basic|bearer
 	 *
 	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
 	 * @throws \GuzzleHttp\Exception\BadResponseException
@@ -101,7 +102,8 @@ class WebDavHelper {
 		$requestBody = null,
 		$davPathVersionToUse = 1,
 		$type = "files",
-		$sourceIpAddress = null
+		$sourceIpAddress = null,
+		$authType = "basic"
 	) {
 		$baseUrl = self::sanitizeUrl($baseUrl, true);
 		$davPath = self::getDavPath($user, $davPathVersionToUse, $type);
@@ -115,7 +117,13 @@ class WebDavHelper {
 		if (!\is_null($requestBody)) {
 			$options['body'] = $requestBody;
 		}
-		$options['auth'] = [$user, $password];
+		
+		if ($authType === 'basic') {
+			$options['auth'] = [$user, $password];
+		}
+		if ($authType === 'bearer') {
+			$headers['Authorization'] = 'Bearer ' . $password;
+		}
 		
 		if (!\is_null($sourceIpAddress)) {
 			$options['config']


### PR DESCRIPTION
## Description
Allow bearer auth, as well as basic auth, to be used by ``makeDavRequest()``

## Motivation and Context
The ``oauth2`` app will need to use bearer auth for acceptance testing.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test infrastructure

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
