### PR TITLE
Allow slash in group names in provisioning API

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -64,9 +64,9 @@ $groups = new Groups(
 
 API::register('get', '/cloud/groups', [$groups, 'getGroups'], 'provisioning_api', API::SUBADMIN_AUTH);
 API::register('post', '/cloud/groups', [$groups, 'addGroup'], 'provisioning_api', API::SUBADMIN_AUTH);
-API::register('get', '/cloud/groups/{groupid}', [$groups, 'getGroup'], 'provisioning_api', API::SUBADMIN_AUTH);
-API::register('delete', '/cloud/groups/{groupid}', [$groups, 'deleteGroup'], 'provisioning_api', API::ADMIN_AUTH);
-API::register('get', '/cloud/groups/{groupid}/subadmins', [$groups, 'getSubAdminsOfGroup'], 'provisioning_api', API::ADMIN_AUTH);
+API::register('get', '/cloud/groups/{groupid}', [$groups, 'getGroup'], 'provisioning_api', API::SUBADMIN_AUTH, [], ['groupid' => '.+(?<!/subadmins)$']);
+API::register('delete', '/cloud/groups/{groupid}', [$groups, 'deleteGroup'], 'provisioning_api', API::ADMIN_AUTH, [], ['groupid' => '.+']);
+API::register('get', '/cloud/groups/{groupid}/subadmins', [$groups, 'getSubAdminsOfGroup'], 'provisioning_api', API::ADMIN_AUTH, [], ['groupid' => '.+(?<!/subadmins)$']);
 
 // Apps
 $apps = new Apps(\OC::$server->getAppManager());

--- a/apps/provisioning_api/lib/Groups.php
+++ b/apps/provisioning_api/lib/Groups.php
@@ -133,6 +133,11 @@ class Groups {
 			\OCP\Util::writeLog('provisioning_api', 'Group name not supplied', \OCP\Util::ERROR);
 			return new OC_OCS_Result(null, 101, 'Invalid group name');
 		}
+		if ((\substr($groupId, -10) === '/subadmins')) {
+			\OCP\Util::writeLog('provisioning_api', 'Group name cannot end with /subadmins', \OCP\Util::ERROR);
+			return new OC_OCS_Result(null, 101, 'Invalid group name, group name cannot end with /subadmins');
+		}
+
 		// Check if it exists
 		if ($this->groupManager->groupExists($groupId)) {
 			return new OC_OCS_Result(null, 102);

--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -35,7 +35,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 
 	# Note: these groups do get created OK, but the "should exist" step fails
 	# because the API to check their existence does not work.
-	@skip @issue-31015
+	@issue-31015
 	Scenario Outline: admin creates a group with a forward-slash in the group name
 		When the administrator sends a group creation request for group "<group_id>" using the provisioning API
 		Then the OCS status code should be "100"
@@ -50,7 +50,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 
 	# A group name must not end in "/subadmins" because that would create ambiguity
 	# with the endpoint for getting the subadmins of a group
-	@skip @issue-31015
+	@issue-31015
 	Scenario: admin tries to create a group with name ending in "/subadmins"
 		Given group "new-group" has been created
 		When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -35,7 +35,7 @@ So that I can give a user access to the resources of the group
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
-	@skip @issue-31015
+	@issue-31015
 	Scenario Outline: adding a user to a group that has a forward-slash in the group name
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -34,7 +34,7 @@ So that I can remove unnecessary groups
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
-	@skip @issue-31015
+	@issue-31015
 	Scenario Outline: admin deletes a group that has a forward-slash in the group name
 		Given group "<group_id>" has been created
 		When the administrator deletes group "<group_id>" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
@@ -31,7 +31,7 @@ So that I can manage group membership
 		And the HTTP status code should be "200"
 
 	# Note: when the issue is fixed, use this scenario and delete the scenario above.
-	@skip @issue-31015
+	@issue-31015
 	Scenario: admin gets groups of an user, including groups containing a slash
 		Given user "brand-new-user" has been created
 		And group "unused-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -37,7 +37,7 @@ So that I can manage user access to group resources
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
-	@skip @issue-31015
+	@issue-31015
 	Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -35,7 +35,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 
 	# Note: these groups do get created OK, but the "should exist" step fails
 	# because the API to check their existence does not work.
-	@skip @issue-31015
+	@issue-31015
 	Scenario Outline: admin creates a group with a forward-slash in the group name
 		When the administrator sends a group creation request for group "<group_id>" using the provisioning API
 		Then the OCS status code should be "200"
@@ -50,7 +50,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 
 	# A group name must not end in "/subadmins" because that would create ambiguity
 	# with the endpoint for getting the subadmins of a group
-	@skip @issue-31015
+	@issue-31015
 	Scenario: admin tries to create a group with name ending in "/subadmins"
 		Given group "new-group" has been created
 		When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -35,7 +35,7 @@ So that I can give a user access to the resources of the group
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
-	@skip @issue-31015
+	@issue-31015
 	Scenario Outline: adding a user to a group that has a forward-slash in the group name
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -34,7 +34,7 @@ So that I can remove unnecessary groups
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
-	@skip @issue-31015
+	@issue-31015
 	Scenario Outline: admin deletes a group that has a forward-slash in the group name
 		Given group "<group_id>" has been created
 		When the administrator deletes group "<group_id>" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
@@ -31,7 +31,7 @@ So that I can manage group membership
 		And the HTTP status code should be "200"
 
 	# Note: when the issue is fixed, use this scenario and delete the scenario above.
-	@skip @issue-31015
+	@issue-31015
 	Scenario: admin gets groups of an user, including groups containing a slash
 		Given user "brand-new-user" has been created
 		And group "unused-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -37,7 +37,7 @@ So that I can manage user access to group resources
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
-	@skip @issue-31015
+	@issue-31015
 	Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created


### PR DESCRIPTION
## Description
1) In the routes for groups, allow ``groupid`` to have any characters (including ``/``) except for group names that end in ``/subadmins``
2) When creating a group, do not allow group names that end in ``/subadmins`` because that would cause conflict with being able to get the subadmins of a group.
3) Add API acceptance tests to cover these new group name possibilities

## Related Issue
#31015 

## Motivation and Context
The provisioning API should be able to manage groups with a slash in their name.

## How Has This Been Tested?
Local API acceptance test runs, and trying stuff with ``curl`` commands.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
