### PR TITLE
[Stable10] Use l10n from settings

### DIFF
--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -184,7 +184,7 @@ class Controller {
 		$defaults = new \OC_Defaults();
 		$from = \OCP\Util::getDefaultEmailAddress('lostpassword-noreply');
 		$mailer = \OC::$server->getMailer();
-		$lion = \OC::$server->getL10N('lib');
+		$l10n = \OC::$server->getL10N('settings');
 
 		if ($email !== null && $email !== '') {
 			$tmpl = new \OC_Template('core', 'lostpassword/notify');
@@ -193,12 +193,12 @@ class Controller {
 			try {
 				$message = $mailer->createMessage();
 				$message->setTo([$email => $username]);
-				$message->setSubject($lion->t('%s password changed successfully', [$defaults->getName()]));
+				$message->setSubject($l10n->t('%s password changed successfully', [$defaults->getName()]));
 				$message->setPlainBody($msg);
 				$message->setFrom([$from => $defaults->getName()]);
 				$mailer->send($message);
 			} catch (\Exception $e) {
-				throw new \Exception($lion->t(
+				throw new \Exception($l10n->t(
 					'Couldn\'t send reset email. Please contact your administrator.'
 				));
 			}


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/31513
## Description
Use correct l10n to translate 'password was changed' email

## Related Issue
https://github.com/owncloud/enterprise/issues/2536

## Motivation and Context
Fixes translation for the 'password has been changed' email subject

## How Has This Been Tested?
0. Specify user email, setup SMTP
1. change user lang  to Russian (or any non-English)
2. update user password

### Expected 
Subject of email is in language from 1.

### Actual
Subject of email is always in English.

## Screenshot
The most recent message - this branch (subject in Russian as expected)
Previous message - master (subject still in English)
![screenshot_20180525_165655](https://user-images.githubusercontent.com/991300/40548216-c0abadf0-603c-11e8-991b-38ea00f626ae.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
