### PR TITLE
[stable10] Restrict group admin create groups using userprovision API

### DIFF
--- a/apps/provisioning_api/lib/Groups.php
+++ b/apps/provisioning_api/lib/Groups.php
@@ -116,9 +116,8 @@ class Groups{
 			}, $users);
 			$users = array_values($users);
 			return new OC_OCS_Result(['users' => $users]);
-		} else {
-			return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED, 'User does not have access to specified group');
 		}
+		return new OC_OCS_Result(null, \OCP\API::RESPOND_UNAUTHORISED, 'User does not have access to specified group');
 	}
 
 	/**
@@ -138,8 +137,17 @@ class Groups{
 		if($this->groupManager->groupExists($groupId)){
 			return new OC_OCS_Result(null, 102);
 		}
-		$this->groupManager->createGroup($groupId);
-		return new OC_OCS_Result(null, 100);
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return new OC_OCS_Result(null, 102);
+		}
+		// Only admin has got privilege to create group
+		if ($this->groupManager->isAdmin($user->getUID())) {
+			$this->groupManager->createGroup($groupId);
+			return new OC_OCS_Result(null, 100);
+		}
+
+		return new OC_OCS_Result(null, 997);
 	}
 
 	/**
@@ -150,12 +158,12 @@ class Groups{
 		// Check it exists
 		if(!$this->groupManager->groupExists($parameters['groupid'])){
 			return new OC_OCS_Result(null, 101);
-		} else if($parameters['groupid'] === 'admin' || !$this->groupManager->get($parameters['groupid'])->delete()){
+		}
+		if($parameters['groupid'] === 'admin' || !$this->groupManager->get($parameters['groupid'])->delete()){
 			// Cannot delete admin group
 			return new OC_OCS_Result(null, 102);
-		} else {
-			return new OC_OCS_Result(null, 100);
 		}
+		return new OC_OCS_Result(null, 100);
 	}
 
 	/**

--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -47,13 +47,12 @@ So that I can more easily manage access to resources by groups rather than indiv
 		And the HTTP status code should be "401"
 		And group "new-group" should not exist
 
-	@skip @issue-31283
 	Scenario: subadmin tries to create a group
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
 			| groupid   | another-group   |
-		Then the OCS status code should be "102"
-		And the HTTP status code should be "200"
+		Then the OCS status code should be "997"
+		And the HTTP status code should be "401"
 		And group "another-group" should not exist

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -48,13 +48,12 @@ So that I can more easily manage access to resources by groups rather than indiv
 		And the HTTP status code should be "401"
 		And group "new-group" should not exist
 
-	@skip @issue-31283
 	Scenario: subadmin tries to create a group
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
 			| groupid   | another-group   |
-		Then the OCS status code should be "401"
+		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And group "another-group" should not exist


### PR DESCRIPTION
Using userprovision API, restrict group admin create
groups. Its against the design.
Also made minor changes in the method deleteGroup
for better code readability.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Subadmin or group admin should not be able to create groups. This is violated when clients tries to create groups using userprovision API. This change helps to restrict group admins to create groups.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/31283

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Subadmin or group admin should not be able to create groups. This is violated when clients tries to create groups using userprovision API. This change helps to restrict group admins to create groups.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] Tested using version 1 and version 2 as follows:
```
➜  owncloud3 git:(master) ✗ curl http://admin:admin@localhost/testing3/ocs/v2.php/cloud/groups -d groupid="a3"
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>200</statuscode>
  <message/>
 </meta>
 <data/>
</ocs>
➜  owncloud3 git:(master) ✗ curl http://user1:1@localhost/testing3/ocs/v2.php/cloud/groups -d groupid="a3a"   
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>400</statuscode>
  <message/>
 </meta>
 <data/>
</ocs>
➜  owncloud3 git:(master) ✗ curl http://admin:admin@localhost/testing3/ocs/v1.php/cloud/groups -d groupid="a4"
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>100</statuscode>
  <message/>
 </meta>
 <data/>
</ocs>
➜  owncloud3 git:(master) ✗ curl http://user1:1@localhost/testing3/ocs/v1.php/cloud/groups -d groupid="a4"    
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>failure</status>
  <statuscode>102</statuscode>
  <message/>
 </meta>
 <data/>
</ocs>
➜  owncloud3 git:(master) ✗ 
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

