### PR TITLE
AppManager text typo and PHPdoc return tags

### DIFF
--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -884,7 +884,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 *
 	 * @param int $addressBookId
 	 * @param string $uri
-	 * @returns array
+	 * @return array
 	 */
 	public function getContact($addressBookId, $uri) {
 		$result = [];

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -193,7 +193,7 @@ class AppManager implements IAppManager {
 
 			if (!\is_array($groupIds)) {
 				$jsonError = \json_last_error();
-				\OC::$server->getLogger()->warning('AppManger::checkAppForUser - can\'t decode group IDs: ' . \print_r($enabled, true) . ' - json error code: ' . $jsonError, ['app' => 'lib']);
+				\OC::$server->getLogger()->warning('AppManager::checkAppForUser - can\'t decode group IDs: ' . \print_r($enabled, true) . ' - json error code: ' . $jsonError, ['app' => 'lib']);
 				return false;
 			}
 

--- a/lib/private/App/DependencyAnalyzer.php
+++ b/lib/private/App/DependencyAnalyzer.php
@@ -48,7 +48,7 @@ class DependencyAnalyzer {
 
 	/**
 	 * @param array $app
-	 * @returns array of missing dependencies
+	 * @return array of missing dependencies
 	 */
 	public function analyze(array $app) {
 		$this->appInfo = $app;

--- a/lib/private/App/PlatformRepository.php
+++ b/lib/private/App/PlatformRepository.php
@@ -208,6 +208,7 @@ class PlatformRepository {
 
 	/**
 	 * @param string $stability
+	 * @return string
 	 */
 	private function expandStability($stability) {
 		$stability = \strtolower($stability);

--- a/lib/private/Encryption/Manager.php
+++ b/lib/private/Encryption/Manager.php
@@ -118,6 +118,7 @@ class Manager implements IManager {
 
 	/**
 	 * @param string $user
+	 * @return bool
 	 */
 	public function isReadyForUser($user) {
 		if (!$this->isReady()) {

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -798,6 +798,7 @@ class Filesystem {
 
 	/**
 	 * @param string $query
+	 * @return FileInfo[] array of file info
 	 */
 	public static function searchByMime($query) {
 		return self::$defaultInstance->searchByMime($query);
@@ -806,7 +807,7 @@ class Filesystem {
 	/**
 	 * @param string|int $tag name or tag id
 	 * @param string $userId owner of the tags
-	 * @return FileInfo[] array or file info
+	 * @return FileInfo[] array of file info
 	 */
 	public static function searchByTag($tag, $userId) {
 		return self::$defaultInstance->searchByTag($tag, $userId);

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -178,7 +178,7 @@ class Installer {
 	/**
 	 * @brief checks whether or not an app is installed
 	 * @param string $app app
-	 * @returns bool
+	 * @return bool
 	 *
 	 * Checks whether or not an app is installed, i.e. registered in apps table.
 	 */

--- a/lib/private/Share/Helper.php
+++ b/lib/private/Share/Helper.php
@@ -79,6 +79,7 @@ class Helper extends \OC\Share\Constants {
 	 * @param string $uidOwner The user that the parent was shared with (optional)
 	 * @param int $newParent new parent for the childrens
 	 * @param bool $excludeGroupChildren exclude group children elements
+	 * @return array of deleted items
 	 */
 	public static function delete($parent, $excludeParent = false, $uidOwner = null, $newParent = null, $excludeGroupChildren = false) {
 		$ids = [$parent];

--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -90,6 +90,7 @@ class OC_Defaults {
 
 	/**
 	 * @param string $method
+	 * @return bool
 	 */
 	private function themeExist($method) {
 		if (isset($this->theme) && \method_exists($this->theme, $method)) {

--- a/lib/private/legacy/template/functions.php
+++ b/lib/private/legacy/template/functions.php
@@ -191,6 +191,8 @@ function preview_icon($path) {
 
 /**
  * @param string $path
+ * @param string $token
+ * @return string link to the public preview
  */
 function publicPreview_icon($path, $token) {
 	return \OC::$server->getURLGenerator()->linkToRoute('core_ajax_public_preview', ['x' => 32, 'y' => 32, 'file' => $path, 't' => $token]);


### PR DESCRIPTION
## Description
Fix a typo in text string ``AppManger`` => ``AppManager``
Fix some PHPdoc tags that had ``returns`` => ``return``
Add some other missing ``return``  tags where they seemed easy

## Motivation and Context
Quickly fixup little crud that I noticed when resolving backport conflicts.
Follow the bouncing ball a little while where PHPstorm shouts at me.
Stop when I realize how much more PHPstorm wants to shout :)

## How Has This Been Tested?
CI will know - comment and error message text changes only.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
