### PR TITLE
Add phan as static code analyser

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,6 +80,15 @@ pipeline:
       matrix:
         TEST_SUITE: php-cs-fixer
 
+  php-phan:
+    image: owncloudci/php:7.1
+    pull: true
+    commands:
+      - make test-php-phan
+    when:
+      matrix:
+        TEST_SUITE: phan
+
   install-server:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -408,6 +417,10 @@ matrix:
   # php-cs-fixer
     - TEST_SUITE: php-cs-fixer
       PHP_VERSION: 7.2
+
+  # phan
+    - TEST_SUITE: phan
+      PHP_VERSION: 7.1
 
   # Litmus
     - PHP_VERSION: 7.1

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /apps/inc.php
 /assets
 /build/composer.phar
+/build/phan.phar
 /core/vendor
 
 # ignore all apps except core ones

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command line arguments will be applied
+ * after this file is read.
+ */
+
+return [
+
+	// Supported values: '7.0', '7.1', '7.2', null.
+	// If this is set to null,
+	// then Phan assumes the PHP version which is closest to the minor version
+	// of the php executable used to execute phan.
+	'target_php_version' => null,
+
+	// A list of directories that should be parsed for class and
+	// method information. After excluding the directories
+	// defined in exclude_analysis_directory_list, the remaining
+	// files will be statically analyzed for errors.
+	//
+	// Thus, both first-party and third-party code being used by
+	// your application should be included in this list.
+	'directory_list' => [
+		'apps',
+		'core',
+		'lib',
+		'ocs',
+		'ocs-provider',
+		'settings'
+	],
+
+	// A directory list that defines files that will be excluded
+	// from static analysis, but whose class and method
+	// information should be included.
+	//
+	// Generally, you'll want to include the directories for
+	// third-party code (such as "vendor/") in this list.
+	//
+	// n.b.: If you'd like to parse but not analyze 3rd
+	//       party code, directories containing that code
+	//       should be added to both the `directory_list`
+	//       and `exclude_analysis_directory_list` arrays.
+	'exclude_analysis_directory_list' => [
+		'lib/composer',
+		'apps/files_external/3rdparty',
+		'tests'
+	],
+
+	// A regular expression to match files to be excluded
+	// from parsing and analysis and will not be read at all.
+	//
+	// This is useful for excluding groups of test or example
+	// directories/files, unanalyzable files, or files that
+	// can't be removed for whatever reason.
+	// (e.g. '@Test\.php$@', or '@vendor/.*/(tests|Tests)/@')
+	'exclude_file_regex' => '@.*/[^/]*(tests|Tests|templates)/@',
+
+	// If true, missing properties will be created when
+	// they are first seen. If false, we'll report an
+	// error message.
+	"allow_missing_properties" => true,
+
+	// If enabled, allow null to be cast as any array-like type.
+	// This is an incremental step in migrating away from null_casts_as_any_type.
+	// If null_casts_as_any_type is true, this has no effect.
+	"null_casts_as_any_type" => true,
+
+	// Backwards Compatibility Checking. This is slow
+	// and expensive, but you should consider running
+	// it before upgrading your version of PHP to a
+	// new version that has backward compatibility
+	// breaks.
+	'backward_compatibility_checks' => false,
+
+	// The initial scan of the function's code block has no
+	// type information for `$arg`. It isn't until we see
+	// the call and rescan test()'s code block that we can
+	// detect that it is actually returning the passed in
+	// `string` instead of an `int` as declared.
+	'quick_mode' => true,
+
+	// The minimum severity level to report on. This can be
+	// set to Issue::SEVERITY_LOW, Issue::SEVERITY_NORMAL or
+	// Issue::SEVERITY_CRITICAL. Setting it to only
+	// critical issues is a good place to start on a big
+	// sloppy mature code base.
+	'minimum_severity' => 10,
+
+	// A set of fully qualified class-names for which
+	// a call to parent::__construct() is required
+	'parent_constructor_required' => [
+	],
+
+];

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -22,6 +22,7 @@ return [
 	// Thus, both first-party and third-party code being used by
 	// your application should be included in this list.
 	'directory_list' => [
+		'.phan/stubs',
 		'apps',
 		'core',
 		'lib',

--- a/.phan/stubs/OC_Theme.php
+++ b/.phan/stubs/OC_Theme.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @author Patrick Jahns <github@patrickjahns.de>
+ *
+ * @copyright Copyright (c) 2018, Patrick Jahns.
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+class OC_Theme {
+	public function getBaseUrl() {}
+
+	public function getSyncClientUrl() {}
+
+	public function getDocBaseUrl() {}
+
+	public function getTitle() {}
+
+	public function getName() {}
+
+	public function getHTMLName() {}
+
+	public function getEntity() {}
+
+	public function getSlogan() {}
+
+	public function getLogoClaim() {}
+
+	public function getShortFooter() {}
+
+	public function getLongFooter() {}
+
+	public function buildDocLinkToKey($key) {}
+
+	public function getMailHeaderColor() {}
+}

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ KARMA=$(NODE_PREFIX)/node_modules/.bin/karma
 JSDOC=$(NODE_PREFIX)/node_modules/.bin/jsdoc
 PHPUNIT="$(shell pwd)/lib/composer/phpunit/phpunit/phpunit"
 COMPOSER_BIN=build/composer.phar
+PHAN_BIN=build/phan.phar
 
 TEST_DATABASE=sqlite
 TEST_EXTERNAL_ENV=smb-silvershell
@@ -108,6 +109,8 @@ help:
 $(COMPOSER_BIN):
 	cd build && ./getcomposer.sh
 
+$(PHAN_BIN):
+	cd build && curl -s -L https://github.com/phan/phan/releases/download/0.12.10/phan.phar -o phan.phar;
 #
 # ownCloud core PHP dependencies
 #
@@ -189,6 +192,11 @@ test-php-lint: $(composer_dev_deps)
 .PHONY: test-php-style
 test-php-style: $(composer_dev_deps)
 	$(composer_deps)/bin/php-cs-fixer fix -v --diff --diff-format udiff --dry-run --allow-risky yes
+
+
+.PHONY: test-php-phan
+test-php-phan: $(PHAN_BIN)
+	php $(PHAN_BIN) --config-file .phan/config.php --require-config-exists -p
 
 .PHONY: test
 test: test-php-lint test-php-style test-php test-js test-acceptance

--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -200,10 +200,12 @@ class SyncService {
 		$multiStatus = $xml->expect('{DAV:}multistatus', $body);
 
 		$result = [];
+		/** @phan-suppress-next-line PhanNonClassMethodCall */
 		foreach ($multiStatus->getResponses() as $response) {
 			$result[$response->getHref()] = $response->getResponseProperties();
 		}
 
+		/** @phan-suppress-next-line PhanNonClassMethodCall */
 		return ['response' => $result, 'token' => $multiStatus->getSyncToken()];
 	}
 

--- a/apps/dav/lib/Connector/Sabre/AutorenamePlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AutorenamePlugin.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Patrick Jahns <github@patrickjahns.de>
  *
  * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0
@@ -21,6 +22,7 @@
 
 namespace OCA\DAV\Connector\Sabre;
 
+use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\ServerPlugin;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
@@ -54,6 +56,14 @@ class AutorenamePlugin extends ServerPlugin {
 		$this->server->on('method:PUT', [$this, 'handlePut'], 1);
 	}
 
+	/**
+	 * @param RequestInterface $request
+	 * @param ResponseInterface $response
+	 * @return bool|void
+	 * @throws \Sabre\DAV\Exception\BadRequest
+	 * @throws \Sabre\DAV\Exception\Conflict
+	 * @throws \Sabre\DAV\Exception\NotFound
+	 */
 	public function handlePut(RequestInterface $request, ResponseInterface $response) {
 		if ($request->getHeader('OC-Autorename') !== '1') {
 			return;
@@ -70,7 +80,7 @@ class AutorenamePlugin extends ServerPlugin {
 
 			   Reference: http://tools.ietf.org/html/rfc7231#section-4.3.4
 			*/
-			throw new Exception\BadRequest('Content-Range on PUT requests are forbidden.');
+			throw new BadRequest('Content-Range on PUT requests are forbidden.');
 		}
 
 		if ($this->server->tree->nodeExists($path)) {

--- a/apps/dav/lib/Files/ZsyncPlugin.php
+++ b/apps/dav/lib/Files/ZsyncPlugin.php
@@ -34,7 +34,7 @@ class ZsyncPlugin extends ServerPlugin {
 	// namespace
 	const ZSYNC_PROPERTYNAME = '{http://owncloud.org/ns}zsync';
 
-	/** @var OC\Files\View */
+	/** @var View */
 	private $view;
 
 	public function __construct(View $view) {

--- a/apps/dav/lib/Upload/AssemblyStreamZsync.php
+++ b/apps/dav/lib/Upload/AssemblyStreamZsync.php
@@ -31,7 +31,7 @@ use Sabre\DAV\IFile;
  */
 class AssemblyStreamZsync extends AssemblyStream {
 
-	/** @var array */
+	/** @var IFile */
 	private $backingFile = null;
 
 	/** @var array */

--- a/apps/dav/lib/Upload/ChunkingPluginZsync.php
+++ b/apps/dav/lib/Upload/ChunkingPluginZsync.php
@@ -31,7 +31,7 @@ class ChunkingPluginZsync extends ServerPlugin {
 	private $server;
 	/** @var FutureFileZsync */
 	private $sourceNode;
-	/** @var OC\Files\View */
+	/** @var View */
 	private $view;
 
 	public function __construct(View $view) {

--- a/apps/federatedfilesharing/lib/RequestHandler.php
+++ b/apps/federatedfilesharing/lib/RequestHandler.php
@@ -34,6 +34,7 @@ use OCP\IDBConnection;
 use OCP\IRequest;
 use OCP\IUserManager;
 use OCP\Share;
+use OCP\Share\IShare;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -47,6 +47,7 @@ use Icewind\Streams\CallbackWrapper;
 use Icewind\Streams\IteratorDirectory;
 use OC\Cache\CappedMemoryCache;
 use OC\Files\Filesystem;
+use OCP\Files\Cache\ICache;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Util;
 
@@ -67,7 +68,7 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 	protected $root;
 
 	/**
-	 * @var \Icewind\SMB\IFileInfo[]
+	 * @var ICache
 	 */
 	protected $statCache;
 

--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -111,7 +111,7 @@ class Swift extends \OCP\Files\Storage\StorageAdapter {
 	 * that one will be returned.
 	 *
 	 * @param string $path
-	 * @return \OpenCloud\OpenStack\ObjectStorage\Resource\DataObject|bool object
+	 * @return DataObject | bool object
 	 * or false if the object did not exist
 	 */
 	private function fetchObject($path) {

--- a/apps/files_external/lib/config.php
+++ b/apps/files_external/lib/config.php
@@ -30,6 +30,7 @@
  */
 
 use OCA\Files_External\AppInfo\Application;
+use OCP\Files\External\Backend\Backend;
 
 /**
  * Class to configure mount.json globally and for users

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -41,6 +41,7 @@ use OC\Files\Filesystem;
 use OC\Files\View;
 use OCA\Files_Trashbin\AppInfo\Application;
 use OCA\Files_Trashbin\Command\Expire;
+use OCP\Encryption\Keys\IStorage;
 use OCP\Files\NotFoundException;
 use OCP\User;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -375,7 +376,9 @@ class Trashbin {
 	 * @param string $owner owner user id
 	 * @param string $ownerPath path relative to the owner's home storage
 	 * @param integer $timestamp when the file was deleted
+	 * @param IStorage|null $sourceStorage
 	 * @param bool $forceCopy true to only make a copy of the versions into the trashbin
+	 * @throws Exceptions\CopyRecursiveException
 	 */
 	private static function retainVersions($filename, $owner, $ownerPath, $timestamp, $sourceStorage = null, $forceCopy = false) {
 		if (\OCP\App::isEnabled('files_versions') && !empty($ownerPath)) {

--- a/lib/private/Files/External/LegacyUtil.php
+++ b/lib/private/Files/External/LegacyUtil.php
@@ -208,7 +208,7 @@ class LegacyUtil {
 					$storage->setAvailability(false);
 					throw $e;
 				}
-			} catch (Exception $exception) {
+			} catch (\Exception $exception) {
 				\OCP\Util::logException('files_external', $exception);
 				throw $exception;
 			}

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -46,6 +46,7 @@ use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Util;
 use Sabre\DAV\Xml\Property\ResourceType;
+use Sabre\HTTP\Client;
 use Sabre\HTTP\ClientHttpException;
 use Sabre\DAV\Exception\InsufficientStorage;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -139,6 +139,7 @@ class Redis extends Cache implements IMemcacheTTL {
 		}
 		self::$cache->watch($this->getNameSpace() . $key);
 		if ($this->get($key) === $old) {
+			/** @phan-suppress-next-line PhanNonClassMethodCall */
 			$result = self::$cache->multi()
 				->set($this->getNameSpace() . $key, $new)
 				->exec();
@@ -158,6 +159,7 @@ class Redis extends Cache implements IMemcacheTTL {
 	public function cad($key, $old) {
 		self::$cache->watch($this->getNameSpace() . $key);
 		if ($this->get($key) === $old) {
+			/** @phan-suppress-next-line PhanNonClassMethodCall */
 			$result = self::$cache->multi()
 				->del($this->getNameSpace() . $key)
 				->exec();

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -26,6 +26,7 @@
 namespace OC\Share20;
 
 use OCP\Files\File;
+use OCP\Share\IShare;
 use OCP\Share\IShareProvider;
 use OC\Share20\Exception\InvalidShare;
 use OC\Share20\Exception\ProviderException;

--- a/lib/private/legacy/user.php
+++ b/lib/private/legacy/user.php
@@ -99,6 +99,7 @@ class OC_User {
 					\OC::$server->getUserManager()->registerBackend(self::$_usedBackends[$backend]);
 					break;
 				case 'dummy':
+					/* @phan-suppress-next-line PhanUndeclaredClassMethod */
 					self::$_usedBackends[$backend] = new \Test\Util\User\Dummy();
 					\OC::$server->getUserManager()->registerBackend(self::$_usedBackends[$backend]);
 					break;


### PR DESCRIPTION
## Description
https://github.com/phan/phan is a static code analysis tool that can help us improve our code basis and help find bugs.

Right now the `.phan/config` is very lenient - we should first get it to be ✅ for this lenient definition, merge / introduce it to our code basis and then gradually increase the ruleset to further improve our code base.

note: phan is currently introduced as phar - this allows us for backporting it to stable10 - without having dependencie issues, as phan officialy needs to run on php7+ ( however it can analyse code in 7 to be backward compatible to php5.6 )

## Motivation and Context
Improve code quality and ownCloud as project

## pending fixes

```
lib/private/Encryption/Util.php:123 PhanUndeclaredClassConstant Reference to constant ID from undeclared class \OCA\Encryption\Crypto\Encryption
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] QA / code related

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

