### PR TITLE
Lock dialog form fields while processing

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -121,7 +121,10 @@
 			var deferred = $.Deferred();
 			var $el = this.$el;
 
-			var $password = $el.find('.linkPassText'),
+			var $dialog = $el,
+				$formElements = $el.find('input, textarea, select, button'),
+				$select2Elements = $el.find('.select2-search-choice-close'),
+				$password = $el.find('.linkPassText'),
 				$inputs = $el.find('.linkPassText, .expirationDate, .permission'), // all input fields combined
 				$errorMessageGlobal = $el.find('.error-message-global'),
 				$loading = $el.find('.loading'),
@@ -129,6 +132,10 @@
 				expirationDate = this.expirationView.getValue();
 
 			$el.find('.error-message').addClass('hidden');
+
+			// prevent tinkering with form while loading
+			$formElements.attr('disabled', true);
+			$select2Elements.addClass('hidden');
 
 			// remove errors (if present)
 			// ***
@@ -205,6 +212,8 @@
 					var msg = xhr.responseJSON.ocs.meta.message;
 					// destroy old tooltips
 					$loading.addClass('hidden');
+					$formElements.removeAttr('disabled');
+					$select2Elements.removeClass('hidden');
 					$errorMessageGlobal.removeClass('hidden').text(msg);
 					deferred.reject(self.model);
 				}

--- a/core/js/tests/specs/sharedialoglinkshareviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinkshareviewSpec.js
@@ -257,6 +257,23 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 			}
 		});
 
+		it('locks all input fields while processing', function() {
+			view._save();
+			expect(view.$('input, textarea, select, button').prop('disabled')).toEqual(true);
+		});
+		it('unlocks all input fields when saving failed', function() {
+			view._save();
+			saveStub.yieldTo('error', model, {
+				responseJSON: {
+					ocs: {
+						meta: {
+							message: 'Little error'
+						}
+					}
+				}
+			});
+			expect(view.$('input, textarea, select, button').prop('disabled')).toEqual(false);
+		});
 		it('reads values from the fields and saves', function() {
 			view.$('.linkPassText').val('newpassword');
 			view._save();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Lock dialog form fields while processing to prevent further tinkering with its contents.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes https://github.com/owncloud/core/issues/31654

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Visual tests on IE, FF and Chrome
- Added unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

