### PR TITLE
Tag scenario that is not relevant to encryption

### DIFF
--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -12,7 +12,6 @@ So that I can login to my account again after forgetting the password
 		And the user has browsed to the login page
 		And the user logs in with username "user1" and invalid password "invalidpassword" using the webUI
 		
-
 	Scenario: send password reset email
 		When the user requests the password reset link using the webUI
 		Then a message with this text should be displayed on the webUI:
@@ -24,7 +23,8 @@ So that I can login to my account again after forgetting the password
 			Use the following link to reset your password: <a href=
 			"""
 
-	Scenario: reset password
+	@skipOnEncryption
+	Scenario: reset password for the ordinary (no encryption) case
 		When the user requests the password reset link using the webUI
 		And the user follows the password reset link from email address "u1@oc.com.np"
 		Then the user should be redirected to a webUI page with the title "ownCloud"


### PR DESCRIPTION
## Description
Tag ``resetPassword.feature`` scenario about reset password UI page with ``@skipOnEncryption``

## Related Issue
Encryption PR https://github.com/owncloud/encryption/pull/34 needs this.

## Motivation and Context
We need a way to indicate which core webUI tests are testing behavior that is overridden/changed in some app(s), or tests that just do not work nicely in some app(s). We already do this for LDAP by tagging such scenarios ``@skipOnLDAP``.

Now we want to run the webUI tests with backend encryption on. At the moment just 1 scenario fails - when a user resets their password. For encryption, there is an extra warning and checkbox to check. So in core, tag that scenario ``@skipOnEncryption``. Then the encryption app can easily skip it.

The encryption app can be responsible for implementing its own test scenario to check the different behavior that it introduces.

## How Has This Been Tested?
CI in encryption will know, when this skip tag gets merged.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test infrastructure

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
