### PR TITLE
Refactor acceptance test scripts

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -71,9 +71,6 @@ default:
       context: &common_webui_suite_context
         parameters:
           ocPath: apps/testing/api/v1/occ
-          adminUsername: admin
-          adminPassword: admin
-          regularUserPassword: 123456
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -153,6 +153,36 @@ trait BasicStructure {
 		if ($testRemoteServerUrl !== false) {
 			$this->remoteBaseUrl = \rtrim($testRemoteServerUrl, '/');
 		}
+
+		// get the admin username from the environment (if defined)
+		$adminUsernameFromEnvironment = $this->getAdminUsernameFromEnvironment();
+		if ($adminUsernameFromEnvironment !== false) {
+			$this->adminUsername = $adminUsernameFromEnvironment;
+		}
+
+		// get the admin password from the environment (if defined)
+		$adminPasswordFromEnvironment = $this->getAdminPasswordFromEnvironment();
+		if ($adminPasswordFromEnvironment !== false) {
+			$this->adminPassword = $adminPasswordFromEnvironment;
+		}
+	}
+
+	/**
+	 * Get the externally-defined admin username, if any
+	 *
+	 * @return string|false
+	 */
+	private static function getAdminUsernameFromEnvironment() {
+		return \getenv('ADMIN_USERNAME');
+	}
+
+	/**
+	 * Get the externally-defined admin password, if any
+	 *
+	 * @return string|false
+	 */
+	private static function getAdminPasswordFromEnvironment() {
+		return \getenv('ADMIN_PASSWORD');
 	}
 
 	/**
@@ -1023,6 +1053,18 @@ trait BasicStructure {
 				$adminPassword = $context[__CLASS__]['adminPassword'];
 				break;
 			}
+		}
+
+		// get the admin username from the environment (if defined)
+		$adminUsernameFromEnvironment = self::getAdminUsernameFromEnvironment();
+		if ($adminUsernameFromEnvironment !== false) {
+			$adminUsername = $adminUsernameFromEnvironment;
+		}
+
+		// get the admin password from the environment (if defined)
+		$adminPasswordFromEnvironment = self::getAdminPasswordFromEnvironment();
+		if ($adminPasswordFromEnvironment !== false) {
+			$adminPassword = $adminPasswordFromEnvironment;
 		}
 
 		if (($adminUsername === null) || ($adminPassword === null)) {

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -16,7 +16,7 @@ So that I can organise my data structure
 		When the user renames the file "data.zip" to "simple-folder/data.zip" using the webUI
 		Then near the file "data.zip" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
 
-	@skipOnFIREFOX47+
+	@skipOnFIREFOX
 	Scenario: move a file into a folder
 		When the user moves the file "data.zip" into the folder "simple-empty-folder" using the webUI
 		Then the file "data.zip" should not be listed on the webUI
@@ -30,7 +30,7 @@ So that I can organise my data structure
 		Then the file "strängé filename (duplicate #2 &).txt" should not be listed on the webUI
 		But the file "strängé filename (duplicate #2 &).txt" should be listed in the folder "strängé नेपाली folder empty" on the webUI
 
-	@skipOnFIREFOX47+
+	@skipOnFIREFOX
 	Scenario: move a file into a folder where a file with the same name already exists
 		When the user moves the file "data.zip" into the folder "simple-folder" using the webUI
 		And the user moves the file "data.zip" into the folder "strängé नेपाली folder" using the webUI
@@ -39,14 +39,14 @@ So that I can organise my data structure
 			|Could not move "data.zip", target exists|
 		And the file "data.zip" should be listed on the webUI
 
-	@skipOnFIREFOX47+
+	@skipOnFIREFOX
 	Scenario: move a file into a folder where a file with the same name already exists
 		When the user moves the file "strängé filename (duplicate #2 &).txt" into the folder "strängé नेपाली folder" using the webUI
 		Then notifications should be displayed on the webUI with the text
 			|Could not move "strängé filename (duplicate #2 &).txt", target exists|
 		And the file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
 
-	@skipOnFIREFOX47+
+	@skipOnFIREFOX
 	Scenario: Move multiple files at once
 		When the user batch moves these files into the folder "simple-empty-folder" using the webUI
 		| name        |
@@ -57,7 +57,7 @@ So that I can organise my data structure
 		And the moved elements should not be listed on the webUI after a page reload
 		But the moved elements should be listed in the folder "simple-empty-folder" on the webUI
 
-	@skipOnFIREFOX47+
+	@skipOnFIREFOX
 	Scenario: move a file into a folder (problematic characters)
 		When the user renames the following file using the webUI
 			| from-name-parts         | to-name-parts          |

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -16,7 +16,7 @@ So that I can organise my data structure
 		When the user renames the folder "simple-empty-folder" to "simple-folder/simple-empty-folder" using the webUI
 		Then near the folder "simple-empty-folder" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
 
-	@skipOnFIREFOX47+
+	@skipOnFIREFOX
 	Scenario: move a folder into another folder
 		When the user moves the folder "simple-folder" into the folder "simple-empty-folder" using the webUI
 		Then the folder "simple-folder" should not be listed on the webUI
@@ -26,14 +26,14 @@ So that I can organise my data structure
 		Then the folder "strängé नेपाली folder" should not be listed on the webUI
 		But the folder "strängé नेपाली folder" should be listed in the folder "strängé नेपाली folder empty" on the webUI
 
-	@skipOnFIREFOX47+
+	@skipOnFIREFOX
 	Scenario: move a folder into another folder where a folder with the same name already exists
 		When the user moves the folder "simple-empty-folder" into the folder "simple-folder" using the webUI
 		Then notifications should be displayed on the webUI with the text
 			|Could not move "simple-empty-folder", target exists|
 		And the folder "simple-empty-folder" should be listed on the webUI
 
-	@skipOnFIREFOX47+
+	@skipOnFIREFOX
 	Scenario: Move multiple folders at once
 		When the user batch moves these folders into the folder "simple-empty-folder" using the webUI
 		| name               |
@@ -43,7 +43,7 @@ So that I can organise my data structure
 		And the moved elements should not be listed on the webUI after a page reload
 		But the moved elements should be listed in the folder "simple-empty-folder" on the webUI
 
-	@skipOnFIREFOX47+
+	@skipOnFIREFOX
 	Scenario: move a folder into another folder (problematic characters)
 		When the user renames the following folder using the webUI
 			| from-name-parts         | to-name-parts          |

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -15,6 +15,23 @@ BEHAT=${OC_PATH}lib/composer/behat/behat/bin/behat
 SCENARIO_TO_RUN=$1
 HIDE_OC_LOGS=$2
 
+# Provide a default admin username and password.
+# But let the caller pass them if they wish
+if [ -z "${ADMIN_USERNAME}" ]
+then
+	ADMIN_USERNAME="admin"
+fi
+
+if [ -z "${ADMIN_PASSWORD}" ]
+then
+	ADMIN_PASSWORD="admin"
+fi
+
+ADMIN_AUTH="${ADMIN_USERNAME}:${ADMIN_PASSWORD}"
+
+export ADMIN_USERNAME
+export ADMIN_PASSWORD
+
 function env_alt_home_enable {
 	${OCC} config:app:set testing enable_alt_user_backend --value yes
 }

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -4,11 +4,11 @@
 
 # from http://stackoverflow.com/a/630387
 SCRIPT_PATH="`dirname \"$0\"`"              # relative
-SCRIPT_PATH="`( cd \"$SCRIPT_PATH\" && pwd )`"  # absolutized and normalized
+SCRIPT_PATH="`( cd \"${SCRIPT_PATH}\" && pwd )`"  # absolutized and normalized
 
-echo 'Script path: '$SCRIPT_PATH
+echo 'Script path: '${SCRIPT_PATH}
 
-OC_PATH=$SCRIPT_PATH/../../
+OC_PATH=${SCRIPT_PATH}/../../
 OCC=${OC_PATH}occ
 BEHAT=${OC_PATH}lib/composer/behat/behat/bin/behat
 
@@ -16,41 +16,41 @@ SCENARIO_TO_RUN=$1
 HIDE_OC_LOGS=$2
 
 function env_alt_home_enable {
-	$OCC config:app:set testing enable_alt_user_backend --value yes
+	${OCC} config:app:set testing enable_alt_user_backend --value yes
 }
 
 function env_alt_home_clear {
-	$OCC app:disable testing || { echo "Unable to disable testing app" >&2; exit 1; }
+	${OCC} app:disable testing || { echo "Unable to disable testing app" >&2; exit 1; }
 }
 
 function env_encryption_enable {
-	$OCC app:enable encryption
-	$OCC encryption:enable
+	${OCC} app:enable encryption
+	${OCC} encryption:enable
 }
 
 function env_encryption_enable_master_key {
 	env_encryption_enable || { echo "Unable to enable masterkey encryption" >&2; exit 1; }
-	$OCC encryption:select-encryption-type masterkey --yes
+	${OCC} encryption:select-encryption-type masterkey --yes
 }
 
 function env_encryption_enable_user_keys {
 	env_encryption_enable || { echo "Unable to enable user-keys encryption" >&2; exit 1; }
-	$OCC encryption:select-encryption-type user-keys --yes
+	${OCC} encryption:select-encryption-type user-keys --yes
 }
 
 function env_encryption_disable {
-	$OCC encryption:disable
-	$OCC app:disable encryption
+	${OCC} encryption:disable
+	${OCC} app:disable encryption
 }
 
 function env_encryption_disable_master_key {
 	env_encryption_disable || { echo "Unable to disable masterkey encryption" >&2; exit 1; }
-	$OCC config:app:delete encryption useMasterKey
+	${OCC} config:app:delete encryption useMasterKey
 }
 
 function env_encryption_disable_user_keys {
 	env_encryption_disable || { echo "Unable to disable user-keys encryption" >&2; exit 1; }
-	$OCC config:app:delete encryption userSpecificKey
+	${OCC} config:app:delete encryption userSpecificKey
 }
 
 declare -x TEST_SERVER_URL
@@ -62,84 +62,84 @@ if [ "${TEST_WITH_PHPDEVSERVER}" != "true" ]
 then
     echo "Not using php inbuilt server for running scenario ..."
     echo "Updating .htaccess for proper rewrites"
-    $OCC config:system:set htaccess.RewriteBase --value /
-    $OCC maintenance:update:htaccess
+    ${OCC} config:system:set htaccess.RewriteBase --value /
+    ${OCC} maintenance:update:htaccess
 else
     echo "Using php inbuilt server for running scenario ..."
 
     # avoid port collision on jenkins - use $EXECUTOR_NUMBER
     declare -x EXECUTOR_NUMBER
-    [[ -z "$EXECUTOR_NUMBER" ]] && EXECUTOR_NUMBER=0
+    [[ -z "${EXECUTOR_NUMBER}" ]] && EXECUTOR_NUMBER=0
 
-    PORT=$((8080 + $EXECUTOR_NUMBER))
-    echo $PORT
-    php -S localhost:$PORT -t "$OC_PATH" &
+    PORT=$((8080 + ${EXECUTOR_NUMBER}))
+    echo ${PORT}
+    php -S localhost:${PORT} -t "$OC_PATH" &
     PHPPID=$!
-    echo $PHPPID
+    echo ${PHPPID}
 
-    PORT_FED=$((8180 + $EXECUTOR_NUMBER))
-    echo $PORT_FED
-    php -S localhost:$PORT_FED -t ../.. &
+    PORT_FED=$((8180 + ${EXECUTOR_NUMBER}))
+    echo ${PORT_FED}
+    php -S localhost:${PORT_FED} -t ../.. &
     PHPPID_FED=$!
-    echo $PHPPID_FED
+    echo ${PHPPID_FED}
 
-    export TEST_SERVER_URL="http://localhost:$PORT"
-    export TEST_SERVER_FED_URL="http://localhost:$PORT_FED"
+    export TEST_SERVER_URL="http://localhost:${PORT}"
+    export TEST_SERVER_FED_URL="http://localhost:${PORT_FED}"
 fi
 
 # Set up personalized skeleton
-PREVIOUS_SKELETON_DIR=$($OCC --no-warnings config:system:get skeletondirectory)
-$OCC config:system:set skeletondirectory --value="$(pwd)/skeleton"
+PREVIOUS_SKELETON_DIR=$(${OCC} --no-warnings config:system:get skeletondirectory)
+${OCC} config:system:set skeletondirectory --value="$(pwd)/skeleton"
 
-PREVIOUS_HTTP_FALLBACK_SETTING=$($OCC --no-warnings config:system:get sharing.federation.allowHttpFallback)
-$OCC config:system:set sharing.federation.allowHttpFallback --type boolean --value true
+PREVIOUS_HTTP_FALLBACK_SETTING=$(${OCC} --no-warnings config:system:get sharing.federation.allowHttpFallback)
+${OCC} config:system:set sharing.federation.allowHttpFallback --type boolean --value true
 
 # Enable external storage app
-$OCC config:app:set core enable_external_storage --value=yes
-$OCC config:system:set files_external_allow_create_new_local --value=true
+${OCC} config:app:set core enable_external_storage --value=yes
+${OCC} config:system:set files_external_allow_create_new_local --value=true
 
-PREVIOUS_TESTING_APP_STATUS=$($OCC --no-warnings app:list "^testing$")
+PREVIOUS_TESTING_APP_STATUS=$(${OCC} --no-warnings app:list "^testing$")
 
-if [[ "$PREVIOUS_TESTING_APP_STATUS" =~ ^Disabled: ]]
+if [[ "${PREVIOUS_TESTING_APP_STATUS}" =~ ^Disabled: ]]
 then
-	$OCC app:enable testing || { echo "Unable to enable testing app" >&2; exit 1; }
+	${OCC} app:enable testing || { echo "Unable to enable testing app" >&2; exit 1; }
 	TESTING_ENABLED_BY_SCRIPT=true;
 else
 	TESTING_ENABLED_BY_SCRIPT=false;
 fi
 
 mkdir -p work/local_storage || { echo "Unable to create work folder" >&2; exit 1; }
-OUTPUT_CREATE_STORAGE=`$OCC files_external:create local_storage local null::null -c datadir=$SCRIPT_PATH/work/local_storage` 
+OUTPUT_CREATE_STORAGE=`${OCC} files_external:create local_storage local null::null -c datadir=${SCRIPT_PATH}/work/local_storage`
 
-ID_STORAGE=`echo $OUTPUT_CREATE_STORAGE | awk {'print $5'}`
+ID_STORAGE=`echo ${OUTPUT_CREATE_STORAGE} | awk {'print $5'}`
 
-$OCC files_external:option $ID_STORAGE enable_sharing true
+${OCC} files_external:option ${ID_STORAGE} enable_sharing true
 
-if [ "$OC_TEST_ALT_HOME" = "1" ]
+if [ "${OC_TEST_ALT_HOME}" = "1" ]
 then
 	env_alt_home_enable
 fi
 
 # Enable encryption if requested
-if [ "$OC_TEST_ENCRYPTION_ENABLED" = "1" ]
+if [ "${OC_TEST_ENCRYPTION_ENABLED}" = "1" ]
 then
 	env_encryption_enable
 	BEHAT_FILTER_TAGS="~@no_encryption&&~@no_default_encryption"
-elif [ "$OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED" = "1" ]
+elif [ "${OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED}" = "1" ]
 then
 	env_encryption_enable_master_key
 	BEHAT_FILTER_TAGS="~@no_encryption&&~@no_masterkey_encryption"
-elif [ "$OC_TEST_ENCRYPTION_USER_KEYS_ENABLED" = "1" ]
+elif [ "${OC_TEST_ENCRYPTION_USER_KEYS_ENABLED}" = "1" ]
 then
 	env_encryption_enable_user_keys
 	BEHAT_FILTER_TAGS="~@no_encryption&&~@no_userkeys_encryption"
 fi
 
-if [ -n "$BEHAT_FILTER_TAGS" ]
+if [ -n "${BEHAT_FILTER_TAGS}" ]
 then
-    if [[ $BEHAT_FILTER_TAGS != *@skip* ]]
+    if [[ ${BEHAT_FILTER_TAGS} != *@skip* ]]
     then
-    	BEHAT_FILTER_TAGS="$BEHAT_FILTER_TAGS&&~@skip"
+    	BEHAT_FILTER_TAGS="${BEHAT_FILTER_TAGS}&&~@skip"
    	fi
 else
 	BEHAT_FILTER_TAGS="~@skip&&~@masterkey_encryption"
@@ -147,101 +147,100 @@ fi
 
 if [ "$OC_TEST_ON_OBJECTSTORE" = "1" ]
 then
-   	BEHAT_FILTER_TAGS="$BEHAT_FILTER_TAGS&&~@skip_on_objectstore"
+   	BEHAT_FILTER_TAGS="${BEHAT_FILTER_TAGS}&&~@skip_on_objectstore"
 fi
 
+BEHAT_FILTER_TAGS="${BEHAT_FILTER_TAGS}&&@api"
 
-BEHAT_FILTER_TAGS="$BEHAT_FILTER_TAGS&&@api"
-
-if [ -n "$BEHAT_FILTER_TAGS" ]
+if [ -n "${BEHAT_FILTER_TAGS}" ]
 then
 	BEHAT_PARAMS='{ 
 		"gherkin": {
 			"filters": {
-				"tags": "'"$BEHAT_FILTER_TAGS"'"
+				"tags": "'"${BEHAT_FILTER_TAGS}"'"
 			}
 		}
 	}'
 fi
 
 # If a feature file has been specified but no suite, then deduce the suite
-if [ -n "$SCENARIO_TO_RUN" ] && [ -z "$BEHAT_SUITE" ]
+if [ -n "${SCENARIO_TO_RUN}" ] && [ -z "${BEHAT_SUITE}" ]
 then
-    FEATURE_PATH=`dirname $SCENARIO_TO_RUN`
-    BEHAT_SUITE=`basename $FEATURE_PATH`
+    FEATURE_PATH=`dirname ${SCENARIO_TO_RUN}`
+    BEHAT_SUITE=`basename ${FEATURE_PATH}`
 fi
 
-if [ "$BEHAT_SUITE" ]
+if [ "${BEHAT_SUITE}" ]
 then
-	BEHAT_SUITE_OPTION="--suite=$BEHAT_SUITE"
+	BEHAT_SUITE_OPTION="--suite=${BEHAT_SUITE}"
 else
 	BEHAT_SUITE_OPTION=""
 fi
 
-BEHAT_PARAMS="$BEHAT_PARAMS" $BEHAT --strict -f junit -f pretty $BEHAT_SUITE_OPTION $SCENARIO_TO_RUN
+BEHAT_PARAMS="${BEHAT_PARAMS}" ${BEHAT} --strict -f junit -f pretty ${BEHAT_SUITE_OPTION} ${SCENARIO_TO_RUN}
 RESULT=$?
 
 if [ "${TEST_WITH_PHPDEVSERVER}" == "true" ]
 then
-    kill $PHPPID
-    kill $PHPPID_FED
+    kill ${PHPPID}
+    kill ${PHPPID_FED}
 fi
 
-$OCC files_external:delete -y $ID_STORAGE
+${OCC} files_external:delete -y ${ID_STORAGE}
 
 # Disable external storage app
-$OCC config:app:set core enable_external_storage --value=no
+${OCC} config:app:set core enable_external_storage --value=no
 
 # Put back state of the testing app
-if [ "$TESTING_ENABLED_BY_SCRIPT" = true ]
+if [ "${TESTING_ENABLED_BY_SCRIPT}" = true ]
 then
-	$OCC app:disable testing
+	${OCC} app:disable testing
 fi
 
 # Put back personalized skeleton
-if [ "A$PREVIOUS_SKELETON_DIR" = "A" ]
+if [ "A${PREVIOUS_SKELETON_DIR}" = "A" ]
 then
-	$OCC config:system:delete skeletondirectory
+	${OCC} config:system:delete skeletondirectory
 else
-	$OCC config:system:set skeletondirectory --value="$PREVIOUS_SKELETON_DIR"
+	${OCC} config:system:set skeletondirectory --value="${PREVIOUS_SKELETON_DIR}"
 fi
 
 # Put back HTTP fallback setting
-if [ "A$PREVIOUS_HTTP_FALLBACK_SETTING" = "A" ]
+if [ "A${PREVIOUS_HTTP_FALLBACK_SETTING}" = "A" ]
 then
-	$OCC config:system:delete sharing.federation.allowHttpFallback
+	${OCC} config:system:delete sharing.federation.allowHttpFallback
 else
-	$OCC config:system:set sharing.federation.allowHttpFallback --type boolean --value="$PREVIOUS_HTTP_FALLBACK_SETTING"
+	${OCC} config:system:set sharing.federation.allowHttpFallback --type boolean --value="${PREVIOUS_HTTP_FALLBACK_SETTING}"
 fi
 
 # Clear storage folder
 rm -Rf work/local_storage/*
 
-if [ "$OC_TEST_ALT_HOME" = "1" ]
+if [ "${OC_TEST_ALT_HOME}" = "1" ]
 then
 	env_alt_home_clear
 fi
 
 # Disable encryption if requested
-if [ "$OC_TEST_ENCRYPTION_ENABLED" = "1" ]
+if [ "${OC_TEST_ENCRYPTION_ENABLED}" = "1" ]
 then
 	env_encryption_disable
 fi
 
-if [ "$OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED" = "1" ]
+if [ "${OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED}" = "1" ]
 then
 	env_encryption_disable_master_key
 fi
 
-if [ "$OC_TEST_ENCRYPTION_USER_KEYS_ENABLED" = "1" ]
+if [ "${OC_TEST_ENCRYPTION_USER_KEYS_ENABLED}" = "1" ]
 then
 	env_encryption_disable_user_keys
 fi
 
-if [ -z $HIDE_OC_LOGS ]
+if [ -z ${HIDE_OC_LOGS} ]
 then
 	tail "${OC_PATH}/data/owncloud.log"
 fi
 
-echo "runsh: Exit code: $RESULT"
-exit $RESULT
+echo "runsh: Exit code: ${RESULT}"
+exit ${RESULT}

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-#composer install
+# composer install
 
 # from http://stackoverflow.com/a/630387
 SCRIPT_PATH="`dirname \"$0\"`"              # relative
@@ -58,7 +58,8 @@ declare -x TEST_SERVER_FED_URL
 declare -x TEST_WITH_PHPDEVSERVER
 [[ -z "${TEST_SERVER_URL}" || -z "${TEST_SERVER_FED_URL}" ]] && TEST_WITH_PHPDEVSERVER="true"
 
-if [ "${TEST_WITH_PHPDEVSERVER}" != "true" ]; then
+if [ "${TEST_WITH_PHPDEVSERVER}" != "true" ]
+then
     echo "Not using php inbuilt server for running scenario ..."
     echo "Updating .htaccess for proper rewrites"
     $OCC config:system:set htaccess.RewriteBase --value /
@@ -86,18 +87,19 @@ else
     export TEST_SERVER_FED_URL="http://localhost:$PORT_FED"
 fi
 
-#Set up personalized skeleton
+# Set up personalized skeleton
 PREVIOUS_SKELETON_DIR=$($OCC --no-warnings config:system:get skeletondirectory)
 $OCC config:system:set skeletondirectory --value="$(pwd)/skeleton"
 
 PREVIOUS_HTTP_FALLBACK_SETTING=$($OCC --no-warnings config:system:get sharing.federation.allowHttpFallback)
 $OCC config:system:set sharing.federation.allowHttpFallback --type boolean --value true
 
-#Enable external storage app
+# Enable external storage app
 $OCC config:app:set core enable_external_storage --value=yes
 $OCC config:system:set files_external_allow_create_new_local --value=true
 
 PREVIOUS_TESTING_APP_STATUS=$($OCC --no-warnings app:list "^testing$")
+
 if [[ "$PREVIOUS_TESTING_APP_STATUS" =~ ^Disabled: ]]
 then
 	$OCC app:enable testing || { echo "Unable to enable testing app" >&2; exit 1; }
@@ -113,38 +115,46 @@ ID_STORAGE=`echo $OUTPUT_CREATE_STORAGE | awk {'print $5'}`
 
 $OCC files_external:option $ID_STORAGE enable_sharing true
 
-if test "$OC_TEST_ALT_HOME" = "1"; then
+if [ "$OC_TEST_ALT_HOME" = "1" ]
+then
 	env_alt_home_enable
 fi
 
 # Enable encryption if requested
-if test "$OC_TEST_ENCRYPTION_ENABLED" = "1"; then
+if [ "$OC_TEST_ENCRYPTION_ENABLED" = "1" ]
+then
 	env_encryption_enable
 	BEHAT_FILTER_TAGS="~@no_encryption&&~@no_default_encryption"
-elif test "$OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED" = "1"; then
+elif [ "$OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED" = "1" ]
+then
 	env_encryption_enable_master_key
 	BEHAT_FILTER_TAGS="~@no_encryption&&~@no_masterkey_encryption"
-elif test "$OC_TEST_ENCRYPTION_USER_KEYS_ENABLED" = "1"; then
+elif [ "$OC_TEST_ENCRYPTION_USER_KEYS_ENABLED" = "1" ]
+then
 	env_encryption_enable_user_keys
 	BEHAT_FILTER_TAGS="~@no_encryption&&~@no_userkeys_encryption"
 fi
 
-if test "$BEHAT_FILTER_TAGS"; then
-    if [[ $BEHAT_FILTER_TAGS != *@skip* ]]; then
+if [ -n "$BEHAT_FILTER_TAGS" ]
+then
+    if [[ $BEHAT_FILTER_TAGS != *@skip* ]]
+    then
     	BEHAT_FILTER_TAGS="$BEHAT_FILTER_TAGS&&~@skip"
    	fi
 else
 	BEHAT_FILTER_TAGS="~@skip&&~@masterkey_encryption"
 fi
 
-if test "$OC_TEST_ON_OBJECTSTORE" = "1"; then
+if [ "$OC_TEST_ON_OBJECTSTORE" = "1" ]
+then
    	BEHAT_FILTER_TAGS="$BEHAT_FILTER_TAGS&&~@skip_on_objectstore"
 fi
 
 
 BEHAT_FILTER_TAGS="$BEHAT_FILTER_TAGS&&@api"
 
-if test "$BEHAT_FILTER_TAGS"; then
+if [ -n "$BEHAT_FILTER_TAGS" ]
+then
 	BEHAT_PARAMS='{ 
 		"gherkin": {
 			"filters": {
@@ -155,13 +165,14 @@ if test "$BEHAT_FILTER_TAGS"; then
 fi
 
 # If a feature file has been specified but no suite, then deduce the suite
-if test -n "$SCENARIO_TO_RUN" && test -z "$BEHAT_SUITE"
+if [ -n "$SCENARIO_TO_RUN" ] && [ -z "$BEHAT_SUITE" ]
 then
     FEATURE_PATH=`dirname $SCENARIO_TO_RUN`
     BEHAT_SUITE=`basename $FEATURE_PATH`
 fi
 
-if test "$BEHAT_SUITE"; then
+if [ "$BEHAT_SUITE" ]
+then
 	BEHAT_SUITE_OPTION="--suite=$BEHAT_SUITE"
 else
 	BEHAT_SUITE_OPTION=""
@@ -170,30 +181,34 @@ fi
 BEHAT_PARAMS="$BEHAT_PARAMS" $BEHAT --strict -f junit -f pretty $BEHAT_SUITE_OPTION $SCENARIO_TO_RUN
 RESULT=$?
 
-if [ "${TEST_WITH_PHPDEVSERVER}" == "true" ]; then
+if [ "${TEST_WITH_PHPDEVSERVER}" == "true" ]
+then
     kill $PHPPID
     kill $PHPPID_FED
 fi
 
 $OCC files_external:delete -y $ID_STORAGE
 
-#Disable external storage app
+# Disable external storage app
 $OCC config:app:set core enable_external_storage --value=no
 
 # Put back state of the testing app
-if test "$TESTING_ENABLED_BY_SCRIPT" = true; then
+if [ "$TESTING_ENABLED_BY_SCRIPT" = true ]
+then
 	$OCC app:disable testing
 fi
 
 # Put back personalized skeleton
-if test "A$PREVIOUS_SKELETON_DIR" = "A"; then
+if [ "A$PREVIOUS_SKELETON_DIR" = "A" ]
+then
 	$OCC config:system:delete skeletondirectory
 else
 	$OCC config:system:set skeletondirectory --value="$PREVIOUS_SKELETON_DIR"
 fi
 
 # Put back HTTP fallback setting
-if test "A$PREVIOUS_HTTP_FALLBACK_SETTING" = "A"; then
+if [ "A$PREVIOUS_HTTP_FALLBACK_SETTING" = "A" ]
+then
 	$OCC config:system:delete sharing.federation.allowHttpFallback
 else
 	$OCC config:system:set sharing.federation.allowHttpFallback --type boolean --value="$PREVIOUS_HTTP_FALLBACK_SETTING"
@@ -202,24 +217,29 @@ fi
 # Clear storage folder
 rm -Rf work/local_storage/*
 
-if test "$OC_TEST_ALT_HOME" = "1"; then
+if [ "$OC_TEST_ALT_HOME" = "1" ]
+then
 	env_alt_home_clear
 fi
 
 # Disable encryption if requested
-if test "$OC_TEST_ENCRYPTION_ENABLED" = "1"; then
+if [ "$OC_TEST_ENCRYPTION_ENABLED" = "1" ]
+then
 	env_encryption_disable
 fi
 
-if test "$OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED" = "1"; then
+if [ "$OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED" = "1" ]
+then
 	env_encryption_disable_master_key
 fi
 
-if test "$OC_TEST_ENCRYPTION_USER_KEYS_ENABLED" = "1"; then
+if [ "$OC_TEST_ENCRYPTION_USER_KEYS_ENABLED" = "1" ]
+then
 	env_encryption_disable_user_keys
 fi
 
-if [ -z $HIDE_OC_LOGS ]; then
+if [ -z $HIDE_OC_LOGS ]
+then
 	tail "${OC_PATH}/data/owncloud.log"
 fi
 

--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -279,15 +279,10 @@ done
 
 # we need to skip some tests in certain browsers
 # and also skip tests if tags were given in the call of this script
-if [ "$BROWSER" == "internet explorer" ] || [ "$BROWSER" == "MicrosoftEdge" ] || ([ "$BROWSER" == "firefox" ] && verlt "47.0" "$BROWSER_VERSION")
+if [ "$BROWSER" == "internet explorer" ] || [ "$BROWSER" == "MicrosoftEdge" ] || [ "$BROWSER" == "firefox" ]
 then
 	BROWSER_IN_CAPITALS=${BROWSER//[[:blank:]]/}
 	BROWSER_IN_CAPITALS=${BROWSER_IN_CAPITALS^^}
-	
-	if [ "$BROWSER" == "firefox" ]
-	then
-		BROWSER_IN_CAPITALS="$BROWSER_IN_CAPITALS"47+
-	fi
 	
 	if [ "$BEHAT_TAGS_OPTION_FOUND" = true ]
 	then
@@ -340,14 +335,10 @@ then
 	# set screen resolution so that hopefully dragable elements will be visible
 	# FF gives problems if the destination element is not visible
 	EXTRA_CAPABILITIES='"screenResolution":"1920x1080",'
-	
-	# FF 47 needs a specific selenium version
-	if verlte "$BROWSER_VERSION" "47.0"
-	then
-		EXTRA_CAPABILITIES='"seleniumVersion":"2.53.1",'$EXTRA_CAPABILITIES
-	else
-		EXTRA_CAPABILITIES='"seleniumVersion":"3.4.0",'$EXTRA_CAPABILITIES
-	fi
+
+	# this selenium version works for Firefox after V47
+	# we no longer need to support testing of Firefox V47 or earlier
+	EXTRA_CAPABILITIES='"seleniumVersion":"3.4.0",'$EXTRA_CAPABILITIES
 fi
 
 if [ "$BROWSER" == "internet explorer" ]

--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -9,7 +9,7 @@ RED='\033[0;31m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-#Functions to compare version strings
+# Functions to compare version strings
 verlte() {
 	[ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
 }
@@ -18,15 +18,15 @@ verlt() {
 	[ "$1" = "$2" ] && return 1 || verlte $1 $2
 }
 
-#@param $1 admin password
-#@param $2 occ url
-#@param $3 command
-#sets $REMOTE_OCC_STDOUT and $REMOTE_OCC_STDERR from returned xml date
-#@return occ return code given in the xml data
+# @param $1 admin password
+# @param $2 occ url
+# @param $3 command
+# sets $REMOTE_OCC_STDOUT and $REMOTE_OCC_STDERR from returned xml date
+# @return occ return code given in the xml data
 remote_occ() {
 	RESULT=`curl -s -u admin:$1 $2 -d "command=$3"`
 	RETURN=`echo $RESULT | xmllint --xpath "string(ocs/data/code)" - | sed 's/ //g'`
-	#we could not find a proper return of the testing app, so something went wrong
+	# we could not find a proper return of the testing app, so something went wrong
 	if [ -z "$RETURN" ]
 	then
 		RETURN=1
@@ -38,8 +38,8 @@ remote_occ() {
 	return $RETURN
 }
 
-#save the current language and set the language to "C"
-#we want to have it all in english to be able to parse outputs
+# save the current language and set the language to "C"
+# we want to have it all in english to be able to parse outputs
 OLD_LANG=$LANG
 export LANG=C
 
@@ -197,18 +197,22 @@ fi
 
 BEHAT_TAG_OPTION="--tags"
 
-if [ -z "$MAILHOG_HOST" ]; then
+if [ -z "$MAILHOG_HOST" ]
+then
 	MAILHOG_HOST="127.0.0.1"
 fi
-if [ -z "$MAILHOG_SMTP_PORT" ]; then
+if [ -z "$MAILHOG_SMTP_PORT" ]
+then
 	MAILHOG_SMTP_PORT="1025"
 fi
 
-#check if we can rely on a local ./occ command or if we are testing a remote instance (e.g. inside docker)
-#if we have a remote instance we cannot enable the testing app and we have to hope its enabled by other ways
-if test "$REMOTE_ONLY" = false
+# check if we can rely on a local ./occ command or if we are testing
+# a remote instance (e.g. inside docker).
+# if we have a remote instance we cannot enable the testing app and
+# we have to hope it is enabled by other ways
+if [ "$REMOTE_ONLY" = false ]
 then
-	#enable testing app
+	# enable testing app
 	PREVIOUS_TESTING_APP_STATUS=$($OCC --no-warnings app:list "^testing$")
 	if [[ "$PREVIOUS_TESTING_APP_STATUS" =~ ^Disabled: ]]
 	then
@@ -221,7 +225,7 @@ else
 	TESTING_ENABLED_BY_SCRIPT=false;
 fi
 
-#set SMTP settings
+# set SMTP settings
 remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings config:system:get mail_domain"
 PREVIOUS_MAIL_DOMAIN=$REMOTE_OCC_STDOUT
 remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings config:system:get mail_from_address"
@@ -239,10 +243,10 @@ remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_smtpmode --value=smt
 remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_smtphost --value=$MAILHOG_HOST"
 remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_smtpport --value=$MAILHOG_SMTP_PORT"
 
-#get the current backgroundjobs_mode
+# get the current backgroundjobs_mode
 remote_occ $ADMIN_PASSWORD $OCC_URL "config:app:get core backgroundjobs_mode"
 PREVIOUS_BACKGROUNDJOBS_MODE=$REMOTE_OCC_STDOUT
-#switch to webcron
+# switch to webcron
 remote_occ $ADMIN_PASSWORD $OCC_URL "config:app:set core backgroundjobs_mode --value webcron"
 if [ $? -ne 0 ]
 then
@@ -273,8 +277,8 @@ for APP_TO_ENABLE in $APPS_TO_ENABLE; do
 	fi
 done
 
-#we need to skip some tests in certain browsers
-#and also skip tests if tags were given in the call of this script
+# we need to skip some tests in certain browsers
+# and also skip tests if tags were given in the call of this script
 if [ "$BROWSER" == "internet explorer" ] || [ "$BROWSER" == "MicrosoftEdge" ] || ([ "$BROWSER" == "firefox" ] && verlt "47.0" "$BROWSER_VERSION")
 then
 	BROWSER_IN_CAPITALS=${BROWSER//[[:blank:]]/}
@@ -308,12 +312,12 @@ else
 	fi
 fi
 
-#skip tests tagged with the current oC version
-#one, two or three parts of the version can be used
-#e.g.
-#@skipOnOcV10.0.4
-#@skipOnOcV10.0
-#@skipOnOcV10
+# skip tests tagged with the current oC version
+# one, two or three parts of the version can be used
+# e.g.
+# @skipOnOcV10.0.4
+# @skipOnOcV10.0
+# @skipOnOcV10
 
 remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:get version"
 OWNCLOUD_VERSION=`echo $REMOTE_OCC_STDOUT | cut -d"." -f1-3`
@@ -323,8 +327,8 @@ BEHAT_TAGS='~@skipOnOcV'$OWNCLOUD_VERSION'&&'$BEHAT_TAGS
 OWNCLOUD_VERSION=`echo $OWNCLOUD_VERSION | cut -d"." -f1`
 BEHAT_TAGS='~@skipOnOcV'$OWNCLOUD_VERSION'&&'$BEHAT_TAGS
 
-#if we running remote only tests add an other skip '@skipWhenTestingRemoteSystems'
-if test "$REMOTE_ONLY" = true
+# if we running remote only tests add an other skip '@skipWhenTestingRemoteSystems'
+if [ "$REMOTE_ONLY" = true ]
 then
 	BEHAT_TAGS='~@skipWhenTestingRemoteSystems&&'$BEHAT_TAGS
 fi
@@ -333,11 +337,11 @@ BEHAT_TAGS='@webUI&&'$BEHAT_TAGS
 
 if [ "$BROWSER" == "firefox" ]
 then
-	#set screen resolution so that hopefully dragable elements will be visible
-	#FF gives problems if the destination element is not visible
+	# set screen resolution so that hopefully dragable elements will be visible
+	# FF gives problems if the destination element is not visible
 	EXTRA_CAPABILITIES='"screenResolution":"1920x1080",'
 	
-	#FF 47 needs a specific selenium version
+	# FF 47 needs a specific selenium version
 	if verlte "$BROWSER_VERSION" "47.0"
 	then
 		EXTRA_CAPABILITIES='"seleniumVersion":"2.53.1",'$EXTRA_CAPABILITIES
@@ -353,16 +357,16 @@ fi
 
 EXTRA_CAPABILITIES=$EXTRA_CAPABILITIES'"browserVersion":"'$BROWSER_VERSION'","maxDuration":"3600"'
 
-#Set up personalized skeleton
+# Set up personalized skeleton
 remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings config:system:get skeletondirectory"
 
 PREVIOUS_SKELETON_DIR=$REMOTE_OCC_STDOUT
 
-#$SRC_SKELETON_DIR is the path to the skeleton folder on the machine where the tests are executed
-#it is used for file comparisons in various tests
+# $SRC_SKELETON_DIR is the path to the skeleton folder on the machine where the tests are executed
+# it is used for file comparisons in various tests
 export SRC_SKELETON_DIR=$(pwd)/tests/acceptance/webUISkeleton
-#$SKELETON_DIR is the path to the skeleton folder on the machine where oC runs (system under test)
-#it is used to give users a defined set of files and folders for the tests
+# $SKELETON_DIR is the path to the skeleton folder on the machine where oC runs (system under test)
+# it is used to give users a defined set of files and folders for the tests
 if [ -z "$SKELETON_DIR" ]
 then
 	export SKELETON_DIR="$SRC_SKELETON_DIR"
@@ -480,34 +484,44 @@ then
 fi
 
 # Put back personalized skeleton
-if test "A$PREVIOUS_SKELETON_DIR" = "A"; then
+if [ "A$PREVIOUS_SKELETON_DIR" = "A" ]
+then
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete skeletondirectory"
 else
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set skeletondirectory --value=$PREVIOUS_SKELETON_DIR"
 fi
 
 # Put back smtp settings
-if test "A$PREVIOUS_MAIL_DOMAIN" = "A"; then
+if [ "A$PREVIOUS_MAIL_DOMAIN" = "A" ]
+then
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete mail_domain"
 else
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_domain --value=$PREVIOUS_MAIL_DOMAIN"
 fi
-if test "A$PREVIOUS_MAIL_FROM_ADDRESS" = "A"; then
+
+if [ "A$PREVIOUS_MAIL_FROM_ADDRESS" = "A" ]
+then
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete mail_from_address"
 else
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_from_address --value=$PREVIOUS_MAIL_FROM_ADDRESS"
 fi
-if test "A$PREVIOUS_MAIL_SMTP_MODE" = "A"; then
+
+if [ "A$PREVIOUS_MAIL_SMTP_MODE" = "A" ]
+then
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete mail_smtpmode"
 else
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_smtpmode --value=$PREVIOUS_MAIL_SMTP_MODE"
 fi
-if test "A$PREVIOUS_MAIL_SMTP_HOST" = "A"; then
+
+if [ "A$PREVIOUS_MAIL_SMTP_HOST" = "A" ]
+then
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete mail_smtphost"
 else
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_smtphost --value=$PREVIOUS_MAIL_SMTP_HOST"
 fi
-if test "A$PREVIOUS_MAIL_SMTP_PORT" = "A"; then
+
+if [ "A$PREVIOUS_MAIL_SMTP_PORT" = "A" ]
+then
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete mail_smtpport"
 else
 	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_smtpport --value=$PREVIOUS_MAIL_SMTP_PORT"
@@ -525,7 +539,8 @@ done
 remote_occ $ADMIN_PASSWORD $OCC_URL "config:app:set core backgroundjobs_mode --value $PREVIOUS_BACKGROUNDJOBS_MODE"
 
 # Put back state of the testing app
-if test "$TESTING_ENABLED_BY_SCRIPT" = true; then
+if [ "$TESTING_ENABLED_BY_SCRIPT" = true ]
+then
 	$OCC app:disable testing
 fi
 

--- a/tests/travis/start_ui_tests.sh
+++ b/tests/travis/start_ui_tests.sh
@@ -25,84 +25,84 @@ verlt() {
 # @return occ return code given in the xml data
 remote_occ() {
 	RESULT=`curl -s -u admin:$1 $2 -d "command=$3"`
-	RETURN=`echo $RESULT | xmllint --xpath "string(ocs/data/code)" - | sed 's/ //g'`
+	RETURN=`echo ${RESULT} | xmllint --xpath "string(ocs/data/code)" - | sed 's/ //g'`
 	# we could not find a proper return of the testing app, so something went wrong
-	if [ -z "$RETURN" ]
+	if [ -z "${RETURN}" ]
 	then
 		RETURN=1
-		REMOTE_OCC_STDERR=$RESULT
+		REMOTE_OCC_STDERR=${RESULT}
 	else
-		REMOTE_OCC_STDOUT=`echo $RESULT | xmllint --xpath "string(ocs/data/stdOut)" - | sed 's/ //g'`
-		REMOTE_OCC_STDERR=`echo $RESULT | xmllint --xpath "string(ocs/data/stdErr)" - | sed 's/ //g'`
+		REMOTE_OCC_STDOUT=`echo ${RESULT} | xmllint --xpath "string(ocs/data/stdOut)" - | sed 's/ //g'`
+		REMOTE_OCC_STDERR=`echo ${RESULT} | xmllint --xpath "string(ocs/data/stdErr)" - | sed 's/ //g'`
 	fi
-	return $RETURN
+	return ${RETURN}
 }
 
 # save the current language and set the language to "C"
 # we want to have it all in english to be able to parse outputs
-OLD_LANG=$LANG
+OLD_LANG=${LANG}
 export LANG=C
 
 OCC=./occ
 
-BASE_URL="http://$SRV_HOST_NAME"
-if [ ! -z "$SRV_HOST_PORT" ] && [ "$SRV_HOST_PORT" != "80" ]
+BASE_URL="http://${SRV_HOST_NAME}"
+if [ ! -z "${SRV_HOST_PORT}" ] && [ "${SRV_HOST_PORT}" != "80" ]
 then
-	BASE_URL="$BASE_URL:$SRV_HOST_PORT"
+	BASE_URL="${BASE_URL}:${SRV_HOST_PORT}"
 fi
 
-IPV4_URL="$BASE_URL"
-IPV6_URL="$BASE_URL"
+IPV4_URL="${BASE_URL}"
+IPV6_URL="${BASE_URL}"
 
-if [ -n "$SRV_HOST_URL" ]
+if [ -n "${SRV_HOST_URL}" ]
 then
-	BASE_URL="$BASE_URL/$SRV_HOST_URL"
-	IPV4_URL="$IPV4_URL/$SRV_HOST_URL"
-	IPV6_URL="$IPV6_URL/$SRV_HOST_URL"
+	BASE_URL="${BASE_URL}/${SRV_HOST_URL}"
+	IPV4_URL="${IPV4_URL}/${SRV_HOST_URL}"
+	IPV6_URL="${IPV6_URL}/${SRV_HOST_URL}"
 fi
 
-REMOTE_FED_BASE_URL="http://$REMOTE_FED_SRV_HOST_NAME"
+REMOTE_FED_BASE_URL="http://${REMOTE_FED_SRV_HOST_NAME}"
 
-if [ ! -z "$REMOTE_FED_SRV_HOST_PORT" ] && [ "$REMOTE_FED_SRV_HOST_PORT" != "80" ]
+if [ ! -z "${REMOTE_FED_SRV_HOST_PORT}" ] && [ "${REMOTE_FED_SRV_HOST_PORT}" != "80" ]
 then
-	REMOTE_FED_BASE_URL="$REMOTE_FED_BASE_URL:$REMOTE_FED_SRV_HOST_PORT"
+	REMOTE_FED_BASE_URL="${REMOTE_FED_BASE_URL}:${REMOTE_FED_SRV_HOST_PORT}"
 fi
 
-if [ ! -z "$IPV4_HOST_NAME" ]
+if [ ! -z "${IPV4_HOST_NAME}" ]
 then
-	IPV4_URL="http://$IPV4_HOST_NAME"
-	if [ ! -z "$SRV_HOST_PORT" ] && [ "$SRV_HOST_PORT" != "80" ]
+	IPV4_URL="http://${IPV4_HOST_NAME}"
+	if [ ! -z "${SRV_HOST_PORT}" ] && [ "${SRV_HOST_PORT}" != "80" ]
 	then
-		IPV4_URL="$IPV4_URL:$SRV_HOST_PORT"
+		IPV4_URL="${IPV4_URL}:${SRV_HOST_PORT}"
 	fi
 fi
 
-if [ ! -z "$IPV6_HOST_NAME" ]
+if [ ! -z "${IPV6_HOST_NAME}" ]
 then
-	IPV6_URL="http://$IPV6_HOST_NAME"
-	if [ ! -z "$SRV_HOST_PORT" ] && [ "$SRV_HOST_PORT" != "80" ]
+	IPV6_URL="http://${IPV6_HOST_NAME}"
+	if [ ! -z "${SRV_HOST_PORT}" ] && [ "${SRV_HOST_PORT}" != "80" ]
 	then
-		IPV6_URL="$IPV6_URL:$SRV_HOST_PORT"
+		IPV6_URL="${IPV6_URL}:${SRV_HOST_PORT}"
 	fi
 fi
 
-if [ -n "$REMOTE_FED_SRV_HOST_URL" ]
+if [ -n "${REMOTE_FED_SRV_HOST_URL}" ]
 then
-	REMOTE_FED_BASE_URL="$REMOTE_FED_BASE_URL/$REMOTE_FED_SRV_HOST_URL"
+	REMOTE_FED_BASE_URL="${REMOTE_FED_BASE_URL}/${REMOTE_FED_SRV_HOST_URL}"
 fi
 
-OCC_URL="$BASE_URL/ocs/v2.php/apps/testing/api/v1/occ"
-if [ -z "$ADMIN_PASSWORD" ]
+OCC_URL="${BASE_URL}/ocs/v2.php/apps/testing/api/v1/occ"
+if [ -z "${ADMIN_PASSWORD}" ]
 then
 	ADMIN_PASSWORD="admin"
 fi
 
-if [ -z "$APPS_TO_DISABLE" ]
+if [ -z "${APPS_TO_DISABLE}" ]
 then
 	APPS_TO_DISABLE="firstrunwizard notifications"
 fi
 
-if [ -z "$APPS_TO_ENABLE" ]
+if [ -z "${APPS_TO_ENABLE}" ]
 then
 	APPS_TO_ENABLE=""
 fi
@@ -165,18 +165,18 @@ then
 fi
 
 # If a feature file has been specified but no suite, then deduce the suite
-if [ -n "$BEHAT_FEATURE" ] && [ -z "$BEHAT_SUITE" ]
+if [ -n "${BEHAT_FEATURE}" ] && [ -z "${BEHAT_SUITE}" ]
 then
-    FEATURE_PATH=`dirname $BEHAT_FEATURE`
-    BEHAT_SUITE=`basename $FEATURE_PATH`
+    FEATURE_PATH=`dirname ${BEHAT_FEATURE}`
+    BEHAT_SUITE=`basename ${FEATURE_PATH}`
 fi
 
-if [ -z "$BEHAT_YML" ]
+if [ -z "${BEHAT_YML}" ]
 then
 	BEHAT_YML="tests/acceptance/config/behat.yml"
 fi
 
-if [ -z "$BEHAT_SUITE" ] && [ "$ALL_SUITES" = false ]
+if [ -z "${BEHAT_SUITE}" ] && [ "${ALL_SUITES}" = false ]
 then
 	echo "ERROR: webUI tests must be run by suite."
 	echo "No suite specified. Specify a suite by either:"
@@ -187,21 +187,21 @@ then
 	echo "Running all webUI suites in a single run will take significant time"
 	exit 1
 else
-	if [ "$ALL_SUITES" = true ]
+	if [ "${ALL_SUITES}" = true ]
 	then
 		BEHAT_SUITE_OPTION=""
 	else
-		BEHAT_SUITE_OPTION="--suite=$BEHAT_SUITE"
+		BEHAT_SUITE_OPTION="--suite=${BEHAT_SUITE}"
 	fi
 fi
 
 BEHAT_TAG_OPTION="--tags"
 
-if [ -z "$MAILHOG_HOST" ]
+if [ -z "${MAILHOG_HOST}" ]
 then
 	MAILHOG_HOST="127.0.0.1"
 fi
-if [ -z "$MAILHOG_SMTP_PORT" ]
+if [ -z "${MAILHOG_SMTP_PORT}" ]
 then
 	MAILHOG_SMTP_PORT="1025"
 fi
@@ -210,13 +210,13 @@ fi
 # a remote instance (e.g. inside docker).
 # if we have a remote instance we cannot enable the testing app and
 # we have to hope it is enabled by other ways
-if [ "$REMOTE_ONLY" = false ]
+if [ "${REMOTE_ONLY}" = false ]
 then
 	# enable testing app
-	PREVIOUS_TESTING_APP_STATUS=$($OCC --no-warnings app:list "^testing$")
-	if [[ "$PREVIOUS_TESTING_APP_STATUS" =~ ^Disabled: ]]
+	PREVIOUS_TESTING_APP_STATUS=$(${OCC} --no-warnings app:list "^testing$")
+	if [[ "${PREVIOUS_TESTING_APP_STATUS}" =~ ^Disabled: ]]
 	then
-		$OCC app:enable testing
+		${OCC} app:enable testing
 		TESTING_ENABLED_BY_SCRIPT=true;
 	else
 		TESTING_ENABLED_BY_SCRIPT=false;
@@ -226,28 +226,28 @@ else
 fi
 
 # set SMTP settings
-remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings config:system:get mail_domain"
-PREVIOUS_MAIL_DOMAIN=$REMOTE_OCC_STDOUT
-remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings config:system:get mail_from_address"
-PREVIOUS_MAIL_FROM_ADDRESS=$REMOTE_OCC_STDOUT
-remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings config:system:get mail_smtpmode"
-PREVIOUS_MAIL_SMTP_MODE=$REMOTE_OCC_STDOUT
-remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings config:system:get mail_smtphost"
-PREVIOUS_MAIL_SMTP_HOST=$REMOTE_OCC_STDOUT
-remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings config:system:get mail_smtpport"
-PREVIOUS_MAIL_SMTP_PORT=$REMOTE_OCC_STDOUT
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "--no-warnings config:system:get mail_domain"
+PREVIOUS_MAIL_DOMAIN=${REMOTE_OCC_STDOUT}
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "--no-warnings config:system:get mail_from_address"
+PREVIOUS_MAIL_FROM_ADDRESS=${REMOTE_OCC_STDOUT}
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "--no-warnings config:system:get mail_smtpmode"
+PREVIOUS_MAIL_SMTP_MODE=${REMOTE_OCC_STDOUT}
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "--no-warnings config:system:get mail_smtphost"
+PREVIOUS_MAIL_SMTP_HOST=${REMOTE_OCC_STDOUT}
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "--no-warnings config:system:get mail_smtpport"
+PREVIOUS_MAIL_SMTP_PORT=${REMOTE_OCC_STDOUT}
 
-remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_domain --value=foobar.com"
-remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_from_address --value=owncloud"
-remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_smtpmode --value=smtp"
-remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_smtphost --value=$MAILHOG_HOST"
-remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_smtpport --value=$MAILHOG_SMTP_PORT"
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:set mail_domain --value=foobar.com"
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:set mail_from_address --value=owncloud"
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:set mail_smtpmode --value=smtp"
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:set mail_smtphost --value=${MAILHOG_HOST}"
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:set mail_smtpport --value=${MAILHOG_SMTP_PORT}"
 
 # get the current backgroundjobs_mode
-remote_occ $ADMIN_PASSWORD $OCC_URL "config:app:get core backgroundjobs_mode"
-PREVIOUS_BACKGROUNDJOBS_MODE=$REMOTE_OCC_STDOUT
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:app:get core backgroundjobs_mode"
+PREVIOUS_BACKGROUNDJOBS_MODE=${REMOTE_OCC_STDOUT}
 # switch to webcron
-remote_occ $ADMIN_PASSWORD $OCC_URL "config:app:set core backgroundjobs_mode --value webcron"
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:app:set core backgroundjobs_mode --value webcron"
 if [ $? -ne 0 ]
 then
 	echo "WARNING: Could not set backgroundjobs mode to 'webcron'"
@@ -255,50 +255,50 @@ fi
 
 APPS_TO_REENABLE="";
 
-for APP_TO_DISABLE in $APPS_TO_DISABLE; do
-	remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:list ^$APP_TO_DISABLE$"
-	PREVIOUS_APP_STATUS=$REMOTE_OCC_STDOUT
-	if [[ "$PREVIOUS_APP_STATUS" =~ ^Enabled: ]]
+for APP_TO_DISABLE in ${APPS_TO_DISABLE}; do
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "--no-warnings app:list ^${APP_TO_DISABLE}$"
+	PREVIOUS_APP_STATUS=${REMOTE_OCC_STDOUT}
+	if [[ "${PREVIOUS_APP_STATUS}" =~ ^Enabled: ]]
 	then
-		APPS_TO_REENABLE="$APPS_TO_REENABLE $APP_TO_DISABLE";
-		remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:disable $APP_TO_DISABLE"
+		APPS_TO_REENABLE="${APPS_TO_REENABLE} ${APP_TO_DISABLE}";
+		remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "--no-warnings app:disable ${APP_TO_DISABLE}"
 	fi
 done
 
 APPS_TO_REDISABLE="";
 
-for APP_TO_ENABLE in $APPS_TO_ENABLE; do
-	remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:list ^$APP_TO_ENABLE$"
-	PREVIOUS_APP_STATUS=$REMOTE_OCC_STDOUT
-	if [[ "$PREVIOUS_APP_STATUS" =~ ^Disabled: ]]
+for APP_TO_ENABLE in ${APPS_TO_ENABLE}; do
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "--no-warnings app:list ^${APP_TO_ENABLE}$"
+	PREVIOUS_APP_STATUS=${REMOTE_OCC_STDOUT}
+	if [[ "${PREVIOUS_APP_STATUS}" =~ ^Disabled: ]]
 	then
-		APPS_TO_REDISABLE="$APPS_TO_REDISABLE $APP_TO_ENABLE";
-		remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:enable $APP_TO_ENABLE"
+		APPS_TO_REDISABLE="${APPS_TO_REDISABLE} ${APP_TO_ENABLE}";
+		remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "--no-warnings app:enable ${APP_TO_ENABLE}"
 	fi
 done
 
 # we need to skip some tests in certain browsers
 # and also skip tests if tags were given in the call of this script
-if [ "$BROWSER" == "internet explorer" ] || [ "$BROWSER" == "MicrosoftEdge" ] || [ "$BROWSER" == "firefox" ]
+if [ "${BROWSER}" == "internet explorer" ] || [ "${BROWSER}" == "MicrosoftEdge" ] || [ "${BROWSER}" == "firefox" ]
 then
 	BROWSER_IN_CAPITALS=${BROWSER//[[:blank:]]/}
 	BROWSER_IN_CAPITALS=${BROWSER_IN_CAPITALS^^}
 	
-	if [ "$BEHAT_TAGS_OPTION_FOUND" = true ]
+	if [ "${BEHAT_TAGS_OPTION_FOUND}" = true ]
 	then
-		if [ -z "$BEHAT_TAGS" ]
+		if [ -z "${BEHAT_TAGS}" ]
 		then
-			BEHAT_TAGS='~@skipOn'$BROWSER_IN_CAPITALS
+			BEHAT_TAGS='~@skipOn'${BROWSER_IN_CAPITALS}
 		else
-			BEHAT_TAGS="$BEHAT_TAGS&&~@skipOn"$BROWSER_IN_CAPITALS
+			BEHAT_TAGS="${BEHAT_TAGS}&&~@skipOn"${BROWSER_IN_CAPITALS}
 		fi
 	else
-		BEHAT_TAGS='~@skip&&~@skipOn'$BROWSER_IN_CAPITALS
+		BEHAT_TAGS='~@skip&&~@skipOn'${BROWSER_IN_CAPITALS}
 	fi
 else
-	if [ "$BEHAT_TAGS_OPTION_FOUND" = true ]
+	if [ "${BEHAT_TAGS_OPTION_FOUND}" = true ]
 	then
-		if [ -z "$BEHAT_TAGS" ]
+		if [ -z "${BEHAT_TAGS}" ]
 		then
 			BEHAT_TAG_OPTION=""
 		fi
@@ -314,23 +314,23 @@ fi
 # @skipOnOcV10.0
 # @skipOnOcV10
 
-remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:get version"
-OWNCLOUD_VERSION=`echo $REMOTE_OCC_STDOUT | cut -d"." -f1-3`
-BEHAT_TAGS='~@skipOnOcV'$OWNCLOUD_VERSION'&&'$BEHAT_TAGS
-OWNCLOUD_VERSION=`echo $OWNCLOUD_VERSION | cut -d"." -f1-2`
-BEHAT_TAGS='~@skipOnOcV'$OWNCLOUD_VERSION'&&'$BEHAT_TAGS
-OWNCLOUD_VERSION=`echo $OWNCLOUD_VERSION | cut -d"." -f1`
-BEHAT_TAGS='~@skipOnOcV'$OWNCLOUD_VERSION'&&'$BEHAT_TAGS
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:get version"
+OWNCLOUD_VERSION=`echo ${REMOTE_OCC_STDOUT} | cut -d"." -f1-3`
+BEHAT_TAGS='~@skipOnOcV'${OWNCLOUD_VERSION}'&&'${BEHAT_TAGS}
+OWNCLOUD_VERSION=`echo ${OWNCLOUD_VERSION} | cut -d"." -f1-2`
+BEHAT_TAGS='~@skipOnOcV'${OWNCLOUD_VERSION}'&&'${BEHAT_TAGS}
+OWNCLOUD_VERSION=`echo ${OWNCLOUD_VERSION} | cut -d"." -f1`
+BEHAT_TAGS='~@skipOnOcV'${OWNCLOUD_VERSION}'&&'${BEHAT_TAGS}
 
 # if we running remote only tests add an other skip '@skipWhenTestingRemoteSystems'
-if [ "$REMOTE_ONLY" = true ]
+if [ "${REMOTE_ONLY}" = true ]
 then
-	BEHAT_TAGS='~@skipWhenTestingRemoteSystems&&'$BEHAT_TAGS
+	BEHAT_TAGS='~@skipWhenTestingRemoteSystems&&'${BEHAT_TAGS}
 fi
 
-BEHAT_TAGS='@webUI&&'$BEHAT_TAGS
+BEHAT_TAGS='@webUI&&'${BEHAT_TAGS}
 
-if [ "$BROWSER" == "firefox" ]
+if [ "${BROWSER}" == "firefox" ]
 then
 	# set screen resolution so that hopefully dragable elements will be visible
 	# FF gives problems if the destination element is not visible
@@ -338,114 +338,114 @@ then
 
 	# this selenium version works for Firefox after V47
 	# we no longer need to support testing of Firefox V47 or earlier
-	EXTRA_CAPABILITIES='"seleniumVersion":"3.4.0",'$EXTRA_CAPABILITIES
+	EXTRA_CAPABILITIES='"seleniumVersion":"3.4.0",'${EXTRA_CAPABILITIES}
 fi
 
-if [ "$BROWSER" == "internet explorer" ]
+if [ "${BROWSER}" == "internet explorer" ]
 then
 	EXTRA_CAPABILITIES='"iedriverVersion": "3.4.0","requiresWindowFocus":true,"screenResolution":"1920x1080",'
 fi
 
-EXTRA_CAPABILITIES=$EXTRA_CAPABILITIES'"browserVersion":"'$BROWSER_VERSION'","maxDuration":"3600"'
+EXTRA_CAPABILITIES=$EXTRA_CAPABILITIES'"browserVersion":"'${BROWSER_VERSION}'","maxDuration":"3600"'
 
 # Set up personalized skeleton
-remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings config:system:get skeletondirectory"
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "--no-warnings config:system:get skeletondirectory"
 
-PREVIOUS_SKELETON_DIR=$REMOTE_OCC_STDOUT
+PREVIOUS_SKELETON_DIR=${REMOTE_OCC_STDOUT}
 
 # $SRC_SKELETON_DIR is the path to the skeleton folder on the machine where the tests are executed
 # it is used for file comparisons in various tests
 export SRC_SKELETON_DIR=$(pwd)/tests/acceptance/webUISkeleton
 # $SKELETON_DIR is the path to the skeleton folder on the machine where oC runs (system under test)
 # it is used to give users a defined set of files and folders for the tests
-if [ -z "$SKELETON_DIR" ]
+if [ -z "${SKELETON_DIR}" ]
 then
-	export SKELETON_DIR="$SRC_SKELETON_DIR"
+	export SKELETON_DIR="${SRC_SKELETON_DIR}"
 fi
 
-remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set skeletondirectory --value=$SKELETON_DIR"
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:set skeletondirectory --value=${SKELETON_DIR}"
 if [ $? -ne 0 ]
 then
-	echo -e "Could not set skeleton directory. Result:\n'$REMOTE_OCC_STDERR'"
+	echo -e "Could not set skeleton directory. Result:\n'${REMOTE_OCC_STDERR}'"
 	exit 1
 fi
 
 TEST_LOG_FILE=$(mktemp)
 
-if [ -z "$SELENIUM_HOST" ]
+if [ -z "${SELENIUM_HOST}" ]
 then
 	SELENIUM_HOST=localhost
 fi
 
-if [ -z "$SELENIUM_PORT" ]
+if [ -z "${SELENIUM_PORT}" ]
 then
 	SELENIUM_PORT=4445
 fi
 
-if [ "$ALL_SUITES" = true ]
+if [ "${ALL_SUITES}" = true ]
 then
 	SUITE_FEATURE_TEXT="all"
 else
-	SUITE_FEATURE_TEXT="$BEHAT_SUITE"
+	SUITE_FEATURE_TEXT="${BEHAT_SUITE}"
 fi
 
-if [ -n "$BEHAT_FEATURE" ]
+if [ -n "${BEHAT_FEATURE}" ]
 then
     # If running a whole feature, it will be something like login.feature
     # If running just a single scenario, it will also have the line number
     # like login.feature:36 - which will be parsed correctly like a "file"
     # by basename.
-    BEHAT_FEATURE_FILE=`basename $BEHAT_FEATURE`
-    SUITE_FEATURE_TEXT="$SUITE_FEATURE_TEXT $BEHAT_FEATURE_FILE"
+    BEHAT_FEATURE_FILE=`basename ${BEHAT_FEATURE}`
+    SUITE_FEATURE_TEXT="${SUITE_FEATURE_TEXT} ${BEHAT_FEATURE_FILE}"
 fi
 
-echo "Running $SUITE_FEATURE_TEXT tests on '$BROWSER' ($BROWSER_VERSION) on $PLATFORM" | tee $TEST_LOG_FILE
-export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"browser_name": "'$BROWSER'", "base_url" : "'$BASE_URL'", "selenium2":{"capabilities": {"marionette":null, "browser": "'$BROWSER'", "version": "'$BROWSER_VERSION'", "platform": "'$PLATFORM'", "name": "'$TRAVIS_REPO_SLUG' - '$TRAVIS_JOB_NUMBER'", "extra_capabilities": {'$EXTRA_CAPABILITIES'}}, "wd_host":"http://'$SAUCE_USERNAME:$SAUCE_ACCESS_KEY'@'$SELENIUM_HOST':'$SELENIUM_PORT'/wd/hub"}}, "SensioLabs\\Behat\\PageObjectExtension" : {}}}'
+echo "Running ${SUITE_FEATURE_TEXT} tests on '${BROWSER}' (${BROWSER_VERSION}) on ${PLATFORM}" | tee ${TEST_LOG_FILE}
+export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"browser_name": "'${BROWSER}'", "base_url" : "'${BASE_URL}'", "selenium2":{"capabilities": {"marionette":null, "browser": "'${BROWSER}'", "version": "'${BROWSER_VERSION}'", "platform": "'${PLATFORM}'", "name": "'${TRAVIS_REPO_SLUG}' - '${TRAVIS_JOB_NUMBER}'", "extra_capabilities": {'${EXTRA_CAPABILITIES}'}}, "wd_host":"http://'${SAUCE_USERNAME}:${SAUCE_ACCESS_KEY}'@'${SELENIUM_HOST}':'${SELENIUM_PORT}'/wd/hub"}}, "SensioLabs\\Behat\\PageObjectExtension" : {}}}'
 export IPV4_URL
 export IPV6_URL
 export REMOTE_FED_BASE_URL
 export FILES_FOR_UPLOAD="$(pwd)/tests/acceptance/filesForUpload/"
 
 # Provide TEST_SERVER* env vars. Some API acceptance test code uses these.
-export TEST_SERVER_URL="$BASE_URL"
-export TEST_SERVER_FED_URL="$REMOTE_FED_BASE_URL"
+export TEST_SERVER_URL="${BASE_URL}"
+export TEST_SERVER_FED_URL="${REMOTE_FED_BASE_URL}"
 
-if [ ! -w $FILES_FOR_UPLOAD ]
+if [ ! -w ${FILES_FOR_UPLOAD} ]
 then
-	echo "WARNING: cannot write to upload folder '$FILES_FOR_UPLOAD', some upload tests might fail"
+	echo "WARNING: cannot write to upload folder '${FILES_FOR_UPLOAD}', some upload tests might fail"
 fi
 
-lib/composer/bin/behat --strict -c $BEHAT_YML $BEHAT_SUITE_OPTION $BEHAT_TAG_OPTION $BEHAT_TAGS $BEHAT_FEATURE -v  2>&1 | tee -a $TEST_LOG_FILE
+lib/composer/bin/behat --strict -c ${BEHAT_YML} ${BEHAT_SUITE_OPTION} ${BEHAT_TAG_OPTION} ${BEHAT_TAGS} ${BEHAT_FEATURE} -v  2>&1 | tee -a ${TEST_LOG_FILE}
 
 BEHAT_EXIT_STATUS=${PIPESTATUS[0]}
 
-if [ $BEHAT_EXIT_STATUS -eq 0 ]
+if [ ${BEHAT_EXIT_STATUS} -eq 0 ]
 then
 	PASSED=true
 else
 	PASSED=false
 fi
 
-if [ "$PASSED" = false ] && [ "${RERUN_FAILED_WEBUI_SCENARIOS}" = true ]
+if [ "${PASSED}" = false ] && [ "${RERUN_FAILED_WEBUI_SCENARIOS}" = true ]
 then
-	echo test run failed with exit status: $BEHAT_EXIT_STATUS
+	echo test run failed with exit status: ${BEHAT_EXIT_STATUS}
 	PASSED=true
 	SOME_SCENARIO_RERUN=false
-	FAILED_SCENARIOS=`awk '/Failed scenarios:/',0 $TEST_LOG_FILE | grep feature`
-	for FEATURE in $FAILED_SCENARIOS
+	FAILED_SCENARIOS=`awk '/Failed scenarios:/',0 ${TEST_LOG_FILE} | grep feature`
+	for FEATURE in ${FAILED_SCENARIOS}
 		do
 			SOME_SCENARIO_RERUN=true
-			echo rerun failed tests: $FEATURE
-			lib/composer/bin/behat --strict -c $BEHAT_YML $BEHAT_SUITE_OPTION $BEHAT_TAG_OPTION $BEHAT_TAGS $FEATURE -v  2>&1 | tee -a $TEST_LOG_FILE
+			echo rerun failed tests: ${FEATURE}
+			lib/composer/bin/behat --strict -c ${BEHAT_YML} ${BEHAT_SUITE_OPTION} ${BEHAT_TAG_OPTION} ${BEHAT_TAGS} ${FEATURE} -v  2>&1 | tee -a ${TEST_LOG_FILE}
 			BEHAT_EXIT_STATUS=${PIPESTATUS[0]}
-			if [ $BEHAT_EXIT_STATUS -ne 0 ]
+			if [ ${BEHAT_EXIT_STATUS} -ne 0 ]
 			then
-				echo test rerun failed with exit status: $BEHAT_EXIT_STATUS
+				echo test rerun failed with exit status: ${BEHAT_EXIT_STATUS}
 				PASSED=false
 			fi
 		done
 
-	if [ "$SOME_SCENARIO_RERUN" = false ]
+	if [ "${SOME_SCENARIO_RERUN}" = false ]
 	then
 		# If the original Behat had a fatal PHP error and exited directly with
 		# a "bad" exit code, then it may not have even logged a summary of the
@@ -455,98 +455,98 @@ then
 	fi
 fi
 
-if [ "$BEHAT_TAGS_OPTION_FOUND" != true ]
+if [ "${BEHAT_TAGS_OPTION_FOUND}" != true ]
 then
 	# The behat run above specified to skip scenarios tagged @skip
 	# Report them in a dry-run so they can be seen
 	# Big red error output is displayed if there are no matching scenarios - send it to null
 	DRY_RUN_FILE=$(mktemp)
-	lib/composer/bin/behat --dry-run --colors -c $BEHAT_YML --tags '@webUI&&@skip' $BEHAT_FEATURE 1>$DRY_RUN_FILE 2>/dev/null
-	if grep -q -m 1 'No scenarios' "$DRY_RUN_FILE"
+	lib/composer/bin/behat --dry-run --colors -c ${BEHAT_YML} --tags '@webUI&&@skip' ${BEHAT_FEATURE} 1>$DRY_RUN_FILE 2>/dev/null
+	if grep -q -m 1 'No scenarios' "${DRY_RUN_FILE}"
 	then
 		# If there are no skip scenarios, then no need to report that
 		:
 	else
 		echo ""
 		echo "The following tests were skipped because they are tagged @skip:"
-		cat "$DRY_RUN_FILE" | tee -a $TEST_LOG_FILE
+		cat "${DRY_RUN_FILE}" | tee -a ${TEST_LOG_FILE}
 	fi
-	rm -f "$DRY_RUN_FILE"
+	rm -f "${DRY_RUN_FILE}"
 fi
 
 # Put back personalized skeleton
-if [ "A$PREVIOUS_SKELETON_DIR" = "A" ]
+if [ "A${PREVIOUS_SKELETON_DIR}" = "A" ]
 then
-	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete skeletondirectory"
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:delete skeletondirectory"
 else
-	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set skeletondirectory --value=$PREVIOUS_SKELETON_DIR"
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:set skeletondirectory --value=${PREVIOUS_SKELETON_DIR}"
 fi
 
 # Put back smtp settings
-if [ "A$PREVIOUS_MAIL_DOMAIN" = "A" ]
+if [ "A${PREVIOUS_MAIL_DOMAIN}" = "A" ]
 then
-	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete mail_domain"
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:delete mail_domain"
 else
-	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_domain --value=$PREVIOUS_MAIL_DOMAIN"
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:set mail_domain --value=${PREVIOUS_MAIL_DOMAIN}"
 fi
 
-if [ "A$PREVIOUS_MAIL_FROM_ADDRESS" = "A" ]
+if [ "A${PREVIOUS_MAIL_FROM_ADDRESS}" = "A" ]
 then
-	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete mail_from_address"
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:delete mail_from_address"
 else
-	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_from_address --value=$PREVIOUS_MAIL_FROM_ADDRESS"
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:set mail_from_address --value=${PREVIOUS_MAIL_FROM_ADDRESS}"
 fi
 
-if [ "A$PREVIOUS_MAIL_SMTP_MODE" = "A" ]
+if [ "A${PREVIOUS_MAIL_SMTP_MODE}" = "A" ]
 then
-	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete mail_smtpmode"
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:delete mail_smtpmode"
 else
-	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_smtpmode --value=$PREVIOUS_MAIL_SMTP_MODE"
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:set mail_smtpmode --value=${PREVIOUS_MAIL_SMTP_MODE}"
 fi
 
-if [ "A$PREVIOUS_MAIL_SMTP_HOST" = "A" ]
+if [ "A${PREVIOUS_MAIL_SMTP_HOST}" = "A" ]
 then
-	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete mail_smtphost"
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:delete mail_smtphost"
 else
-	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_smtphost --value=$PREVIOUS_MAIL_SMTP_HOST"
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:set mail_smtphost --value=${PREVIOUS_MAIL_SMTP_HOST}"
 fi
 
-if [ "A$PREVIOUS_MAIL_SMTP_PORT" = "A" ]
+if [ "A${PREVIOUS_MAIL_SMTP_PORT}" = "A" ]
 then
-	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:delete mail_smtpport"
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:delete mail_smtpport"
 else
-	remote_occ $ADMIN_PASSWORD $OCC_URL "config:system:set mail_smtpport --value=$PREVIOUS_MAIL_SMTP_PORT"
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:system:set mail_smtpport --value=${PREVIOUS_MAIL_SMTP_PORT}"
 fi
 
-for APP_TO_ENABLE in $APPS_TO_REENABLE; do
-	remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:enable $APP_TO_ENABLE"
+for APP_TO_ENABLE in ${APPS_TO_REENABLE}; do
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "--no-warnings app:enable ${APP_TO_ENABLE}"
 done
 
-for APP_TO_DISABLE in $APPS_TO_REDISABLE; do
-	remote_occ $ADMIN_PASSWORD $OCC_URL "--no-warnings app:disable $APP_TO_DISABLE"
+for APP_TO_DISABLE in ${APPS_TO_REDISABLE}; do
+	remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "--no-warnings app:disable ${APP_TO_DISABLE}"
 done
 
 # put back the backgroundjobs_mode
-remote_occ $ADMIN_PASSWORD $OCC_URL "config:app:set core backgroundjobs_mode --value $PREVIOUS_BACKGROUNDJOBS_MODE"
+remote_occ ${ADMIN_PASSWORD} ${OCC_URL} "config:app:set core backgroundjobs_mode --value ${PREVIOUS_BACKGROUNDJOBS_MODE}"
 
 # Put back state of the testing app
-if [ "$TESTING_ENABLED_BY_SCRIPT" = true ]
+if [ "${TESTING_ENABLED_BY_SCRIPT}" = true ]
 then
 	$OCC app:disable testing
 fi
 
 #upload log file for later analysis
-if [ "$PASSED" = false ] && [ ! -z "$REPORTING_WEBDAV_USER" ] && [ ! -z "$REPORTING_WEBDAV_PWD" ] && [ ! -z "$REPORTING_WEBDAV_URL" ]
+if [ "${PASSED}" = false ] && [ ! -z "${REPORTING_WEBDAV_USER}" ] && [ ! -z "${REPORTING_WEBDAV_PWD}" ] && [ ! -z "${REPORTING_WEBDAV_URL}" ]
 then
-	curl -u $REPORTING_WEBDAV_USER:$REPORTING_WEBDAV_PWD -T $TEST_LOG_FILE $REPORTING_WEBDAV_URL/"$TRAVIS_JOB_NUMBER"_`date "+%F_%T"`.log
+	curl -u ${REPORTING_WEBDAV_USER}:${REPORTING_WEBDAV_PWD} -T ${TEST_LOG_FILE} ${REPORTING_WEBDAV_URL}/"${TRAVIS_JOB_NUMBER}"_`date "+%F_%T"`.log
 fi
 
 #reset the original language
-export LANG=$OLD_LANG
+export LANG=${OLD_LANG}
 
-rm -f "$TEST_LOG_FILE"
+rm -f "${TEST_LOG_FILE}"
 
-if [ "$PASSED" = true ]
+if [ "${PASSED}" = true ]
 then
 	exit 0
 else


### PR DESCRIPTION
## Description
1) standardize the format of ``if`` tests in the acceptance test scripts
2) remove special Firefox V47 checks from webUI testing - we don;t care about old Firefox any more
3) put {} around env var usages - as my IDE reminds me constantly
4) pass ADMIN_USERNAME in run.sh and start_ui_tests.sh scripts (ADMIN_PASSWORD can be passed from outside, so for future testing of "black box" installs we should be able to pass in the admin username also, just in case it is not "admin".
5) remove unused webUI username and password definitions - those are already defined and used from FeatureContext anyway.

## Motivation and Context
Commit refactoring of scripts separately to the merge of webUI and API acceptance test scripts. Because that will reduce the noise in the diffs of the PR that does the merge.

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
