### PR TITLE
[Stable10] remove bower symlink

### DIFF
--- a/build/bin/bower
+++ b/build/bin/bower
@@ -1,1 +1,0 @@
-../lib/node_modules/bower/bin/bower


### PR DESCRIPTION

## Description
remove deprecated symlink - this causes havoc in docker containers or other environments that can not dereference the broken link

## Related Issue
None

## Motivation and Context
Solve errors when creating environments based on stable10 branch

## How Has This Been Tested?
manually

## Screenshots (if appropriate):
-

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] ~~All new and existing tests passed.~~

