### PR TITLE
[stable10] Handle enable-disable of apps in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1686,8 +1686,9 @@ trait Provisioning {
 	 * 
 	 * @return void
 	 */
-	public function rememberEnabledApps() {
+	public function rememberAppEnabledDisabledState() {
 		$this->enabledApps = $this->getEnabledApps();
+		$this->disabledApps = $this->getDisabledApps();
 	}
 	
 	/**
@@ -1695,12 +1696,19 @@ trait Provisioning {
 	 * 
 	 * @return void
 	 */
-	public function restoreDisabledApps() {
-		$this->disabledApps = $this->getDisabledApps();
-		
-		foreach ($this->disabledApps as $disabledApp) {
+	public function restoreAppEnabledDisabledState() {
+		$currentlyDisabledApps = $this->getDisabledApps();
+		$currentlyEnabledApps = $this->getEnabledApps();
+
+		foreach ($currentlyDisabledApps as $disabledApp) {
 			if (\in_array($disabledApp, $this->enabledApps)) {
-				$this->enableApp($disabledApp);
+				$this->adminEnablesOrDisablesApp('enables', $disabledApp);
+			}
+		}
+
+		foreach ($currentlyEnabledApps as $enabledApp) {
+			if (\in_array($enabledApp, $this->disabledApps)) {
+				$this->adminEnablesOrDisablesApp('disables', $enabledApp);
 			}
 		}
 	}
@@ -1731,20 +1739,5 @@ trait Provisioning {
 		$options['auth'] = $this->getAuthOptionForAdmin();
 		$this->response = $client->get($fullUrl, $options);
 		return ($this->getArrayOfAppsResponded($this->response));
-	}
-
-	/**
-	 * Enable app
-	 *
-	 * @param string $app
-	 *
-	 * @return void
-	 */
-	public function enableApp($app) {
-		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/apps/$app";
-		$client = new Client();
-		$options = [];
-		$options['auth'] = $this->getAuthOptionForAdmin();
-		$this->response = $client->post($fullUrl, $options);
 	}
 }

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -115,8 +115,40 @@ ${OCC} config:system:set sharing.federation.allowHttpFallback --type boolean --v
 ${OCC} config:app:set core enable_external_storage --value=yes
 ${OCC} config:system:set files_external_allow_create_new_local --value=true
 
-PREVIOUS_TESTING_APP_STATUS=$(${OCC} --no-warnings app:list "^testing$")
+#Enable and disable apps as required for default
+if [ -z "${APPS_TO_DISABLE}" ]
+then
+	APPS_TO_DISABLE="firstrunwizard notifications"
+fi
 
+if [ -z "${APPS_TO_ENABLE}" ]
+then
+	APPS_TO_ENABLE=""
+fi
+
+APPS_TO_REENABLE="";
+
+for APP_TO_DISABLE in ${APPS_TO_DISABLE}; do
+	PREVIOUS_APP_STATUS=$(${OCC} --no-warnings app:list "^${APP_TO_DISABLE}$")
+	if [[ "${PREVIOUS_APP_STATUS}" =~ ^Enabled: ]]
+	then
+		APPS_TO_REENABLE="${APPS_TO_REENABLE} ${APP_TO_DISABLE}";
+		${OCC} app:disable ${APP_TO_DISABLE} || { echo "Unable to disable ${APP_TO_DISABLE} app" >&2; exit 1; }
+	fi
+done
+
+APPS_TO_REDISABLE="";
+
+for APP_TO_ENABLE in ${APPS_TO_ENABLE}; do
+	PREVIOUS_APP_STATUS=$(${OCC} --no-warnings app:list "^${APP_TO_ENABLE}$")
+	if [[ "${PREVIOUS_APP_STATUS}" =~ ^Disabled: ]]
+	then
+		APPS_TO_REDISABLE="${APPS_TO_REDISABLE} ${APP_TO_ENABLE}";
+		${OCC} app:enable ${APP_TO_ENABLE} || { echo "Unable to enable ${APP_TO_ENABLE} app" >&2; exit 1; }
+	fi
+done
+
+PREVIOUS_TESTING_APP_STATUS=$(${OCC} --no-warnings app:list "^testing$")
 if [[ "${PREVIOUS_TESTING_APP_STATUS}" =~ ^Disabled: ]]
 then
 	${OCC} app:enable testing || { echo "Unable to enable testing app" >&2; exit 1; }
@@ -202,6 +234,16 @@ ${OCC} files_external:delete -y ${ID_STORAGE}
 
 # Disable external storage app
 ${OCC} config:app:set core enable_external_storage --value=no
+
+# Enable any apps that were disabled for the test run
+for APP_TO_ENABLE in ${APPS_TO_REENABLE}; do
+	${OCC} app:enable ${APP_TO_ENABLE} || { echo "Unable to enable ${APP_TO_ENABLE} app at end of test run" >&2; exit 1; }
+done
+
+# Disable any apps that were enabled for the test run
+for APP_TO_DISABLE in ${APPS_TO_REDISABLE}; do
+	${OCC} app:disable ${APP_TO_DISABLE} || { echo "Unable to disable ${APP_TO_DISABLE} app at end of test run" >&2; exit 1; }
+done
 
 # Put back state of the testing app
 if [ "${TESTING_ENABLED_BY_SCRIPT}" = true ]


### PR DESCRIPTION
Backport #31661 part 1

This is the code part of the PR from ``master``.
The feature/scenarios that use this code are related to notifications app testing, and have not yet been backported to ``stable10`` - that is waiting in backport PR #31613 which I will add to.