### PR TITLE
Temporarily cache objectstore stat metadata for duration of storage->getMetadata

### DIFF
--- a/lib/private/Files/ObjectStore/StatCache.php
+++ b/lib/private/Files/ObjectStore/StatCache.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @author Piotr Mrowczynski <piotr@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\ObjectStore;
+
+use OC\Files\Cache\CacheEntry;
+
+class StatCache {
+
+	/**
+	 * @var \OC\Files\Cache\CacheEntry[] $cache
+	 */
+	private $cache;
+
+	/**
+	 * @var string[] $statCacheEnabled
+	 */
+	private $statCacheEnabled;
+
+	public function __construct() {
+	}
+
+	public function enable($path) {
+		$this->statCacheEnabled[$path] = true;
+	}
+
+	public function disable($path) {
+		unset($this->statCacheEnabled[$path]);
+	}
+
+	public function put($path, CacheEntry $cache) {
+		if ($this->isEnabled($path)) {
+			$this->cache[$path] = $cache;
+		}
+	}
+
+	public function get($path) {
+		if ($this->isEnabled($path) && isset($this->cache[$path])) {
+			return $this->cache[$path];
+		}
+		return false;
+	}
+
+	private function isEnabled($path) {
+		return isset($this->statCacheEnabled[$path]);
+	}
+}


### PR DESCRIPTION
## Description
In objectstore, each filesystem attribute needed to be retrieved using separate stat -> this implements more "filesystem" like caching of these properties. 

Now, within the duration of storage->getMetadata, stat will be kept in cache and thus repetitive calls will hit stat cache instead of filecache. 

## Related Issue
This PR is much safer way of avoiding filecache hits then cache of filecache globally - https://github.com/owncloud/core/pull/28166.  

## How Has This Been Tested?
I used diagnostic app

### Old implementation - single put - files_primary_s3 

{"type":"SUMMARY","reqId":"uSvspzacGpeHBg5MWWB6","time":"2018-05-19T23:22:33+00:00","remoteAddr":"::1","user":"admin","method":"PUT","url":"\/octest\/remote.php\/dav\/files\/admin\/testnew.txt","diagnostics":{"**totalSQLQueries":176**,"totalSQLDurationmsec":20.77317237854004,"totalSQLParams":405,"totalEvents":16,"totalEventsDurationmsec":61.043500900268555}}

### New implementation - single put - files_primary_s3 

{"type":"SUMMARY","reqId":"N3I4Dz8W75GB6yScxrCi","time":"2018-05-19T23:23:13+00:00","remoteAddr":"::1","user":"admin","method":"PUT","url":"\/octest\/remote.php\/dav\/files\/admin\/testnew.txt","diagnostics":{**"totalSQLQueries":136**,"totalSQLDurationmsec":16.56365394592285,"totalSQLParams":318,"totalEvents":16,"totalEventsDurationmsec":45.438289642333984}}

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@butonic @DeepDiver1975 @PVince81 @patrickjahns  