### PR TITLE
Move notifications context API steps used by core into core

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -151,7 +151,6 @@ pipeline:
     commands:
       - git clone https://github.com/owncloud/notifications.git apps/notifications
       - php occ a:e notifications
-      - echo "export APPS_TO_ENABLE=notifications" > environment.sh
     when:
       matrix:
         INSTALL_NOTIFICATIONS-APP: true
@@ -224,7 +223,6 @@ pipeline:
       - PLATFORM=Linux
       - MAILHOG_HOST=email
     commands:
-      - if [ -f ./environment.sh  ]; then . ./environment.sh; fi
       - bash tests/travis/start_ui_tests.sh --remote
     when:
       matrix:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -72,7 +72,7 @@ default:
         - %paths.base%/../features/apiSharingNotifications
       contexts:
         - FeatureContext: *common_feature_context_params
-        - NotificationsContext:
+        - NotificationsCoreContext:
 
     webUILogin:
       paths:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -222,12 +222,12 @@ default:
       context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
+        - NotificationsCoreContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIFilesContext:
         - WebUISharingContext:
-        - WebUINotificationsContext
-        - NotificationsContext
+        - WebUINotificationsContext:
 
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:

--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -1,4 +1,4 @@
-@api
+@api @app-required @notifications-app-required
 Feature: Display notifications when receiving a share
 	As a user
 	I want to see notifications about shares that have been offered to me

