### PR TITLE
[stable10] Backport checkAttributesForUser step from PR 30920 to stable10

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1441,6 +1441,22 @@ trait Provisioning {
 	}
 
 	/**
+	 * @Then the attributes of user :user returned by the API should include
+	 *
+	 * @param string $user
+	 * @param \Behat\Gherkin\Node\TableNode $body
+	 *
+	 * @return void
+	 */
+	public function checkAttributesForUser($user, $body) {
+		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+			$this->getAdminUsername(), "GET", "/cloud/users/$user",
+			null
+		);
+		$this->checkUserAttributes($body);
+	}
+
+	/**
 	 * @BeforeScenario
 	 * @AfterScenario
 	 *


### PR DESCRIPTION
This step was added to master in PR #30920 - but that PR (as a whole) is not to be backported.

Now we have made use of this step in PR #31351 and so the step definition/code needs to be backported into ``stable10`` so that the backport of PR #31351 can work.