### PR TITLE
birthday calendar exposes no access share state and is…

### DIFF
--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -102,7 +102,13 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IShareable {
 				'principal' => $this->getOwner(),
 				'protected' => true,
 			]];
-		if ($this->getName() !== BirthdayService::BIRTHDAY_CALENDAR_URI) {
+		if ($this->getName() === BirthdayService::BIRTHDAY_CALENDAR_URI) {
+			$acl[] = [
+				'privilege' => '{DAV:}write-properties',
+				'principal' => $this->getOwner(),
+				'protected' => true,
+			];
+		} else {
 			$acl[] = [
 				'privilege' => '{DAV:}write',
 				'principal' => $this->getOwner(),

--- a/apps/dav/lib/CalDAV/Plugin.php
+++ b/apps/dav/lib/CalDAV/Plugin.php
@@ -21,9 +21,24 @@
 
 namespace OCA\DAV\CalDAV;
 
+use Sabre\DAV;
+use Sabre\DAV\Xml\Property\ShareAccess;
 use Sabre\HTTP\URLUtil;
 
 class Plugin extends \Sabre\CalDAV\Plugin {
+	public function initialize(DAV\Server $server) {
+		parent::initialize($server);
+	}
+
+	public function propFind(DAV\PropFind $propFind, DAV\INode $node) {
+		parent::propFind($propFind, $node);
+
+		if ($node instanceof Calendar && $node->getName() === BirthdayService::BIRTHDAY_CALENDAR_URI) {
+			$propFind->handle('{DAV:}share-access', function () use ($node) {
+				return new ShareAccess(DAV\Sharing\Plugin::ACCESS_NOACCESS);
+			});
+		}
+	}
 
 	/**
 	 * @inheritdoc

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -29,6 +29,7 @@ use OCP\IL10N;
 use Sabre\DAV\PropPatch;
 use Sabre\VObject\Reader;
 use Test\TestCase;
+use Sabre\DAV\Exception\Forbidden;
 
 class CalendarTest extends TestCase {
 
@@ -37,7 +38,7 @@ class CalendarTest extends TestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
+		$this->l10n = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
 		$this->l10n
 			->expects($this->any())
@@ -115,7 +116,7 @@ class CalendarTest extends TestCase {
 		$c = new Calendar($backend, $calendarInfo, $this->l10n);
 
 		if ($throws) {
-			$this->setExpectedException('\Sabre\DAV\Exception\Forbidden');
+			$this->expectException(Forbidden::class);
 		}
 		$c->propPatch(new PropPatch($mutations));
 		if (!$throws) {
@@ -157,6 +158,10 @@ class CalendarTest extends TestCase {
 		if ($uri === BirthdayService::BIRTHDAY_CALENDAR_URI) {
 			$expectedAcl = [[
 				'privilege' => '{DAV:}read',
+				'principal' => $hasOwnerSet ? 'user1' : 'user2',
+				'protected' => true
+			], [
+				'privilege' => '{DAV:}write-properties',
 				'principal' => $hasOwnerSet ? 'user1' : 'user2',
 				'protected' => true
 			]];

--- a/apps/dav/tests/unit/CalDAV/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/PluginTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace OCA\DAV\Tests\unit\CalDAV;
+
+use OCA\DAV\CalDAV\BirthdayService;
+use OCA\DAV\CalDAV\Calendar;
+use OCA\DAV\CalDAV\Plugin;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\Xml\Property\ShareAccess;
+use Test\TestCase;
+
+class PluginTest extends TestCase {
+
+	/** @var Plugin */
+	private $plugin;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->plugin = new Plugin();
+	}
+
+	public function testPropFind() {
+		$propFind = new PropFind('/calendar/user/birthday_calendar', [
+			'{DAV:}share-access'
+		]);
+		$node = $this->createMock(Calendar::class);
+		$node->method('getName')->willReturn(BirthdayService::BIRTHDAY_CALENDAR_URI);
+		$this->plugin->propFind($propFind, $node);
+
+		$this->assertEquals(200, $propFind->getStatus('{DAV:}share-access'));
+		$this->assertInstanceOf(ShareAccess::class, $propFind->get('{DAV:}share-access'));
+		$this->assertEquals(\Sabre\DAV\Sharing\Plugin::ACCESS_NOACCESS, $propFind->get('{DAV:}share-access')->getValue());
+	}
+
+	public function testGetCalendarHomeForPrincipal() {
+		$calendarHome = $this->plugin->getCalendarHomeForPrincipal('principals/users/alice');
+		$this->assertEquals('calendars/alice', $calendarHome);
+	}
+}


### PR DESCRIPTION
… then not selected for attendee scheduling

## Description
For local delivery of scheduling of calendar objects always the first calendar is chosen for a user.
In some cases this is the birthday calendar which is bad because the user cannot edit event in there.

In order to solve this the birthday calendar exposes the {DAV:}share-access property with the value NOACCESS which indicates that the user has no access. The next calendar will be chosen.

This is a bit hacky but acceptable because we are not using this property in any other case.


## Related Issue
fixes #26746

## How Has This Been Tested?
- manual testing of adding a local user to an event. this user has only the birthday calendar

more testing is necessary to make sure that there is no impact on sharing of calendars.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

