### PR TITLE
Enhance log file contains acceptance test steps

### DIFF
--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -36,8 +36,9 @@ trait Logging {
 	 * order of the table has to be the same as in the log file
 	 * empty cells in the table will not be checked!
 	 *
-	 * @Then the last lines of the log file should contain log-entries with these attributes:
+	 * @Then /^the last lines of the log file should contain log-entries (with|containing) these attributes:$/
 	 *
+	 * @param string $withOrContaining
 	 * @param TableNode $expectedLogEntries table with headings that correspond
 	 *                                      to the json keys in the log entry
 	 *                                      e.g.
@@ -47,7 +48,7 @@ trait Logging {
 	 * @throws \Exception
 	 */
 	public function theLastLinesOfTheLogFileShouldContainEntriesWithTheseAttributes(
-		TableNode $expectedLogEntries
+		$withOrContaining, TableNode $expectedLogEntries
 	) {
 		//-1 because getRows gives also the header
 		$linesToRead = \count($expectedLogEntries->getRows()) - 1;
@@ -69,10 +70,18 @@ trait Logging {
 					"' in log entry: '" . $logLines[$lineNo] . "'"
 				);
 				if ($expectedLogEntry[$attribute] !== "") {
-					PHPUnit_Framework_Assert::assertEquals(
-						$expectedLogEntry[$attribute], $logEntry[$attribute],
-						"log entry:\n" . $logLines[$lineNo] . "\n"
-					);
+					$message = "log entry:\n" . $logLines[$lineNo] . "\n";
+					if ($withOrContaining === 'with') {
+						PHPUnit_Framework_Assert::assertEquals(
+							$expectedLogEntry[$attribute], $logEntry[$attribute],
+							$message
+						);
+					} else {
+						PHPUnit_Framework_Assert::assertContains(
+							$expectedLogEntry[$attribute], $logEntry[$attribute],
+							$message
+						);
+					}
 				}
 			}
 			$lineNo++;
@@ -85,8 +94,9 @@ trait Logging {
 	 * attributes in the table that are empty will match any value in the
 	 * corresponding attribute in the log file
 	 *
-	 * @Then the log file should not contain any log-entries with these attributes:
+	 * @Then /^the log file should not contain any log-entries (with|containing) these attributes:$/
 	 *
+	 * @param string $withOrContaining
 	 * @param TableNode $logEntriesExpectedNotToExist table with headings that
 	 *                                                correspond to the json
 	 *                                                keys in the log entry
@@ -97,25 +107,28 @@ trait Logging {
 	 * @throws \Exception
 	 */
 	public function theLogFileShouldNotContainAnyLogEntriesWithTheseAttributes(
-		TableNode $logEntriesExpectedNotToExist
+		$withOrContaining, TableNode $logEntriesExpectedNotToExist
 	) {
 		$logLines = \file(LoggingHelper::getLogFilePath());
 		foreach ($logLines as $logLine) {
-			$logEntries = \json_decode($logLine, true);
+			$logEntry = \json_decode($logLine, true);
 			foreach ($logEntriesExpectedNotToExist as $logEntryExpectedNotToExist) {
+				$match = true; // start by assuming the worst, we match the unwanted log entry
 				foreach (\array_keys($logEntryExpectedNotToExist) as $attribute) {
 					$logEntryExpectedNotToExist[$attribute]
 						= $this->featureContext->substituteInLineCodes(
 							$logEntryExpectedNotToExist[$attribute]
 						);
-					if (isset($logEntries[$attribute])
-						&& ($logEntryExpectedNotToExist[$attribute] === ""
-						|| $logEntryExpectedNotToExist[$attribute] === $logEntries[$attribute])
-					) {
-						$match = true;
-					} else {
-						$match = false;
-						break;
+
+					if (isset($logEntry[$attribute]) && ($logEntryExpectedNotToExist[$attribute] !== "")) {
+						if ($withOrContaining === 'with') {
+							$match = ($logEntryExpectedNotToExist[$attribute] === $logEntry[$attribute]);
+						} else {
+							$match = (\strpos($logEntry[$attribute], $logEntryExpectedNotToExist[$attribute]) !== false);
+						}
+						if (!$match) {
+							break;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Description
Allow an acceptance test step to check if the log file contains (or not) an entry that has text that itself contains some string.

## Motivation and Context
Currently in acceptance tests you can check if the log file contains (or not) an entry with some specific text (and it allows some substitutions). But you cannot check just for some substring.
Checking for a substring will be useful. e.g. in ``files_antivirus`` I want to check for ``Infected file deleted`` and the rest of the text in the logged message is quite complex and variable (depending on the file name, the virus detected, whether chunking was used...).

## How Has This Been Tested?
Making tests locally for ``files_antivirus``, which will come in a PR to that repo.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test enhancement

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
