### PR TITLE
[POC] Feature/introduce amd to MOVE

### DIFF
--- a/apps/dav/appinfo/Migrations/Version20180622095921.php
+++ b/apps/dav/appinfo/Migrations/Version20180622095921.php
@@ -1,0 +1,34 @@
+<?php
+namespace OCA\dav\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use OCP\Migration\ISchemaMigration;
+
+class Version20180622095921 implements ISchemaMigration {
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+		if ($schema->hasTable("${prefix}dav_job_status")) {
+			return;
+		}
+		$table = $schema->createTable("${prefix}dav_job_status");
+		$table->addColumn('id', Type::BIGINT, [
+			'autoincrement' => true,
+			'notnull' => true,
+			'length' => 20,
+		]);
+		$table->addColumn('uuid', Type::GUID, [
+			'notnull' => true,
+		]);
+		$table->addColumn('user_id', Type::STRING, [
+			'notnull' => true,
+			'length' => 64,
+		]);
+		$table->addColumn('status_info', Type::STRING, [
+			'notnull' => true,
+			'length' => 4000,
+		]);
+		$table->setPrimaryKey(['id']);
+		$table->addUniqueIndex(['uuid']);
+	}
+}

--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -22,17 +22,36 @@
 namespace OCA\DAV;
 
 use OCP\Capabilities\ICapability;
+use OCP\IConfig;
 
 class Capabilities implements ICapability {
+	/** @var IConfig */
+	private $config;
+
+	/**
+	 * Capabilities constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
 	public function getCapabilities() {
-		return [
+		$cap =  [
 			'dav' => [
 				'chunking' => '1.0',
 				'zsync' => '1.0',
 				'reports' => [
 					'search-files',
-				],
+				]
 			]
 		];
+
+		if ($this->config->getSystemValue('dav.enable.async', true)) {
+			$cap['async'] = '1.0';
+		}
+
+		return $cap;
 	}
 }

--- a/apps/dav/lib/Connector/Sabre/Server.php
+++ b/apps/dav/lib/Connector/Sabre/Server.php
@@ -25,6 +25,8 @@
 namespace OCA\DAV\Connector\Sabre;
 
 use OCA\DAV\DAV\CopyPlugin;
+use OCA\DAV\DAV\LazyOpsPlugin;
+use OCA\DAV\JobStatus\Entity\JobStatusMapper;
 
 /**
  * Class \OCA\DAV\Connector\Sabre\Server
@@ -37,6 +39,8 @@ class Server extends \Sabre\DAV\Server {
 
 	/**
 	 * @see \Sabre\DAV\Server
+	 * @param null $treeOrNode
+	 * @throws \OCP\AppFramework\QueryException
 	 * @throws \Sabre\DAV\Exception
 	 */
 	public function __construct($treeOrNode = null) {
@@ -44,5 +48,12 @@ class Server extends \Sabre\DAV\Server {
 		self::$exposeVersion = false;
 		$this->enablePropfindDepthInfinity = true;
 		$this->addPlugin(new CopyPlugin());
+		$this->addPlugin(new LazyOpsPlugin(
+			\OC::$server->getUserSession(),
+			\OC::$server->getURLGenerator(),
+			\OC::$server->getShutdownHandler(),
+			\OC::$server->query(JobStatusMapper::class),
+			\OC::$server->getLogger()
+		));
 	}
 }

--- a/apps/dav/lib/Connector/Sabre/Server.php
+++ b/apps/dav/lib/Connector/Sabre/Server.php
@@ -25,8 +25,6 @@
 namespace OCA\DAV\Connector\Sabre;
 
 use OCA\DAV\DAV\CopyPlugin;
-use OCA\DAV\DAV\LazyOpsPlugin;
-use OCA\DAV\JobStatus\Entity\JobStatusMapper;
 
 /**
  * Class \OCA\DAV\Connector\Sabre\Server
@@ -40,7 +38,6 @@ class Server extends \Sabre\DAV\Server {
 	/**
 	 * @see \Sabre\DAV\Server
 	 * @param null $treeOrNode
-	 * @throws \OCP\AppFramework\QueryException
 	 * @throws \Sabre\DAV\Exception
 	 */
 	public function __construct($treeOrNode = null) {
@@ -48,12 +45,5 @@ class Server extends \Sabre\DAV\Server {
 		self::$exposeVersion = false;
 		$this->enablePropfindDepthInfinity = true;
 		$this->addPlugin(new CopyPlugin());
-		$this->addPlugin(new LazyOpsPlugin(
-			\OC::$server->getUserSession(),
-			\OC::$server->getURLGenerator(),
-			\OC::$server->getShutdownHandler(),
-			\OC::$server->query(JobStatusMapper::class),
-			\OC::$server->getLogger()
-		));
 	}
 }

--- a/apps/dav/lib/DAV/LazyOpsPlugin.php
+++ b/apps/dav/lib/DAV/LazyOpsPlugin.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\DAV;
+
+use OCA\DAV\JobStatus\Entity\JobStatus;
+use OCA\DAV\JobStatus\Entity\JobStatusMapper;
+use OCP\ILogger;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+use OCP\Shutdown\IShutdownManager;
+use Sabre\DAV\Exception;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\DAV\UUIDUtil;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\Response;
+use Sabre\HTTP\ResponseInterface;
+
+/**
+ * Class LazyOpsPlugin
+ *
+ * @package OCA\DAV\DAV
+ */
+class LazyOpsPlugin extends ServerPlugin {
+
+	/** @var Server */
+	private $server;
+	/** @var string */
+	private $jobId;
+	/** @var JobStatus */
+	private $entity;
+	/** @var IUserSession */
+	private $userSession;
+	/** @var IURLGenerator */
+	private $urlGenerator;
+	/** @var IShutdownManager */
+	private $shutdownManager;
+	/** @var ILogger */
+	private $logger;
+	/** @var JobStatusMapper */
+	private $mapper;
+
+	public function __construct(IUserSession $userSession,
+								IURLGenerator $urlGenerator,
+								IShutdownManager $shutdownManager,
+								JobStatusMapper $jobStatusMapper,
+								ILogger $logger) {
+		$this->userSession = $userSession;
+		$this->urlGenerator = $urlGenerator;
+		$this->shutdownManager = $shutdownManager;
+		$this->logger = $logger;
+		$this->mapper = $jobStatusMapper;
+	}
+
+	/**
+	 * @param Server $server
+	 */
+	public function initialize(Server $server) {
+		$this->server = $server;
+		$server->on('method:MOVE', [$this, 'httpMove'], 90);
+	}
+
+	/**
+	 * @param RequestInterface $request
+	 * @param ResponseInterface $response
+	 * @return bool
+	 * @throws Exception\NotAuthenticated
+	 */
+	public function httpMove(RequestInterface $request, ResponseInterface $response) {
+		if (!$request->getHeader('OC-LazyOps')) {
+			return true;
+		}
+
+		$this->jobId = UUIDUtil::getUUID();
+		$this->setJobStatus([
+			'status' => 'init'
+		]);
+		$userId = $this->getUserId();
+		$location = $this->urlGenerator
+				->linkTo('', 'remote.php') . "/dav/job-status/{$userId}/{$this->jobId}";
+
+		$response->setStatus(202);
+		$response->setHeader('Connection', 'close');
+		$response->setHeader('OC-JobStatus-Location', $location);
+
+		$this->shutdownManager->register(function () use ($request, $response) {
+			return $this->afterResponse($request, $response);
+		}, IShutdownManager::HIGH);
+
+		return false;
+	}
+
+	public function afterResponse(RequestInterface $request, ResponseInterface $response) {
+		if (!$request->getHeader('OC-LazyOps')) {
+			return true;
+		}
+
+		\flush();
+		$request->removeHeader('OC-LazyOps');
+		$responseDummy = new Response();
+		try {
+			$this->setJobStatus([
+				'status' => 'started'
+			]);
+			$this->server->emit('method:MOVE', [$request, $responseDummy]);
+
+			$this->setJobStatus([
+				'status' => 'finished',
+				'fileId' => $response->getHeader('OC-FileId'),
+				'ETag' => $response->getHeader('ETag')
+			]);
+		} catch (\Exception $ex) {
+			$this->logger->logException($ex);
+
+			$this->setJobStatus([
+				'status' => 'error',
+				'errorCode' => $ex instanceof Exception ? $ex->getHTTPCode() : 500,
+				'errorMessage' => $ex->getMessage()
+			]);
+		}
+		return false;
+	}
+
+	private function setJobStatus(array $status) {
+		if ($this->entity === null) {
+			$userId = $this->getUserId();
+
+			$this->entity = new JobStatus();
+			$this->entity->setStatusInfo(\json_encode($status));
+			$this->entity->setUserId($userId);
+			$this->entity->setUuid($this->jobId);
+			$this->mapper->insert($this->entity);
+		} else {
+			$this->entity->setStatusInfo(\json_encode($status));
+			$this->mapper->update($this->entity);
+		}
+	}
+
+	/**
+	 * @return string
+	 * @throws Exception\NotAuthenticated
+	 */
+	private function getUserId() {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new Exception\NotAuthenticated();
+		}
+		return $user->getUID();
+	}
+}

