### PR TITLE
Put defaultMailHeaderColor back

### DIFF
--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -46,6 +46,7 @@ class OC_Defaults {
 	private $defaultDocVersion;
 	private $defaultSlogan;
 	private $defaultLogoClaim;
+	private $defaultMailHeaderColor;
 	/**
 	 * @var \OCP\IConfig
 	 */


### PR DESCRIPTION
this line was unintentionally removed in https://github.com/owncloud/core/pull/31683