### PR TITLE
also try syncing quote from preferences if backend provided no quota

### DIFF
--- a/lib/private/User/SyncService.php
+++ b/lib/private/User/SyncService.php
@@ -196,7 +196,8 @@ class SyncService {
 			if ($quota !== null) {
 				$a->setQuota($quota);
 			}
-		} else {
+		}
+		if ($quota === null) {
 			list($hasKey, $quota) = $this->readUserConfig($uid, 'files', 'quota');
 			if ($hasKey) {
 				$a->setQuota($quota);


### PR DESCRIPTION
When upgrading from 9.1 to 10 a sync of ldap users should also sync the quota when ldap does not provide a quota.

- tests included