### PR TITLE
proper session configuration

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -407,6 +407,10 @@ class OC {
 		$cookie_path = OC::$WEBROOT ? : '/';
 		\ini_set('session.cookie_path', $cookie_path);
 
+		if (self::$server->getRequest()->getServerProtocol() === 'https') {
+			\ini_set('session.cookie_secure', true);
+		}
+
 		// Let the session name be changed in the initSession Hook
 		$sessionName = OC_Util::getInstanceId();
 
@@ -586,9 +590,6 @@ class OC {
 		self::checkInstalled();
 
 		OC_Response::addSecurityHeaders();
-		if (self::$server->getRequest()->getServerProtocol() === 'https') {
-			\ini_set('session.cookie_secure', true);
-		}
 
 		if (!\defined('OC_CONSOLE')) {
 			$errors = OC_Util::checkServer(\OC::$server->getConfig());


### PR DESCRIPTION
## Description

Refering http://php.net/manual/en/session.configuration.php#117668 - using `init_set` on session parameters has only affect, before you start the session.

PHP7.2 changed the silently ignoring behavior to becoming more verbose:
```
ini_set(): A session is active. You cannot change the session module's ini settings at this time ...
```
This PR moves the change before the session creation 

‼️ - as it was silently ignored before - this might now cause havoc ‼️

## Related Issue
This should address #31524 

## Motivation and Context
Fix #31524 

## How Has This Been Tested?

~~First manually testing seemed to work~~ -  let's get this tested by 🤖

This needs careful manual review with an instance with https deployed ( as 🤖 only tests on http )

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

