### PR TITLE
fclose the target file, not the object, when skeleton is copied

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -433,8 +433,9 @@ class OC_Util {
 						throw new NoReadAccessException('No read permission for file ' . $file);
 					}
 					$child = $target->newFile($file);
-					\stream_copy_to_stream($sourceFileHandle, $child->fopen('w'));
-					\fclose($child);
+					$targetFileHandle = $child->fopen('w');
+					\stream_copy_to_stream($sourceFileHandle, $targetFileHandle);
+					\fclose($targetFileHandle);
 					\fclose($sourceFileHandle);
 
 					// update cache sizes


### PR DESCRIPTION
## Description
Solves PHP warning about fclose needing a resource, not object

## Related Issue
Fixes https://github.com/owncloud/core/issues/31514

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Run acceptance tests for "guests" app and see that after this fix the fclose warnings are gone.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

No unit test possible for this case...