### PR TITLE
Handle SSL certificate verifications for others than Let's Encrypt

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -69,7 +69,7 @@
   RewriteRule ^\.well-known/caldav /remote.php/dav/ [R=301,L]
   RewriteRule ^remote/(.*) remote.php [QSA,L]
   RewriteRule ^(?:build|tests|config|lib|3rdparty|templates)/.* - [R=404,L]
-  RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/.*
+  RewriteCond %{REQUEST_URI} !^/.well-known/(acme-challenge|pki-validation)/.*
   RewriteRule ^(?:\.|autotest|occ|issue|indie|db_|console).* - [R=404,L]
 </IfModule>
 <IfModule mod_mime.c>

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -448,7 +448,7 @@ class Setup {
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/ocs/v2.php";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/updater/";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/ocs-provider/";
-			$content .= "\n  RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/.*";
+			$content .= "\n  RewriteCond %{REQUEST_URI} !^/.well-known/(acme-challenge|pki-validation)/.*";
 			$content .= "\n  RewriteRule . index.php [PT,E=PATH_INFO:$1]";
 			$content .= "\n  RewriteBase " . $rewriteBase;
 			$content .= "\n  <IfModule mod_env.c>";


### PR DESCRIPTION
Do no longer (wrongly) rewrite URLs like

  - http://example.net/.well-known/pki-validation/file.txt (Comodo)
  - http://example.net/.well-known/pki-validation/fileauth.txt (DigiCert, Thawte, GeoTrust)
  - http://example.net/.well-known/pki-validation/gsdv.txt (GlobalSign)
  - http://example.net/.well-known/pki-validation/starfield.htm (Starfield, GoDaddy)
  - http://example.net/.well-known/pki-validation/swisssign-check.txt (SwissSign)

for automated SSL certificate verifications. All (common commercial) certificate authorities (CA) except Let's Encrypt (via ACME) seem to use "pki-validation" rather "acme-challenge" for their domain control validation (DCV). Note that this is required inside of ownCloud rather on web server level due to shared web hosting systems, where the customer/user might not be able to do this on web server level (Apache/Nginx configuration changes for the virtual host).

As per https://owncloud.org/community/develop/contributor-agreement/ I am releasing my code/contribution (this PR) under the MIT license.