### PR TITLE
Include new capabilities for the password enforcement for sharing

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -70,7 +70,14 @@ class Capabilities implements ICapability {
 			$public['enabled'] = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes';
 			if ($public['enabled']) {
 				$public['password'] = [];
-				$public['password']['enforced'] = ($this->config->getAppValue('core', 'shareapi_enforce_links_password', 'no') === 'yes');
+				$public['password']['enforced_for'] = [];
+				$roPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_only', 'no') === 'yes';
+				$rwPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_read_write', 'no') === 'yes';
+				$woPasswordEnforced = $this->config->getAppValue('core', 'shareapi_enforce_links_password_write_only', 'no') === 'yes';
+				$public['password']['enforced_for']['read_only'] = $roPasswordEnforced;
+				$public['password']['enforced_for']['read_write'] = $rwPasswordEnforced;
+				$public['password']['enforced_for']['upload_only'] = $woPasswordEnforced;
+				$public['password']['enforced'] = $roPasswordEnforced || $rwPasswordEnforced || $woPasswordEnforced;
 
 				$public['expire_date'] = [];
 				$public['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date', 'no') === 'yes';

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -296,7 +296,7 @@ class ApiTest extends TestCase {
 		$this->assertTrue($result->succeeded());
 	}
 
-	public function testEnfoceLinkPassword() {
+	public function testEnforceLinkPassword() {
 		$appConfig = \OC::$server->getAppConfig();
 		$appConfig->setValue('core', 'shareapi_enforce_links_password_read_only', 'yes');
 

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -119,28 +119,56 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertTrue($result['public']['enabled']);
 	}
 
-	public function testLinkPassword() {
+	public function linkPasswordProvider() {
+		return [
+			['no', 'no', 'yes'],
+			['no', 'yes', 'no'],
+			['no', 'yes', 'yes'],
+			['yes', 'no', 'no'],
+			['yes', 'no', 'yes'],
+			['yes', 'yes', 'no'],
+			['yes', 'yes', 'yes'],
+		];
+	}
+
+	/**
+	 * @dataProvider linkPasswordProvider
+	 */
+	public function testLinkPassword($readOnly, $readWrite, $writeOnly) {
 		$map = [
 			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
-			['core', 'shareapi_enforce_links_password', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_only', 'no', $readOnly],
+			['core', 'shareapi_enforce_links_password_read_write', 'no', $readWrite],
+			['core', 'shareapi_enforce_links_password_write_only', 'no', $writeOnly],
 		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('password', $result['public']);
 		$this->assertArrayHasKey('enforced', $result['public']['password']);
+		$this->assertArrayHasKey('enforced_for', $result['public']['password']);
 		$this->assertTrue($result['public']['password']['enforced']);
+
+		$this->assertEquals($readOnly === 'yes', $result['public']['password']['enforced_for']['read_only']);
+		$this->assertEquals($readWrite === 'yes', $result['public']['password']['enforced_for']['read_write']);
+		$this->assertEquals($writeOnly === 'yes', $result['public']['password']['enforced_for']['upload_only']);
 	}
 
 	public function testLinkNoPassword() {
 		$map = [
 			['core', 'shareapi_enabled', 'yes', 'yes'],
 			['core', 'shareapi_allow_links', 'yes', 'yes'],
-			['core', 'shareapi_enforce_links_password', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_read_only', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_read_write', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_write_only', 'no', 'no'],
 		];
 		$result = $this->getResults($map);
 		$this->assertArrayHasKey('password', $result['public']);
 		$this->assertArrayHasKey('enforced', $result['public']['password']);
+		$this->assertArrayHasKey('enforced_for', $result['public']['password']);
 		$this->assertFalse($result['public']['password']['enforced']);
+		$this->assertFalse($result['public']['password']['enforced_for']['read_only']);
+		$this->assertFalse($result['public']['password']['enforced_for']['read_write']);
+		$this->assertFalse($result['public']['password']['enforced_for']['upload_only']);
 	}
 
 	public function testLinkNoExpireDate() {

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -180,29 +180,77 @@ Feature: capabilities
 			| files         | undelete                              | 1                 |
 			| files         | versioning                            | 1                 |
 
-	Scenario: Changing password enforce
-		Given parameter "shareapi_enforce_links_password" of app "core" has been set to "yes"
+	Scenario: Changing "password enforced for read-only public link shares"
+		Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability    | path_to_element                       | value             |
-			| core          | pollinterval                          | 60                |
-			| core          | webdav-root                           | remote.php/webdav |
-			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | public@@@enabled                      | 1                 |
-			| files_sharing | public@@@upload                       | 1                 |
-			| files_sharing | public@@@send_mail                    | EMPTY             |
-			| files_sharing | public@@@social_share                 | 1                 |
-			| files_sharing | public@@@password@@@enforced          | 1                 |
-			| files_sharing | resharing                             | 1                 |
-			| files_sharing | federation@@@outgoing                 | 1                 |
-			| files_sharing | federation@@@incoming                 | 1                 |
-			| files_sharing | group_sharing                         | 1                 |
-			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled            | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
-			| files         | bigfilechunking                       | 1                 |
-			| files         | undelete                              | 1                 |
-			| files         | versioning                            | 1                 |
+			| capability    | path_to_element                        | value             |
+			| core          | pollinterval                           | 60                |
+			| core          | webdav-root                            | remote.php/webdav |
+			| files_sharing | api_enabled                            | 1                 |
+			| files_sharing | public@@@enabled                       | 1                 |
+			| files_sharing | public@@@upload                        | 1                 |
+			| files_sharing | public@@@send_mail                     | EMPTY             |
+			| files_sharing | public@@@social_share                  | 1                 |
+			| files_sharing | public@@@password@@@enforced_read_only | 1                 |
+			| files_sharing | resharing                              | 1                 |
+			| files_sharing | federation@@@outgoing                  | 1                 |
+			| files_sharing | federation@@@incoming                  | 1                 |
+			| files_sharing | group_sharing                          | 1                 |
+			| files_sharing | share_with_group_members_only          | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled             | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only  | EMPTY             |
+			| files         | bigfilechunking                        | 1                 |
+			| files         | undelete                               | 1                 |
+			| files         | versioning                             | 1                 |
+
+	Scenario: Changing "password enforced for read-write public link shares"
+		Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
+			| capability    | path_to_element                         | value             |
+			| core          | pollinterval                            | 60                |
+			| core          | webdav-root                             | remote.php/webdav |
+			| files_sharing | api_enabled                             | 1                 |
+			| files_sharing | public@@@enabled                        | 1                 |
+			| files_sharing | public@@@upload                         | 1                 |
+			| files_sharing | public@@@send_mail                      | EMPTY             |
+			| files_sharing | public@@@social_share                   | 1                 |
+			| files_sharing | public@@@password@@@enforced_read_write | 1                 |
+			| files_sharing | resharing                               | 1                 |
+			| files_sharing | federation@@@outgoing                   | 1                 |
+			| files_sharing | federation@@@incoming                   | 1                 |
+			| files_sharing | group_sharing                           | 1                 |
+			| files_sharing | share_with_group_members_only           | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled              | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only   | EMPTY             |
+			| files         | bigfilechunking                         | 1                 |
+			| files         | undelete                                | 1                 |
+			| files         | versioning                              | 1                 |
+
+	Scenario: Changing "password enforced for write-only public link shares"
+		Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
+			| capability    | path_to_element                         | value             |
+			| core          | pollinterval                            | 60                |
+			| core          | webdav-root                             | remote.php/webdav |
+			| files_sharing | api_enabled                             | 1                 |
+			| files_sharing | public@@@enabled                        | 1                 |
+			| files_sharing | public@@@upload                         | 1                 |
+			| files_sharing | public@@@send_mail                      | EMPTY             |
+			| files_sharing | public@@@social_share                   | 1                 |
+			| files_sharing | public@@@password@@@enforced_write_only | 1                 |
+			| files_sharing | resharing                               | 1                 |
+			| files_sharing | federation@@@outgoing                   | 1                 |
+			| files_sharing | federation@@@incoming                   | 1                 |
+			| files_sharing | group_sharing                           | 1                 |
+			| files_sharing | share_with_group_members_only           | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled              | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only   | EMPTY             |
+			| files         | bigfilechunking                         | 1                 |
+			| files         | undelete                                | 1                 |
+			| files         | versioning                              | 1                 |
 
 	Scenario: Changing public notifications
 		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -184,73 +184,76 @@ Feature: capabilities
 		Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability    | path_to_element                        | value             |
-			| core          | pollinterval                           | 60                |
-			| core          | webdav-root                            | remote.php/webdav |
-			| files_sharing | api_enabled                            | 1                 |
-			| files_sharing | public@@@enabled                       | 1                 |
-			| files_sharing | public@@@upload                        | 1                 |
-			| files_sharing | public@@@send_mail                     | EMPTY             |
-			| files_sharing | public@@@social_share                  | 1                 |
-			| files_sharing | public@@@password@@@enforced_read_only | 1                 |
-			| files_sharing | resharing                              | 1                 |
-			| files_sharing | federation@@@outgoing                  | 1                 |
-			| files_sharing | federation@@@incoming                  | 1                 |
-			| files_sharing | group_sharing                          | 1                 |
-			| files_sharing | share_with_group_members_only          | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled             | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only  | EMPTY             |
-			| files         | bigfilechunking                        | 1                 |
-			| files         | undelete                               | 1                 |
-			| files         | versioning                             | 1                 |
+			| capability    | path_to_element                              | value             |
+			| core          | pollinterval                                 | 60                |
+			| core          | webdav-root                                  | remote.php/webdav |
+			| files_sharing | api_enabled                                  | 1                 |
+			| files_sharing | public@@@enabled                             | 1                 |
+			| files_sharing | public@@@upload                              | 1                 |
+			| files_sharing | public@@@send_mail                           | EMPTY             |
+			| files_sharing | public@@@social_share                        | 1                 |
+			| files_sharing | public@@@password@@@enforced                 | 1                 |
+			| files_sharing | public@@@password@@@enforced_for@@@read_only | 1                 |
+			| files_sharing | resharing                                    | 1                 |
+			| files_sharing | federation@@@outgoing                        | 1                 |
+			| files_sharing | federation@@@incoming                        | 1                 |
+			| files_sharing | group_sharing                                | 1                 |
+			| files_sharing | share_with_group_members_only                | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled                   | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only        | EMPTY             |
+			| files         | bigfilechunking                              | 1                 |
+			| files         | undelete                                     | 1                 |
+			| files         | versioning                                   | 1                 |
 
 	Scenario: Changing "password enforced for read-write public link shares"
 		Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability    | path_to_element                         | value             |
-			| core          | pollinterval                            | 60                |
-			| core          | webdav-root                             | remote.php/webdav |
-			| files_sharing | api_enabled                             | 1                 |
-			| files_sharing | public@@@enabled                        | 1                 |
-			| files_sharing | public@@@upload                         | 1                 |
-			| files_sharing | public@@@send_mail                      | EMPTY             |
-			| files_sharing | public@@@social_share                   | 1                 |
-			| files_sharing | public@@@password@@@enforced_read_write | 1                 |
-			| files_sharing | resharing                               | 1                 |
-			| files_sharing | federation@@@outgoing                   | 1                 |
-			| files_sharing | federation@@@incoming                   | 1                 |
-			| files_sharing | group_sharing                           | 1                 |
-			| files_sharing | share_with_group_members_only           | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled              | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only   | EMPTY             |
-			| files         | bigfilechunking                         | 1                 |
-			| files         | undelete                                | 1                 |
-			| files         | versioning                              | 1                 |
+			| capability    | path_to_element                               | value             |
+			| core          | pollinterval                                  | 60                |
+			| core          | webdav-root                                   | remote.php/webdav |
+			| files_sharing | api_enabled                                   | 1                 |
+			| files_sharing | public@@@enabled                              | 1                 |
+			| files_sharing | public@@@upload                               | 1                 |
+			| files_sharing | public@@@send_mail                            | EMPTY             |
+			| files_sharing | public@@@social_share                         | 1                 |
+			| files_sharing | public@@@password@@@enforced                  | 1                 |
+			| files_sharing | public@@@password@@@enforced_for@@@read_write | 1                 |
+			| files_sharing | resharing                                     | 1                 |
+			| files_sharing | federation@@@outgoing                         | 1                 |
+			| files_sharing | federation@@@incoming                         | 1                 |
+			| files_sharing | group_sharing                                 | 1                 |
+			| files_sharing | share_with_group_members_only                 | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled                    | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only         | EMPTY             |
+			| files         | bigfilechunking                               | 1                 |
+			| files         | undelete                                      | 1                 |
+			| files         | versioning                                    | 1                 |
 
 	Scenario: Changing "password enforced for write-only public link shares"
 		Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
 		When the user retrieves the capabilities using the API
 		Then the capabilities should contain
-			| capability    | path_to_element                         | value             |
-			| core          | pollinterval                            | 60                |
-			| core          | webdav-root                             | remote.php/webdav |
-			| files_sharing | api_enabled                             | 1                 |
-			| files_sharing | public@@@enabled                        | 1                 |
-			| files_sharing | public@@@upload                         | 1                 |
-			| files_sharing | public@@@send_mail                      | EMPTY             |
-			| files_sharing | public@@@social_share                   | 1                 |
-			| files_sharing | public@@@password@@@enforced_write_only | 1                 |
-			| files_sharing | resharing                               | 1                 |
-			| files_sharing | federation@@@outgoing                   | 1                 |
-			| files_sharing | federation@@@incoming                   | 1                 |
-			| files_sharing | group_sharing                           | 1                 |
-			| files_sharing | share_with_group_members_only           | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled              | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only   | EMPTY             |
-			| files         | bigfilechunking                         | 1                 |
-			| files         | undelete                                | 1                 |
-			| files         | versioning                              | 1                 |
+			| capability    | path_to_element                                | value             |
+			| core          | pollinterval                                   | 60                |
+			| core          | webdav-root                                    | remote.php/webdav |
+			| files_sharing | api_enabled                                    | 1                 |
+			| files_sharing | public@@@enabled                               | 1                 |
+			| files_sharing | public@@@upload                                | 1                 |
+			| files_sharing | public@@@send_mail                             | EMPTY             |
+			| files_sharing | public@@@social_share                          | 1                 |
+			| files_sharing | public@@@password@@@enforced                   | 1                 |
+			| files_sharing | public@@@password@@@enforced_for@@@upload_only | 1                 |
+			| files_sharing | resharing                                      | 1                 |
+			| files_sharing | federation@@@outgoing                          | 1                 |
+			| files_sharing | federation@@@incoming                          | 1                 |
+			| files_sharing | group_sharing                                  | 1                 |
+			| files_sharing | share_with_group_members_only                  | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled                     | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
+			| files         | bigfilechunking                                | 1                 |
+			| files         | undelete                                       | 1                 |
+			| files         | versioning                                     | 1                 |
 
 	Scenario: Changing public notifications
 		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"

--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -81,9 +81,23 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 				],
 				[
 					'capabilitiesApp' => 'files_sharing',
-					'capabilitiesParameter' => 'public@@@password@@@enforced',
+					'capabilitiesParameter' => 'public@@@password@@@enforced_read_only',
 					'testingApp' => 'core',
-					'testingParameter' => 'shareapi_enforce_links_password',
+					'testingParameter' => 'shareapi_enforce_links_password_read_only',
+					'testingState' => false
+				],
+				[
+					'capabilitiesApp' => 'files_sharing',
+					'capabilitiesParameter' => 'public@@@password@@@enforced_read_write',
+					'testingApp' => 'core',
+					'testingParameter' => 'shareapi_enforce_links_password_read_write',
+					'testingState' => false
+				],
+				[
+					'capabilitiesApp' => 'files_sharing',
+					'capabilitiesParameter' => 'public@@@password@@@enforced_write_only',
+					'testingApp' => 'core',
+					'testingParameter' => 'shareapi_enforce_links_password_write_only',
 					'testingState' => false
 				],
 				[

--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -81,21 +81,21 @@ class CapabilitiesContext implements Context, SnippetAcceptingContext {
 				],
 				[
 					'capabilitiesApp' => 'files_sharing',
-					'capabilitiesParameter' => 'public@@@password@@@enforced_read_only',
+					'capabilitiesParameter' => 'public@@@password@@@enforced_for@@@read_only',
 					'testingApp' => 'core',
 					'testingParameter' => 'shareapi_enforce_links_password_read_only',
 					'testingState' => false
 				],
 				[
 					'capabilitiesApp' => 'files_sharing',
-					'capabilitiesParameter' => 'public@@@password@@@enforced_read_write',
+					'capabilitiesParameter' => 'public@@@password@@@enforced_for@@@read_write',
 					'testingApp' => 'core',
 					'testingParameter' => 'shareapi_enforce_links_password_read_write',
 					'testingState' => false
 				],
 				[
 					'capabilitiesApp' => 'files_sharing',
-					'capabilitiesParameter' => 'public@@@password@@@enforced_write_only',
+					'capabilitiesParameter' => 'public@@@password@@@enforced_for@@@upload_only',
 					'testingApp' => 'core',
 					'testingParameter' => 'shareapi_enforce_links_password_write_only',
 					'testingState' => false


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Files sharing capabilities will include these new options. The previous "password enforced" capability (which wasn't working properly in 10.0.8) will indicate if any of the options are active. This should keep backwards compatiblity because the clients should enforce the password for all the options, which is more restrictive but should be less problematic for old clients.

Note that the internal sharing API remains unchanged, particularly https://github.com/owncloud/core/blob/master/lib/public/Share/IManager.php#L239

## Related Issue
https://github.com/owncloud/core/issues/31492

## Motivation and Context
Broken capability in 10.0.8

## How Has This Been Tested?
Unittest as well as checking "/ocs/v1.php/cloud/capabilities" endpoint

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
