### PR TITLE
userCancelsUploadWithId gherkin format fix

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1605,7 +1605,7 @@ trait WebDav {
 
 	/**
 	 * @When user :user cancels chunking-upload with id :id using the API
-	 * @Given user :user has canceled new chunking-uploadwith id :id
+	 * @Given user :user has canceled new chunking-upload with id :id
 	 *
 	 * @param string $user
 	 * @param string $id


### PR DESCRIPTION
Acceptance test step ``userCancelsUploadWithId`` was introduced in #31596 (stable10) and #31618 (core). The ```Given`` version of the step text had a missing space. Nothing uses that form of the words just yet, but fix it for when something does use it.