### PR TITLE
[stable10] Fix deletion of selected files in trashbin

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -695,16 +695,21 @@
 
 		/**
 		 * Event handler for when selecting/deselecting all files
+		 * modifiedFiles if not passed then this.files would be used.
+		 * modifiedFiles was introduced, so that if we have to alter
+		 * any fields of this.files, its better to use modifiedFiles
+		 * instead of directly making change in this.files.
 		 */
-		_onClickSelectAll: function(e) {
+		_onClickSelectAll: function(e, modifiedFiles) {
+			var filesViewed = modifiedFiles ? modifiedFiles : this.files;
 			var checked = $(e.target).prop('checked');
 			this.$fileList.find('td.filename>.selectCheckBox').prop('checked', checked)
 				.closest('tr').toggleClass('selected', checked);
 			this._selectedFiles = {};
 			this._selectionSummary.clear();
 			if (checked) {
-				for (var i = 0; i < this.files.length; i++) {
-					var fileData = this.files[i];
+				for (var i = 0; i < filesViewed.length; i++) {
+					var fileData = filesViewed[i];
 					this._selectedFiles[fileData.id] = fileData;
 					this._selectionSummary.add(fileData);
 				}

--- a/apps/files_trashbin/js/filelist.js
+++ b/apps/files_trashbin/js/filelist.js
@@ -156,6 +156,29 @@
 			this.enableActions();
 		},
 
+		/**
+		 * Event handler for when selecting/deselecting all files
+		 */
+		_onClickSelectAll: function(e) {
+			/*
+			trashbinFiles is a variable which is a clone of this.files.
+			Any change to trashbinFiles will not have any change to this.files
+			 */
+			var trashbinFiles = [];
+			for (var i = 0, len = this.files.length; i < len; i++) {
+				trashbinFiles[i] = {};
+				for (var prop in this.files[i]) {
+					trashbinFiles[i][prop] = this.files[i][prop];
+				}
+			}
+
+			for (var i = 0; i < trashbinFiles.length; i++) {
+				trashbinFiles[i].name = trashbinFiles[i].name + '.d' +
+					Math.floor(trashbinFiles[i].mtime/1000);
+			}
+			OCA.Files.FileList.prototype._onClickSelectAll.call(this, e, trashbinFiles);
+		},
+
 		_onClickRestoreSelected: function(event) {
 			event.preventDefault();
 			var self = this;

--- a/apps/files_trashbin/tests/js/filelistSpec.js
+++ b/apps/files_trashbin/tests/js/filelistSpec.js
@@ -311,6 +311,35 @@ describe('OCA.Trashbin.FileList tests', function() {
 				expect(fileList.findFileEl('somedir.d99999').length).toEqual(0);
 				expect(fileList.findFileEl('Two.jpg.d22222').length).toEqual(1);
 			});
+			it('Deletes selected files when all files selected, some unselected, and "Delete" clicked', function() {
+				var request;
+				$('.select-all').click();
+				fileList.findFileEl('Two.jpg.d22222').find('input:checkbox').click();
+				fileList.findFileEl('Three.pdf.d33333').find('input:checkbox').click();
+				$('.selectedActions .delete-selected').click();
+				expect(fakeServer.requests.length).toEqual(1);
+				request = fakeServer.requests[0];
+				expect(request.url).toEqual(OC.webroot + '/index.php/apps/files_trashbin/ajax/delete.php');
+				expect(OC.parseQueryString(request.requestBody))
+					.toEqual({'dir': '/', files: '["One.txt.d11111","somedir.d99999"]'});
+				fakeServer.requests[0].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({
+						status: 'success',
+						data: {
+							success: [
+								{filename: 'One.txt.d11111'},
+								{filename: 'somedir.d99999'}
+							]
+						}
+					})
+				);
+				expect(fileList.findFileEl('One.txt.d11111').length).toEqual(0);
+				expect(fileList.findFileEl('somedir.d99999').length).toEqual(0);
+				expect(fileList.findFileEl('Two.jpg.d22222').length).toEqual(1);
+				expect(fileList.findFileEl('Three.pdf.d33333').length).toEqual(1);
+			});
 			it('Deletes all files when all selected when "Delete" clicked', function() {
 				var request;
 				$('.select-all').click();
@@ -355,6 +384,35 @@ describe('OCA.Trashbin.FileList tests', function() {
 				expect(fileList.findFileEl('Three.pdf.d33333').length).toEqual(0);
 				expect(fileList.findFileEl('somedir.d99999').length).toEqual(0);
 				expect(fileList.findFileEl('Two.jpg.d22222').length).toEqual(1);
+			});
+			it('Restores selected files when all files selected, some unselected, and "Restore" clicked', function() {
+				var request;
+				$('.select-all').click();
+				fileList.findFileEl('Two.jpg.d22222').find('input:checkbox').click();
+				fileList.findFileEl('Three.pdf.d33333').find('input:checkbox').click();
+				$('.selectedActions .undelete').click();
+				expect(fakeServer.requests.length).toEqual(1);
+				request = fakeServer.requests[0];
+				expect(request.url).toEqual(OC.webroot + '/index.php/apps/files_trashbin/ajax/undelete.php');
+				expect(OC.parseQueryString(request.requestBody))
+					.toEqual({'dir': '/', files: '["One.txt.d11111","somedir.d99999"]'});
+				fakeServer.requests[0].respond(
+					200,
+					{ 'Content-Type': 'application/json' },
+					JSON.stringify({
+						status: 'success',
+						data: {
+							success: [
+								{filename: 'One.txt.d11111'},
+								{filename: 'somedir.d99999'}
+							]
+						}
+					})
+				);
+				expect(fileList.findFileEl('One.txt.d11111').length).toEqual(0);
+				expect(fileList.findFileEl('somedir.d99999').length).toEqual(0);
+				expect(fileList.findFileEl('Two.jpg.d22222').length).toEqual(1);
+				expect(fileList.findFileEl('Three.pdf.d33333').length).toEqual(1);
 			});
 			it('Restores all files when all selected when "Restore" clicked', function() {
 				var request;

--- a/tests/acceptance/features/webUITrashbin/restore.feature
+++ b/tests/acceptance/features/webUITrashbin/restore.feature
@@ -50,6 +50,29 @@ So that I can recover accidentally deleted files/folders in ownCloud
 		But the file "data.zip" should not be listed in the files page on the webUI
 		And the folder "simple-folder" should not be listed in the files page on the webUI
 
+	Scenario: Select all except for some trashbin files and restore them in a batch
+		Given the following files have been deleted
+			| name          |
+			| data.zip      |
+			| lorem.txt     |
+			| lorem-big.txt |
+			| simple-folder |
+		And the user has browsed to the trashbin page
+		When the user marks all files for batch action using the webUI
+		And the user unmarks these files for batch action using the webUI
+			| name          |
+			| lorem.txt     |
+			| lorem-big.txt |
+		And the user batch restores the marked files using the webUI
+		Then the file "lorem.txt" should be listed on the webUI
+		And the file "lorem-big.txt" should be listed on the webUI
+		But the file "data.zip" should not be listed on the webUI
+		And the folder "simple-folder" should not be listed on the webUI
+		And the file "data.zip" should be listed in the files page on the webUI
+		And the folder "simple-folder" should be listed in the files page on the webUI
+		But the file "lorem.txt" should not be listed in the files page on the webUI
+		And the file "lorem-big.txt" should not be listed in the files page on the webUI
+
 	Scenario: Select all trashbin files and restore them in a batch
 		Given the following files have been deleted
 			| name          |

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -44,6 +44,23 @@ Feature: files and folders can be deleted from the trashbin
     And the file "lorem.txt" should not be listed in the files page on the webUI
     And the file "lorem-big.txt" should not be listed in the files page on the webUI
 
+  Scenario: Select all except for some files and delete from trashbin in a batch
+    When the user marks all files for batch action using the webUI
+    And the user unmarks these files for batch action using the webUI
+      | name          |
+      | lorem.txt     |
+      | lorem-big.txt |
+    And the user batch deletes the marked files using the webUI
+    Then the file "lorem.txt" should be listed on the webUI
+    And the file "lorem-big.txt" should be listed on the webUI
+    But the file "data.zip" should not be listed on the webUI
+    And the folder "simple-folder" should not be listed on the webUI
+
+  Scenario: Select all files and delete from trashbin in a batch
+    When the user marks all files for batch action using the webUI
+    And the user batch deletes the marked files using the webUI
+    Then the folder should be empty on the webUI
+
   Scenario: Select all files and delete from trashbin in a batch
     When the user marks all files for batch action using the webUI
     And the user batch deletes the marked files using the webUI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
The filenames passed in the ajax were the files seen in UI. But that is not the case with trashbin files. This change fixes the issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/30942

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The filenames passed in the ajax were the files seen in UI. But that is not the case with trashbin files. This change fixes the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Create 2 files. And delete them.
- [x] Select all and then change the decision to select only one. Delete the file. The file is deleted.
- [x] The same experiment is repeated with multiple files. And the files were deleted.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

