### PR TITLE
Do not set the password again if it hasn't changed

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -165,7 +165,7 @@ class Manager implements IManager {
 			throw new \Exception($message);
 		}
 
-		\OC::$server->getEventDispatcher()->dispatch(
+		$this->eventDispatcher->dispatch(
 			'OCP\Share::validatePassword',
 			new GenericEvent(null, ['password' => $password])
 		);
@@ -921,7 +921,7 @@ class Manager implements IManager {
 			'recipientPath' => $share->getTarget(),
 			'ownerPath' => $share->getNode()->getPath(),
 			'nodeType' => $share->getNodeType()]);
-		\OC::$server->getEventDispatcher()->dispatch('fromself.unshare', $event);
+		$this->eventDispatcher->dispatch('fromself.unshare', $event);
 	}
 
 	/**

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -720,15 +720,15 @@ class Manager implements IManager {
 			// Password updated.
 			if ($share->getPassword() !== $originalShare->getPassword() ||
 					$share->getPermissions() !== $originalShare->getPermissions()) {
-				//Verify the password
+				//Verify the password. Permissions must be taken into account in case the password must be enforced
 				if ($this->passwordMustBeEnforced($share->getPermissions()) && $share->getPassword() === null) {
 					throw new \InvalidArgumentException('Passwords are enforced for link shares');
 				} else {
 					$this->verifyPassword($share->getPassword(), $share->getPermissions());
 				}
 
-				// If a password is set. Hash it!
-				if ($share->getPassword() !== null) {
+				// If a password is set. Hash it! (only if the password has changed)
+				if ($share->getPassword() !== null && $share->getPassword() !== $originalShare->getPassword()) {
 					$share->setPassword($this->hasher->hash($share->getPassword()));
 				}
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Do not set the password again in case the permissions has changed.

### Steps (copied from central)
1. share a folder with owncloud
2. choose public links
3. create new link setting a password for read only
4. Now check the modify permission

### Expected
Password-protected link still works with the password set in step 3

### Actual
Password-protected link can't be access due to weird password. Password set in step 3 doesn't work.

## Related Issue
Reported for 10.0.8 in https://central.owncloud.org/t/password-request-for-link-share/13342

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested for 10.0.8
Added unittest

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.