### PR TITLE
API test for apiProvisioningUsingAppPassword

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
@@ -1,0 +1,65 @@
+@api
+Feature: access user provisioning API using app password
+As an ownCloud user
+I want to be able to use the provisioning API with an app password
+So that I can make a client app or script for provisioning users/groups that can use an app password instead of my real password.
+	Background:
+		Given using API version "1"
+
+	Scenario: admin deletes the user
+		Given user "brand-new-user" has been created
+		And group "new-group" has been created
+		And a new client token for "admin" has been generated
+		And a new browser session for "admin" has been started
+		And the user has generated a new app password named "my-client"
+		When the user requests "/ocs/v1.php/cloud/users/brand-new-user" with "DELETE" using the generated app password 
+		Then the HTTP status code should be "200"
+		And user "brand-new-user" should not exist
+
+	Scenario: subadmin gets user of his group
+		Given user "brand-new-user" has been created
+		And user "another-new-user" has been created
+		And group "new-group" has been created
+		And user "another-new-user" has been added to group "new-group"
+		And user "brand-new-user" has been made a subadmin of group "new-group"
+		And a new client token for "brand-new-user" has been generated
+		And a new browser session for "brand-new-user" has been started
+		And the user has generated a new app password named "my-client"
+		When the user requests "/ocs/v1.php/cloud/users" with "GET" using the generated app password 
+		Then the users returned by the API should be
+			| another-new-user |
+		And the HTTP status code should be "200"
+
+	Scenario: normal user gets his own information using the app password
+		Given user "newuser" has been created
+		And a new client token for "newuser" has been generated
+		Given a new browser session for "newuser" has been started
+		And the user has generated a new app password named "my-client"
+		When the user requests "/ocs/v1.php/cloud/users/newuser" with "GET" using the generated app password
+		Then the HTTP status code should be "200"
+		And the display name returned by the API should be "newuser"
+
+	Scenario: subadmin tries to get users of other group
+		Given user "brand-new-user" has been created
+		And user "another-new-user" has been created
+		And group "new-group" has been created
+		And group "another-new-group" has been created
+		And user "another-new-user" has been added to group "another-new-group"
+		And user "brand-new-user" has been made a subadmin of group "new-group"
+		And a new client token for "brand-new-user" has been generated
+		And a new browser session for "brand-new-user" has been started
+		And the user has generated a new app password named "my-client"
+		When the user requests "/ocs/v1.php/cloud/users" with "GET" using the generated app password 
+		Then the users returned by the API should not include "another-new-user"
+		And the HTTP status code should be "200"
+
+	Scenario: normal user tries to get other user information using the app password
+		Given user "newuser" has been created
+		And user "anotheruser" has been created
+		And a new client token for "newuser" has been generated
+		Given a new browser session for "newuser" has been started
+		And the user has generated a new app password named "my-client"
+		When the user requests "/ocs/v1.php/cloud/users/anotheruser" with "GET" using the generated app password
+		Then the OCS status code should be "997"
+		And the HTTP status code should be "401"
+		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
@@ -1,0 +1,64 @@
+@api
+Feature: access user provisioning API using app password
+As an ownCloud user
+I want to be able to use the provisioning API with an app password
+So that I can make a client app or script for provisioning users/groups that can use an app password instead of my real password.
+	Background:
+		Given using API version "2"
+
+	Scenario: admin deletes the user
+		Given user "brand-new-user" has been created
+		And group "new-group" has been created
+		And a new client token for "admin" has been generated
+		And a new browser session for "admin" has been started
+		And the user has generated a new app password named "my-client"
+		When the user requests "/ocs/v2.php/cloud/users/brand-new-user" with "DELETE" using the generated app password 
+		Then the HTTP status code should be "200"
+		And user "brand-new-user" should not exist
+
+	Scenario: subadmin gets user of his group
+		Given user "brand-new-user" has been created
+		And user "another-new-user" has been created
+		And group "new-group" has been created
+		And user "another-new-user" has been added to group "new-group"
+		And user "brand-new-user" has been made a subadmin of group "new-group"
+		And a new client token for "brand-new-user" has been generated
+		And a new browser session for "brand-new-user" has been started
+		And the user has generated a new app password named "my-client"
+		When the user requests "/ocs/v2.php/cloud/users" with "GET" using the generated app password 
+		Then the users returned by the API should be
+			| another-new-user |
+		And the HTTP status code should be "200"
+
+	Scenario: normal user gets his own information using the app password
+		Given user "newuser" has been created
+		And a new client token for "newuser" has been generated
+		Given a new browser session for "newuser" has been started
+		And the user has generated a new app password named "my-client"
+		When the user requests "/ocs/v2.php/cloud/users/newuser" with "GET" using the generated app password
+		Then the HTTP status code should be "200"
+		And the display name returned by the API should be "newuser"
+
+	Scenario: subadmin tries to get users of other group
+		Given user "brand-new-user" has been created
+		And user "another-new-user" has been created
+		And group "new-group" has been created
+		And group "another-new-group" has been created
+		And user "another-new-user" has been added to group "another-new-group"
+		And user "brand-new-user" has been made a subadmin of group "new-group"
+		And a new client token for "brand-new-user" has been generated
+		And a new browser session for "brand-new-user" has been started
+		And the user has generated a new app password named "my-client"
+		When the user requests "/ocs/v1.php/cloud/users" with "GET" using the generated app password 
+		Then the users returned by the API should not include "another-new-user"
+		And the HTTP status code should be "200"
+
+	Scenario: normal user tries to get other user information using the app password
+		Given user "newuser" has been created
+		And user "anotheruser" has been created
+		And a new client token for "newuser" has been generated
+		Given a new browser session for "newuser" has been started
+		And the user has generated a new app password named "my-client"
+		When the user requests "/ocs/v2.php/cloud/users/anotheruser" with "GET" using the generated app password
+		Then the HTTP status code should be "401"
+		And the API should not return any data

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -350,6 +350,7 @@ trait Provisioning {
 			$this->userExists($user),
 			"User '$user' should not exist but does exist"
 		);
