### PR TITLE
[Stable10] Add a new admin section for Imprint and Privacy Policy settings

### DIFF
--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -52,6 +52,7 @@ use OC\Settings\Panels\Admin\BackgroundJobs;
 use OC\Settings\Panels\Admin\Certificates;
 use OC\Settings\Panels\Admin\Encryption;
 use OC\Settings\Panels\Admin\FileSharing;
+use OC\Settings\Panels\Admin\Legal;
 use OC\Settings\Panels\Admin\Mail;
 use OC\Settings\Panels\Admin\Logging;
 use OC\Settings\Panels\Admin\SecurityWarning;
@@ -236,6 +237,7 @@ class SettingsManager implements ISettingsManager {
 				Encryption::class,
 				Certificates::class,
 				Apps::class,
+				Legal::class,
 				Status::class
 			];
 		} else if($type === 'personal') {
@@ -291,7 +293,8 @@ class SettingsManager implements ISettingsManager {
 				$this->lockingProvider),
 			Tips::class => new Tips(),
 			LegacyAdmin::class => new LegacyAdmin($this->helper),
-			Apps::class => new Apps($this->config)
+			Apps::class => new Apps($this->config),
+			Legal::class => new Legal($this->config)
 		];
 		if(isset($panels[$className])) {
 			return $panels[$className];

--- a/settings/Application.php
+++ b/settings/Application.php
@@ -41,6 +41,7 @@ use OC\Settings\Controller\CertificateController;
 use OC\Settings\Controller\CheckSetupController;
 use OC\Settings\Controller\EncryptionController;
 use OC\Settings\Controller\GroupsController;
+use OC\Settings\Controller\LegalSettingsController;
 use OC\Settings\Controller\LogSettingsController;
 use OC\Settings\Controller\MailSettingsController;
 use OC\Settings\Controller\SecuritySettingsController;
@@ -184,7 +185,15 @@ class Application extends App {
 				$c->query('L10N')
 			);
 		});
