### PR TITLE
Use the displayname in lost password emails where possible

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -319,8 +319,9 @@ class LostController extends Controller {
 					return false;
 				case 1:
 					$this->logger->info('User with input as email address found. User: {user}', ['app' => 'core', 'user' => $user]);
-					$email = $users[0]->getEMailAddress();
-					$user = $users[0]->getUID();
+					$userObject = $users[0];
+					$email = $userObject->getEMailAddress();
+					$user = $userObject->getUID();
 					break;
 				default:
 					$this->logger->error('Could not send reset email because the email id is not unique. User: {user}', ['app' => 'core', 'user' => $user]);

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -259,6 +259,7 @@ class LostController extends Controller {
 	protected function sendNotificationMail($userId) {
 		$user = $this->userManager->get($userId);
 		$email = $user->getEMailAddress();
+		$name = $user->getDisplayName();
 
 		if ($email !== '') {
 			$tmpl = new \OC_Template('core', 'lostpassword/notify');
@@ -266,7 +267,7 @@ class LostController extends Controller {
 
 			try {
 				$message = $this->mailer->createMessage();
-				$message->setTo([$email => $userId]);
+				$message->setTo([$email => $name]);
 				$message->setSubject($this->l10n->t('%s password changed successfully', [$this->defaults->getName()]));
 				$message->setPlainBody($msg);
 				$message->setFrom([$this->from => $this->defaults->getName()]);
@@ -344,10 +345,11 @@ class LostController extends Controller {
 		$tmplAlt = new \OC_Template('core', 'lostpassword/altemail');
 		$tmplAlt->assign('link', $link);
 		$msgAlt = $tmplAlt->fetchPage();
+		$name = $userObject->getDisplayName();
 
 		try {
 			$message = $this->mailer->createMessage();
-			$message->setTo([$email => $user]);
+			$message->setTo([$email => $name]);
 			$message->setSubject($this->l10n->t('%s password reset', [$this->defaults->getName()]));
 			$message->setPlainBody($msgAlt);
 			$message->setHtmlBody($msg);

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -80,6 +80,11 @@ class LostControllerTest extends TestCase {
 			->method('getEMailAddress')
 			->willReturn('test@example.com');
 
+		$this->existingUser
+			->expects($this->any())
+			->method('getDisplayName')
+			->willReturn('Existing User Name');
+
 		$this->config = $this->getMockBuilder('\OCP\IConfig')
 			->disableOriginalConstructor()->getMock();
 		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
@@ -355,7 +360,7 @@ class LostControllerTest extends TestCase {
 		$message
 			->expects($this->at(0))
 			->method('setTo')
-			->with(['test@example.com' => 'ExistingUser']);
+			->with(['test@example.com' => 'Existing User Name']);
 		$message
 			->expects($this->at(1))
 			->method('setSubject')
@@ -420,7 +425,7 @@ class LostControllerTest extends TestCase {
 		$message
 			->expects($this->at(0))
 			->method('setTo')
-			->with(['test@example.com' => 'ExistingUser']);
+			->with(['test@example.com' => 'Existing User Name']);
 		$message
 			->expects($this->at(1))
 			->method('setSubject')
@@ -503,6 +508,9 @@ class LostControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getEMailAddress')
 			->will($this->returnValue('test@example.com'));
+		$user
+			->method('getDisplayName')
+			->will($this->returnValue('ValidTokenUser'));
 
 		$message = $this->getMockBuilder('\OC\Mail\Message')
 			->disableOriginalConstructor()->getMock();

--- a/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
+++ b/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
@@ -17,7 +17,7 @@ Feature: reset the password using an email address
     When the user requests the password reset link using the webUI
     Then a message with this text should be displayed on the webUI:
 			"""
-			The link to reset your password has been sent to your email. If you do not receive it within a reasonable amount of time, check your spam/junk folders. If it is not there ask your local administrator.
+			Wrong password. Reset it?
 			"""
     And the email address "user1@example.org" should have received an email with the body containing
 			"""

--- a/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
+++ b/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
@@ -17,7 +17,7 @@ Feature: reset the password using an email address
     When the user requests the password reset link using the webUI
     Then a message with this text should be displayed on the webUI:
 			"""
-			Wrong password. Reset it?
+			The link to reset your password has been sent to your email. If you do not receive it within a reasonable amount of time, check your spam/junk folders. If it is not there ask your local administrator.
 			"""
     And the email address "user1@example.org" should have received an email with the body containing
 			"""


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Use displayname in email to fields where possible, nicer than the uid

## Motivation and Context
Looks nicer.

## How Has This Been Tested?
Manually sending lost password mails and looking at mailhog.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

