### PR TITLE
Add login of test user to enforce storage creation

### DIFF
--- a/tests/acceptance/features/apiSharing-v1/updateShare.feature
+++ b/tests/acceptance/features/apiSharing-v1/updateShare.feature
@@ -254,7 +254,6 @@ Feature: sharing
 			| storage           | A_NUMBER             |
 			| mail_send         | 0                    |
 			| uid_owner         | user1                |
-			| storage_id        | home::user1          |
 			| file_parent       | A_NUMBER             |
 			| displayname_owner | user1                |
 			| mimetype          | httpd/unix-directory |

--- a/tests/lib/Repair/RemoveRootSharesTest.php
+++ b/tests/lib/Repair/RemoveRootSharesTest.php
@@ -104,6 +104,7 @@ class RemoveRootSharesTest extends \Test\TestCase {
 	public function testRootSharesDontExist() {
 		//Add test user
 		$user = $this->createUser('test', 'test');
+		$this->loginAsUser('test');
 		$userFolder = $this->rootFolder->getUserFolder('test');
 		$fileId = $userFolder->getId();
 		$user->updateLastLoginTimestamp();


### PR DESCRIPTION
## Description
fixes failing unit test on objectstore
```
There was 1 error:

1) Test\Repair\RemoveRootSharesTest::testRootSharesDontExist
OCP\Files\StorageNotAvailableException: 

/drone/server/lib/private/Files/Storage/Wrapper/Availability.php:75
/drone/server/lib/private/Files/Storage/Wrapper/Availability.php:457
/drone/server/lib/private/Files/Storage/Wrapper/Checksum.php:194
/drone/server/lib/private/Files/ObjectStore/NoopScanner.php:59
/drone/server/lib/private/Files/View.php:1361
/drone/server/lib/private/Files/View.php:1402
/drone/server/lib/private/Files/Node/Root.php:188
/drone/server/lib/private/Files/Node/Root.php:361
/drone/server/tests/lib/Repair/RemoveRootSharesTest.php:107
```

## How Has This Been Tested?
- local unit test execution with scaility

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

