### PR TITLE
Add version restore tests when sharee has moved the shared folder or file

### DIFF
--- a/tests/acceptance/features/apiMain/dav-versions.feature
+++ b/tests/acceptance/features/apiMain/dav-versions.feature
@@ -50,7 +50,7 @@ Feature: dav-versions
       | permissions | 8            |
     Then the version folder of fileId "<<FILEID>>" for user "user1" should contain "1" element
 
-	Scenario: sharer of a file see the old version information when the sharee changes the content of the file
+	Scenario: sharer of a file can see the old version information when the sharee changes the content of the file
 		Given user "user0" has been created
 		And user "user1" has been created
 		And user "user0" has uploaded file with content "user0 content" to "sharefile.txt"
@@ -59,7 +59,7 @@ Feature: dav-versions
 		Then the HTTP status code should be "204"
 		And the version folder of file "/sharefile.txt" for user "user0" should contain "1" element
 
-	Scenario: sharer of a file can restore the original content of the file after the file has been modified by the sharee
+	Scenario: sharer of a file can restore the original content of a shared file after the file has been modified by the sharee
 		Given user "user0" has been created
 		And user "user1" has been created
 		And user "user0" has uploaded file with content "user0 content" to "sharefile.txt"
@@ -67,9 +67,10 @@ Feature: dav-versions
 		And user "user1" has uploaded file with content "user1 content" to "/sharefile.txt"
 		When user "user0" restores version index "1" of file "/sharefile.txt" using the API
 		Then the HTTP status code should be "204"
-		And the downloaded content when downloading file "/sharefile.txt" for user "user0" with range "bytes=0-12" should be "user0 content"
+		And the content of file "/sharefile.txt" for user "user0" should be "user0 content"
+		And the content of file "/sharefile.txt" for user "user1" should be "user0 content"
 
-	Scenario: sharer restores the file inside a shared folder modified by sharee
+	Scenario: sharer can restore a file inside a shared folder modified by sharee
 		Given user "user0" has been created
 		And user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
@@ -78,9 +79,10 @@ Feature: dav-versions
 		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
 		When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the API
 		Then the HTTP status code should be "204"
-		And the downloaded content when downloading file "/sharingfolder/sharefile.txt" for user "user0" with range "bytes=0-12" should be "user0 content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user0 content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
 
-	Scenario: sharee restores the file inside a shared folder modified by sharee
+	Scenario: sharee can restore a file inside a shared folder modified by sharee
 		Given user "user0" has been created
 		And user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
@@ -89,9 +91,10 @@ Feature: dav-versions
 		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
 		When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the API
 		Then the HTTP status code should be "204"
-		And the downloaded content when downloading file "/sharingfolder/sharefile.txt" for user "user1" with range "bytes=0-12" should be "user0 content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user0 content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
 
-	Scenario: sharer restores the file inside a shared folder created by sharee and modified by sharer
+	Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharer
 		Given user "user0" has been created
 		And user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
@@ -100,9 +103,10 @@ Feature: dav-versions
 		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
 		When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the API
 		Then the HTTP status code should be "204"
-		And the downloaded content when downloading file "/sharingfolder/sharefile.txt" for user "user0" with range "bytes=0-12" should be "user1 content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user1 content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user1 content"
 
-	Scenario: sharee restores the file inside a shared folder created by sharee and modified by sharer
+	Scenario: sharee can restore a file inside a shared folder created by sharee and modified by sharer
 		Given user "user0" has been created
 		And user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
@@ -111,9 +115,10 @@ Feature: dav-versions
 		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
 		When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the API
 		Then the HTTP status code should be "204"
-		And the downloaded content when downloading file "/sharingfolder/sharefile.txt" for user "user1" with range "bytes=0-12" should be "user1 content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user1 content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user1 content"
 
-	Scenario: sharer restores the file inside a shared folder created by sharee and modified by sharee
+	Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharee
 		Given user "user0" has been created
 		And user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
