### PR TITLE
[stable10] drop check for build event for running drone exec locally

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -93,7 +93,6 @@ pipeline:
       - ./tests/drone/install-server.sh
       - ./tests/drone/test-phpunit.sh
     when:
-      event: [push, pull_request]
       matrix:
         TEST_SUITE: phpunit
 


### PR DESCRIPTION
backport of #31439 