--- a/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * @author Joas Schilling <nickvergessen@owncloud.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License,
+ * version 3, along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use GuzzleHttp\Message\ResponseInterface;
+use TestHelpers\OcsApiHelper;
+
+require_once 'bootstrap.php';
+
+/**
+ * Defines application features from the specific context.
+ */
+class NotificationsCoreContext implements Context, SnippetAcceptingContext {
+
+	/**
+	 * @var array[]
+	 */
+	protected $notificationIds;
+
+	/**
+	 * @var int
+	 */
+	protected $deletedNotification;
+
+	/**
+	 * @var FeatureContext
+	 */
+	private $featureContext;
+
+	/**
+	 * @return array[]
+	 */
+	public function getNotificationIds() {
+		return $this->notificationIds;
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function getLastNotificationIds() {
+		return \end($this->notificationIds);
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getDeletedNotification() {
+		return $this->deletedNotification;
+	}
+
+	/**
+	 * @param int $deletedNotification
+	 * @return void
+	 */
+	public function setDeletedNotification($deletedNotification) {
+		$this->deletedNotification = $deletedNotification;
+	}
+
+	/**
+	 * @Then /^the list of notifications should have (\d+) (?:entry|entries)$/
+	 *
+	 * @param int $numNotifications
+	 *
+	 * @return void
+	 */
+	public function checkNumNotifications($numNotifications) {
+		$notifications = $this->getArrayOfNotificationsResponded(
+			$this->featureContext->getResponse()
+		);
+		PHPUnit_Framework_Assert::assertCount(
+			(int) $numNotifications, $notifications
+		);
+
+		$notificationIds = [];
+		foreach ($notifications as $notification) {
+			$notificationIds[] = (int) $notification['notification_id'];
+		}
+
+		$this->notificationIds[] = $notificationIds;
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" should have (\d+) notification(?:s|)(| missing the last one| missing the first one)$/
+	 *
+	 * @param string $user
+	 * @param int $numNotifications
+	 * @param string $missingLast
+	 *
+	 * @return void
+	 */
+	public function userNumNotifications($user, $numNotifications, $missingLast) {
+		$this->featureContext->userSendingTo(
+			$user, 'GET', '/apps/notifications/api/v1/notifications?format=json'
+		);
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->featureContext->getResponse()->getStatusCode()
+		);
+
+		$previousNotificationIds = [];
+		if ($missingLast) {
+			PHPUnit_Framework_Assert::assertNotEmpty($this->getNotificationIds());
+			$previousNotificationIds = $this->getLastNotificationIds();
+		}
+
+		$this->checkNumNotifications((int) $numNotifications);
+
+		if ($missingLast) {
+			$now = $this->getLastNotificationIds();
+			if ($missingLast === ' missing the last one') {
+				\array_unshift($now, $this->getDeletedNotification());
+			} else {
+				$now[] = $this->getDeletedNotification();
+			}
+
+			PHPUnit_Framework_Assert::assertEquals($previousNotificationIds, $now);
+		}
+	}
+
+	/**
+	 * @Then /^the (first|last) notification of user "([^"]*)" should match$/
+	 *
+	 * @param string $notification first|last
+	 * @param string $user
+	 * @param \Behat\Gherkin\Node\TableNode $formData
+	 *
+	 * @return void
+	 */
+	public function matchNotificationPlain(
+		$notification, $user, $formData
+	) {
+		$this->matchNotification(
+			$notification, $user, false, $formData
+		);
+	}
+
+	/**
+	 * @Then /^the (first|last) notification of user "([^"]*)" should match these regular expressions$/
+	 *
+	 * @param string $notification first|last
+	 * @param string $user
+	 * @param \Behat\Gherkin\Node\TableNode $formData
+	 *
+	 * @return void
+	 */
+	public function matchNotificationRegularExpression(
+		$notification, $user, $formData
+	) {
+		$this->matchNotification(
+			$notification, $user, true, $formData
+		);
+	}
+
+	/**
+	 * @param string $notification first|last
+	 * @param string $user
+	 * @param bool $regex
+	 * @param \Behat\Gherkin\Node\TableNode $formData
+	 *
+	 * @return void
+	 */
+	public function matchNotification(
+		$notification, $user, $regex, $formData
+	) {
+		$lastNotifications = $this->getLastNotificationIds();
+		if ($notification === 'first') {
+			$notificationId = \reset($lastNotifications);
+		} else /* if ($notification === 'last')*/ {
+			$notificationId = \end($lastNotifications);
+		}
+
+		$this->featureContext->userSendingTo(
+			$user, 'GET', '/apps/notifications/api/v1/notifications/' .
+			$notificationId . '?format=json'
+		);
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->featureContext->getResponse()->getStatusCode()
+		);
+		$response = \json_decode(
+			$this->featureContext->getResponse()->getBody()->getContents(), true
+		);
+
+		foreach ($formData->getRowsHash() as $key => $value) {
+			PHPUnit_Framework_Assert::assertArrayHasKey(
+				$key, $response['ocs']['data']
+			);
+			if ($regex) {
+				$value = $this->featureContext->substituteInLineCodes(
+					$value, ['preg_quote' => ['/'] ]
+				);
+				PHPUnit_Framework_Assert::assertNotFalse(
+					(bool)\preg_match($value, $response['ocs']['data'][$key]),
+					"'$value' does not match '" . $response['ocs']['data'][$key] . "'"
+				);
+			} else {
+				$value = $this->featureContext->substituteInLineCodes($value);
+				PHPUnit_Framework_Assert::assertEquals(
+					$value, $response['ocs']['data'][$key]
+				);
+			}
+		}
+	}
+
+	/**
+	 * Parses the xml answer to get the array of notifications returned.
+	 *
+	 * @param ResponseInterface $resp
+	 *
+	 * @return array
+	 */
+	public function getArrayOfNotificationsResponded(ResponseInterface $resp) {
+		$jsonResponse = \json_decode($resp->getBody()->getContents(), 1);
+		return $jsonResponse['ocs']['data'];
+	}
+
+	/**
+	 *
+	 * @AfterScenario
+	 *
+	 * @return void
+	 */
+	public function clearNotifications() {
+		$response = OcsApiHelper::sendRequest(
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			"DELETE",
+			'/apps/testing/api/v1/notifications'
+		);
+		PHPUnit_Framework_Assert::assertEquals(200, $response->getStatusCode());
+		PHPUnit_Framework_Assert::assertEquals(
+			200, (int) $this->featureContext->getOCSResponseStatusCode($response)
+		);
+	}
+
+	/**
+	 * @BeforeScenario
+	 *
+	 * @param BeforeScenarioScope $scope
+	 *
+	 * @return void
+	 */
+	public function setUpScenario(BeforeScenarioScope $scope) {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->featureContext = $environment->getContext('FeatureContext');
+		$this->clearNotifications();
+	}
+}

--- a/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+require_once 'bootstrap.php';
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\TableNode;
+use Behat\MinkExtension\Context\RawMinkContext;
+use Page\NotificationsEnabledOwncloudPage;
+use Page\Notification;
+
+/**
+ * Context for Notifications App
+ *
+ */
+class WebUINotificationsContext extends RawMinkContext implements Context {
+	/**
+	 *
+	 * @var NotificationsEnabledOwncloudPage
+	 */
+	private $owncloudPage;
+
+	/**
+	 *
+	 * @param NotificationsEnabledOwncloudPage $owncloudPage
+	 */
+	public function __construct(
+		NotificationsEnabledOwncloudPage $owncloudPage
+	) {
+		$this->owncloudPage = $owncloudPage;
+	}
+	
+	/**
+	 *
+	 * @Then /^the user should see (\d+) notification(?:s|) on the webUI with these details$/
+	 *
+	 * @param int $number
+	 * @param TableNode $expectedNotifications
+	 *
+	 * @return void
+	 */
+	public function assertNotificationsOnWebUI(
+		$number, TableNode $expectedNotifications
+	) {
+		$notificationsDialog = $this->openNotificationsDialog();
+		$notifications = $notificationsDialog->getAllNotifications();
+		PHPUnit_Framework_Assert::assertEquals(
+			$number,
+			\count($notifications),
+			"expected $number notifications, found " . \count($notifications)
+		);
+		foreach ($expectedNotifications as $expectedNotification) {
+			foreach ($notifications as $notification) {
+				$found = false;
+				foreach ($expectedNotification as $expectedKey => $expectedValue) {
+					if ($notification[$expectedKey] === $expectedValue) {
+						$found = true;
+					} else {
+						$found = false;
+						break;
+					}
+				}
+				if ($found) {
+					break;
+				}
+			}
+			if (!$found) {
+				PHPUnit_Framework_Assert::fail(
+					"could not find expected notification: " .
+					\print_r($expectedNotification, true) .
+					" in viewed notifications: " .
+					\print_r($notifications, true)
+				);
+			}
+		}
+	}
+
+	/**
+	 * @When /^the user follows the link of the (first|last) notification on the webUI$/
+	 *
+	 * @param string $firstOrLast first|last
+	 *
+	 * @throws InvalidArgumentException
+	 * @throws \Exception
+	 *
+	 * @return void
+	 */
+	public function userFollowsLink($firstOrLast) {
+		$notificationsDialog = $this->openNotificationsDialog();
+		$notifications = $notificationsDialog->getAllNoficationObjects();
+		if ($firstOrLast === 'first') {
+			/**
+			 *
+			 * @var Notification $notification
+			 */
+			$notification = \reset($notifications);
+		} elseif ($firstOrLast === 'last') {
+			$notification = \end($notifications);
+		} else {
+			throw new InvalidArgumentException();
+		}
+		if ($notification === false) {
+			throw new \Exception(__METHOD__ . " no notifications found");
+		}
+		$notification->followLink($this->getSession());
+	}
+
+	/**
+	 * @When /^the user reacts with "(Accept|Decline)" to all notifications on the webUI$/
+	 *
+	 * @param string $reaction
+	 *
+	 * @return void
+	 */
+	public function userReactsToAllNotificationsOnTheWebUI($reaction) {
+		$notificationsDialog = $this->openNotificationsDialog();
+		$notifications = $notificationsDialog->getAllNoficationObjects();
+		while (\count($notifications) > 0) {
+			$notifications[0]->react($reaction, $this->getSession());
+			//we need to rescan again, because the DOM changes
+			$notifications = $notificationsDialog->getAllNoficationObjects();
+		}
+	}
+
+	/**
+	 * @When the user accepts all shares displayed in the notifications on the webUI
+	 *
+	 * @return void
+	 */
+	public function userAcceptsAllShares() {
+		$this->userReactsToAllNotificationsOnTheWebUI("Accept");
+	}
+
+	/**
+	 * @When the user declines all shares displayed in the notifications on the webUI
+	 *
+	 * @return void
+	 */
+	public function userDeclinesAllShares() {
+		$this->userReactsToAllNotificationsOnTheWebUI("Decline");
+	}
+
+	/**
+	 *
+	 * @return \Page\NotificationsAppDialog
+	 */
+	protected function openNotificationsDialog() {
+		$this->getSession()->reload();
+		$this->owncloudPage->waitTillPageIsLoaded($this->getSession());
+		$this->owncloudPage->waitForNotifications();
+		return $this->owncloudPage->openNotifications();
+	}
+}

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -25,9 +25,6 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 $classLoader = new \Composer\Autoload\ClassLoader();
 $classLoader->addPsr4("Page\\", __DIR__ . "/../lib", true);
 $classLoader->addPsr4("TestHelpers\\", __DIR__ . "/../../../TestHelpers", true);
-$classLoader->addPsr4(
-	"", __DIR__ . "/../../../../apps/notifications/tests/acceptance/features/bootstrap", true
-);
 $classLoader->register();
 
 // Sleep for 10 milliseconds

--- a/tests/acceptance/features/lib/Notification.php
+++ b/tests/acceptance/features/lib/Notification.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page;
+
+use Behat\Mink\Session;
+use Behat\Mink\Element\NodeElement;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+
+/**
+ * PageObject for a single notification
+ */
+class Notification extends OwncloudPage {
+	
+	/**
+	 *
+	 * @var NodeElement
+	 */
+	private $notificationElement;
+	
+	private $buttonByTextXpath = "//button[text()='%s']";
+	private $notificationLinkXpath = "//a[@class='notification-link']";
+	
+	/**
+	 * sets the NodeElement for the current notification
+	 * a little bit like __construct() but as we access this "sub-page-object"
+	 * from an other Page Object by $this->getPage("Notification")
+	 * there is no real __construct() that can take arguments
+	 *
+	 * @param \Behat\Mink\Element\NodeElement $notificationElement
+	 *
+	 * @return void
+	 */
+	public function setElement(NodeElement $notificationElement) {
+		$this->notificationElement = $notificationElement;
+	}
+
+	/**
+	 *
+	 * @param Session $session
+	 * @param int $timeout_msec
+	 *
+	 * @throws ElementNotFoundException
+	 *
+	 * @return void
+	 */
+	public function followLink(
+		Session $session, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+	) {
+		$link = $this->notificationElement->find(
+			"xpath", $this->notificationLinkXpath
+		);
+		if ($link === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ . " could not find notification link " .
+				"with xpath " . $this->notificationLinkXpath
+			);
+		}
+		$destination = $link->getAttribute('href');
+		$link->click();
+		$currentTime = \microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
+			if ($destination === $session->getCurrentUrl()) {
+				break;
+			}
+			$currentTime = \microtime(true);
+		}
+	}
+
+	/**
+	 *
+	 * @param string $reaction
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function react($reaction, Session $session) {
+		$buttonXpath = \sprintf($this->buttonByTextXpath, $reaction);
+		$button = $this->notificationElement->find(
+			"xpath", $buttonXpath
+		);
+		if ($button === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath " . $buttonXpath .
+				" could not find button with the given text"
+			);
+		}
+		$button->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+}

--- a/tests/acceptance/features/lib/NotificationsAppDialog.php
+++ b/tests/acceptance/features/lib/NotificationsAppDialog.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page;
+
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+
+/**
+ * PageObject for the Notifications area
+ */
+class NotificationsAppDialog extends OwncloudPage {
+	private $notificationContainerXpath = "//div[@class='notification']";
+	private $notificationTitleXpath = "//h3[@class='notification-title']";
+	private $notificationLinkXpath = "//a[@class='notification-link']";
+	private $notificationMessageXpath = "//p[@class='notification-message']";
+	
+	/**
+	 *
+	 * @return array with notifications details title,link,message
+	 */
+	public function getAllNotifications() {
+		$notifications = $this->findAll("xpath", $this->notificationContainerXpath);
+		$notificationsArray = [];
+		foreach ($notifications as $notification) {
+			$title = $notification->find("xpath", $this->notificationTitleXpath);
+			if ($title === null) {
+				throw new ElementNotFoundException(
+					__METHOD__ . " could not find notification title " .
+					"with xpath " . $this->notificationTitleXpath
+				);
+			}
+			$link = $notification->find("xpath", $this->notificationLinkXpath);
+			if ($link === null) {
+				throw new ElementNotFoundException(
+					__METHOD__ . " could not find notification link " .
+					"with xpath " . $this->notificationLinkXpath
+				);
+			}
+			$message = $notification->find("xpath", $this->notificationMessageXpath);
+			if ($message === null) {
+				throw new ElementNotFoundException(
+					__METHOD__ . " could not find notification message " .
+					"with xpath " . $this->notificationMessageXpath
+				);
+			}
+			$notificationsArray[] = [
+				'title' => $title->getText(),
+				'link' => $link->getAttribute('href'),
+				'message' => $message->getText()
+			];
+		}
+		return $notificationsArray;
+	}
+
+	/**
+	 *
+	 * @return \Page\Notification[]
+	 */
+	public function getAllNoficationObjects() {
+		$notificationsElement = $this->findAll("xpath", $this->notificationContainerXpath);
+		$notificationObjects = [];
+		foreach ($notificationsElement as $notificationElement) {
+			/**
+			 *
+			 * @var Notification $notificationObject
+			 */
+			$notificationObject = $this->getPage("Notification");
+			$notificationObject->setElement($notificationElement);
+			$notificationObjects[] = $notificationObject;
+		}
+		return $notificationObjects;
+	}
+}

