### PR TITLE
[stable10] Use the userid obtained from checkPassword after login is …

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -489,40 +489,50 @@ class Session implements IUserSession, Emitter {
 	/**
 	 * Log an user in via login name and password
 	 *
-	 * @param string $uid
+	 * @param string $login
 	 * @param string $password
 	 * @return boolean
 	 * @throws LoginException if an app canceld the login process or the user is not enabled
+	 *
+	 * Two new keys 'login' in the before event and 'user' in the after event
+	 * are introduced. We should use this keys in future when trying to listen
+	 * the events emitted from this method. We have kept the key 'uid' for
+	 * compatibility.
 	 */
-	private function loginWithPassword($uid, $password) {
-		return $this->emittingCall(function () use (&$uid, &$password) {
-			$this->manager->emit('\OC\User', 'preLogin', [$uid, $password]);
-			$user = $this->manager->checkPassword($uid, $password);
-			if ($user === false) {
-				$this->manager->emit('\OC\User', 'failedLogin', [$uid]);
-				$this->emitFailedLogin($uid);
-				return false;
-			}
+	private function loginWithPassword($login, $password) {
+		$beforeEvent = new GenericEvent(null, ['login' => $login, 'uid' => $login, '_uid' => 'deprecated: please use \'login\', the real uid is not yet known', 'password' => $password]);
+		$this->eventDispatcher->dispatch('user.beforelogin', $beforeEvent);
+		$this->manager->emit('\OC\User', 'preLogin', [$login, $password]);
 
-			if ($user->isEnabled()) {
-				$this->setUser($user);
-				$this->setLoginName($uid);
-				$firstTimeLogin = $user->updateLastLoginTimestamp();
-				$this->manager->emit('\OC\User', 'postLogin', [$user, $password]);
-				if ($this->isLoggedIn()) {
-					$this->prepareUserLogin($firstTimeLogin);
-					return true;
-				} else {
-					// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
-					$message = \OC::$server->getL10N('lib')->t('Login canceled by app');
-					throw new LoginException($message);
-				}
+		$user = $this->manager->checkPassword($login, $password);
+		if ($user === false) {
+			$this->manager->emit('\OC\User', 'failedLogin', [$login]);
+			$this->emitFailedLogin($login);
+			return false;
+		}
+
+		if ($user->isEnabled()) {
+			$this->setUser($user);
+			$this->setLoginName($login);
+			$firstTimeLogin = $user->updateLastLoginTimestamp();
+			$this->manager->emit('\OC\User', 'postLogin', [$user, $password]);
+			if ($this->isLoggedIn()) {
+				$this->prepareUserLogin($firstTimeLogin);
+
+				$afterEvent = new GenericEvent(null, ['user' => $user, 'uid' => $user->getUID(), 'password' => $password]);
+				$this->eventDispatcher->dispatch('user.afterlogin', $afterEvent);
+
+				return true;
 			} else {
 				// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
-				$message = \OC::$server->getL10N('lib')->t('User disabled');
+				$message = \OC::$server->getL10N('lib')->t('Login canceled by app');
 				throw new LoginException($message);
 			}
-		}, ['before' => ['uid' => $uid, 'password' => $password], 'after' => ['uid' => $uid, 'password' => $password]], 'user', 'login');
+		} else {
+			// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
+			$message = \OC::$server->getL10N('lib')->t('User disabled');
+			throw new LoginException($message);
+		}
 	}
 
 	/**

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -256,7 +256,7 @@ class SessionTest extends TestCase {
 		$userSession->expects($this->once())
 			->method('prepareUserLogin');
 		$calledUserLogin = [];
-		\OC::$server->getEventDispatcher()->addListener('user.afterlogin', function (GenericEvent $event) use (&$calledUserLogin) {
+		$this->eventDispatcher->addListener('user.afterlogin', function (GenericEvent $event) use (&$calledUserLogin) {
 			$calledUserLogin[] = 'user.afterlogin';
 			$calledUserLogin[] = $event;
 		});
@@ -1211,6 +1211,10 @@ class SessionTest extends TestCase {
 		$iUser->expects($this->any())
 			->method('isEnabled')
 			->willReturn(true);
+		$iUser->expects($this->any())
+			->method('getUID')
+			->willReturn('foo');
+
 		$userManager->expects($this->once())->method('checkPassword')->willReturn($iUser);
 
 		$userSession = new Session($userManager, $session, $timeFactory,
@@ -1218,13 +1222,13 @@ class SessionTest extends TestCase {
 			$this->userSyncService, $this->eventDispatcher);
 
 		$calledUserBeforeLogin = [];
-		\OC::$server->getEventDispatcher()->addListener('user.beforelogin',
+		$this->eventDispatcher->addListener('user.beforelogin',
 			function (GenericEvent $event) use (&$calledUserBeforeLogin) {
 				$calledUserBeforeLogin[] = 'user.beforelogin';
 				$calledUserBeforeLogin[] = $event;
 			});
 		$calledUserAfterLogin = [];
-		\OC::$server->getEventDispatcher()->addListener('user.afterlogin',
+		$this->eventDispatcher->addListener('user.afterlogin',
 			function (GenericEvent $event) use (&$calledUserAfterLogin) {
 				$calledUserAfterLogin[] = 'user.afterlogin';
 				$calledUserAfterLogin[] = $event;
@@ -1236,13 +1240,21 @@ class SessionTest extends TestCase {
 
 		$this->assertEquals('user.beforelogin', $calledUserBeforeLogin[0]);
 		$this->assertInstanceOf(GenericEvent::class, $calledUserBeforeLogin[1]);
+		$this->assertArrayHasKey('login', $calledUserBeforeLogin[1]);
+		$this->assertEquals('foo', $calledUserBeforeLogin[1]->getArgument('login'));
 		$this->assertArrayHasKey('uid', $calledUserBeforeLogin[1]);
 		$this->assertEquals('foo', $calledUserBeforeLogin[1]->getArgument('uid'));
 		$this->assertArrayHasKey('password', $calledUserBeforeLogin[1]);
 		$this->assertEquals('foopass', $calledUserBeforeLogin[1]->getArgument('password'));
+		$this->assertArrayHasKey('_uid', $calledUserBeforeLogin[1]);
+		$this->assertEquals('deprecated: please use \'login\', the real uid is not yet known', $calledUserBeforeLogin[1]->getArgument('_uid'));
+
 		$this->assertEquals('user.afterlogin', $calledUserAfterLogin[0]);
 		$this->assertInstanceOf(GenericEvent::class, $calledUserAfterLogin[1]);
+		$this->assertArrayHasKey('user', $calledUserAfterLogin[1]);
+		$this->assertInstanceOf(IUser::class, $calledUserAfterLogin[1]->getArgument('user'));
 		$this->assertArrayHasKey('uid', $calledUserAfterLogin[1]);
+		$this->assertEquals('foo', $calledUserAfterLogin[1]->getArgument('user')->getUID());
 		$this->assertEquals('foo', $calledUserAfterLogin[1]->getArgument('uid'));
 		$this->assertArrayHasKey('password', $calledUserAfterLogin[1]);
 		$this->assertEquals('foopass', $calledUserAfterLogin[1]->getArgument('password'));


### PR DESCRIPTION
…validated

This change includes:
a) Change the function argument from 'uid' to 'login'. The php
doc is also updated.
b) before event argument would use 'login' to have loginname
c) after event argument would use 'user' instead of 'uid', because
'user' is an instance of IUser. We pass User object.

The user id sent to the after event should use the id obtained
from checkPassword method, which validates the login credentials
passed to loginWithPassword method. This change would help the
the subscriber of the after event to get the appropriate userid.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Use the uid returned from `checkPassword()` instead of the uid passed to `loginWithPassword()`. Updated the after event data accordingly to pick the uid.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/31509

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Use the uid returned from `checkPassword()` instead of the uid passed to `loginWithPassword()`. Updated the after event data accordingly to pick the uid.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] With the unit test written for `loginWithPassword()`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

