### PR TITLE
Properly detect home storage on objectstores as well

### DIFF
--- a/lib/private/Files/Cache/Wrapper/ReadOnlyCachePermissionsMask.php
+++ b/lib/private/Files/Cache/Wrapper/ReadOnlyCachePermissionsMask.php
@@ -85,10 +85,11 @@ class ReadOnlyCachePermissionsMask extends CacheWrapper {
 	}
 
 	private function isHomeStorage($storageId) {
-		return \substr($storageId, 0, \strlen('home::')) === 'home::';
+		return $this->startsWith($storageId, 'home::') ||
+			$this->startsWith($storageId, 'object::');
 	}
 
 	private function startsWith($haystack, $needle) {
-		return (\substr($haystack, 0, \strlen($needle)) === $needle);
+		return (\strpos($haystack, $needle) === 0);
 	}
 }


### PR DESCRIPTION
## Description
On objectstore home storages have a different prefix

## Related Issue
???

## How Has This Been Tested?
- local unit tests
- needs guests acceptance tests to be executed with objectstore 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

