### PR TITLE
Make acceptance test function getUserDisplayName more robust

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -85,7 +85,7 @@ trait Provisioning {
 	 * returns the display name of the current user
 	 * if no "Display Name" is set the user-name is returned instead
 	 *
-	 * @return array
+	 * @return string
 	 */
 	public function getCurrentUserDisplayName() {
 		return $this->getUserDisplayName($this->getCurrentUser());
@@ -93,18 +93,20 @@ trait Provisioning {
 
 	/**
 	 * returns the display name of a user
-	 * if no "Display Name" is set the user-name is returned instead
+	 * if no "Display Name" is set the username is returned instead
 	 *
 	 * @param string $username
 	 *
-	 * @return array
+	 * @return string
 	 */
 	public function getUserDisplayName($username) {
-		$displayName = $this->createdUsers[$username]['displayname'];
-		if (($displayName === null) || ($displayName === '')) {
-			$displayName = $username;
+		if (isset($this->createdUsers[$username]['displayname'])) {
+			$displayName = (string) $this->createdUsers[$username]['displayname'];
+			if ($displayName !== '') {
+				return $displayName;
+			}
 		}
-		return $displayName;
+		return $username;
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by: Phil Davis <phil@jankaritech.com>

## Description
Check if the ``displayname`` array entry for the user exists before accessing it.

## Related Issue
#31747 

## Motivation and Context
The code in ``getUserDisplayName()`` could fail with:
```
Notice: Undefined index: user1 in /var/www/owncloud/tests/acceptance/features/bootstrap/Provisioning.php line 103
```
if passed a username that it knew nothing about.
That happened in a scenario run from ``user_ldap`` app.
Make it more robust so that it returns the passed-in username if it cannot find a displayname.


## How Has This Been Tested?
Local run of:
```
bash tests/travis/start_ui_tests.sh --feature tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature:106
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test code fix

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
