### PR TITLE
use unused offset and limit value in favorites test

### DIFF
--- a/tests/acceptance/features/apiMain/favorites.feature
+++ b/tests/acceptance/features/apiMain/favorites.feature
@@ -103,7 +103,7 @@ Feature: favorite
 			| old           |
 			| new           |
 
-    Scenario Outline: Get favorited elements paginated
+    Scenario Outline: Get favorited elements paginated with some offset
         Given using <dav_version> DAV path
         And user "user0" has been created
         And user "user0" has created a folder "/subfolder"
@@ -120,8 +120,32 @@ Feature: favorite
         And user "user0" favorites element "/subfolder/textfile4.txt" using the API
         And user "user0" favorites element "/subfolder/textfile5.txt" using the API
         Then user "user0" in folder "/subfolder" should have favorited the following elements from offset 3 and limit 2
-            | /subfolder/textfile2.txt |
             | /subfolder/textfile3.txt |
+            | /subfolder/textfile4.txt |
+        Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
+    Scenario Outline: Get favorited elements paginated with zero offset
+        Given using <dav_version> DAV path
+        And user "user0" has been created
+        And user "user0" has created a folder "/subfolder"
+        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile0.txt"
+        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile1.txt"
+        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile2.txt"
+        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile3.txt"
+        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile4.txt"
+        And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile5.txt"
+        When user "user0" favorites element "/subfolder/textfile0.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile1.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile2.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile3.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile4.txt" using the API
+        And user "user0" favorites element "/subfolder/textfile5.txt" using the API
+        Then user "user0" in folder "/subfolder" should have favorited the following elements from offset 0 and limit 2
+            | /subfolder/textfile0.txt |
+            | /subfolder/textfile1.txt |
         Examples:
 			| dav_version   |
 			| old           |

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -995,7 +995,6 @@ trait WebDav {
 		$user, $path, $properties, $filterRules, $offset = null, $limit = null
 	) {
 		$client = $this->getSabreClient($user);
-
 		$body = '<?xml version="1.0" encoding="utf-8" ?>
 					<oc:filter-files xmlns:a="DAV:" xmlns:oc="http://owncloud.org/ns" >
 						<a:prop>
@@ -1951,7 +1950,7 @@ trait WebDav {
 	 */
 	public function checkFavoritedElements($user, $folder, $expectedElements) {
 		$this->checkFavoritedElementsPaginated(
-			$user, $folder, $expectedElements, null, null
+			$user, $folder, null, null, $expectedElements
 		);
 	}
 
@@ -1960,20 +1959,24 @@ trait WebDav {
 	 *
 	 * @param string $user
 	 * @param string $folder
+	 * @param int|null $offset
+	 * @param int|null $limit
 	 * @param TableNode|null $expectedElements
-	 * @param int $offset unused
-	 * @param int $limit unused
 	 *
 	 * @return void
 	 */
 	public function checkFavoritedElementsPaginated(
-		$user, $folder, $expectedElements, $offset, $limit
+		$user, $folder, $offset, $limit, $expectedElements
 	) {
+		$offset === null ?  $offset : \settype($offset, 'integer');
+		$limit === null ? $limit : \settype($limit, 'integer');
 		$elementList = $this->reportFolder(
 			$user,
 			$folder,
 			'<oc:favorite/>',
-			'<oc:favorite>1</oc:favorite>'
+			'<oc:favorite>1</oc:favorite>',
+			$offset,
+			$limit
 		);
 		if ($expectedElements instanceof TableNode) {
 			$elementRows = $expectedElements->getRows();


### PR DESCRIPTION
## Description
Previously `offset` and `limit` values were not utilized in PHP function eventhough they were being used by scenario steps. This PR makes use of those `offset` and `limit` values.

## Related Issue
#31725

## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.