### PR TITLE
 Fix not-useful capabilities unit tests 

### DIFF
--- a/apps/files_sharing/lib/API/Share20OCS.php
+++ b/apps/files_sharing/lib/API/Share20OCS.php
@@ -783,7 +783,7 @@ class Share20OCS {
 		}
 
 		if ($permissions !== null && $share->getShareOwner() !== $this->currentUser->getUID()) {
-			/* Check if this is an incomming share */
+			/* Check if this is an incoming share */
 			$incomingShares = $this->shareManager->getSharedWith($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_USER, $share->getNode(), -1, 0);
 			$incomingShares = \array_merge($incomingShares, $this->shareManager->getSharedWith($this->currentUser->getUID(), \OCP\Share::SHARE_TYPE_GROUP, $share->getNode(), -1, 0));
 

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -399,7 +399,7 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertTrue($result['user_enumeration']['group_members_only']);
 	}
 
-	public function testFederatedSharingIncomming() {
+	public function testFederatedSharingIncoming() {
 		$map = [
 			['files_sharing', 'incoming_server2server_share_enabled', 'yes', 'yes'],
 		];
@@ -408,7 +408,7 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertTrue($result['federation']['incoming']);
 	}
 
-	public function testFederatedSharingNoIncomming() {
+	public function testFederatedSharingNoIncoming() {
 		$map = [
 			['files_sharing', 'incoming_server2server_share_enabled', 'yes', 'no'],
 		];

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -83,9 +83,9 @@ class CapabilitiesTest extends \Test\TestCase {
 		];
 		$result = $this->getResults($map);
 		$this->assertTrue($result['api_enabled']);
-		$this->assertContains('public', $result);
-		$this->assertContains('user', $result);
-		$this->assertContains('resharing', $result);
+		$this->assertArrayHasKey('public', $result);
+		$this->assertArrayHasKey('user', $result);
+		$this->assertArrayHasKey('resharing', $result);
 	}
 
 	public function testDisabledSharingAPI() {
@@ -94,9 +94,9 @@ class CapabilitiesTest extends \Test\TestCase {
 		];
 		$result = $this->getResults($map);
 		$this->assertFalse($result['api_enabled']);
-		$this->assertNotContains('public', $result);
-		$this->assertNotContains('user', $result);
-		$this->assertNotContains('resharing', $result);
+		$this->assertFalse($result['public']['enabled']);
+		$this->assertFalse($result['user']['send_mail']);
+		$this->assertFalse($result['resharing']);
 	}
 
 	public function testNoLinkSharing() {

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -2045,7 +2045,7 @@ class ManagerTest extends \Test\TestCase {
 		$manager->createShare($share);
 	}
 
-	public function testCreateShareOfIncommingFederatedShare() {
+	public function testCreateShareOfIncomingFederatedShare() {
 		$manager = $this->createManagerMock()
 			->setMethods(['canShare', 'generalCreateChecks', 'userCreateChecks', 'pathCreateChecks'])
 			->getMock();


### PR DESCRIPTION
## Description
Make the Capabilities unit tests assert things about array keys when it is array keys they care about.

## Related Issue
#31588 

## Motivation and Context
Some of the Capabilities unit tests are rubbish - they are checking for values in the array rather than that keys exist. The test assertions do not do what you think they do!

See #31568 for a demonstration of what rubbish can pass.

## How Has This Been Tested?
Run unit tests locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Unit test "bugfix"

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
(and pass even better)