--- a/apps/dav/lib/JobStatus/Entity/JobStatus.php
+++ b/apps/dav/lib/JobStatus/Entity/JobStatus.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\JobStatus\Entity;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class JobStatus
+ *
+ * @method string getUuid()
+ * @method void setUuid(string $uuid)
+ * @method string getUserId()
+ * @method void setUserId(string $userId)
+ * @method string getStatusInfo()
+ * @method void setStatusInfo(string $statusInfo)
+ *
+ * @package OCA\DAV\JobStatus\Entity
+ */
+class JobStatus extends Entity {
+	protected $uuid;
+	protected $userId;
+	protected $statusInfo;
+}

--- a/apps/dav/lib/JobStatus/Entity/JobStatusMapper.php
+++ b/apps/dav/lib/JobStatus/Entity/JobStatusMapper.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\JobStatus\Entity;
+
+use OCP\AppFramework\Db\Mapper;
+use OCP\IDBConnection;
+
+class JobStatusMapper extends Mapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'dav_job_status');
+	}
+
+	/**
+	 * @param string $userId
+	 * @param string $jobId
+	 * @return JobStatus
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 */
+	public function findByUserIdAndJobId($userId, $jobId) {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq('uuid', $query->createNamedParameter($jobId)))
+			->andWhere($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
+		return $this->mapRowToEntity($this->findOneQuery($query->getSQL(), $query->getParameters()));
+	}
+}

