### PR TITLE
Restrict group admin create groups using userprovision API

### DIFF
--- a/apps/provisioning_api/tests/GroupsTest.php
+++ b/apps/provisioning_api/tests/GroupsTest.php
@@ -30,6 +30,7 @@ use OCA\Provisioning_API\Groups;
 use OCP\API;
 use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
 use OCP\IUserSession;
 
 class GroupsTest extends \Test\TestCase {
@@ -364,6 +365,58 @@ class GroupsTest extends \Test\TestCase {
 		$this->assertEquals(102, $result->getStatusCode());
 	}
 
+	public function testAddGroupUserDoesNotExist() {
+		$this->request
+			->method('getParam')
+			->with('groupid')
+			->willReturn('NewGroup');
+
+		$this->groupManager
+			->method('groupExists')
+			->with('NewGroup')
+			->willReturn(false);
+
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn(null);
+
+		$result = $this->api->addGroup([]);
+		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertFalse($result->succeeded());
+		$this->assertEquals(102, $result->getStatusCode());
+	}
+
+	public function testAddGroupUserNotAdmin() {
+		$this->request
+			->method('getParam')
+			->with('groupid')
+			->willReturn('NewGroup');
+
+		$this->groupManager
+			->method('groupExists')
+			->with('NewGroup')
+			->willReturn(false);
+
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->willReturn(false);
+
+		$iUser = $this->createMock(IUser::class);
+		$iUser->expects($this->once())
+			->method('getUID')
+			->willReturn('user1');
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($iUser);
+
+		$result = $this->api->addGroup([]);
+		$this->assertInstanceOf('OC_OCS_Result', $result);
+		$this->assertFalse($result->succeeded());
+		$this->assertEquals(997, $result->getStatusCode());
+	}
+
 	public function testAddGroup() {
 		$this->request
 			->method('getParam')
@@ -379,6 +432,19 @@ class GroupsTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('createGroup')
 			->with('NewGroup');
+
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->willReturn(true);
+
+		$iUser = $this->createMock(IUser::class);
+		$iUser->expects($this->once())
+			->method('getUID')
+			->willReturn('user1');
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($iUser);
 
 		$result = $this->api->addGroup([]);
 		$this->assertInstanceOf('OC_OCS_Result', $result);
@@ -400,6 +466,19 @@ class GroupsTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('createGroup')
 			->with('Iñtërnâtiônàlizætiøn');
+
+		$this->groupManager->expects($this->once())
+			->method('isAdmin')
+			->willReturn(true);
+
+		$iUser = $this->createMock(IUser::class);
+		$iUser->expects($this->once())
+			->method('getUID')
+			->willReturn('user1');
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($iUser);
 
 		$result = $this->api->addGroup([]);
 		$this->assertInstanceOf('OC_OCS_Result', $result);
@@ -450,5 +529,6 @@ class GroupsTest extends \Test\TestCase {
 		]);
 		$this->assertInstanceOf('OC_OCS_Result', $result);
 		$this->assertTrue($result->succeeded());
+		$this->assertEquals(100, $result->getStatusCode());
 	}
 }

--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -47,13 +47,12 @@ So that I can more easily manage access to resources by groups rather than indiv
 		And the HTTP status code should be "401"
 		And group "new-group" should not exist
 
-	@skip @issue-31283
 	Scenario: subadmin tries to create a group
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
 			| groupid   | another-group   |
-		Then the OCS status code should be "102"
-		And the HTTP status code should be "200"
+		Then the OCS status code should be "997"
+		And the HTTP status code should be "401"
 		And group "another-group" should not exist

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -48,13 +48,12 @@ So that I can more easily manage access to resources by groups rather than indiv
 		And the HTTP status code should be "401"
 		And group "new-group" should not exist
 
-	@skip @issue-31283
 	Scenario: subadmin tries to create a group
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
 			| groupid   | another-group   |
-		Then the OCS status code should be "401"
+		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And group "another-group" should not exist


### PR DESCRIPTION
Using userprovision API, restrict group admin create
groups. Its against the design.
Also made minor changes in the method deleteGroup
for better code readability.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Subadmin or group admin should not be able to create groups. This is violated when clients tries to create groups using userprovision API. This change helps to restrict group admins to create groups.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/31283

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Subadmin or group admin should not be able to create groups. This is violated when clients tries to create groups using userprovision API. This change helps to restrict group admins to create groups.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Tested using version 1 and version 2 as follows:
```
➜  owncloud3 git:(master) ✗ curl http://admin:admin@localhost/testing3/ocs/v2.php/cloud/groups -d groupid="a3"
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>200</statuscode>
  <message/>
 </meta>
 <data/>
</ocs>
➜  owncloud3 git:(master) ✗ curl http://user1:1@localhost/testing3/ocs/v2.php/cloud/groups -d groupid="a3a"   
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>400</statuscode>
  <message/>
 </meta>
 <data/>
</ocs>
➜  owncloud3 git:(master) ✗ curl http://admin:admin@localhost/testing3/ocs/v1.php/cloud/groups -d groupid="a4"
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>100</statuscode>
  <message/>
 </meta>
 <data/>
</ocs>
➜  owncloud3 git:(master) ✗ curl http://user1:1@localhost/testing3/ocs/v1.php/cloud/groups -d groupid="a4"    
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>102</statuscode>
  <message/>
 </meta>
 <data/>
</ocs>
➜  owncloud3 git:(master) ✗ 
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

