### PR TITLE
[stable10] Proceed encrypt-all by enabling user-keys if no mode is selected by user

### DIFF
--- a/apps/encryption/lib/AppInfo/Application.php
+++ b/apps/encryption/lib/AppInfo/Application.php
@@ -94,7 +94,7 @@ class Application extends \OCP\AppFramework\App {
 					$container->query('Util'),
 					$container->query('Session'),
 					$container->query('Crypt'),
-					$container->query('Recovery'))
+					$container->query('Recovery'), $server->getConfig())
 			]);
 
 			$hookManager->fireHooks();

--- a/apps/encryption/lib/Hooks/UserHooks.php
+++ b/apps/encryption/lib/Hooks/UserHooks.php
@@ -26,6 +26,7 @@ namespace OCA\Encryption\Hooks;
 
 
 use OC\Files\Filesystem;
+use OCP\IConfig;
 use OCP\IUserManager;
 use OCP\Util as OCUtil;
 use OCA\Encryption\Hooks\Contracts\IHook;
@@ -76,6 +77,10 @@ class UserHooks implements IHook {
 	 * @var Crypt
 	 */
 	private $crypt;
+	/**
+	 * @var IConfig
+	 */
+	private $config;
 
 	/**
 	 * UserHooks constructor.
@@ -89,6 +94,7 @@ class UserHooks implements IHook {
 	 * @param Session $session
 	 * @param Crypt $crypt
 	 * @param Recovery $recovery
+	 * @param IConfig $config
 	 */
 	public function __construct(KeyManager $keyManager,
 								IUserManager $userManager,
@@ -98,7 +104,7 @@ class UserHooks implements IHook {
 								Util $util,
 								Session $session,
 								Crypt $crypt,
-								Recovery $recovery) {
+								Recovery $recovery, IConfig $config) {
 
 		$this->keyManager = $keyManager;
 		$this->userManager = $userManager;
@@ -109,6 +115,7 @@ class UserHooks implements IHook {
 		$this->session = $session;
 		$this->recovery = $recovery;
 		$this->crypt = $crypt;
+		$this->config = $config;
 	}
 
 	/**
@@ -164,6 +171,11 @@ class UserHooks implements IHook {
 		}
 		if ($this->util->isMasterKeyEnabled() === false) {
 			$this->userSetup->setupUser($params['uid'], $params['password']);
+		}
+
+		if (($this->util->isMasterKeyEnabled() === false) &&
+			($this->config->getAppValue('encryption', 'userSpecificKey', '') === '')) {
+			$this->config->setAppValue('encryption', 'userSpecificKey', '1');
 		}
 
 		$this->keyManager->init($params['uid'], $params['password']);

--- a/apps/encryption/tests/Hooks/UserHooksTest.php
+++ b/apps/encryption/tests/Hooks/UserHooksTest.php
@@ -30,6 +30,8 @@ namespace OCA\Encryption\Tests\Hooks;
 
 use OCA\Encryption\Crypto\Crypt;
 use OCA\Encryption\Hooks\UserHooks;
+use OCA\Encryption\Util;
+use OCP\IConfig;
 use Test\TestCase;
 
 /**
@@ -76,6 +78,7 @@ class UserHooksTest extends TestCase {
 	 * @var \PHPUnit_Framework_MockObject_MockObject
 	 */
 	private $loggerMock;
+	private $config;
 	/**
 	 * @var UserHooks
 	 */
@@ -91,6 +94,12 @@ class UserHooksTest extends TestCase {
 		$this->keyManagerMock->expects($this->once())
 			->method('init')
 			->with('testUser', 'password');
+
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->willReturnMap([
+				['encryption', 'userSpecificKey', '', ''],
+			]);
 
 		$this->assertNull($this->instance->login($this->params));
 	}
@@ -136,7 +145,8 @@ class UserHooksTest extends TestCase {
 					$this->utilMock,
 					$this->sessionMock,
 					$this->cryptMock,
-					$this->recoveryMock
+					$this->recoveryMock,
+					$this->config
 				]
 			)
 			->setMethods(['setPassphrase'])
@@ -215,7 +225,8 @@ class UserHooksTest extends TestCase {
 					$this->utilMock,
 					$this->sessionMock,
 					$this->cryptMock,
-					$this->recoveryMock
+					$this->recoveryMock,
+					$this->config
 				]
 			)->setMethods(['initMountPoints'])->getMock();
 
@@ -278,7 +289,8 @@ class UserHooksTest extends TestCase {
 					$this->utilMock,
 					$this->sessionMock,
 					$this->cryptMock,
-					$this->recoveryMock
+					$this->recoveryMock,
+					$this->config
 				]
 			)->setMethods(['initMountPoints'])->getMock();
 