--- a/apps/dav/lib/JobStatus/EventStreamPlugin.php
+++ b/apps/dav/lib/JobStatus/EventStreamPlugin.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\JobStatus;
+
+use Hhxsv5\SSE\SSE;
+use Hhxsv5\SSE\Update;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+
+class EventStreamPlugin extends ServerPlugin {
+
+	/** @var Server */
+	private $server;
+
+	/**
+	 * This initializes the plugin.
+	 *
+	 * This function is called by Sabre\DAV\Server, after
+	 * addPlugin is called.
+	 *
+	 * This method should set up the required event subscriptions.
+	 *
+	 * @param Server $server
+	 * @return void
+	 */
+	public function initialize(Server $server) {
+		$this->server = $server;
+		$server->on('method:GET', [$this, 'httpGet'], 90);
+	}
+
+	/**
+	 * Intercepts GET requests on addressbook urls ending with ?photo.
+	 *
+	 * @param RequestInterface $request
+	 * @param ResponseInterface $response
+	 * @return bool
+	 */
+	public function httpGet(RequestInterface $request, ResponseInterface $response) {
+		$queryParams = $request->getQueryParameters();
+		if (!\array_key_exists('sse', $queryParams)) {
+			return true;
+		}
+
+		$path = $request->getPath();
+		$node = $this->server->tree->getNodeForPath($path);
+
+		if (!($node instanceof JobStatus)) {
+			return true;
+		}
+
+		$response->setHeader('Content-Type', 'text/event-stream');
+		$response->setHeader('Connection', 'keep-alive');
+		$response->setHeader('Cache-Control', 'no-cache');
+		$response->setHeader('X-Accel-Buffering', 'no');
+		$response->setStatus(200);
+
+		$this->server->sapi->sendResponse($response);
+		\ob_flush();
+		\flush();
+
+		$etag = '';
+
+		(new SSE())->start(new Update(function () use ($node, &$etag) {
+			$node->refreshStatus();
+			if ($node->getETag() === $etag) {
+				return false;
+			}
+			$etag = $node->getETag();
+			return $node->get();
+		}), 'job-status');
+
+		// Returning false to break the event chain
+		return false;
+	}
+}

--- a/apps/dav/lib/JobStatus/Home.php
+++ b/apps/dav/lib/JobStatus/Home.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\JobStatus;
+
+use OCA\DAV\DAV\LazyOpsPlugin;
+use OCA\DAV\JobStatus\Entity\JobStatusMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use Sabre\DAV\Collection;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\Exception\MethodNotAllowed;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\SimpleFile;
+use Sabre\HTTP\URLUtil;
+
+class Home extends Collection {
+	/** @var array */
+	private $principalInfo;
+	/** @var JobStatusMapper */
+	private $mapper;
+
+	/**
+	 * Home constructor.
+	 *
+	 * @param array $principalInfo
+	 * @param JobStatusMapper $mapper
+	 */
+	public function __construct($principalInfo, JobStatusMapper $mapper) {
+		$this->principalInfo = $principalInfo;
+		$this->mapper = $mapper;
+	}
+
+	public function getChild($name) {
+		try {
+			$entity = $this->mapper->findByUserIdAndJobId($this->getName(), $name);
+
+			return new JobStatus($this->getName(), $name, $this->mapper, $entity);
+		} catch (DoesNotExistException $ex) {
+			throw new NotFound();
+		}
+	}
+
+	public function getChildren() {
+		throw new MethodNotAllowed('Listing members of this collection is disabled');
+	}
+
+	public function getName() {
+		list(, $name) = URLUtil::splitPath($this->principalInfo['uri']);
+		return $name;
+	}
+}

