### PR TITLE
Add Imprint and Privacy Policy to getShortFooter()

### DIFF
--- a/core/css/global.css
+++ b/core/css/global.css
@@ -77,3 +77,7 @@
 .text-left {
 	text-align: left;
 }
+
+.nowrap {
+	white-space: nowrap;
+}

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -261,7 +261,6 @@ a.two-factor-cancel {
 	text-align: center;
 }
 #body-login p.info {
-	width: 22em;
 	margin: 0 auto;
 	padding-top: 20px;
 	-webkit-user-select: none;
@@ -438,10 +437,6 @@ label.infield {
 #body-login p.info a:hover,
 #body-login p.info a:focus  {
 	opacity: .6;
-}
-
-#body-login footer .info {
-	white-space: nowrap;
 }
 
 /* Show password toggle */

--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -250,11 +250,13 @@ class OC_Defaults {
 			$footer  = '<a href="' . $this->getBaseUrl() . '" target="_blank" rel="noreferrer">' . $this->getEntity() . '</a>';
 			$footer .= ' &ndash; ' . $this->getSlogan();
 
-			if ($this->getImprintUrl() !== '')
+			if ($this->getImprintUrl() !== '') {
 				$footer .= '<span class="nowrap"> | <a href="' . $this->getImprintUrl() . '" target="_blank">' . $this->l->t('Imprint') . '</a></span>';
+			}
 
-			if ($this->getPrivacyPolicyUrl() !== '')
+			if ($this->getPrivacyPolicyUrl() !== '') {
 				$footer .= '<span class="nowrap"> | <a href="'. $this->getPrivacyPolicyUrl() .'" target="_blank">'. $this->l->t('Privacy Policy') .'</a></span>';
+			}
 		}
 
 		return $footer;

--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -251,10 +251,10 @@ class OC_Defaults {
 			$footer .= ' &ndash; ' . $this->getSlogan();
 
 			if ($this->getImprintUrl() !== '')
-				$footer .= '<span class="nowrap"> | <a href="' . $this->getImprintUrl() . '">' . $this->l->t('Imprint') . '</a></span>';
+				$footer .= '<span class="nowrap"> | <a href="' . $this->getImprintUrl() . '" target="_blank">' . $this->l->t('Imprint') . '</a></span>';
 
 			if ($this->getPrivacyPolicyUrl() !== '')
-				$footer .= '<span class="nowrap"> | <a href="'. $this->getPrivacyPolicyUrl() .'">'. $this->l->t('Privacy Policy') .'</a></span>';
+				$footer .= '<span class="nowrap"> | <a href="'. $this->getPrivacyPolicyUrl() .'" target="_blank">'. $this->l->t('Privacy Policy') .'</a></span>';
 		}
 
 		return $footer;

--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -247,9 +247,14 @@ class OC_Defaults {
 		if ($this->themeExist('getShortFooter')) {
 			$footer = $this->theme->getShortFooter();
 		} else {
-			$footer = '<a href="'. $this->getBaseUrl() . '" target="_blank"' .
-				' rel="noreferrer">' .$this->getEntity() . '</a>'.
-				' – ' . $this->getSlogan();
+			$footer  = '<a href="' . $this->getBaseUrl() . '" target="_blank" rel="noreferrer">' . $this->getEntity() . '</a>';
+			$footer .= ' &ndash; ' . $this->getSlogan();
+
+			if ($this->getImprintUrl() !== '')
+				$footer .= '<span class="nowrap"> | <a href="' . $this->getImprintUrl() . '">' . $this->l->t('Imprint') . '</a></span>';
+
+			if ($this->getPrivacyPolicyUrl() !== '')
+				$footer .= '<span class="nowrap"> | <a href="'. $this->getPrivacyPolicyUrl() .'">'. $this->l->t('Privacy Policy') .'</a></span>';
 		}
 
 		return $footer;

--- a/tests/lib/legacy/DefaultsTest.php
+++ b/tests/lib/legacy/DefaultsTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+namespace Test\legacy;
+
+use OC_Defaults;
+use Test\TestCase;
+
+class DefaultsTest extends TestCase {
+	/**
+	 * @var OC_Defaults | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected $defaults;
+
+	protected function setUp() {
+		$this->defaults = $this->getMockBuilder(OC_Defaults::class)
+			->setMethods(['themeExist', 'getImprintUrl', 'getPrivacyPolicyUrl'])
+			->getMock();
+		return parent::setUp();
+	}
+
+	public function testGetShortFooterFromCore() {
+		$imprintUrl = 'http://example.org/imprint';
+		$privacyPolicyUrl = 'http://example.org/privacy';
+		$this->defaults->expects($this->any())
+			->method('themeExist')
+			->willReturn(false);
+		$this->defaults->expects($this->exactly(2))
+			->method('getImprintUrl')
+			->willReturn($imprintUrl);
+		$this->defaults->expects($this->exactly(2))
+			->method('getPrivacyPolicyUrl')
+			->willReturn($privacyPolicyUrl);
+		$footer = $this->defaults->getShortFooter();
+		$this->assertContains($privacyPolicyUrl, $footer);
+		$this->assertContains($imprintUrl, $footer);
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Add imprint and privacy policy links in the global footer

## Related Issue
https://github.com/owncloud/enterprise/issues/2537

## How Has This Been Tested?
Visual tests in FF, Chrome & IE11 on
- login page footer
- public link page footer
- full screen error page footer

## Screenshots (if appropriate):
![fireshot capture 26 - owncloud - http___localhost_8000_index php_s_a1jbqp5smbmjlap](https://user-images.githubusercontent.com/12717530/41200336-13600830-6ca3-11e8-9348-f25b00f61468.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

