### PR TITLE
Skip autocompletion tests on LDAP - they rely on a complex user and g…

### DIFF
--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -32,7 +32,8 @@ So that I can efficiently share my files with other users or groups
 		When the user types "us" in the share-with-field
 		Then all users and groups that contain the string "us" in their name should be listed in the autocomplete list on the webUI
 		And the users own name should not be listed in the autocomplete list on the webUI
-		
+
+	@skipOnLDAP
 	Scenario: autocompletion of regular existing groups
 		Given the user has logged in with username "regularuser" and password "1234" using the webUI
 		And the user has browsed to the files page
@@ -121,7 +122,8 @@ So that I can efficiently share my files with other users or groups
 		When the user types "user" in the share-with-field
 		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Ggg"
 		And the users own name should not be listed in the autocomplete list on the webUI
-	
+
+	@skipOnLDAP
 	Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
 		Given the user has logged in with username "regularuser" and password "1234" using the webUI
 		And the user has browsed to the files page
@@ -131,6 +133,7 @@ So that I can efficiently share my files with other users or groups
 		Then all users and groups that contain the string "fi" in their name should be listed in the autocomplete list on the webUI except group "finance1"
 		And the users own name should not be listed in the autocomplete list on the webUI
 
+	@skipOnLDAP
 	Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (file)
 		Given the user has logged in with username "regularuser" and password "1234" using the webUI
 		And the user has browsed to the files page


### PR DESCRIPTION
…roup list

Signed-off-by: Phil Davis <phil@jankaritech.com>

## Description
Skip sharing auto-complete test scenarios on LDAP (older scenarios were already skipped).
Because they rely on having a more complex mix of users and groups than are set up in the LDAP tests at the moment.

## Related Issue
#31747 

## Motivation and Context
New sharing autocomplete tests were added to better check the autocomplete matches under a mix of user ids, group ids and user display names. PR #31714 and backport #31729 
Those tests require a suitable mix of users, display names and groups to exist. But ``user_ldap`` acceptance tests currently have a fixed list of users and groups.
So skip these scenarios on LDAP test runs.
We can add some more simple scenarios to the LDAP tests to check the autocomplete behavior there.

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix to acceptance tests

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
