### PR TITLE
[stable10] Skip filecache repair step for version greater than 10.0.4

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -160,11 +160,12 @@ class Scan extends Base {
 		$repairStep = new RepairMismatchFileCachePath(
 			$connection,
 			$this->mimeTypeLoader,
-			$this->logger
+			$this->logger,
+			$this->config
 		);
 		$repairStep->setStorageNumericId(null);
 		$repairStep->setCountOnly(false);
-		$repairStep->run(new ConsoleOutput($output));
+		$repairStep->doRepair(new ConsoleOutput($output));
 	}
 
 	protected function scanFiles($user, $path, $verbose, OutputInterface $output, $backgroundScan = false, $shouldRepair = false) {
@@ -183,7 +184,8 @@ class Scan extends Base {
 					$repairStep = new RepairMismatchFileCachePath(
 						$connection,
 						$this->mimeTypeLoader,
-						$this->logger
+						$this->logger,
+						$this->config
 					);
 					$repairStep->setStorageNumericId($storage->getCache()->getNumericStorageId());
 					$repairStep->setCountOnly(false);

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -132,7 +132,8 @@ class Repair implements IOutput{
 			new RepairMismatchFileCachePath(
 				\OC::$server->getDatabaseConnection(),
 				\OC::$server->getMimeTypeLoader(),
-				\OC::$server->getLogger()),
+				\OC::$server->getLogger(),
+				\OC::$server->getConfig()),
 			new FillETags(\OC::$server->getDatabaseConnection()),
 			new CleanTags(\OC::$server->getDatabaseConnection(), \OC::$server->getUserManager()),
 			new DropOldTables(\OC::$server->getDatabaseConnection()),

--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -21,6 +21,7 @@
 
 namespace OC\Repair;
 
+use OCP\IConfig;
 use OCP\ILogger;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -58,15 +59,20 @@ class RepairMismatchFileCachePath implements IRepairStep {
 	/** @var ILogger  */
 	protected $logger;
 
+	/** @var IConfig */
+	protected $config;
+
 	/**
 	 * @param \OCP\IDBConnection $connection
 	 */
 	public function __construct(IDBConnection $connection,
 								IMimeTypeLoader $mimeLoader,
-								ILogger $logger) {
+								ILogger $logger,
+								IConfig $config) {
 		$this->connection = $connection;
 		$this->mimeLoader = $mimeLoader;
 		$this->logger = $logger;
+		$this->config = $config;
 	}
 
 	public function getName() {
@@ -534,12 +540,13 @@ class RepairMismatchFileCachePath implements IRepairStep {
 	}
 
 	/**
-	 * Run the repair step
+	 * The purpose of this function is to let execute the run method
+	 * irrespective of version. For example when triggered from files:scan
+	 * this repair step shouldn't be blocked.
 	 *
-	 * @param IOutput $out output
+	 * @param IOutput $out
 	 */
-	public function run(IOutput $out) {
-
+	public function doRepair(IOutput $out) {
 		$this->dirMimeTypeId = $this->mimeLoader->getId('httpd/unix-directory');
 		$this->dirMimePartId = $this->mimeLoader->getId('httpd');
 
@@ -571,6 +578,21 @@ class RepairMismatchFileCachePath implements IRepairStep {
 			}
 			$out->finishProgress();
 			$out->info('');
+		}
+	}
+
+	/**
+	 * Run the repair step
+	 *
+	 * @param IOutput $out output
+	 */
+	public function run(IOutput $out) {
+		$currentVersion = $this->config->getSystemValue('version', '0.0.0');
+		$versionCompareStatus = \version_compare($currentVersion, '10.0.4', '<');
+		//Execute repair step if version is less than 10.0.4 during upgrade
+		//This is not applicable when called from file scan command
+		if ($versionCompareStatus) {
+			$this->doRepair($out);
 		}
 	}
 }

--- a/tests/lib/Repair/RepairMismatchFileCachePathTest.php
+++ b/tests/lib/Repair/RepairMismatchFileCachePathTest.php
@@ -10,6 +10,7 @@ namespace Test\Repair;
 
 use OC\Repair\RepairMismatchFileCachePath;
 use OCP\Files\IMimeTypeLoader;
+use OCP\IConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Test\TestCase;
@@ -30,6 +31,7 @@ class RepairMismatchFileCachePathTest extends TestCase {
 	/** @var \OCP\IDBConnection */
 	private $connection;
 
+	private $config;
 	protected function setUp() {
 		parent::setUp();
 
@@ -44,7 +46,8 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		/** @var \PHPUnit_Framework_MockObject_MockObject | ILogger $logger */
 		$logger = $this->createMock(ILogger::class);
-		$this->repair = new RepairMismatchFileCachePath($this->connection, $mimeLoader, $logger);
+		$this->config = $this->createMock(IConfig::class);
+		$this->repair = new RepairMismatchFileCachePath($this->connection, $mimeLoader, $logger, $this->config);
 		$this->repair->setCountOnly(false);
 	}
 
@@ -209,7 +212,11 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$doNotTouchId = $this->createFileCacheEntry($sourceStorageId, 'files/source/do_not_touch', $sourceId);
 
 		$outputMock = $this->createMock(IOutput::class);
-		if (is_null($repairStoragesOrder)) {
+		$this->config->expects($this->any())
+			->method('getSystemValue')
+			->with('version', '0.0.0')
+			->willReturn('10.0.3');
+		if ($repairStoragesOrder === null) {
 			// no storage selected, full repair
 			$this->repair->setStorageNumericId(null);
 			$this->repair->run($outputMock);
@@ -350,6 +357,10 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		$outputMock = $this->createMock(IOutput::class);
 		$this->repair->setStorageNumericId($storageId);
+		$this->config->expects($this->any())
+			->method('getSystemValue')
+			->with('version', '0.0.0')
+			->willReturn('10.0.3');
 		$this->repair->run($outputMock);
 
 		// self-referencing updated
@@ -540,6 +551,10 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		$outputMock = $this->createMock(IOutput::class);
 		$this->repair->setStorageNumericId($storageId);
+		$this->config->expects($this->any())
+			->method('getSystemValue')
+			->with('version', '0.0.0')
+			->willReturn('10.0.3');
 		$this->repair->run($outputMock);
 
 		// wrong parent root reparented to actual root
@@ -598,6 +613,10 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		$outputMock = $this->createMock(IOutput::class);
 		$this->repair->setStorageNumericId($storageId);
+		$this->config->expects($this->any())
+			->method('getSystemValue')
+			->with('version', '0.0.0')
+			->willReturn('10.0.3');
 		$this->repair->run($outputMock);
 
 		// orphaned entry reattached
@@ -705,6 +724,10 @@ class RepairMismatchFileCachePathTest extends TestCase {
 
 		$outputMock = $this->createMock(IOutput::class);
 		$this->repair->setStorageNumericId($storageId);
+		$this->config->expects($this->any())
+			->method('getSystemValue')
+			->with('version', '0.0.0')
+			->willReturn('10.0.3');
 		$this->repair->run($outputMock);
 
 		// orphaned entry with no root reattached
@@ -732,5 +755,31 @@ class RepairMismatchFileCachePathTest extends TestCase {
 		$this->assertEquals((string)$testStorageId, $entry['storage']);
 		$this->assertEquals('', $entry['path']);
 		$this->assertEquals(md5(''), $entry['path_hash']);
+	}
+
+	public function provideVersions() {
+		return [
+			['10.0.3'],
+			['10.0.4'],
+			['10.0.3.9'],
+		];
+	}
+
+	/**
+	 * @dataProvider provideVersions
+	 * @param $version
+	 */
+	public function testVersions($version) {
+		$this->config->expects($this->any())
+			->method('getSystemValue')
+			->with('version', '0.0.0')
+			->willReturn($version);
+		$outputMock = $this->createMock(IOutput::class);
+		if (\version_compare(\OC::$server->getConfig()->getSystemValue('version', '0.0.0'), $version, '<')) {
+			$outputMock->expects($this->any())
+				->method('info')
+				->with($this->repair->getName() . ' is not executed');
+		}
+		$this->repair->run($outputMock);
 	}
 }


### PR DESCRIPTION
Skip filecache repair step for version greater than 10.0.4

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
The file cache repair step can be omitted if the current oC version is 10.0.4 or greater than 10.0.4.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/31464

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The file cache repair step can be omitted if the current oC version is 10.0.4 or greater than 10.0.4.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Same as mentioned in https://github.com/owncloud/core/pull/31795

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

