### PR TITLE
Exclude users from sharing if they are a member of any excluded group

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1505,14 +1505,11 @@ class Manager implements IManager {
 			}
 			$user = $this->userManager->get($userId);
 			$usersGroups = $this->groupManager->getUserGroupIds($user);
-			if (!empty($usersGroups)) {
-				$remainingGroups = \array_diff($usersGroups, $excludedGroups);
-				// if the user is only in groups which are disabled for sharing then
-				// sharing is also disabled for the user
-				if (empty($remainingGroups)) {
-					$this->sharingDisabledForUsersCache[$userId] = true;
-					return true;
-				}
+			$matchingGroups = \array_intersect($usersGroups, $excludedGroups);
+			if (!empty($matchingGroups)) {
+				// If the user is a member of any of the excluded groups they cannot use sharing
+				$this->sharingDisabledForUsersCache[$userId] = true;
+				return true;
 			}
 		}
 

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1587,13 +1587,13 @@ class ManagerTest extends \Test\TestCase {
 		$data[] = ['yes', 'group1,group2', \json_encode(['group1', 'group2']), [], false];
 
 		// Old list partly groups in common
-		$data[] = ['yes', 'group1,group2', \json_encode(['group1', 'group2']), ['group1', 'group3'], false];
+		$data[] = ['yes', 'group1,group2', \json_encode(['group1', 'group2']), ['group1', 'group3'], true];
 
 		// Old list only groups in common
 		$data[] = ['yes', 'group1,group2', \json_encode(['group1', 'group2']), ['group1'], true];
 
 		// New list partly in common
-		$data[] = ['yes', \json_encode(['group1', 'group2']), null, ['group1', 'group3'], false];
+		$data[] = ['yes', \json_encode(['group1', 'group2']), null, ['group1', 'group3'], true];
 
 		// New list only groups in common
 		$data[] = ['yes', \json_encode(['group1', 'group2']), null, ['group2'], true];


### PR DESCRIPTION
## Description
Sharing is disabled, if a user is a member of any of the excluded groups.

## Related Issue
https://github.com/owncloud/enterprise/issues/2508

## Motivation and Context
The existing feature is redundant if the user gets added to another group. 

## How Has This Been Tested?
Manually. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

