### PR TITLE
API test for disabled public upload share

### DIFF
--- a/tests/acceptance/features/apiSharing-v1/uploadToShare.feature
+++ b/tests/acceptance/features/apiSharing-v1/uploadToShare.feature
@@ -230,3 +230,35 @@ Feature: sharing
 		When the quota of user "user0" has been set to "0"
 		Then publicly uploading a file should not work
 		And the HTTP status code should be "507"
+
+	Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder
+		Given user "user0" has been created
+		And user "user0" has created a share with settings
+			| path        | FOLDER |
+			| shareType   | 3      |
+			| permissions | 4      |
+		When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "no" using the API
+		Then publicly uploading a file should not work
+		And the HTTP status code should be "403"
+
+	Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder
+		Given user "user0" has been created
+		And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+		And user "user0" has created a share with settings
+			| path        | FOLDER |
+			| shareType   | 3      |
+			| permissions | 31      |
+		When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "yes" using the API
+		Then publicly uploading a file should not work
+		And the HTTP status code should be "403"
+
+	Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder
+		Given user "user0" has been created
+		And user "user0" has created a share with settings
+			| path        | FOLDER |
+			| shareType   | 3      |
+			| permissions | 4      |
+		And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+		And parameter "shareapi_allow_public_upload" of app "core" has been set to "yes"
+		When the public uploads file "test.txt" with content "test" using the API
+		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"


### PR DESCRIPTION
## Description
This PR adds tests to:
1) Make sure public cannot upload a file to a shared folder when `allow public upload` is `disabled`.
2) Make sure publicly uploading to a publicly shared folder doesn't work when a folder has been shared after `allow public upload` has been `disabled` and again `enabled` after file has been shared.
3) Make sure publicly uploading to a publicly shared folder works if `allow public upload` is `disabled` and re-enabled after the folder has been shared

## Related Issue
#31531 

## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.