### PR TITLE
make sendRequest public and only send token if set

### DIFF
--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -64,7 +64,7 @@ trait Auth {
 	 *
 	 * @return void
 	 */
-	private function sendRequest(
+	public function sendRequest(
 		$url, $method, $authHeader = null, $useCookies = false
 	) {
 		$fullUrl = $this->getBaseUrl() . $url;
@@ -82,7 +82,9 @@ trait Auth {
 				$request->setHeader('Authorization', $authHeader);
 			}
 			$request->setHeader('OCS-APIREQUEST', 'true');
-			$request->setHeader('requesttoken', $this->requestToken);
+			if (isset($this->requestToken)) {
+				$request->setHeader('requesttoken', $this->requestToken);
+			}
 			$this->response = $this->client->send($request);
 		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();


### PR DESCRIPTION
## Description
making the function public and only sending the token when needed makes it possible to use the function in more cases

## Motivation and Context
use the function in acceptance tests for oauth

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

