### PR TITLE
Align master and stable10 run.sh

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -115,8 +115,6 @@ ${OCC} config:system:set sharing.federation.allowHttpFallback --type boolean --v
 ${OCC} config:app:set core enable_external_storage --value=yes
 ${OCC} config:system:set files_external_allow_create_new_local --value=true
 
-PREVIOUS_TESTING_APP_STATUS=$(${OCC} --no-warnings app:list "^testing$")
-
 #Enable and disable apps as required for default
 if [ -z "${APPS_TO_DISABLE}" ]
 then
@@ -196,7 +194,7 @@ else
 	BEHAT_FILTER_TAGS="~@skip&&~@masterkey_encryption"
 fi
 
-if [ "$OC_TEST_ON_OBJECTSTORE" = "1" ]
+if [ "${OC_TEST_ON_OBJECTSTORE}" = "1" ]
 then
    	BEHAT_FILTER_TAGS="${BEHAT_FILTER_TAGS}&&~@skip_on_objectstore"
 fi


### PR DESCRIPTION
## Description
1) Remove bonus ``PREVIOUS_TESTING_APP_STATUS`` line - it is done further down.
2) Format of ``OC_TEST_ON_OBJECTSTORE`` test

## Motivation and Context
In backport and forward port of the acceptance test ``run.sh`` a  couple of minor things became different between ``stable10`` and ``master``. Actually the ``stable10`` code is better! To align ``master`` to be the same.

## How Has This Been Tested?
CI knows.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
