### PR TITLE
don't delete the source files when generating thumbnails

### DIFF
--- a/lib/private/Preview/MP3.php
+++ b/lib/private/Preview/MP3.php
@@ -54,7 +54,7 @@ class MP3 implements IProvider2 {
 
 		$getID3 = new ID3Parser();
 		$tags = $getID3->analyze($absPath);
-		\unlink($absPath);
+
 		$picture = isset($tags['id3v2']['APIC'][0]['data']) ? $tags['id3v2']['APIC'][0]['data'] : null;
 		if ($picture === null && isset($tags['id3v2']['PIC'][0]['data'])) {
 			$picture = $tags['id3v2']['PIC'][0]['data'];

--- a/lib/private/Preview/Office.php
+++ b/lib/private/Preview/Office.php
@@ -63,7 +63,7 @@ abstract class Office implements IProvider2 {
 		$pdfPreview = null;
 		try {
 			$pathInfo = \pathinfo($absPath);
-			$pdfPreview = $pathInfo['dirname'] . '/' . $pathInfo['filename'] . '.pdf';
+			$pdfPreview = $tmpDir . '/' . $pathInfo['filename'] . '.pdf';
 
 			$pdf = new \imagick($pdfPreview . '[0]');
 			$pdf->setImageFormat('jpg');
@@ -77,7 +77,6 @@ abstract class Office implements IProvider2 {
 		$image = new \OC_Image();
 		$image->loadFromData($pdf);
 
-		\unlink($absPath);
 		\unlink($pdfPreview);
 
 		if ($image->valid()) {

--- a/tests/lib/Preview/Provider.php
+++ b/tests/lib/Preview/Provider.php
@@ -21,6 +21,7 @@
 
 namespace Test\Preview;
 
+use OCP\Files\File;
 use OCP\Files\Node;
 use OCP\Preview\IProvider2;
 use Test\Traits\UserTrait;
@@ -28,7 +29,7 @@ use Test\Traits\UserTrait;
 abstract class Provider extends \Test\TestCase {
 	use UserTrait;
 
-	/** @var Node */
+	/** @var File */
 	protected $imgPath;
 	/** @var int */
 	protected $width;
@@ -46,8 +47,6 @@ abstract class Provider extends \Test\TestCase {
 	protected $userId;
 	/** @var \OC\Files\View */
 	protected $rootView;
-	/** @var \OC\Files\Storage\Storage */
-	protected $storage;
 
 	protected function setUp() {
 		parent::setUp();
@@ -59,12 +58,7 @@ abstract class Provider extends \Test\TestCase {
 		$this->createUser($userId, $userId);
 		$this->loginAsUser($userId);
 
-		$this->storage = new \OC\Files\Storage\Temporary([]);
-		\OC\Files\Filesystem::mount($this->storage, [], '/' . $userId . '/');
-
 		$this->rootView = new \OC\Files\View('');
-		$this->rootView->mkdir('/' . $userId);
-		$this->rootView->mkdir('/' . $userId . '/files');
 
 		$this->userId = $userId;
 	}
@@ -77,10 +71,10 @@ abstract class Provider extends \Test\TestCase {
 
 	public static function dimensionsDataProvider() {
 		return [
-			[-\rand(5, 100), -\rand(5, 100)],
-			[\rand(5, 100), \rand(5, 100)],
-			[-\rand(5, 100), \rand(5, 100)],
-			[\rand(5, 100), -\rand(5, 100)],
+			[-\random_int(5, 100), -\random_int(5, 100)],
+			[\random_int(5, 100), \random_int(5, 100)],
+			[-\random_int(5, 100), \random_int(5, 100)],
+			[\random_int(5, 100), -\random_int(5, 100)],
 		];
 	}
 
@@ -119,14 +113,14 @@ abstract class Provider extends \Test\TestCase {
 	 * @param string $fileContent path to file to use for test
 	 *
 	 * @return Node
+	 * @throws \Exception
+	 * @throws \OCP\Files\NotFoundException
 	 */
 	protected function prepareTestFile($fileName, $fileContent) {
 		$imgData = \file_get_contents($fileContent);
 		$imgPath = '/' . $this->userId . '/files/' . $fileName;
 		$this->rootView->file_put_contents($imgPath, $imgData);
 
-		$scanner = $this->storage->getScanner();
-		$scanner->scan('');
 		return \OC::$server->getUserFolder($this->userId)->get($fileName);
 	}
 
@@ -136,12 +130,16 @@ abstract class Provider extends \Test\TestCase {
 	 * @param IProvider2 $provider
 	 *
 	 * @return bool|\OCP\IImage
+	 * @throws \OCP\Files\NotPermittedException
 	 */
 	private function getPreview($provider) {
 		$preview = $provider->getThumbnail($this->imgPath, $this->maxWidth, $this->maxHeight, $this->scalingUp);
 
 		$this->assertNotFalse($preview);
 		$this->assertTrue($preview->valid());
+
+		// test that the file still exists
+		$this->assertNotNull($this->imgPath->getContent());
 
 		return $preview;
 	}


### PR DESCRIPTION
## Description
Thumbnail providers shall not delete the source files.

## Related Issue
fixes #31655

## How Has This Been Tested?
- local unit test execution with necessary tools installed: libreoffice + jre + ffmpeg + php-imagick

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

