### PR TITLE
Adding background:queue commands: status and delete

### DIFF
--- a/core/Command/Background/Queue/Delete.php
+++ b/core/Command/Background/Queue/Delete.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Background\Queue;
+
+use OCP\BackgroundJob\IJobList;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Delete extends Command {
+
+	/** @var \OCP\BackgroundJob\IJobList */
+	private $jobList;
+
+	public function __construct(IJobList $jobList) {
+		$this->jobList = $jobList;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('background:queue:delete')
+			->setDescription('Delete a job from the queue')
+			->addArgument('id', InputArgument::REQUIRED, 'id of the job to be deleted');
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$id = $input->getArgument('id');
+
+		$job = $this->jobList->getById($id);
+		if ($job === null) {
+			$output->writeln("Job with id <$id> is not known.");
+			return 1;
+		}
+
+		$this->jobList->removeById($id);
+		$output->writeln('Job has been deleted.');
+		return 0;
+	}
+}

--- a/core/Command/Background/Queue/Status.php
+++ b/core/Command/Background/Queue/Status.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Background\Queue;
+
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\IJobList;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Status extends Command {
+
+	/** @var \OCP\BackgroundJob\IJobList */
+	private $jobList;
+
+	public function __construct(IJobList $jobList) {
+		$this->jobList = $jobList;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('background:queue:status')
+			->setDescription('List queue status');
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return void
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$t = new Table($output);
+		$t->setHeaders(['Id', 'Job', 'Last run', 'Job Arguments']);
+		$this->jobList->listJobs(function (IJob $job) use ($t) {
+			$t->addRow([$job->getId(), \get_class($job), \date('c', $job->getLastRun()), $job->getArgument()]);
+		});
+		$t->render();
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -71,6 +71,8 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Background\Cron(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Background\WebCron(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Background\Ajax(\OC::$server->getConfig()));
+	$application->add(new OC\Core\Command\Background\Queue\Status(\OC::$server->getJobList()));
+	$application->add(new OC\Core\Command\Background\Queue\Delete(\OC::$server->getJobList()));
 
 	$application->add(new OC\Core\Command\Config\App\DeleteConfig(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Config\App\GetConfig(\OC::$server->getConfig()));

--- a/db_structure.xml
+++ b/db_structure.xml
@@ -724,7 +724,6 @@
 				<default></default>
 				<notnull>false</notnull>
 			</field>
-
 			<field>
 				<!-- timestamp when the job was checked if it needs execution the last time -->
 				<name>last_checked</name>

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -127,4 +127,19 @@ interface IJobList {
 	 * @since 10.0.0
 	 */
 	public function setExecutionTime($job, $timeTaken);
+
+	/**
+	 * iterate over all jobs in the queue
+	 *
+	 * @return void
+	 * @since 10.0.9
+	 */
+	public function listJobs(\Closure $callback);
+
+	/**
+	 * remove a specific job by id
+	 * @return void
+	 * @since 10.0.9
+	 */
+	public function removeById($id);
 }

--- a/tests/Core/Command/Background/Queue/DeleteTest.php
+++ b/tests/Core/Command/Background/Queue/DeleteTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\Background\Queue;
+
+use OC\Core\Command\Background\Queue\Delete;
+use OCP\BackgroundJob\IJobList;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ * Class DeleteTest
+ *
+ * @group DB
+ */
+class DeleteTest extends TestCase {
+
+	/** @var CommandTester */
+	private $commandTester;
+	/** @var IJobList */
+	private $jobList;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->jobList = $this->createMock(IJobList::class);
+		$this->jobList->expects($this->any())->method('getById')
+			->willReturnCallback(function ($id) {
+				return ($id !== '666') ? true : null;
+			});
+
+		$command = new Delete($this->jobList);
+		$this->commandTester = new CommandTester($command);
+	}
+
+	/**
+	 * @dataProvider providesJobIds
+	 * @param $jobId
+	 * @param $expectedOutput
+	 */
+	public function testCommandInput($jobId, $expectedOutput) {
+		$input = ['id' => $jobId];
+		$this->commandTester->execute($input);
+		$output = $this->commandTester->getDisplay();
+		$this->assertContains($expectedOutput, $output);
+	}
+
+	public function providesJobIds() {
+		return [
+			['666', 'Job with id <666> is not known.'],
+			['1', 'Job has been deleted.'],
+		];
+	}
+}

--- a/tests/Core/Command/Background/Queue/StatusTest.php
+++ b/tests/Core/Command/Background/Queue/StatusTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\Background\Queue;
+
+use OC\BackgroundJob\Legacy\RegularJob;
+use OC\Core\Command\Background\Queue\Status;
+use OCP\BackgroundJob\IJobList;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ * Class StatusTest
+ *
+ * @group DB
+ */
+class StatusTest extends TestCase {
+
+	/** @var CommandTester */
+	private $commandTester;
+	/** @var IJobList */
+	private $jobList;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->jobList = $this->createMock(IJobList::class);
+		$this->jobList->expects($this->any())->method('listJobs')
+			->willReturnCallback(function (\Closure $callBack) {
+				$job = new RegularJob();
+				$job->setId(666);
+				$callBack($job);
+			});
+
+		$command = new Status($this->jobList);
+		$command->setApplication(new Application());
+		$this->commandTester = new CommandTester($command);
+	}
+
+	public function testCommandInput() {
+		$this->commandTester->execute([]);
+		$output = $this->commandTester->getDisplay();
+		$expected = <<<EOS
++-----+------------------------------------+---------------------------+---------------+
+| Id  | Job                                | Last run                  | Job Arguments |
++-----+------------------------------------+---------------------------+---------------+
+| 666 | OC\BackgroundJob\Legacy\RegularJob | 1970-01-01T00:00:00+00:00 |               |
++-----+------------------------------------+---------------------------+---------------+
+EOS;
+
+		$this->assertContains($expected, $output);
+	}
+}


### PR DESCRIPTION
## Description
Adding two new commands for listing background jobs and deleting individual jobs

## Related Issue
#31617 

## Motivation and Context
Adding a full feature set around occ and background jobs

## How Has This Been Tested?
- manual testing
- unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

