### PR TITLE
While decrypting userkey prepareEncryptionModules() must be called, keep fileid on decrypt

### DIFF
--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -165,6 +165,11 @@ class DecryptAll {
 				return false;
 			}
 			$this->userManager->callForSeenUsers(function (IUser $user) use ($progress, &$userNo, $numberOfUsers) {
+				if (\OC::$server->getAppConfig()->getValue('encryption', 'userSpecificKey', '0') !== 0) {
+					if ($this->prepareEncryptionModules($user->getUID()) === false) {
+						return false;
+					}
+				}
 				$this->decryptUsersFiles(
 					$user->getUID(),
 					$progress,

--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -59,6 +59,8 @@ class DecryptAll {
 	protected $logger;
 
 	/**
+	 * DecryptAll constructor.
+	 *
 	 * @param Manager $encryptionManager
 	 * @param IUserManager $userManager
 	 * @param View $rootView
@@ -165,7 +167,7 @@ class DecryptAll {
 				return false;
 			}
 			$this->userManager->callForSeenUsers(function (IUser $user) use ($progress, &$userNo, $numberOfUsers) {
-				if (\OC::$server->getAppConfig()->getValue('encryption', 'userSpecificKey', '0') !== 0) {
+				if (\OC::$server->getAppConfig()->getValue('encryption', 'userSpecificKey', '0') !== '0') {
 					if ($this->prepareEncryptionModules($user->getUID()) === false) {
 						return false;
 					}
@@ -250,7 +252,7 @@ class DecryptAll {
 	 */
 	protected function decryptFile($path) {
 		$source = $path;
-		$target = $path . '.decrypted.' . $this->getTimestamp();
+		$target = $path . '.decrypted.' . $this->getTimestamp() . '.part';
 
 		try {
 			\OC\Files\Storage\Wrapper\Encryption::setDisableWriteEncryption(true);


### PR DESCRIPTION
Regression was caused because of omitting call to method
prepareEncryptionModules. This change will get the userkey encryption
work as before.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Call to `prepareEncryptionModules()` was omitted and the check for `userkeys` also got missing. This resulted in regression. And hence encryption with userkey was not decrypted properly. This change would help to fix the regression.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Call to `prepareEncryptionModules()` was omitted and the check for `userkeys` also got missing. This resulted in regression. And hence encryption with userkey was not decrypted properly. This change would help to fix the regression.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Enable userkey encryption
- [x] execute `./occ encryption:decrypt-all`
- [x] The files should be decrypted.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

