### PR TITLE
Prefer API over direct config access

### DIFF
--- a/core/Command/Encryption/Enable.php
+++ b/core/Command/Encryption/Enable.php
@@ -53,9 +53,10 @@ class Enable extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		if ($this->config->getAppValue('core', 'encryption_enabled', 'no') === 'yes') {
+		if ($this->encryptionManager->isEnabled()) {
 			$output->writeln('Encryption is already enabled');
 		} else {
+			// TODO add and use api to enable encryption
 			$this->config->setAppValue('core', 'encryption_enabled', 'yes');
 			$output->writeln('<info>Encryption enabled</info>');
 		}
@@ -65,8 +66,8 @@ class Enable extends Command {
 		if (empty($modules)) {
 			$output->writeln('<error>No encryption module is loaded</error>');
 		} else {
-			$defaultModule = $this->config->getAppValue('core', 'default_encryption_module', null);
-			if ($defaultModule === null) {
+			$defaultModule = $this->encryptionManager->getDefaultEncryptionModuleId();
+			if ($defaultModule === '') {
 				$output->writeln('<error>No default module is set</error>');
 			} elseif (!isset($modules[$defaultModule])) {
 				$output->writeln('<error>The current default module does not exist: ' . $defaultModule . '</error>');

--- a/tests/Core/Command/Encryption/EnableTest.php
+++ b/tests/Core/Command/Encryption/EnableTest.php
@@ -75,11 +75,11 @@ class EnableTest extends TestCase {
 	 * @param string $expectedDefaultModuleString
 	 */
 	public function testEnable($oldStatus, $defaultModule, $availableModules, $isUpdating, $expectedString, $expectedDefaultModuleString) {
+		$defaultModule = ($defaultModule === null) ? '' : $defaultModule;
 		$invokeCount = 0;
-		$this->config->expects($this->at($invokeCount))
-			->method('getAppValue')
-			->with('core', 'encryption_enabled', $this->anything())
-			->willReturn($oldStatus);
+		$this->manager->method('isEnabled')
+			->willReturn(\filter_var($oldStatus, FILTER_VALIDATE_BOOLEAN));
+
 		$invokeCount++;
 
 		if ($isUpdating) {
@@ -93,11 +93,15 @@ class EnableTest extends TestCase {
 			->method('getEncryptionModules')
 			->willReturn($availableModules);
 
+		$this->manager->method('getEncryptionModules')
+			->willReturn($availableModules);
 		if (!empty($availableModules)) {
-			$this->config->expects($this->at($invokeCount))
+			$this->manager->method('getDefaultEncryptionModuleId')
+				->willReturn($defaultModule);
+			/*$this->config->expects($this->at($invokeCount))
 				->method('getAppValue')
 				->with('core', 'default_encryption_module', $this->anything())
-				->willReturn($defaultModule);
+				->willReturn($defaultModule);*/
 		}
 
 		$this->consoleOutput->expects($this->at(0))


### PR DESCRIPTION
Direct config access should be avoided if we can use a proper API. Also added a TODO for the missing API to enable encryption.

Found while reviewing https://github.com/owncloud/core/pull/31598