### PR TITLE
occ files:scan fix groups with comma, plus tests 

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -107,8 +107,8 @@ class Scan extends Base {
 			->addOption(
 				'groups',
 				'g',
-				InputArgument::OPTIONAL,
-				'Scan user(s) under the group(s). This option can be used as --groups=foo,bar to scan groups foo and bar'
+				InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED,
+				'Scan user(s) under the group(s). This option can be used as --groups=foo --groups=bar to scan groups foo and bar'
 			)
 			->addOption(
 				'quiet',
@@ -276,7 +276,7 @@ class Scan extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$inputPath = $input->getOption('path');
-		$groups = $input->getOption('groups') ? \explode(',', $input->getOption('groups')) : [];
+		$groups = $input->getOption('groups');
 		$shouldRepairStoragesIndividually = (bool) $input->getOption('repair');
 
 		if (\count($groups) >= 1) {

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -105,10 +105,10 @@ class Scan extends Base {
 				'Limit rescan to this path, e.g., --path="/alice/files/Music", the user_id is determined by the path and the user_id parameter and --all are ignored.'
 			)
 			->addOption(
-				'groups',
+				'group',
 				'g',
 				InputOption::VALUE_IS_ARRAY|InputOption::VALUE_REQUIRED,
-				'Scan user(s) under the group(s). This option can be used as --groups=foo --groups=bar to scan groups foo and bar'
+				'Scan user(s) under the group(s). This option can be used as --group=foo --group=bar to scan groups foo and bar'
 			)
 			->addOption(
 				'quiet',
@@ -276,7 +276,7 @@ class Scan extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$inputPath = $input->getOption('path');
-		$groups = $input->getOption('groups');
+		$groups = $input->getOption('group');
 		$shouldRepairStoragesIndividually = (bool) $input->getOption('repair');
 
 		if (\count($groups) >= 1) {

--- a/apps/files/tests/Command/ScanTest.php
+++ b/apps/files/tests/Command/ScanTest.php
@@ -140,8 +140,9 @@ class ScanTest extends TestCase {
 
 	public function dataInput() {
 		return [
-			[['--groups' => 'haystack'], 'Group name haystack doesn\'t exist'],
-			[['--groups' => 'group1'], 'Starting scan for user 1 out of 1 (user1)'],
+			[['--groups' => ['haystack']], 'Group name haystack doesn\'t exist'],
+			[['--groups' => ['haystack,barn']], 'Group name haystack,barn doesn\'t exist'],
+			[['--groups' => ['group1']], 'Starting scan for user 1 out of 1 (user1)'],
 			[['user_id' => ['user1']], 'Starting scan for user 1 out of 1 (user1)'],
 			[['user_id' => ['user2']], 'Starting scan for user 1 out of 1 (user2)']
 		];
@@ -158,7 +159,7 @@ class ScanTest extends TestCase {
 
 	public function userInputData() {
 		return [
-			[['--groups' => 'group1'], 'Starting scan for user 1 out of 200']
+			[['--groups' => ['group1']], 'Starting scan for user 1 out of 200']
 		];
 	}
 
@@ -171,7 +172,7 @@ class ScanTest extends TestCase {
 		//First we populate the users
 		$user = 'user';
 		$numberOfUsersInGroup = 210;
-		for ($i = 2; $i <= 210; $i++) {
+		for ($i = 2; $i <= $numberOfUsersInGroup; $i++) {
 			$userObj = $this->createUser($user.$i);
 			$this->groupManager->get('group1')->addUser($userObj);
 		}
@@ -180,13 +181,13 @@ class ScanTest extends TestCase {
 		$output = $this->commandTester->getDisplay();
 		$this->assertContains($expectedOutput, $output);
 		//If pagination works then below assert shouldn't fail
-		$this->assertNotContains('Starting scan for user 1 out of 210', $output);
+		$this->assertNotContains("Starting scan for user 1 out of $numberOfUsersInGroup", $output);
 	}
 
 	public function multipleGroupTest() {
 		return [
-			[['--groups' => 'group1,group2'], ''],
-			[['--groups' => 'group1,group2,group3'], '']
+			[['--groups' => ['group1,x','group2']], ''],
+			[['--groups' => ['group1','group2,x','group3']], '']
 		];
 	}
 
@@ -196,7 +197,7 @@ class ScanTest extends TestCase {
 	 */
 	public function testMultipleGroups($input) {
 		//Create 10 users in each group
-		$groups = \explode(',', $input['--groups']);
+		$groups = $input['--groups'];
 		$user = "user";
 		$userObj = [];
 		for ($i = 1; $i <= (10 * \count($groups)); $i++) {

--- a/apps/files/tests/Command/ScanTest.php
+++ b/apps/files/tests/Command/ScanTest.php
@@ -140,9 +140,9 @@ class ScanTest extends TestCase {
 
 	public function dataInput() {
 		return [
-			[['--groups' => ['haystack']], 'Group name haystack doesn\'t exist'],
-			[['--groups' => ['haystack,barn']], 'Group name haystack,barn doesn\'t exist'],
-			[['--groups' => ['group1']], 'Starting scan for user 1 out of 1 (user1)'],
+			[['--group' => ['haystack']], 'Group name haystack doesn\'t exist'],
+			[['--group' => ['haystack,barn']], 'Group name haystack,barn doesn\'t exist'],
+			[['--group' => ['group1']], 'Starting scan for user 1 out of 1 (user1)'],
 			[['user_id' => ['user1']], 'Starting scan for user 1 out of 1 (user1)'],
 			[['user_id' => ['user2']], 'Starting scan for user 1 out of 1 (user2)']
 		];
@@ -159,7 +159,7 @@ class ScanTest extends TestCase {
 
 	public function userInputData() {
 		return [
-			[['--groups' => ['group1']], 'Starting scan for user 1 out of 200']
+			[['--group' => ['group1']], 'Starting scan for user 1 out of 200']
 		];
 	}
 
@@ -186,8 +186,8 @@ class ScanTest extends TestCase {
 
 	public function multipleGroupTest() {
 		return [
-			[['--groups' => ['group1,x','group2']], ''],
-			[['--groups' => ['group1','group2,x','group3']], '']
+			[['--group' => ['group1,x','group2']], ''],
+			[['--group' => ['group1','group2,x','group3']], '']
 		];
 	}
 
@@ -197,7 +197,7 @@ class ScanTest extends TestCase {
 	 */
 	public function testMultipleGroups($input) {
 		//Create 10 users in each group
-		$groups = $input['--groups'];
+		$groups = $input['--group'];
 		$user = "user";
 		$userObj = [];
 		for ($i = 1; $i <= (10 * \count($groups)); $i++) {

--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -16,6 +16,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली                                   | Unicode group name                       |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -18,6 +18,7 @@ So that I can give a user access to the resources of the group
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली              | Unicode group name                      |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -17,6 +17,7 @@ So that I can remove unnecessary groups
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली              | Unicode group name                      |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -20,6 +20,7 @@ So that I can manage user access to group resources
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली              | Unicode group name                      |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -16,6 +16,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली                                   | Unicode group name                       |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -18,6 +18,7 @@ So that I can give a user access to the resources of the group
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली              | Unicode group name                      |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -17,6 +17,7 @@ So that I can remove unnecessary groups
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली              | Unicode group name                      |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -20,6 +20,7 @@ So that I can manage user access to group resources
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली              | Unicode group name                      |
 			| 0                   | The "false" group                       |

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1637,6 +1637,15 @@ class ManagerTest extends \Test\TestCase {
 		// New list only groups in common
 		$data[] = ['yes', \json_encode(['group1', 'group2']), null, ['group2'], true];
 
+		// New list partly in common, group names containing comma
+		$data[] = ['yes', \json_encode(['group1,a', 'group2']), null, ['group1,a', 'group3'], true];
+		$data[] = ['yes', \json_encode(['group1,a', 'group2,b']), null, ['group1,a', 'group3'], true];
+		$data[] = ['yes', \json_encode(['group1,a', 'group2']), null, ['group1,a', 'group3,c'], true];
+
+		// New list only groups in common, group names containing comma
+		$data[] = ['yes', \json_encode(['group1', 'group2,a']), null, ['group2,a'], true];
+		$data[] = ['yes', \json_encode(['group1,a', 'group2,a']), null, ['group2,a'], true];
+
 		return $data;
 	}
 


### PR DESCRIPTION
## Description
1) Test that groups containing a comma work OK in the Provisioning API.
2) Test that groups containing a comma work OK in the "excluded from sharing" group list.
3) Adjust the ``files_scan`` command so that the groups to scan are not put in a comma-separated list. Instead, list the groups to be scanned like ``--group=foo --group=bar`` - this allows specifying group names that contain commas.

## Related Issue
#31578 
#31835

## Motivation and Context
@tomneedham asked if comma is allowed in group names - this demonstrates that it works in the Provisioning API.

## How Has This Been Tested?
Local test runs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test enhancement

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. https://github.com/owncloud/documentation/issues/4215
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
