### PR TITLE
Fix SharingBlacklistTest setGetBlacklistedReceiverGroupsProvider

### DIFF
--- a/apps/files_sharing/tests/SharingBlacklistTest.php
+++ b/apps/files_sharing/tests/SharingBlacklistTest.php
@@ -44,7 +44,7 @@ class SharingBlacklistTest extends \Test\TestCase {
 		return [
 			[[]],
 			[["group1"]],
-			[["group1", "group2", "$group3"]],
+			[["group1", "group2", "group3"]],
 		];
 	}
 


### PR DESCRIPTION
## Description
Remove invalid ``$`` in ``setGetBlacklistedReceiverGroupsProvider`` array.

## Motivation and Context
Noticed in drone logs, e.g. https://drone.owncloud.com/owncloud/core/8097/115
```
[PHP Notice:  Undefined variable: group3 in /drone/src/apps/files_sharing/tests/SharingBlacklistTest.php on line 47]
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Runtime:       PHPDBG 7.1.18-1+ubuntu16.04.1+deb.sury.org+1
Configuration: /drone/src/tests/phpunit-autotest.xml

............................................................. 61 / 9155 ( 0%)
```

## How Has This Been Tested?
CI knows what to do

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) - to unit tests only
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
