### PR TITLE
[stable10] Exclude uploads directory from read-only cache mask

### DIFF
--- a/lib/private/Files/Cache/Wrapper/ReadOnlyCachePermissionsMask.php
+++ b/lib/private/Files/Cache/Wrapper/ReadOnlyCachePermissionsMask.php
@@ -63,6 +63,8 @@ class ReadOnlyCachePermissionsMask extends CacheWrapper {
 	protected function formatCacheEntry($entry) {
 		$storageId = $entry->getStorageId();
 
+		// Give all permissions to whitelisted "internal" paths and their
+		// subdirectories
 		if ($this->isHomeStorage($storageId)) {
 			foreach ($this->whitelist as $path) {
 				if ($this->startsWith($entry->getPath(), $path)) {
@@ -72,6 +74,7 @@ class ReadOnlyCachePermissionsMask extends CacheWrapper {
 			}
 		}
 
+		// Allow creation of skeleton files
 		if ($this->isHomeStorage($storageId) && $entry->getPath() === '') {
 			$entry['permissions'] = Constants::PERMISSION_CREATE;
 			$this->mask = Constants::PERMISSION_CREATE;

--- a/lib/private/Files/Cache/Wrapper/ReadOnlyCachePermissionsMask.php
+++ b/lib/private/Files/Cache/Wrapper/ReadOnlyCachePermissionsMask.php
@@ -38,6 +38,16 @@ class ReadOnlyCachePermissionsMask extends CacheWrapper {
 	protected $mask;
 
 	/**
+	 * System internal paths which should not be protected
+	 * @var array
+	 */
+	private $whitelist = [
+		'uploads',
+		'cache',
+		'files_zsync'
+	];
+
+	/**
 	 * @param \OCP\Files\Cache\ICache $cache
 	 * @param int $mask
 	 */
@@ -53,13 +63,30 @@ class ReadOnlyCachePermissionsMask extends CacheWrapper {
 	protected function formatCacheEntry($entry) {
 		$storageId = $entry->getStorageId();
 
-		if (substr($storageId, 0, strlen('home::')) === 'home::' && $entry->getPath() === "") {
+		if ($this->isHomeStorage($storageId)) {
+			foreach ($this->whitelist as $path) {
+				if ($this->startsWith($entry->getPath(), $path)) {
+					$entry['permissions'] = Constants::PERMISSION_ALL;
+					return $entry;
+				}
+			}
+		}
+
+		if ($this->isHomeStorage($storageId) && $entry->getPath() === '') {
 			$entry['permissions'] = Constants::PERMISSION_CREATE;
 			$this->mask = Constants::PERMISSION_CREATE;
 		}
 
 		$entry['permissions'] &= $this->mask;
-
 		return $entry;
 	}
+
+	private function isHomeStorage($storageId) {
+		return \substr($storageId, 0, strlen('home::')) === 'home::';
+	}
+
+	function startsWith($haystack, $needle) {
+		return (\substr($haystack, 0, \strlen($needle)) === $needle);
+	}
 }
+

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1451,6 +1451,21 @@ trait WebDav {
 	}
 
 	/**
+	 * @When user :user cancels chunking-upload with id :id using the API
+	 * @Given user :user has canceled new chunking-uploadwith id :id
+	 *
+	 * @param string $user
+	 * @param string $id
+	 *
+	 * @return void
+	 */
+	public function userCancelsUploadWithId(
+		$user, $id
+	) {
+		$this->deleteUpload($user, $id, []);
+	}
+
+	/**
 	 * @When user :user moves new chunk file with id :id to :dest with size :size using the API
 	 * @Given user :user has moved new chunk file with id :id to :dest with size :size
 	 *
@@ -1507,6 +1522,27 @@ trait WebDav {
 		try {
 			$this->response = $this->makeDavRequest(
 				$user, 'MOVE', $source, $headers, null, "uploads"
+			);
+		} catch (BadResponseException $ex) {
+			$this->response = $ex->getResponse();
+		}
+	}
+
+	/**
+	 * Delete chunked-upload directory
+	 *
+	 * @param string $user user
+	 * @param string $id upload id
+	 * @param array $headers extra headers
+	 *
+	 * @return void
+	 */
+	private function deleteUpload($user, $id, $headers) {
+		$source = '/uploads/' . $user . '/' . $id;
+
+		try {
+			$this->response = $this->makeDavRequest(
+				$user, 'DELETE', $source, $headers, null, "uploads"
 			);
 		} catch (BadResponseException $ex) {
 			$this->response = $ex->getResponse();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
GuestApp "Jail" was too strong resulting in no permissions to write in to uploads directory.

## Related Issue
Closes https://github.com/owncloud/guests/issues/198

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

