### PR TITLE
VerifyChecksum: Ignore files which are in filecache but not in the storage

### DIFF
--- a/apps/files/tests/Command/VerifyChecksumsTest.php
+++ b/apps/files/tests/Command/VerifyChecksumsTest.php
@@ -90,7 +90,7 @@ class VerifyChecksumsTest extends TestCase {
 			if (!empty($subDir)) {
 				$currentDir = "$currentDir/$subDir";
 				if (!$userFolder->nodeExists($currentDir)) {
-					$userFolder->newFolder("$currentDir");
+					$userFolder->newFolder($currentDir);
 				}
 			}
 		}
@@ -189,8 +189,8 @@ class VerifyChecksumsTest extends TestCase {
 
 		$output = $this->cmd->getDisplay();
 
-		$this->assertContains("Mismatch for {$file1->getInternalPath()}", $output);
-		$this->assertContains("Mismatch for {$file2->getInternalPath()}", $output);
+		$this->assertContains($file1->getInternalPath(), $output);
+		$this->assertContains($file2->getInternalPath(), $output);
 		$this->assertContains(self::BROKEN_CHECKSUM_STRING, $output);
 		$this->assertContains($this->testFiles[4]['expectedChecksums'](), $output);
 		$this->assertContains($this->testFiles[7]['expectedChecksums'](), $output);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
The verifier currently produces false-positives for files which are in filecache but not on the storage.

## Related Issue
https://github.com/owncloud/enterprise/issues/2518



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

