### PR TITLE
Reload the filelist view when accepting or rejecting a share

### DIFF
--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -118,10 +118,16 @@ OCA.Sharing.App = {
 		}
 	},
 
+	registerNotificationHandler: function() {
+		this._onNotificationEvent = _.bind(this._onNotificationEvent, this);
+		$('body').on('OCA.Notification.Action', this._onNotificationEvent);
+	},
+
 	/**
 	 * Destroy the app
 	 */
 	destroy: function() {
+		$('body').off('OCA.Notification.Action', this._onNotificationEvent);
 		OCA.Files.fileActions.off('setDefault.app-sharing', this._onActionsUpdated);
 		OCA.Files.fileActions.off('registerAction.app-sharing', this._onActionsUpdated);
 		this.removeSharingIn();
@@ -131,6 +137,19 @@ OCA.Sharing.App = {
 		this._outFileList = null;
 		this._linkFileList = null;
 		delete this._globalActionsInitialized;
+	},
+
+	_onNotificationEvent: function(e) {
+		if (e.notification.app === 'files_sharing') {
+			if (this._inFileList) {
+				this._inFileList.reload();
+			}
+			if (e.action.type === 'POST' && OCA.Files && OCA.Files.App && OCA.Files.App.fileList) {
+				// reload the file list only if the share is accepted
+				// both internal sharing and remote sharing
+				OCA.Files.App.fileList.reload();
+			}
+		}
 	},
 
 	_createFileActions: function() {
@@ -319,5 +338,6 @@ $(document).ready(function() {
 	$('#app-content-sharinglinks').on('hide', function() {
 		OCA.Sharing.App.removeSharingLinks();
 	});
+	OCA.Sharing.App.registerNotificationHandler();
 });
 

--- a/apps/files_sharing/tests/js/appSpec.js
+++ b/apps/files_sharing/tests/js/appSpec.js
@@ -310,8 +310,8 @@ describe('OCA.Sharing.App tests', function() {
 			});
 			$('body').trigger(ev);
 
-			expect(1).toEqual(fileListInReloadStub.callCount);
-			expect(1).toEqual(appReloadStub.callCount);
+			expect(fileListInReloadStub.callCount).toEqual(1);
+			expect(appReloadStub.callCount).toEqual(1);
 		});
 		it('reject share only triggers reload of sharein fileList', function() {
 			var ev = new $.Event('OCA.Notification.Action', {
@@ -325,7 +325,7 @@ describe('OCA.Sharing.App tests', function() {
 			});
 			$('body').trigger(ev);
 
-			expect(1).toEqual(fileListInReloadStub.callCount);
+			expect(fileListInReloadStub.callCount).toEqual(1);
 			expect(appReloadStub.notCalled).toEqual(true);
 		});
 		it('ignore events from notifications not related to files_sharing', function() {
@@ -357,8 +357,8 @@ describe('OCA.Sharing.App tests', function() {
 			App.destroy();
 			$('body').trigger(ev);
 
-			expect(0).toEqual(fileListInReloadStub.callCount);
-			expect(0).toEqual(appReloadStub.callCount);
+			expect(fileListInReloadStub.notCalled).toEqual(true);
+			expect(appReloadStub.notCalled).toEqual(true);
 		});
 	});
 });


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
The "all files" list will be reloaded when a share notification is accepted, either local or remote.
The "shared with you" list will be reloaded when any action for a share notification (local or remote) is taken.

As remark, the "all files" list won't be reloaded if the share is rejected.

## Related Issue
https://github.com/owncloud/core/issues/31549

## Motivation and Context
User would need to manually reload the page to see the changes.

## How Has This Been Tested?
Manually tested

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


I haven't found a good way to trigger the reload of the "all files" list. Right now there is an explicit dependency between the files_sharing and files app (the `OCA.Files.App.fileList.reload()` call). For now this is the easiest way to fix the problem.

We might want to refine when we want to reload the "all files" view in order to reload only if the file would appear in the current folder.