### PR TITLE
group principals are now verified as well when sharing…

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -45,10 +45,13 @@ $principalBackend = new Principal(
 	\OC::$server->getGroupManager(),
 	'principals/'
 );
+$groupPrincipalBackend = new \OCA\DAV\DAV\GroupPrincipalBackend(
+	\OC::$server->getGroupManager()
+);
 $db = \OC::$server->getDatabaseConnection();
 $config = \OC::$server->getConfig();
 $random = \OC::$server->getSecureRandom();
-$calDavBackend = new CalDavBackend($db, $principalBackend, $config, $random, true);
+$calDavBackend = new CalDavBackend($db, $principalBackend, $groupPrincipalBackend, $random, true);
 
 $debugging = \OC::$server->getConfig()->getSystemValue('debug', false);
 

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -45,8 +45,11 @@ $principalBackend = new Principal(
 	\OC::$server->getGroupManager(),
 	'principals/'
 );
+$groupPrincipalBackend = new \OCA\DAV\DAV\GroupPrincipalBackend(
+	\OC::$server->getGroupManager()
+);
 $db = \OC::$server->getDatabaseConnection();
-$cardDavBackend = new CardDavBackend($db, $principalBackend, null, true);
+$cardDavBackend = new CardDavBackend($db, $principalBackend, $groupPrincipalBackend, null, true);
 
 $debugging = \OC::$server->getConfig()->getSystemValue('debug', false);
 

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -28,6 +28,7 @@ namespace OCA\DAV\CardDAV;
 
 use OC\Cache\CappedMemoryCache;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCA\DAV\DAV\GroupPrincipalBackend;
 use OCA\DAV\DAV\Sharing\Backend;
 use OCA\DAV\DAV\Sharing\IShareable;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -78,16 +79,19 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 *
 	 * @param IDBConnection $db
 	 * @param Principal $principalBackend
+	 * @param GroupPrincipalBackend $groupPrincipalBackend
 	 * @param EventDispatcherInterface $dispatcher
+	 * @param bool $legacyMode
 	 */
 	public function __construct(IDBConnection $db,
 								Principal $principalBackend,
+								GroupPrincipalBackend $groupPrincipalBackend,
 								EventDispatcherInterface $dispatcher = null,
 								$legacyMode = false) {
 		$this->db = $db;
 		$this->principalBackend = $principalBackend;
 		$this->dispatcher = $dispatcher;
-		$this->sharingBackend = new Backend($this->db, $principalBackend, 'addressbook');
+		$this->sharingBackend = new Backend($this->db, $principalBackend, $groupPrincipalBackend, 'addressbook');
 		$this->legacyMode = $legacyMode;
 		$this->idCache = new CappedMemoryCache();
 	}

--- a/apps/dav/lib/Command/CreateCalendar.php
+++ b/apps/dav/lib/Command/CreateCalendar.php
@@ -23,6 +23,7 @@ namespace OCA\DAV\Command;
 
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCA\DAV\DAV\GroupPrincipalBackend;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUserManager;
@@ -75,11 +76,14 @@ class CreateCalendar extends Command {
 			$this->userManager,
 			$this->groupManager
 		);
+		$groupPrincipalBackend = new GroupPrincipalBackend(
+			$this->groupManager
+		);
 		$config = \OC::$server->getConfig();
 		$random = \OC::$server->getSecureRandom();
 
 		$name = $input->getArgument('name');
-		$caldav = new CalDavBackend($this->dbConnection, $principalBackend, $config, $random);
+		$caldav = new CalDavBackend($this->dbConnection, $principalBackend, $groupPrincipalBackend, $random);
 		$caldav->createCalendar("principals/users/$user", $name, []);
 	}
 }

