### PR TITLE
Exclude apps* from PHP style checks

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -34,6 +34,16 @@ foreach ($dirIterator as $fileinfo) {
     }
 }
 
+// Exclude any folders "apps*" except the folder "apps"
+$topDirIterator = new DirectoryIterator(__DIR__);
+
+foreach ($topDirIterator as $fileinfo) {
+    $filename = $fileinfo->getFilename();
+    if ($fileinfo->isDir() && (strncmp($filename, "apps", 4) === 0) && (strlen($filename) > 4)) {
+        $excludeDirs[] = $filename;
+    }
+}
+
 $finder = PhpCsFixer\Finder::create()
     ->exclude($excludeDirs)
     ->in(__DIR__);


### PR DESCRIPTION
## Description
Exclude any folders called ``apps*`` (usually ``apps2`` ``apps3`` etc) from being checked for code style.

## Related Issue
#31863 

## Motivation and Context
Devs often create extra apps folders called ``apps2`` ``apps3``  etc when testing bonus apps. Such folders are not part of core repo code, so they should not be checked by core ``make test-php-style``

## How Has This Been Tested?
1. Create folders ``apps2/aaa`` ``apps3/bbb`` ``apps99/ccc``
2. Copy a PHP code file with style errors into each of those folders
3. ``make test-php-style`` - it reports the style issues in each of those folders
4. apply this change
5. ``make test-php-style`` - it passes

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue) - to development infrastructure only
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
