### PR TITLE
Add loadAdditionalScripts hook when displaying public link page

### DIFF
--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -96,6 +96,7 @@ class ShareController extends Controller {
 	 * @param ISession $session
 	 * @param IPreview $previewManager
 	 * @param IRootFolder $rootFolder
+	 * @param EventDispatcher $eventDispatcher
 	 */
 	public function __construct($appName,
 								IRequest $request,
@@ -255,6 +256,8 @@ class ShareController extends Controller {
 	}
 
 	/**
+	 * Renders and displays the public link page template
+	 *
 	 * @PublicPage
 	 * @NoCSRFRequired
 	 *
@@ -369,6 +372,8 @@ class ShareController extends Controller {
 		} else {
 			$shareTmpl['previewImage'] = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'favicon-fb.png'));
 		}
+
+		$this->eventDispatcher->dispatch('OCA\Files_Sharing::loadAdditionalScripts');
 
 		$csp = new OCP\AppFramework\Http\ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain('\'self\'');

--- a/apps/files_sharing/tests/Controllers/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controllers/ShareControllerTest.php
@@ -71,8 +71,7 @@ class ShareControllerTest extends \Test\TestCase {
 	private $shareManager;
 	/** @var IUserManager | \PHPUnit_Framework_MockObject_MockObject */
 	private $userManager;
-	/** @var  FederatedShareProvider | \PHPUnit_Framework_MockObject_MockObject */
-	private $federatedShareProvider;
+	/** @var EventDispatcher | \PHPUnit_Framework_MockObject_MockObject */
 	private $eventDispatcher;
 
 	protected function setUp() {
@@ -85,12 +84,6 @@ class ShareControllerTest extends \Test\TestCase {
 		$this->previewManager = $this->createMock('\OCP\IPreview');
 		$this->config = $this->createMock('\OCP\IConfig');
 		$this->userManager = $this->createMock('\OCP\IUserManager');
-		$this->federatedShareProvider = $this->getMockBuilder('OCA\FederatedFileSharing\FederatedShareProvider')
-			->disableOriginalConstructor()->getMock();
-		$this->federatedShareProvider->expects($this->any())
-			->method('isOutgoingServer2serverShareEnabled')->willReturn(true);
-		$this->federatedShareProvider->expects($this->any())
-			->method('isIncomingServer2serverShareEnabled')->willReturn(true);
 		$this->eventDispatcher = new EventDispatcher();
 
 		$this->shareController = new \OCA\Files_Sharing\Controllers\ShareController(
@@ -105,8 +98,7 @@ class ShareControllerTest extends \Test\TestCase {
 			$this->session,
 			$this->previewManager,
 			$this->createMock('\OCP\Files\IRootFolder'),
-			$this->eventDispatcher,
-			$this->federatedShareProvider
+			$this->eventDispatcher
 		);
 
 		// Store current user
@@ -375,6 +367,11 @@ class ShareControllerTest extends \Test\TestCase {
 
 		$this->userManager->method('get')->with('ownerUID')->willReturn($owner);
 
+		$loadAdditionalScriptsCalled = false;
+		$this->eventDispatcher->addListener('OCA\Files_Sharing::loadAdditionalScripts', function () use (&$loadAdditionalScriptsCalled) {
+			$loadAdditionalScriptsCalled = true;
+		});
+
 		$response = $this->shareController->showShare('token');
 		$sharedTmplParams = [
 			'displayName' => 'ownerDisplay',
@@ -405,6 +402,8 @@ class ShareControllerTest extends \Test\TestCase {
 		$expectedResponse->setContentSecurityPolicy($csp);
 
 		$this->assertEquals($expectedResponse, $response);
+
+		$this->assertTrue($loadAdditionalScriptsCalled, 'Hook for loading additional scripts was called');
 	}
 
 	/**


### PR DESCRIPTION
## Description
Makes it possibles for apps to load custom JS code or styles as required
for file viewers.

## Related Issue
Fixes https://github.com/owncloud/core/issues/22328

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

