### PR TITLE
Prevent PHP CS scanning stray folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ Vagrantfile
 clover.xml
 /tests/output
 .php_cs.cache
+.php_cs

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -4,41 +4,41 @@ $dirToParse = 'apps';
 $dirIterator = new DirectoryIterator(__DIR__ . '/' . $dirToParse);
 
 $bundledApps = [
-    'comments',
-    'dav',
-    'federatedfilesharing',
-    'federation',
-    'files',
-    'files_external',
-    'files_sharing',
-    'files_trashbin',
-    'files_versions',
-    'provisioning_api',
-    'systemtags',
-    'testing',
-    'updatenotification'
+	'comments',
+	'dav',
+	'federatedfilesharing',
+	'federation',
+	'files',
+	'files_external',
+	'files_sharing',
+	'files_trashbin',
+	'files_versions',
+	'provisioning_api',
+	'systemtags',
+	'testing',
+	'updatenotification'
 ];
 
 $excludeDirs = [
-    'lib/composer',
-    'build',
-    'apps/files_external/3rdparty',
-    'config',
-    'data',
-    '3rdparty',
+	'lib/composer',
+	'build',
+	'apps/files_external/3rdparty',
+	'config',
+	'data',
+	'3rdparty',
 ];
 
 foreach ($dirIterator as $fileinfo) {
-    $filename = $fileinfo->getFilename();
-    if ($fileinfo->isDir() && !$fileinfo->isDot() && !in_array($filename, $bundledApps)) {
-        $excludeDirs[] = $dirToParse . '/' . $filename;
-    }
+	$filename = $fileinfo->getFilename();
+	if ($fileinfo->isDir() && !$fileinfo->isDot() && !in_array($filename, $bundledApps)) {
+		$excludeDirs[] = $dirToParse . '/' . $filename;
+	}
 }
 
 $finder = PhpCsFixer\Finder::create()
-    ->exclude($excludeDirs)
-    ->notPath('tests/autoconfig*')
-    ->in(__DIR__);
+	->exclude($excludeDirs)
+	->notPath('tests/autoconfig*')
+	->in(__DIR__);
 
 $config = new OC\CodingStandard\Config();
 $config->setFinder($finder);

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -24,7 +24,8 @@ $excludeDirs = [
     'build',
     'apps/files_external/3rdparty',
     'config',
-    'data'
+    'data',
+    '3rdparty',
 ];
 
 foreach ($dirIterator as $fileinfo) {
@@ -36,6 +37,7 @@ foreach ($dirIterator as $fileinfo) {
 
 $finder = PhpCsFixer\Finder::create()
     ->exclude($excludeDirs)
+    ->notPath('tests/autoconfig*')
     ->in(__DIR__);
 
 $config = new OC\CodingStandard\Config();

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -23,6 +23,7 @@ $excludeDirs = [
 	'lib/composer',
 	'build',
 	'apps/files_external/3rdparty',
+	'apps-external',
 	'config',
 	'data',
 	'3rdparty',


### PR DESCRIPTION
When swiching from stable9.1 the "3rdparty" folder can remain in some
cases.
Also exluded "tests/autoconfig*" which are sometimes generated when
running unit tests.

Fixes https://github.com/owncloud/core/issues/31863

Any additions must be made to ".php_cs" folder as I did for my own setup with "apps2" and "apps3"