### PR TITLE
[stable10] Move select2 lib to core

### DIFF
--- a/apps/systemtags/appinfo/app.php
+++ b/apps/systemtags/appinfo/app.php
@@ -27,11 +27,7 @@ use OCP\SystemTag\MapperEvent;
 $eventDispatcher = \OC::$server->getEventDispatcher();
 $eventDispatcher->addListener(
 	'OCA\Files::loadAdditionalScripts',
-	function() {
-		// FIXME: no public API for these ?
-		\OC_Util::addVendorScript('select2/select2');
-		\OC_Util::addVendorStyle('select2/select2');
-
+	function () {
 		\OCP\Util::addScript('select2-toggleselect');
 		\OCP\Util::addScript('oc-backbone-webdav');
 		\OCP\Util::addScript('systemtags/systemtags');

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -109,20 +109,19 @@ class OC_Template extends \OC\Template\Base {
 				}
 			}
 
-			OC_Util::addStyle("tooltip",null,true);
-			OC_Util::addStyle('jquery-ui-fixes',null,true);
-			OC_Util::addVendorStyle('jquery-ui/themes/base/jquery-ui',null,true);
-			OC_Util::addVendorStyle('select2/select2',null,true);
-			OC_Util::addStyle("mobile",null,true);
-			OC_Util::addStyle("multiselect",null,true);
-			OC_Util::addStyle("fixes",null,true);
-			OC_Util::addStyle("global",null,true);
-			OC_Util::addStyle("apps",null,true);
-			OC_Util::addStyle("fonts",null,true);
-			OC_Util::addStyle("icons",null,true);
-			OC_Util::addStyle("header",null,true);
-			OC_Util::addStyle("inputs",null,true);
-			OC_Util::addStyle("styles",null,true);
+			OC_Util::addStyle("tooltip", null, true);
+			OC_Util::addStyle('jquery-ui-fixes', null, true);
+			OC_Util::addVendorStyle('jquery-ui/themes/base/jquery-ui', null, true);
+			OC_Util::addStyle("mobile", null, true);
+			OC_Util::addStyle("multiselect", null, true);
+			OC_Util::addStyle("fixes", null, true);
+			OC_Util::addStyle("global", null, true);
+			OC_Util::addStyle("apps", null, true);
+			OC_Util::addStyle("fonts", null, true);
+			OC_Util::addStyle("icons", null, true);
+			OC_Util::addStyle("header", null, true);
+			OC_Util::addStyle("inputs", null, true);
+			OC_Util::addStyle("styles", null, true);
 
 			// avatars
 			if (\OC::$server->getSystemConfig()->getValue('enable_avatars', true) === true) {
@@ -132,6 +131,8 @@ class OC_Template extends \OC\Template\Base {
 
 			OC_Util::addScript('oc-backbone', null, true);
 			OC_Util::addVendorScript('core', 'backbone/backbone', true);
+			OC_Util::addVendorScript('core', 'select2/select2', true);
+			OC_Util::addVendorStyle('select2/select2', null, true);
 			OC_Util::addVendorScript('snapjs/dist/latest/snap', null, true);
 			OC_Util::addScript('mimetypelist', null, true);
 			OC_Util::addScript('mimetype', null, true);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Move the select2 js library from systemtags app to core for global usage.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes: https://github.com/owncloud/core/issues/31338
Backporting: https://github.com/owncloud/core/pull/31498#pullrequestreview-122562300

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.