### PR TITLE
Add UI for switching public mail notification language

### DIFF
--- a/lib/private/Helper/LocaleHelper.php
+++ b/lib/private/Helper/LocaleHelper.php
@@ -108,8 +108,8 @@ class LocaleHelper {
 
 			// TRANSLATORS this is a self-name of your language for the language switcher
 			$endonym = (string)$l->t('__language_name__');
-			//Check if the language name is in the translation file
-			// Fallback to hardcoded language name if translation is
+			// Check if the language name is in the translation file
+			// Fallback to hardcoded language name if it isn't
 			$languageName = ($l->getLanguageCode() === $languageCode
 				&& \substr($endonym, 0, 1) !== '_'
 			) ? $endonym

--- a/lib/private/Helper/LocaleHelper.php
+++ b/lib/private/Helper/LocaleHelper.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Helper;
+
+use OCP\L10N\IFactory;
+
+class LocaleHelper {
+	/**
+	 * @var string[]
+	 */
+	private $commonLanguages = [
+		'en',
+		'es',
+		'fr',
+		'de',
+		'de_DE',
+		'ja',
+		'ar',
+		'ru',
+		'nl',
+		'it',
+		'pt_BR',
+		'pt_PT',
+		'da',
+		'fi_FI',
+		'nb_NO',
+		'sv',
+		'tr',
+		'zh_CN',
+		'ko'
+	];
+
+	/**
+	 * @var string[]
+	 */
+	private $languageCodes = [
+		'el' => 'Ελληνικά',
+		'en' => 'English',
+		'fa' => 'فارسى',
+		'fi_FI' => 'Suomi',
+		'hi' => 'हिन्दी',
+		'id' => 'Bahasa Indonesia',
+		'lb' => 'Lëtzebuergesch',
+		'ms_MY' => 'Bahasa Melayu',
+		'nb_NO' => 'Norwegian Bokmål',
+		'pt_BR' => 'Português brasileiro',
+		'pt_PT' => 'Português',
+		'ro' => 'română',
+		'sr@latin' => 'Srpski',
+		'sv' => 'Svenska',
+		'hu_HU' => 'Magyar',
+		'hr' => 'Hrvatski',
+		'ar' => 'العربية',
+		'lv' => 'Latviešu',
+		'mk' => 'македонски',
+		'uk' => 'Українська',
+		'vi' => 'Tiếng Việt',
+		'zh_TW' => '正體中文（臺灣）',
+		'af_ZA' => 'Afrikaans',
+		'bn_BD' => 'Bengali',
+		'ta_LK' => 'தமிழ்',
+		'zh_HK' => '繁體中文（香港）',
+		'is' => 'Icelandic',
+		'ka_GE' => 'Georgian for Georgia',
+		'ku_IQ' => 'Kurdish Iraq',
+		'si_LK' => 'Sinhala',
+		'be' => 'Belarusian',
+		'ka' => 'Kartuli (Georgian)',
+		'my_MM' => 'Burmese - MYANMAR',
+		'ur_PK' => 'Urdu (Pakistan)'
+	];
+
+	/**
+	 * Get available languages split to the current, common and the rest
+	 *
+	 * @param IFactory $langFactory
+	 * @param string $activeLangCode
+	 *
+	 * @return array
+	 */
+	public function getNormalizedLanguages(IFactory $langFactory, $activeLangCode) {
+		$userLang = null;
+		$commonLanguages = [];
+		$languages = [];
+
+		$availableCodes = $langFactory->findAvailableLanguages();
+		foreach ($availableCodes as $languageCode) {
+			$l = $langFactory->get('settings', $languageCode);
+
+			// TRANSLATORS this is a self-name of your language for the language switcher
+			$endonym = (string)$l->t('__language_name__');
+			//Check if the language name is in the translation file
+			// Fallback to hardcoded language name if translation is
+			$languageName = ($l->getLanguageCode() === $languageCode
+				&& \substr($endonym, 0, 1) !== '_'
+			) ? $endonym
+				: $this->getLanguageNameByCode($languageCode);
+
+			$ln = [
+				'code' => $languageCode,
+				'name' => $languageName
+			];
+			$languageWeight = $this->getCommonLanguageWeight($languageCode);
+			if ($languageCode === $activeLangCode) {
+				$userLang = $ln;
+			} elseif ($languageWeight !== false) {
+				$commonLanguages[$languageWeight] = $ln;
+			} else {
+				$languages[] = $ln;
+			}
+		}
+
+		// if user language is not available but set somehow
+		// show the actual code as name
+		if ($userLang === null) {
+			$userLang = [
+				'code' => $activeLangCode,
+				'name' => $activeLangCode,
+			];
+		}
+
+		\ksort($commonLanguages);
+		\usort($languages, [$this, 'compareLanguagesByName']);
+
+		return [$userLang, $commonLanguages, $languages];
+	}
+
+	/**
+	 * Get common language weight or false if language is not common
+	 *
+	 * @param string $languageCode
+	 *
+	 * @return false|int
+	 */
+	public function getCommonLanguageWeight($languageCode) {
+		return \array_search($languageCode, $this->commonLanguages);
+	}
+
+	/**
+	 * Get language name by code
+	 *
+	 * @param string $code
+	 *
+	 * @return string
+	 */
+	public function getLanguageNameByCode($code) {
+		return (isset($this->languageCodes[$code]))
+			? $this->languageCodes[$code]
+			: $code;
+	}
+
+	/**
+	 * Compare language arrays by name
+	 * both arrays should have 'code' and 'name' keys
+	 *
+	 * @param string[] $a
+	 * @param string[] $b
+	 *
+	 * @return int
+	 */
+	protected function compareLanguagesByName($a, $b) {
+		if ($a['code'] === $a['name'] && $b['code'] !== $b['name']) {
+			// If a doesn't have a name, but b does, list b before a
+			return 1;
+		}
+		if ($a['code'] !== $a['name'] && $b['code'] === $b['name']) {
+			// If a does have a name, but b doesn't, list a before b
+			return -1;
+		}
+		// Otherwise compare the names
+		return \strcmp($a['name'], $b['name']);
+	}
+}

--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -265,7 +265,9 @@ class SettingsManager implements ISettingsManager {
 				$this->config,
 				$this->groupManager,
 				$this->userSession,
-				$this->lfactory),
+				$this->lfactory,
+				new \OC\Helper\LocaleHelper()
+			),
 			LegacyPersonal::class => new LegacyPersonal($this->helper),
 			Clients::class => new Clients($this->config, $this->defaults),
 			Version::class => new Version(),

