### PR TITLE
Add contentOfFileShouldBe acceptance test scripts and refactor

### DIFF
--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -132,8 +132,7 @@ Feature: federated
 		And using server "REMOTE"
 		When user "user1" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the API
 		And using server "LOCAL"
-		And user "user0" downloads file "/textfile0.txt" with range "bytes=0-8" using the API
-		Then the downloaded content should be "BLABLABLA"
+		Then the content of file "/textfile0.txt" for user "user0" should be "BLABLABLA" plus end-of-line
 
 	Scenario: Overwrite a federated shared folder as recipient
 		Given using server "REMOTE"
@@ -146,8 +145,7 @@ Feature: federated
 		And using server "REMOTE"
 		When user "user1" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the API
 		And using server "LOCAL"
-		And user "user0" downloads file "/PARENT/textfile0.txt" with range "bytes=0-8" using the API
-		Then the downloaded content should be "BLABLABLA"
+		Then the content of file "/PARENT/textfile0.txt" for user "user0" should be "BLABLABLA" plus end-of-line
 
 	Scenario: Overwrite a federated shared file as recipient using old chunking
 		Given using server "REMOTE"
@@ -158,11 +156,10 @@ Feature: federated
 		And user "user0" from server "LOCAL" has shared "/textfile0.txt" with user "user1" from server "REMOTE"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		And user "user1" has uploaded chunk file "1" of "3" with "AAAAA" to "/textfile0 (2).txt"
-		And user "user1" has uploaded chunk file "2" of "3" with "BBBBB" to "/textfile0 (2).txt"
-		And user "user1" has uploaded chunk file "3" of "3" with "CCCCC" to "/textfile0 (2).txt"
-		When user "user1" downloads file "/textfile0 (2).txt" with range "bytes=0-4" using the API
-		Then the downloaded content should be "AAAAA"
+		When user "user1" uploads chunk file "1" of "3" with "AAAAA" to "/textfile0 (2).txt" using the API
+		And user "user1" uploads chunk file "2" of "3" with "BBBBB" to "/textfile0 (2).txt" using the API
+		And user "user1" uploads chunk file "3" of "3" with "CCCCC" to "/textfile0 (2).txt" using the API
+		Then the content of file "/textfile0 (2).txt" for user "user1" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Overwrite a federated shared folder as recipient using old chunking
 		Given using server "REMOTE"
@@ -173,11 +170,10 @@ Feature: federated
 		And user "user0" from server "LOCAL" has shared "/PARENT" with user "user1" from server "REMOTE"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		And user "user1" has uploaded chunk file "1" of "3" with "AAAAA" to "/PARENT (2)/textfile0.txt"
-		And user "user1" has uploaded chunk file "2" of "3" with "BBBBB" to "/PARENT (2)/textfile0.txt"
-		And user "user1" has uploaded chunk file "3" of "3" with "CCCCC" to "/PARENT (2)/textfile0.txt"
-		When user "user1" downloads file "/PARENT (2)/textfile0.txt" with range "bytes=3-13" using the API
-		Then the downloaded content should be "AABBBBBCCCC"
+		When user "user1" uploads chunk file "1" of "3" with "AAAAA" to "/PARENT (2)/textfile0.txt" using the API
+		And user "user1" uploads chunk file "2" of "3" with "BBBBB" to "/PARENT (2)/textfile0.txt" using the API
+		And user "user1" uploads chunk file "3" of "3" with "CCCCC" to "/PARENT (2)/textfile0.txt" using the API
+		Then the content of file "/PARENT (2)/textfile0.txt" for user "user1" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Trusted server handshake does not require authenticated requests - we force 403 by sending an empty body
 		Given using server "LOCAL"

--- a/tests/acceptance/features/apiMain/dav-versions.feature
+++ b/tests/acceptance/features/apiMain/dav-versions.feature
@@ -29,8 +29,7 @@ Feature: dav-versions
     And user "user0" has uploaded file with content "12345" to "/davtest.txt"
     And the version folder of file "/davtest.txt" for user "user0" should contain "1" element
     When user "user0" restores version index "1" of file "/davtest.txt" using the API
