### PR TITLE
Remove session token creation for dav requests during loadApps

### DIFF
--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -129,17 +129,6 @@ class OC_App {
 		}
 		\ob_end_clean();
 
-		// once all authentication apps are loaded we can validate the session
-		if (\is_null($types) || \in_array('authentication', $types)) {
-			if (\OC::$server->getUserSession()) {
-				$request = \OC::$server->getRequest();
-				$session = \OC::$server->getUserSession();
-				$davUser = \OC::$server->getUserSession()->getSession()->get(\OCA\DAV\Connector\Sabre\Auth::DAV_AUTHENTICATED);
-				if (\is_null($davUser)) {
-					$session->validateSession();
-				}
-			}
-		}
 		if (\is_array($types)) {
 			self::$loadedTypes = \array_merge(self::$loadedTypes, $types);
 		}

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -137,24 +137,6 @@ class OC_App {
 				$davUser = \OC::$server->getUserSession()->getSession()->get(\OCA\DAV\Connector\Sabre\Auth::DAV_AUTHENTICATED);
 				if (\is_null($davUser)) {
 					$session->validateSession();
-				} else {
-					/** @var \OC\Authentication\Token\DefaultTokenProvider $tokenProvider */
-					$tokenProvider = \OC::$server->query('\OC\Authentication\Token\DefaultTokenProvider');
-					$token = null;
-					try {
-						$token = $tokenProvider->getToken($session->getSession()->getId());
-					} catch (\Exception $ex) {
-						$password = null;
-						if (isset($_SERVER['PHP_AUTH_PW'])) {
-							$password = $_SERVER['PHP_AUTH_PW'];
-						}
-
-						$session->createSessionToken($request, $session->getUser()->getUID(), $session->getLoginName(), $password);
-					}
-
-					if ($token) {
-						$tokenProvider->updateToken($token);
-					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
There was a new code path added here: https://github.com/owncloud/core/pull/28879 to create session tokens for dav requests. This is a partial revert. DAV requests use basic auth by default, which should be picked up here: 

https://github.com/owncloud/core/blob/31544601c5d3cc2f2ab63ed26c9d1c9d0648f0dc/lib/private/User/Session.php#L452

and token creation here:

https://github.com/owncloud/core/blob/31544601c5d3cc2f2ab63ed26c9d1c9d0648f0dc/lib/private/User/Session.php#L350

Which leaves this code path redundant. This can result in duplicate tokens because created causing UniqueViolation exceptions and confusing the client.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