--- a/tests/acceptance/features/lib/NotificationsEnabledOwncloudPage.php
+++ b/tests/acceptance/features/lib/NotificationsEnabledOwncloudPage.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page;
+
+use Behat\Mink\Element\NodeElement;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+
+/**
+ * PageObject that has everything the general OwncloudPage does
+ * plus what the notifications App adds to it
+ */
+class NotificationsEnabledOwncloudPage extends OwncloudPage {
+	private $notificationsButtonXpath = "//div[contains(@class,'notifications-button')]";
+	
+	/**
+	 *
+	 * @throws ElementNotFoundException
+	 * @return NodeElement
+	 */
+	private function findNotificationsButton() {
+		$button = $this->waitTillElementIsNotNull($this->notificationsButtonXpath);
+		if ($button === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ . " could not find notifications button " .
+				"with xpath " . $this->notificationsButtonXpath
+			);
+		}
+		return $button;
+	}
+
+	/**
+	 * wait till the new notifications button is visible
+	 *
+	 * @return void
+	 */
+	public function waitForNotifications() {
+		$button = $this->findNotificationsButton();
+		$this->waitFor(
+			STANDARDUIWAITTIMEOUTMILLISEC / 1000, [$button, 'isVisible']
+		);
+	}
+
+	/**
+	 * @return NotificationsAppDialog
+	 */
+	public function openNotifications() {
+		$this->findNotificationsButton()->click();
+		return $this->getPage("NotificationsAppDialog");
+	}
+}

