### PR TITLE
Remove deprecated SnippetAcceptingContext

### DIFF
--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -23,7 +23,6 @@
  */
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 
@@ -32,7 +31,7 @@ require_once 'bootstrap.php';
 /**
  * Capabilities context.
  */
-class CapabilitiesContext implements Context, SnippetAcceptingContext {
+class CapabilitiesContext implements Context {
 
 	/**
 	 *

--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -21,7 +21,6 @@
  */
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Gherkin\Node\PyStringNode;
 use TestHelpers\EmailHelper;
 
@@ -30,7 +29,7 @@ require_once 'bootstrap.php';
 /**
  * context file for email related steps.
  */
-class EmailContext implements Context, SnippetAcceptingContext {
+class EmailContext implements Context {
 	private $mailhogUrl = null;
 	
 	/**

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -23,7 +23,6 @@
  */
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use GuzzleHttp\Message\ResponseInterface;
 
@@ -32,7 +31,7 @@ require_once 'bootstrap.php';
 /**
  * Federation context.
  */
-class FederationContext implements Context, SnippetAcceptingContext {
+class FederationContext implements Context {
 
 	/**
 	 *

--- a/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
@@ -21,7 +21,6 @@
  */
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use GuzzleHttp\Message\ResponseInterface;
 use TestHelpers\OcsApiHelper;
@@ -31,7 +30,7 @@ require_once 'bootstrap.php';
 /**
  * Defines application features from the specific context.
  */
-class NotificationsCoreContext implements Context, SnippetAcceptingContext {
+class NotificationsCoreContext implements Context {
 
 	/**
 	 * @var array[]

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -23,7 +23,6 @@
  */
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Message\ResponseInterface;
@@ -33,7 +32,7 @@ require_once 'bootstrap.php';
 /**
  * Sharees context.
  */
-class ShareesContext implements Context, SnippetAcceptingContext {
+class ShareesContext implements Context {
 
 	/**
 	 *


### PR DESCRIPTION
## Description
Remove references to ``SnippetAcceptingContext``

## Related Issue

## Motivation and Context
``SnippetAcceptingContext`` is deprecated and does nothing in Behat any more. Get rid of it.

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