--- a/apps/dav/lib/DAV/GroupPrincipalBackend.php
+++ b/apps/dav/lib/DAV/GroupPrincipalBackend.php
@@ -28,7 +28,7 @@ use Sabre\DAV\PropPatch;
 use Sabre\DAVACL\PrincipalBackend\BackendInterface;
 
 class GroupPrincipalBackend implements BackendInterface {
-	const PRINCIPAL_PREFIX = 'principals/groups';
+	public const PRINCIPAL_PREFIX = 'principals/groups';
 
 	/** @var IGroupManager */
 	private $groupManager;
@@ -96,7 +96,6 @@ class GroupPrincipalBackend implements BackendInterface {
 	 *
 	 * @param string $principal
 	 * @return string[]
-	 * @throws Exception
 	 */
 	public function getGroupMemberSet($principal) {
 		$elements = \explode('/', $principal);
@@ -123,7 +122,6 @@ class GroupPrincipalBackend implements BackendInterface {
 	 *
 	 * @param string $principal
 	 * @return array
-	 * @throws Exception
 	 */
 	public function getGroupMembership($principal) {
 		return [];
@@ -167,6 +165,13 @@ class GroupPrincipalBackend implements BackendInterface {
 	 * @return string
 	 */
 	public function findByUri($uri, $principalPrefix) {
+		if (\strpos($uri, 'principal:') === 0) {
+			$principal = \substr($uri, 10);
+			$principal = $this->getPrincipalByPath($principal);
+			if ($principal !== null) {
+				return $principal['uri'];
+			}
+		}
 		return '';
 	}
 

--- a/apps/dav/lib/DAV/Sharing/Backend.php
+++ b/apps/dav/lib/DAV/Sharing/Backend.php
@@ -25,6 +25,7 @@
 namespace OCA\DAV\DAV\Sharing;
 
 use OCA\DAV\Connector\Sabre\Principal;
+use OCA\DAV\DAV\GroupPrincipalBackend;
 use OCP\IDBConnection;
 
 class Backend {
@@ -33,21 +34,25 @@ class Backend {
 	private $db;
 	/** @var Principal */
 	private $principalBackend;
+	/** @var GroupPrincipalBackend */
+	private $groupPrincipalBackend;
 	/** @var string */
 	private $resourceType;
 
-	const ACCESS_OWNER = 1;
-	const ACCESS_READ_WRITE = 2;
-	const ACCESS_READ = 3;
+	public const ACCESS_OWNER = 1;
+	public const ACCESS_READ_WRITE = 2;
+	public const ACCESS_READ = 3;
 
 	/**
 	 * @param IDBConnection $db
 	 * @param Principal $principalBackend
+	 * @param GroupPrincipalBackend $groupPrincipalBackend
 	 * @param string $resourceType
 	 */
-	public function __construct(IDBConnection $db, Principal $principalBackend, $resourceType) {
+	public function __construct(IDBConnection $db, Principal $principalBackend, GroupPrincipalBackend $groupPrincipalBackend, $resourceType) {
 		$this->db = $db;
 		$this->principalBackend = $principalBackend;
+		$this->groupPrincipalBackend = $groupPrincipalBackend;
 		$this->resourceType = $resourceType;
 	}
 
@@ -58,17 +63,25 @@ class Backend {
 	 */
 	public function updateShares($shareable, $add, $remove) {
 		foreach ($add as $element) {
-			$principal = $this->principalBackend->findByUri($element['href'], '');
+			$principal = $this->findByUri($element['href']);
 			if ($principal !== '') {
 				$this->shareWith($shareable, $element);
 			}
 		}
 		foreach ($remove as $element) {
-			$principal = $this->principalBackend->findByUri($element, '');
+			$principal = $this->findByUri($element);
 			if ($principal !== '') {
 				$this->unshare($shareable, $element);
 			}
 		}
+	}
+
+	private function findByUri($uri) {
+		$principal = $this->principalBackend->findByUri($uri, '');
+		if ($principal !== '') {
+			return $principal;
+		}
+		return $this->groupPrincipalBackend->findByUri($uri, '');
 	}
 
 	/**
@@ -174,9 +187,9 @@ class Backend {
 			$p = $this->principalBackend->getPrincipalByPath($row['principaluri']);
 			$shares[]= [
 				'href' => "principal:${row['principaluri']}",
-				'commonName' => isset($p['{DAV:}displayname']) ? $p['{DAV:}displayname'] : '',
+				'commonName' => $p['{DAV:}displayname'] ?? '',
 				'status' => 1,
-				'readOnly' => ($row['access'] == self::ACCESS_READ),
+				'readOnly' => $row['access'] == self::ACCESS_READ,
 				'{http://owncloud.org/ns}principal' => $row['principaluri'],
 				'{http://owncloud.org/ns}group-share' => $p === null
 			];
@@ -197,13 +210,13 @@ class Backend {
 		foreach ($shares as $share) {
 			$acl[] = [
 				'privilege' => '{DAV:}read',
-				'principal' => $share['{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}principal'],
+				'principal' => $share['{' . Plugin::NS_OWNCLOUD . '}principal'],
 				'protected' => true,
 			];
 			if (!$share['readOnly']) {
 				$acl[] = [
 					'privilege' => '{DAV:}write',
-					'principal' => $share['{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}principal'],
+					'principal' => $share['{' . Plugin::NS_OWNCLOUD . '}principal'],
 					'protected' => true,
 				];
 			} elseif ($this->resourceType === 'calendar') {
@@ -211,7 +224,7 @@ class Backend {
 				// so users can change the visibility.
 				$acl[] = [
 					'privilege' => '{DAV:}write-properties',
-					'principal' => $share['{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}principal'],
+					'principal' => $share['{' . Plugin::NS_OWNCLOUD . '}principal'],
 					'protected' => true,
 				];
 			}

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -58,7 +58,7 @@ class RootCollection extends SimpleCollection {
 		$systemPrincipals->disableListing = $disableListing;
 		$filesCollection = new Files\RootCollection($userPrincipalBackend, 'principals/users');
 		$filesCollection->disableListing = $disableListing;
-		$caldavBackend = new CalDavBackend($db, $userPrincipalBackend, $config, $random);
+		$caldavBackend = new CalDavBackend($db, $userPrincipalBackend, $groupPrincipalBackend, $random);
 		$calendarRoot = new CalendarRoot($userPrincipalBackend, $caldavBackend, 'principals/users');
 		$calendarRoot->disableListing = $disableListing;
 		$publicCalendarRoot = new PublicCalendarRoot($caldavBackend);
@@ -77,11 +77,11 @@ class RootCollection extends SimpleCollection {
 			\OC::$server->getRootFolder()
 		);
 
-		$usersCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, $dispatcher);
+		$usersCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, $groupPrincipalBackend, $dispatcher);
 		$usersAddressBookRoot = new AddressBookRoot($userPrincipalBackend, $usersCardDavBackend, 'principals/users');
 		$usersAddressBookRoot->disableListing = $disableListing;
 
-		$systemCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, $dispatcher);
+		$systemCardDavBackend = new CardDavBackend($db, $userPrincipalBackend, $groupPrincipalBackend, $dispatcher);
 		$systemAddressBookRoot = new AddressBookRoot(new SystemPrincipalBackend(), $systemCardDavBackend, 'principals/system');
 		$systemAddressBookRoot->disableListing = $disableListing;
 

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackendTest.php
@@ -24,6 +24,7 @@ namespace OCA\DAV\Tests\unit\CalDAV;
 
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCA\DAV\DAV\GroupPrincipalBackend;
 use OCP\IConfig;
 use OCP\Security\ISecureRandom;
 use Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet;
@@ -43,6 +44,9 @@ abstract class AbstractCalDavBackendTest extends TestCase {
 
 	/** @var Principal | \PHPUnit_Framework_MockObject_MockObject */
 	protected $principal;
+
+	/** @var GroupPrincipalBackend | \PHPUnit_Framework_MockObject_MockObject */
+	protected $groupPrincipal;
 
 	/** @var IConfig */
 	protected $config;
@@ -69,10 +73,11 @@ abstract class AbstractCalDavBackendTest extends TestCase {
 			->withAnyParameters()
 			->willReturn([self::UNIT_TEST_GROUP]);
 
+		$this->groupPrincipal = $this->createMock(GroupPrincipalBackend::class);
 		$db = \OC::$server->getDatabaseConnection();
 		$this->config = \OC::$server->getConfig();
 		$this->random = \OC::$server->getSecureRandom();
-		$this->backend = new CalDavBackend($db, $this->principal, $this->config, $this->random);
+		$this->backend = new CalDavBackend($db, $this->principal, $this->groupPrincipal, $this->random);
 
 		$this->tearDown();
 	}

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -25,6 +25,7 @@ use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\Calendar;
 use OCA\DAV\CalDAV\PublicCalendarRoot;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCA\DAV\DAV\GroupPrincipalBackend;
 use OCP\IL10N;
 use OCP\Security\ISecureRandom;
 use Test\TestCase;
@@ -54,6 +55,9 @@ class PublicCalendarRootTest extends TestCase {
 	/** @var Principal */
 	private $principal;
 
+	/** @var GroupPrincipalBackend */
+	private $groupPrincipal;
+
 	/** @var ISecureRandom */
 	private $random;
 
@@ -67,7 +71,9 @@ class PublicCalendarRootTest extends TestCase {
 		$this->config = \OC::$server->getConfig();
 		$this->random = \OC::$server->getSecureRandom();
 
-		$this->backend = new CalDavBackend($db, $this->principal, $this->config, $this->random);
+		$this->groupPrincipal = $this->createMock(GroupPrincipalBackend::class);
+
+		$this->backend = new CalDavBackend($db, $this->principal, $this->groupPrincipal, $this->random);
 
 		$this->publicCalendarRoot = new PublicCalendarRoot($this->backend);
 

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -29,6 +29,7 @@ use InvalidArgumentException;
 use OCA\DAV\CardDAV\AddressBook;
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCA\DAV\DAV\GroupPrincipalBackend;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use Sabre\DAV\PropPatch;
@@ -50,6 +51,9 @@ class CardDavBackendTest extends TestCase {
 
 	/** @var Principal | \PHPUnit_Framework_MockObject_MockObject */
 	private $principal;
+
+	/** @var GroupPrincipalBackend | \PHPUnit_Framework_MockObject_MockObject */
+	private $groupPrincipal;
 
 	/** @var  IDBConnection */
 	private $db;
@@ -79,9 +83,11 @@ class CardDavBackendTest extends TestCase {
 			->withAnyParameters()
 			->willReturn([self::UNIT_TEST_GROUP]);
 
+		$this->groupPrincipal = $this->createMock(GroupPrincipalBackend::class);
+
 		$this->db = \OC::$server->getDatabaseConnection();
 
-		$this->backend = new CardDavBackend($this->db, $this->principal, null);
+		$this->backend = new CardDavBackend($this->db, $this->principal, $this->groupPrincipal, null);
 
 		// start every test with a empty cards_properties and cards table
 		$query = $this->db->getQueryBuilder();
@@ -166,7 +172,7 @@ class CardDavBackendTest extends TestCase {
 
 		/** @var CardDavBackend | \PHPUnit_Framework_MockObject_MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)
-				->setConstructorArgs([$this->db, $this->principal, null])
+				->setConstructorArgs([$this->db, $this->principal, $this->groupPrincipal, null])
 				->setMethods(['updateProperties', 'purgeProperties'])->getMock();
 
 		// create a new address book
@@ -214,7 +220,7 @@ class CardDavBackendTest extends TestCase {
 	 */
 	public function testMultiCard() {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
-			->setConstructorArgs([$this->db, $this->principal, null])
+			->setConstructorArgs([$this->db, $this->principal, $this->groupPrincipal, null])
 			->setMethods(['updateProperties'])->getMock();
 
 		// create a new address book
@@ -263,7 +269,7 @@ class CardDavBackendTest extends TestCase {
 	 */
 	public function testDeleteWithoutCard() {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
-			->setConstructorArgs([$this->db, $this->principal, null])
+			->setConstructorArgs([$this->db, $this->principal, $this->groupPrincipal, null])
 			->setMethods([
 				'getCardId',
 				'addChange',
@@ -306,7 +312,7 @@ class CardDavBackendTest extends TestCase {
 	 */
 	public function testSyncSupport() {
 		$this->backend = $this->getMockBuilder(CardDavBackend::class)
-			->setConstructorArgs([$this->db, $this->principal, null])
+			->setConstructorArgs([$this->db, $this->principal, $this->groupPrincipal, null])
 			->setMethods(['updateProperties'])->getMock();
 
 		// create a new address book
@@ -366,7 +372,7 @@ class CardDavBackendTest extends TestCase {
 		$cardId = 2;
 
 		$backend = $this->getMockBuilder(CardDavBackend::class)
-			->setConstructorArgs([$this->db, $this->principal, null])
+			->setConstructorArgs([$this->db, $this->principal, $this->groupPrincipal, null])
 			->setMethods(['getCardId'])->getMock();
 
 		$backend->expects($this->any())->method('getCardId')->willReturn($cardId);

--- a/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
+++ b/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
@@ -26,6 +26,7 @@ use OCA\DAV\DAV\GroupPrincipalBackend;
 use OCP\IGroupManager;
 use PHPUnit_Framework_MockObject_MockObject;
 use Sabre\DAV\PropPatch;
+use OC\Group\Group;
 
 class GroupPrincipalTest extends \Test\TestCase {
 
@@ -36,7 +37,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 	private $connector;
 
 	public function setUp() {
-		$this->groupManager = $this->getMockBuilder('\OCP\IGroupManager')
+		$this->groupManager = $this->getMockBuilder(IGroupManager::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->connector = new GroupPrincipalBackend($this->groupManager);
@@ -151,11 +152,30 @@ class GroupPrincipalTest extends \Test\TestCase {
 		$this->assertSame([], $this->connector->searchPrincipals('principals/groups', []));
 	}
 
+	public function testFindByUriWithEmptyUrl() {
+		$this->assertEquals('', $this->connector->findByUri('', ''));
+	}
+
+	public function testFindByUriWithUnknownGroup() {
+		$this->assertEquals('', $this->connector->findByUri('principal:principals/groups/group1', ''));
+	}
+
+	public function testFindByUriWithKnownGroup() {
+		$group1 = $this->mockGroup('group1');
+		$this->groupManager
+			->expects($this->once())
+			->method('get')
+			->with('group1')
+			->will($this->returnValue($group1));
+		$this->assertEquals('principals/groups/group1', $this->connector->findByUri('principal:principals/groups/group1', ''));
+	}
+
 	/**
+	 * @param $gid
 	 * @return PHPUnit_Framework_MockObject_MockObject
 	 */
 	private function mockGroup($gid) {
-		$fooUser = $this->getMockBuilder('\OC\Group\Group')
+		$fooUser = $this->getMockBuilder(Group::class)
 			->disableOriginalConstructor()->getMock();
 		$fooUser
 			->expects($this->exactly(1))


### PR DESCRIPTION
… a dav resource with a group


## Description
Since 10.0.8 calendars and addressbooks can no longer be shared with groups.
This regression was introduced because of a verification was added to ensure that the principal is valid.
Group principals have simply been forgotten :man_facepalming: 

## Related Issue
fixes #31402 

## How Has This Been Tested?
- manual testing as described in  #31402

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

