### PR TITLE
Update public link share in transfer ownership command

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -298,35 +298,7 @@ class TransferOwnership extends Command {
 
 		foreach ($this->shares as $share) {
 			try {
-				if ($share->getSharedWith() === $this->destinationUser) {
-					// Unmount the shares before deleting, so we don't try to get the storage later on.
-					$shareMountPoint = $this->mountManager->find('/' . $this->destinationUser . '/files' . $share->getTarget());
-					if ($shareMountPoint) {
-						$this->mountManager->removeMount($shareMountPoint->getMountPoint());
-					}
-					$this->shareManager->deleteShare($share);
-				} else {
-					if ($share->getShareOwner() === $this->sourceUser) {
-						$share->setShareOwner($this->destinationUser);
-					}
-					if ($share->getSharedBy() === $this->sourceUser) {
-						$share->setSharedBy($this->destinationUser);
-					}
-					/*
-					 * If the share is already moved then updateShare would cause exception
-					 * This can happen if the folder is shared and file(s) inside the folder
-					 * has shares, for example public link
-					 */
-					if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
-						$sharePath = \ltrim($share->getNode()->getPath(), '/');
-						if (\strpos($sharePath, $this->finalTarget) !== false) {
-							//The share is already moved
-							continue;
-						}
-					}
-
-					$this->shareManager->updateShare($share);
-				}
+				$this->shareManager->transferShare($share, $this->sourceUser, $this->destinationUser, $this->finalTarget);
 			} catch (\OCP\Files\NotFoundException $e) {
 				$output->writeln('<error>Share with id ' . $share->getId() . ' points at deleted file, skipping</error>');
 			} catch (\Exception $e) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -869,7 +869,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$factory,
 				$c->getUserManager(),
 				$c->getLazyRootFolder(),
-				$c->getEventDispatcher()
+				$c->getEventDispatcher(),
+				new View('/')
 			);
 
 			return $manager;

--- a/lib/public/Share/Exceptions/TransferSharesException.php
+++ b/lib/public/Share/Exceptions/TransferSharesException.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCP\Share\Exceptions;
+
+/**
+ * Class TransferSharesException
+ *
+ * @package OCP\Share\Exceptions
+ * @since 10.0.9
+ */
+class TransferSharesException extends GenericShareException {
+
+	/**
+	 * TransferSharesException constructor.
+	 *
+	 * @param string $message
+	 * @param string $hint
+	 * @param int $code
+	 * @param \Exception|null $previous
+	 * @since 10.0.9
+	 */
+	public function __construct($message = '', $hint = '', $code = 0, \Exception $previous = null) {
+		parent::__construct($message, $hint, $code, $previous);
+	}
+}

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -23,7 +23,9 @@ namespace OCP\Share;
 
 use OCP\Files\Node;
 
+use OCP\Files\NotFoundException;
 use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\Exceptions\TransferSharesException;
 
 /**
  * Interface IManager
@@ -111,6 +113,28 @@ interface IManager {
 	 * @since 9.0.0
 	 */
 	public function getSharesBy($userId, $shareType, $path = null, $reshares = false, $limit = 50, $offset = 0);
+
+	/**
+	 * Transfer shares from oldOwner to newOwner. Both old and new owners are uid
+	 *
+	 * @param IShare $share
+	 * @param string $oldOwner - is the previous owner of the share, the uid string
+	 * @param string $newOwner - is the new owner of the share, the uid string
+	 * @param string $finalTarget - is the target folder where share has to be moved
+	 *
+	 * finalTarget is of the form "user1/files/transferred from admin on 20180509"
+	 *
+	 * TransferShareException would be thrown when:
+	 *  - oldOwner, newOwner does not exist.
+	 *  - oldOwner and newOwner are same
+	 * NotFoundException would be thrown when finalTarget does not exist in the file
+	 * system
+	 *
+	 * @throws TransferSharesException
+	 * @throws NotFoundException
+	 * @since 10.0.9
+	 */
+	public function transferShare(IShare $share, $oldOwner, $newOwner, $finalTarget);
 
 	/**
 	 * Get shares shared with $userId for specified share types.

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -20,12 +20,14 @@
  */
 namespace Test\Share20;
 