-    And user "user0" downloads the file "davtest.txt" using the API
-    Then the downloaded content should be "123"
+    Then the content of file "/davtest.txt" for user "user0" should be "123"
 
   Scenario: User cannot access meta folder of a file which is owned by somebody else
     Given user "user1" has been created

--- a/tests/acceptance/features/apiSharing-v1/downloadFromShare.feature
+++ b/tests/acceptance/features/apiSharing-v1/downloadFromShare.feature
@@ -27,8 +27,8 @@ Feature: sharing
 		And user "user1" has shared file "textfile0.txt" with user "user2"
 		And user "user1" has moved file "/textfile0.txt" to "/common/textfile0.txt"
 		And user "user1" has moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
-		And user "user2" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the API
-		When user "user2" downloads file "/common/sub/textfile0.txt" with range "bytes=0-8" using the API
+		When user "user2" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the API
+		And user "user2" downloads file "/common/sub/textfile0.txt" with range "bytes=0-8" using the API
 		Then the downloaded content should be "BLABLABLA"
 		And the downloaded content when downloading file "/textfile0 (2).txt" for user "user2" with range "bytes=0-8" should be "BLABLABLA"
 		And user "user2" should see the following elements

--- a/tests/acceptance/features/apiSharing-v1/uploadToShare.feature
+++ b/tests/acceptance/features/apiSharing-v1/uploadToShare.feature
@@ -11,12 +11,10 @@ Feature: sharing
 			| path        | FOLDER |
 			| shareType   | 3      |
 			| permissions | 4      |
-		And the public has uploaded file "test.txt" with content "test"
-		And the public has uploaded file "test.txt" with content "test2" with autorename mode
-		When the user downloads the file "/FOLDER/test.txt" using the API
-		Then the downloaded content should be "test"
-		And the user downloads the file "/FOLDER/test (2).txt" using the API
-		And the downloaded content should be "test2"
+		When the public uploads file "test.txt" with content "test" using the API
+		And the public uploads file "test.txt" with content "test2" with autorename mode using the API
+		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
+		And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
 
 	Scenario: Uploading file to a public upload-only share that was deleted does not work
 		Given user "user0" has been created
@@ -68,9 +66,8 @@ Feature: sharing
 			| path        | FOLDER |
 			| shareType   | 3      |
 			| permissions | 4      |
-		And the public has uploaded file "test.txt" with content "test"
-		When the user downloads the file "/FOLDER/test.txt" using the API
-		Then the downloaded content should be "test"
+		When the public uploads file "test.txt" with content "test" using the API
+		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
 	Scenario: Uploading to a public upload-only share with password
 		Given user "user0" has been created
@@ -80,9 +77,8 @@ Feature: sharing
 			| shareType   | 3        |
 			| password    | publicpw |
 			| permissions | 4        |
-		And the public has uploaded file "test.txt" with password "publicpw" and content "test"
-		When the user downloads the file "/FOLDER/test.txt" using the API
-		Then the downloaded content should be "test"
+		When the public uploads file "test.txt" with password "publicpw" and content "test" using the API
+		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
 	Scenario: Uploading file to a user upload-only share folder works
 		Given user "user0" has been created
@@ -116,9 +112,8 @@ Feature: sharing
 			| shareType   | 3        |
 			| password    | publicpw |
 			| permissions | 15       |
-		And the public has uploaded file "test.txt" with password "publicpw" and content "test"
-		When the user downloads the file "/FOLDER/test.txt" using the API
-		Then the downloaded content should be "test"
+		When the public uploads file "test.txt" with password "publicpw" and content "test" using the API
+		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
 	Scenario: Uploading file to a user read/write share folder works
 		Given user "user0" has been created
@@ -161,9 +156,8 @@ Feature: sharing
 			| shareType   | 3        |
 			| password    | publicpw |
 			| permissions | 15       |
-		And the public has uploaded file "test.txt" with password "publicpw" and content "test"
-		When the user downloads the file "/FOLDER/test.txt" using the API
-		Then the downloaded content should be "test"
+		When the public uploads file "test.txt" with password "publicpw" and content "test" using the API
+		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
 	Scenario: Uploading to a user shared folder with read/write permission when the sharer has unsufficient quota does not work
 		Given user "user0" has been created

