### PR TITLE
Fix broken web setup page 

### DIFF
--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -1,4 +1,7 @@
 <?php
+
+use OCP\IConfig;
+
 /**
  * @author Björn Schießle <bjoern@schiessle.org>
  * @author Jan-Christoph Borchardt <hey@jancborchardt.net>
@@ -48,7 +51,7 @@ class OC_Defaults {
 	private $defaultLogoClaim;
 	private $defaultMailHeaderColor;
 	/**
-	 * @var \OCP\IConfig
+	 * @var IConfig
 	 */
 	private $config;
 
@@ -303,7 +306,11 @@ class OC_Defaults {
 	 * @return string
 	 */
 	public function getImprintUrl() {
-		return $this->config->getAppValue('core', 'legal.imprint_url', '');
+		try {
+			return $this->config->getAppValue('core', 'legal.imprint_url', '');
+		} catch (\Exception $e) {
+			return '';
+		}
 	}
 
 	/**
@@ -311,6 +318,19 @@ class OC_Defaults {
 	 * @return string
 	 */
 	public function getPrivacyPolicyUrl() {
-		return $this->config->getAppValue('core', 'legal.privacy_policy_url', '');
+		try {
+			return $this->config->getAppValue('core', 'legal.privacy_policy_url', '');
+		} catch (\Exception $e) {
+			return '';
+		}
+	}
+
+	/**
+	 * @internal Used for unit tests
+	 *
+	 * @param IConfig $config
+	 */
+	public function setConfig(IConfig $config) {
+		$this->config = $config;
 	}
 }


### PR DESCRIPTION
## Description
Fix chicken-egg regression in OC_Defaults

## Related Issue
Fixes https://github.com/owncloud/core/issues/31741

## Motivation and Context
Broken Web UI

## How Has This Been Tested?
1. `git clone git@github.com:owncloud/core.git test-install`
2. `cd test-install`
3. `make`
4. Open it in browser

### Expected
Setup page appears

### Actual 
Error page is printed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