--- a/apps/dav/lib/JobStatus/JobStatus.php
+++ b/apps/dav/lib/JobStatus/JobStatus.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\JobStatus;
+
+use OCA\DAV\DAV\LazyOpsPlugin;
+use OCA\DAV\JobStatus\Entity\JobStatus as JobStatusEntity;
+use OCA\DAV\JobStatus\Entity\JobStatusMapper;
+use Sabre\DAV\File;
+
+class JobStatus extends File {
+
+	/** @var string */
+	private $jobId;
+	/** @var string */
+	private $userId;
+	/** @var string */
+	private $data;
+	/** @var JobStatusMapper */
+	private $mapper;
+	/** @var JobStatusEntity */
+	private $entity;
+
+	public function __construct($userId, $jobId,
+								JobStatusMapper $mapper,
+								JobStatusEntity $entity) {
+		$this->userId = $userId;
+		$this->jobId = $jobId;
+		$this->mapper = $mapper;
+		$this->entity = $entity;
+	}
+
+	/**
+	 * Returns the name of the node.
+	 *
+	 * This is used to generate the url.
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return $this->jobId;
+	}
+
+	public function get() {
+		if ($this->entity === null) {
+			$this->entity = $this->mapper
+				->findByUserIdAndJobId($this->userId, $this->jobId);
+		}
+		return $this->entity->getStatusInfo();
+	}
+
+	public function getETag() {
+		return '"' . \sha1($this->get()) . '"';
+	}
+
+	public function getSize() {
+		return \strlen($this->get());
+	}
+
+	public function refreshStatus() {
+		$this->entity = null;
+	}
+}

--- a/apps/dav/lib/JobStatus/RootCollection.php
+++ b/apps/dav/lib/JobStatus/RootCollection.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\JobStatus;
+
+use OCA\DAV\JobStatus\Entity\JobStatusMapper;
+use Sabre\DAVACL\AbstractPrincipalCollection;
+
+class RootCollection extends AbstractPrincipalCollection {
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getChildForPrincipal(array $principalInfo) {
+		/** @var JobStatusMapper $mapper */
+		$mapper = \OC::$server->query(JobStatusMapper::class);
+		return new Home($principalInfo, $mapper);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function getName() {
+		return 'job-status';
+	}
+}

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -91,6 +91,9 @@ class RootCollection extends SimpleCollection {
 		$avatarCollection = new Avatars\RootCollection($userPrincipalBackend, 'principals/users');
 		$avatarCollection->disableListing = $disableListing;
 
+		$queueCollection = new JobStatus\RootCollection($userPrincipalBackend, 'principals/users');
+		$queueCollection->disableListing = $disableListing;
+
 		$children = [
 				new SimpleCollection('principals', [
 						$userPrincipals,
@@ -106,7 +109,8 @@ class RootCollection extends SimpleCollection {
 				$systemTagRelationsCollection,
 				$uploadCollection,
 				$avatarCollection,
-				new \OCA\DAV\Meta\RootCollection(\OC::$server->getRootFolder())
+				new \OCA\DAV\Meta\RootCollection(\OC::$server->getRootFolder()),
+				$queueCollection
 		];
 
 		parent::__construct('root', $children);

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -52,6 +52,7 @@ use OCA\DAV\DAV\PublicAuth;
 use OCA\DAV\Files\BrowserErrorPagePlugin;
 use OCA\DAV\Files\PreviewPlugin;
 use OCA\DAV\Files\ZsyncPlugin;
+use OCA\DAV\JobStatus\EventStreamPlugin;
 use OCA\DAV\SystemTag\SystemTagPlugin;
 use OCA\DAV\Upload\ChunkingPlugin;
 use OCA\DAV\Upload\ChunkingPluginZsync;
@@ -173,6 +174,7 @@ class Server {
 
 		$this->server->addPlugin(new CopyEtagHeaderPlugin());
 		$this->server->addPlugin(new ChunkingPlugin());
+		$this->server->addPlugin(new EventStreamPlugin());
 
 		// Some WebDAV clients do require Class 2 WebDAV support (locking), since
 		// we do not provide locking we emulate it using a fake locking plugin.

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -26,7 +26,6 @@
  */
 namespace OCA\DAV;
 
-use OC\Files\Filesystem;
 use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\CalDAV\Schedule\IMipPlugin;
 use OCA\DAV\CardDAV\ImageExportPlugin;
@@ -47,11 +46,13 @@ use OCA\DAV\Connector\Sabre\TagsPlugin;
 use OCA\DAV\Connector\Sabre\ValidateRequestPlugin;
 use OCA\DAV\DAV\FileCustomPropertiesBackend;
 use OCA\DAV\DAV\FileCustomPropertiesPlugin;
+use OCA\DAV\DAV\LazyOpsPlugin;
 use OCA\DAV\DAV\MiscCustomPropertiesBackend;
 use OCA\DAV\DAV\PublicAuth;
 use OCA\DAV\Files\BrowserErrorPagePlugin;
 use OCA\DAV\Files\PreviewPlugin;
 use OCA\DAV\Files\ZsyncPlugin;
+use OCA\DAV\JobStatus\Entity\JobStatusMapper;
 use OCA\DAV\JobStatus\EventStreamPlugin;
 use OCA\DAV\SystemTag\SystemTagPlugin;
 use OCA\DAV\Upload\ChunkingPlugin;
@@ -76,6 +77,8 @@ class Server {
 	 *
 	 * @param IRequest $request
 	 * @param string $baseUri
+	 * @throws \OCP\AppFramework\QueryException
+	 * @throws \Sabre\DAV\Exception
 	 */
 	public function __construct(IRequest $request, $baseUri) {
 		$this->request = $request;
@@ -86,6 +89,17 @@ class Server {
 		$root = new RootCollection();
 		$tree = new \OCA\DAV\Tree($root);
 		$this->server = new \OCA\DAV\Connector\Sabre\Server($tree);
+
+		$config = \OC::$server->getConfig();
+		if ($config->getSystemValue('dav.enable.async', true)) {
+			$this->server->addPlugin(new LazyOpsPlugin(
+				\OC::$server->getUserSession(),
+				\OC::$server->getURLGenerator(),
+				\OC::$server->getShutdownHandler(),
+				\OC::$server->query(JobStatusMapper::class),
+				\OC::$server->getLogger()
+			));
+		}
 
 		// Backends
 		$authBackend = new Auth(
@@ -100,7 +114,6 @@ class Server {
 		$this->server->httpRequest->setUrl($this->request->getRequestUri());
 		$this->server->setBaseUri($this->baseUri);
 
-		$config = \OC::$server->getConfig();
 		$this->server->addPlugin(new MaintenancePlugin($config));
 		$this->server->addPlugin(new ValidateRequestPlugin('dav'));
 		$this->server->addPlugin(new BlockLegacyClientPlugin($config));
@@ -298,7 +311,7 @@ class Server {
 	}
 
 	/**
-	 * @param string[] $subTree
+	 * @param string[] $subTrees
 	 * @return bool
 	 */
 	private function isRequestForSubtree(array $subTrees) {

--- a/apps/dav/tests/unit/DAV/LazyOpsPluginTest.php
+++ b/apps/dav/tests/unit/DAV/LazyOpsPluginTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\unit\DAV;
+
+use OCA\DAV\DAV\LazyOpsPlugin;
+use OCA\DAV\JobStatus\Entity\JobStatus;
+use OCA\DAV\JobStatus\Entity\JobStatusMapper;
+use OCP\ILogger;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\Shutdown\IShutdownManager;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\Server;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Test\TestCase;
+
+class LazyOpsPluginTest extends TestCase {
+
+	/** @var LazyOpsPlugin */
+	private $plugin;
+	/** @var ILogger */
+	private $logger;
+	/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject */
+	private $jobStatusMapper;
+	/** @var IShutdownManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $shutdownManager;
+	/** @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject */
+	private $urlGenerator;
+	/** @var IUserSession | \PHPUnit_Framework_MockObject_MockObject */
+	private $userSession;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->urlGenerator= $this->createMock(IURLGenerator::class);
+		$this->shutdownManager = $this->createMock(IShutdownManager::class);
+		$this->jobStatusMapper = $this->createMock(JobStatusMapper::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->plugin = new LazyOpsPlugin($this->userSession, $this->urlGenerator,
+			$this->shutdownManager, $this->jobStatusMapper, $this->logger);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+	}
+
+	public function testInit() {
+		$server = $this->createMock(Server::class);
+		$server->expects(self::once())->method('on')->with('method:MOVE');
+		$this->plugin->initialize($server);
+	}
+
+	public function testMoveWithoutLazyOpsHeader() {
+		$request = $this->createMock(RequestInterface::class);
+		$response= $this->createMock(ResponseInterface::class);
+		$response->expects($this->never())->method('setStatus');
+		$this->plugin->httpMove($request, $response);
+	}
+
+	public function testMoveWithLazyOpsHeader() {
+		$request = $this->createMock(RequestInterface::class);
+		$request->method('getHeader')->with('OC-LazyOps')->willReturn(true);
+		$response= $this->createMock(ResponseInterface::class);
+		$response->expects($this->once())->method('setStatus')->with(202);
+		$response->expects($this->exactly(2))->method('setHeader')->withConsecutive(
+			['Connection', 'close'],
+			['OC-JobStatus-Location', self::stringStartsWith('/remote.php/dav/job-status/alice/')]
+		);
+
+		$this->urlGenerator->expects(self::once())->method('linkTo')->willReturn('/remote.php');
+
+		$this->jobStatusMapper->expects(self::once())
+			->method('insert')->willReturnCallback(function (JobStatus $entity) {
+				self::assertEquals('alice', $entity->getUserId());
+				self::assertEquals('{"status":"init"}', $entity->getStatusInfo());
+			});
+
+		$this->shutdownManager->expects(self::once())->method('register');
+
+		$this->plugin->httpMove($request, $response);
+	}
+
+	public function testAfterResponseProcessing() {
+		$request = $this->createMock(RequestInterface::class);
+		$request->method('getHeader')->with('OC-LazyOps')->willReturn(true);
+		$request->expects(self::once())->method('removeHeader')->with('OC-LazyOps')->willReturn(true);
+
+		$response= $this->createMock(ResponseInterface::class);
+		$response->expects($this->exactly(2))->method('getHeader')->withConsecutive(
+			['OC-FileId'],
+			['ETag']
+		)->willReturnOnConsecutiveCalls(
+			'oc1234',
+			'"abcdef"'
+		);
+
+		$this->jobStatusMapper->expects(self::once())
+			->method('insert')->willReturnCallback(function (JobStatus $entity) {
+				self::assertEquals('alice', $entity->getUserId());
+				self::assertEquals('{"status":"started"}', $entity->getStatusInfo());
+			});
+		$this->jobStatusMapper->expects(self::once())
+			->method('update')->willReturnCallback(function (JobStatus $entity) {
+				self::assertEquals('alice', $entity->getUserId());
+				self::assertEquals('{"status":"finished","fileId":"oc1234","ETag":"\"abcdef\""}', $entity->getStatusInfo());
+			});
+
+		$server = $this->createMock(Server::class);
+		$server->expects(self::once())->method('emit')->with('method:MOVE');
+
+		$this->plugin->initialize($server);
+		$this->plugin->afterResponse($request, $response);
+	}
+
+	public function testAfterResponseProcessingThrowingAnException() {
+		$request = $this->createMock(RequestInterface::class);
+		$request->method('getHeader')->with('OC-LazyOps')->willReturn(true);
+		$request->expects(self::once())->method('removeHeader')->with('OC-LazyOps')->willReturn(true);
+
+		$response= $this->createMock(ResponseInterface::class);
+
+		$this->jobStatusMapper->expects(self::once())
+			->method('insert')->willReturnCallback(function (JobStatus $entity) {
+				self::assertEquals('alice', $entity->getUserId());
+				self::assertEquals('{"status":"started"}', $entity->getStatusInfo());
+			});
+		$this->jobStatusMapper->expects(self::once())
+			->method('update')->willReturnCallback(function (JobStatus $entity) {
+				self::assertEquals('alice', $entity->getUserId());
+				self::assertEquals('{"status":"error","errorCode":404,"errorMessage":""}', $entity->getStatusInfo());
+			});
+
+		$server = $this->createMock(Server::class);
+		$server->expects(self::once())->method('emit')->willThrowException(new NotFound());
+
+		$this->plugin->initialize($server);
+		$this->plugin->afterResponse($request, $response);
+	}
+}

--- a/apps/dav/tests/unit/JobStatus/Entity/JobStatusMapperTest.php
+++ b/apps/dav/tests/unit/JobStatus/Entity/JobStatusMapperTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\JobStatus\Entity;
+
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use OCA\DAV\JobStatus\Entity\JobStatus;
+use OCA\DAV\JobStatus\Entity\JobStatusMapper;
+use OCP\IDBConnection;
+use Sabre\DAV\UUIDUtil;
+use Test\TestCase;
+
+/**
+ * Class JobStatusMapperTest
+ *
+ * @package OCA\DAV\Tests\Unit\JobStatus\Entity
+ * @group DB
+ */
+class JobStatusMapperTest extends TestCase {
+	/** @var JobStatusMapper */
+	private $mapper;
+	/** @var IDBConnection */
+	private $database;
+	/** @var JobStatus */
+	private $testJobStatus;
+
+	public function setUp() {
+		parent::setUp();
+		$this->database = \OC::$server->getDatabaseConnection();
+		$this->mapper = new JobStatusMapper($this->database);
+
+		// test entity
+		$this->testJobStatus = new JobStatus();
+		$this->testJobStatus->setUserId('xxx');
+		$this->testJobStatus->setUuid(UUIDUtil::getUUID());
+		$this->testJobStatus->setStatusInfo(\json_encode([]));
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		if ($this->mapper !== null && $this->testJobStatus !== null) {
+			$this->mapper->delete($this->testJobStatus);
+		}
+	}
+
+	/**
+	 * @expectedException \Doctrine\DBAL\Exception\UniqueConstraintViolationException
+	 */
+	public function testInsert() {
+		$this->mapper->insert($this->testJobStatus);
+		$this->assertNotNull($this->testJobStatus->getId());
+		// below throws exception due to unique constraint violation
+		$this->mapper->insert($this->testJobStatus);
+	}
+
+	/**
+	 * @depends testInsert
+	 */
+	public function testQuery() {
+		$this->mapper->insert($this->testJobStatus);
+		$entity = $this->mapper->findByUserIdAndJobId($this->testJobStatus->getUserId(),
+			$this->testJobStatus->getUuid());
+		$this->assertInstanceOf(JobStatus::class, $entity);
+		$this->assertEquals($this->testJobStatus->getId(), $entity->getId());
+		$this->assertEquals($this->testJobStatus->getUserId(), $entity->getUserId());
+		$this->assertEquals($this->testJobStatus->getUuid(), $entity->getUuid());
+		$this->assertEquals($this->testJobStatus->getStatusInfo(), $entity->getStatusInfo());
+	}
+}

--- a/apps/dav/tests/unit/JobStatus/EventStreamPluginTest.php
+++ b/apps/dav/tests/unit/JobStatus/EventStreamPluginTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\JobStatus;
+
+use OCA\DAV\JobStatus\Entity\JobStatus as JobStatusEntity;
+use OCA\DAV\JobStatus\Entity\JobStatusMapper;
+use OCA\DAV\JobStatus\Home;
+use OCA\DAV\JobStatus\JobStatus;
+use OCP\AppFramework\Db\DoesNotExistException;
+use Test\TestCase;
+
+/**
+ * Class HomeTest
+ *
+ * @package OCA\DAV\Tests\Unit\JobStatus
+ */
+class HomeTest extends TestCase {
+
+	public function testGetName() {
+		/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject $mapper */
+		$mapper = $this->createMock(JobStatusMapper::class);
+		$home = new Home(['uri' => 'principals/users/user1'], $mapper);
+		$this->assertEquals('user1', $home->getName());
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
+	 */
+	public function testGetChildren() {
+		/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject $mapper */
+		$mapper = $this->createMock(JobStatusMapper::class);
+		$home = new Home(['uri' => 'principals/users/user1'], $mapper);
+		$home->getChildren();
+	}
+
+	public function testGetChild() {
+		/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject $mapper */
+		$mapper = $this->createMock(JobStatusMapper::class);
+
+		$jobStatusEntity = new JobStatusEntity();
+		$mapper->method('findByUserIdAndJobId')->willReturn($jobStatusEntity);
+		$home = new Home(['uri' => 'principals/users/user1'], $mapper);
+		$child = $home->getChild('1234567890');
+		$this->assertInstanceOf(JobStatus::class, $child);
+		$this->assertEquals('1234567890', $child->getName());
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\NotFound
+	 */
+	public function testGetChildNotFound() {
+		/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject $mapper */
+		$mapper = $this->createMock(JobStatusMapper::class);
+
+		$ex = new DoesNotExistException('');
+		$mapper->method('findByUserIdAndJobId')->willThrowException($ex);
+		$home = new Home(['uri' => 'principals/users/user1'], $mapper);
+		$home->getChild('1234567890');
+	}
+}

--- a/apps/dav/tests/unit/JobStatus/HomeTest.php
+++ b/apps/dav/tests/unit/JobStatus/HomeTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\JobStatus;
+
+use OCA\DAV\JobStatus\Entity\JobStatus as JobStatusEntity;
+use OCA\DAV\JobStatus\Entity\JobStatusMapper;
+use OCA\DAV\JobStatus\Home;
+use OCA\DAV\JobStatus\JobStatus;
+use OCP\AppFramework\Db\DoesNotExistException;
+use Test\TestCase;
+
+/**
+ * Class HomeTest
+ *
+ * @package OCA\DAV\Tests\Unit\JobStatus
+ */
+class HomeTest extends TestCase {
+	public function testGetName() {
+		/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject $mapper */
+		$mapper = $this->createMock(JobStatusMapper::class);
+		$home = new Home(['uri' => 'principals/users/user1'], $mapper);
+		$this->assertEquals('user1', $home->getName());
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\MethodNotAllowed
+	 */
+	public function testGetChildren() {
+		/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject $mapper */
+		$mapper = $this->createMock(JobStatusMapper::class);
+		$home = new Home(['uri' => 'principals/users/user1'], $mapper);
+		$home->getChildren();
+	}
+
+	public function testGetChild() {
+		/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject $mapper */
+		$mapper = $this->createMock(JobStatusMapper::class);
+
+		$jobStatusEntity = new JobStatusEntity();
+		$mapper->method('findByUserIdAndJobId')->willReturn($jobStatusEntity);
+		$home = new Home(['uri' => 'principals/users/user1'], $mapper);
+		$child = $home->getChild('1234567890');
+		$this->assertInstanceOf(JobStatus::class, $child);
+		$this->assertEquals('1234567890', $child->getName());
+	}
+
+	/**
+	 * @expectedException \Sabre\DAV\Exception\NotFound
+	 */
+	public function testGetChildNotFound() {
+		/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject $mapper */
+		$mapper = $this->createMock(JobStatusMapper::class);
+
+		$ex = new DoesNotExistException('');
+		$mapper->method('findByUserIdAndJobId')->willThrowException($ex);
+		$home = new Home(['uri' => 'principals/users/user1'], $mapper);
+		$home->getChild('1234567890');
+	}
+}

--- a/apps/dav/tests/unit/JobStatus/JobStatusTest.php
+++ b/apps/dav/tests/unit/JobStatus/JobStatusTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\JobStatus;
+
+use OCA\DAV\JobStatus\Entity\JobStatus as JobStatusEntity;
+use OCA\DAV\JobStatus\Entity\JobStatusMapper;
+use OCA\DAV\JobStatus\JobStatus;
+use Test\TestCase;
+
+/**
+ * Class JobStatusTest
+ *
+ * @package OCA\DAV\Tests\Unit\JobStatus
+ */
+class JobStatusTest extends TestCase {
+
+	/** @var JobStatus */
+	private $jobStatus;
+	/** @var JobStatusEntity */
+	private $jobStatusEntity;
+	/** @var JobStatusMapper | \PHPUnit_Framework_MockObject_MockObject */
+	private $mapper;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->mapper = $this->createMock(JobStatusMapper::class);
+
+		$this->jobStatusEntity = new JobStatusEntity();
+		$this->mapper->method('findByUserIdAndJobId')->willReturn($this->jobStatusEntity);
+
+		$this->jobStatus = new JobStatus('user1', '1234567890', $this->mapper, $this->jobStatusEntity);
+	}
+
+	public function testGetChild() {
+		$this->assertEquals('1234567890', $this->jobStatus->getName());
+	}
+
+	public function testGet() {
+		$this->jobStatusEntity->setStatusInfo('abc');
+		$this->assertEquals('abc', $this->jobStatus->get());
+		$this->assertEquals('"a9993e364706816aba3e25717850c26c9cd0d89d"', $this->jobStatus->getETag());
+		$this->assertEquals(3, $this->jobStatus->getSize());
+
+		$this->jobStatus->refreshStatus();
+		$newJobStatusEntity = new JobStatusEntity();
+		$newJobStatusEntity->setStatusInfo('def');
+		$this->mapper->method('findByUserIdAndJobId')->willReturn($newJobStatusEntity);
+		$this->assertEquals('abc', $this->jobStatus->get());
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
         "deepdiver/zipstreamer": "^1.1",
         "zendframework/zend-inputfilter": "^2.8",
         "zendframework/zend-servicemanager": "^3.3",
-        "symfony/translation": "^3.4"
+        "symfony/translation": "^3.4",
+        "hhxsv5/php-sse": "^1.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff18e9c01a4dc2372c06e5c666e39972",
+    "content-hash": "e2cf98105c3262074a6063b1cfffe807",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -756,6 +756,54 @@
                 "stream"
             ],
             "time": "2014-10-12T19:18:40+00:00"
+        },
+        {
+            "name": "hhxsv5/php-sse",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hhxsv5/php-sse.git",
+                "reference": "f0d1eacc206d6d7f2d9f72b72fd8b6bf3f89f190"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hhxsv5/php-sse/zipball/f0d1eacc206d6d7f2d9f72b72fd8b6bf3f89f190",
+                "reference": "f0d1eacc206d6d7f2d9f72b72fd8b6bf3f89f190",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Hhxsv5\\SSE\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Xie Biao",
+                    "email": "hhxsv5@sina.com"
+                }
+            ],
+            "description": "A simple and efficient library implemented HTML5's server-sent events by PHP, is used to real-time push events from server to client, and easier than Websocket, instead of AJAX request.",
+            "homepage": "https://github.com/hhxsv5/php-sse",
+            "keywords": [
+                "Server-Sent Events",
+                "event-stream",
+                "events",
+                "eventsource",
+                "sever-events",
+                "sse"
+            ],
+            "time": "2018-06-22T09:02:22+00:00"
         },
         {
             "name": "icewind/streams",

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1403,4 +1403,9 @@ $CONFIG = array(
  */
 'smb.logging.enable' => false, 
 
+
+/**
+ * Async dav extensions can be enabled or disabled.
+ */
+'dav.enable.async' => true,
 );

--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -672,7 +672,7 @@
 			).then(
 				function(result) {
 					if (self._isSuccessStatus(result.status)) {
-						deferred.resolve(result.status);
+						deferred.resolve(result.status, result);
 					} else {
 						result = _.extend(result, self._getSabreException(result));
 						deferred.reject(result.status, result);
@@ -697,7 +697,7 @@
 			).then(
 				function(result) {
 					if (self._isSuccessStatus(result.status)) {
-						deferred.resolve(result.status);
+						deferred.resolve(result.status, result);
 					} else {
 						result = _.extend(result, self._getSabreException(result));
 						deferred.reject(result.status, result);
@@ -740,7 +740,7 @@
 			).then(
 				function(result) {
 					if (self._isSuccessStatus(result.status)) {
-						deferred.resolve(result.status);
+						deferred.resolve(result.status, result);
 					} else {
 						result = _.extend(result, self._getSabreException(result));
 						deferred.reject(result.status, result);


### PR DESCRIPTION
## Description
We want to avoid situations where the clients have to wait for the long MOVE operation on assembly to finish. The connection can be terminated by any reason before the server sends the response back to the client. And after that the client has no capability to query for the status of the assembly.

1. AMD - Asynchronous Method Dispatch
We return the http status code 202 right after we received the MOVE request. The client can then terminate the connection and knows that the server is working on it.
The implementation uses php's register_callback functionality to process the real MOVE *after* the response is sent to the client. register_callback can not be terminated by the system - we should be pretty save on this one .... 
The 202 response will hold a header 'OC-JobStatus-Location' which will point the client to the job status endpoint

2. Job Status Endpoint
The job status endpoint is a DAV resource in the following format: /dav/job-status/{$userId}/{$this->jobId}. It will return a json object holding the job status information.

Property | Description
---|---
status | init, started, finished, error
fileId | the file id of the target file - set only once the MOVE was successful
ETag | the ETag of the file *after* MOVE on the target location - set only once the MOVE was successfull
errorCode | http error code - in case there was an error
errorMessage | there error message - in case of an error

3. Server Side Event on the job status endpoint
The client can request the job status in simple request/response manner or request an event stream following the Server Side Event protocol. To initiate SSE handling the query parameter sse=1 is appended to the GET request. As a result the server will not terminate the connection but keep it open and stream job status changes to the client. The client is asked to close the connection once the status is success or error

4. Capabilities and LazyOps header
The server will announce to the clients via the capabilities API if this new mode of operations is available or not. A system config value is necessary to allow the admin to turn this feature explicitly on.

Furthermore in order not to break regular WebDAV client an additional http header is to be sent from the client to the server so that the server knows if this operation mode shall be used or not. 

## Todo
- [x] add capability
- [ ] add COPY support
- [ ] detailed implementation to run MOVE pre flight checks before sending 202

## Motivation and Context
Introduce a more generic async mechanism

## How Has This Been Tested?
move

```sh
deepdiver@deepdiver:~$ curl -X MOVE  http://192.168.178.44:8080/remote.php/dav/files/admin/welcome.txt -uadmin -H 'OC-LazyOps: true' -H 'Destination: http://192.168.178.44:8080/remote.php/dav/files/admin/x/welcome.txt' -v
Enter host password for user 'admin':
*   Trying 192.168.178.44...
* TCP_NODELAY set
* Connected to 192.168.178.44 (192.168.178.44) port 8080 (#0)
* Server auth using Basic with user 'admin'
> MOVE /remote.php/dav/files/admin/welcome.txt HTTP/1.1
> Host: 192.168.178.44:8080
> Authorization: Basic YWRtaW46YWRtaW4=
> User-Agent: curl/7.60.0
> Accept: */*
> OC-LazyOps: true
> Destination: http://192.168.178.44:8080/remote.php/dav/files/admin/x/welcome.txt
> 
< HTTP/1.1 202 Accepted
< Host: 192.168.178.44:8080
< Date: Thu, 21 Jun 2018 08:44:43 +0000
< Connection: close
< X-Powered-By: PHP/7.1.18-1+ubuntu18.04.1+deb.sury.org+1
< Expires: Thu, 19 Nov 1981 08:52:00 GMT
< Cache-Control: no-store, no-cache, must-revalidate
< Pragma: no-cache
< Set-Cookie: oc_sessionPassphrase=YABFWiAVwlohlGBpO8j3dv9zD%2FZhAesNpb482kp8Xt9iESpBU5tVGJuvrlCwvfWH1dLz23CknJcfzaFYgxzsmfZ6gMmtAkgBKpI4IlX8NKfPf9MVBShNTtzswKsaGoG%2B; path=/; HttpOnly
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Robots-Tag: none
< X-Download-Options: noopen
< X-Permitted-Cross-Domain-Policies: none
< Content-Security-Policy: default-src 'none';
< Set-Cookie: oc9fy8f2gwa8=n18gf5i45fkdkka1ual4c8mgvt; path=/; HttpOnly
< Set-Cookie: cookie_test=test; expires=Thu, 21-Jun-2018 09:44:40 GMT; Max-Age=3600
< Connection: close
< OC-Location: /remote.php/dav/admin/queue/d3c011a2-e640-4b94-bd7d-897aa99e9585
< Content-type: text/html; charset=UTF-8
< 
* Closing connection 0
```

Query for the status:
```sh
deepdiver@deepdiver:~$ curl -v -uadmin http://192.168.178.44:8080/remote.php/dav/queue/admin/d3c011a2-e640-4b94-bd7d-897aa99e9585
Enter host password for user 'admin':
*   Trying 192.168.178.44...
* TCP_NODELAY set
* Connected to 192.168.178.44 (192.168.178.44) port 8080 (#0)
* Server auth using Basic with user 'admin'
> GET /remote.php/dav/queue/admin/d3c011a2-e640-4b94-bd7d-897aa99e9585 HTTP/1.1
> Host: 192.168.178.44:8080
> Authorization: Basic YWRtaW46YWRtaW4=
> User-Agent: curl/7.60.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Host: 192.168.178.44:8080
< Date: Thu, 21 Jun 2018 09:00:06 +0000
< Connection: close
< X-Powered-By: PHP/7.1.18-1+ubuntu18.04.1+deb.sury.org+1
< Expires: Thu, 19 Nov 1981 08:52:00 GMT
< Cache-Control: no-store, no-cache, must-revalidate
< Pragma: no-cache
< Set-Cookie: oc_sessionPassphrase=PFsuMhAl1oNSkKVHkAKY2vxSPKtJ%2BVBMMWx1zf6%2B6O%2FQU4PBz1%2BEssbXozILMCwXwNanx%2BnuaSSooLekzD2%2BOq46tDOCN9ZEjW412Ot2s%2FD55hKzLAAfFtGqFNVlBr7Z; path=/; HttpOnly
< X-XSS-Protection: 1; mode=block
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Robots-Tag: none
< X-Download-Options: noopen
< X-Permitted-Cross-Domain-Policies: none
< Content-Security-Policy: default-src 'none';
< Set-Cookie: oc9fy8f2gwa8=8fbdm6ijnlah8162lc7lanf7ba; path=/; HttpOnly
< Set-Cookie: cookie_test=test; expires=Thu, 21-Jun-2018 10:00:06 GMT; Max-Age=3600
< Content-Type: application/json
< ETag: "e12309511a0155a316c6223c64511ba15b217a1a"
< Content-Length: 99
< OC-ETag: "e12309511a0155a316c6223c64511ba15b217a1a"
< 
* Closing connection 0
{"status":"finished","fileId":"00003061oc9fy8f2gwa8","ETag":"\"f3610808373e6aad584d69b4a0a068f5\""}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

