### PR TITLE
[stable10] Do not set the password again if it hasn't changed

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -166,7 +166,7 @@ class Manager implements IManager {
 			throw new \Exception($message);
 		}
 
-		\OC::$server->getEventDispatcher()->dispatch(
+		$this->eventDispatcher->dispatch(
 			'OCP\Share::validatePassword',
 			new GenericEvent(null, ['password' => $password])
 		);
@@ -925,7 +925,7 @@ class Manager implements IManager {
 			'recipientPath' => $share->getTarget(),
 			'ownerPath' => $share->getNode()->getPath(),
 			'nodeType' => $share->getNodeType()]);
-		\OC::$server->getEventDispatcher()->dispatch('fromself.unshare',$event);
+		$this->eventDispatcher->dispatch('fromself.unshare',$event);
 	}
 
 	/**

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -722,15 +722,15 @@ class Manager implements IManager {
 			// Password updated.
 			if ($share->getPassword() !== $originalShare->getPassword() ||
 					$share->getPermissions() !== $originalShare->getPermissions()) {
-				//Verify the password
+				//Verify the password. Permissions must be taken into account in case the password must be enforced
 				if ($this->passwordMustBeEnforced($share->getPermissions()) && $share->getPassword() === null) {
 					throw new \InvalidArgumentException('Passwords are enforced for link shares');
 				} else {
 					$this->verifyPassword($share->getPassword(), $share->getPermissions());
 				}
 
-				// If a password is set. Hash it!
-				if ($share->getPassword() !== null) {
+				// If a password is set. Hash it! (only if the password has changed)
+				if ($share->getPassword() !== null && $share->getPassword() !== $originalShare->getPassword()) {
 					$share->setPassword($this->hasher->hash($share->getPassword()));
 				}
 			}

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -23,6 +23,8 @@ namespace Test\Share20;
 use OC\Share20\Manager;
 use OC\Share20\Share;
 use OCP\Files\IRootFolder;
+use OCP\Files\File;
+use OCP\Files\Folder;
 use OCP\Files\Mount\IMountManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -2863,6 +2865,85 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertNull($calledAfterUpdate[1]->getArgument('oldexpirationdate'));
 		$this->assertArrayHasKey('shareobject', $calledAfterUpdate[1]);
 		$this->assertInstanceOf(Share::class, $calledAfterUpdate[1]->getArgument('shareobject'));
+	}
+
+	public function testUpdateShareLinkNoPasswordChange() {
+		\OC_Hook::clear('\OC\Share', 'verifyPassword');
+
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['core', 'shareapi_enabled', 'yes', 'yes'],
+				['core', 'shareapi_exclude_groups', 'no', 'no'],
+				['core', 'shareapi_allow_links', 'yes', 'yes'],
+				['core', 'shareapi_allow_public_upload', 'yes', 'yes'],
+			]));
+
+		$this->userManager->method('userExists')
+			->will($this->returnValueMap([
+				['user1', true],
+			]));
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getPath')->willReturn('/user1/files');
+
+		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		$node = $this->createMock(File::class);
+		$node->method('getPath')->willReturn('/user1/files/path/to/share');
+		$node->method('isShareable')->willReturn(true);
+		$node->method('getPermissions')->willReturn(\OCP\Constants::PERMISSION_ALL);
+
+		$originalShare = $this->createMock(IShare::class);
+		$originalShare->method('getId')->willReturn(10);
+		$originalShare->method('getFullId')->willReturn('foo:10');
+		$originalShare->method('getShareType')->willReturn(\OCP\Share::SHARE_TYPE_LINK);
+		$originalShare->method('getPassword')->willReturn('123456');
+		$originalShare->method('getPermissions')->willReturn(\OCP\Constants::PERMISSION_READ);
+		$originalShare->method('getSharedBy')->willReturn('user1');
+		$originalShare->method('getNode')->willReturn($node);
+
+		$provider = $this->createMock(IShareProvider::class);
+		$provider->method('getShareById')
+			->with($this->equalTo(10), $this->anything())
+			->willReturn($originalShare);
+
+		// TODO: Mocking the factory should be done in the setup.
+		$this->factory = $this->createMock(IProviderFactory::class);
+		$this->factory->method('getProvider')->willReturn($provider);
+		$this->factory->method('getProviderForType')->willReturn($provider);
+
+		$this->manager = new Manager(
+			$this->logger,
+			$this->config,
+			$this->secureRandom,
+			$this->hasher,
+			$this->mountManager,
+			$this->groupManager,
+			$this->l,
+			$this->factory,
+			$this->userManager,
+			$this->rootFolder,
+			$this->eventDispatcher
+		);
+
+		$share = $this->createMock(IShare::class);
+		$share->method('getId')->willReturn(10);
+		$share->method('getFullId')->willReturn('foo:10');
+		$share->method('getShareType')->willReturn(\OCP\Share::SHARE_TYPE_LINK);
+		$share->method('getPassword')->willReturn('123456');
+		$share->method('getPermissions')->willReturn(\OCP\Constants::PERMISSION_UPDATE);
+		$share->method('getSharedBy')->willReturn('user1');
+		$share->method('getNode')->willReturn($node);
+
+		$share->expects($this->never())
+			->method('setPassword');
+
+		$provider->expects($this->once())
+			->method('update')
+			->with($share)
+			->will($this->returnArgument(0));
+
+		$updatedShare = $this->manager->updateShare($share);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Backport of https://github.com/owncloud/core/pull/31367 to stable10

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually checked against 10.0.8

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

