### PR TITLE
removed dead code

### DIFF
--- a/apps/files_sharing/lib/Migration.php
+++ b/apps/files_sharing/lib/Migration.php
@@ -157,16 +157,6 @@ class Migration {
 			->andWhere($query->expr()->isNotNull('parent'))
 			->orderBy('id', 'asc');
 		return $query->execute();
-
-		$shares = $result->fetchAll();
-		$result->closeCursor();
-
-		$ordered = [];
-		foreach ($shares as $share) {
-			$ordered[(int)$share['id']] = $share;
-		}
-
-		return $ordered;
 	}
 
 	/**


### PR DESCRIPTION
## Motivation and Context
The code was not reached, as the function exits before via `return`.

This was spotted by **phpstan**
```
 ------ -------------------------------------- 
  Line   apps/files_sharing/lib/Migration.php  
 ------ -------------------------------------- 
  161    Undefined variable: $result           
  162    Undefined variable: $result           
 ------ -------------------------------------- 
```

## How Has This Been Tested?
not needed - as code was never executed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

