### PR TITLE
[stable10][feature] provide original exception via logging events

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
@@ -106,7 +106,6 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 				$level = \OCP\Util::DEBUG;
 			}
 		}
-
 		$message = $ex->getMessage();
 		if ($ex instanceof Exception) {
 			if (empty($message)) {
@@ -116,17 +115,14 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 			$message = "HTTP/1.1 {$ex->getHTTPCode()} $message";
 		}
 
-		$user = \OC_User::getUser();
+		$this->logger->logException(
+			$ex,
+			[
+				'app' 		=> $this->appName,
+				'message' 	=> 'Exception: '.$message,
+				'level' 	=> $level
+			]
+		);
 
-		$exception = [
-			'Message' => $message,
-			'Exception' => $exceptionClass,
-			'Code' => $ex->getCode(),
-			'Trace' => $ex->getTraceAsString(),
-			'File' => $ex->getFile(),
-			'Line' => $ex->getLine(),
-			'User' => $user,
-		];
-		$this->logger->log($level, 'Exception: ' . json_encode($exception), ['app' => $this->appName]);
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
@@ -76,14 +76,14 @@ class ExceptionLoggerPluginTest extends TestCase {
 			$this->assertNull($result);
 		} else {
 			$this->assertEquals($expectedLogLevel, $this->logger->level);
-			$this->assertStringStartsWith('Exception: {"Message":"' . $expectedMessage, $this->logger->message);
+			$this->assertStringStartsWith('Exception: ' . $expectedMessage, $this->logger->message);
 		}
 	}
 
 	public function providesExceptions() {
 		return [
-			[0, 'HTTP\/1.1 404 Not Found', new NotFound()],
-			[4, 'HTTP\/1.1 400 This path leads to nowhere', new InvalidPath('This path leads to nowhere')],
+			[0, 'HTTP/1.1 404 Not Found', new NotFound()],
+			[4, 'HTTP/1.1 400 This path leads to nowhere', new InvalidPath('This path leads to nowhere')],
 			[0, '', new FileContentNotAllowedException("Testing", 0, new FileContentNotAllowedException("pervious exception", 0))],
 		];
 	}

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -409,6 +409,11 @@ class Log implements ILogger {
 	 */
 	public function logException($exception, array $context = []) {
 		$context['exception'] =  $exception;
+		$level = Util::ERROR;
+		if (isset($context['level'])) {
+			$level = $context['level'];
+			unset($context['level']);
+		}
 		$exception = [
 			'Exception' => get_class($exception),
 			'Message' => $exception->getMessage(),
@@ -423,6 +428,6 @@ class Log implements ILogger {
 		}
 		$msg = isset($context['message']) ? $context['message'] : 'Exception';
 		$msg .= ': ' . json_encode($exception);
-		$this->error($msg, $context);
+		$this->log($level, $msg, $context);
 	}
 }

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -265,6 +265,12 @@ class Log implements ILogger {
 			$extraFields = $context['extraFields'];
 			unset($context['extraFields']);
 		}
+
+		$exception = null;
+		if (isset($context['exception'])) {
+			$exception = $context['exception'];
+			unset($context['exception']);
+		}
 		array_walk($context, [$this->normalizer, 'format']);
 
 		if (isset($context['app'])) {
@@ -361,6 +367,7 @@ class Log implements ILogger {
 			'formattedMessage' => $formattedMessage,
 			'context' => $context,
 			'extraFields' => $extraFields,
+			'exception' => $exception
 		];
 
 		// note: regardless of log level we let listeners receive messages
@@ -401,6 +408,7 @@ class Log implements ILogger {
 	 * @since 8.2.0
 	 */
 	public function logException($exception, array $context = []) {
+		$context['exception'] =  $exception;
 		$exception = [
 			'Exception' => get_class($exception),
 			'Message' => $exception->getMessage(),

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -275,9 +275,27 @@ class LoggerTest extends TestCase {
 				'test' => 'replaced',
 			],
 			'extraFields' => ['extra' => 'one'],
+			'exception' => null
 		];
 
 		$this->assertEquals($expectedArgs, $beforeWriteEvent->getArguments(), 'before event arguments match');
 		$this->assertEquals($expectedArgs, $afterWriteEvent->getArguments(), 'after event arguments match');
+	}
+
+	public function testOriginalExceptionIsProvidedAsExtraField() {
+		$e = new \Exception('test');
+
+
+		$beforeWriteEvent = null;
+		$this->eventDispatcher->addListener(
+			'log.beforewrite',
+			function(GenericEvent $event) use (&$beforeWriteEvent) {
+				$beforeWriteEvent = $event;
+			}
+		);
+		$this->logger->logException($e);
+		$eventArguments = $beforeWriteEvent->getArguments();
+		$this->assertArrayHasKey('exception', $eventArguments, 'exception field is set');
+		$this->assertSame($e, $eventArguments['exception'], 'the original exception is passed');
 	}
 }


### PR DESCRIPTION
## Description
When logging an exception, we add the original exception to the context. 
During the actual logging, the exception is extracted from context and provided in the event as original object so it can be used/handled by event listeners

This allows apps to also provide further information on any incidents 

## Motivation and Context
If just logging the message from ownCloud, we loose features of exception traces with parameters.

Note: 
- any app that accesses the exception, is itself responsible for handling the part of removing sensitive data. 

- the logging format for exceptions catched from sabredav will slightly change apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php

## How Has This Been Tested?
- ✅ unit tests provided
- ✅ demo app for sentry written

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

