### PR TITLE
Reorder the buttons for the internal share notification

### DIFF
--- a/apps/files_sharing/lib/Service/NotificationPublisher.php
+++ b/apps/files_sharing/lib/Service/NotificationPublisher.php
@@ -103,16 +103,16 @@ class NotificationPublisher {
 
 			$notification->setSubject('local_share', [$share->getShareOwner(), $share->getSharedBy(), $share->getNode()->getName()]);
 
+			$declineAction = $notification->createAction();
+			$declineAction->setLabel('decline');
+			$declineAction->setLink($endpointUrl, 'DELETE');
+			$notification->addAction($declineAction);
+
 			$acceptAction = $notification->createAction();
 			$acceptAction->setLabel('accept');
 			$acceptAction->setLink($endpointUrl, 'POST');
 			$acceptAction->setPrimary(true);
 			$notification->addAction($acceptAction);
-
-			$declineAction = $notification->createAction();
-			$declineAction->setLabel('decline');
-			$declineAction->setLink($endpointUrl, 'DELETE');
-			$notification->addAction($declineAction);
 
 			$this->notificationManager->notify($notification);
 		}

--- a/apps/files_sharing/tests/Service/NotificationPublisherTest.php
+++ b/apps/files_sharing/tests/Service/NotificationPublisherTest.php
@@ -210,20 +210,20 @@ class NotificationPublisherTest extends TestCase {
 			$action1 = $this->createMock(\OCP\Notification\IAction::class);
 			$action1->expects($this->once())
 				->method('setLabel')
-				->with('accept')
+				->with('decline')
 				->will($this->returnSelf());
 			$action1->expects($this->once())
 				->method('setLink')
-				->with($endpointUrl, 'POST')
+				->with($endpointUrl, 'DELETE')
 				->will($this->returnSelf());
 			$action2 = $this->createMock(\OCP\Notification\IAction::class);
 			$action2->expects($this->once())
 				->method('setLabel')
-				->with('decline')
+				->with('accept')
 				->will($this->returnSelf());
 			$action2->expects($this->once())
 				->method('setLink')
-				->with($endpointUrl, 'DELETE')
+				->with($endpointUrl, 'POST')
 				->will($this->returnSelf());
 
 			$notification->method('createAction')
@@ -266,20 +266,20 @@ class NotificationPublisherTest extends TestCase {
 		$action1 = $this->createMock(\OCP\Notification\IAction::class);
 		$action1->expects($this->once())
 			->method('setLabel')
-			->with('accept')
+			->with('decline')
 			->will($this->returnSelf());
 		$action1->expects($this->once())
 			->method('setLink')
-			->with($endpointUrl, 'POST')
+			->with($endpointUrl, 'DELETE')
 			->will($this->returnSelf());
 		$action2 = $this->createMock(\OCP\Notification\IAction::class);
 		$action2->expects($this->once())
 			->method('setLabel')
-			->with('decline')
+			->with('accept')
 			->will($this->returnSelf());
 		$action2->expects($this->once())
 			->method('setLink')
-			->with($endpointUrl, 'DELETE')
+			->with($endpointUrl, 'POST')
 			->will($this->returnSelf());
 
 		$notification->method('createAction')


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Reorder the order of the buttons for the internal share notification

## Related Issue
https://github.com/owncloud/core/issues/31764

## Motivation and Context
Bad UX could make people accept or reject shares by mistake

## How Has This Been Tested?
Manually tested

![screen shot 2018-06-14 at 09 52 08](https://user-images.githubusercontent.com/1477829/41398867-0b55c99a-6fb9-11e8-9156-e1ff8a124e3d.png)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
