### PR TITLE
Objectstore storage metadata layer handler

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreMetadata.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreMetadata.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * @author Piotr Mrowczynski <piotr@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\ObjectStore;
+
+use OCP\Files\Cache\ICache;
+
+/**
+ * Metadata cache for objectstorage file objects.
+ *
+ * ObjectStore uses oc_filecache as storage metadata representation, thus
+ * this class serves as filecache (storage metadata caching layer).
+ */
+class ObjectStoreMetadata extends \OC\Files\Cache\Cache {
+
+	/**
+	 * @@var \OC\Files\Cache\CacheEntry
+	 */
+	private $fileCacheEntry = null;
+
+	/**
+	 * @param \OC\Files\Storage\Storage|string $storage
+	 */
+	public function __construct($storage) {
+		parent::__construct($storage);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function get($file) {
+		$key = $this->getPathKey($this->getNumericStorageId(), $file);
+		if ($this->isFileCacheMatch($key)) {
+			return $this->fileCacheEntry;
+		}
+
+		// Cache only single objects metadata
+		$data = parent::get($file);
+		if ($data && $data->getMimeType() !== 'httpd/unix-directory') {
+			$this->fileCacheEntry = $data;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getId($file) {
+		$key = $this->getPathKey($this->getNumericStorageId(), $file);
+		if ($this->isFileCacheMatch($key)) {
+			return $this->fileCacheEntry->getId();
+		}
+		return parent::getId($file);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getPathById($id) {
+		$key = $this->getIdKey($this->getNumericStorageId(), $id);
+		if ($this->isFileCacheMatch($key)) {
+			return $this->fileCacheEntry->getPath();
+		}
+		return parent::getPathById($id);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getAll() {
+		return parent::getAll();
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getFolderContentsById($fileId) {
+		return parent::getFolderContentsById($fileId);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function search($pattern) {
+		return parent::search($pattern);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function searchByMime($mimetype) {
+		return parent::searchByMime($mimetype);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function searchByTag($tag, $userId) {
+		return parent::searchByTag($tag, $userId);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function insert($file, array $data) {
+		$this->invalidateFileCache();
+		return parent::insert($file, $data);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function update($id, array $data) {
+		$this->invalidateFileCache();
+		parent::update($id, $data);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function remove($file) {
+		$this->invalidateFileCache();
+		parent::remove($file);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function move($source, $target) {
+		$this->invalidateFileCache();
+		parent::move($source, $target);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath) {
+		$this->invalidateFileCache();
+		parent::moveFromCache($sourceCache, $sourcePath, $targetPath);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function clear() {
+		$this->invalidateFileCache();
+		parent::clear();
+	}
+
+	/**
+	 * Construct unique id key
+	 */
+	private function getIdKey($storageId, $id) {
+		return $storageId.'-id-'.$id;
+	}
+
+	/**
+	 * Construct unique path key
+	 */
+	private function getPathKey($storageId, $path) {
+		return $storageId.'-path-'.$path;
+	}
+
+	/**
+	 * Check if there is match between the requested key and
+	 * filecache entry
+	 */
+	private function isFileCacheMatch($key) {
+		// Cache only repetitive calls to the same record
+		if (!isset($this->fileCacheEntry)) {
+			return false;
+		}
+
+		$storageId = $this->fileCacheEntry->getStorageId();
+		$id = $this->fileCacheEntry->getId();
+		$path = $this->fileCacheEntry->getPath();
+		if ($key === $this->getIdKey($storageId, $id) ||
+			$key === $this->getPathKey($storageId, $path)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Invalidate cache entry
+	 */
+	private function invalidateFileCache() {
+		unset($this->fileCacheEntry);
+	}
+}

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -501,4 +501,18 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		}
 		return parent::restoreVersion($internalPath, $versionId);
 	}
+
+	public function getCache($path = '', $storage = null) {
+		// If storage is not specified, it means ObjectStoreStorage storage has to be used
+		if (!$storage) {
+			$storage = $this;
+		}
+
+		// ObjectStore uses oc_filecache as storage metadata representation, thus
+		// set and return ObjectStoreMetadata as filecache (storage metadata caching layer)
+		if (!isset($storage->cache)) {
+			$storage->cache = new ObjectStoreMetadata($storage);
+		}
+		return $storage->cache;
+	}
 }


### PR DESCRIPTION
## Description
This PR implements metadata handler for objectstorage file objects. This is objectstore storage filecache handler, as in objectstore implementation filecache is storage source of truth.

## Related Issue
- Obsoletes https://github.com/owncloud/core/pull/31482

- This PR is much safer way of avoiding filecache hits then cache of filecache globally https://github.com/owncloud/core/pull/28166

## Motivation and Context

Metastore handler uses single object entries caching. Objectstore metadata cache can be safely used since in objectstore, filecache is source of truth. However, to ensure high level of filecache -> storage cache consistency, only one object entry is being cached at the time, and any other call than ->get clears the cache. This sort of caching ensures that repetitive calls to filecache for the same object are consistent across application logic.

## How Has This Been Tested?
Diagnostic app with new file puts

#### "master" branch with files_primary_s3 implementation

New & edit single file PUT

{"type":"SUMMARY","reqId":"65HpLqGkulVX9tsLkZoX","time":"2018-05-20T12:53:35+00:00","remoteAddr":"::1","user":"admin","method":"PUT","url":"\/octest\/remote.php\/dav\/files\/admin\/testnew.txt","diagnostics":{**"totalSQLQueries":177**,"totalSQLDurationmsec":20.37215232849121,"totalSQLParams":400,"totalEvents":16,"totalEventsDurationmsec":52.40273475646973}}

{"type":"SUMMARY","reqId":"4ShcmHORhPgT6GKWdHY5","time":"2018-05-20T12:53:35+00:00","remoteAddr":"::1","user":"admin","method":"PUT","url":"\/octest\/remote.php\/dav\/files\/admin\/testnew.txt","diagnostics":{**"totalSQLQueries":177,**"totalSQLDurationmsec":19.32239532470703,"totalSQLParams":407,"totalEvents":16,"totalEventsDurationmsec":63.67301940917969}}

#### "objectstore metalayer" branch with files_primary_s3 implementation

New & edit single file PUT

{"type":"SUMMARY","reqId":"yEkjg1qNcTeAbkr1r9Mu","time":"2018-05-20T12:52:38+00:00","remoteAddr":"::1","user":"admin","method":"PUT","url":"\/octest\/remote.php\/dav\/files\/admin\/testnew.txt","diagnostics":{**"totalSQLQueries":136**,"totalSQLDurationmsec":17.536163330078125,"totalSQLParams":318,"totalEvents":16,"totalEventsDurationmsec":44.013261795043945}}

{"type":"SUMMARY","reqId":"vGxuK4coHDR5KWz21wes","time":"2018-05-20T12:52:38+00:00","remoteAddr":"::1","user":"admin","method":"PUT","url":"\/octest\/remote.php\/dav\/files\/admin\/testnew.txt","diagnostics":{**"totalSQLQueries":119**,"totalSQLDurationmsec":16.158103942871094,"totalSQLParams":291,"totalEvents":16,"totalEventsDurationmsec":49.94559288024902}}

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.