+		$this->rememberThatUserIsNotExpectedToExist($user);
 	}
 
 	/**
@@ -1139,7 +1140,6 @@ trait Provisioning {
 				$usersSimplified, $respondedArray, "", 0.0, 10, true
 			);
 		}
-
 	}
 
 	/**
@@ -1158,7 +1158,6 @@ trait Provisioning {
 				$groupsSimplified, $respondedArray, "", 0.0, 10, true
 			);
 		}
-
 	}
 
 	/**
@@ -1183,6 +1182,18 @@ trait Provisioning {
 	public function theGroupsReturnedByTheApiShouldNotInclude($group) {
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
 		PHPUnit_Framework_Assert::assertNotContains($group, $respondedArray);
+	}
+
+	/**
+	 * @Then /^the users returned by the API should not include "([^"]*)"$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function theUsersReturnedByTheApiShouldNotInclude($user) {
+		$respondedArray = $this->getArrayOfUsersResponded($this->response);
+		PHPUnit_Framework_Assert::assertNotContains($user, $respondedArray);
 	}
 
 	/**
@@ -1277,6 +1288,18 @@ trait Provisioning {
 			$user,
 			$listOfSubadmins
 		);
+	}
+
+	/**
+	 * @Then /^the display name returned by the API should be "([^"]*)"$/
+	 * 
+	 * @param string $displayname
+	 * 
+	 * @return void
+	 */
+	public function theDisplayNameReturnedByTheApiShouldBe($displayname) {
+		$responseName = $this->response->xml()->data[0]->displayname;
+		PHPUnit_Framework_Assert::assertEquals($displayname, $responseName);
 	}
 
 	/**
@@ -1507,6 +1530,16 @@ trait Provisioning {
 			null
 		);
 		$this->checkUserAttributes($body);
+	}
+
+	/**
+	 * @Then /^the API should not return any data$/
+	 * 
+	 * @return void
+	 */
+	public function theApiShouldNotReturnAnyData() {
+		$responseData = $this->response->xml()->data[0];
+		PHPUnit_Framework_Assert::assertEmpty($responseData, "Response data is not empty but it should be empty");
 	}
 
 	/**


### PR DESCRIPTION
## Description
API test to check if the ownCloud users can use userprovisioning API using app password

## Related Issue
#31533 

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

