### PR TITLE
[POC]Introduce AMD style MOVE operation

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Server.php
+++ b/apps/dav/lib/Connector/Sabre/Server.php
@@ -25,6 +25,7 @@
 namespace OCA\DAV\Connector\Sabre;
 
 use OCA\DAV\DAV\CopyPlugin;
+use OCA\DAV\DAV\LazyOpsPlugin;
 
 /**
  * Class \OCA\DAV\Connector\Sabre\Server
@@ -44,5 +45,6 @@ class Server extends \Sabre\DAV\Server {
 		self::$exposeVersion = false;
 		$this->enablePropfindDepthInfinity = true;
 		$this->addPlugin(new CopyPlugin());
+		$this->addPlugin(new LazyOpsPlugin());
 	}
 }

--- a/apps/dav/lib/DAV/LazyOpsPlugin.php
+++ b/apps/dav/lib/DAV/LazyOpsPlugin.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\DAV;
+
+use OCA\DAV\Connector\Sabre\Exception\Forbidden;
+use OCA\DAV\Connector\Sabre\File;
+use OCA\DAV\Files\ICopySource;
+use OCP\Files\ForbiddenException;
+use OCP\Lock\ILockingProvider;
+use Sabre\DAV\Exception;
+use Sabre\DAV\IFile;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\Response;
+use Sabre\HTTP\ResponseInterface;
+
+/**
+ * Class LazyOpsPlugin
+ *
+ * @package OCA\DAV\DAV
+ */
+class LazyOpsPlugin extends ServerPlugin {
+
+	/** @var Server */
+	private $server;
+
+	/**
+	 * @param Server $server
+	 */
+	public function initialize(Server $server) {
+		$this->server = $server;
+		$server->on('method:MOVE', [$this, 'httpMove'], 90);
+//		$server->on('afterResponse', [$this, 'afterResponse']);
+	}
+
+	public function httpMove(RequestInterface $request, ResponseInterface $response) {
+		if (!$request->getHeader('OC-LazyOps')) {
+			return true;
+		}
+		$response->setStatus(202);
+		$response->addHeader('Connection', 'close');
+
+		\register_shutdown_function(function () use ($request, $response) {
+			return $this->afterResponse($request, $response);
+		});
+
+		return false;
+	}
+
+	public function afterResponse(RequestInterface $request, ResponseInterface $response) {
+		if (!$request->getHeader('OC-LazyOps')) {
+			return true;
+		}
+
+		\flush();
+		$request->removeHeader('OC-LazyOps');
+		$responseDummy = new Response();
+		try {
+			$this->server->emit('method:MOVE', [$request, $responseDummy]);
+		} catch (\Exception $ex) {
+			\OC::$server->getLogger()->logException($ex);
+		}
+	}
+}

