### PR TITLE
[stable10] While decrypting userkey prepareEncryptionModules() must b…

### DIFF
--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -60,6 +60,8 @@ class DecryptAll {
 	protected $logger;
 
 	/**
+	 * DecryptAll constructor.
+	 *
 	 * @param Manager $encryptionManager
 	 * @param IUserManager $userManager
 	 * @param View $rootView
@@ -168,6 +170,11 @@ class DecryptAll {
 				return false;
 			}
 			$this->userManager->callForSeenUsers(function(IUser $user) use ($progress, &$userNo, $numberOfUsers) {
+				if (\OC::$server->getAppConfig()->getValue('encryption', 'userSpecificKey', '0') !== '0') {
+					if ($this->prepareEncryptionModules($user->getUID()) === false) {
+						return false;
+					}
+				}
 				$this->decryptUsersFiles(
 					$user->getUID(),
 					$progress,
@@ -250,7 +257,7 @@ class DecryptAll {
 	protected function decryptFile($path) {
 
 		$source = $path;
-		$target = $path . '.decrypted.' . $this->getTimestamp();
+		$target = $path . '.decrypted.' . $this->getTimestamp() . '.part';
 
 		try {
 			\OC\Files\Storage\Wrapper\Encryption::setDisableWriteEncryption(true);


### PR DESCRIPTION
…e called, keep fileid on decrypt

Below are the 2 causes addressed by this change:
1. Regression was caused because of omitting call to method
prepareEncryptionModules. This change will get the userkey encryption
work as before.

2. The shares were not available in the UI, even if they
were available in oc_share table. The reason for this
was due to the copy and rename operation done in the
decrypt-all operation. And the share table wasn't updated
with the new file. This change updates the share table
with the updated id, which helps the UI to show the share
files.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Call to prepareEncryptionModules() was omitted and the check for userkeys also got missing. This resulted in regression. And hence encryption with userkey was not decrypted properly. This change would help to fix the regression. Keep the fileid after the decrypt operation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Call to prepareEncryptionModules() was omitted and the check for userkeys also got missing. This resulted in regression. And hence encryption with userkey was not decrypted properly. This change would help to fix the regression. Keep the fileid after the decrypt operation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

