### PR TITLE
return all failed recipients in sendLinkShareMailFromBody

### DIFF
--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -257,8 +257,28 @@ class MailNotifications {
 
 			return $this->mailer->send($message);
 		} catch (\Exception $e) {
-			$this->logger->error("Can't send mail with public link to $recipient: ".$e->getMessage(), ['app' => 'sharing']);
-			return [$recipient];
+			$allRecipientsArr = [];
+			if ($recipient !== null && $recipient !== '') {
+				$allRecipientsArr = \explode(',', $recipient);
+			}
+			if (isset($options['cc']) && $options['cc'] !== '') {
+				$allRecipientsArr = \array_merge(
+					$allRecipientsArr,
+					\explode(',', $options['cc'])
+				);
+			}
+			if (isset($options['bcc']) && $options['bcc'] !== '') {
+				$allRecipientsArr = \array_merge(
+					$allRecipientsArr,
+					\explode(',', $options['bcc'])
+				);
+			}
+			$allRecipients = \implode(',', $allRecipientsArr);
+			$this->logger->error(
+				"Can't send mail with public link to $allRecipients: ".$e->getMessage(),
+				['app' => 'sharing']
+			);
+			return [$allRecipients];
 		}
 	}
 


### PR DESCRIPTION
## Description
Construct a comma-separated string of all the recipient addresses in the failed email - To, Bcc and Cc.
Return that complete list to the caller of ``sendLinkShareMailFromBody()``
This is specially useful, because usually these emails have no ``To`` recipient.

## Related Issue
#31845 

## Motivation and Context
Mention all email addresses when an attempt to send an email about a public link fails.

## How Has This Been Tested?
1. do not start any mail server (or do something else to make mail sending fail in general)
2. set the system log level to debug (0)
3. In admin, settings, sharing, enable "Allow users to send mail notification for shared files"
4. Login as an ordinary user
5. Share a file or folder as a public link
6. Enter some email address/es in "Send link via email"
7. Click "Share"

Error dialog is displayed that includes the failed email addresses:
  An error occurred while sending email
  Couldn't send mail to following recipient(s):
    mail1@example.com,mail2@example.com

``owncloud.log`` contains an entry like:
```
Can't send mail with public link to mail1@example.com,mail2@example.com: Connection could not be established with host 127.0.0.1 [Connection refused #111]
```

## Screenshots (if appropriate):
![screenshot-2018-6-20 files - owncloud 1](https://user-images.githubusercontent.com/1535615/41666910-59907166-74cb-11e8-91b2-7db2d879c004.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
