### PR TITLE
Save timezone as given during login

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -173,8 +173,8 @@ class LoginController extends Controller {
 		 * user is trying to access files for which he needs to login.
 		 */
 
-		if ((!empty($redirect_url)) and ($remember_login === null) and
-			($this->userSession->isLoggedIn() === false) and
+		if (!empty($redirect_url) && ($remember_login === null) &&
+			($this->userSession->isLoggedIn() === false) &&
 			(\strpos($this->urlGenerator->getAbsoluteURL(\urldecode($redirect_url)),
 				$this->urlGenerator->getAbsoluteURL('/index.php/f/')) !== false)) {
 			$parameters['accessLink'] = true;
@@ -192,9 +192,12 @@ class LoginController extends Controller {
 	 * @param string $user
 	 * @param string $password
 	 * @param string $redirect_url
+	 * @param string $timezone
 	 * @return RedirectResponse
+	 * @throws \OCP\PreConditionNotMetException
+	 * @throws \OC\User\LoginException
 	 */
-	public function tryLogin($user, $password, $redirect_url) {
+	public function tryLogin($user, $password, $redirect_url, $timezone = null) {
 		$originalUser = $user;
 		// TODO: Add all the insane error handling
 		$loginResult = $this->userSession->login($user, $password);
@@ -229,6 +232,11 @@ class LoginController extends Controller {
 
 		// User has successfully logged in, now remove the password reset link, when it is available
 		$this->config->deleteUserValue($userObject->getUID(), 'owncloud', 'lostpassword');
+
+		// Save the timezone
+		if ($timezone !== null) {
+			$this->config->setUserValue($userObject->getUID(), 'core', 'timezone', $timezone);
+		}
 
 		if ($this->twoFactorManager->isTwoFactorAuthenticated($userObject)) {
 			$this->twoFactorManager->prepareTwoFactorLogin($userObject);

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -347,7 +347,7 @@ class LoginControllerTest extends TestCase {
 
 		$expected = new RedirectResponse($indexPageUrl);
 
-		$this->loginController = $this->getMockBuilder('OC\Core\Controller\LoginController')
+		$this->loginController = $this->getMockBuilder(LoginController::class)
 			->setMethods(['getDefaultUrl'])
 			->setConstructorArgs([
 				'core',


### PR DESCRIPTION
## Description
During the login request the timezone of the browser is passed to the server.
The timezone is now saved again for later reuse.

## Related Issue
Regression as introduced with https://github.com/owncloud/core/pull/24189
https://github.com/owncloud/core/commit/d8cde414bd13c327ec2edaf1ae38380073c93e3e#diff-3267a2e9d16decfe96b1574917f584dbL1069

## How Has This Been Tested?
- manually
- unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

