### PR TITLE
Improve webUI autocompletion acceptance tests

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -287,7 +287,7 @@ $CONFIG = array(
  * the minimum characters have been entered. The search is case insensitive.
  * e.g. entering "tom" will always return "Tom" if there is an exact match.
  */
-'user.search_min_length' => 4,
+'user.search_min_length' => 2,
 
 /**
  * Mail Parameters

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -274,6 +274,16 @@
 							if (!view.configModel.get('allowGroupSharing')) {
 								title = t('core', 'No users found for {search}', {search: $('.shareWithField').val()});
 							}
+							var suggestStarts = OC.getCapabilities().files_sharing.search_min_length;
+							if (suggestStarts > $('.shareWithField').val().length) {
+								title = title + " " + n(
+									'core',
+									'Please enter at least {chars} character for suggestions',
+									'Please enter at least {chars} characters for suggestions',
+									suggestStarts,
+									{chars: suggestStarts}
+								);
+							}
 							$('.shareWithField').addClass('error')
 								.attr('data-original-title', title)
 								.tooltip('hide')

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -108,7 +108,7 @@ describe('OC.Share.ShareDialogView', function() {
 		capsSpec = sinon.stub(OC, 'getCapabilities');
 		capsSpec.returns({
 			'files_sharing': {
-				'search_min_length': 4
+				'search_min_length': 2
 			}
 		});
 	});

--- a/lib/public/Util/UserSearch.php
+++ b/lib/public/Util/UserSearch.php
@@ -64,6 +64,6 @@ class UserSearch {
 	 * @since 10.0.8
 	 */
 	public function getSearchMinLength() {
-		return $this->config->getSystemValue('user.search_min_length', 4);
+		return $this->config->getSystemValue('user.search_min_length', 2);
 	}
 }

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -82,7 +82,33 @@ trait Provisioning {
 	}
 
 	/**
-	 * returns an array of the real displayed names
+	 * returns the display name of the current user
+	 * if no "Display Name" is set the user-name is returned instead
+	 *
+	 * @return array
+	 */
+	public function getCurrentUserDisplayName() {
+		return $this->getUserDisplayName($this->getCurrentUser());
+	}
+
+	/**
+	 * returns the display name of a user
+	 * if no "Display Name" is set the user-name is returned instead
+	 *
+	 * @param string $username
+	 *
+	 * @return array
+	 */
+	public function getUserDisplayName($username) {
+		$displayName = $this->createdUsers[$username]['displayname'];
+		if (($displayName === null) || ($displayName === '')) {
+			$displayName = $username;
+		}
+		return $displayName;
+	}
+
+	/**
+	 * returns an array of the display names, keyed by username
 	 * if no "Display Name" is set the user-name is returned instead
 	 *
 	 * @return array
@@ -90,11 +116,7 @@ trait Provisioning {
 	public function getCreatedUserDisplayNames() {
 		$result = [];
 		foreach ($this->getCreatedUsers() as $username => $user) {
-			if ($user['displayname'] === null) {
-				$result[] = $username;
-			} else {
-				$result[] = $user['displayname'];
-			}
+			$result[$username] = $this->getUserDisplayName($username);
 		}
 		return $result;
 	}

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -470,6 +470,30 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			);
 		}
 	}
+
+	/**
+	 * @Then only :userOrGroupName should be listed in the autocomplete list on the webUI
+	 *
+	 * @param string $userOrGroupName
+	 *
+	 * @return void
+	 */
+	public function onlyUserOrGroupNameShouldBeListedInTheAutocompleteList(
+		$userOrGroupName
+	) {
+		$autocompleteItems = $this->sharingDialog->getAutocompleteItemsList();
+		PHPUnit_Framework_Assert::assertCount(
+			1,
+			$autocompleteItems,
+			"expected 1 autocomplete item but there are " . \count($autocompleteItems)
+		);
+		PHPUnit_Framework_Assert::assertContains(
+			$userOrGroupName,
+			$autocompleteItems,
+			"'" . $userOrGroupName . "' not in autocomplete list"
+		);
+	}
+
 	/**
 	 * @Then all users and groups that contain the string :requiredString in their name should be listed in the autocomplete list on the webUI
 	 *
@@ -502,25 +526,38 @@ class WebUISharingContext extends RawMinkContext implements Context {
 				= $this->sharingDialog->groupStringsToMatchAutoComplete($notToBeListed);
 		}
 		$autocompleteItems = $this->sharingDialog->getAutocompleteItemsList();
-		$createdGroups = $this->sharingDialog->groupStringsToMatchAutoComplete(
+		// Keep separate arrays of users and groups, because the names can overlap
+		$createdElements = [];
+		$createdElements['groups'] = $this->sharingDialog->groupStringsToMatchAutoComplete(
 			$this->featureContext->getCreatedGroups()
 		);
-		$usersAndGroups = \array_merge(
-			$this->featureContext->getCreatedUserDisplayNames(),
-			$createdGroups
-		);
-		foreach ($usersAndGroups as $expectedUserOrGroup) {
-			if (\strpos($expectedUserOrGroup, $requiredString) !== false
-				&& $expectedUserOrGroup !== $notToBeListed
-				&& $expectedUserOrGroup !== $this->featureContext->getCurrentUser()
-			) {
-				PHPUnit_Framework_Assert::assertContains(
-					$expectedUserOrGroup,
-					$autocompleteItems,
-					"'" . $expectedUserOrGroup . "' not in autocomplete list"
-				);
+		$createdElements['users'] = $this->featureContext->getCreatedUserDisplayNames();
+		$numExpectedItems = 0;
+		foreach ($createdElements as $elementArray) {
+			foreach ($elementArray as $internalName => $displayName) {
+				// Matching should be case-insensitive on the internal or display name
+				if (((\stripos($internalName, $requiredString) !== false)
+						|| (\stripos($displayName, $requiredString) !== false))
+					&& ($displayName !== $notToBeListed)
+					&& ($displayName !== $this->featureContext->getCurrentUser())
+					&& ($displayName !== $this->featureContext->getCurrentUserDisplayName())
+				) {
+					PHPUnit_Framework_Assert::assertContains(
+						$displayName,
+						$autocompleteItems,
+						"'" . $displayName . "' not in autocomplete list"
+					);
+					$numExpectedItems = $numExpectedItems + 1;
+				}
 			}
 		}
+
+		PHPUnit_Framework_Assert::assertCount(
+			$numExpectedItems,
+			$autocompleteItems,
+			'expected ' . $numExpectedItems . ' in autocomplete list but there are ' . \count($autocompleteItems)
+		);
+
 		PHPUnit_Framework_Assert::assertNotContains(
 			$notToBeListed,
 			$this->sharingDialog->getAutocompleteItemsList()

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -119,13 +119,13 @@ class SharingDialog extends OwncloudPage {
 	 *
 	 * @param string|array $groupNames
 	 *
-	 * @return array
+	 * @return string|array
 	 */
 	public function groupStringsToMatchAutoComplete($groupNames) {
 		if (\is_array($groupNames)) {
 			$autocompleteStrings = [];
 			foreach ($groupNames as $groupName => $groupData) {
-				$autocompleteStrings[] = $groupName . $this->suffixToIdentifyGroups;
+				$autocompleteStrings[$groupName] = $groupName . $this->suffixToIdentifyGroups;
 			}
 		} else {
 			$autocompleteStrings = $groupNames . $this->suffixToIdentifyGroups;

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -6,69 +6,107 @@ So that I can efficiently share my files with other users or groups
 
 	Background:
 		Given these users have been created but not initialized:
-			| username    | password | displayname  | email                 |
-			| user1       | 1234     | User One     | u1@oc.com.np          |
-			| user2       | 1234     | User Two     | u2@oc.com.np          |
-			| user3       | 1234     | User Three   | u2@oc.com.np          |
-			| usergrp     | 1234     | User Grp     | u@oc.com.np           |
-			| regularuser | 1234     | User Regular | regularuser@oc.com.np |
+			| username    | password | displayname     | email                 |
+			| user1       | 1234     | User One        | u1@oc.com.np          |
+			| two         | 1234     | User Two        | u2@oc.com.np          |
+			| user3       | 1234     | Three           | u3@oc.com.np          |
+			| u444        | 1234     | Four            | u3@oc.com.np          |
+			| usergrp     | 1234     | User Ggg        | u@oc.com.np           |
+			| five        | 1234     | User Group      | five@oc.com.np        |
+			| regularuser | 1234     | User Regular    | regularuser@oc.com.np |
+			| usersmith   | 1234     | John Finn Smith | js@oc.com.np          |
 		And these groups have been created:
-			|groupname|
-			|group1     |
-			|group2     |
-			|group3     |
-			|groupuser  |
+			| groupname     |
+			| finance1      |
+			| finance2      |
+			| finance3      |
+			| users-finance |
+			| other         |
 		And the user has browsed to the login page
-		And the user has logged in with username "regularuser" and password "1234" using the webUI
-		And the user has browsed to the files page
 
 	@skipOnLDAP @user_ldap#175
 	Scenario: autocompletion of regular existing users
-		Given the user has opened the share dialog for the folder "simple-folder"
-		When the user types "user" in the share-with-field
-		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI
+		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has browsed to the files page
+		And the user has opened the share dialog for the folder "simple-folder"
+		When the user types "us" in the share-with-field
+		Then all users and groups that contain the string "us" in their name should be listed in the autocomplete list on the webUI
 		And the users own name should not be listed in the autocomplete list on the webUI
 		
 	Scenario: autocompletion of regular existing groups
-		Given the user has opened the share dialog for the folder "simple-folder"
-		When the user types "grou" in the share-with-field
-		Then all users and groups that contain the string "grou" in their name should be listed in the autocomplete list on the webUI
+		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has browsed to the files page
+		And the user has opened the share dialog for the folder "simple-folder"
+		When the user types "fi" in the share-with-field
+		Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI
 		And the users own name should not be listed in the autocomplete list on the webUI
 		
 	Scenario: autocompletion for a pattern that does not match any user or group
-		Given the user has opened the share dialog for the folder "simple-folder"
+		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has browsed to the files page
+		And the user has opened the share dialog for the folder "simple-folder"
 		When the user types "doesnotexist" in the share-with-field
 		Then a tooltip with the text "No users or groups found for doesnotexist" should be shown near the share-with-field on the webUI
 		And the autocomplete list should not be displayed on the webUI
 
 	@skipOnLDAP
-	Scenario: autocomplete short user names when completely typed
-		Given these users have been created but not initialized:
-			| username  | password | displayname  | email                 |
-			| uu1       | 1234     | UU One       | uu1@oc.com.np         |
+	Scenario: autocomplete short user/display names when completely typed
+		Given the administrator has set the minimum characters for sharing autocomplete to "4"
+		And the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has browsed to the files page
+		And these users have been created but not initialized:
+			| username | password | displayname | email        |
+			| use      | 1234     | Use         | uz@oc.com.np |
 		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "uu1" in the share-with-field
-		Then all users and groups that contain the string "uu1" in their name should be listed in the autocomplete list on the webUI
+		When the user types "Use" in the share-with-field
+		Then only "Use" should be listed in the autocomplete list on the webUI
 
 	@skipOnLDAP
-	Scenario: autocompletion when not enough characters typed
-		Given the administrator has set the minimum characters for sharing autocomplete to "8"
+	Scenario: autocomplete short group names when completely typed
+		Given the administrator has set the minimum characters for sharing autocomplete to "3"
+		And these groups have been created:
+			| groupname |
+			| fi        |
+		And the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has browsed to the files page
 		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "use" in the share-with-field
-		Then a tooltip with the text "No users or groups found for use Please enter at least 8 characters for suggestions" should be shown near the share-with-field on the webUI
+		When the user types "fi" in the share-with-field
+		Then only "fi (group)" should be listed in the autocomplete list on the webUI
+
+	@skipOnLDAP
+	Scenario: autocompletion when minimum characters is the default (2) and not enough characters are typed
+		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has browsed to the files page
+		And the user has opened the share dialog for the folder "simple-folder"
+		When the user types "u" in the share-with-field
+		Then a tooltip with the text "No users or groups found for u Please enter at least 2 characters for suggestions" should be shown near the share-with-field on the webUI
 		And the autocomplete list should not be displayed on the webUI
 
 	@skipOnLDAP
-	Scenario: autocompletion when changing minimum characters for sharing autocomplete
-		Given the administrator has set the minimum characters for sharing autocomplete to "2"
+	Scenario: autocompletion when minimum characters is increased and not enough characters are typed
+		Given the administrator has set the minimum characters for sharing autocomplete to "4"
+		And the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has browsed to the files page
 		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "us" in the share-with-field
-		Then all users and groups that contain the string "us" in their name should be listed in the autocomplete list on the webUI
+		When the user types "use" in the share-with-field
+		Then a tooltip with the text "No users or groups found for use Please enter at least 4 characters for suggestions" should be shown near the share-with-field on the webUI
+		And the autocomplete list should not be displayed on the webUI
+
+	@skipOnLDAP
+	Scenario: autocompletion when increasing the minimum characters for sharing autocomplete
+		Given the administrator has set the minimum characters for sharing autocomplete to "3"
+		And the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has browsed to the files page
+		And the user has opened the share dialog for the folder "simple-folder"
+		When the user types "use" in the share-with-field
+		Then all users and groups that contain the string "use" in their name should be listed in the autocomplete list on the webUI
 		And the users own name should not be listed in the autocomplete list on the webUI
 
 	@skipOnLDAP @user_ldap#175
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
-		Given the user has shared the folder "simple-folder" with the user "User One" using the webUI
+		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has browsed to the files page
+		And the user has shared the folder "simple-folder" with the user "User One" using the webUI
 		And the user has opened the share dialog for the folder "simple-folder"
 		When the user types "user" in the share-with-field
 		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User One"
@@ -76,23 +114,28 @@ So that I can efficiently share my files with other users or groups
 
 	@skipOnLDAP @user_ldap#175
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (file)
-		Given the user has shared the file "data.zip" with the user "User Grp" using the webUI
+		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has browsed to the files page
+		And the user has shared the file "data.zip" with the user "User Ggg" using the webUI
 		And the user has opened the share dialog for the file "data.zip"
 		When the user types "user" in the share-with-field
-		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Grp"
+		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Ggg"
 		And the users own name should not be listed in the autocomplete list on the webUI
 	
 	Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
-		Given the user shares the folder "simple-folder" with the group "group1" using the webUI
+		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has browsed to the files page
+		And the user shares the folder "simple-folder" with the group "finance1" using the webUI
 		And the user has opened the share dialog for the folder "simple-folder"
-		When the user types "grou" in the share-with-field
-		Then all users and groups that contain the string "grou" in their name should be listed in the autocomplete list on the webUI except group "group1"
+		When the user types "fi" in the share-with-field
+		Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
 		And the users own name should not be listed in the autocomplete list on the webUI
 
 	Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (file)
-		Given the user shares the file "data.zip" with the group "groupuser" using the webUI
+		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has browsed to the files page
+		And the user shares the file "data.zip" with the group "finance1" using the webUI
 		And the user has opened the share dialog for the file "data.zip"
-		When the user types "grou" in the share-with-field
-		Then all users and groups that contain the string "grou" in their name should be listed in the autocomplete list on the webUI except group "groupuser"
+		When the user types "fi" in the share-with-field
+		Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
 		And the users own name should not be listed in the autocomplete list on the webUI
-

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -52,9 +52,10 @@ So that I can efficiently share my files with other users or groups
 
 	@skipOnLDAP
 	Scenario: autocompletion when not enough characters typed
-		Given the user has opened the share dialog for the folder "simple-folder"
+		Given the administrator has set the minimum characters for sharing autocomplete to "8"
+		And the user has opened the share dialog for the folder "simple-folder"
 		When the user types "use" in the share-with-field
-		Then a tooltip with the text "No users or groups found for use" should be shown near the share-with-field on the webUI
+		Then a tooltip with the text "No users or groups found for use Please enter at least 8 characters for suggestions" should be shown near the share-with-field on the webUI
 		And the autocomplete list should not be displayed on the webUI
 
 	@skipOnLDAP


### PR DESCRIPTION
## Description
1) Make a more interesting list of users and groups for the tests - that have userid and display name that do not both match, where group names like "finance" match with user display names like "John Finn Smith" and so on.
2) Make the acceptance test code expect case-insensitive matches on user-id, display-name and group-id - so it will expect a lot more stuff in the auto-complete list.
3) Make the acceptance test code count how many things it matched, and assert that the auto-complete list is that big. i.e. there are not "bonus" matches in the list.
4) Add a step that more easily tests for a single match.
5) Re-order test setup steps - we have to change ``user.search_min_length`` before the user logs in and gets to the files page, otherwise their JavaScript does not know the current value of that setting, and so we do not always get the expected behavior.

## Related Issue
#31137 

## Motivation and Context
The autoCompletion webUI tests are not so great - make them great (again?)
Actually the auto-complete matches on group-id, user-id and user-display-name. If you try to share with "fin" then you will get matches in the list for "finance (group)", "John Finn" (display name), "fin123" (user-id - it will show the display name, which might not even contain "fin"). The matching is case-insensitive.
So the tests should check this range of matching.

## How Has This Been Tested?
Local webUI test runs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