--- a/tests/acceptance/features/apiWebdav/webdav-related-new-endpoint.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related-new-endpoint.feature
@@ -464,47 +464,48 @@ Feature: webdav-related-new-endpoint
 	Scenario: Upload chunked file asc with new chunking
 		Given using new DAV path
 		And user "user0" has been created
-		And user "user0" has created a new chunking upload with id "chunking-42"
-		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
-		And user "user0" has moved new chunk file with id "chunking-42" to "/myChunkedFile.txt"
-		When user "user0" downloads the file "/myChunkedFile.txt" using the API
-		Then the downloaded content should be "AAAAABBBBBCCCCC"
+		When user "user0" creates a new chunking upload with id "chunking-42" using the API
+		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the API
+		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
+		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the API
+		And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" using the API
+		Then as "user0" the file "/myChunkedFile.txt" should exist
+		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file desc with new chunking
 		Given using new DAV path
 		And user "user0" has been created
-		And user "user0" has created a new chunking upload with id "chunking-42"
-		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
-		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" has moved new chunk file with id "chunking-42" to "/myChunkedFile.txt"
-		When user "user0" downloads the file "/myChunkedFile.txt" using the API
-		Then the downloaded content should be "AAAAABBBBBCCCCC"
+		When user "user0" creates a new chunking upload with id "chunking-42" using the API
+		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the API
+		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
+		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the API
+		And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" using the API
+		Then as "user0" the file "/myChunkedFile.txt" should exist
+		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file random with new chunking
 		Given using new DAV path
 		And user "user0" has been created
-		And user "user0" has created a new chunking upload with id "chunking-42"
-		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
-		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" has moved new chunk file with id "chunking-42" to "/myChunkedFile.txt"
-		When user "user0" downloads the file "/myChunkedFile.txt" using the API
-		Then the downloaded content should be "AAAAABBBBBCCCCC"
+		When user "user0" creates a new chunking upload with id "chunking-42" using the API
+		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
+		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the API
+		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the API
+		And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" using the API
+		Then as "user0" the file "/myChunkedFile.txt" should exist
+		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Checking file id after a move overwrite using new chunking endpoint
 		Given using new DAV path
 		And user "user0" has been created
 		And user "user0" has copied file "/textfile0.txt" to "/existingFile.txt"
 		And user "user0" has stored id of file "/existingFile.txt"
-		And user "user0" has created a new chunking upload with id "chunking-42"
-		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
-		When user "user0" moves new chunk file with id "chunking-42" to "/existingFile.txt" using the API
+		When user "user0" creates a new chunking upload with id "chunking-42" using the API
+		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the API
+		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
+		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the API
+		And user "user0" moves new chunk file with id "chunking-42" to "/existingFile.txt" using the API
 		Then user "user0" file "/existingFile.txt" should have the previously stored id
+		And the content of file "/existingFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Checking file id after a move between received shares
 		Given using new DAV path
@@ -578,17 +579,19 @@ Feature: webdav-related-new-endpoint
 		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
 		When user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with size 15 using the API
 		Then the HTTP status code should be "201"
+		And as "user0" the file "/myChunkedFile.txt" should exist
+		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario Outline: Upload files with difficult names using new chunking
 		Given using new DAV path
 		And user "user0" has been created
-		And user "user0" has created a new chunking upload with id "chunking-42"
-		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
-		And user "user0" has moved new chunk file with id "chunking-42" to "/<file-name>"
-		When user "user0" downloads the file "/<file-name>" using the API
-		Then the downloaded content should be "AAAAABBBBBCCCCC"
+		When user "user0" creates a new chunking upload with id "chunking-42" using the API
+		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the API
+		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
+		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the API
+		And user "user0" moves new chunk file with id "chunking-42" to "/<file-name>" using the API
+		Then as "user0" the file "/<file-name>" should exist
+		And the content of file "/<file-name>" for user "user0" should be "AAAAABBBBBCCCCC"
 		Examples:
 			| file-name |
 			| &#?       |
@@ -599,14 +602,14 @@ Feature: webdav-related-new-endpoint
 	Scenario: Upload a file called "0" using new chunking
 		Given using new DAV path
 		And user "user0" has been created
