### PR TITLE
Handle enable-disable of apps in acceptance tests

### DIFF
--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -5,7 +5,8 @@ Feature: Display notifications when receiving a share
 	So that I can easily decide what I want to do with new received shares
 
 	Background:
-		Given using API version "1"
+		Given the app "notifications" has been enabled
+		And using API version "1"
 		And using new DAV path
 		And user "user0" has been created
 		And user "user1" has been created

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1686,8 +1686,9 @@ trait Provisioning {
 	 *
 	 * @return void
 	 */
-	public function rememberEnabledApps() {
+	public function rememberAppEnabledDisabledState() {
 		$this->enabledApps = $this->getEnabledApps();
+		$this->disabledApps = $this->getDisabledApps();
 	}
 	
 	/**
@@ -1695,12 +1696,19 @@ trait Provisioning {
 	 *
 	 * @return void
 	 */
-	public function restoreDisabledApps() {
-		$this->disabledApps = $this->getDisabledApps();
-		
-		foreach ($this->disabledApps as $disabledApp) {
+	public function restoreAppEnabledDisabledState() {
+		$currentlyDisabledApps = $this->getDisabledApps();
+		$currentlyEnabledApps = $this->getEnabledApps();
+
+		foreach ($currentlyDisabledApps as $disabledApp) {
 			if (\in_array($disabledApp, $this->enabledApps)) {
-				$this->enableApp($disabledApp);
+				$this->adminEnablesOrDisablesApp('enables', $disabledApp);
+			}
+		}
+
+		foreach ($currentlyEnabledApps as $enabledApp) {
+			if (\in_array($enabledApp, $this->disabledApps)) {
+				$this->adminEnablesOrDisablesApp('disables', $enabledApp);
 			}
 		}
 	}
@@ -1731,20 +1739,5 @@ trait Provisioning {
 		$options['auth'] = $this->getAuthOptionForAdmin();
 		$this->response = $client->get($fullUrl, $options);
 		return ($this->getArrayOfAppsResponded($this->response));
-	}
-
-	/**
-	 * Enable app
-	 *
-	 * @param string $app
-	 *
-	 * @return void
-	 */
-	public function enableApp($app) {
-		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/apps/$app";
-		$client = new Client();
-		$options = [];
-		$options['auth'] = $this->getAuthOptionForAdmin();
-		$this->response = $client->post($fullUrl, $options);
 	}
 }

--- a/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
@@ -5,7 +5,8 @@ I want to use the notification header as a link
 So that I will be redirected to the most appropriate screen
 
 	Background:
-		Given these users have been created:
+		Given the app "notifications" has been enabled
+		And these users have been created:
 			|username|password|displayname|email       |
 			|user1   |1234    |User One   |u1@oc.com.np|
 			|user2   |1234    |User Two   |u2@oc.com.np|

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -5,7 +5,8 @@ I want to share files and folders with groups
 So that those groups can access the files and folders
 
 	Background:
-		Given these users have been created:
+		Given the app "notifications" has been enabled
+		And these users have been created:
 			|username|password|displayname|email       |
 			|user1   |1234    |User One   |u1@oc.com.np|
 			|user2   |1234    |User Two   |u2@oc.com.np|

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -5,7 +5,8 @@ I want to share files and folders with other users
 So that those users can access the files and folders
 
 	Background:
-		Given these users have been created:
+		Given the app "notifications" has been enabled
+		And these users have been created:
 			|username|password|displayname|email       |
 			|user1   |1234    |User One   |u1@oc.com.np|
 			|user2   |1234    |User Two   |u2@oc.com.np|


### PR DESCRIPTION
## Description
1) In API acceptance tests, do the same as for UI acceptance tests - disable firstrunwizard and notifications apps by default. Restore previous app state at end of test run.
2) Enable notifications app for features/scenarios that require it.
3) Fixup handling of enabled/disabled apps in ```BeforeScenario``` and ``AfterScenario`` so that if a scenario changes the enabled/disabled state of apps, they will be put back on the way out.

## Related Issue

## Motivation and Context
The notifications app is needed for some scenarios and not for others. Enable it in the feature files when it is needed. That will allow local test runs to use whatever scenarios they like, without having to remember to enable or disable the notifications app before running the scenarios. It will also let someone run a whole set of tests in a single run (multiple suites) and the scenarios will handle whhat apps come-and-go.

## How Has This Been Tested?
Local test runs starting with notifications app enabled or disabled.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test enhancement

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
