### PR TITLE
[stable10] Let CopyPlugin fall back to default impl if no ICopySource

### DIFF
--- a/apps/dav/tests/unit/DAV/CopyPluginTest.php
+++ b/apps/dav/tests/unit/DAV/CopyPluginTest.php
@@ -33,6 +33,9 @@ use Sabre\DAV\Tree;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Test\TestCase;
+use OCP\Files\FileInfo;
+use OCP\Files\ForbiddenException;
+use OCA\DAV\Files\ICopySource;
 
 class CopyPluginTest extends TestCase {
 
@@ -71,7 +74,7 @@ class CopyPluginTest extends TestCase {
 	public function testCopyPluginReturnTrue($destinationExists, $destinationNode, $sourceNode) {
 
 		$this->tree->expects($this->once())->method('getNodeForPath')->willReturn($sourceNode);
-		$this->server->expects($this->once())->method('getCopyAndMoveInfo')->willReturn([
+		$this->server->expects($this->any())->method('getCopyAndMoveInfo')->willReturn([
 			'destinationExists' => $destinationExists,
 			'destinationNode' => $destinationNode
 		]);
@@ -82,16 +85,16 @@ class CopyPluginTest extends TestCase {
 
 	public function providesSourceAndDestinations() {
 		return [
-			'destination does not exist' => [false, null, null],
-			'destination is not a File' => [true, $this->createMock(Directory::class), $this->createMock(IFile::class)],
-			'source is not a IFile' => [true, $this->createMock(File::class), $this->createMock(ICollection::class)],
+			'source is not a ICopySource' => [true, null, $this->createMock(IFile::class)],
+			'destination does not exist' => [false, null, $this->createMock(ICopySource::class)],
+			'destination is not a File' => [true, $this->createMock(Directory::class), $this->createMock(ICopySource::class)],
 		];
 	}
 
 	public function testCopyPluginReturnFalse() {
 
 		$destinationNode = $this->createMock(File::class);
-		$sourceNode = $this->createMock(IFile::class);
+		$sourceNode = $this->createMock([IFile::class, ICopySource::class]);
 
 		$this->tree->expects($this->once())->method('getNodeForPath')->willReturn($sourceNode);
 		$this->server->expects($this->once())->method('getCopyAndMoveInfo')->willReturn([
@@ -104,9 +107,12 @@ class CopyPluginTest extends TestCase {
 		$this->server->expects($this->exactly(2))->method('emit')->withConsecutive(
 			['beforeBind', ['destination.txt']], ['afterBind', ['destination.txt']])->willReturn(true);
 
-		// make sure the file content is actually copied over
-		$sourceNode->expects($this->once())->method('get')->willReturn('123456');
-		$destinationNode->expects($this->once())->method('put')->with('123456');
+		$fileInfo = $this->createMock(FileInfo::class);
+		$fileInfo->method('getPath')->willReturn('path/to/destination.txt');
+
+		$sourceNode->expects($this->once())->method('copy')->with('path/to/destination.txt');
+
+		$destinationNode->expects($this->once())->method('getFileInfo')->willReturn($fileInfo);
 
 		// make sure http status and content length are properly set
 		$this->response->expects($this->once())->method('setHeader')->with('Content-Length', '0');
@@ -114,5 +120,39 @@ class CopyPluginTest extends TestCase {
 
 		$returnValue = $this->plugin->httpCopy($this->request, $this->response);
 		$this->assertFalse($returnValue);
+	}
+
+	/**
+	 * @expectedException OCA\DAV\Connector\Sabre\Exception\Forbidden
+	 * @expectedExceptionMessage Test exception
+	 */
+	public function testCopyPluginRethrowForbidden() {
+
+		$destinationNode = $this->createMock(File::class);
+		$sourceNode = $this->createMock([ICopySource::class, IFile::class]);
+
+		$this->tree->expects($this->once())->method('getNodeForPath')->willReturn($sourceNode);
+		$this->server->expects($this->once())->method('getCopyAndMoveInfo')->willReturn([
+			'destinationExists' => true,
+			'destinationNode' => $destinationNode,
+			'destination' => 'destination.txt'
+		]);
+
+		// make sure the plugin properly emits beforeBind and afterBind
+		$this->server->expects($this->once(2))
+			->method('emit')
+			->with('beforeBind', ['destination.txt'])
+			->willReturn(true);
+
+		$sourceNode->expects($this->once())
+			->method('copy')
+			->will($this->throwException(new ForbiddenException('Test exception', false)));
+
+		$fileInfo = $this->createMock(FileInfo::class);
+		$fileInfo->method('isDeletable')->willReturn(true);
+
+		$destinationNode->expects($this->once())->method('getFileInfo')->willReturn($fileInfo);
+
+		$this->plugin->httpCopy($this->request, $this->response);
 	}
 }


### PR DESCRIPTION
## Description
ICopySource is the new behavior introduced for copying versions without
deleting the destination.

To be able to preserve the old behavior for regular files, especially in
regards to permissions, we need to fall back to the old behavior instead
of trying to replicate it partly in the plugin.

Eventually we will move the regular DAV file Node implementation to
support ICopySource as well. This will likely trigger some change of
behaviors.

## Related Issue
Fixes https://github.com/owncloud/core/issues/31789

## Motivation and Context
Align with old expectation.
We can discuss later if we want to change expectations, which would trigger release notes.
The failure of https://github.com/owncloud/core/pull/31796#issuecomment-397655454

## How Has This Been Tested?
- [x] Unit test CopyPluginTest
- [x] Smashbox tests `bin/smash lib/oc-tests/test_sharePermissions.py -a` (all share permission suites pass!)
- [x] manual test for version restoration: file is not deleted and still has old versions attached

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

