### PR TITLE
[master] Subadmin shouldn`t be able to add users to the group(s) he manages

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -480,8 +480,7 @@ class Users {
 			return new Result(null, 102);
 		}
 
-		// Check they're an admin or subadmin of the group
-		if (!$this->canUserManageGroup($user, $group)) {
+		if (!$this->groupManager->isAdmin($user->getUID())) {
 			return new Result(null, 104);
 		}
 

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -1722,12 +1722,10 @@ class UsersTest extends OriginalTest {
 
 		$loggedInUser = $this->createMock(IUser::class);
 		$loggedInUser
-			->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('admin'));
 		$targetGroup = $this->createMock(IGroup::class);
 		$this->userSession
-			->expects($this->once())
 			->method('getUser')
 			->will($this->returnValue($loggedInUser));
 		$this->groupManager
@@ -1750,27 +1748,22 @@ class UsersTest extends OriginalTest {
 
 		$loggedInUser = $this->createMock(IUser::class);
 		$loggedInUser
-			->expects($this->once())
 			->method('getUID')
 			->will($this->returnValue('unauthorizedUser'));
 		$targetGroup = $this->createMock(IGroup::class);
 		$this->userSession
-			->expects($this->once())
 			->method('getUser')
 			->will($this->returnValue($loggedInUser));
 		$this->groupManager
-			->expects($this->once())
 			->method('get')
 			->with('GroupToAddTo')
 			->will($this->returnValue($targetGroup));
 		$subAdminManager = $this->getMockBuilder('\OC\Subadmin')
 			->disableOriginalConstructor()->getMock();
 		$this->groupManager
-			->expects($this->once())
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 		$this->groupManager
-			->expects($this->once())
 			->method('isAdmin')
 			->with('unauthorizedUser')
 			->will($this->returnValue(false));
@@ -1811,12 +1804,10 @@ class UsersTest extends OriginalTest {
 		$subAdminManager = $this->getMockBuilder('\OC\Subadmin')
 			->disableOriginalConstructor()->getMock();
 		$subAdminManager
-			->expects($this->once())
 			->method('isSubAdminofGroup')
 			->with($loggedInUser, $targetGroup)
 			->will($this->returnValue(false));
 		$this->groupManager
-			->expects($this->once())
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 		$this->groupManager
@@ -1876,16 +1867,13 @@ class UsersTest extends OriginalTest {
 		$targetUser = $this->createMock(IUser::class);
 		$targetGroup = $this->createMock(IGroup::class);
 		$this->userSession
-			->expects($this->once())
 			->method('getUser')
 			->will($this->returnValue($loggedInUser));
 		$this->groupManager
-			->expects($this->once())
 			->method('get')
 			->with('group1')
 			->will($this->returnValue($targetGroup));
 		$this->userManager
-			->expects($this->once())
 			->method('get')
 			->with('AnotherUser')
 			->will($this->returnValue($targetUser));
@@ -1895,22 +1883,19 @@ class UsersTest extends OriginalTest {
 			->with('subadmin')
 			->will($this->returnValue(false));
 		$targetGroup
-			->expects($this->once())
 			->method('addUser')
 			->with($targetUser);
 		$subAdminManager = $this->getMockBuilder('\OC\Subadmin')
 			->disableOriginalConstructor()->getMock();
 		$subAdminManager
-			->expects($this->once())
 			->method('isSubAdminOfGroup')
 			->with($loggedInUser, $targetGroup)
 			->will($this->returnValue(true));
 		$this->groupManager
-			->expects($this->once())
 			->method('getSubAdmin')
 			->will($this->returnValue($subAdminManager));
 
-		$expected = new Result(null, 100);
+		$expected = new Result(null, 104);
 		$this->assertEquals($expected, $this->api->addToGroup(['userid' => 'AnotherUser']));
 	}
 	public function testRemoveFromGroupWithoutLogIn() {
@@ -1936,11 +1921,9 @@ class UsersTest extends OriginalTest {
 	public function testRemoveFromGroupWithNotExistingTargetGroup() {
 		$loggedInUser = $this->createMock(IUser::class);
 		$this->userSession
-			->expects($this->once())
 			->method('getUser')
 			->will($this->returnValue($loggedInUser));
 		$this->groupManager
-			->expects($this->once())
 			->method('get')
 			->with('TargetGroup')
 			->will($this->returnValue(null));

--- a/lib/private/legacy/api.php
+++ b/lib/private/legacy/api.php
@@ -492,6 +492,8 @@ class OC_API {
 				return null;
 			case 100:
 				return Http::STATUS_OK;
+			case 104:
+				return Http::STATUS_FORBIDDEN;
 		}
 		// any 2xx, 4xx and 5xx will be used as is
 		if ($sc >= 200 && $sc < 600) {

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -68,18 +68,18 @@ So that I can give a user access to the resources of the group
 		And the HTTP status code should be "200"
 		And the API should not return any data
 
-	Scenario: subadmin adds users to groups the subadmin is responsible for
+	Scenario: a subadmin can not add users to groups the subadmin is responsible for
 		Given user "subadmin" has been created
 		And user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
 		When user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
-		Then the OCS status code should be "100"
+		Then the OCS status code should be "104"
 		And the HTTP status code should be "200"
-		And user "brand-new-user" should belong to group "new-group"
+		And user "brand-new-user" should not belong to group "new-group"
 
-	Scenario: subadmin tries to add user to groups the subadmin is not responsible for
+	Scenario: a subadmin cannot add users to groups the subadmin is not responsible for
 		Given user "other-subadmin" has been created
 		And user "brand-new-user" has been created
 		And group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -76,9 +76,9 @@ So that I can give a user access to the resources of the group
 		And user "subadmin" has been made a subadmin of group "new-group"
 		When user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
-		Then the OCS status code should be "200"
-		And the HTTP status code should be "200"
-		And user "brand-new-user" should belong to group "new-group"
+		Then the OCS status code should be "403"
+		And the HTTP status code should be "403"
+		And user "brand-new-user" should not belong to group "new-group"
 
 	Scenario: subadmin tries to add user to groups the subadmin is not responsible for
 		Given user "other-subadmin" has been created
@@ -88,6 +88,6 @@ So that I can give a user access to the resources of the group
 		And user "other-subadmin" has been made a subadmin of group "other-group"
 		When user "other-subadmin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
+		Then the OCS status code should be "403"
+		And the HTTP status code should be "403"
 		And user "brand-new-user" should not belong to group "new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -66,8 +66,8 @@ So that I can manage user access to group resources
 		And user "other-subadmin" has been made a subadmin of group "other-group"
 		When user "other-subadmin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
-		Then the OCS status code should be "400"
-		And the HTTP status code should be "400"
+		Then the OCS status code should be "403"
+		And the HTTP status code should be "403"
 		And user "brand-new-user" should belong to group "new-group"
 
 	@skip @issue-31276

--- a/tests/lib/OCS/MapStatusCodeTest.php
+++ b/tests/lib/OCS/MapStatusCodeTest.php
@@ -36,7 +36,7 @@ class MapStatusCodeTest extends \Test\TestCase {
 	public function providesStatusCodes() {
 		return [
 			[Http::STATUS_OK, 100],
-			[Http::STATUS_BAD_REQUEST, 104],
+			[Http::STATUS_FORBIDDEN, 104],
 			[Http::STATUS_BAD_REQUEST, 1000],
 			[201, 201],
 		];


### PR DESCRIPTION
Forward port of PR #31337 to ``master``

## Description
Prevent sub-admins from adding users to the group they manage.

## Motivation and Context
With the current implementation a sub-admin can assimilate all users into his/her group and e.g. impersonate or delete and so one all users

## How Has This Been Tested?
- [x] Add acceptance test
- [x] Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