@@ -331,9 +343,9 @@ class UserHooksTest extends TestCase {
 			->method($this->anything())
 			->will($this->returnSelf());
 
-		$utilMock = $this->getMockBuilder('OCA\Encryption\Util')
+		/*$utilMock = $this->getMockBuilder('OCA\Encryption\Util')
 			->disableOriginalConstructor()
-			->getMock();
+			->getMock();*/
 
 		$sessionMock = $this->getMockBuilder('OCA\Encryption\Session')
 			->disableOriginalConstructor()
@@ -345,10 +357,11 @@ class UserHooksTest extends TestCase {
 		$recoveryMock = $this->getMockBuilder('OCA\Encryption\Recovery')
 			->disableOriginalConstructor()
 			->getMock();
+		$this->config = $this->createMock(IConfig::class);
 
 		$this->sessionMock = $sessionMock;
 		$this->recoveryMock = $recoveryMock;
-		$this->utilMock = $utilMock;
+		$this->utilMock = $this->createMock(Util::class);
 		$this->utilMock->expects($this->any())->method('isMasterKeyEnabled')->willReturn(false);
 
 		$this->instance = $this->getMockBuilder('OCA\Encryption\Hooks\UserHooks')
@@ -362,7 +375,8 @@ class UserHooksTest extends TestCase {
 					$this->utilMock,
 					$this->sessionMock,
 					$this->cryptMock,
-					$this->recoveryMock
+					$this->recoveryMock,
+					$this->config
 				]
 			)->setMethods(['setupFS'])->getMock();
 

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -107,6 +107,15 @@ class EncryptAll extends Command {
 			throw new \Exception('Server side encryption is not enabled');
 		}
 
+		$masterKeyEnabled = $this->config->getAppValue('encryption', 'useMasterKey', '');
+		$userKeyEnabled = $this->config->getAppValue('encryption', 'userSpecificKey', '');
+		if (($masterKeyEnabled === '') && ($userKeyEnabled === '')) {
+			/**
+			 * Enable user specific encryption if nothing is enabled.
+			 */
+			$this->config->setAppValue('encryption', 'userSpecificKey', '1');
+		}
+
 		$output->writeln("\n");
 		$output->writeln('You are about to encrypt all files stored in your ownCloud installation.');
 		$output->writeln('Depending on the number of available files, and their size, this may take quite some time.');

--- a/tests/Core/Command/Encryption/EncryptAllTest.php
+++ b/tests/Core/Command/Encryption/EncryptAllTest.php
@@ -99,6 +99,15 @@ class EncryptAllTest extends TestCase {
 
 		$this->encryptionManager->expects($this->once())->method('isEnabled')->willReturn(true);
 		$this->questionHelper->expects($this->once())->method('ask')->willReturn($askResult);
+		$this->config->expects($this->any())
+			->method('getAppValue')
+			->willReturnMap([
+				['encryption', 'useMasterKey', '', ''],
+				['encryption', 'userSpecificKey', '', '']
+			]);
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->willReturn(null);
 
 		if ($answer === 'Y' || $answer === 'y') {
 			$this->encryptionManager->expects($this->once())


### PR DESCRIPTION
Proceed encrypt-all by enabling user-keys, if user
had not selected any encryption mode before executing
the command.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Enable user-keys encryption if the encryption is enabled and neither maserkey or user-keys are enabled. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Enable user-keys encryption if the encryption is enabled and neither maserkey or user-keys are enabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Enable encryption app
- [x] Enable encryption
- [x] Try to login
- [x] Verify the encryption page in Admin Settings page -> Encryption ( not the personal encryption ). User should see user-keys encryption selected.
- Same way tested with encrypt-all command by enabling app and enabling encryption. After encrypt-all command was run, the user-keys were enabled.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