@@ -122,9 +127,10 @@ Feature: dav-versions
 		And user "user1" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
 		When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the API
 		Then the HTTP status code should be "204"
-		And the downloaded content when downloading file "/sharingfolder/sharefile.txt" for user "user0" with range "bytes=0-12" should be "old content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "old content"
 
-	Scenario: sharee restores the file inside a shared folder created by sharer and modified by sharer
+	Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer
 		Given user "user0" has been created
 		And user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
@@ -133,9 +139,51 @@ Feature: dav-versions
 		And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
 		When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the API
 		Then the HTTP status code should be "204"
-		And the downloaded content when downloading file "/sharingfolder/sharefile.txt" for user "user1" with range "bytes=0-12" should be "old content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "old content"
 
-	Scenario: sharer restores the file inside a group shared folder modified by sharee
+	Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer, when the folder has been moved by the sharee
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/sharingfolder"
+		And user "user0" has shared folder "/sharingfolder" with user "user1"
+		And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
+		And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
+		And user "user1" has created a folder "/received"
+		And user "user1" has moved folder "/sharingfolder" to "/received/sharingfolder"
+		When user "user1" restores version index "1" of file "/received/sharingfolder/sharefile.txt" using the API
+		Then the HTTP status code should be "201"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
+		And the content of file "/received/sharingfolder/sharefile.txt" for user "user1" should be "old content"
+
+	Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is at the top level of the sharer)
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has uploaded file with content "old content" to "/sharefile.txt"
+		And user "user0" has uploaded file with content "new content" to "/sharefile.txt"
+		And user "user0" has shared file "/sharefile.txt" with user "user1"
+		And user "user1" has created a folder "/received"
+		And user "user1" has moved file "/sharefile.txt" to "/received/sharefile.txt"
+		When user "user1" restores version index "1" of file "/received/sharefile.txt" using the API
+		Then the HTTP status code should be "201"
+		And the content of file "/sharefile.txt" for user "user0" should be "old content"
+		And the content of file "/received/sharefile.txt" for user "user1" should be "old content"
+
+	Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is inside a folder of the sharer)
+		Given user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/sharingfolder"
+		And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
+		And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
+		And user "user0" has shared file "/sharingfolder/sharefile.txt" with user "user1"
+		And user "user1" has created a folder "/received"
+		And user "user1" has moved file "/sharefile.txt" to "/received/sharefile.txt"
+		When user "user1" restores version index "1" of file "/received/sharefile.txt" using the API
+		Then the HTTP status code should be "201"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
+		And the content of file "/received/sharefile.txt" for user "user1" should be "old content"
+
+	Scenario: sharer can restore a file inside a group shared folder modified by sharee
 		Given user "user0" has been created
 		And user "user1" has been created
 		And user "user2" has been created
@@ -149,4 +197,6 @@ Feature: dav-versions
 		And user "user2" has uploaded file with content "user2 content" to "/sharingfolder/sharefile.txt"
 		When user "user0" restores version index "2" of file "/sharingfolder/sharefile.txt" using the API
 		Then the HTTP status code should be "204"
-		And the downloaded content when downloading file "/sharingfolder/sharefile.txt" for user "user0" with range "bytes=0-12" should be "user0 content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user0 content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
+		And the content of file "/sharingfolder/sharefile.txt" for user "user2" should be "user0 content"


### PR DESCRIPTION
## Description
Add test cases for when a sharee receives a file or folder, then moves that file or folder and then tries to restore old versions.

Refactor some existing tests to check the version recovery a bit more cleanly.

## Related Issue
#31681 

## Motivation and Context
Some issues have been reported when the sharee (receiver of a shared file or folder) moves the received share, then tries to restore an old version. Make some tests to check this behavior.

## How Has This Been Tested?
Local API acceptance test run

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] acceptance test enhancement

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
