### PR TITLE
[stable10] Symfony events added for login failed and public link acce…

### DIFF
--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -57,7 +57,8 @@ class Application extends App {
 				$server->getShareManager(),
 				$server->getSession(),
 				$server->getPreviewManager(),
-				$server->getRootFolder()
+				$server->getRootFolder(),
+				$server->getEventDispatcher()
 			);
 		});
 		$container->registerService('ExternalSharesController', function (SimpleContainer $c) use ($server) {

--- a/apps/files_sharing/tests/Controllers/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controllers/ShareControllerTest.php
@@ -40,6 +40,8 @@ use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
 use OCP\Share\Exceptions\ShareNotFound;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * @group DB
@@ -71,6 +73,7 @@ class ShareControllerTest extends \Test\TestCase {
 	private $userManager;
 	/** @var  FederatedShareProvider | \PHPUnit_Framework_MockObject_MockObject */
 	private $federatedShareProvider;
+	private $eventDispatcher;
 
 	protected function setUp() {
 		parent::setUp();
@@ -88,6 +91,7 @@ class ShareControllerTest extends \Test\TestCase {
 			->method('isOutgoingServer2serverShareEnabled')->willReturn(true);
 		$this->federatedShareProvider->expects($this->any())
 			->method('isIncomingServer2serverShareEnabled')->willReturn(true);
+		$this->eventDispatcher = new EventDispatcher();
 
 		$this->shareController = new \OCA\Files_Sharing\Controllers\ShareController(
 			$this->appName,
@@ -101,6 +105,7 @@ class ShareControllerTest extends \Test\TestCase {
 			$this->session,
 			$this->previewManager,
 			$this->createMock('\OCP\Files\IRootFolder'),
+			$this->eventDispatcher,
 			$this->federatedShareProvider
 		);
 
@@ -257,6 +262,13 @@ class ShareControllerTest extends \Test\TestCase {
 		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['access'])->getMock();
 		\OCP\Util::connectHook('OCP\Share', 'share_link_access',  $hookListner, 'access');
 
+		$calledShareLinkAccess = [];
+		$this->eventDispatcher->addListener('share.linkaccess',
+			function (GenericEvent $event) use (&$calledShareLinkAccess) {
+				$calledShareLinkAccess[] = 'share.linkaccess';
+				$calledShareLinkAccess[] = $event;
+			});
+
 		$hookListner->expects($this->once())
 			->method('access')
 			->with($this->callback(function(array $data) {
@@ -271,6 +283,16 @@ class ShareControllerTest extends \Test\TestCase {
 		$response = $this->shareController->authenticate('token', 'invalidpassword');
 		$expectedResponse =  new TemplateResponse($this->appName, 'authenticate', ['wrongpw' => true], 'guest');
 		$this->assertEquals($expectedResponse, $response);
+
+		$this->assertEquals('share.linkaccess', $calledShareLinkAccess[0]);
+		$this->assertInstanceOf(GenericEvent::class, $calledShareLinkAccess[1]);
+		$this->assertArrayHasKey('shareObject', $calledShareLinkAccess[1]);
+		$this->assertEquals('42', $calledShareLinkAccess[1]->getArgument('shareObject')->getId());
+		$this->assertEquals('file', $calledShareLinkAccess[1]->getArgument('shareObject')->getNodeType());
+		$this->assertEquals('initiator', $calledShareLinkAccess[1]->getArgument('shareObject')->getSharedBy());
+		$this->assertEquals('token', $calledShareLinkAccess[1]->getArgument('shareObject')->getToken());
+		$this->assertEquals(403, $calledShareLinkAccess[1]->getArgument('errorCode'));
+		$this->assertEquals('Wrong password', $calledShareLinkAccess[1]->getArgument('errorMessage'));
 	}
 
 	public function testShowShareInvalidToken() {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -321,7 +321,7 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			$userSyncService = new SyncService($c->getConfig(), $c->getLogger(), $c->getAccountMapper());
 
 			$userSession = new Session($manager, $session, $timeFactory,
-				$defaultTokenProvider, $c->getConfig(), $c->getLogger(), $this, $userSyncService);
+				$defaultTokenProvider, $c->getConfig(), $c->getLogger(), $this, $userSyncService, $c->getEventDispatcher());
 			$userSession->listen('\OC\User', 'preCreateUser', function ($uid, $password) {
 				\OC_Hook::emit('OC_User', 'pre_createUser', ['run' => true, 'uid' => $uid, 'password' => $password]);
 			});

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -62,6 +62,7 @@ use OCP\IUserSession;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use OCP\UserInterface;
 use OCP\Util;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -114,7 +115,12 @@ class Session implements IUserSession, Emitter {
 	/** @var SyncService */
 	protected $userSyncService;
 
+	/** @var EventDispatcher */
+	protected $eventDispatcher;
+
 	/**
+	 * Session constructor.
+	 *
 	 * @param IUserManager $manager
 	 * @param ISession $session
 	 * @param ITimeFactory $timeFactory
@@ -123,11 +129,12 @@ class Session implements IUserSession, Emitter {
 	 * @param ILogger $logger
 	 * @param IServiceLoader $serviceLoader
 	 * @param SyncService $userSyncService
+	 * @param EventDispatcher $eventDispatcher
 	 */
 	public function __construct(IUserManager $manager, ISession $session,
 								ITimeFactory $timeFactory, IProvider $tokenProvider,
 								IConfig $config, ILogger $logger, IServiceLoader $serviceLoader,
-								SyncService $userSyncService) {
+								SyncService $userSyncService, EventDispatcher $eventDispatcher) {
 		$this->manager = $manager;
 		$this->session = $session;
 		$this->timeFactory = $timeFactory;
@@ -136,6 +143,7 @@ class Session implements IUserSession, Emitter {
 		$this->logger = $logger;
 		$this->serviceLoader = $serviceLoader;
 		$this->userSyncService = $userSyncService;
+		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	/**
@@ -444,7 +452,7 @@ class Session implements IUserSession, Emitter {
 			}
 
 			// trigger any other initialization
-			\OC::$server->getEventDispatcher()->dispatch(IUser::class . '::firstLogin', new GenericEvent($this->getUser()));
+			$this->eventDispatcher->dispatch(IUser::class . '::firstLogin', new GenericEvent($this->getUser()));
 		}
 	}
 
@@ -492,6 +500,7 @@ class Session implements IUserSession, Emitter {
 			$user = $this->manager->checkPassword($uid, $password);
 			if ($user === false) {
 				$this->manager->emit('\OC\User', 'failedLogin', [$uid]);
+				$this->emitFailedLogin($uid);
 				return false;
 			}
 
@@ -544,6 +553,7 @@ class Session implements IUserSession, Emitter {
 		$user = $this->manager->get($uid);
 		if (is_null($user)) {
 			// user does not exist
+			$this->emitFailedLogin($uid);
 			return false;
 		}
 		if (!$user->isEnabled()) {
@@ -623,6 +633,7 @@ class Session implements IUserSession, Emitter {
 		$user = $this->manager->get($uid);
 		if ($user === null) {
 			$this->manager->emit('\OC\User', 'failedLogin', [$uid]);
+			$this->emitFailedLogin($uid);
 			return false;
 		}
 
@@ -850,6 +861,8 @@ class Session implements IUserSession, Emitter {
 	protected function loginUser($user, $password) {
 		return $this->emittingCall(function () use (&$user, &$password) {
 			if (is_null($user)) {
+				//Cannot extract the uid when $user is null, hence pass null
+				$this->emitFailedLogin(null);
 				return false;
 			}
 
@@ -857,6 +870,7 @@ class Session implements IUserSession, Emitter {
 
 			if (!$user->isEnabled()) {
 				$message = \OC::$server->getL10N('lib')->t('User disabled');
+				$this->emitFailedLogin($user->getUID());
 				throw new LoginException($message);
 			}
 
@@ -896,6 +910,7 @@ class Session implements IUserSession, Emitter {
 		$tokens = OC::$server->getConfig()->getUserKeys($uid, 'login_token');
 		// test cookies token against stored tokens
 		if (!in_array($currentToken, $tokens, true)) {
+			$this->emitFailedLogin($uid);
 			return false;
 		}
 		// replace successfully used token with a new one
@@ -919,8 +934,7 @@ class Session implements IUserSession, Emitter {
 	public function logout() {
 		return $this->emittingCall(function () {
 			$event = new GenericEvent(null, ['cancel' => false]);
-			$eventDispatcher = \OC::$server->getEventDispatcher();
-			$eventDispatcher->dispatch('\OC\User\Session::pre_logout', $event);
+			$this->eventDispatcher->dispatch('\OC\User\Session::pre_logout', $event);
 
 			$this->manager->emit('\OC\User', 'preLogout');
 
@@ -1049,5 +1063,14 @@ class Session implements IUserSession, Emitter {
 		if ($includeBuiltIn) {
 			yield new BasicAuthModule($this->config, $this->logger, $this->manager, $this->session, $this->timeFactory);
 		}
+	}
+
+	/**
+	 * This method triggers symfony event for failed login
+	 * @param string $user
+	 */
+	protected function emitFailedLogin($user) {
+		$loginFailedEvent = new GenericEvent(null, ['user' => $user]);
+		$this->eventDispatcher->dispatch('user.loginfailed', $loginFailedEvent);
 	}
 }

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -25,7 +25,6 @@ use OC\Share20\Manager;
 use OCP\Files\File;
 use OC\Share20\Share;
 use OCP\Files\IRootFolder;
-use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Storage;
@@ -3237,7 +3236,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->factory,
 			$this->userManager,
 			$this->rootFolder,
-			$this->eventDispatcher
+			$this->eventDispatcher,
+			$this->view
 		);
 
 		$share = $this->createMock(IShare::class);


### PR DESCRIPTION
…ssed

New symfony events added when:
a) login attempt is failed
b) public link share is acced

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
This change comprises of emitting symfony events when :
- A user fails to login
- A public link share is accessed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/core/issues/31462
- https://github.com/owncloud/core/issues/31465

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The login failure can be logged using the event triggered. Which would be helpful for the administrators to know which user tried to login and failed. Public link share event would also help in the same way.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- For the public link share access, tested in the debug mode. When the link is accessed, the control reaches the dispatcher.
- For the login failed tested using debug mode.
- Updated the tests for the same.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

