### PR TITLE
Split public password enforced capabilities into read-only, read_writ…

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -70,7 +70,14 @@ class Capabilities implements ICapability {
 			$public['enabled'] = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes';
 			if ($public['enabled']) {
 				$public['password'] = [];
-				$public['password']['enforced'] = ($this->config->getAppValue('core', 'shareapi_enforce_links_password', 'no') === 'yes');
+				$public['password']['enforced_for'] = [];
+				$roPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_only', 'no') === 'yes';
+				$rwPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write', 'no') === 'yes';
+				$woPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_write_only', 'no') === 'yes';
+				$public['password']['enforced_for']['read_only'] = $roPasswordEnforced;
+				$public['password']['enforced_for']['read_write'] = $rwPasswordEnforced;
+				$public['password']['enforced_for']['upload_only'] = $woPasswordEnforced;
+				$public['password']['enforced'] = $roPasswordEnforced || $rwPasswordEnforced || $woPasswordEnforced;
 
 				$public['expire_date'] = [];
 				$public['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no') === 'yes';

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -296,7 +296,7 @@ class ApiTest extends TestCase {
 		$this->assertTrue($result->succeeded());
 	}
 
-	public function testEnfoceLinkPassword() {
+	public function testEnforceLinkPassword() {
 		$appConfig = \OC::$server->getAppConfig();
 		$appConfig->setValue('core', 'shareapi_enforce_links_password_read_only', 'yes');
 

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -119,28 +119,56 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertTrue($result['public']['enabled']);
 	}
 
-	public function testLinkPassword() {
+	public function linkPasswordProvider() {
+		return [
+			['no', 'no', 'yes'],
+			['no', 'yes', 'no'],
+			['no', 'yes', 'yes'],
+			['yes', 'no', 'no'],
+			['yes', 'no', 'yes'],
+			['yes', 'yes', 'no'],
+			['yes', 'yes', 'yes'],
+		];
+	}
+
+	/**
+	 * @dataProvider linkPasswordProvider
+	 */
+	public function testLinkPassword($readOnly, $readWrite, $writeOnly) {
 		$map = [
 			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
-			['core', 'shareapi_enforce_links_password', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_only', 'no', $readOnly],
+			['core', 'shareapi_enforce_links_password_read_write', 'no', $readWrite],
+			['core', 'shareapi_enforce_links_password_write_only', 'no', $writeOnly],
 		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('password', $result['public']);
 		$this->assertArrayHasKey('enforced', $result['public']['password']);
+		$this->assertArrayHasKey('enforced_for', $result['public']['password']);
 		$this->assertTrue($result['public']['password']['enforced']);
+
+		$this->assertEquals($readOnly === 'yes', $result['public']['password']['enforced_for']['read_only']);
+		$this->assertEquals($readWrite === 'yes', $result['public']['password']['enforced_for']['read_write']);
+		$this->assertEquals($writeOnly === 'yes', $result['public']['password']['enforced_for']['upload_only']);
 	}
 
 	public function testLinkNoPassword() {
 		$map = [
 			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
-			['core', 'shareapi_enforce_links_password', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_read_only', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_read_write', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_write_only', 'no', 'no'],
 		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('password', $result['public']);
 		$this->assertArrayHasKey('enforced', $result['public']['password']);
+		$this->assertArrayHasKey('enforced_for', $result['public']['password']);
 		$this->assertFalse($result['public']['password']['enforced']);
+		$this->assertFalse($result['public']['password']['enforced_for']['read_only']);
+		$this->assertFalse($result['public']['password']['enforced_for']['read_write']);
+		$this->assertFalse($result['public']['password']['enforced_for']['upload_only']);
 	}
 
 	public function testLinkNoExpireDate() {

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -180,29 +180,83 @@ Feature: capabilities
 			| files         | undelete                              | 1                 |
 			| files         | versioning                            | 1                 |
 
-	Scenario: Changing password enforce
-		Given parameter "shareapi_enforce_links_password" of app "core" has been set to "yes"
+	Scenario: Changing "password enforced for read-only public link shares"
+		Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | 1                 |
-			| files_sharing | public@@@send_mail                    | EMPTY             |
-			| files_sharing | public@@@social_share                 | 1                 |
-			| files_sharing | public@@@password@@@enforced          | 1                 |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+			| capability    | path_to_element                                | value             |
+			| core          | pollinterval                                   | 60                |
+			| core          | webdav-root                                    | remote.php/webdav |
+			| files_sharing | api_enabled                                    | 1                 |
+			| files_sharing | public@@@enabled                               | 1                 |
+			| files_sharing | public@@@upload                                | 1                 |
+			| files_sharing | public@@@send_mail                             | EMPTY             |
+			| files_sharing | public@@@social_share                          | 1                 |
+			| files_sharing | public@@@password@@@enforced_for@@@read_only   | 1                 |
+			| files_sharing | public@@@password@@@enforced_for@@@read_write  | EMPTY             |
+			| files_sharing | public@@@password@@@enforced_for@@@upload_only | EMPTY             |
+			| files_sharing | resharing                                      | 1                 |
+			| files_sharing | federation@@@outgoing                          | 1                 |
+			| files_sharing | federation@@@incoming                          | 1                 |
+			| files_sharing | group_sharing                                  | 1                 |
+			| files_sharing | share_with_group_members_only                  | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled                     | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
+			| files         | bigfilechunking                                | 1                 |
+			| files         | undelete                                       | 1                 |
+			| files         | versioning                                     | 1                 |
+
+	Scenario: Changing "password enforced for read-write public link shares"
+		Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
+			| capability    | path_to_element                                | value             |
+			| core          | pollinterval                                   | 60                |
+			| core          | webdav-root                                    | remote.php/webdav |
+			| files_sharing | api_enabled                                    | 1                 |
+			| files_sharing | public@@@enabled                               | 1                 |
+			| files_sharing | public@@@upload                                | 1                 |
+			| files_sharing | public@@@send_mail                             | EMPTY             |
+			| files_sharing | public@@@social_share                          | 1                 |
+			| files_sharing | public@@@password@@@enforced_for@@@read_only   | EMPTY             |
+			| files_sharing | public@@@password@@@enforced_for@@@read_write  | 1                 |
+			| files_sharing | public@@@password@@@enforced_for@@@upload_only | EMPTY             |
+			| files_sharing | resharing                                      | 1                 |
+			| files_sharing | federation@@@outgoing                          | 1                 |
+			| files_sharing | federation@@@incoming                          | 1                 |
+			| files_sharing | group_sharing                                  | 1                 |
+			| files_sharing | share_with_group_members_only                  | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled                     | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
+			| files         | bigfilechunking                                | 1                 |
+			| files         | undelete                                       | 1                 |
+			| files         | versioning                                     | 1                 |
+
+	Scenario: Changing "password enforced for write-only public link shares"
+		Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
+			| capability    | path_to_element                                | value             |
+			| core          | pollinterval                                   | 60                |
+			| core          | webdav-root                                    | remote.php/webdav |
+			| files_sharing | api_enabled                                    | 1                 |
+			| files_sharing | public@@@enabled                               | 1                 |
+			| files_sharing | public@@@upload                                | 1                 |
+			| files_sharing | public@@@send_mail                             | EMPTY             |
+			| files_sharing | public@@@social_share                          | 1                 |
+			| files_sharing | public@@@password@@@enforced_for@@@read_only   | EMPTY             |
+			| files_sharing | public@@@password@@@enforced_for@@@read_write  | EMPTY             |
+			| files_sharing | public@@@password@@@enforced_for@@@upload_only | 1                 |
+			| files_sharing | resharing                                      | 1                 |
+			| files_sharing | federation@@@outgoing                          | 1                 |
+			| files_sharing | federation@@@incoming                          | 1                 |
+			| files_sharing | group_sharing                                  | 1                 |
+			| files_sharing | share_with_group_members_only                  | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled                     | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
+			| files         | bigfilechunking                                | 1                 |
+			| files         | undelete                                       | 1                 |
+			| files         | versioning                                     | 1                 |
 
 	Scenario: Changing public notifications
 		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"

--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -81,9 +81,23 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 				],
 				[
 					'capabilitiesApp' => 'files_sharing',
-					'capabilitiesParameter' => 'public@@@password@@@enforced',
+					'capabilitiesParameter' => 'public@@@password@@@enforced_for@@@read_only',
 					'testingApp' => 'core',
-					'testingParameter' => 'shareapi_enforce_links_password',
+					'testingParameter' => 'shareapi_enforce_links_password_read_only',
+					'testingState' => false
+				],
+				[
+					'capabilitiesApp' => 'files_sharing',
+					'capabilitiesParameter' => 'public@@@password@@@enforced_for@@@read_write',
+					'testingApp' => 'core',
+					'testingParameter' => 'shareapi_enforce_links_password_read_write',
+					'testingState' => false
+				],
+				[
+					'capabilitiesApp' => 'files_sharing',
+					'capabilitiesParameter' => 'public@@@password@@@enforced_for@@@upload_only',
+					'testingApp' => 'core',
+					'testingParameter' => 'shareapi_enforce_links_password_write_only',
 					'testingState' => false
 				],
 				[


### PR DESCRIPTION
…e and write_only

## Description
Report the 3 different capabilities for public link shares:
```
[public][enforced_for][read_only]
[public][enforced_for][read_write]
[public][enforced_for][upload_only]
```

If all are enforced then set the "old" capability:
```
[public][enforced]
```
so that an "old" client will at least know when public link passwords are always enforced.

## Related Issue
#31492 

## Motivation and Context
Clients need to be able to know the detailed settings for these, so they can be nice to users.

## How Has This Been Tested?
Run the new/changed acceptance tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
It fixes a "bug" because this information should have been exposed by the original PR.
It is a "feature" because it is now changing the "API" for getting these capabilities.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

If this is the way to go, then capabilities doc will need updating.