### PR TITLE
[test] Trigger CI

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# add a line to trigger CI
 # composer install
 
 # from http://stackoverflow.com/a/630387


### PR DESCRIPTION
CI is always failing:

```
There was 1 failure:

1) OCA\Files_External\Tests\Storage\SmbTest::testStat
Failed asserting that 1527225218 is equal to 1527225217 or is less than 1527225217.

/drone/src/tests/lib/Files/Storage/Storage.php:302

FAILURES!
Tests: 85, Assertions: 378, Failures: 1.
```
https://drone.owncloud.com/owncloud/core/7095/150