--- a/settings/Application.php
+++ b/settings/Application.php
@@ -39,12 +39,9 @@ use OC\Settings\Controller\AppSettingsController;
 use OC\Settings\Controller\AuthSettingsController;
 use OC\Settings\Controller\CertificateController;
 use OC\Settings\Controller\CheckSetupController;
-use OC\Settings\Controller\GroupsController;
 use OC\Settings\Controller\LegalSettingsController;
 use OC\Settings\Controller\LogSettingsController;
 use OC\Settings\Controller\MailSettingsController;
-use OC\Settings\Controller\UsersController;
-use OC\Settings\Middleware\SubadminMiddleware;
 use OCP\AppFramework\App;
 use OCP\IContainer;
 use OCP\Util;
@@ -61,14 +58,6 @@ class Application extends App {
 		parent::__construct('settings', $urlParams);
 
 		$container = $this->getContainer();
-
-		$container->registerService('Profile', function (IContainer $c) {
-			return new \OC\Settings\Panels\Personal\Profile(
-			   $c->query('Config'),
-			   $c->query('GroupManager'),
-			   $c->query('ServerContainer')->getURLGenerator()
-		   );
-		});
 
 		/**
 		 * Controllers

--- a/settings/Panels/Personal/Profile.php
+++ b/settings/Panels/Personal/Profile.php
@@ -88,6 +88,7 @@ class Profile implements ISettings {
 		);
 
 		$selector = new Template('settings', 'language');
+		$selector->assign('selectName', 'lang');
 		$selector->assign('selectId', 'languageinput');
 		$selector->assign('activelanguage', $userLang);
 		$selector->assign('commonlanguages', $commonLanguages);

--- a/settings/Panels/Personal/Profile.php
+++ b/settings/Panels/Personal/Profile.php
@@ -24,6 +24,7 @@
 
 namespace OC\Settings\Panels\Personal;
 
+use OC\Helper\LocaleHelper;
 use OCP\Settings\ISettings;
 use OCP\Template;
 use OCP\IGroupManager;
@@ -42,14 +43,31 @@ class Profile implements ISettings {
 	/** @var IFactory */
 	protected $lfactory;
 
+	/**
+	 * @var LocaleHelper
+	 */
+	private $localeHelper;
+
+	/**
+	 * Profile constructor.
+	 *
+	 * @param IConfig $config
+	 * @param IGroupManager $groupManager
+	 * @param IUserSession $userSession
+	 * @param IFactory $lfactory
+	 * @param LocaleHelper $localeHelper
+	 */
 	public function __construct(IConfig $config,
-								IGroupManager $groupManager,
-								IUserSession $userSession,
-								IFactory $lfactory) {
+								   IGroupManager $groupManager,
+								   IUserSession $userSession,
+								   IFactory $lfactory,
+								   LocaleHelper $localeHelper
+	) {
 		$this->config = $config;
 		$this->groupManager = $groupManager;
 		$this->userSession = $userSession;
 		$this->lfactory = $lfactory;
+		$this->localeHelper = $localeHelper;
 	}
 
 	public function getPriority() {
@@ -57,62 +75,19 @@ class Profile implements ISettings {
 	}
 
 	public function getPanel() {
+		$activeLangCode = $this->config->getUserValue(
+			$this->userSession->getUser()->getUID(),
+			'core',
+			'lang',
+			$this->lfactory->findLanguage()
+		);
+
+		list($userLang, $commonLanguages, $languages) = $this->localeHelper->getNormalizedLanguages(
+			$this->lfactory,
+			$activeLangCode
+		);
+
 		$tmpl = new Template('settings', 'panels/personal/profile');
-
-		// Assign some data
-		$lang = $this->lfactory->findLanguage();
-		$userLang = $this->config->getUserValue($this->userSession->getUser()->getUID(), 'core', 'lang', $lang);
-		$languageCodes = $this->lfactory->findAvailableLanguages();
-		// array of common languages
-		$commonLangCodes = [
-			'en', 'es', 'fr', 'de', 'de_DE', 'ja', 'ar', 'ru', 'nl', 'it', 'pt_BR', 'pt_PT', 'da', 'fi_FI', 'nb_NO', 'sv', 'tr', 'zh_CN', 'ko'
-		];
-		$languageNames = $this->getLanguageCodes();
-		$languages= [];
-		$commonLanguages = [];
-		foreach ($languageCodes as $lang) {
-			$l = $this->lfactory->get('settings', $lang);
-			// TRANSLATORS this is the language name for the language switcher in the personal settings and should be the localized version
-			$potentialName = (string) $l->t('__language_name__');
-			if ($l->getLanguageCode() === $lang && \substr($potentialName, 0, 1) !== '_') {//first check if the language name is in the translation file
-				$ln = ['code'=>$lang, 'name'=> $potentialName];
-			} elseif (isset($languageNames[$lang])) {
-				$ln = ['code'=>$lang, 'name'=>$languageNames[$lang]];
-			} else {//fallback to language code
-				$ln = ['code'=>$lang, 'name'=>$lang];
-			}
-			// put appropriate languages into appropriate arrays, to print them sorted
-			// used language -> common languages -> divider -> other languages
-			if ($lang === $userLang) {
-				$userLang = $ln;
-			} elseif (\in_array($lang, $commonLangCodes)) {
-				$commonLanguages[\array_search($lang, $commonLangCodes)]=$ln;
-			} else {
-				$languages[]=$ln;
-			}
-		}
-		// if user language is not available but set somehow: show the actual code as name
-		if (!\is_array($userLang)) {
-			$userLang = [
-				'code' => $userLang,
-				'name' => $userLang,
-			];
-		}
-		\ksort($commonLanguages);
-		// sort now by displayed language not the iso-code
-		\usort($languages, function ($a, $b) {
-			if ($a['code'] === $a['name'] && $b['code'] !== $b['name']) {
-				// If a doesn't have a name, but b does, list b before a
-				return 1;
-			}
-			if ($a['code'] !== $a['name'] && $b['code'] === $b['name']) {
-				// If a does have a name, but b doesn't, list a before b
-				return -1;
-			}
-			// Otherwise compare the names
-			return \strcmp($a['name'], $b['name']);
-		});
-
 		$tmpl->assign('email', $this->userSession->getUser()->getEMailAddress());
 		$tmpl->assign('languages', $languages);
 		$tmpl->assign('commonlanguages', $commonLanguages);
@@ -126,45 +101,6 @@ class Profile implements ISettings {
 		\sort($groups);
 		$tmpl->assign('groups', $groups);
 		return $tmpl;
-	}
-
-	protected function getLanguageCodes() {
-		return [
-			'el' => 'Ελληνικά',
-			'en' => 'English',
-			'fa' => 'فارسى',
-			'fi_FI' => 'Suomi',
-			'hi' => 'हिन्दी',
-			'id' => 'Bahasa Indonesia',
-			'lb' => 'Lëtzebuergesch',
-			'ms_MY' => 'Bahasa Melayu',
-			'nb_NO' => 'Norwegian Bokmål',
-			'pt_BR' => 'Português brasileiro',
-			'pt_PT' => 'Português',
-			'ro' => 'română',
-			'sr@latin' => 'Srpski',
-			'sv' => 'Svenska',
-			'hu_HU' => 'Magyar',
-			'hr' => 'Hrvatski',
-			'ar' => 'العربية',
-			'lv' => 'Latviešu',
-			'mk' => 'македонски',
-			'uk' => 'Українська',
-			'vi' => 'Tiếng Việt',
-			'zh_TW' => '正體中文（臺灣）',
-			'af_ZA' => 'Afrikaans',
-			'bn_BD' => 'Bengali',
-			'ta_LK' => 'தமிழ்',
-			'zh_HK' => '繁體中文（香港）',
-			'is' => 'Icelandic',
-			'ka_GE' => 'Georgian for Georgia',
-			'ku_IQ' => 'Kurdish Iraq',
-			'si_LK' => 'Sinhala',
-			'be' => 'Belarusian',
-			'ka' => 'Kartuli (Georgian)',
-			'my_MM' => 'Burmese - MYANMAR ',
-			'ur_PK' => 'Urdu (Pakistan)'
-		];
 	}
 
 	public function getSectionID() {

--- a/settings/Panels/Personal/Profile.php
+++ b/settings/Panels/Personal/Profile.php
@@ -87,11 +87,14 @@ class Profile implements ISettings {
 			$activeLangCode
 		);
 
+		$selector = new Template('settings', 'language');
+		$selector->assign('selectId', 'languageinput');
+		$selector->assign('activelanguage', $userLang);
+		$selector->assign('commonlanguages', $commonLanguages);
+		$selector->assign('languages', $languages);
+
 		$tmpl = new Template('settings', 'panels/personal/profile');
 		$tmpl->assign('email', $this->userSession->getUser()->getEMailAddress());
-		$tmpl->assign('languages', $languages);
-		$tmpl->assign('commonlanguages', $commonLanguages);
-		$tmpl->assign('activelanguage', $userLang);
 		$tmpl->assign('displayName', $this->userSession->getUser()->getDisplayName());
 		$tmpl->assign('enableAvatars', $this->config->getSystemValue('enable_avatars', true) === true);
 		$tmpl->assign('avatarChangeSupported', $this->userSession->getUser()->canChangeAvatar());
@@ -100,6 +103,7 @@ class Profile implements ISettings {
 		$groups = $this->groupManager->getUserGroupIds($this->userSession->getUser());
 		\sort($groups);
 		$tmpl->assign('groups', $groups);
+		$tmpl->assign('languageSelector', $selector->fetchPage());
 		return $tmpl;
 	}
 

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -78,6 +78,19 @@ $(document).ready(function(){
 		$('#setDefaultExpireDate').toggleClass('hidden', !(this.checked && $('#shareapiDefaultExpireDate')[0].checked));
 	});
 
+	$('#allowPublicMailNotification').change(function() {
+		$("#publicMailNotificationLang").toggleClass('hidden', !this.checked);
+	});
+
+	$('#shareapiPublicNotificationLang').change(function() {
+		var value = $(this).val();
+		if (value === 'owner') {
+			OC.AppConfig.deleteKey('core', $(this).attr('name'));
+		} else {
+			OC.AppConfig.setValue('core', $(this).attr('name'), $(this).val());
+		}
+	});
+
 
 	$('#allowGroupSharing').change(function() {
 		$('#allowGroupSharing').toggleClass('hidden', !this.checked);

--- a/settings/templates/language.php
+++ b/settings/templates/language.php
@@ -1,0 +1,16 @@
+<select id="<?php p($_['selectId'])?>" name="lang" data-placeholder="<?php p($l->t('Language'));?>">
+	<option value="<?php p($_['activelanguage']['code']);?>">
+		<?php p($_['activelanguage']['name']);?>
+	</option>
+	<?php foreach ($_['commonlanguages'] as $language):?>
+		<option value="<?php p($language['code']);?>">
+			<?php p($language['name']);?>
+		</option>
+	<?php endforeach;?>
+	<optgroup label="––––––––––"></optgroup>
+	<?php foreach ($_['languages'] as $language):?>
+		<option value="<?php p($language['code']);?>">
+			<?php p($language['name']);?>
+		</option>
+	<?php endforeach;?>
+</select>

--- a/settings/templates/language.php
+++ b/settings/templates/language.php
@@ -1,4 +1,4 @@
-<select id="<?php p($_['selectId'])?>" name="lang" data-placeholder="<?php p($l->t('Language'));?>">
+<select id="<?php p($_['selectId'])?>" name="<?php p($_['selectName'])?>" data-placeholder="<?php p($l->t('Language'));?>">
 	<option value="<?php p($_['activelanguage']['code']);?>">
 		<?php p($_['activelanguage']['name']);?>
 	</option>

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -62,6 +62,14 @@
 	print_unescaped('checked="checked"');
 } ?> />
 		<label for="allowPublicMailNotification"><?php p($l->t('Allow users to send mail notification for shared files'));?></label><br/>
+	<span id="publicMailNotificationLang" <?php if ($_['allowPublicMailNotification'] == 'no') {
+	print_unescaped('class="hidden"');
+} ?>>
+		<label><?php p($l->t('Language used for public mail notifications for shared files'));?></label>
+		<?php print_unescaped($_['publicMailNotificationLang']); ?>
+		<br>
+	</span>
+
 
 		<input type="checkbox" name="shareapi_allow_social_share" id="allowSocialShare" class="checkbox"
 			   value="1" <?php if ($_['allowSocialShare'] == 'yes') {

--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -131,31 +131,15 @@ if ($_['passwordChangeSupported']) {
 <?php
 	}
 ?>
-
-<form id="language" class="section">
+<form class="section">
 	<h2>
-		<label for="languageinput"><?php p($l->t('Language'));?></label>
+		<label><?php p($l->t('Language'));?></label>
 	</h2>
-	<select id="languageinput" name="lang" data-placeholder="<?php p($l->t('Language'));?>">
-		<option value="<?php p($_['activelanguage']['code']);?>">
-			<?php p($_['activelanguage']['name']);?>
-		</option>
-		<?php foreach ($_['commonlanguages'] as $language):?>
-			<option value="<?php p($language['code']);?>">
-				<?php p($language['name']);?>
-			</option>
-		<?php endforeach;?>
-		<optgroup label="––––––––––"></optgroup>
-		<?php foreach ($_['languages'] as $language):?>
-			<option value="<?php p($language['code']);?>">
-				<?php p($language['name']);?>
-			</option>
-		<?php endforeach;?>
-	</select>
+	<?php print_unescaped($_['languageSelector']); ?>
 	<?php if (OC_Util::getEditionString() === OC_Util::EDITION_COMMUNITY): ?>
-	<a href="https://www.transifex.com/projects/p/owncloud/"
-		target="_blank" rel="noreferrer">
-		<em><?php p($l->t('Help translate'));?></em>
-	</a>
+		<a href="https://www.transifex.com/projects/p/owncloud/"
+		   target="_blank" rel="noreferrer">
+			<em><?php p($l->t('Help translate'));?></em>
+		</a>
 	<?php endif; ?>
 </form>

--- a/tests/Settings/Controller/SettingsPageControllerTest.php
+++ b/tests/Settings/Controller/SettingsPageControllerTest.php
@@ -21,6 +21,7 @@
 
 namespace Test;
 
+use OC\Helper\LocaleHelper;
 use OC\Settings\Controller\SettingsPageController;
 use OC\Settings\Panels\Personal\Profile;
 use OC\Settings\Section;
@@ -92,7 +93,10 @@ class SettingsPageControllerTest extends TestCase {
 					$this->config,
 					$this->groupManager,
 					$this->userSession,
-					$this->lfactory));
+					$this->lfactory,
+					new LocaleHelper()
+				)
+			);
 		$response = $this->pageController->getPersonal('general');
 		$this->assertArrayHasKey('personalNav', $response->getParams());
 		$this->assertArrayHasKey('adminNav', $response->getParams());
@@ -132,7 +136,10 @@ class SettingsPageControllerTest extends TestCase {
 					$this->config,
 					$this->groupManager,
 					$this->userSession,
-					$this->lfactory));
+					$this->lfactory,
+					new LocaleHelper()
+				)
+			);
 		$response = $this->pageController->getPersonal('general');
 		$this->assertArrayHasKey('personalNav', $response->getParams());
 		$this->assertArrayHasKey('adminNav', $response->getParams());

