### PR TITLE
[stable10] files_primary_s3 is not compatible with php5.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -581,12 +581,6 @@ matrix:
       INSTALL_SERVER: true
 
   # files_primary_s3
-    - PHP_VERSION: 5.6
-      TEST_SUITE: phpunit
-      DB_TYPE: sqlite
-      OBJECTSTORE: scality
-      PRIMARY_OBJECTSTORE: files_primary_s3
-      INSTALL_SERVER: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: phpunit


### PR DESCRIPTION

## Motivation and Context
with https://github.com/owncloud/files_primary_s3/pull/84 - it became hard dependency to require php7.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] ci related

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

