### PR TITLE
Add API test for creating a public read-write share of a file

### DIFF
--- a/tests/acceptance/features/apiSharing-v1/createShare.feature
+++ b/tests/acceptance/features/apiSharing-v1/createShare.feature
@@ -53,7 +53,7 @@ Feature: sharing
 			| permissions            | 19                 |
 			| uid_owner              | user0              |
 
-	Scenario: Creating a new public share
+	Scenario: Creating a new public share of a file
 		Given user "user0" has been created
 		When user "user0" creates a share using the API with settings
 			| path      | welcome.txt |
@@ -62,7 +62,7 @@ Feature: sharing
 		And the HTTP status code should be "200"
 		And the last public shared file should be able to be downloaded without a password
 
-	Scenario: Creating a new public share with password
+	Scenario: Creating a new public share of a file with password
 		Given user "user0" has been created
 		When user "user0" creates a share using the API with settings
 			| path      | welcome.txt |
@@ -71,6 +71,23 @@ Feature: sharing
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the last public shared file should be able to be downloaded with password "publicpw"
+
+	Scenario: Trying to create a new public share of a file with edit permissions results in a read-only share
+		Given user "user0" has been created
+		When user "user0" creates a share using the API with settings
+			| path        | welcome.txt |
+			| shareType   | 3           |
+			| permissions | 31          |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And the share fields of the last share should include
+			| file_target            | /welcome.txt       |
+			| path                   | /welcome.txt       |
+			| item_type              | file               |
+			| share_type             | 3                  |
+			| permissions            | 1                  |
+			| uid_owner              | user0              |
+		And the last public shared file should be able to be downloaded without a password
 
 	Scenario: Creating a new public share of a folder
 		Given user "user0" has been created


### PR DESCRIPTION
## Description
Try to create a public read-write share of a single file, and see that it results in a read-only share.

## Related Issue
#31366 

## Motivation and Context
It is nice to know what happens if someone attempts to create a public share of a single file with read-write permissions.

## How Has This Been Tested?
Run the new acceptance test.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New acceptance test

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
