### PR TITLE
Skip filecache repair step for version greater than 10.0.4

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -160,11 +160,12 @@ class Scan extends Base {
 		$repairStep = new RepairMismatchFileCachePath(
 			$connection,
 			$this->mimeTypeLoader,
-			$this->logger
+			$this->logger,
+			$this->config
 		);
 		$repairStep->setStorageNumericId(null);
 		$repairStep->setCountOnly(false);
-		$repairStep->run(new ConsoleOutput($output));
+		$repairStep->doRepair(new ConsoleOutput($output));
 	}
 
 	protected function scanFiles($user, $path, $verbose, OutputInterface $output, $backgroundScan = false, $shouldRepair = false) {
@@ -183,7 +184,8 @@ class Scan extends Base {
 					$repairStep = new RepairMismatchFileCachePath(
 						$connection,
 						$this->mimeTypeLoader,
-						$this->logger
+						$this->logger,
+						$this->config
 					);
 					$repairStep->setStorageNumericId($storage->getCache()->getNumericStorageId());
 					$repairStep->setCountOnly(false);

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -132,7 +132,8 @@ class Repair implements IOutput {
 			new RepairMismatchFileCachePath(
 				\OC::$server->getDatabaseConnection(),
 				\OC::$server->getMimeTypeLoader(),
-				\OC::$server->getLogger()),
+				\OC::$server->getLogger(),
+				\OC::$server->getConfig()),
 			new FillETags(\OC::$server->getDatabaseConnection()),
 			new CleanTags(\OC::$server->getDatabaseConnection(), \OC::$server->getUserManager()),
 			new DropOldTables(\OC::$server->getDatabaseConnection()),


### PR DESCRIPTION
Skip the filecache repair step for version greater than 10.0.4

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
The file cache repair step can be omitted if the current oC version is 10.0.4 or greater than 10.0.4.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/31464

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The file cache repair step can be omitted if the current oC version is 10.0.4 or greater than 10.0.4.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Below are the steps done for verification:
```
➜  owncloud4 rm -fr * ; tar jxf ~/Downloads/owncloud-enterprise-complete-10.0.3.tar.bz2; mv owncloud/* . 
zsh: sure you want to delete all the files in /home/sujith/test/owncloud4 [yn]? y
➜  owncloud4 rm -fr data config/config.php; ./occ  maintenance:install --admin-user "admin" --admin-pass "admin"
Cannot load Xdebug - it was already loaded
ownCloud is not installed - only a limited number of commands are available
creating sqlite db
ownCloud was successfully installed
➜  owncloud4 vim config/config.php 
➜  owncloud4 ./occ user:add user1
Cannot load Xdebug - it was already loaded
Enter password: 
Confirm password: 
The user "user1" was created successfully
➜  owncloud4 cp -fa config/config.php /tmp/backup/10.0.3 ; cp -fa data /tmp/backup/10.0.3    
➜  owncloud4 rm -fr * ; tar jxf ~/Downloads/owncloud-enterprise-complete-10.0.4.tar.bz2; mv owncloud/* .        
zsh: sure you want to delete all the files in /home/sujith/test/owncloud4 [yn]? y

➜  owncloud4 
➜  owncloud4 cp -fa /tmp/backup/10.0.3/config.php config/ ; cp -fa /tmp/backup/10.0.3/data . 
➜  owncloud4 ./occ maintenance:mode --on; sudo /etc/init.d/apache2 stop                      
Cannot load Xdebug - it was already loaded
ownCloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
Maintenance mode enabled
Please also consider to stop the web server on all ownCloud instances
[ ok ] Stopping apache2 (via systemctl): apache2.service.
➜  owncloud4 

➜  owncloud4 ./occ upgrade                                                                   
Cannot load Xdebug - it was already loaded
ownCloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
2018-06-15T07:15:11+00:00 Set log level to debug
2018-06-15T07:15:11+00:00 Turned on maintenance mode
2018-06-15T07:15:11+00:00 Repair step: Repair MySQL database engine
2018-06-15T07:15:11+00:00 Repair info: Not a mysql database -> nothing to do
2018-06-15T07:15:11+00:00 Repair step: Repair MySQL collation
2018-06-15T07:15:11+00:00 Repair info: Not a mysql database -> nothing to do
2018-06-15T07:15:11+00:00 Repair step: Repair SQLite autoincrement
2018-06-15T07:15:12+00:00 Repair step: Repair duplicate entries in oc_lucene_status
2018-06-15T07:15:12+00:00 Repair info: lucene_status table does not exist -> nothing to do
2018-06-15T07:15:12+00:00 Repair step: Upgrade app code from the marketplace
2018-06-15T07:15:12+00:00 Repair info: Using market to update existing apps
2018-06-15T07:15:12+00:00 Repair info: Attempting to update the following existing compatible apps from market: 
2018-06-15T07:15:12+00:00 Repair info: Fetching app from market: activity
2018-06-15T07:15:16+00:00 Repair info: 
2018-06-15T07:15:16+00:00 Repair info: Fetching app from market: admin_audit
2018-06-15T07:15:19+00:00 Repair info: 
2018-06-15T07:15:19+00:00 Repair info: Fetching app from market: comments
2018-06-15T07:15:23+00:00 Repair info: App (comments) is not known at the marketplace.
2018-06-15T07:15:23+00:00 Repair info: Fetching app from market: configreport
2018-06-15T07:15:26+00:00 Repair info: App (configreport) is not known at the marketplace.
2018-06-15T07:15:26+00:00 Repair info: Fetching app from market: dav
2018-06-15T07:15:29+00:00 Repair info: App (dav) is not known at the marketplace.
2018-06-15T07:15:29+00:00 Repair info: Fetching app from market: diagnostics
2018-06-15T07:15:33+00:00 Repair info: 
2018-06-15T07:15:33+00:00 Repair info: Fetching app from market: enterprise_key
2018-06-15T07:15:40+00:00 Repair warning: Marketplace API key missing
2018-06-15T07:15:40+00:00 Updating database schema
2018-06-15T07:15:40+00:00 Updated database
2018-06-15T07:15:40+00:00 Updating <market> ...
2018-06-15T07:15:40+00:00 Updated <market> to 0.2.3
2018-06-15T07:15:40+00:00 Updating <dav> ...
2018-06-15T07:15:40+00:00 Updated <dav> to 0.3.2
2018-06-15T07:15:40+00:00 Updating <notifications> ...
2018-06-15T07:15:40+00:00 Updated <notifications> to 0.3.2
2018-06-15T07:15:40+00:00 Repair step: Repair mime types
2018-06-15T07:15:40+00:00 Repair step: Detect file cache entries with path that does not match parent-child relationships
2018-06-15T07:15:40+00:00 Repair step: Generate ETags for file where no ETag is present.
2018-06-15T07:15:40+00:00 Repair info: ETags have been fixed for 0 files/folders.
2018-06-15T07:15:40+00:00 Repair step: Clean tags and favorites
2018-06-15T07:15:40+00:00 Repair info: 0 tags of deleted users have been removed.
2018-06-15T07:15:40+00:00 Repair info: 0 tags for delete files have been removed.
2018-06-15T07:15:40+00:00 Repair info: 0 tag entries for deleted tags have been removed.
2018-06-15T07:15:40+00:00 Repair info: 0 tags with no entries have been removed.
2018-06-15T07:15:40+00:00 Repair step: Drop old database tables
2018-06-15T07:15:40+00:00 Drop old database tables
2018-06-15T07:15:40+00:00 
                                                    2018-06-15T07:15:40+00:00  Done
 28/28 [============================] 100%2018-06-15T07:15:40+00:00 
2018-06-15T07:15:40+00:00 Repair step: Drop old background jobs
2018-06-15T07:15:40+00:00 Repair step: Remove getetag entries in properties table
2018-06-15T07:15:40+00:00 Repair info: Removed 0 unneeded "{DAV:}getetag" entries from properties table.
2018-06-15T07:15:40+00:00 Repair step: Repair outdated OCS IDs
2018-06-15T07:15:40+00:00 Repair step: Repair invalid shares
2018-06-15T07:15:40+00:00 Repair step: Remove old share propagation app entries
2018-06-15T07:15:40+00:00 Repair step: Move user avatars outside the homes to the new location
2018-06-15T07:15:40+00:00 Repair step: Remove shares of a users root folder
2018-06-15T07:15:40+00:00 Repair step: Repair unmerged shares
2018-06-15T07:15:40+00:00 Starting code integrity check...
2018-06-15T07:16:19+00:00 Finished code integrity check
2018-06-15T07:16:19+00:00 Update successful
2018-06-15T07:16:19+00:00 Turned off maintenance mode
2018-06-15T07:16:19+00:00 Reset log level
➜  owncloud4

➜  owncloud4 cp -fa config/config.php /tmp/backup/10.0.4 ; cp -fa data /tmp/backup/10.0.4

➜  owncloud4 cp -fa /tmp/backup/10.0.4/config.php config/ ; cp -fa /tmp/backup/10.0.4/data .

➜  owncloud4 rm -fr * ; tar jxf ~/Downloads/owncloud-enterprise-complete-10.0.8.tar.bz2; mv owncloud/* .

➜  owncloud4 cp -f /tmp/RepairMismatchFileCachePath.php lib/private/Repair/RepairMismatchFileCachePath.php
➜  owncloud4 cp -f /tmp/Repair.php lib/private/Repair.php


➜  owncloud4 ./occ upgrade                                                                                
Cannot load Xdebug - it was already loaded
ownCloud or one of the apps require upgrade - only a limited number of commands are available
You may use your browser or the occ upgrade command to do the upgrade
2018-06-15T07:43:24+00:00 Set log level to debug
2018-06-15T07:43:24+00:00 Turned on maintenance mode
2018-06-15T07:43:24+00:00 Repair step: Repair MySQL database engine
2018-06-15T07:43:24+00:00 Repair info: Not a mysql database -> nothing to do
2018-06-15T07:43:24+00:00 Repair step: Repair MySQL collation
2018-06-15T07:43:24+00:00 Repair info: Not a mysql database -> nothing to do
2018-06-15T07:43:24+00:00 Repair step: Repair SQLite autoincrement
2018-06-15T07:43:24+00:00 Repair step: Repair orphaned reshare
2018-06-15T07:43:24+00:00 Repair step: Repair duplicate entries in oc_lucene_status
2018-06-15T07:43:24+00:00 Repair info: lucene_status table does not exist -> nothing to do
2018-06-15T07:43:24+00:00 Repair step: Upgrade app code from the marketplace
2018-06-15T07:43:24+00:00 Repair info: Using market to update existing apps
2018-06-15T07:43:24+00:00 Repair info: Attempting to update the following missing apps from market: diagnostics
2018-06-15T07:43:24+00:00 Repair info: Fetching app from market: diagnostics
2018-06-15T07:43:31+00:00 Repair info: Attempting to update the following existing compatible apps from market: diagnostics
2018-06-15T07:43:31+00:00 Repair info: Fetching app from market: activity
2018-06-15T07:43:32+00:00 Repair info: 
2018-06-15T07:43:32+00:00 Repair info: Fetching app from market: admin_audit
2018-06-15T07:43:34+00:00 Repair info: 
2018-06-15T07:43:34+00:00 Repair info: Fetching app from market: comments
2018-06-15T07:43:35+00:00 Repair info: App (comments) is not known at the marketplace.
2018-06-15T07:43:35+00:00 Repair info: Fetching app from market: configreport
2018-06-15T07:43:37+00:00 Repair info: App (configreport) is not known at the marketplace.
2018-06-15T07:43:37+00:00 Repair info: Fetching app from market: dav
2018-06-15T07:43:38+00:00 Repair info: App (dav) is not known at the marketplace.
2018-06-15T07:43:38+00:00 Repair info: Fetching app from market: enterprise_key
2018-06-15T07:43:40+00:00 Repair info: 
2018-06-15T07:43:40+00:00 Repair info: Fetching app from market: federatedfilesharing
2018-06-15T07:43:41+00:00 Repair info: App (federatedfilesharing) is not known at the marketplace.
2018-06-15T07:43:41+00:00 Repair info: Fetching app from market: federation
2018-06-15T07:43:42+00:00 Repair info: App (federation) is not known at the marketplace.
2018-06-15T07:43:42+00:00 Repair info: Fetching app from market: files
2018-06-15T07:43:44+00:00 Repair info: App (files) is not known at the marketplace.
2018-06-15T07:43:44+00:00 Repair info: Fetching app from market: files_external
2018-06-15T07:43:45+00:00 Repair info: App (files_external) is not known at the marketplace.
2018-06-15T07:43:45+00:00 Repair info: Fetching app from market: files_pdfviewer
2018-06-15T07:43:47+00:00 Repair info: 
2018-06-15T07:43:47+00:00 Repair info: Fetching app from market: files_sharing
2018-06-15T07:43:48+00:00 Repair info: App (files_sharing) is not known at the marketplace.
2018-06-15T07:43:48+00:00 Repair info: Fetching app from market: files_texteditor
2018-06-15T07:43:50+00:00 Repair info: 
2018-06-15T07:43:50+00:00 Repair info: Fetching app from market: files_trashbin
2018-06-15T07:43:51+00:00 Repair info: App (files_trashbin) is not known at the marketplace.
2018-06-15T07:43:51+00:00 Repair info: Fetching app from market: files_versions
2018-06-15T07:43:53+00:00 Repair info: App (files_versions) is not known at the marketplace.
2018-06-15T07:43:53+00:00 Repair info: Fetching app from market: files_videoplayer
2018-06-15T07:43:54+00:00 Repair info: App (files_videoplayer) is not known at the marketplace.
2018-06-15T07:43:54+00:00 Repair info: Fetching app from market: firewall
2018-06-15T07:43:56+00:00 Repair info: 
2018-06-15T07:43:56+00:00 Repair info: Fetching app from market: firstrunwizard
2018-06-15T07:43:57+00:00 Repair info: App (firstrunwizard) is not known at the marketplace.
2018-06-15T07:43:57+00:00 Repair info: Fetching app from market: gallery
2018-06-15T07:43:59+00:00 Repair info: 
2018-06-15T07:43:59+00:00 Repair info: Fetching app from market: market
2018-06-15T07:44:00+00:00 Repair info: 
2018-06-15T07:44:00+00:00 Repair info: Fetching app from market: notifications
2018-06-15T07:44:02+00:00 Repair info: App (notifications) is not known at the marketplace.
2018-06-15T07:44:02+00:00 Repair info: Fetching app from market: provisioning_api
2018-06-15T07:44:03+00:00 Repair info: App (provisioning_api) is not known at the marketplace.
2018-06-15T07:44:03+00:00 Repair info: Fetching app from market: systemtags
2018-06-15T07:44:04+00:00 Repair info: App (systemtags) is not known at the marketplace.
2018-06-15T07:44:04+00:00 Repair info: Fetching app from market: systemtags_management
2018-06-15T07:44:06+00:00 Repair info: 
2018-06-15T07:44:06+00:00 Repair info: Fetching app from market: templateeditor
2018-06-15T07:44:07+00:00 Repair info: 
2018-06-15T07:44:07+00:00 Repair info: Fetching app from market: theme-enterprise
2018-06-15T07:44:09+00:00 Repair info: 
2018-06-15T07:44:09+00:00 Repair info: Fetching app from market: updatenotification
2018-06-15T07:44:10+00:00 Repair info: App (updatenotification) is not known at the marketplace.
2018-06-15T07:44:10+00:00 Repair info: Fetching app from market: windows_network_drive
2018-06-15T07:44:11+00:00 Repair info: 
2018-06-15T07:44:11+00:00 Repair info: Fetching app from market: workflow
2018-06-15T07:44:13+00:00 Repair info: 
2018-06-15T07:44:13+00:00 Repair info: App was not updated: activity
2018-06-15T07:44:13+00:00 Repair info: App was not updated: admin_audit
2018-06-15T07:44:13+00:00 Repair info: App was not updated: comments
2018-06-15T07:44:13+00:00 Repair info: App was not updated: configreport
2018-06-15T07:44:13+00:00 Repair info: App was not updated: dav
2018-06-15T07:44:13+00:00 Repair info: App was not updated: enterprise_key
2018-06-15T07:44:13+00:00 Repair info: App was not updated: federatedfilesharing
2018-06-15T07:44:13+00:00 Repair info: App was not updated: federation
2018-06-15T07:44:13+00:00 Repair info: App was not updated: files
2018-06-15T07:44:13+00:00 Repair info: App was not updated: files_external
2018-06-15T07:44:13+00:00 Repair info: App was not updated: files_pdfviewer
2018-06-15T07:44:13+00:00 Repair info: App was not updated: files_sharing
2018-06-15T07:44:13+00:00 Repair info: App was not updated: files_texteditor
2018-06-15T07:44:13+00:00 Repair info: App was not updated: files_trashbin
2018-06-15T07:44:13+00:00 Repair info: App was not updated: files_versions
2018-06-15T07:44:13+00:00 Repair info: App was not updated: files_videoplayer
2018-06-15T07:44:13+00:00 Repair info: App was not updated: firewall
2018-06-15T07:44:13+00:00 Repair info: App was not updated: firstrunwizard
2018-06-15T07:44:13+00:00 Repair info: App was not updated: gallery
2018-06-15T07:44:13+00:00 Repair info: App was not updated: market
2018-06-15T07:44:13+00:00 Repair info: App was not updated: notifications
2018-06-15T07:44:13+00:00 Repair info: App was not updated: provisioning_api
2018-06-15T07:44:13+00:00 Repair info: App was not updated: systemtags
2018-06-15T07:44:13+00:00 Repair info: App was not updated: systemtags_management
2018-06-15T07:44:13+00:00 Repair info: App was not updated: templateeditor
2018-06-15T07:44:13+00:00 Repair info: App was not updated: theme-enterprise
2018-06-15T07:44:13+00:00 Repair info: App was not updated: updatenotification
2018-06-15T07:44:13+00:00 Repair info: App was not updated: windows_network_drive
2018-06-15T07:44:13+00:00 Repair info: App was not updated: workflow
2018-06-15T07:44:13+00:00 Updating database schema
2018-06-15T07:44:13+00:00 Updated database
2018-06-15T07:44:13+00:00 Updating <market> ...
2018-06-15T07:44:13+00:00 Updated <market> to 0.2.4
2018-06-15T07:44:13+00:00 Updating <templateeditor> ...
2018-06-15T07:44:13+00:00 Updated <templateeditor> to 0.3
2018-06-15T07:44:13+00:00 Updating <theme-enterprise> ...
2018-06-15T07:44:13+00:00 Updated <theme-enterprise> to 2.0.1
2018-06-15T07:44:13+00:00 Updating <enterprise_key> ...
2018-06-15T07:44:13+00:00 Updated <enterprise_key> to 0.1.4
2018-06-15T07:44:13+00:00 Updating <firewall> ...
2018-06-15T07:44:13+00:00 Updated <firewall> to 2.5.0
2018-06-15T07:44:13+00:00 Updating <windows_network_drive> ...
2018-06-15T07:44:13+00:00 Updated <windows_network_drive> to 0.7.1
2018-06-15T07:44:13+00:00 Updating <workflow> ...
2018-06-15T07:44:13+00:00 Repair step: Remove old background jobs
2018-06-15T07:44:13+00:00 Repair step: Convert the workflow types to strings
2018-06-15T07:44:13+00:00 Convert the workflow types to strings
2018-06-15T07:44:13+00:00 
                                                    2018-06-15T07:44:13+00:00  Done
 2/2 [============================] 100%2018-06-15T07:44:13+00:00 
2018-06-15T07:44:13+00:00 Updated <workflow> to 0.2.6
2018-06-15T07:44:13+00:00 Updating <admin_audit> ...
2018-06-15T07:44:13+00:00 Updated <admin_audit> to 1.0.0
2018-06-15T07:44:13+00:00 Updating <notifications> ...
2018-06-15T07:44:13+00:00 Updated <notifications> to 0.3.3
2018-06-15T07:44:13+00:00 Repair step: Repair mime types
2018-06-15T07:44:13+00:00 Repair step: Detect file cache entries with path that does not match parent-child relationships
2018-06-15T07:44:13+00:00 Repair info: Since the version is greater than 10.0.4 no need to apply this repair
2018-06-15T07:44:13+00:00 Repair step: Generate ETags for file where no ETag is present.
2018-06-15T07:44:13+00:00 Repair info: ETags have been fixed for 0 files/folders.
2018-06-15T07:44:13+00:00 Repair step: Clean tags and favorites
2018-06-15T07:44:13+00:00 Repair info: 0 tags of deleted users have been removed.
2018-06-15T07:44:13+00:00 Repair info: 0 tags for delete files have been removed.
2018-06-15T07:44:13+00:00 Repair info: 0 tag entries for deleted tags have been removed.
2018-06-15T07:44:13+00:00 Repair info: 0 tags with no entries have been removed.
2018-06-15T07:44:13+00:00 Repair step: Drop old database tables
2018-06-15T07:44:13+00:00 Drop old database tables
                                                    2018-06-15T07:44:13+00:00  Done
 28/28 [============================] 100%2018-06-15T07:44:13+00:00 
2018-06-15T07:44:13+00:00 Repair step: Drop old background jobs
2018-06-15T07:44:13+00:00 Repair step: Remove getetag entries in properties table
2018-06-15T07:44:13+00:00 Repair info: Removed 0 unneeded "{DAV:}getetag" entries from properties table.
2018-06-15T07:44:13+00:00 Repair step: Repair outdated OCS IDs
2018-06-15T07:44:13+00:00 Repair step: Repair invalid shares
2018-06-15T07:44:13+00:00 Repair step: Remove old share propagation app entries
2018-06-15T07:44:13+00:00 Repair step: Move user avatars outside the homes to the new location
2018-06-15T07:44:13+00:00 Repair step: Remove shares of a users root folder
2018-06-15T07:44:13+00:00 Repair step: Repair unmerged shares
2018-06-15T07:44:13+00:00 Repair step: Disable extra themes
2018-06-15T07:44:13+00:00 Repair step: Repair sub shares
2018-06-15T07:44:13+00:00 Starting code integrity check...
2018-06-15T07:45:06+00:00 Finished code integrity check
2018-06-15T07:45:06+00:00 Update successful
2018-06-15T07:45:06+00:00 Turned off maintenance mode
2018-06-15T07:45:06+00:00 Reset log level
➜  owncloud4 
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

