### PR TITLE
Acceptance tests for issue 31870 share auto-accept for groups

### DIFF
--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -50,6 +50,74 @@ Feature: Display notifications when receiving a share
 			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
 			| object_type | /^local_share$/                              |
 
+	# This scenario documents behavior discussed in core issue 31870
+	# An old share keeps its old auto-accept behavior, even after auto-accept has been disabled.
+	Scenario: share to group does not send notifications to either existing or new members for an old share created before auto-accept is disabled
+		Given user "user0" has shared folder "/PARENT" with group "grp1"
+		When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "no"
+		And the administrator creates the user "user3" using the provisioning API
+		And the administrator adds user "user3" to group "grp1" using the provisioning API
+		Then user "user1" should have 0 notifications
+		And user "user2" should have 0 notifications
+		And user "user3" should have 0 notifications
+
+	# This scenario documents behavior discussed in core issue 31870
+	# As users are added to an existing group, they are not sent notifications about group shares.
+	Scenario: share to group sends notifications to existing members, but not to new members, for a share created after auto-accept is disabled
+		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+		And the administrator creates the user "user3" using the provisioning API
+		And the administrator adds user "user3" to group "grp1" using the provisioning API
+		Then user "user1" should have 1 notification
+		And the last notification of user "user1" should match these regular expressions
+			| app         | /^files_sharing$/                       |
+			| subject     | /^"User Zero" shared "PARENT" with you$/ |
+			| message     | /^"User Zero" invited you to view "PARENT"$/ |
+			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
+			| object_type | /^local_share$/                         |
+		And user "user2" should have 1 notification
+		And the last notification of user "user2" should match these regular expressions
+			| app         | /^files_sharing$/                       |
+			| subject     | /^"User Zero" shared "PARENT" with you$/ |
+			| message     | /^"User Zero" invited you to view "PARENT"$/ |
+			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
+			| object_type | /^local_share$/                         |
+		And user "user3" should have 0 notifications
+
+	# This scenario documents behavior discussed in core issue 31870
+	# Similar to the previous scenario, a new user added to the group does not get a notification,
+	# even though the group, when originally created, had notifications on.
+	Scenario: share to group sends notifications to existing members, but not to new members, for an old share created before auto-accept is enabled
+		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+		And user "user0" has shared folder "/PARENT" with group "grp1"
+		When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "yes"
+		And the administrator creates the user "user3" using the provisioning API
+		And the administrator adds user "user3" to group "grp1" using the provisioning API
+		Then user "user1" should have 1 notification
+		And the last notification of user "user1" should match these regular expressions
+			| app         | /^files_sharing$/                       |
+			| subject     | /^"User Zero" shared "PARENT" with you$/ |
+			| message     | /^"User Zero" invited you to view "PARENT"$/ |
+			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
+			| object_type | /^local_share$/                         |
+		And user "user2" should have 1 notification
+		And the last notification of user "user2" should match these regular expressions
+			| app         | /^files_sharing$/                       |
+			| subject     | /^"User Zero" shared "PARENT" with you$/ |
+			| message     | /^"User Zero" invited you to view "PARENT"$/ |
+			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
+			| object_type | /^local_share$/                         |
+		And user "user3" should have 0 notifications
+
+	Scenario: share to group does not send notifications to existing and new members for a share created after auto-accept is enabled
+		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+		And the administrator creates the user "user3" using the provisioning API
+		And the administrator adds user "user3" to group "grp1" using the provisioning API
+		Then user "user1" should have 0 notifications
+		And user "user2" should have 0 notifications
+		And user "user3" should have 0 notifications
+
 	Scenario: when auto-accepting is enabled no notifications are sent
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
 		When user "user0" shares folder "/PARENT" with user "user1" using the sharing API


### PR DESCRIPTION
## Description
1) ``sharingNotifications.feature:55`` - make a group share when auto-accept is on. Now turn off auto-accept. Make a new user in the group. You might think that all the users (or at least the new user) should get notifications, but they don't.

2) ``sharingNotifications.feature:66`` - make a group share when auto-accept is off. Make a new user in the group. Existing users get a notification - good. You might think that he new user should also get a notification, but they do not - this is accepted as "the behavior".

3) ``sharingNotifications.feature:90`` - make a group share when auto-accept is off. Turn on auto-accept. Make a new user in the group. The new user gets no notification - expected. But the existing users still have their notifications - this is accepted as "the behavior".

4) ``sharingNotifications.feature:112`` - make a group share when auto-accept is on. Make a new user in the group. None of the users get notifications. This is what would normally be expected anyway.

## Related Issue
#31870 

## Motivation and Context
Share auto-accept for members of groups is inconsistent.
Make test scenarios that demonstrate the issue.

## How Has This Been Tested?
1) Run scenarios locally and confirm that they fail against current ``master``
2) Now, after discussion in the issue, the scenarios have been adjusted to document the agreed existing behavior.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance tests

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed - except the ones that are supposed to fail ;)
