### PR TITLE
Use udiff format for php-cs-fixer diff output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ test-php-lint: $(composer_dev_deps)
 
 .PHONY: test-php-style
 test-php-style: $(composer_dev_deps)
-	$(composer_deps)/bin/php-cs-fixer fix -v --diff --dry-run --allow-risky yes
+	$(composer_deps)/bin/php-cs-fixer fix -v --diff --diff-format udiff --dry-run --allow-risky yes
 
 .PHONY: test
 test: test-php-lint test-php-style test-php test-js test-acceptance


### PR DESCRIPTION
## Description
Use the ``udiff`` format when logging diffs of ``php-cs-fixer`` code style fixes.

## Related Issue

## Motivation and Context
Currently ``php-cs-fixer`` uses a diff output format that:
1) does not provide line numbers (making it more annoying when trying to find the problem place in the code)
2) outputs contents of the whole file after the point of the first diff (making the output annoying long)

These days there is a ``--diff-format udiff`` option which provides a diff that solves the above issues, and looks a lot more like the diff that developers will be used to seeing for patches etc.

## How Has This Been Tested?
Make some rubbish changes to code, then run:
```
make test-php-style
```
and see more compact diff output.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test/code quality infrastructure

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