+use OC\Files\View;
 use OC\Share20\Manager;
 use OC\Share20\Share;
 use OCP\Files\IRootFolder;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\Mount\IMountManager;
+use OCP\Files\Storage;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
@@ -40,6 +42,7 @@ use OCP\Share\IShare;
 use OCP\Share\IShareProvider;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Test\Traits\UserTrait;
 
 /**
  * Class ManagerTest
@@ -48,6 +51,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @group DB
  */
 class ManagerTest extends \Test\TestCase {
+	use UserTrait;
 
 	/** @var Manager */
 	protected $manager;
@@ -73,7 +77,10 @@ class ManagerTest extends \Test\TestCase {
 	protected $userManager;
 	/** @var IRootFolder | \PHPUnit_Framework_MockObject_MockObject */
 	protected $rootFolder;
+	/** @var EventDispatcher */
 	protected $eventDispatcher;
+	/** @var  View */
+	protected $view;
 
 	public function setUp() {
 		parent::setUp();
@@ -87,6 +94,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->userManager = $this->createMock('\OCP\IUserManager');
 		$this->rootFolder = $this->createMock('\OCP\Files\IRootFolder');
 		$this->eventDispatcher = new EventDispatcher();
+		$this->view = $this->createMock(View::class);
 
 		$this->l = $this->createMock('\OCP\IL10N');
 		$this->l->method('t')
@@ -107,7 +115,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->factory,
 			$this->userManager,
 			$this->rootFolder,
-			$this->eventDispatcher
+			$this->eventDispatcher,
+			$this->view
 		);
 
 		$this->defaultProvider = $this->getMockBuilder('\OC\Share20\DefaultShareProvider')
@@ -133,7 +142,8 @@ class ManagerTest extends \Test\TestCase {
 				$this->factory,
 				$this->userManager,
 				$this->rootFolder,
-				$this->eventDispatcher
+				$this->eventDispatcher,
+				$this->view
 			]);
 	}
 
@@ -1674,6 +1684,304 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, !$exception);
 	}
 
