### PR TITLE
Properly detect thumbnail availability in PreviewPlugin

### DIFF
--- a/apps/dav/lib/Files/PreviewPlugin.php
+++ b/apps/dav/lib/Files/PreviewPlugin.php
@@ -27,6 +27,7 @@ use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\Files\ForbiddenException;
 use OCP\Files\IPreviewNode;
 use OCP\Files\StorageNotAvailableException;
+use OCP\IPreview;
 use OCP\Lock\LockedException;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
@@ -42,14 +43,18 @@ class PreviewPlugin extends ServerPlugin {
 	protected $server;
 	/** @var ITimeFactory */
 	private $timeFactory;
+	/** @var IPreview */
+	private $previewManager;
 
 	/**
 	 * PreviewPlugin constructor.
 	 *
 	 * @param ITimeFactory $timeFactory
+	 * @param IPreview $previewManager
 	 */
-	public function __construct(ITimeFactory $timeFactory) {
+	public function __construct(ITimeFactory $timeFactory, IPreview $previewManager) {
 		$this->timeFactory = $timeFactory;
+		$this->previewManager = $previewManager;
 	}
 
 	/**
@@ -101,6 +106,10 @@ class PreviewPlugin extends ServerPlugin {
 		}
 
 		try {
+			if (!$this->previewManager->isAvailable($fileNode)) {
+				// no preview available or preview disabled
+				throw new NotFound();
+			}
 			if ($image = $fileNode->getThumbnail($queryParams)) {
 				if ($image === null || !$image->valid()) {
 					throw new NotFound();

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -188,7 +188,7 @@ class Server {
 			$this->server->addPlugin(new BrowserErrorPagePlugin());
 		}
 
-		$this->server->addPlugin(new PreviewPlugin(\OC::$server->getTimeFactory()));
+		$this->server->addPlugin(new PreviewPlugin(\OC::$server->getTimeFactory(), \OC::$server->getPreviewManager()));
 		// wait with registering these until auth is handled and the filesystem is setup
 		$this->server->on('beforeMethod', function () use ($root) {
 			// custom properties plugin must be the last one

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -33,6 +33,7 @@ use OCP\IImage;
 use OCP\IPreview;
 use OCP\IUserSession;
 use OCP\Preview\IProvider;
+use OCP\Preview\IProvider2;
 
 class PreviewManager implements IPreview {
 	/** @var IConfig */
@@ -212,7 +213,7 @@ class PreviewManager implements IPreview {
 			if (\preg_match($supportedMimeType, $file->getMimetype())) {
 				foreach ($providers as $closure) {
 					$provider = $closure();
-					if (!($provider instanceof IProvider)) {
+					if (!($provider instanceof IProvider) && !($provider instanceof IProvider2)) {
 						continue;
 					}
 

--- a/tests/lib/PreviewManagerTest.php
+++ b/tests/lib/PreviewManagerTest.php
@@ -32,6 +32,9 @@ use OCP\IUser;
 use OCP\IUserSession;
 use Test\Traits\MountProviderTrait;
 use Test\Traits\UserTrait;
+use OCP\IPreview;
+use OCP\Files\File;
+use OCP\Files\Mount\IMountPoint;
 
 /**
  * Class PreviewManagerTest
@@ -50,6 +53,10 @@ class PreviewManagerTest extends TestCase {
 	private $user;
 	/** @var View */
 	private $rootView;
+	/** @var IConfig */
+	private $config;
+	/** @var IPreview */
+	private $previewManager;
 
 	protected function setUp() {
 		parent::setUp();
@@ -67,20 +74,64 @@ class PreviewManagerTest extends TestCase {
 		$imgData = \file_get_contents(\OC::$SERVERROOT . '/tests/data/testimage.jpg');
 		$imgPath = '/' . self::TEST_PREVIEW_USER1 . '/files/testimage.jpg';
 		$this->rootView->file_put_contents($imgPath, $imgData);
-	}
+		$this->config = $this->createMock(IConfig::class);
 
-	public function testCreatePreview() {
-		/** @var IConfig $config */
-		$config = $this->createMock(IConfig::class);
 		/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject $userSession */
 		$userSession = $this->createMock(IUserSession::class);
 		$userSession->method('getUser')->willReturn($this->user);
 
 		$rootFolder = \OC::$server->getLazyRootFolder();
-		$previewManager = new PreviewManager($config, $rootFolder, $userSession);
 
-		$image = $previewManager->createPreview('files/testimage.jpg');
+		$this->previewManager = new PreviewManager($this->config, $rootFolder, $userSession);
+	}
+
+	public function testCreatePreview() {
+		$image = $this->previewManager->createPreview('files/testimage.jpg');
 		$this->assertInstanceOf(IImage::class, $image);
 		$this->assertTrue($image->valid());
+	}
+
+	public function testIsAvailable() {
+		// return defaults
+		$this->config->method('getSystemValue')->will($this->returnArgument(1));
+
+		$file = $this->createMock(File::class);
+		$file->expects($this->atLeastOnce())
+			->method('getMimetype')
+			->willReturn('image/jpeg');
+
+		$this->assertTrue($this->previewManager->isAvailable($file));
+	}
+
+	public function testIsAvailableGloballyDisabled() {
+		// return defaults
+		$this->config->method('getSystemValue')->with('enable_previews', true)->willReturn(false);
+
+		$file = $this->createMock(File::class);
+		$file->expects($this->never())->method('getMimetype');
+
+		$this->assertFalse($this->previewManager->isAvailable($file));
+	}
+
+	public function testIsAvailableDisabledOnMountPoint() {
+		// return defaults
+		$this->config->method('getSystemValue')->will($this->returnArgument(1));
+
+		$file = $this->createMock(File::class);
+		$file->expects($this->atLeastOnce())
+			->method('getMimetype')
+			->willReturn('image/jpeg');
+
+		$mountPoint = $this->createMock(IMountPoint::class);
+		$mountPoint->expects($this->once())
+			->method('getOption')
+			->with('previews', true)
+			->willReturn(false);
+
+		$file->expects($this->once())
+			->method('getMountPoint')
+			->willReturn($mountPoint);
+
+		$this->assertFalse($this->previewManager->isAvailable($file));
 	}
 }


### PR DESCRIPTION
## Description
Use preview manager's "isAvailable" method.
Also fixes isAvailable to properly recognize IProvider2 instances.


## Related Issue
Fixes https://github.com/owncloud/core/issues/31763

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test with external storage where previews are disabled (cog icon): network console shows 404 for every preview. Outside of external storage, previews still render.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