--- a/tests/Settings/Panels/Personal/ProfileTest.php
+++ b/tests/Settings/Panels/Personal/ProfileTest.php
@@ -10,6 +10,7 @@
 
 namespace Tests\Settings\Panels\Personal;
 
+use OC\Helper\LocaleHelper;
 use OC\Settings\Panels\Personal\Profile;
 use OCP\IConfig;
 use OCP\IGroupManager;
@@ -43,7 +44,9 @@ class ProfileTest extends \Test\TestCase {
 			$this->config,
 			$this->groupManager,
 			$this->userSession,
-			$this->lfactory);
+			$this->lfactory,
+			new LocaleHelper()
+		);
 	}
 
 	public function testGetSection() {

--- a/tests/Settings/Panels/Personal/ProfileTest.php
+++ b/tests/Settings/Panels/Personal/ProfileTest.php
@@ -70,6 +70,6 @@ class ProfileTest extends \Test\TestCase {
 		$this->assertContains('test@example.com', $templateHtml);
 		$this->assertContains('<div id="groups" class="section">', $templateHtml);
 		$this->assertContains('group2', $templateHtml);
-		$this->assertContains('<form id="language" class="section">', $templateHtml);
+		$this->assertContains('<select id="languageinput" name="lang"', $templateHtml);
 	}
 }

