### PR TITLE
exclude data from php style checks

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -23,7 +23,8 @@ $excludeDirs = [
     'lib/composer',
     'build',
     'apps/files_external/3rdparty',
-    'config'
+    'config',
+    'data'
 ];
 
 foreach ($dirIterator as $fileinfo) {


### PR DESCRIPTION
## Description
Exclude the ``data`` folder from PHP code style checks

## Related Issue
#31863 

## Motivation and Context
It is very annoying to report code style errors for code that is not part of the real core.

## How Has This Been Tested?
1. In a local dev environment, upload some crap PHP code to a test user account
2. ``make test-php-style``
3. It fails on the crap code in the test user account
4. checkout the branch with this change
5. ``make test-php-style``
6. It passes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) - to dev environnment
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
