### PR TITLE
[stable10] Use '.part' name appended to the file name for encryptall

### DIFF
--- a/apps/encryption/lib/Crypto/EncryptAll.php
+++ b/apps/encryption/lib/Crypto/EncryptAll.php
@@ -265,6 +265,10 @@ class EncryptAll {
 		while($root = array_pop($directories)) {
 			$content = $this->rootView->getDirectoryContent($root);
 			foreach ($content as $file) {
+				// only encrypt files owned by the user, exclude incoming local shares, and incoming federated shares
+				if ($file->getStorage()->instanceOfStorage('\OCA\Files_Sharing\ISharedStorage')) {
+					continue;
+				}
 				$path = $root . '/' . $file['name'];
 				if ($this->rootView->is_dir($path)) {
 					$directories[] = $path;
@@ -290,7 +294,7 @@ class EncryptAll {
 	protected function encryptFile($path) {
 
 		$source = $path;
-		$target = $path . '.encrypted.' . time();
+		$target = $path . '.encrypted.' . $this->getTimeStamp() . '.part';
 
 		try {
 			$this->keyManager->setVersion($source, 0, $this->rootView);
@@ -377,6 +381,15 @@ class EncryptAll {
 	protected function setupUserFS($uid) {
 		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($uid);
+	}
+
+	/**
+	 * get current timestamp
+	 *
+	 * @return int
+	 */
+	protected function getTimeStamp() {
+		return \time();
 	}
 
 	/**

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -650,7 +650,7 @@ class EncryptAllTest extends TestCase {
 		$this->assertFalse($this->invokePrivate($encryptAll, 'encryptFile', [$path]));
 	}
 
-	/** A dummy test for getTimeStamp */
+	/** A dummy test for getTimeStamp  */
 	public function testGetTimeStamp() {
 		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
 		$encryptAll = $this->getMockBuilder(EncryptAll::class)

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -25,12 +25,29 @@
 namespace OCA\Encryption\Tests\Crypto;
 
 
+use OC\Encryption\Exceptions\DecryptionFailedException;
+use OC\Files\FileInfo;
+use OC\Files\Storage\Common;
+use OC\Files\View;
+use OC\Mail\Message;
 use OCA\Encryption\Crypto\EncryptAll;
+use OCP\Files\Storage;
+use OCP\IUser;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
+use Test\Traits\UserTrait;
 
+/**
+ * Class EncryptAllTest
+ *
+ * @group DB
+ *
+ * @package OCA\Encryption\Tests\Crypto
+ */
 class EncryptAllTest extends TestCase {
+	use UserTrait;
 
 	/** @var  \PHPUnit_Framework_MockObject_MockObject | \OCA\Encryption\KeyManager */
 	protected $keyManager;
@@ -128,7 +145,7 @@ class EncryptAllTest extends TestCase {
 
 	public function testEncryptAll() {
 		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
-		$encryptAll = $this->getMockBuilder('OCA\Encryption\Crypto\EncryptAll')
+		$encryptAll = $this->getMockBuilder(EncryptAll::class)
 			->setConstructorArgs(
 				[
 					$this->setupUser,
@@ -157,7 +174,7 @@ class EncryptAllTest extends TestCase {
 
 	public function testEncryptAllWithMasterKey() {
 		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
-		$encryptAll = $this->getMockBuilder('OCA\Encryption\Crypto\EncryptAll')
+		$encryptAll = $this->getMockBuilder(EncryptAll::class)
 			->setConstructorArgs(
 				[
 					$this->setupUser,
@@ -187,7 +204,7 @@ class EncryptAllTest extends TestCase {
 
 	public function testCreateKeyPairs() {
 		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
-		$encryptAll = $this->getMockBuilder('OCA\Encryption\Crypto\EncryptAll')
+		$encryptAll = $this->getMockBuilder(EncryptAll::class)
 			->setConstructorArgs(
 				[
 					$this->setupUser,
@@ -234,9 +251,44 @@ class EncryptAllTest extends TestCase {
 		$this->assertSame('', $userPasswords['user2']);
 	}
 
-	public function testEncryptAllUsersFiles() {
+	public function testCreateMailBody() {
 		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
-		$encryptAll = $this->getMockBuilder('OCA\Encryption\Crypto\EncryptAll')
+		$encryptAll = $this->getMockBuilder(EncryptAll::class)
+			->setConstructorArgs(
+				[
+					$this->setupUser,
+					$this->userManager,
+					$this->view,
+					$this->keyManager,
+					$this->util,
+					$this->config,
+					$this->mailer,
+					$this->l,
+					$this->questionHelper,
+					$this->secureRandom
+				]
+			)
+			->setMethods(['encryptUsersFiles'])
+			->getMock();
+		$result = $this->invokePrivate($encryptAll, 'createMailBody', ['foo']);
+		$this->assertEquals(2, \count($result));
+		$this->assertGreaterThan(1, strlen($result[0]));
+		$this->assertGreaterThan(1, strlen($result[1]));
+	}
+
+	public function providerSendMailStatus() {
+		return [
+			[true],
+			[false]
+		];
+	}
+
+	/**
+	 * @dataProvider providerSendMailStatus
+	 */
+	public function testSendPasswordsByMail($sendStatus) {
+		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
+		$encryptAll = $this->getMockBuilder(EncryptAll::class)
 			->setConstructorArgs(
 				[
 					$this->setupUser,
@@ -254,22 +306,133 @@ class EncryptAllTest extends TestCase {
 			->setMethods(['encryptUsersFiles'])
 			->getMock();
 
-		$this->util->expects($this->any())->method('isMasterKeyEnabled')->willReturn(false);
+		// set protected property $output
+		$this->invokePrivate($encryptAll, 'output', [$this->outputInterface]);
+
+		$this->invokePrivate($encryptAll, 'userPasswords', [['user1' => 'pwd1']]);
+
+		$iUser = $this->createMock(IUser::class);
+		$iUser->expects($this->once())
+			->method('getDisplayName')
+			->willReturn('user1');
+		$iUser->expects($this->once())
+			->method('getEMailAddress')
+			->willReturn('user1@foo.com');
+		$this->userManager->expects($this->once())
+			->method('get')
+			->willReturn($iUser);
+		$messageMock = $this->createMock(Message::class);
+		$messageMock->expects($this->once())
+			->method('setSubject')
+			->willReturn($messageMock);
+		$messageMock->expects($this->once())
+			->method('setTo')
+			->willReturn($messageMock);
+		$messageMock->expects($this->once())
+			->method('setHtmlBody')
+			->willReturn($messageMock);
+		$messageMock->expects($this->once())
+			->method('setPlainBody')
+			->willReturn($messageMock);
+		$messageMock->expects($this->once())
+			->method('setFrom')
+			->willReturn($messageMock);
+
+		$this->mailer->expects($this->once())
+			->method('createMessage')
+			->willReturn($messageMock);
+
+		if ($sendStatus === true) {
+			$this->mailer->expects($this->once())
+				->method('send')
+				->willReturn(true);
+		} else {
+			$this->mailer->expects($this->once())
+				->method('send')
+				->willThrowException(new \Exception());
+		}
+
+		$this->assertNull($this->invokePrivate($encryptAll, 'sendPasswordsByMail', []));
+	}
+
+	public function testOutputPasswords() {
+		$this->view = new View('/');
+		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
+		$encryptAll = $this->getMockBuilder(EncryptAll::class)
+			->setConstructorArgs(
+				[
+					$this->setupUser,
+					$this->userManager,
+					$this->view,
+					$this->keyManager,
+					$this->util,
+					$this->config,
+					$this->mailer,
+					$this->l,
+					$this->questionHelper,
+					$this->secureRandom
+				]
+			)
+			->setMethods(['encryptUsersFiles'])
+			->getMock();
+
+		// set protected property $output, $input
+		$this->invokePrivate($encryptAll, 'output', [$this->outputInterface]);
+		$this->invokePrivate($encryptAll, 'input', [$this->inputInterface]);
+		$this->invokePrivate($encryptAll, 'userPasswords', [['user1' => 'pwd1']]);
+		$this->questionHelper->expects($this->once())
+			->method('ask')
+			->willReturn(false);
+		$this->assertNull($this->invokePrivate($encryptAll, 'outputPasswords', []));
+	}
+
+	public function providerMasterKeyEncryptionStatus() {
+		return [
+			[false],
+			[true]
+		];
+	}
+
+	/**
+	 * @dataProvider providerMasterKeyEncryptionStatus
+	 */
+	public function testEncryptAllUsersFiles($masterKeyEnabled) {
+		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
+		$encryptAll = $this->getMockBuilder(EncryptAll::class)
+			->setConstructorArgs(
+				[
+					$this->setupUser,
+					$this->userManager,
+					$this->view,
+					$this->keyManager,
+					$this->util,
+					$this->config,
+					$this->mailer,
+					$this->l,
+					$this->questionHelper,
+					$this->secureRandom
+				]
+			)
+			->setMethods(['encryptUsersFiles'])
+			->getMock();
+
+		$this->util->expects($this->any())->method('isMasterKeyEnabled')->willReturn($masterKeyEnabled);
 
 		// set protected property $output
 		$this->invokePrivate($encryptAll, 'output', [$this->outputInterface]);
-		$this->invokePrivate($encryptAll, 'userPasswords', [['user1' => 'pwd1', 'user2' => 'pwd2']]);
+		if ($masterKeyEnabled === false) {
+			$this->invokePrivate($encryptAll, 'userPasswords', [['user1' => 'pwd1', 'user2' => 'pwd2']]);
 
-		$encryptAll->expects($this->at(0))->method('encryptUsersFiles')->with('user1');
-		$encryptAll->expects($this->at(1))->method('encryptUsersFiles')->with('user2');
+			$encryptAll->expects($this->at(0))->method('encryptUsersFiles')->with('user1');
+			$encryptAll->expects($this->at(1))->method('encryptUsersFiles')->with('user2');
+		}
 
 		$this->invokePrivate($encryptAll, 'encryptAllUsersFiles');
-
 	}
 
 	public function testEncryptUsersFiles() {
 		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
-		$encryptAll = $this->getMockBuilder('OCA\Encryption\Crypto\EncryptAll')
+		$encryptAll = $this->getMockBuilder(EncryptAll::class)
 			->setConstructorArgs(
 				[
 					$this->setupUser,
@@ -289,20 +452,24 @@ class EncryptAllTest extends TestCase {
 
 		$this->util->expects($this->any())->method('isMasterKeyEnabled')->willReturn(false);
 
-		$this->view->expects($this->at(0))->method('getDirectoryContent')
-			->with('/user1/files')->willReturn(
-				[
-					['name' => 'foo', 'type'=>'dir'],
-					['name' => 'bar', 'type'=>'file'],
-				]
-			);
-
-		$this->view->expects($this->at(3))->method('getDirectoryContent')
-			->with('/user1/files/foo')->willReturn(
-				[
-					['name' => 'subfile', 'type'=>'file']
-				]
-			);
+		$storage = $this->createMock(Storage::class);
+		$storage->expects($this->any())
+			->method('getId')
+			->will($this->returnValue('home::someuser'));
+		$commonStorage = $this->createMock(Common::class);
+		$commonStorage->expects($this->any())
+			->method('instanceOfStorage')
+			->willReturn(false);
+		//$fileInfo = $this->createMock(FileInfo::class);
+		$fileInfo1 = new FileInfo('/user1/files/foo', $storage, 'foo',
+			['name' => 'foo'], null);
+		$fileInfo2 = new FileInfo('/user1/files/foo/subfile', $storage, 'foo/subfile',
+			['name' => 'foo/subfile'], null);
+		$fileInfo3 = new FileInfo('/user1/files/bar', $storage, 'bar',
+			['name' => 'bar'], null);
+		$this->view->expects($this->any())
+			->method('getDirectoryContent')
+			->willReturnOnConsecutiveCalls([$fileInfo1, $fileInfo2, $fileInfo3], []);
 
 		$this->view->expects($this->any())->method('is_dir')
 			->willReturnCallback(
@@ -314,14 +481,94 @@ class EncryptAllTest extends TestCase {
 				}
 			);
 
-		$encryptAll->expects($this->at(1))->method('encryptFile')->with('/user1/files/bar');
-		$encryptAll->expects($this->at(2))->method('encryptFile')->with('/user1/files/foo/subfile');
+		$encryptAll->expects($this->any())
+			->method('encryptFile')
+			->willReturnMap([
+				['/user1/files/foo/subfile', true],
+				['/user1/files/bar', true]
+			]);
 
 		$output = new ConsoleOutput();
 		$progressBar = new ProgressBar($output);
-
 		$this->invokePrivate($encryptAll, 'encryptUsersFiles', ['user1', $progressBar, '']);
+	}
 
+	public function testEncryptUsersFilesIncomingShares() {
+		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
+		$encryptAll = $this->getMockBuilder(EncryptAll::class)
+			->setConstructorArgs(
+				[
+					$this->setupUser,
+					$this->userManager,
+					$this->view,
+					$this->keyManager,
+					$this->util,
+					$this->config,
+					$this->mailer,
+					$this->l,
+					$this->questionHelper,
+					$this->secureRandom
+				]
+			)
+			->setMethods(['encryptFile', 'setupUserFS'])
+			->getMock();
+
+		$this->util->expects($this->any())->method('isMasterKeyEnabled')->willReturn(false);
+
+		$commonStorage = $this->createMock(Common::class);
+		$commonStorage->expects($this->once())
+			->method('instanceOfStorage')
+			->with('\OCA\Files_Sharing\ISharedStorage')
+			->willReturn(true);
+		$fileInfo = $this->createMock(FileInfo::class);
+		$fileInfo->expects($this->once())
+			->method('getStorage')
+			->willReturn($commonStorage);
+		$this->view->expects($this->any())
+			->method('getDirectoryContent')
+			->with('/user1/files')
+			->willReturn([$fileInfo]);
+
+		$outputInterface = $this->createMock(OutputInterface::class);
+		$progressBar = new ProgressBar($outputInterface);
+
+		$result = $this->invokePrivate($encryptAll, 'encryptUsersFiles', ['user1', $progressBar, '']);
+		$this->assertNull($result);
+	}
+
+	public function testEncryptFileFileId() {
+		$this->createUser('user1', 'user1');
+		\OC::$server->getUserFolder('user1');
+
+		$view = new View('/user1/files');
+		$view->touch('bar.txt');
+		$oldFileInfo = $view->getFileInfo('bar.txt');
+
+		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
+		$encryptAll = $this->getMockBuilder(EncryptAll::class)
+			->setConstructorArgs(
+				[
+					$this->setupUser,
+					$this->userManager,
+					$this->view,
+					$this->keyManager,
+					$this->util,
+					$this->config,
+					$this->mailer,
+					$this->l,
+					$this->questionHelper,
+					$this->secureRandom
+				]
+			)
+			->setMethods(['setupUserFS', 'getTimeStamp'])
+			->getMock();
+
+		$result = $this->invokePrivate($encryptAll, 'encryptFile', ['/user1/files/bar.txt']);
+		$this->assertTrue($result);
+
+		$view1 = new View('/');
+		$fileInfo = $view1->getFileInfo('/user1/files/bar.txt');
+		$this->assertEquals($fileInfo->getId(), $oldFileInfo->getId());
 	}
 
 	public function testGenerateOneTimePassword() {
@@ -334,4 +581,96 @@ class EncryptAllTest extends TestCase {
 		$this->assertSame($password, $userPasswords['user1']);
 	}
 
+	public function testEncryptFilePositiveTest() {
+		$path = 'test.txt';
+
+		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
+		$encryptAll = $this->getMockBuilder(EncryptAll::class)
+			->setConstructorArgs(
+				[
+					$this->setupUser,
+					$this->userManager,
+					$this->view,
+					$this->keyManager,
+					$this->util,
+					$this->config,
+					$this->mailer,
+					$this->l,
+					$this->questionHelper,
+					$this->secureRandom
+				]
+			)
+			->setMethods(['setupUserFS', 'getTimeStamp'])
+			->getMock();
+
+		$encryptAll->expects($this->any())->method('getTimestamp')->willReturn(55);
+
+		$this->view->expects($this->once())
+			->method('copy')
+			->with($path, $path . '.encrypted.55.part');
+		$this->view->expects($this->once())
+			->method('rename')
+			->with($path . '.encrypted.55.part', $path);
+
+		$this->assertTrue($this->invokePrivate($encryptAll, 'encryptFile', [$path]));
+	}
+
+	public function testEncryptFileFails() {
+		$path = 'test.txt';
+
+		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
+		$encryptAll = $this->getMockBuilder(EncryptAll::class)
+			->setConstructorArgs(
+				[
+					$this->setupUser,
+					$this->userManager,
+					$this->view,
+					$this->keyManager,
+					$this->util,
+					$this->config,
+					$this->mailer,
+					$this->l,
+					$this->questionHelper,
+					$this->secureRandom
+				]
+			)
+			->setMethods(['setupUserFS', 'getTimeStamp'])
+			->getMock();
+
+		$encryptAll->expects($this->any())->method('getTimestamp')->willReturn(55);
+
+		$this->view->expects($this->once())
+			->method('copy')
+			->with($path, $path . '.encrypted.55.part');
+		$this->view->expects($this->once())
+			->method('rename')
+			->with($path . '.encrypted.55.part', $path)
+			->willThrowException(new DecryptionFailedException("failed to encrypt"));
+
+		$this->assertFalse($this->invokePrivate($encryptAll, 'encryptFile', [$path]));
+	}
+
+	/** A dummy test for getTimeStamp */
+	public function testGetTimeStamp() {
+		/** @var EncryptAll  | \PHPUnit_Framework_MockObject_MockObject  $encryptAll */
+		$encryptAll = $this->getMockBuilder(EncryptAll::class)
+			->setConstructorArgs(
+				[
+					$this->setupUser,
+					$this->userManager,
+					$this->view,
+					$this->keyManager,
+					$this->util,
+					$this->config,
+					$this->mailer,
+					$this->l,
+					$this->questionHelper,
+					$this->secureRandom
+				]
+			)
+			->getMock();
+
+		$result = $this->invokePrivate($encryptAll, 'getTimeStamp', []);
+		$this->assertGreaterThan(10000, $result);
+	}
 }

--- a/apps/encryption/tests/HookManagerTest.php
+++ b/apps/encryption/tests/HookManagerTest.php
@@ -27,6 +27,7 @@ namespace OCA\Encryption\Tests;
 
 use OCA\Encryption\HookManager;
 use OCA\Encryption\Hooks\Contracts\IHook;
+use OCA\Encryption\Hooks\UserHooks;
 use Test\TestCase;
 
 class HookManagerTest extends TestCase {
@@ -79,7 +80,14 @@ class HookManagerTest extends TestCase {
 
 		$hookInstances = self::invokePrivate(self::$instance, 'hookInstances');
 		$this->assertCount(3, $hookInstances);
-
 	}
 
+	public function testFireHooks() {
+		$userHookMock = $this->createMock(UserHooks::class);
+		$userHookMock->expects($this->once())
+			->method('addHooks')
+			->willReturn(null);
+		self::invokePrivate(self::$instance, 'hookInstances', array([$userHookMock]));
+		$this->assertNull(self::$instance->fireHooks());
+	}
 }

--- a/tests/drone/test-phpunit.sh
+++ b/tests/drone/test-phpunit.sh
@@ -44,6 +44,12 @@ else
   GROUP="--group DB"
 fi
 
+# still required on stable10 to run unit tests for encryption
+php occ app:enable encryption
+
+# show a little debug information
+php occ app:list
+
 phpunit_cmd="php ./lib/composer/bin/phpunit"
 if [[ "${COVERAGE}" == "true" ]]; then
     phpunit_cmd="phpdbg -d memory_limit=4096M -rr ./lib/composer/bin/phpunit"


### PR DESCRIPTION
When dealing with copy and rename operation in
encryptall, its better to use '.part' appended
to the file name.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
While handling encrypt operation, its better to use '.part' file name during copy and rename.
Also no encryption should be made done for incoming shares.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
While handling encrypt operation, its better to use '.part' file name during copy and rename.
Also no encryption should be made done for incoming shares.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

