### PR TITLE
[stable10] Add caldav test to drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -136,6 +136,15 @@ pipeline:
       matrix:
         INSTALL_SERVER: true
 
+  setup-caldav-tests:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - bash apps/dav/tests/travis/caldav/install.sh
+    when:
+      matrix:
+        TEST_SUITE: caldav
+
   fix-permissions:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -208,6 +217,15 @@ pipeline:
     when:
       matrix:
         TEST_SUITE: selenium
+
+  caldav-tests:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - bash apps/dav/tests/travis/caldav/script.sh
+    when:
+      matrix:
+        TEST_SUITE: caldav
 
 services:
 
@@ -696,6 +714,15 @@ matrix:
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium
       BEHAT_SUITE: webUIUpload
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+
+    # caldav test
+    - PHP_VERSION: 7.1
+      TEST_SUITE: caldav
       DB_TYPE: mariadb
       USE_SERVER: true
       INSTALL_SERVER: true


### PR DESCRIPTION
Backport #31272 

IMO we should backport this, to avoid having more conflicts in future. Then when we decide the next step of moving more caldav/carddav to drone, maybe that will backport easily.