### PR TITLE
[stable10] remove deprecated snippet accepting context

### DIFF
--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -23,7 +23,6 @@
  */
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 
@@ -32,7 +31,7 @@ require_once 'bootstrap.php';
 /**
  * Capabilities context.
  */
-class CapabilitiesContext implements Context, SnippetAcceptingContext {
+class CapabilitiesContext implements Context {
 
 	/**
 	 *

--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -21,7 +21,6 @@
  */
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Gherkin\Node\PyStringNode;
 use TestHelpers\EmailHelper;
 
@@ -30,7 +29,7 @@ require_once 'bootstrap.php';
 /**
  * context file for email related steps.
  */
-class EmailContext implements Context, SnippetAcceptingContext {
+class EmailContext implements Context {
 	private $mailhogUrl = null;
 	
 	/**

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -22,14 +22,13 @@
  */
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\SnippetAcceptingContext;
 
 require_once 'bootstrap.php';
 
 /**
  * Features context.
  */
-class FeatureContext implements Context, SnippetAcceptingContext {
+class FeatureContext implements Context {
 	use BasicStructure;
 
 	/**

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -23,7 +23,6 @@
  */
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use GuzzleHttp\Message\ResponseInterface;
 
@@ -32,7 +31,7 @@ require_once 'bootstrap.php';
 /**
  * Federation context.
  */
-class FederationContext implements Context, SnippetAcceptingContext {
+class FederationContext implements Context {
 
 	/**
 	 *

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -23,7 +23,6 @@
  */
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Message\ResponseInterface;
@@ -33,7 +32,7 @@ require_once 'bootstrap.php';
 /**
  * Sharees context.
  */
-class ShareesContext implements Context, SnippetAcceptingContext {
+class ShareesContext implements Context {
 
 	/**
 	 *


### PR DESCRIPTION
Backport #31687 
and remove from ``FeatureContext``
(in ``master``, ``FeatureContext`` does different stuff and so already had no reference to ``SnippetAcceptingContext``)