### PR TITLE
Do not throw an error when the same theme enabled twice

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -253,6 +253,9 @@ class AppManager implements IAppManager {
 		) {
 			$apps = $this->getInstalledApps();
 			foreach ($apps as $installedAppId) {
+				if ($installedAppId === $appId) {
+					continue;
+				}
 				if ($this->isTheme($installedAppId)) {
 					throw new AppManagerException("$appId can't be enabled until $installedAppId is disabled.");
 				}


### PR DESCRIPTION
## Description
>I shouldn't get a serious exception when I enable an app a 2nd time. Other apps doesn't have this problem

TL;DR
#31475 

## Related Issue
Fixes #31475 

## Motivation and Context
https://github.com/owncloud/core/issues/31475#issuecomment-390200916

## How Has This Been Tested?
enabling the same the twice with no error:
```
deo@jah-mobile:> php occ app:enable theme-example
theme-example enabled
deo@jah-mobile:> php occ app:enable theme-example
theme-example enabled
```

enabling a different theme (exception is expected in this case):
```
> php occ app:enable theme-hey

In AppManager.php line 260:
                                                               
  theme-hey can't be enabled until theme-example is disabled.  
                                                               

app:enable [-g|--groups GROUPS] [--] <app-id>
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

