### PR TITLE
Add provisioning API disableApp feature

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
@@ -1,0 +1,33 @@
+@api
+Feature: disable an app
+As an admin
+I want to be able to disable an enabled app
+So that I can stop the app features being used
+
+	Background:
+		Given using API version "1"
+
+	Scenario: Admin disables an app
+		Given the app "comments" has been enabled
+		When the administrator disables the app "comments"
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And app "comments" should be disabled
+
+	Scenario: subadmin tries to disable an app
+		Given user "subadmin" has been created
+		And group "newgroup" has been created
+		And user "subadmin" has been made a subadmin of group "newgroup"
+		And the app "comments" has been enabled
+		When user "subadmin" disables the app "comments"
+		Then the OCS status code should be "997"
+		And the HTTP status code should be "401"
+		And app "comments" should be enabled
+
+	Scenario: normal user tries to disable an app
+		Given user "newuser" has been created
+		And the app "comments" has been enabled
+		When user "newuser" disables the app "comments"
+		Then the OCS status code should be "997"
+		And the HTTP status code should be "401"
+		And app "comments" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -1,5 +1,5 @@
 @api
-Feature: get app info
+Feature: enable an app
 As an admin
 I want to be able to enable a disabled app
 So that I can use the app features again
@@ -9,7 +9,7 @@ So that I can use the app features again
 
 	Scenario: Admin enables an app
 		Given the app "comments" has been disabled
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/apps/comments"
+		When the administrator enables the app "comments"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And app "comments" should be enabled
@@ -19,7 +19,7 @@ So that I can use the app features again
 		And group "newgroup" has been created
 		And user "subadmin" has been made a subadmin of group "newgroup"
 		And the app "comments" has been disabled
-		When user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/apps/comments"
+		When user "subadmin" enables the app "comments"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And app "comments" should be disabled
@@ -27,7 +27,7 @@ So that I can use the app features again
 	Scenario: normal user tries to enable an app
 		Given user "newuser" has been created
 		And the app "comments" has been disabled
-		When user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/apps/comments"
+		When user "newuser" enables the app "comments"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And app "comments" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
@@ -1,0 +1,35 @@
+@api
+Feature: disable an app
+As an admin
+I want to be able to disable an enabled app
+So that I can stop the app features being used
+
+	Background:
+		Given using API version "2"
+
+	Scenario: Admin disables an app
+		Given the app "comments" has been enabled
+		When the administrator disables the app "comments"
+		Then the OCS status code should be "200"
+		And the HTTP status code should be "200"
+		And app "comments" should be disabled
+
+	@skip @issue-31276
+	Scenario: subadmin tries to disable an app
+		Given user "subadmin" has been created
+		And group "newgroup" has been created
+		And user "subadmin" has been made a subadmin of group "newgroup"
+		And the app "comments" has been enabled
+		When user "subadmin" disables the app "comments"
+		Then the OCS status code should be "997"
+		And the HTTP status code should be "401"
+		And app "comments" should be enabled
+
+	@skip @issue-31276
+	Scenario: normal user tries to disable an app
+		Given user "newuser" has been created
+		And the app "comments" has been enabled
+		When user "newuser" disables the app "comments"
+		Then the OCS status code should be "997"
+		And the HTTP status code should be "401"
+		And app "comments" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -1,5 +1,5 @@
 @api
-Feature: get app info
+Feature: enable an app
 As an admin
 I want to be able to enable a disabled app
 So that I can use the app features again
@@ -9,7 +9,7 @@ So that I can use the app features again
 
 	Scenario: Admin enables an app
 		Given the app "comments" has been disabled
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/apps/comments"
+		When the administrator enables the app "comments"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And app "comments" should be enabled
@@ -20,7 +20,7 @@ So that I can use the app features again
 		And group "newgroup" has been created
 		And user "subadmin" has been made a subadmin of group "newgroup"
 		And the app "comments" has been disabled
-		When user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/apps/comments"
+		When user "subadmin" enables the app "comments"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And app "comments" should be disabled
@@ -29,7 +29,7 @@ So that I can use the app features again
 	Scenario: normal user tries to enable an app
 		Given user "newuser" has been created
 		And the app "comments" has been disabled
-		When user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/apps/comments"
+		When user "newuser" enables the app "comments"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And app "comments" should be disabled

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -238,18 +238,61 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^the app "([^"]*)" has been disabled$/
+	 * @When /^user "([^"]*)" (enables|disables) the app "([^"]*)"$/
 	 *
+	 * @param string $user
+	 * @param string $action enables or disables
 	 * @param string $app
 	 *
 	 * @return void
 	 */
-	public function theAppHasBeenDisabled($app) {
+	public function userEnablesOrDisablesApp($user, $action, $app) {
 		$fullUrl = $this->getBaseUrl()
 			. "/ocs/v{$this->apiVersion}.php/cloud/apps/" . $app;
 		$options = [];
-		$options['auth'] = $this->getAuthOptionForAdmin();
-		$this->client->delete($fullUrl, $options);
+		$options['auth'] = $this->getAuthOptionForUser($user);
+		try {
+			if ($action === 'enables') {
+				$this->response = $this->client->post($fullUrl, $options);
+			} else {
+				$this->response = $this->client->delete($fullUrl, $options);
+			}
+		} catch (BadResponseException $e) {
+			$this->response = $e->getResponse();
+		}
+	}
+
+	/**
+	 * @When /^the administrator (enables|disables) the app "([^"]*)"$/
+	 *
+	 * @param string $action enables or disables
+	 * @param string $app
+	 *
+	 * @return void
+	 */
+	public function adminEnablesOrDisablesApp($action, $app) {
+		$this->userEnablesOrDisablesApp(
+			$this->getAdminUsername(), $action, $app
+		);
+	}
+
+	/**
+	 * @Given /^the app "([^"]*)" has been (enabled|disabled)$/
+	 *
+	 * @param string $app
+	 * @param string $action enabled or disabled
+	 *
+	 * @return void
+	 */
+	public function theAppHasBeenDisabled($app, $action) {
+		if ($action === 'enabled') {
+			$action = 'enables';
+		} else {
+			$action = 'disables';
+		}
+		$this->userEnablesOrDisablesApp(
+			$this->getAdminUsername(), $action, $app
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
- refactor acceptance test code that tests enabling an app, so that there is a  specific step for enabling an app
- add scenarios for admin, subadmin and normal user trying to disable an app

## Related Issue

## Motivation and Context
I want to be able to say stuff like:
```
Given app "notifications" has been enabled
Given app "notifications" has been disabled
```
to control apps for scenarios, if needed.

Along the way I noticed that there was an ``enableApp.feature`` but not  a ``disableApp.feature`` - so make one.

## How Has This Been Tested?
Local API test runs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test enhancement

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
