### PR TITLE
[stable10] Add symfony event for public links shared by email

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -128,7 +128,8 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				\OC::$server->getMailer(),
 				\OC::$server->getLogger(),
 				$defaults,
-				\OC::$server->getURLGenerator()
+				\OC::$server->getURLGenerator(),
+				\OC::$server->getEventDispatcher()
 			);
 
 			$result = $mailNotification->sendInternalShareMail($recipientList, $itemSource, $itemType);
@@ -191,7 +192,8 @@ if (isset($_POST['action']) && isset($_POST['itemType']) && isset($_POST['itemSo
 				\OC::$server->getMailer(),
 				\OC::$server->getLogger(),
 				$defaults,
-				\OC::$server->getURLGenerator()
+				\OC::$server->getURLGenerator(),
+				\OC::$server->getEventDispatcher()
 			);
 
 			$expiration = null;

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -38,6 +38,8 @@ use OCP\ILogger;
 use OCP\Defaults;
 use OCP\Util;
 use OC\Share\Filters\MailNotificationFilter;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Class MailNotifications
@@ -62,6 +64,8 @@ class MailNotifications {
 	private $logger;
 	/** @var IURLGenerator */
 	private $urlGenerator;
+	/** @var EventDispatcher  */
+	private $eventDispatcher;
 
 	/**
 	 * @param IUser $user
@@ -76,13 +80,15 @@ class MailNotifications {
 								IMailer $mailer,
 								ILogger $logger,
 								Defaults $defaults,
-								IURLGenerator $urlGenerator) {
+								IURLGenerator $urlGenerator,
+								EventDispatcher $eventDispatcher) {
 		$this->l = $l10n;
 		$this->user = $user;
 		$this->mailer = $mailer;
 		$this->logger = $logger;
 		$this->defaults = $defaults;
 		$this->urlGenerator = $urlGenerator;
+		$this->eventDispatcher = $eventDispatcher;
 
 		$this->replyTo = $this->user->getEMailAddress();
 
@@ -187,6 +193,17 @@ class MailNotifications {
 		$subject = (string)$this->l->t('%s shared »%s« with you', [$this->senderDisplayName, $filename]);
 		list($htmlBody, $textBody) = $this->createMailBody($filename, $link, $expiration, $personalNote);
 
+		/**
+		 * The event consumer of share.sendmail would have following data
+		 * - link ( the public link created )
+		 * - to ( the to recipient in mail )
+		 * - cc ( the cc recipient in mail )
+		 * - bcc ( the bcc recipient in mail )
+		 */
+		$ccRecipients = isset($options['cc']) ? $options['cc'] : '';
+		$bccRecipients = isset($options['bcc']) ? $options['bcc'] : '';
+		$event = new GenericEvent(null, ['link' => $link, 'to' => $recipient, 'cc' => $ccRecipients, 'bcc' => $bccRecipients]);
+		$this->eventDispatcher->dispatch('share.sendmail', $event);
 		return $this->sendLinkShareMailFromBody($recipient, $subject, $htmlBody, $textBody, $options);
 	}
 

--- a/tests/lib/Share/MailNotificationsTest.php
+++ b/tests/lib/Share/MailNotificationsTest.php
@@ -29,10 +29,14 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\Mail\IMailer;
 use OCP\Util;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Test\TestCase;
 
 /**
  * Class MailNotificationsTest
+ *
+ * @group DB
  */
 class MailNotificationsTest extends TestCase {
 	/** @var IL10N */
@@ -47,6 +51,7 @@ class MailNotificationsTest extends TestCase {
 	private $user;
 	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
 	private $urlGenerator;
+	private $eventDispatcher;
 
 
 	public function setUp() {
@@ -63,6 +68,7 @@ class MailNotificationsTest extends TestCase {
 		$this->user = $this->getMockBuilder('\OCP\IUser')
 				->disableOriginalConstructor()->getMock();
 		$this->urlGenerator = $this->createMock('\OCP\IURLGenerator');
+		$this->eventDispatcher = new EventDispatcher();
 
 		$this->l10n->expects($this->any())
 			->method('t')
@@ -125,10 +131,77 @@ class MailNotificationsTest extends TestCase {
 			$this->mailer,
 			$this->logger,
 			$this->defaults,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->eventDispatcher
 		);
 
 		$this->assertSame([], $mailNotifications->sendLinkShareMail('lukas@owncloud.com', 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600));
+	}
+
+	public function testSendLinkShareMailWithRecipientAndOptions() {
+		$message = $this->getMockBuilder('\OC\Mail\Message')
+			->disableOriginalConstructor()->getMock();
+
+		$message
+			->expects($this->once())
+			->method('setSubject')
+			->with('TestUser shared »MyFile« with you');
+		$message
+			->expects($this->once())
+			->method('setTo')
+			->with(['lukas@owncloud.com']);
+		$message
+			->expects($this->once())
+			->method('setHtmlBody')
+			->with($this->stringContains('personal note'));
+		$message
+			->expects($this->once())
+			->method('setPlainBody')
+			->with($this->stringContains('personal note'));
+
+		$message
+			->expects($this->once())
+			->method('setFrom')
+			->with([Util::getDefaultEmailAddress('sharing-noreply') => 'TestUser via UnitTestCloud']);
+
+		$this->mailer
+			->expects($this->once())
+			->method('createMessage')
+			->will($this->returnValue($message));
+
+		$this->mailer
+			->expects($this->once())
+			->method('send')
+			->with($message)
+			->will($this->returnValue([]));
+
+		$mailNotifications = new MailNotifications(
+			$this->user,
+			$this->l10n,
+			$this->mailer,
+			$this->logger,
+			$this->defaults,
+			$this->urlGenerator,
+			$this->eventDispatcher
+		);
+
+		$calledEvent = [];
+		$this->eventDispatcher->addListener('share.sendmail', function (GenericEvent $event) use (&$calledEvent) {
+			$calledEvent[] = 'share.sendmail';
+			$calledEvent[] = $event;
+		});
+		$this->assertSame([], $mailNotifications->sendLinkShareMail('lukas@owncloud.com', 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600, 'personal note', ['bcc' => 'foo@bar.com,fabulous@world.com', 'cc' => 'abc@foo.com,tester@world.com']));
+
+		$this->assertEquals('share.sendmail', $calledEvent[0]);
+		$this->assertInstanceOf(GenericEvent::class, $calledEvent[1]);
+		$this->assertArrayHasKey('link', $calledEvent[1]);
+		$this->assertEquals('https://owncloud.com/file/?foo=bar', $calledEvent[1]->getArgument('link'));
+		$this->assertArrayHasKey('to', $calledEvent[1]);
+		$this->assertEquals('lukas@owncloud.com', $calledEvent[1]->getArgument('to'));
+		$this->assertArrayHasKey('bcc', $calledEvent[1]);
+		$this->assertEquals('foo@bar.com,fabulous@world.com', $calledEvent[1]->getArgument('bcc'));
+		$this->assertArrayHasKey('cc', $calledEvent[1]);
+		$this->assertEquals('abc@foo.com,tester@world.com', $calledEvent[1]->getArgument('cc'));
 	}
 
 	public function testSendLinkShareMailPersonalNote() {
@@ -174,10 +247,23 @@ class MailNotificationsTest extends TestCase {
 			$this->mailer,
 			$this->logger,
 			$this->defaults,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->eventDispatcher
 		);
 
+		$calledEvent = [];
+		$this->eventDispatcher->addListener('share.sendmail', function (GenericEvent $event) use (&$calledEvent) {
+			$calledEvent[] = 'share.sendmail';
+			$calledEvent[] = $event;
+		});
 		$this->assertSame([], $mailNotifications->sendLinkShareMail('lukas@owncloud.com', 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600, 'personal note'));
+
+		$this->assertEquals('share.sendmail', $calledEvent[0]);
+		$this->assertInstanceOf(GenericEvent::class, $calledEvent[1]);
+		$this->assertArrayHasKey('link', $calledEvent[1]);
+		$this->assertEquals('https://owncloud.com/file/?foo=bar', $calledEvent[1]->getArgument('link'));
+		$this->assertArrayHasKey('to', $calledEvent[1]);
+		$this->assertEquals('lukas@owncloud.com', $calledEvent[1]->getArgument('to'));
 	}
 
 	public function dataSendLinkShareMailWithReplyTo() {
@@ -239,7 +325,8 @@ class MailNotificationsTest extends TestCase {
 			$this->mailer,
 			$this->logger,
 			$this->defaults,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->eventDispatcher
 		);
 		$this->assertSame([], $mailNotifications->sendLinkShareMail($to, 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600));
 	}
@@ -253,7 +340,8 @@ class MailNotificationsTest extends TestCase {
 			$this->mailer,
 			$this->logger,
 			$this->defaults,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->eventDispatcher
 		);
 
 		$this->assertSame(['lukas@owncloud.com'], $mailNotifications->sendLinkShareMail('lukas@owncloud.com', 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600));
@@ -271,14 +359,15 @@ class MailNotificationsTest extends TestCase {
 				$this->mailer,
 				$this->logger,
 				$this->defaults,
-				$this->urlGenerator
+				$this->urlGenerator,
+				$this->eventDispatcher
 			])
 			->getMock();
 
 		$mailNotifications->method('getItemSharedWithUser')
 			->withAnyParameters()
 			->willReturn([
-				['file_target' => '/<welcome>.txt', 'item_source' => 123],
+				['file_target' => '/<welcome>.txt', 'item_source' => 123, 'expiration' => '2017-01-01T15:03:01.012345Z'],
 			]);
 
 		$recipient = $this->getMockBuilder('\OCP\IUser')
@@ -307,6 +396,90 @@ class MailNotificationsTest extends TestCase {
 
 	}
 
+	public function testSendInternalShareMailException() {
+		$this->setupMailerMock('TestUser shared »&lt;welcome&gt;.txt« with you', ['recipient@owncloud.com' => 'Recipient'], false);
+
+		/** @var MailNotifications | \PHPUnit_Framework_MockObject_MockObject $mailNotifications */
+		$mailNotifications = $this->getMockBuilder('OC\Share\MailNotifications')
+			->setMethods(['getItemSharedWithUser'])
+			->setConstructorArgs([
+				$this->user,
+				$this->l10n,
+				$this->mailer,
+				$this->logger,
+				$this->defaults,
+				$this->urlGenerator,
+				$this->eventDispatcher
+			])
+			->getMock();
+
+		$mailNotifications->method('getItemSharedWithUser')
+			->withAnyParameters()
+			->willReturn([
+				['file_target' => '/<welcome>.txt', 'item_source' => 123, 'expiration' => 'foo'],
+			]);
+
+		$recipient = $this->getMockBuilder('\OCP\IUser')
+			->disableOriginalConstructor()->getMock();
+		$recipient
+			->expects($this->once())
+			->method('getEMailAddress')
+			->willReturn('recipient@owncloud.com');
+		$recipient
+			->expects($this->once())
+			->method('getDisplayName')
+			->willReturn('Recipient');
+
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRouteAbsolute')
+			->with(
+				$this->equalTo('files.viewcontroller.showFile'),
+				$this->equalTo([
+					'fileId' => 123,
+				])
+			);
+
+		$this->mailer->expects($this->once())
+			->method('send')
+			->willThrowException(new \Exception());
+
+		$recipientList = [$recipient];
+		$result = $mailNotifications->sendInternalShareMail($recipientList, '3', 'file');
+		$this->assertEquals(['Recipient'], $result);
+	}
+
+	public function testGetItemSharedWithUser() {
+		$mailNotifications = new MailNotifications(
+			$this->user,
+			$this->l10n,
+			$this->mailer,
+			$this->logger,
+			$this->defaults,
+			$this->urlGenerator,
+			$this->eventDispatcher
+		);
+		/**
+		 * The below piece of code is borrowed from
+		 * https://github.com/owncloud/core/blob/master/tests/lib/Share/ShareTest.php#L621-L639
+		 */
+		$uid1 = $this->getUniqueID('user1_');
+		$uid2 = $this->getUniqueID('user2_');
+		$user2 = $this->createMock(IUser::class);
+		$user2->expects($this->once())
+			->method('getUID')
+			->willReturn($uid2);
+
+		//add dummy values to the share table
+		$query = \OC_DB::prepare('INSERT INTO `*PREFIX*share` ('
+			.' `item_type`, `item_source`, `item_target`, `share_type`,'
+			.' `share_with`, `uid_owner`) VALUES (?,?,?,?,?,?)');
+		$args = ['test', 99, 'target1', \OCP\Share::SHARE_TYPE_USER, $uid2, $uid1];
+		$query->execute($args);
+
+		$result = $this->invokePrivate($mailNotifications, 'getItemSharedWithUser', [99, 'test', $user2]);
+		$this->assertCount(1, $result);
+	}
+
 	public function emptinessProvider() {
 		return [
 			[null],
@@ -327,7 +500,8 @@ class MailNotificationsTest extends TestCase {
 				$this->mailer,
 				$this->logger,
 				$this->defaults,
-				$this->urlGenerator
+				$this->urlGenerator,
+				$this->eventDispatcher
 			])
 			->getMock();
 


### PR DESCRIPTION
Adding symfony event for public links shared by email.
When an email is triggered, the recipient, the cc or
bcc and the link data is shared using the event.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Add new symfony event, when a public link is shared by email. The details include:
a) recipient
b) link
d) cc or bcc

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add new symfony event, when a public link is shared by email. The details include:
a) recipient
b) link
d) cc or bcc

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Tested if the event is called using debugger
- [x] With the unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

