### PR TITLE
[stable10] Add can_share to capabilities

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -22,8 +22,6 @@ namespace OCA\Files_Sharing;
 
 use OCP\Capabilities\ICapability;
 use OCP\IConfig;
-use OCP\IGroupManager;
-use OCP\IUserSession;
 use OCP\Util\UserSearch;
 
 /**
@@ -42,26 +40,14 @@ class Capabilities implements ICapability {
 	private $userSearch;
 
 	/**
-	 * @var IUserSession
-	 */
-	private $userSession;
-
-	/**
-	 * @var IGroupManager
-	 */
-	private $groupManager;
-
-	/**
 	 * Capabilities constructor.
 	 *
 	 * @param IConfig $config
 	 * @param UserSearch $userSearch
 	 */
-	public function __construct(IConfig $config, UserSearch $userSearch, IUserSession $userSession, IGroupManager $groupManager) {
+	public function __construct(IConfig $config, UserSearch $userSearch) {
 		$this->config = $config;
 		$this->userSearch = $userSearch;
-		$this->userSession = $userSession;
-		$this->groupManager = $groupManager;
 	}
 
 	/**
@@ -120,7 +106,7 @@ class Capabilities implements ICapability {
 			$res['share_with_group_members_only'] = $this->config->getAppValue('core', 'shareapi_only_share_with_group_members', 'yes') === 'yes';
 			$res['share_with_membership_groups_only'] = $this->config->getAppValue('core', 'shareapi_only_share_with_membership_groups', 'yes') === 'yes';
 
-			if (\OC_Util::isSharingDisabledForUser($this->config, $this->groupManager, $this->userSession->getUser())) {
+			if (\OCP\Util::isSharingDisabledForUser()) {
 				$res['can_share'] = false;
 			} else {
 				$res['can_share'] = true;

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -36,6 +36,12 @@ class CapabilitiesTest extends \Test\TestCase {
 	 */
 	protected $userSearch;
 
+	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	protected $session;
+
+	/** @var \OCP\IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
+	protected $groupManager;
+
 	/**
 	 *
 	 */
@@ -44,6 +50,15 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->userSearch = $this->getMockBuilder(\OCP\Util\UserSearch::class)
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->session = $this->getMockBuilder(\OCP\IUserSession::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->groupManager = $this->getMockBuilder(\OCP\IGroupManager::class)
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->userSearch->expects($this->any())
 			->method('getSearchMinLength')
 			->willReturn(1);
@@ -72,7 +87,7 @@ class CapabilitiesTest extends \Test\TestCase {
 	private function getResults(array $map) {
 		$stub = $this->getMockBuilder('\OCP\IConfig')->disableOriginalConstructor()->getMock();
 		$stub->method('getAppValue')->will($this->returnValueMap($map));
-		$cap = new Capabilities($stub, $this->userSearch);
+		$cap = new Capabilities($stub, $this->userSearch, $this->session, $this->groupManager);
 		$result = $this->getFilesSharingPart($cap->getCapabilities());
 		return $result;
 	}
@@ -83,6 +98,7 @@ class CapabilitiesTest extends \Test\TestCase {
 		];
 		$result = $this->getResults($map);
 		$this->assertTrue($result['api_enabled']);
+		$this->assertTrue($result['can_share']);
 		$this->assertArrayHasKey('public', $result);
 		$this->assertArrayHasKey('user', $result);
 		$this->assertArrayHasKey('resharing', $result);
@@ -94,6 +110,7 @@ class CapabilitiesTest extends \Test\TestCase {
 		];
 		$result = $this->getResults($map);
 		$this->assertFalse($result['api_enabled']);
+		$this->assertFalse($result['can_share']);
 		$this->assertFalse($result['public']['enabled']);
 		$this->assertFalse($result['user']['send_mail']);
 		$this->assertFalse($result['resharing']);

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -36,12 +36,6 @@ class CapabilitiesTest extends \Test\TestCase {
 	 */
 	protected $userSearch;
 
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
-	protected $session;
-
-	/** @var \OCP\IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
-	protected $groupManager;
-
 	/**
 	 *
 	 */

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -51,14 +51,6 @@ class CapabilitiesTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->session = $this->getMockBuilder(\OCP\IUserSession::class)
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->groupManager = $this->getMockBuilder(\OCP\IGroupManager::class)
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->userSearch->expects($this->any())
 			->method('getSearchMinLength')
 			->willReturn(1);
@@ -87,7 +79,7 @@ class CapabilitiesTest extends \Test\TestCase {
 	private function getResults(array $map) {
 		$stub = $this->getMockBuilder('\OCP\IConfig')->disableOriginalConstructor()->getMock();
 		$stub->method('getAppValue')->will($this->returnValueMap($map));
-		$cap = new Capabilities($stub, $this->userSearch, $this->session, $this->groupManager);
+		$cap = new Capabilities($stub, $this->userSearch);
 		$result = $this->getFilesSharingPart($cap->getCapabilities());
 		return $result;
 	}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1485,8 +1485,6 @@ class Manager implements IManager {
 	/**
 	 * Copied from \OC_Util::isSharingDisabledForUser
 	 *
-	 * TODO: Deprecate function from OC_Util
-	 *
 	 * @param string $userId
 	 * @return bool
 	 */

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -319,32 +319,6 @@ class OC_Util {
 	}
 
 	/**
-	 * check if sharing is disabled for the current user
-	 * @param IConfig $config
-	 * @param IGroupManager $groupManager
-	 * @param IUser|null $user
-	 * @return bool
-	 */
-	public static function isSharingDisabledForUser(IConfig $config, IGroupManager $groupManager, $user) {
-		if ($config->getAppValue('core', 'shareapi_exclude_groups', 'no') === 'yes') {
-			$groupsList = $config->getAppValue('core', 'shareapi_exclude_groups_list', '');
-			$excludedGroups = json_decode($groupsList);
-			if (is_null($excludedGroups)) {
-				$excludedGroups = explode(',', $groupsList);
-				$newValue = json_encode($excludedGroups);
-				$config->setAppValue('core', 'shareapi_exclude_groups_list', $newValue);
-			}
-			$usersGroups = $groupManager->getUserGroupIds($user);
-			$matchingGroups = \array_intersect($usersGroups, $excludedGroups);
-			if (!empty($matchingGroups)) {
-				// If the user is a member of any of the excluded groups they cannot use sharing
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
 	 * check if share API enforces a default expire date
 	 *
 	 * @return boolean

--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -93,7 +93,7 @@ class AppConfigHelper {
 	 *                                 ['capabilitiesParameter'] the parameter name in the capabilities response
 	 *                                 ['testingApp'] the "app" name as understood by "testing"
 	 *                                 ['testingParameter'] the parameter name as understood by "testing"
-	 *                                 ['testingState'] boolean state the parameter must be set to for the test
+	 *                                 ['testingState'] boolean|string that the parameter must be set to for the test
 	 * @param string $savedCapabilitiesXml the original capabilities in XML format
 	 * @param int $apiVersion (1|2)
 	 *
@@ -118,6 +118,12 @@ class AppConfigHelper {
 					$savedCapabilitiesXml
 				);
 
+				if (\is_bool($capabilityToSet['testingState'])) {
+					$testingState = $capabilityToSet['testingState'] ? 'yes' : 'no';
+				} else {
+					$testingState = $capabilityToSet['testingState'];
+				}
+
 				// Always set each config value, because sometimes enabling one
 				// config also changes some sub-settings. So the "interim" state
 				// as we set the config values could be unexpectedly different
@@ -125,7 +131,7 @@ class AppConfigHelper {
 				$appParameterValues[] = [
 					'appid' => $capabilityToSet['testingApp'],
 					'configkey' => $capabilityToSet['testingParameter'],
-					'value' => $capabilityToSet['testingState'] ? 'yes' : 'no'
+					'value' => $testingState
 				];
 
 				// Remember the original state of all capabilities touched

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -19,6 +19,7 @@ Feature: capabilities
 	Scenario: Check that group sharing can be enabled
 		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
 		And the capabilities setting of "files_sharing" path "group_sharing" has been confirmed to be ""
+
 		When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "yes" using the API
 		Then the capabilities setting of "files_sharing" path "group_sharing" should be "1"
 
@@ -35,6 +36,7 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | 1                 |
 			| files_sharing | public@@@upload                       | 1                 |
 			| files_sharing | public@@@send_mail                    | EMPTY             |
@@ -58,6 +60,7 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | 1                 |
 			| files_sharing | public@@@upload                       | EMPTY             |
 			| files_sharing | public@@@send_mail                    | EMPTY             |
@@ -81,6 +84,7 @@ Feature: capabilities
 			| core          | pollinterval          | 60                |
 			| core          | webdav-root           | remote.php/webdav |
 			| files_sharing | api_enabled           | EMPTY             |
+			| files_sharing | can_share             | EMPTY             |
 			| files_sharing | public@@@enabled      | EMPTY             |
 			| files_sharing | public@@@upload       | EMPTY             |
 			| files_sharing | resharing             | EMPTY             |
@@ -98,6 +102,7 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | EMPTY             |
 			| files_sharing | public@@@upload                       | EMPTY             |
 			| files_sharing | resharing                             | 1                 |
@@ -119,6 +124,7 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | 1                 |
 			| files_sharing | public@@@upload                       | 1                 |
 			| files_sharing | public@@@send_mail                    | EMPTY             |
@@ -142,6 +148,7 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | 1                 |
 			| files_sharing | public@@@upload                       | 1                 |
 			| files_sharing | public@@@send_mail                    | EMPTY             |
@@ -165,6 +172,7 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | 1                 |
 			| files_sharing | public@@@upload                       | 1                 |
 			| files_sharing | public@@@send_mail                    | EMPTY             |
@@ -188,6 +196,7 @@ Feature: capabilities
 			| core          | pollinterval                                   | 60                |
 			| core          | webdav-root                                    | remote.php/webdav |
 			| files_sharing | api_enabled                                    | 1                 |
+			| files_sharing | can_share                                      | 1                 |
 			| files_sharing | public@@@enabled                               | 1                 |
 			| files_sharing | public@@@upload                                | 1                 |
 			| files_sharing | public@@@send_mail                             | EMPTY             |
@@ -214,6 +223,7 @@ Feature: capabilities
 			| core          | pollinterval                                   | 60                |
 			| core          | webdav-root                                    | remote.php/webdav |
 			| files_sharing | api_enabled                                    | 1                 |
+			| files_sharing | can_share                                      | 1                 |
 			| files_sharing | public@@@enabled                               | 1                 |
 			| files_sharing | public@@@upload                                | 1                 |
 			| files_sharing | public@@@send_mail                             | EMPTY             |
@@ -240,6 +250,7 @@ Feature: capabilities
 			| core          | pollinterval                                   | 60                |
 			| core          | webdav-root                                    | remote.php/webdav |
 			| files_sharing | api_enabled                                    | 1                 |
+			| files_sharing | can_share                                      | 1                 |
 			| files_sharing | public@@@enabled                               | 1                 |
 			| files_sharing | public@@@upload                                | 1                 |
 			| files_sharing | public@@@send_mail                             | EMPTY             |
@@ -266,6 +277,7 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | 1                 |
 			| files_sharing | public@@@upload                       | 1                 |
 			| files_sharing | public@@@send_mail                    | 1                 |
@@ -289,6 +301,7 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | 1                 |
 			| files_sharing | public@@@upload                       | 1                 |
 			| files_sharing | public@@@send_mail                    | EMPTY             |
@@ -312,6 +325,7 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | 1                 |
 			| files_sharing | public@@@upload                       | 1                 |
 			| files_sharing | public@@@send_mail                    | EMPTY             |
@@ -337,6 +351,7 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | 1                 |
 			| files_sharing | public@@@upload                       | 1                 |
 			| files_sharing | public@@@send_mail                    | EMPTY             |
@@ -362,6 +377,7 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | 1                 |
 			| files_sharing | public@@@upload                       | 1                 |
 			| files_sharing | public@@@send_mail                    | EMPTY             |
@@ -385,6 +401,7 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | 1                 |
 			| files_sharing | public@@@upload                       | 1                 |
 			| files_sharing | public@@@send_mail                    | EMPTY             |
@@ -408,6 +425,7 @@ Feature: capabilities
 			| core          | pollinterval                  | 60                |
 			| core          | webdav-root                   | remote.php/webdav |
 			| files_sharing | api_enabled                   | 1                 |
+			| files_sharing | can_share                     | 1                 |
 			| files_sharing | public@@@enabled              | 1                 |
 			| files_sharing | public@@@upload               | 1                 |
 			| files_sharing | public@@@send_mail            | EMPTY             |
@@ -430,6 +448,7 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
+			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | 1                 |
 			| files_sharing | public@@@upload                       | 1                 |
 			| files_sharing | public@@@send_mail                    | EMPTY             |
@@ -444,3 +463,128 @@ Feature: capabilities
 			| files         | bigfilechunking                       | 1                 |
 			| files         | undelete                              | 1                 |
 			| files         | versioning                            | 1                 |
+
+	Scenario: Changing exclude groups from sharing
+		Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+		And group "grp1" has been created
+		And group "hash#group" has been created
+		And group "group-3" has been created
+		And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
+			| capability    | path_to_element                           | value             |
+			| core          | pollinterval                              | 60                |
+			| core          | webdav-root                               | remote.php/webdav |
+			| files_sharing | api_enabled                               | 1                 |
+			| files_sharing | can_share                                 | 1                 |
+			| files_sharing | public@@@enabled                          | 1                 |
+			| files_sharing | public@@@upload                           | 1                 |
+			| files_sharing | public@@@send_mail                        | EMPTY             |
+			| files_sharing | public@@@social_share                     | 1                 |
+			| files_sharing | resharing                                 | 1                 |
+			| files_sharing | federation@@@outgoing                     | 1                 |
+			| files_sharing | federation@@@incoming                     | 1                 |
+			| files_sharing | group_sharing                             | 1                 |
+			| files_sharing | share_with_group_members_only             | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled                | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only     | EMPTY             |
+			| files         | bigfilechunking                           | 1                 |
+			| files         | undelete                                  | 1                 |
+			| files         | versioning                                | 1                 |
+
+	Scenario: When in a group that is excluded from sharing, can_share is off
+		Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+		And user "user0" has been created
+		And group "grp1" has been created
+		And group "hash#group" has been created
+		And group "group-3" has been created
+		And group "ordinary-group" has been created
+		And user "user0" has been added to group "hash#group"
+		And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
+		And as user "user0"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
+			| capability    | path_to_element                           | value             |
+			| core          | pollinterval                              | 60                |
+			| core          | webdav-root                               | remote.php/webdav |
+			| files_sharing | api_enabled                               | 1                 |
+			| files_sharing | can_share                                 | EMPTY             |
+			| files_sharing | public@@@enabled                          | 1                 |
+			| files_sharing | public@@@upload                           | 1                 |
+			| files_sharing | public@@@send_mail                        | EMPTY             |
+			| files_sharing | public@@@social_share                     | 1                 |
+			| files_sharing | resharing                                 | 1                 |
+			| files_sharing | federation@@@outgoing                     | 1                 |
+			| files_sharing | federation@@@incoming                     | 1                 |
+			| files_sharing | group_sharing                             | 1                 |
+			| files_sharing | share_with_group_members_only             | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled                | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only     | EMPTY             |
+			| files         | bigfilechunking                           | 1                 |
+			| files         | undelete                                  | 1                 |
+			| files         | versioning                                | 1                 |
+
+	Scenario: When not in any group that is excluded from sharing, can_share is on
+		Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+		And user "user0" has been created
+		And group "grp1" has been created
+		And group "hash#group" has been created
+		And group "group-3" has been created
+		And group "ordinary-group" has been created
+		And user "user0" has been added to group "ordinary-group"
+		And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
+		And as user "user0"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
+			| capability    | path_to_element                           | value             |
+			| core          | pollinterval                              | 60                |
+			| core          | webdav-root                               | remote.php/webdav |
+			| files_sharing | api_enabled                               | 1                 |
+			| files_sharing | can_share                                 | 1                 |
+			| files_sharing | public@@@enabled                          | 1                 |
+			| files_sharing | public@@@upload                           | 1                 |
+			| files_sharing | public@@@send_mail                        | EMPTY             |
+			| files_sharing | public@@@social_share                     | 1                 |
+			| files_sharing | resharing                                 | 1                 |
+			| files_sharing | federation@@@outgoing                     | 1                 |
+			| files_sharing | federation@@@incoming                     | 1                 |
+			| files_sharing | group_sharing                             | 1                 |
+			| files_sharing | share_with_group_members_only             | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled                | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only     | EMPTY             |
+			| files         | bigfilechunking                           | 1                 |
+			| files         | undelete                                  | 1                 |
+			| files         | versioning                                | 1                 |
+
+	Scenario: When in a group that is excluded from sharing and in another group, can_share is off
+		Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
+		And user "user0" has been created
+		And group "grp1" has been created
+		And group "hash#group" has been created
+		And group "group-3" has been created
+		And group "ordinary-group" has been created
+		And user "user0" has been added to group "hash#group"
+		And user "user0" has been added to group "ordinary-group"
+		And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
+		And as user "user0"
+		When the user retrieves the capabilities using the API
+		Then the capabilities should contain
+			| capability    | path_to_element                           | value             |
+			| core          | pollinterval                              | 60                |
+			| core          | webdav-root                               | remote.php/webdav |
+			| files_sharing | api_enabled                               | 1                 |
+			| files_sharing | can_share                                 | EMPTY             |
+			| files_sharing | public@@@enabled                          | 1                 |
+			| files_sharing | public@@@upload                           | 1                 |
+			| files_sharing | public@@@send_mail                        | EMPTY             |
+			| files_sharing | public@@@social_share                     | 1                 |
+			| files_sharing | resharing                                 | 1                 |
+			| files_sharing | federation@@@outgoing                     | 1                 |
+			| files_sharing | federation@@@incoming                     | 1                 |
+			| files_sharing | group_sharing                             | 1                 |
+			| files_sharing | share_with_group_members_only             | EMPTY             |
+			| files_sharing | user_enumeration@@@enabled                | 1                 |
+			| files_sharing | user_enumeration@@@group_members_only     | EMPTY             |
+			| files         | bigfilechunking                           | 1                 |
+			| files         | undelete                                  | 1                 |
+			| files         | versioning                                | 1                 |

--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -63,6 +63,28 @@ class CapabilitiesContext implements Context {
 	}
 
 	/**
+	 * @Then the capabilities should not contain
+	 *
+	 * @param TableNode|null $formData
+	 *
+	 * @return void
+	 */
+	public function theCapabilitiesShouldNotContain(TableNode $formData) {
+		$capabilitiesXML = $this->featureContext->getCapabilitiesXml();
+
+		foreach ($formData->getHash() as $row) {
+			PHPUnit_Framework_Assert::assertFalse(
+				$this->featureContext->parameterValueExistsInXml(
+					$capabilitiesXML,
+					$row['capability'],
+					$row['path_to_element']
+				),
+				"Capability " . $row['capability'] . " " . $row['path_to_element'] . " exists but it should not exist"
+			);
+		}
+	}
+
+	/**
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1446,6 +1446,13 @@ trait Sharing {
 			],
 			[
 				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'exclude_groups_from_sharing',
+				'testingApp' => 'core',
+				'testingParameter' => 'shareapi_exclude_groups',
+				'testingState' => false
+			],
+			[
+				'capabilitiesApp' => 'files_sharing',
 				'capabilitiesParameter' =>
 					'user_enumeration@@@enabled',
 				'testingApp' => 'core',

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -248,53 +248,6 @@ class UtilTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataProviderForTestIsSharingDisabledForUser
-	 * @param array $groups existing groups
-	 * @param array $membership groups the user belong to
-	 * @param array $excludedGroups groups which should be excluded from sharing
-	 * @param bool $expected expected result
-	 */
-	function testIsSharingDisabledForUser($groups, $membership, $excludedGroups, $expected) {
-		$config = $this->getMockBuilder('OCP\IConfig')->disableOriginalConstructor()->getMock();
-		$groupManager = $this->getMockBuilder('OCP\IGroupManager')->disableOriginalConstructor()->getMock();
-		$user = $this->getMockBuilder('OCP\IUser')->disableOriginalConstructor()->getMock();
-
-		$config
-				->expects($this->at(0))
-				->method('getAppValue')
-				->with('core', 'shareapi_exclude_groups', 'no')
-				->will($this->returnValue('yes'));
-		$config
-				->expects($this->at(1))
-				->method('getAppValue')
-				->with('core', 'shareapi_exclude_groups_list')
-				->will($this->returnValue(json_encode($excludedGroups)));
-
-		$groupManager
-				->expects($this->at(0))
-				->method('getUserGroupIds')
-				->with($user)
-				->will($this->returnValue($membership));
-
-		$result = \OC_Util::isSharingDisabledForUser($config, $groupManager, $user);
-
-		$this->assertSame($expected, $result);
-	}
-
-	public function dataProviderForTestIsSharingDisabledForUser() {
-		return [
-			// existing groups, groups the user belong to, groups excluded from sharing, expected result
-			[['g1', 'g2', 'g3'], [], ['g1'], false],
-			[['g1', 'g2', 'g3'], [], [], false],
-			[['g1', 'g2', 'g3'], ['g2'], ['g1'], false],
-			[['g1', 'g2', 'g3'], ['g2'], [], false],
-			[['g1', 'g2', 'g3'], ['g1', 'g2'], ['g1'], true],
-			[['g1', 'g2', 'g3'], ['g1', 'g2'], ['g1', 'g2'], true],
-			[['g1', 'g2', 'g3'], ['g1', 'g2'], ['g1', 'g2', 'g3'], true],
-		];
-	}
-
-	/**
 	 * Test default apps
 	 *
 	 * @dataProvider defaultAppsProvider


### PR DESCRIPTION
Backport #31816 and #31823 

Provides an extra item in capabilities. Completely backward-compatible with existing capabilities. This could go in after 10.0.9 is done.

Removes old unused private utility method isSharingDisabledForUser.
