### PR TITLE
Fix apiVersion type and createShare call parameters

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -261,7 +261,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function usingApiVersion($version) {
-		$this->apiVersion = $version;
+		$this->apiVersion = (int) $version;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -595,6 +595,7 @@ trait Sharing {
 				$password,
 				$permissions,
 				$linkName,
+				null, //expireDate
 				$this->apiVersion,
 				$this->sharingApiVersion
 			);


### PR DESCRIPTION
## Description
1) Fix call parameters for ``createShare``
2) Cast the ``apiVersion`` to ``int``` when storing it.

## Related Issue

## Motivation and Context
``createShare()`` has a missing parameter  in the call - fix it.
When we fix it, and/or make use of ``createAPublicShare()`` then ``SharingHelper::createShare()`` complains about "invalid apiVersion/sharingApiVersion" because it now gets ``apiVersion`` in the correct parameter. ``apiVersion`` is suppposed to be an ``int``.

## How Has This Been Tested?
Local API acceptance test runs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test bug fix

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
