### PR TITLE
[stable10] Sort user list by display name

### DIFF
--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -266,8 +266,8 @@ var UserList = {
 		rows.sort(function(a, b) {
 			// FIXME: inefficient way of getting the names,
 			// better use a data attribute
-			a = $(a).find('.name').text();
-			b = $(b).find('.name').text();
+			a = $(a).find('.displayName').text();
+			b = $(b).find('.displayName').text();
 			var firstSort = UserList.preSortSearchString(a, b);
 			if(typeof firstSort !== 'undefined') {
 				return firstSort;


### PR DESCRIPTION
## Description
Sort the user list on the webUI by display name (full name)

## Related Issue
https://github.com/owncloud/core/pull/1948#issuecomment-392653714

## Motivation and Context
I think other people have asked for the users in the users list to be sorted by display name.
It is not difficult, but there are gotchas.

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
