### PR TITLE
Update the sql query to delete duplicate sub share

### DIFF
--- a/lib/private/Repair/RepairSubShares.php
+++ b/lib/private/Repair/RepairSubShares.php
@@ -48,55 +48,75 @@ class RepairSubShares implements IRepairStep {
 	}
 
 	/**
-	 * Set query to remove duplicate rows.
-	 * i.e, except id all columns are same for oc_share
-	 * Also set query to select rows which have duplicate rows of share.
+	 * Get query builder to select rows which have duplicate rows of share
+	 * @return IQueryBuilder
 	 */
-	private function setRemoveAndSelectQuery() {
+	private function getSelectQueryToDetectDuplicatesBuilder() {
 		/**
 		 * Retrieves the duplicate rows with different id's
-		 * of oc_share
+		 * of oc_share. The query would look like:
+		 * SELECT id
+		 * FROM oc_share
+		 * WHERE id NOT IN (
+		 * 		SELECT MIN(id)
+		 * 		FROM oc_share
+		 * 		GROUP BY share_with, parent
+		 * )
+		 * AND share_type=2;
 		 */
 		$builder = $this->connection->getQueryBuilder();
-		$builder
-			->select('id', 'parent', $builder->createFunction('count(*)'))
+		$subQuery = $this->connection->getQueryBuilder();
+		$subQuery
+			->select($subQuery->createFunction('MIN(`id`)'))
 			->from('share')
-			->where($builder->expr()->eq('share_type', $builder->createNamedParameter(2)))
-			->groupBy('parent')
-			->addGroupBy('id')
-			->addGroupBy('share_with')
-			->having('count(*) > 1')->setMaxResults(1000);
+			->groupBy('share_with')
+			->addGroupBy('parent');
 
-		$this->getDuplicateRows = $builder;
+		$builder->select('id')
+			->from('share')
+			->where($builder->expr()->notIn('id', $builder->createFunction($subQuery->getSQL())))
+			->andWhere($builder->expr()->eq('share_type', $builder->createNamedParameter(2)));
+		return $builder;
+	}
 
+	/**
+	 * Get query builder to delete rows which have duplicate rows of share based
+	 * on ids
+	 * @return IQueryBuilder
+	 */
+	private function getDeleteShareIdsBuilder() {
 		$builder = $this->connection->getQueryBuilder();
 		$builder
 			->delete('share')
-			->where($builder->expr()->eq('id', $builder->createParameter('shareId')));
-
-		$this->deleteShareId = $builder;
+			->where($builder->expr()->in('id', $builder->createParameter('shareIds')));
+		return $builder;
 	}
 
 	public function run(IOutput $output) {
 		$deletedEntries = 0;
-		$this->setRemoveAndSelectQuery();
+		$selectDuplicates = $this->getSelectQueryToDetectDuplicatesBuilder();
 
-		/**
-		 * Going for pagination because if there are 1 million rows
-		 * it wont be easy to scale the data
-		 */
-		do {
-			$results = $this->getDuplicateRows->execute();
-			$rows = $results->fetchAll();
-			$results->closeCursor();
-			$lastResultCount = 0;
+		$results = $selectDuplicates->execute();
+		$rows = $results->fetchAll();
+		$results->closeCursor();
+		$rowIds = [];
+		if (\count($rows) > 0) {
+			$rowIds = \array_map(
+				function ($value) {
+					return (int)$value['id'];
+				},
+				$rows
+			);
+		}
 
-			foreach ($rows as $row) {
-				$deletedEntries += $this->deleteShareId->setParameter('shareId', (int) $row['id'])
+		if (\count($rows) > 0) {
+			//Delete in a batch of 1000 ids
+			$deleteShareIds = $this->getDeleteShareIdsBuilder();
+			foreach (\array_chunk($rowIds, 1000) as $getIds) {
+				$deletedEntries += $deleteShareIds->setParameter('shareIds', $getIds, IQueryBuilder::PARAM_INT_ARRAY)
 					->execute();
-				$lastResultCount++;
 			}
-		} while ($lastResultCount > 0);
+		}
 
 		if ($deletedEntries > 0) {
 			$output->info('Removed ' . $deletedEntries . ' shares where duplicate rows where found');


### PR DESCRIPTION
Removal of 'group by id' is required to achieve the
purpose of the repair script. Also made modification
to the query which should support the updated version
of postgresql, mysql.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
`group by id` was causing the results to get skipped and hence returning empty results even if duplicated shares were there. This change would help to solve the issue. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`group by id` was causing the results to get skipped and hence returning empty results even if duplicated shares were there. This change would help to solve the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