--- a/tests/lib/Helper/LocaleHelperTest.php
+++ b/tests/lib/Helper/LocaleHelperTest.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Helper;
+
+use OC\Helper\LocaleHelper;
+use OCP\IL10N;
+use OCP\L10N\IFactory;
+use Test\TestCase;
+
+/**
+ * Class LocaleHelperTest
+ *
+ * @package Test\Helper
+ */
+class LocaleHelperTest extends TestCase {
+	/**
+	 * @var LocaleHelper
+	 */
+	protected $localeHelper;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->localeHelper = new LocaleHelper();
+	}
+
+	public function langDataProvider() {
+		return [
+			[
+				[ 'hi', 'ro', 'php', 'de', 'java' ],
+				'en',
+				// en was omited in the available lang list above. it will have
+				// no translation and will not be available for selection
+				[
+					'code' => 'en',
+					'name' => 'en',
+				],
+				// Only de is common. en was omitted in the available lang list above
+				[
+					3 => [
+						'code' => 'de',
+						'name' => 'de',
+					]
+				],
+				// sorted by name alphabetically but if code was not resolved
+				// to name the item should has less priority
+				[
+					[
+						'code' => 'ro',
+						'name' => 'română',
+					],
+					[
+						'code' => 'hi',
+						'name' => 'हिन्दी',
+					],
+					[
+						'code' => 'java',
+						'name' => 'java',
+					],
+					[
+						'code' => 'php',
+						'name' => 'php',
+					],
+				]
+			],
+			[
+				[ 'hi', 'ro', 'php', 'de', 'java', 'en'],
+				'ro',
+				// Now we have ro in a list. It will be translated
+				[
+					'code' => 'ro',
+					'name' => 'română',
+				],
+				// de and en are common. en should go first
+				[
+					0 => [
+						'code' => 'en',
+						'name' => 'English',
+					],
+					3 => [
+						'code' => 'de',
+						'name' => 'de',
+					]
+				],
+				// sorted by name alphabetically but if code was not resolved
+				// to name the item should has less priority
+				[
+					[
+						'code' => 'hi',
+						'name' => 'हिन्दी',
+					],
+					[
+						'code' => 'java',
+						'name' => 'java',
+					],
+					[
+						'code' => 'php',
+						'name' => 'php',
+					],
+				]
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider langDataProvider
+	 */
+	public function testNormalization($availableCodes,
+								$currentCode,
+								$expectedUserLang,
+								$expectedCommonLanguages,
+								$expectedLanguages
+	) {
+		$l10n = $this->createMock(IL10N::class);
+
+		$langFactory = $this->createMock(IFactory::class);
+		$langFactory->expects($this->any())
+			->method('findAvailableLanguages')
+			->willReturn($availableCodes);
+		$langFactory->expects($this->any())
+			->method('get')
+			->willReturn($l10n);
+
+		list(
+			$userLang,
+			$commonLanguages,
+			$languages
+			) = $this->localeHelper->getNormalizedLanguages($langFactory, $currentCode);
+		$this->assertEquals($expectedUserLang, $userLang);
+		$this->assertEquals($expectedCommonLanguages, $commonLanguages);
+		$this->assertEquals($expectedLanguages, $languages);
+	}
+}


### PR DESCRIPTION
## Description
- [x] Make lang selector reusable
- [x] Reuse it for a new option in the `Sharing` section

## Related Issue
https://github.com/owncloud/enterprise/issues/2435#issuecomment-396551153

## Motivation and Context
Allows admin users change a language used for public mail notifications

## How Has This Been Tested?
0. Language selector in Settings->Personal -> General -> Language should NOT change it's behavior
1. A new option should be visible only when `Allow users to send mail notification for shared files` is checked in Settings->Admin->Sharing
2. Switching the dropdown  to  the value `Owner language` should reset to the current behavior when the notification is sent in the language of the file owner
expected:
`php occ config:app:get core shareapi_public_notification_lang` produces an empty output in this case (no value set)

3. Switching the dropdown to any other value except `Owner language`  should update `shareapi_public_notification_lang` with a respective language code

## Screenshots (if appropriate):
![notification lang](https://user-images.githubusercontent.com/991300/42220725-7f6a9af8-7ed8-11e8-80f2-958cb33edcbb.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
