### PR TITLE
allow edge to gc chunks

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1310,6 +1310,9 @@ OC.Uploader.prototype = _.extend({
 					// reset retries
 					upload.data.retries = 0;
 				});
+				fileupload.on('fileuploadchunkdone', function(e, data) {
+					$(data.xhr().upload).unbind('progress');
+				});
 				fileupload.on('fileuploaddone', function(e, data) {
 					var upload = self.getUpload(data);
 					upload.done().then(function() {


### PR DESCRIPTION
Edge has a hard 5GB memory limit. currently chunked uploading seems to use one indirection too many so edge will never garbage collect the chunks Blob objects.

Unsetting them manually after a chunk is completed is not enough. The memory tab in edge won't show you the objects on the heap, but overall memory consumption will still increase.

![leak](https://user-images.githubusercontent.com/956847/41541453-cdacf0ac-7312-11e8-8145-db9b221c246a.jpg)

This pr allows cs to happen by removing the actual data before passing the options to the anonymous handler: https://github.com/owncloud/core/compare/update-jqfu-fix-edge-oom?expand=1#diff-9e1e26ed9e6e26bd68c321b010edc0d9R772

![gc](https://user-images.githubusercontent.com/956847/41541702-5e98f0fc-7313-11e8-804d-8024d6e8d991.jpg)

The other changes stem from a bump to the latest version, which has some cool things like https://github.com/blueimp/jQuery-File-Upload/pull/3486 that would allow us to use dynamic chunk sizes based on the network bandwith.

- [ ] create PR against upstream
- [ ] use proper dependency management