### PR TITLE
[Stable10] Fix overflowing public share names

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -147,8 +147,11 @@
 }
 
 .link-entry--title {
-	flex-grow  : 1;
-	font-weight: bold;
+	flex-grow    : 1;
+	font-weight  : bold;
+	overflow-x   : hidden;
+	text-overflow: ellipsis;
+	white-space  : nowrap;
 }
 
 .link-entry--icon-button {
@@ -237,10 +240,9 @@
 }
 
 .user-share--permission-preview {
-	white-space      : nowrap;
-	overflow         : hidden;
-	-ms-text-overflow: ellipsis;
-	text-overflow    : ellipsis;
+	white-space  : nowrap;
+	overflow     : hidden;
+	text-overflow: ellipsis;
 }
 
 .user-share--permission-preview li {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Long public-link titles will be ellipsed if they are "too long" to prevent pushing interactive elements out of view (and reach).

## Related Issue
https://central.owncloud.org/t/offentlicher-link-in-version-10-0-4-ist-nicht-kopierbar/11468

## Motivation and Context
See above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visual/functional test in latest FF and Chrome.
(My VM broke so pls test in IE)

## Screenshots (if appropriate):
![before-and-after](https://user-images.githubusercontent.com/12717530/35275473-2d15cc80-0040-11e8-8192-a473047062ad.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

