### PR TITLE
Proceed encrypt-all by enabling user-keys if no mode is selected by user

### DIFF
--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -106,6 +106,15 @@ class EncryptAll extends Command {
 			throw new \Exception('Server side encryption is not enabled');
 		}
 
+		$masterKeyEnabled = $this->config->getAppValue('encryption', 'useMasterKey', '');
+		$userKeyEnabled = $this->config->getAppValue('encryption', 'userSpecificKey', '');
+		if (($masterKeyEnabled === '') && ($userKeyEnabled === '')) {
+			/**
+			 * Enable user specific encryption if nothing is enabled.
+			 */
+			$this->config->setAppValue('encryption', 'userSpecificKey', '1');
+		}
+
 		$output->writeln("\n");
 		$output->writeln('You are about to encrypt all files stored in your ownCloud installation.');
 		$output->writeln('Depending on the number of available files, and their size, this may take quite some time.');

--- a/tests/Core/Command/Encryption/EncryptAllTest.php
+++ b/tests/Core/Command/Encryption/EncryptAllTest.php
@@ -95,6 +95,15 @@ class EncryptAllTest extends TestCase {
 
 		$this->encryptionManager->expects($this->once())->method('isEnabled')->willReturn(true);
 		$this->questionHelper->expects($this->once())->method('ask')->willReturn($askResult);
+		$this->config->expects($this->any())
+			->method('getAppValue')
+			->willReturnMap([
+				['encryption', 'useMasterKey', '', ''],
+				['encryption', 'userSpecificKey', '', '']
+			]);
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->willReturn(null);
 
 		if ($answer === 'Y' || $answer === 'y') {
 			$this->encryptionManager->expects($this->once())


### PR DESCRIPTION
Proceed encrypt-all by enabling user-keys, if user
had not selected any encryption mode before executing
the command.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
If user had not selected either user-keys or masterkey encryption modes, then proceed encrypt-all command by enabling user-keys.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If user had not selected either user-keys or masterkey encryption modes, then proceed encrypt-all command by enabling user-keys.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Create user `admin`
- [x] Enable encryption. Do not select any encryption mode ( this is done from command line )
- [x] Run encrypt-all command
- [x] Verify the db. The user should see 
```
sqlite> select * from oc_appconfig where appid="encryption" and configkey='userSpecificKey';
encryption|userSpecificKey|1
sqlite>
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