--- a/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @app-required @notifications-app-required
 Feature: Display notifications when receiving a share and follow embedded links
 As a user
 I want to use the notification header as a link

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @app-required @notifications-app-required
 Feature: Sharing files and folders with internal groups
 As a user
 I want to share files and folders with groups

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @app-required @notifications-app-required
 Feature: Sharing files and folders with internal users
 As a user
 I want to share files and folders with other users


### PR DESCRIPTION
## Description
1) Make a ``NotificationsCoreContext`` that has the relevant step code for examining notifications through its API.
2) Move ``WebUINotificationsContext`` into core - all the code there was relevant to testing behavior from core or from other apps.
3) Move the other notifications page objects also - they were all needed to let ``WebUINotificationsContext`` do its thing.
4) Adjust ``behat.yml`` and ``bootstrap.php`` so they do not try to look inside the notifications app for acceptance test code.

## Related Issue

## Motivation and Context
Acceptance test code (scenario steps...) that is needed/used by core acceptance test scenarios needs to be in core. In  this case, move relevant scenario steps (and related page objects that define the webUI elements) out of the notifications app and into core, so they can be used by core or any other app, without that app having to find a way to get hold of ``NotificationsContext``... from somewhere inside the notifications app.

After this change, other apps can just enable or disable the notifications app and then can use any of the acceptance test steps in core to examine the behavior of their app when it produces notifications.

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