--- a/apps/dav/lib/DAV/LazyOpsPlugin.php
+++ b/apps/dav/lib/DAV/LazyOpsPlugin.php
@@ -50,7 +50,6 @@ class LazyOpsPlugin extends ServerPlugin {
 	public function initialize(Server $server) {
 		$this->server = $server;
 		$server->on('method:MOVE', [$this, 'httpMove'], 90);
-//		$server->on('afterResponse', [$this, 'afterResponse']);
 	}
 
 	public function httpMove(RequestInterface $request, ResponseInterface $response) {

--- a/apps/dav/lib/Upload/FutureFile.php
+++ b/apps/dav/lib/Upload/FutureFile.php
@@ -112,7 +112,8 @@ class FutureFile implements \Sabre\DAV\IFile {
 	 * @inheritdoc
 	 */
 	public function delete() {
-		$this->root->delete();
+		// temporal hack to keep the folder alive
+//		$this->root->delete();
 	}
 
 	/**

--- a/apps/dav/lib/Upload/UploadHome.php
+++ b/apps/dav/lib/Upload/UploadHome.php
@@ -27,6 +27,7 @@ use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Directory;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\ICollection;
+use Sabre\HTTP\URLUtil;
 
 class UploadHome implements ICollection {
 	private $principalInfo;
@@ -67,7 +68,8 @@ class UploadHome implements ICollection {
 	}
 
 	public function getName() {
-		return 'uploads';
+		list(, $name) = URLUtil::splitPath($this->principalInfo['uri']);
+		return $name;
 	}
 
 	public function setName($name) {

--- a/apps/dav/lib/Upload/Xml/Status.php
+++ b/apps/dav/lib/Upload/Xml/Status.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\Upload\Xml;
+
+use Sabre\Xml\Writer;
+use Sabre\Xml\XmlSerializable;
+
+class Status implements XmlSerializable {
+	const NS_OWNCLOUD = 'http://owncloud.org/ns';
+	private $etag;
+	private $fileId;
+	private $progress;
+
+	public function __construct($progress, $fileId, $etag) {
+		$this->progress = $progress;
+		$this->fileId = $fileId;
+		$this->etag = $etag;
+	}
+
+	public function xmlSerialize(Writer $writer) {
+		switch ($this->progress) {
+			case 0:
+				$writer->writeElement('{' . self::NS_OWNCLOUD . '}progress', 'started');
+				break;
+			case 1:
+				$writer->writeElement('{' . self::NS_OWNCLOUD . '}progress', 'finished');
+				break;
+			default:
+				$writer->writeElement('{' . self::NS_OWNCLOUD . '}progress', 'not-started');
+				break;
+		}
+		if ($this->fileId !== null) {
+			$writer->writeElement('{' . self::NS_OWNCLOUD . '}fileId', $this->fileId);
+		}
+		if ($this->etag !== null) {
+			$writer->writeElement('{' . self::NS_OWNCLOUD . '}ETag', $this->etag);
+		}
+	}
+}


### PR DESCRIPTION
## Description
We want to avoid situations where the clients have to wait for the long MOVE operation on assembly to finish. The connection can be terminated by any reason before the server sends the response back to the client. And after that the client has no capability to query for the status of the assembly.

1. AMD - Asynchronous Method Dispatch
We return the http status code 202 right after we received the MOVE request. The client can then terminate the connection and knows that the server is working on it.
The implementation uses php's register_callback functionality to process the real MOVE *after* the response is sent to the client. register_callback can not be terminated by the system - we should be pretty save on this one .... 

2. Polling for status, success and error
The client can run a PROPFIND on the upload folder and receive additional properties to get an understanding of the assembly status:

Property | Description
---|---
progress | not-started, started, finished, error
fileId | the file id of the target file - set only once the MOVE was successful
ETag | the ETag of the file *after* MOVE on the target location - set only once the MOVE was successfull
errorCode | http error code - in case there was an error
errorMessage | there error message - in case of an error

3. Capabilities and LazyOps header

The server will announce to the clients via the capabilities API if this new mode of operations is available or not. A system config value is necessary to allow the admin to turn this feature explicitly on.

Furthermore in order not to break regular WebDAV client an additional http header is to be sent from the client to the server so that the server knows if this operation mode shall be used or not. 


## To discuss
MOVE will delete the source file (and due to the current implementation the whole source folder).
Because we need the source folder we can either switch over to COPY and the client issues a DELETE or we delete only the source folder and the contained chunks but keep the source folder and the client has to delete the source folder.

This mechanism only works for the chunked upload. It would be great to go one step further and develop a general purpose solution because there are other operations which can take a long time and potentially run into the described timeout issues as well.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
```
deepdiver@deepdiver:~$ curl -X MOVE  http://localhost:8080/remote.php/dav/files/admin/foo/IMG_101522156820911293053.jpeg -uadmin -H 'OC-LazyOps: true' -H 'Destination:  http://localhost:8080/remote.php/dav/files/admin/IMG.jpeg' -v
Enter host password for user 'admin':
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
* Server auth using Basic with user 'admin'
> MOVE /remote.php/dav/files/admin/foo/IMG_101522156820911293053.jpeg HTTP/1.1
> Host: localhost:8080
> Authorization: Basic YWRtaW46YWRtaW4=
> User-Agent: curl/7.60.0
> Accept: */*
> OC-LazyOps: true
> Destination:  http://localhost:8080/remote.php/dav/files/admin/IMG.jpeg
> 
< HTTP/1.1 202 Accepted
< Host: localhost:8080
< Date: Wed, 13 Jun 2018 14:23:59 +0000
< Connection: close
< X-Powered-By: PHP/7.1.16-1+b2
< Expires: Thu, 19 Nov 1981 08:52:00 GMT
< Cache-Control: no-store, no-cache, must-revalidate
< Pragma: no-cache
< Set-Cookie: oc_sessionPassphrase=zEgKseQ63rau9sXrZdshT5dz2KL0nKJ8Wpx09bo9YKHSo0pBlAoZ%2Fr0QLjr5%2FL8WERzf1QH08PODd%2BSI8NIIsl6xbcvdkhpual7CO5ecCv6OGEhrKbrh0E3vVZ3WfEsH; path=/; HttpOnly
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Robots-Tag: none
< X-Download-Options: noopen
< X-Permitted-Cross-Domain-Policies: none
< Content-Security-Policy: default-src 'none';
< Set-Cookie: oc48qu8iku2i=p6mo8boi9tfa3ufpb1495g6r5t; path=/; HttpOnly
< Set-Cookie: cookie_test=test; expires=Wed, 13-Jun-2018 15:23:43 GMT; Max-Age=3600
< Connection: close
< Content-type: text/html; charset=UTF-8
< 
* Closing connection 0

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