-		$container->registerService('CheckSetupController', function(IContainer $c) {
+		$container->registerService('LegalSettingsController', function (IContainer $c) {
+			return new LegalSettingsController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$c->query('L10N'),
+				$c->query('Config')
+			);
+		});
+		$container->registerService('CheckSetupController', function (IContainer $c) {
 			return new CheckSetupController(
 				$c->query('AppName'),
 				$c->query('Request'),

--- a/settings/Controller/LegalSettingsController.php
+++ b/settings/Controller/LegalSettingsController.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Settings\Controller;
+
+use \OCP\AppFramework\Controller;
+use OCP\IRequest;
+use OCP\IL10N;
+use OCP\IConfig;
+
+/**
+ * @package OC\Settings\Controller
+ */
+class LegalSettingsController extends Controller {
+	/**
+	 * @var \OCP\IL10N
+	 */
+	private $l10n;
+
+	/**
+	 * @var \OCP\IConfig
+	 */
+	private $config;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IL10N $l10n
+	 * @param IConfig $config
+	 */
+	public function __construct($appName,
+								IRequest $request,
+								IL10N $l10n,
+								IConfig $config
+	) {
+		parent::__construct($appName, $request);
+		$this->l10n = $l10n;
+		$this->config = $config;
+	}
+
+	/**
+	 * Store imprint URL
+	 *
+	 * @param string $imprintUrl
+	 *
+	 * @return array
+	 */
+	public function setImprintUrl($imprintUrl) {
+		$this->config->setAppValue(
+			'core',
+			'legal.imprint_url',
+			$imprintUrl
+		);
+
+		return [
+			'data' =>
+				[
+					'message' => (string) $this->l10n->t('Saved')
+				],
+			'status' => 'success'
+		];
+	}
+
+	/**
+	 * Store privacy policy URL
+	 *
+	 * @param string $privacyPolicy
+	 *
+	 * @return array
+	 */
+	public function setPrivacyPolicyUrl($privacyPolicy) {
+		$this->config->setAppValue(
+			'core',
+			'legal.privacy_policy_url',
+			$privacyPolicy
+		);
+
+		return [
+			'data' =>
+				[
+					'message' => (string) $this->l10n->t('Saved')
+				],
+			'status' => 'success'
+		];
+	}
+}

--- a/settings/Panels/Admin/Legal.php
+++ b/settings/Panels/Admin/Legal.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Settings\Panels\Admin;
+
+use OCP\IConfig;
+use OCP\Settings\ISettings;
+use OCP\Template;
+
+class Legal implements ISettings {
+
+	/**
+	 * @var IConfig
+	 */
+	protected $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	public function getPriority() {
+		return 5;
+	}
+
+	public function getPanel() {
+		$template = new Template('settings', 'panels/admin/legal');
+		$template->assign('read-only', $this->config->isSystemConfigReadOnly());
+		$template->assign(
+			'legal_imprint',
+			$this->config->getAppValue('core', 'legal.imprint_url', '')
+		);
+		$template->assign(
+			'legal_privacy_policy',
+			$this->config->getAppValue('core', 'legal.privacy_policy_url', '')
+		);
+		return $template;
+	}
+
+	public function getSectionID() {
+		return 'general';
+	}
+}

--- a/settings/js/panels/legal.js
+++ b/settings/js/panels/legal.js
@@ -1,0 +1,20 @@
+$(document).ready(function() {
+	$('#legal_imprint').change(function () {
+		OC.msg.startSaving('#legal_imprint');
+		var post = {
+			imprintUrl : $("#legal_imprint").val()
+		};
+		$.post(OC.generateUrl('/settings/admin/legal/imprint'), post, function (data) {
+			OC.msg.finishedSaving('#legal_imprint_msg', data);
+		});
+	});
+	$('#legal_privacy_policy').change(function () {
+		OC.msg.startSaving('#legal_privacy_policy');
+		var post = {
+			privacyPolicy : $("#legal_privacy_policy").val()
+		};
+		$.post(OC.generateUrl('/settings/admin/legal/privacypolicy'), post, function (data) {
+			OC.msg.finishedSaving('#legal_privacy_policy_msg', data);
+		});
+	});
+});

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -64,7 +64,9 @@ $application->registerRoutes($this, [
 		['name' => 'Users#changeMail', 'url' => '/settings/mailaddress/change/{token}/{userId}', 'verb' => 'GET'],
 		['name' => 'Cors#getDomains', 'url' => '/settings/domains', 'verb' => 'GET'],
 		['name' => 'Cors#addDomain', 'url' => '/settings/domains', 'verb' => 'POST'],
-		['name' => 'Cors#removeDomain', 'url' => '/settings/domains/{id}', 'verb' => 'DELETE']
+		['name' => 'Cors#removeDomain', 'url' => '/settings/domains/{id}', 'verb' => 'DELETE'],
+		['name' => 'LegalSettings#setImprintUrl', 'url' => '/settings/admin/legal/imprint', 'verb' => 'POST'],
+		['name' => 'LegalSettings#setPrivacyPolicyUrl', 'url' => '/settings/admin/legal/privacypolicy', 'verb' => 'POST'],
 	]
 ]);
 

--- a/settings/templates/panels/admin/legal.php
+++ b/settings/templates/panels/admin/legal.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @var array $_
+ * @var \OCP\IL10N $l
+ * @var OC_Defaults $theme
+ */
+script('settings', 'panels/legal');
+?><div class="section">
+	<h2 class="app-name"><?php p($l->t('Legal'));?></h2>
+	<p>
+		<label for="legal_imprint"><?php p($l->t('Imprint URL:')); ?></label>
+		<input type="text" name="legal_imprint" id="legal_imprint" placeholder="<?php p($l->t('Imprint URL'))?>"
+			   value='<?php p($_['legal_imprint']) ?>' />
+		<span id="legal_imprint_msg" class="msg"></span>
+	</p>
+	<p>
+		<label for="legal_privacy_policy"><?php p($l->t('Privacy Policy URL:')); ?></label>
+		<input type="text" name="legal_privacy_policy" id="legal_privacy_policy" placeholder="<?php p($l->t('Privacy Policy URL'))?>"
+		   value='<?php p($_['legal_privacy_policy']) ?>' />
+		<span id="legal_privacy_policy_msg" class="msg"></span>
+	</p>
+</div>

--- a/tests/Settings/Controller/LegalControllerTest.php
+++ b/tests/Settings/Controller/LegalControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Settings\Controller;
+
+use OC\Settings\Application;
+use OC\Settings\Controller\LegalSettingsController;
+use OCP\IConfig;
+
+/**
+ * @package Tests\Settings\Controller
+ */
+class LegalSettingsControllerTest extends \Test\TestCase {
+	/**
+	 * @var \OCP\AppFramework\IAppContainer
+	 */
+	private $container;
+
+	/**
+	 * @var LegalSettingsController
+	 */
+	private $legalSettingsController;
+
+	protected function setUp() {
+		$app = new Application();
+		$this->container = $app->getContainer();
+		$this->container['Config'] = $this->getMockBuilder(IConfig::class)
+			->disableOriginalConstructor()->getMock();
+		$this->container['AppName'] = 'settings';
+		$this->legalSettingsController = $this->container['LegalSettingsController'];
+	}
+
+	/**
+	 * @dataProvider linkData
+	 */
+	public function testSetImprintUrl($link) {
+		$this->container['Config']
+			->expects($this->once())
+			->method('setAppValue')
+			->with('core', 'legal.imprint_url', $link);
+
+		$response = $this->legalSettingsController->setImprintUrl($link);
+		$this->assertArrayHasKey('status', $response);
+	}
+
+	/**
+	 * @dataProvider linkData
+	 */
+	public function testSetPrivacyPolicyUrl($link) {
+		$this->container['Config']
+			->expects($this->once())
+			->method('setAppValue')
+			->with('core', 'legal.privacy_policy_url', $link);
+
+		$response = $this->legalSettingsController->setPrivacyPolicyUrl($link);
+		$this->assertArrayHasKey('status', $response);
+	}
+
+	public function linkData() {
+		return [
+			['https://some.url'],
+		];
+	}
+}

--- a/tests/Settings/Panels/Admin/LegalTest.php
+++ b/tests/Settings/Panels/Admin/LegalTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Settings\Panels\Admin;
+
+use OC\Settings\Panels\Admin\Legal;
+use OCP\IConfig;
+use OCP\IURLGenerator;
+
+/**
+ * @package Tests\Settings\Panels\Admin
+ */
+class LegalTest extends \Test\TestCase {
+	/** @var Legal */
+	private $panel;
+	/** @var IConfig */
+	private $config;
+
+	public function setUp() {
+		parent::setUp();
+		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
+		$this->panel = new Legal($this->config);
+	}
+
+	public function testGetSection() {
+		$this->assertEquals('general', $this->panel->getSectionID());
+	}
+
+	public function testGetPriority() {
+		$this->assertInternalType('int', $this->panel->getPriority());
+		$this->assertGreaterThan(-100, $this->panel->getPriority());
+		$this->assertLessThan(100, $this->panel->getPriority());
+	}
+
+	public function testGetPanel() {
+		$templateHtml = $this->panel->getPanel()->fetchPage();
+		$this->assertContains(
+			'<input type="text" name="legal_imprint" id="legal_imprint"',
+			$templateHtml
+		);
+	}
+}


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/31552

## Description
PHP backend to add links to  Imprint and Privacy Policy 

## Related Issue
https://github.com/owncloud/enterprise/issues/2537

## Motivation and Context
Allows admin  to specify a links to privacy policy or imprint

## How Has This Been Tested?
1. By visiting settings -> admin ->general and setting/resetting the controls
2. CLI: 
`php occ config:app:get core legal.imprint_url`
`php occ config:app:get core legal.privacy_policy_url`
`php occ config:app:set core legal.imprint_url new_value`
`php occ config:app:set core legal.privacy_policy_url new_value`

## Screenshots (if appropriate):
![legal](https://user-images.githubusercontent.com/991300/41052861-aafa4e14-69c2-11e8-8462-2cb1677cc340.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

# Beware: needs to be documeted for OC 10.0.x