### PR TITLE
Add scenario result to webUI test output

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -660,6 +660,8 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		if ($sauceUsername && $sauceAccessKey) {
 			\error_log("SAUCELABS RESULT: ($passOrFail) https://saucelabs.com/jobs/$jobId");
 			\exec('curl -X PUT -s -d "{\"passed\": ' . $passed . '}" -u ' . $sauceUsername . ':' . $sauceAccessKey . ' https://saucelabs.com/rest/v1/$SAUCE_USERNAME/jobs/' . $jobId);
+		} else {
+			\error_log("SCENARIO RESULT: ($passOrFail)");
 		}
 	}
 }


### PR DESCRIPTION
## Description
Report scenario pass/fail status in the output of webUI tests, even when the tests is not running on SauceLabs.

## Motivation and Context
When running webUI acceptance tests on Travis+SauceLabs we write the result of each scenario to the output log. This is handy for quickly finding the scenarios that failed. You can search for ``(fail)``

But when running locally or on drone, this handy output line is not written.

## How Has This Been Tested?
Local webUI test run.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Acceptance test enhancement

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
