### PR TITLE
Remove depreciated function which is not in interface specification

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -750,21 +750,6 @@ class Cache implements ICache {
 	}
 
 	/**
-	 * get all file ids on the files on the storage
-	 *
-	 * @return int[]
-	 */
-	public function getAll() {
-		$sql = 'SELECT `fileid` FROM `*PREFIX*filecache` WHERE `storage` = ?';
-		$result = $this->connection->executeQuery($sql, [$this->getNumericStorageId()]);
-		$ids = [];
-		while ($row = $result->fetch()) {
-			$ids[] = $row['fileid'];
-		}
-		return $ids;
-	}
-
-	/**
 	 * find a folder in the cache which has not been fully scanned
 	 *
 	 * If multiple incomplete folders are in the cache, the one with the highest id will be returned,
@@ -799,33 +784,6 @@ class Cache implements ICache {
 				return '';
 			}
 			return $row['path'];
-		} else {
-			return null;
-		}
-	}
-
-	/**
-	 * get the storage id of the storage for a file and the internal path of the file
-	 * unlike getPathById this does not limit the search to files on this storage and
-	 * instead does a global search in the cache table
-	 *
-	 * @param int $id
-	 * @deprecated use getPathById() instead
-	 * @return array first element holding the storage id, second the path
-	 */
-	public static function getById($id) {
-		$connection = \OC::$server->getDatabaseConnection();
-		$sql = 'SELECT `storage`, `path` FROM `*PREFIX*filecache` WHERE `fileid` = ?';
-		$result = $connection->executeQuery($sql, [$id]);
-		if ($row = $result->fetch()) {
-			$numericId = $row['storage'];
-			$path = $row['path'];
-		} else {
-			return null;
-		}
-
-		if ($id = Storage::getStorageId($numericId)) {
-			return [$id, $path];
 		} else {
 			return null;
 		}

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -456,17 +456,6 @@ class CacheTest extends TestCase {
 		$this->assertEquals([], $this->cache->getFolderContents('foo'));
 	}
 
-	public function testGetById() {
-		$storageId = $this->storage->getId();
-		$data = ['size' => 1000, 'mtime' => 20, 'mimetype' => 'foo/file'];
-		$id = $this->cache->put('foo', $data);
-
-		if (\strlen($storageId) > 64) {
-			$storageId = \md5($storageId);
-		}
-		$this->assertEquals([$storageId, 'foo'], Cache::getById($id));
-	}
-
 	public function testStorageMTime() {
 		$data = ['size' => 1000, 'mtime' => 20, 'mimetype' => 'foo/file'];
 		$this->cache->put('foo', $data);
@@ -487,10 +476,9 @@ class CacheTest extends TestCase {
 	public function testLongId() {
 		$storage = new LongId([]);
 		$cache = $storage->getCache();
-		$storageId = $storage->getId();
 		$data = ['size' => 1000, 'mtime' => 20, 'mimetype' => 'foo/file'];
 		$id = $cache->put('foo', $data);
-		$this->assertEquals([\md5($storageId), 'foo'], Cache::getById($id));
+		$this->assertEquals('foo', $cache->getPathById($id));
 	}
 
 	/**

--- a/tests/lib/Files/Cache/WatcherTest.php
+++ b/tests/lib/Files/Cache/WatcherTest.php
@@ -31,7 +31,6 @@ class WatcherTest extends \Test\TestCase {
 	protected function tearDown() {
 		foreach ($this->storages as $storage) {
 			$cache = $storage->getCache();
-			$ids = $cache->getAll();
 			$cache->clear();
 		}
 

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -110,7 +110,6 @@ class ViewTest extends TestCase {
 		\OC_User::setUserId($this->user);
 		foreach ($this->storages as $storage) {
 			$cache = $storage->getCache();
-			$ids = $cache->getAll();
 			$cache->clear();
 		}
 


### PR DESCRIPTION
## Description

This function is not in ICache interface, is depreciated and no longer used (in legal way I know at least)

## How Has This Been Tested?

Unit/integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