-		And user "user0" has created a new chunking upload with id "chunking-42"
-		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
-		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
-		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
-		And user "user0" has moved new chunk file with id "chunking-42" to "/0"
-		When user "user0" downloads the file "/0" using the API
-		Then the downloaded content should be "AAAAABBBBBCCCCC"
-		
+		When user "user0" creates a new chunking upload with id "chunking-42" using the API
+		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the API
+		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
+		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the API
+		And user "user0" moves new chunk file with id "chunking-42" to "/0" using the API
+		And as "user0" the file "/0" should exist
+		And the content of file "/0" for user "user0" should be "AAAAABBBBBCCCCC"
+
 	Scenario: Retrieving private link
 		Given using new DAV path
 		And user "user0" has been created

--- a/tests/acceptance/features/apiWebdav/webdav-related-old-endpoint.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related-old-endpoint.feature
@@ -452,35 +452,35 @@ Feature: webdav-related-old-endpoint
 
 	Scenario: Upload chunked file asc
 		Given user "user0" has been created
-		And user "user0" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt"
-		And user "user0" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChunkedFile.txt"
-		And user "user0" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChunkedFile.txt"
-		When user "user0" downloads the file "/myChunkedFile.txt" using the API
-		Then the downloaded content should be "AAAAABBBBBCCCCC"
+		When user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt" using the API
+		And user "user0" uploads chunk file "2" of "3" with "BBBBB" to "/myChunkedFile.txt" using the API
+		And user "user0" uploads chunk file "3" of "3" with "CCCCC" to "/myChunkedFile.txt" using the API
+		Then as "user0" the file "/myChunkedFile.txt" should exist
+		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file desc
 		Given user "user0" has been created
-		And user "user0" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChunkedFile.txt"
-		And user "user0" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChunkedFile.txt"
-		And user "user0" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt"
-		When user "user0" downloads the file "/myChunkedFile.txt" using the API
-		Then the downloaded content should be "AAAAABBBBBCCCCC"
+		When user "user0" uploads chunk file "3" of "3" with "CCCCC" to "/myChunkedFile.txt" using the API
+		And user "user0" uploads chunk file "2" of "3" with "BBBBB" to "/myChunkedFile.txt" using the API
+		And user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt" using the API
+		Then as "user0" the file "/myChunkedFile.txt" should exist
+		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file random
 		Given user "user0" has been created
-		And user "user0" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChunkedFile.txt"
-		And user "user0" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChunkedFile.txt"
-		And user "user0" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt"
-		When user "user0" downloads the file "/myChunkedFile.txt" using the API
-		Then the downloaded content should be "AAAAABBBBBCCCCC"
+		When user "user0" uploads chunk file "2" of "3" with "BBBBB" to "/myChunkedFile.txt" using the API
+		And user "user0" uploads chunk file "3" of "3" with "CCCCC" to "/myChunkedFile.txt" using the API
+		And user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt" using the API
+		Then as "user0" the file "/myChunkedFile.txt" should exist
+		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario Outline: Chunked upload files with difficult name
 		Given user "user0" has been created
-		And user "user0" has uploaded chunk file "1" of "3" with "AAAAA" to "/<file-name>"
-		And user "user0" has uploaded chunk file "2" of "3" with "BBBBB" to "/<file-name>"
-		And user "user0" has uploaded chunk file "3" of "3" with "CCCCC" to "/<file-name>"
-		When user "user0" downloads the file "/<file-name>" using the API
-		Then the downloaded content should be "AAAAABBBBBCCCCC"
+		And user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/<file-name>" using the API
+		And user "user0" uploads chunk file "2" of "3" with "BBBBB" to "/<file-name>" using the API
+		And user "user0" uploads chunk file "3" of "3" with "CCCCC" to "/<file-name>" using the API
+		Then as "user0" the file "/<file-name>" should exist
+		And the content of file "/<file-name>" for user "user0" should be "AAAAABBBBBCCCCC"
 		Examples:
 			| file-name |
 			| 0         |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -369,7 +369,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When the public uploads file ":filename" with content ":body"
+	 * @When the public uploads file ":filename" with content ":body" using the API
 	 * @Given the public has uploaded file ":filename" with content ":body"
 	 *
 	 * @param string $filename target file name