+	public function provideTransferShareData() {
+		return [
+			['link'],
+			['user'],
+			['anotherusertest'],
+			['group'],
+			['remote']
+		];
+	}
+
+	/**
+	 * @dataProvider provideTransferShareData
+	 */
+	public function testTransferShare($sharetype) {
+		$this->createUser('user1');
+		$this->createUser('user2');
+		$manager = $this->createManagerMock()
+			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks',
+				'pathCreateChecks', 'deleteChildren', 'groupCreateChecks'])
+			->getMock();
+
+		$user1Folder = \OC::$server->getUserFolder('user1');
+		$user2Folder = \OC::$server->getUserFolder('user2');
+		$user1Folder->newFolder('test_share');
+		$user2Folder->newFolder('user1_transferred');
+
+		$share = $this->manager->newShare();
+		$share->setProviderId('foo')
+			->setId('22')
+			->setSharedBy('user1')
+			->setShareOwner('user1');
+
+		if ($sharetype === 'link') {
+			$share->setShareType(\OCP\Share::SHARE_TYPE_LINK)
+				->setName('test_share link');
+		}
+		if ($sharetype === 'user') {
+			$share->setShareType(\OCP\Share::SHARE_TYPE_USER)
+				->setName('usershare');
+			$share->setSharedWith('user2');
+
+			$manager->expects($this->once())->method('deleteChildren')->with($share);
+			$this->defaultProvider
+				->expects($this->once())
+				->method('delete')
+				->with($share);
+
+			$hookListnerUnshare = $this->getMockBuilder('Dummy')->setMethods(['pre', 'post'])->getMock();
+			\OCP\Util::connectHook('OCP\Share', 'pre_unshare', $hookListnerUnshare, 'pre');
+			\OCP\Util::connectHook('OCP\Share', 'post_unshare', $hookListnerUnshare, 'post');
+		}
+		if ($sharetype === 'anotherusertest') {
+			$share->setShareType(\OCP\Share::SHARE_TYPE_USER);
+			$share->setSharedWith('completelydifferentuser');
+		}
+		if ($sharetype === 'group') {
+			$share->setShareType(\OCP\Share::SHARE_TYPE_GROUP);
+			$share->setSharedWith('foo');
+		}
+		if ($sharetype === 'remote') {
+			$share->setShareType(\OCP\Share::SHARE_TYPE_REMOTE);
+			$share->setSharedWith('differentUser@server.com');
+		}
+
+		$shareOwner = $this->createMock('\OCP\IUser');
+		$shareOwner->method('getUID')->willReturn('user1');
+
+		$storage = $this->createMock(Storage::class);
+		$path = $this->createMock(File::class);
+		$path->method('getOwner')->willReturn($shareOwner);
+		$path->method('getName')->willReturn('test_share');
+		$path->method('getId')->willReturn(1);
+		$path->method('getStorage')->willReturn($storage);
+
+		$share->setNode($path)
+			->setPermissions(15);
+
+		$hookListner = $this->getMockBuilder('Dummy')->setMethods(['listner'])->getMock();
+		\OCP\Util::connectHook('\OC\Share', 'verifyPassword', $hookListner, 'listner');
+		$hookListner->expects($this->any())
+			->method('listner')
+			->will($this->returnCallback(function (array $array) {
+				$array['accepted'] = true;
+				$array['message'] = 'password accepted';
+			}));
+
+		$this->config
+			->method('getAppValue')
+			->will($this->returnValueMap([
+				['core', 'shareapi_allow_links', 'yes', 'yes'],
+				['core', 'shareapi_allow_public_upload', 'yes', 'yes'],
+				['core', 'shareapi_allow_group_sharing', 'yes', 'yes']
+			]));
+
+		$this->defaultProvider
+			->expects($this->once())
+			->method('create')
+			->with($share)
+			->will($this->returnArgument(0));
+
+		if ($sharetype === 'group') {
+			$manager->expects($this->any())
+				->method('groupCreateChecks')
+				->with($share);
+		}
+
+		$share = $manager->createShare($share);
+		$view = new View('/');
+		$view->rename($user1Folder->getPath() . '/test_share', $user2Folder->getPath() . '/user1_transferred/test_share');
+		$node = $user2Folder->get('user1_transferred/test_share');
+		$share->setNode($node);
+
+		$this->defaultProvider->expects($this->any())
+			->method('getShareById')
+			->with(22)
+			->willReturn($share);
+		$this->defaultProvider->expects($this->any())
+			->method('update')
+			->with($share)
+			->willReturn($share);
+		$manager->updateShare($share);
+		$compareToken = $share->getToken();
+
+		$this->view->expects($this->any())
+			->method('file_exists')
+			->willReturn(true);
+
+		$user1 = $this->createMock(IUser::class);
+		$user2 = $this->createMock(IUser::class);
+		$this->userManager->expects($this->any())
+			->method('get')
+			->will($this->returnValueMap([
+				['user1', $user1],
+				['user2', $user2]
+			]));
+
+		if ($sharetype === 'user') {
+			$hookListnerUnshareExpectsPre = [
+				'id' => '22',
+				'itemType' => 'folder',
+				'itemSource' => $share->getNodeId(),
+				'shareType' => \OCP\Share::SHARE_TYPE_USER,
+				'shareWith' => 'user2',
+				'itemparent' => null,
+				'uidOwner' => 'user1',
+				'fileSource' => $share->getNodeId(),
+				'fileTarget' => '/test_share'
+			];
+			$hookListnerUnshareExpectsPost = [
+				'id' => '22',
+				'itemType' => 'folder',
+				'itemSource' => $share->getNodeId(),
+				'shareType' => \OCP\Share::SHARE_TYPE_USER,
+				'shareWith' => 'user2',
+				'itemparent' => null,
+				'uidOwner' => 'user1',
+				'fileSource' => $share->getNodeId(),
+				'fileTarget' => '/test_share',
+				'deletedShares' => [
+					[
+						'id' => 22,
+						'itemType' => 'folder',
+						'itemSource' => $share->getNodeId(),
+						'shareType' => \OCP\Share::SHARE_TYPE_USER,
+						'shareWith' => 'user2',
+						'itemparent' => null,
+						'uidOwner' => 'user1',
+						'fileSource' => $share->getNodeId(),
+						'fileTarget' => '/test_share',
+					]
+				],
+			];
+			$hookListnerUnshare
+				->expects($this->exactly(1))
+				->method('pre')
+				->with($hookListnerUnshareExpectsPre);
+			$hookListnerUnshare
+				->expects($this->exactly(1))
+				->method('post')
+				->with($hookListnerUnshareExpectsPost);
+		}
+
+		$manager->transferShare($share, 'user1', 'user2', \ltrim($user2Folder->getPath() . '/user1_transferred', '/'));
+
+		if ($sharetype === 'link') {
+			$this->assertEquals($share->getShareOwner(), 'user2');
+			$this->assertEquals($share->getSharedBy(), 'user2');
+			$this->assertEquals($share->getTarget(), '/user1_transferred/test_share');
+			$this->assertEquals($share->getName(), 'test_share link');
+			$this->assertEquals($share->getToken(), $compareToken);
+		}
+
+		if ($sharetype === 'anotherusertest') {
+			$this->assertEquals($share->getId(), '22');
+			$this->assertEquals($share->getSharedWith(), 'completelydifferentuser');
+			$this->assertEquals($share->getSharedBy(), 'user2');
+			$this->assertEquals($share->getShareOwner(), 'user2');
+			$this->assertEquals($share->getTarget(), '/user1_transferred/test_share');
+		}
+
+		if ($sharetype === 'group') {
+			$this->assertEquals($share->getId(), '22');
+			$this->assertEquals($share->getSharedWith(), 'foo');
+			$this->assertEquals($share->getSharedBy(), 'user2');
+			$this->assertEquals($share->getShareOwner(), 'user2');
+			$this->assertEquals($share->getTarget(), '/user1_transferred/test_share');
+		}
+
+		if ($sharetype === 'remote') {
+			$this->assertEquals($share->getId(), '22');
+			$this->assertEquals($share->getSharedWith(), 'differentUser@server.com');
+			$this->assertEquals($share->getShareOwner(), 'user2');
+			$this->assertEquals($share->getSharedBy(), 'user2');
+			$this->assertEquals($share->getTarget(), '/user1_transferred/test_share');
+		}
+	}
+
+	/**
+	 * @expectedException \OCP\Share\Exceptions\TransferSharesException
+	 * @expectedExceptionMessage The current owner of the share user1 doesn't exist
+	 */
+	public function testTransferShareNoOldOwner() {
+		$manager = $this->createManagerMock()
+			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks',
+				'pathCreateChecks', 'deleteChildren', 'groupCreateChecks'])
+			->getMock();
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('user1')
+			->willReturn(null);
+		$share = $this->createShare('23', \OCP\Share::SHARE_TYPE_USER,
+			'/foo', 'user2', 'user1', 'user1',
+			15);
+		$manager->transferShare($share, 'user1', 'user2', 'user1/files/transferred');
+	}
+
+	/**
+	 * @expectedException \OCP\Share\Exceptions\TransferSharesException
+	 * @expectedExceptionMessage The future owner user2, where the share has to be moved doesn't exist
+	 */
+	public function testTransferShareNoNewOwner() {
+		$manager = $this->createManagerMock()
+			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks',
+				'pathCreateChecks', 'deleteChildren', 'groupCreateChecks'])
+			->getMock();
+		$this->userManager->method('get')
+			->will($this->returnValueMap([
+				['user1', $this->createMock(IUser::class)],
+				['user2', null]
+			]));
+		$share = $this->createShare('23', \OCP\Share::SHARE_TYPE_USER,
+			'/foo', 'user2', 'user1', 'user1',
+			15);
+		$manager->transferShare($share, 'user1', 'user2', 'user1/files/transferred');
+	}
+
+	/**
+	 * @expectedException \OCP\Share\Exceptions\TransferSharesException
+	 * @expectedExceptionMessage The current owner of the share and the future owner of the share are same
+	 */
+	public function testTransferShareNoSameOwner() {
+		$manager = $this->createManagerMock()
+			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks',
+				'pathCreateChecks', 'deleteChildren', 'groupCreateChecks'])
+			->getMock();
+		$this->userManager->method('get')
+			->will($this->returnValueMap([
+				['user1', $this->createMock(IUser::class)],
+			]));
+		$share = $this->createShare('23', \OCP\Share::SHARE_TYPE_USER,
+			'/foo', 'user2', 'user1', 'user1',
+			15);
+		$manager->transferShare($share, 'user1', 'user1', 'user1/files/transferred');
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotFoundException
+	 * @expectedExceptionMessage The target location user1/files/transferred doesn't exist
+	 */
+	public function testTransferShareNonExistingFinalTarget() {
+		$manager = $this->createManagerMock()
+			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks',
+				'pathCreateChecks', 'deleteChildren', 'groupCreateChecks'])
+			->getMock();
+		$this->userManager->method('get')
+			->will($this->returnValueMap([
+				['user1', $this->createMock(IUser::class)],
+				['user2', $this->createMock(IUser::class)],
+			]));
+		$this->view->expects($this->once())
+			->method('file_exists')
+			->willReturn(false);
+		$share = $this->createShare('23', \OCP\Share::SHARE_TYPE_USER,
+			'/foo', 'user2', 'user1', 'user1',
+			15);
+		$manager->transferShare($share, 'user1', 'user2', 'user1/files/transferred');
+	}
+
 	public function testCreateShareUser() {
 		$manager = $this->createManagerMock()
 			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks', 'pathCreateChecks'])
@@ -2356,7 +2664,8 @@ class ManagerTest extends \Test\TestCase {
 			$factory,
 			$this->userManager,
 			$this->rootFolder,
-			$this->eventDispatcher
+			$this->eventDispatcher,
+			$this->view
 		);
 
 		$share = $this->createMock('\OCP\Share\IShare');
@@ -2389,7 +2698,8 @@ class ManagerTest extends \Test\TestCase {
 			$factory,
 			$this->userManager,
 			$this->rootFolder,
-			$this->eventDispatcher
+			$this->eventDispatcher,
+			$this->view
 		);
 
 		$share = $this->createMock('\OCP\Share\IShare');
@@ -2491,7 +2801,8 @@ class ManagerTest extends \Test\TestCase {
 			$factory,
 			$this->userManager,
 			$this->rootFolder,
-			$this->eventDispatcher
+			$this->eventDispatcher,
+			$this->view
 		);
 
 		$provider1 = $this->getMockBuilder('\OC\Share20\DefaultShareProvider')
@@ -2927,7 +3238,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->factory,
 			$this->userManager,
 			$this->rootFolder,
-			$this->eventDispatcher
+			$this->eventDispatcher,
+			$this->view
 		);
 
 		$share = $this->createMock(IShare::class);


### PR DESCRIPTION
The public link share wasn't updated in the command.
This resulted in failure, when the public links were
accessed after the files were transferred. This change
helps to update the share for public links. And hence
access to the links won't cause any failure.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
The public links were failing after transfer ownership command is executed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/31150

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change allows the public links to work even after the transfer ownership command is executed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

