### PR TITLE
[stable10] Optimize PUT - don't fetch and update checksum again, reuse the one from part file

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -256,18 +256,6 @@ class File extends Node implements IFile, IFileNode {
 			}
 
 			$this->refreshInfo();
-
-			$meta = $partStorage->getMetaData($internalPartPath);
-
-			if (isset($meta['checksum'])) {
-				$this->fileView->putFileInfo(
-					$this->path,
-					['checksum' => $meta['checksum']]
-				);
-			}
-
-			$this->refreshInfo();
-
 		} catch (StorageNotAvailableException $e) {
 			throw new ServiceUnavailable("Failed to check file size: " . $e->getMessage());
 		}

--- a/lib/private/Files/Stream/Checksum.php
+++ b/lib/private/Files/Stream/Checksum.php
@@ -133,11 +133,47 @@ class Checksum extends Wrapper {
 	}
 
 	/**
+	 * Remove .part extension from a file path
+	 * @param string $path Path that may identify a .part file
+	 * @return string File path without .part extension
+	 */
+	private function stripPartialFileExtension($path) {
+		$extension = pathinfo($path, PATHINFO_EXTENSION);
+
+		if ( $extension === 'part') {
+
+			$newLength = strlen($path) - 5; // 5 = strlen(".part")
+			$fPath = substr($path, 0, $newLength);
+
+			// if path also contains a transaction id, we remove it too
+			$extension = pathinfo($fPath, PATHINFO_EXTENSION);
+			if(substr($extension, 0, 12) === 'ocTransferId') { // 12 = strlen("ocTransferId")
+				$newLength = strlen($fPath) - strlen($extension) -1;
+				$fPath = substr($fPath, 0, $newLength);
+			}
+			return $fPath;
+
+		} else {
+			return $path;
+		}
+	}
+
+	/**
+	 * Make checksums available for part files and the original file for which part file has been created
 	 * @return bool
 	 */
 	public function stream_close() {
 		$currentPath = $this->getPathFromStreamContext();
-		self::$checksums[$currentPath] = $this->finalizeHashingContexts();
+		$checksum = $this->finalizeHashingContexts();
+		self::$checksums[$currentPath] = $checksum;
+
+		// If current path belongs to part file, save checksum for original file
+		// As a result, call to getChecksums for original file (of this part file) will
+		// fetch checksum from cache
+		$originalFilePath = $this->stripPartialFileExtension($currentPath);
+		if ($originalFilePath !== $currentPath){
+			self::$checksums[$originalFilePath] = $checksum;
+		}
 
 		return parent::stream_close();
 	}


### PR DESCRIPTION
### Description

Backport of https://github.com/owncloud/core/pull/27532

@PVince81 @DeepDiver1975 

### How did I test?

This fix impacts most objectstorage (filesystem has only few less)

Files_primary_s3 on stable 10 - new file creation

Stable10 - 154 queries
```
{"type":"SUMMARY","reqId":"VbMK5uxQcqJhL0pzrgi5","time":"2018-06-13T18:12:58+00:00","remoteAddr":"::1","user":"admin","method":"PUT","url":"\/octest\/remote.php\/dav\/files\/admin\/testnew.txt","diagnostics":{**"totalSQLQueries":152**,"totalSQLDurationmsec":23.319721221923828,"totalSQLParams":343,"totalEvents":16,"totalEventsDurationmsec":77.06665992736816}}
```

With the fix for stable10 -136 queries 
```
{"type":"SUMMARY","reqId":"OMqwXagbZJJcByxHvTfs","time":"2018-06-13T18:20:07+00:00","remoteAddr":"::1","user":"admin","method":"PUT","url":"\/octest\/remote.php\/dav\/files\/admin\/testnew.txt","diagnostics":{**"totalSQLQueries":136**,"totalSQLDurationmsec":16.814231872558594,"totalSQLParams":310,"totalEvents":16,"totalEventsDurationmsec":106.22668266296387}}
```