### PR TITLE
Allow old-new DAV path to be used in scenario outlines

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -95,7 +95,21 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^using old (?:dav|DAV) path$/
+	 * @Given /^using (old|new) (?:dav|DAV) path$/
+	 *
+	 * @param string $oldOrNewDavPath
+	 * @return void
+	 */
+	public function usingOldOrNewDavPath($oldOrNewDavPath) {
+		if ($oldOrNewDavPath === 'old') {
+			$this->usingOldDavPath();
+		} else {
+			$this->usingNewDavPath();
+		}
+	}
+
+	/**
+	 * Select the old DAV path as the default for later scenario steps
 	 *
 	 * @return void
 	 */
@@ -106,7 +120,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^using new (?:dav|DAV) path$/
+	 * Select the new DAV path as the default for later scenario steps
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
## Description
Allow the words ``old`` and ``new`` to be passed as variables in the scenario step that selects the default DAV path to use.
 
## Motivation and Context
Sometimes an acceptance test scenario works just the same (or almost the same) for both the "old" and "new" DAV path. It would be nice to be able to collapse such scenarios into a single ``Scenario Outline`` that will automagically run the steps for both paths.

I noticed this as I was making new ``files_antivirus`` tests. It could also cut-down on lots of duplication that is currently in in ``webdav-related-new-endpoint.feature``  and ``webdav-related-new-endpoint.feature``

## How Has This Been Tested?
Run some local acceptance test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
