### PR TITLE
Detune testStat storage mtime test

### DIFF
--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -297,9 +297,9 @@ abstract class Storage extends \Test\TestCase {
 		$this->assertTrue($this->instance->hasUpdated('/lorem.txt', $ctimeStart - 5));
 		$this->assertTrue($this->instance->hasUpdated('/', $ctimeStart - 5));
 
-		// check that ($ctimeStart - 5) <= $mTime <= ($ctimeEnd + 1)
+		// check that ($ctimeStart - 5) <= $mTime <= ($ctimeEnd + 5)
 		$this->assertGreaterThanOrEqual(($ctimeStart - 5), $mTime);
-		$this->assertLessThanOrEqual(($ctimeEnd + 1), $mTime);
+		$this->assertLessThanOrEqual(($ctimeEnd + 5), $mTime);
 		$this->assertEquals(\filesize($textFile), $this->instance->filesize('/lorem.txt'));
 
 		$stat = $this->instance->stat('/lorem.txt');


### PR DESCRIPTION
## Description
Allow +-5 seconds for the ``mTime`` of a modified file when doing ``testStat``.

## Related Issue
#31542 

## Motivation and Context
``testStat`` is failing with the error posted below. It seems that if the backend storage is on some other system (e.g. in this case some SMB server-under-test somewhere) then there is the potential for time differences between that system and the system actually executing the test. That can cause false fails.

See #31526 drone CI results for demonstration of the test fail.

## How Has This Been Tested?
CI passes here. CI is still failing without this change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
