### PR TITLE
Fixes #31849 - delete thumbnails on write hooks

### DIFF
--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -1306,11 +1306,22 @@ class Preview {
 	public static function post_delete($args, $prefix = '') {
 		$path = Files\Filesystem::normalizePath($args['path']);
 		if (!isset(self::$deleteFileMapper[$path])) {
-			return;
+			$user = isset($args['user']) ? $args['user'] : \OC_User::getUser();
+			if ($user === false) {
+				$user = Filesystem::getOwner($path);
+			}
+
+			$userFolder = \OC::$server->getUserFolder($user);
+			if ($userFolder === null) {
+				return;
+			}
+
+			$node = $userFolder->get($path);
+		} else {
+			/** @var FileInfo $node */
+			$node = self::$deleteFileMapper[$path];
 		}
 
-		/** @var FileInfo $node */
-		$node = self::$deleteFileMapper[$path];
 		$preview = new Preview($node->getOwner()->getUID(), $prefix, $node);
 		$preview->deleteAllPreviews();
 	}


### PR DESCRIPTION
## Description
Thumbnails only got deleted on delete - not for write events.
On write thumbnails need to be deleted so that a future GET will recreate them as needed.

## Related Issue
Fixes #31849

## How Has This Been Tested?
- manually as described in #31849

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

