### PR TITLE
Proceed encrypt-all after one of the encryption mode is selected

### DIFF
--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -106,6 +106,12 @@ class EncryptAll extends Command {
 			throw new \Exception('Server side encryption is not enabled');
 		}
 
+		$masterKeyEnabled = $this->config->getAppValue('encryption', 'useMasterKey', '');
+		$userKeyEnabled = $this->config->getAppValue('encryption', 'userSpecificKey', '');
+		if (($masterKeyEnabled === '') && ($userKeyEnabled === '')) {
+			throw new \Exception('Select encryption type masterkey or user-keys to continue.');
+		}
+
 		$output->writeln("\n");
 		$output->writeln('You are about to encrypt all files stored in your ownCloud installation.');
 		$output->writeln('Depending on the number of available files, and their size, this may take quite some time.');

--- a/tests/Core/Command/Encryption/EncryptAllTest.php
+++ b/tests/Core/Command/Encryption/EncryptAllTest.php
@@ -125,4 +125,22 @@ class EncryptAllTest extends TestCase {
 		$this->encryptionModule->expects($this->never())->method('encryptAll');
 		$this->invokePrivate($command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
+
+	/**
+	 * @expectedException \Exception
+	 * @expectedExceptionMessage Select encryption type masterkey or user-keys to continue.
+	 */
+	public function testExecuteExceptionForNoModeSelection() {
+		$command = new EncryptAll($this->encryptionManager, $this->appManager, $this->config, $this->questionHelper);
+
+		$this->encryptionManager->expects($this->once())->method('isEnabled')->willReturn(true);
+		$this->config->expects($this->any())
+			->method('getAppValue')
+			->willReturnMap([
+				['encryption', 'useMasterKey', '', ''],
+				['encryption', 'userSpecificKey', '', '']
+			]);
+
+		$this->invokePrivate($command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
 }


### PR DESCRIPTION
Proceed encrypt-all command only after user had selected one
of the encryption mode.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
If user had not selected user-keys or masterkey, then stop execution of encrypt-all command. Throw an exception.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If user had not selected user-keys or masterkey, then stop execution of encrypt-all command. Throw an exception.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Create user `admin`
- [x] Enable encryption. Do not select any encryption mode ( this is done from command line )
- [x] Run encrypt-all command
- [x] Verified that exception is triggered.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