@@ -383,7 +383,7 @@ trait Sharing {
 
 	/**
 	 * @When the public overwrites file ":filename" with content ":body" using the API
-	 * @Given the public has overwritten file ":filename" with content ":body" using the API
+	 * @Given the public has overwritten file ":filename" with content ":body"
 	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
@@ -395,7 +395,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When the public uploads file ":filename" with password ":password" and content ":body"
+	 * @When the public uploads file ":filename" with password ":password" and content ":body" using the API
 	 * @Given the public has uploaded file ":filename" with password ":password" and content ":body"
 	 *
 	 * @param string $filename target file name
@@ -411,7 +411,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When the public uploads file ":filename" with content ":body" with autorename mode
+	 * @When the public uploads file ":filename" with content ":body" with autorename mode using the API
 	 * @Given the public has uploaded file ":filename" with content ":body" with autorename mode
 	 *
 	 * @param string $filename target file name
@@ -487,7 +487,7 @@ trait Sharing {
 
 	/**
 	 * @When /^the user adds an expiration date to the last share using the API$/
-	 * @Given /^the user has added an expiration date to the last share using the API$/
+	 * @Given /^the user has added an expiration date to the last share$/
 	 *
 	 * @return void
 	 */
@@ -848,7 +848,7 @@ trait Sharing {
 
 	/**
 	 * @When /^the user deletes the last share using the API$/
-	 * @Given /^the user has deleted the last share using the API$/
+	 * @Given /^the user has deleted the last share$/
 	 *
 	 * @return void
 	 */
@@ -1155,8 +1155,8 @@ trait Sharing {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has (declined|accepted) the share "([^"]*)" offered by user "([^"]*)"$/
 	 * @When /^user "([^"]*)" (declines|accepts) the share "([^"]*)" offered by user "([^"]*)" using the API$/
+	 * @Given /^user "([^"]*)" has (declined|accepted) the share "([^"]*)" offered by user "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $action

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -409,6 +409,46 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then /^the content of file "([^"]*)" should be "([^"]*)"$/
+	 *
+	 * @param string $fileName
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function contentOfFileShouldBe($fileName, $content) {
+		$this->theUserDownloadsTheFileUsingTheAPI($fileName);
+		$this->downloadedContentShouldBe($content);
+	}
+
+	/**
+	 * @Then /^the content of file "([^"]*)" for user "([^"]*)" should be "([^"]*)"$/
+	 *
+	 * @param string $fileName
+	 * @param string $user
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function contentOfFileForUserShouldBe($fileName, $user, $content) {
+		$this->userDownloadsTheFileUsingTheAPI($user, $fileName);
+		$this->downloadedContentShouldBe($content);
+	}
+
+	/**
+	 * @Then /^the content of file "([^"]*)" for user "([^"]*)" should be "([^"]*)" plus end-of-line$/
+	 *
+	 * @param string $fileName
+	 * @param string $user
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function contentOfFileForUserShouldBePlusEndOfLine($fileName, $user, $content) {
+		$this->contentOfFileForUserShouldBe($fileName, $user, $content . "\n");
+	}
+
+	/**
 	 * @Then /^the downloaded content when downloading file "([^"]*)" with range "([^"]*)" should be "([^"]*)"$/
 	 *
 	 * @param string $fileSource
@@ -417,7 +457,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function downloadedContentWhenDownloadingShouldBe(
+	public function downloadedContentWhenDownloadingWithRangeShouldBe(
 		$fileSource, $range, $content
 	) {
 		$this->downloadFileWithRange($fileSource, $range);
@@ -434,7 +474,7 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function downloadedContentWhenDownloadingForUserShouldBe(
+	public function downloadedContentWhenDownloadingForUserWithRangeShouldBe(
 		$fileSource, $user, $range, $content
 	) {
 		$this->userDownloadsFileWithRange($user, $fileSource, $range);


### PR DESCRIPTION
## Description
Add acceptance test methods that test the content of a file in a single gherkin statement.
Refactor existing code to use the new steps, rather than having multiple "download" followed by "test content" steps.

## Motivation and Context
In various places, checks are done at the end of scenarios where the check has to first download the file, then check the content. This should be done in a single step for better readability etc.

I noticed this while making antivirus tests that often do uploads and then need to check the resulting file content.

## How Has This Been Tested?
Local API acceptance test runs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test enhancement

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
