### PR TITLE
Adjust notification message for the sharing apps

### DIFF
--- a/apps/federatedfilesharing/appinfo/app.php
+++ b/apps/federatedfilesharing/appinfo/app.php
@@ -26,11 +26,13 @@ $app = new \OCA\FederatedFileSharing\AppInfo\Application('federatedfilesharing')
 use OCA\FederatedFileSharing\Notifier;
 use OCP\Share\Events\AcceptShare;
 use OCP\Share\Events\DeclineShare;
+use OCP\Defaults;
 
 $manager = \OC::$server->getNotificationManager();
 $manager->registerNotifier(function () {
 	return new Notifier(
-		\OC::$server->getL10NFactory()
+		\OC::$server->getL10NFactory(),
+		new Defaults()
 	);
 }, function () {
 	$l = \OC::$server->getL10N('files_sharing');

--- a/apps/federatedfilesharing/lib/Notifier.php
+++ b/apps/federatedfilesharing/lib/Notifier.php
@@ -24,16 +24,21 @@ namespace OCA\FederatedFileSharing;
 
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Defaults;
 
 class Notifier implements INotifier {
 	/** @var \OCP\L10N\IFactory */
 	protected $factory;
 
+	/** @var Defaults */
+	protected $defaults;
+
 	/**
 	 * @param \OCP\L10N\IFactory $factory
 	 */
-	public function __construct(\OCP\L10N\IFactory $factory) {
+	public function __construct(\OCP\L10N\IFactory $factory, Defaults $defaults) {
 		$this->factory = $factory;
+		$this->defaults = $defaults;
 	}
 
 	/**
@@ -50,17 +55,30 @@ class Notifier implements INotifier {
 		// Read the language from the notification
 		$l = $this->factory->get('files_sharing', $languageCode);
 
-		switch ($notification->getSubject()) {
+		switch ($notification->getObjectType()) {
 			// Deal with known subjects
 			case 'remote_share':
 				$params = $notification->getSubjectParameters();
 				if ($params[0] !== $params[1] && $params[1] !== null) {
 					$notification->setParsedSubject(
-						(string) $l->t('You received "/%3$s" as a remote share from %1$s (on behalf of %2$s)', $params)
+						(string) $l->t('"%1$s" shared "%3$s" with you (on behalf of "%2$s")', $params)
 					);
 				} else {
 					$notification->setParsedSubject(
-						(string)$l->t('You received "/%3$s" as a remote share from %1$s', $params)
+						(string) $l->t('"%1$s" shared "%3$s" with you', $params)
+					);
+				}
+
+				$instanceName = $this->defaults->getName();
+				$messageParams = $notification->getMessageParameters();
+				$messageParams[3] = $instanceName;
+				if ($messageParams[0] !== $messageParams[1] && $messageParams[1] !== null) {
+					$notification->setParsedMessage(
+						(string) $l->t('"%1$s" invited you to view "%3$s" on %4$s (on behalf of "%2$s")', $messageParams)
+					);
+				} else {
+					$notification->setParsedMessage(
+						(string) $l->t('"%1$s" invited you to view "%3$s" on %4$s', $messageParams)
 					);
 				}
 

--- a/apps/federatedfilesharing/lib/RequestHandler.php
+++ b/apps/federatedfilesharing/lib/RequestHandler.php
@@ -188,7 +188,8 @@ class RequestHandler {
 					->setUser($shareWith)
 					->setDateTime(new \DateTime())
 					->setObject('remote_share', $shareId)
-					->setSubject('remote_share', [$ownerFederatedId, $sharedByFederatedId, \trim($name, '/')]);
+					->setSubject('remote_share', [$ownerFederatedId, $sharedByFederatedId, \trim($name, '/')])
+					->setMessage('remote_share', [$ownerFederatedId, $sharedByFederatedId, \trim($name, '/')]);
 
 				$declineAction = $notification->createAction();
 				$declineAction->setLabel('decline')

--- a/apps/files_sharing/lib/Service/NotificationPublisher.php
+++ b/apps/files_sharing/lib/Service/NotificationPublisher.php
@@ -102,6 +102,7 @@ class NotificationPublisher {
 			$notification->setLink($fileLink);
 
 			$notification->setSubject('local_share', [$share->getShareOwner(), $share->getSharedBy(), $share->getNode()->getName()]);
+			$notification->setMessage('local_share', [$share->getShareOwner(), $share->getSharedBy(), $share->getNode()->getName()]);
 
 			$declineAction = $notification->createAction();
 			$declineAction->setLabel('decline');

--- a/apps/files_sharing/tests/Service/NotificationPublisherTest.php
+++ b/apps/files_sharing/tests/Service/NotificationPublisherTest.php
@@ -122,8 +122,9 @@ class NotificationPublisherTest extends TestCase {
 			->method('setSubject')
 			->with($messageId, $messageParams)
 			->will($this->returnSelf());
-		$notification->expects($this->never())
-			->method('setMessage');
+		$notification->expects($this->once())
+			->method('setMessage')
+			->will($this->returnSelf());
 
 		return $notification;
 	}

--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -24,8 +24,8 @@ Feature: Display notifications when receiving a share
 		Then user "user1" should have 2 notifications
 		And the last notification of user "user1" should match these regular expressions
 			| app         | /^files_sharing$/                       |
-			| subject     | /^User "user0" shared "PARENT" with you$/ |
-			| message     | /^$/                                    |
+			| subject     | /^"user0" shared "PARENT" with you$/    |
+			| message     | /^"user0" invited you to view "PARENT" on ownCloud$/ |
 			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
 			| object_type | /^local_share$/                         |
 
@@ -36,15 +36,15 @@ Feature: Display notifications when receiving a share
 		Then user "user1" should have 2 notifications
 		And the last notification of user "user1" should match these regular expressions
 			| app         | /^files_sharing$/                       |
-			| subject     | /^User "user0" shared "PARENT" with you$/ |
-			| message     | /^$/                                    |
+			| subject     | /^"user0" shared "PARENT" with you$/    |
+			| message     | /^"user0" invited you to view "PARENT" on ownCloud$/ |
 			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
 			| object_type | /^local_share$/                         |
 		And user "user2" should have 2 notifications
 		And the last notification of user "user2" should match these regular expressions
 			| app         | /^files_sharing$/                       |
-			| subject     | /^User "user0" shared "PARENT" with you$/ |
-			| message     | /^$/                                    |
+			| subject     | /^"user0" shared "PARENT" with you$/    |
+			| message     | /^"user0" invited you to view "PARENT" on ownCloud$/ |
 			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
 			| object_type | /^local_share$/                         |
 

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -25,10 +25,10 @@ So that those groups can access the files and folders
 		And user "user3" has shared folder "/data.zip" with group "grp1"
 		Then the user should see 2 notifications on the webUI with these details
 			| title                                            |
-			| User "User Three" shared "simple-folder" with you  |
-			| User "User Three" shared "data.zip" with you       |
+			| "User Three" shared "simple-folder" with you  |
+			| "User Three" shared "data.zip" with you       |
 		When the user re-logs in with username "user1" and password "1234" using the webUI
 		Then the user should see 2 notifications on the webUI with these details
 			| title                                            |
-			| User "User Three" shared "simple-folder" with you  |
-			| User "User Three" shared "data.zip" with you       |
+			| "User Three" shared "simple-folder" with you  |
+			| "User Three" shared "data.zip" with you       |

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -19,8 +19,8 @@ So that those users can access the files and folders
 		And user "user1" has shared folder "/data.zip" with user "user2"
 		Then the user should see 2 notifications on the webUI with these details
 			| title                                          |
-			| User "User One" shared "simple-folder" with you  |
-			| User "User One" shared "data.zip" with you       |
+			| "User One" shared "simple-folder" with you  |
+			| "User One" shared "data.zip" with you       |
 
 	Scenario: Notification is gone after accepting a share
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Adjust the notification message

## Related Issue
Partially fixes https://github.com/owncloud/core/issues/31876

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested

![screen shot 2018-06-25 at 13 18 03](https://user-images.githubusercontent.com/1477829/41847468-606f1a0c-787a-11e8-9ad5-774951ae27e4.png)

<img width="224" alt="screen shot 2018-06-25 at 13 18 53" src="https://user-images.githubusercontent.com/1477829/41847479-6a8e1a10-787a-11e8-8db0-2ee831d78d0c.png">

![screen shot 2018-06-25 at 13 24 16](https://user-images.githubusercontent.com/1477829/41847719-41959e3e-787b-11e8-9786-ce9cd7e18f59.png)

![screen shot 2018-06-25 at 13 25 12](https://user-images.githubusercontent.com/1477829/41847735-50397b22-787b-11e8-96fd-e4aab5de39ab.png)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
