### PR TITLE
Web UI test scrolling enhancements

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1283,7 +1283,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 				$currentTime = \microtime(true);
 			}
 			
-			PHPUnit_Framework_Assert::assertLessThan(
+			PHPUnit_Framework_Assert::assertLessThanOrEqual(
 				$windowHeight, $deleteBtnCoordinates ["top"]
 			);
 			//this will close the menu again

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -37,6 +37,8 @@ const LONGUIWAITTIMEOUTMILLISEC = 60000;
 const STANDARDUIWAITTIMEOUTMILLISEC = 10000;
 // Minimum timeout for use in code that needs to wait for the UI
 const MINIMUMUIWAITTIMEOUTMILLISEC = 500;
+const MINIMUMUIWAITTIMEOUTMICROSEC = MINIMUMUIWAITTIMEOUTMILLISEC * 1000;
+
 // Default number of times to retry where retries are useful
 const STANDARDRETRYCOUNT = 5;
 // Minimum number of times to retry where retries are useful

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -623,6 +623,12 @@ class OwncloudPage extends Page {
 		Session $session, $scrolledElement,
 		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
 	) {
+		// Wait so that, if scrolling is going to happen, it will have started.
+		// Otherwise, we might start checking early, before scrolling begins.
+		// The downside here is that if scrolling is not needed at all then we
+		// wasted time waiting.
+		// TODO: find a way to avoid this sleep
+		\usleep(MINIMUMUIWAITTIMEOUTMICROSEC);
 		$session->executeScript(
 			'
 			jQuery.scrolling = 0;
@@ -640,6 +646,7 @@ class OwncloudPage extends Page {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end && $result !== 0) {
+			\usleep(STANDARDSLEEPTIMEMICROSEC);
 			$result = (int)$session->evaluateScript("jQuery.scrolling");
 			$currentTime = \microtime(true);
 		}


### PR DESCRIPTION
## Description
1) When checking the position of the opened file actions menu, allow it to be exactly at the bottom of the screen.

2) When opening the file actions menu, first "wait a bit" (500msec) to let the file list start scrolling (if it is going to). Then do the loop waiting for scrolling to finish. This wastes a little bit of time when no scrolling is happening, but there seems no good way around this.

## Related Issue
#31792 

## Motivation and Context
Intermittent webUI acceptance test failures have become more frequent. See details in the issue.

## How Has This Been Tested?
Local runs of failing test scenarios, e.g.:
```
bash tests/travis/start_ui_tests.sh --feature tests/acceptance/features/webUIFiles/deleteFilesFolders.feature:15
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test improvement

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
