### PR TITLE
Provide a pre-commit hooks which disallows commit if the code style f…

### DIFF
--- a/.githooks/pre-commit.sh
+++ b/.githooks/pre-commit.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#
+# Installation:
+#  cd .git/hooks
+# ln -s ../../.githooks/pre-commit.sh pre-commit
+
+make test-php-style


### PR DESCRIPTION
…ails

## Description
Committing without having valid php code style in place is pointless.
This pre-commit hook runs make test-php-style and disallows to commit if the code style is wrong.

Please note that this does not automatically install the pre-commit hook. Each and every user has to locally install the hook script

```sh
cd .git/hooks
ln -s ../../build/git-hooks/pre-commit.sh pre-commit
```

## Screenshots (if appropriate):
![screenshot from 2018-06-20 08-35-45](https://user-images.githubusercontent.com/1005065/41641262-0b62a470-7465-11e8-9623-04def4c0687d.png)
![screenshot from 2018-06-20 08-36-06](https://user-images.githubusercontent.com/1005065/41641261-0b245e9a-7465-11e8-916d-6d3fdd034307.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

