### PR TITLE
Install app when enabling via provisioning API

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -228,6 +228,11 @@ class AppManager implements IAppManager {
 		if ($this->getAppPath($appId) === false) {
 			throw new \Exception("$appId can't be enabled since it is not installed.");
 		}
+
+		if (!Installer::isInstalled($appId)) {
+			Installer::installShippedApp($appId);
+		}
+
 		$this->canEnableTheme($appId);
 
 		$this->installedAppsCache[$appId] = 'yes';
@@ -287,6 +292,10 @@ class AppManager implements IAppManager {
 			if (!empty($protectedTypes)) {
 				throw new \Exception("$appId can't be enabled for groups.");
 			}
+		}
+
+		if (!Installer::isInstalled($appId)) {
+			Installer::installShippedApp($appId);
 		}
 
 		$groupIds = \array_map(function ($group) {

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -369,10 +369,6 @@ class OC_App {
 
 		self::checkAppDependencies($config, $l, $info);
 
-		if (!Installer::isInstalled($app)) {
-			Installer::installShippedApp($app);
-		}
-
 		$appManager = \OC::$server->getAppManager();
 		if ($groups !== null) {
 			$groupManager = \OC::$server->getGroupManager();

--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -13,6 +13,7 @@ So that I can use the app features again
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And app "comments" should be enabled
+		And the information for app "comments" should have a valid version
 
 	Scenario: subadmin tries to enable an app
 		Given user "subadmin" has been created

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1448,6 +1448,20 @@ trait Provisioning {
 	}
 
 	/**
+	 * Parses the xml answer to get the array of app info returned for an app.
+	 *
+	 * @param ResponseInterface $resp
+	 *
+	 * @return array
+	 */
+	public function getArrayOfAppInfoResponded($resp) {
+		$listCheckedElements = $resp->xml()->data[0];
+		$extractedElementsArray
+			= \json_decode(\json_encode($listCheckedElements), 1);
+		return $extractedElementsArray;
+	}
+
+	/**
 	 * @Then /^app "([^"]*)" should be disabled$/
 	 *
 	 * @param string $app
@@ -1486,6 +1500,35 @@ trait Provisioning {
 		PHPUnit_Framework_Assert::assertContains($app, $respondedArray);
 		PHPUnit_Framework_Assert::assertEquals(
 			200, $this->response->getStatusCode()
+		);
+	}
+
+	/**
+	 * @Then /^the information for app "([^"]*)" should have a valid version$/
+	 *
+	 * @param string $app
+	 *
+	 * @return void
+	 */
+	public function theInformationForAppShouldHaveAValidVersion($app) {
+		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/apps/$app";
+		$client = new Client();
+		$options = [];
+		$options['auth'] = $this->getAuthOptionForAdmin();
+
+		$this->response = $client->get($fullUrl, $options);
+		PHPUnit_Framework_Assert::assertEquals(
+			200, $this->response->getStatusCode()
+		);
+		$respondedArray = $this->getArrayOfAppInfoResponded($this->response);
+		PHPUnit_Framework_Assert::assertArrayHasKey(
+			'version',
+			$respondedArray,
+			"app info returned for $app app does not have a version");
+		$appVersion = $respondedArray['version'];
+		PHPUnit_Framework_Assert::assertTrue(
+			\substr_count($appVersion, '.') > 1,
+			"app version '$appVersion' returned in app info is not a valid version string"
 		);
 	}
 


### PR DESCRIPTION
## Description
The ``Installer::installShippedApp()`` was only in the code path executed by the `occ app:enable` command. Put it lower down where it will get executed by anything that wants to enable an app - e.g. by the provisioning API call.

## Related Issue
#31669 

## Motivation and Context
Enabling an app via the provisioning API should put it in the same state as enabling it via the `occ` command. See issue for a detailed description.

## How Has This Been Tested?
Case 1)
Enable using ``occ`` command:
```
mysql> delete from oc_appconfig where appid = 'files_texteditor';
```
enable ``files_texteditor`` from ``occ`` command:
```
php occ app:enable files_texteditor
```
database has:
```
mysql> select * from oc_appconfig where appid = 'files_texteditor';
+------------------+-------------------+-------------+
| appid            | configkey         | configvalue |
+------------------+-------------------+-------------+
| files_texteditor | enabled           | yes         |
| files_texteditor | installed_version | 2.2.1       |
| files_texteditor | types             |             |
+------------------+-------------------+-------------+
3 rows in set (0.00 sec)
```
Case 2)
Enable for groups using ``occ`` command:
```
mysql> delete from oc_appconfig where appid = 'files_texteditor';
```
enable ``files_texteditor`` from ``occ`` command:
```
php occ app:enable files_texteditor --groups admin
```
database has:
```
mysql> select * from oc_appconfig where appid = 'files_texteditor';
| appid            | configkey         | configvalue |
+------------------+-------------------+-------------+
| files_texteditor | enabled           | ["admin"]   |
| files_texteditor | installed_version | 2.2.1       |
| files_texteditor | types             |             |
+------------------+-------------------+-------------+
3 rows in set (0.01 sec)
```
Case 3)
Enable using provisioning API:
```
mysql> delete from oc_appconfig where appid = 'files_texteditor';
```
enable ``files_texteditor`` from provisioning API:
```
curl http://admin:admin@172.17.0.1:8080/ocs/v2.php/cloud/apps/files_texteditor -X POST
```
database has:
```
mysql> select * from oc_appconfig where appid = 'files_texteditor';
+------------------+-------------------+-------------+
| appid            | configkey         | configvalue |
+------------------+-------------------+-------------+
| files_texteditor | enabled           | yes         |
| files_texteditor | installed_version | 2.2.1       |
| files_texteditor | types             |             |
+------------------+-------------------+-------------+
3 rows in set (0.00 sec)
```

All 3 cases result in a complete set of data in the ``oc_appconfig`` table.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
