### PR TITLE
[stable10] User Management UI tests

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -247,7 +247,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the administrator deletes the user with the username :username using the webUI
+	 * @When the administrator deletes the user :username using the webUI
 	 *
 	 * @param string $username
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -33,7 +33,6 @@ require_once 'bootstrap.php';
  * WebUI Users context.
  */
 class WebUIUsersContext extends RawMinkContext implements Context {
-
 	private $usersPage;
 
 	/**
@@ -103,7 +102,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	public function theAdminCreatesAUserUsingTheWebUI(
 		$attemptTo, $username, $password, $email=null, TableNode $groupsTable=null
 	) {
-		if (!is_null($groupsTable)) {
+		if ($groupsTable !== null) {
 			$groups = $groupsTable->getColumn(0);
 			//get rid of the header
 			unset($groups[0]);
@@ -119,7 +118,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 		$this->featureContext->addUserToCreatedUsersList(
 			$username, $password, "", $email, $shouldExist
 		);
-		if (is_array($groups)) {
+		if (\is_array($groups)) {
 			foreach ($groups as $group) {
 				$this->featureContext->addGroupToCreatedGroupsList($group);
 			}

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -24,7 +24,6 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Behat\Mink\Exception\ExpectationException;
 use Page\LoginPage;
 use Page\UsersPage;
 
@@ -59,6 +58,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * WebUIUsersContext constructor.
 	 *
 	 * @param UsersPage $usersPage
+	 * @param LoginPage $loginPage
 	 */
 	public function __construct(UsersPage $usersPage, LoginPage $loginPage) {
 		$this->usersPage = $usersPage;
@@ -173,13 +173,12 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * @param string $name
 	 *
 	 * @return void
-	 *
-	 * @throws Exception
 	 */
 	public function theGroupNamedShouldNotBeListedOnTheWebUI($name) {
-		if (in_array($name, $this->usersPage->getAllGroups(), true)) {
-			throw new Exception("group '" . $name . "' is listed but should not");
-		}
+		PHPUnit_Framework_Assert::assertFalse(
+			\in_array($name, $this->usersPage->getAllGroups(), true),
+			"group '" . $name . "' is listed but should not be"
+		);
 	}
 
 	/**
@@ -190,20 +189,18 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * @param TableNode $table
 	 *
 	 * @return void
-	 *
-	 * @throws Exception
 	 */
 	public function theseGroupsShouldBeListedOnTheWebUI($shouldOrNot, TableNode $table) {
 		$should = ($shouldOrNot !== "not");
 		$groups = $this->usersPage->getAllGroups();
 		foreach ($table as $row) {
-			if (in_array($row['groupname'], $groups, true) !== $should) {
-				throw new Exception(
-					"group '" . $row['groupname'] .
-					"' is" . ($should ? " not" : "") .
-					" listed but should" . ($should ? "" : " not") . " be"
-				);
-			}
+			PHPUnit_Framework_Assert::assertEquals(
+				\in_array($row['groupname'], $groups, true),
+				$should,
+				"group '" . $row['groupname'] .
+				"' is" . ($should ? " not" : "") .
+				" listed but should" . ($should ? "" : " not") . " be"
+			);
 		}
 	}
 
@@ -284,17 +281,15 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * @param string $quota
 	 *
 	 * @return void
-	 *
-	 * @throws ExpectationException
 	 */
 	public function quotaOfUserShouldBeSetToOnTheWebUI($username, $quota) {
 		$setQuota = $this->usersPage->getQuotaOfUser($username);
-		if ($setQuota !== $quota) {
-			throw new ExpectationException(
-				'Users quota is set to "' . $setQuota . '" expected "' .
-				$quota . '"', $this->getSession()
-			);
-		}
+		PHPUnit_Framework_Assert::assertEquals(
+			$quota,
+			$setQuota,
+			'Users quota is set to "' . $setQuota .
+			'" but expected "' . $quota . '"'
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -45,6 +45,12 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 
 	/**
 	 *
+	 * @var WebUIGeneralContext
+	 */
+	private $webUIGeneralContext;
+
+	/**
+	 *
 	 * @var FeatureContext
 	 */
 	private $featureContext;
@@ -242,6 +248,33 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 		 */
 		$disabledPage = $this->loginPage->loginAs($username, $password, 'DisabledUserPage');
 		$disabledPage->waitTillPageIsLoaded($this->getSession());
+	}
+
+	/**
+	 * @When the administrator deletes the user with the username :username using the webUI
+	 *
+	 * @param string $username
+	 *
+	 * @return void
+	 */
+	public function theAdministratorDeletesTheUser($username) {
+		$this->usersPage->deleteUser($username);
+		$this->featureContext->rememberThatUserIsNotExpectedToExist($username);
+	}
+
+	/**
+	 *
+	 * @When the deleted user :username tries to login using the password :password using the webUI
+	 *
+	 * @param string $username
+	 *
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function theDeletedUserTriesToLogin($username, $password) {
+		$this->webUIGeneralContext->theUserLogsOutOfTheWebUI();
+		$this->loginPage->loginAs($username, $password, 'LoginPage');
 	}
 
 	/**

--- a/tests/acceptance/features/lib/UserPageElement/GroupList.php
+++ b/tests/acceptance/features/lib/UserPageElement/GroupList.php
@@ -67,11 +67,11 @@ class GroupList extends OwncloudPage {
 	 */
 	public function selectGroup($name) {
 		$name = $this->quotedText($name);
-		$xpathLocator = sprintf($this->groupLiXpath, $name);
+		$xpathLocator = \sprintf($this->groupLiXpath, $name);
 		$groupLi = $this->groupListElement->find(
 			"xpath", $xpathLocator
 		);
-		if (is_null($groupLi)) {
+		if ($groupLi === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $xpathLocator " .
@@ -93,7 +93,7 @@ class GroupList extends OwncloudPage {
 	public function deleteGroup($name) {
 		$groupLi = $this->selectGroup($name);
 		$deleteButton = $groupLi->find("xpath", $this->deleteBtnXpath);
-		if (is_null($deleteButton)) {
+		if ($deleteButton === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->deleteBtnXpath " .
@@ -112,7 +112,7 @@ class GroupList extends OwncloudPage {
 	 */
 	public function addGroup($groupName) {
 		$addLink = $this->find("xpath", $this->addGroupXpath);
-		if (is_null($addLink)) {
+		if ($addLink === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->addGroupXpath " .
@@ -122,7 +122,7 @@ class GroupList extends OwncloudPage {
 		$addLink->click();
 		$this->fillField($this->addNewGroupInputBoxId, $groupName);
 		$addButton = $this->find("xpath", $this->addNewGroupButtonXpath);
-		if (is_null($addButton)) {
+		if ($addButton === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->addNewGroupButtonXpath " .

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -63,6 +63,8 @@ class UsersPage extends OwncloudPage {
 	protected $createGroupWithNewUserInputXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']//input[@type='text']";
 	protected $groupListId = "usergrouplist";
 	protected $disableUserCheckboxXpath = "//input[@type='checkbox']";
+	protected $deleteUserBtnXpath = ".//td[@class='remove']/a[@class='action delete']";
+
 	/**
 	 * @param string $username
 	 *
@@ -419,5 +421,24 @@ class UsersPage extends OwncloudPage {
 	public function disableUser($username) {
 		$userTr = $this->findUserInTable($username);
 		$userTr->find("xpath", $this->disableUserCheckboxXpath)->click();
+	}
+
+	/**
+	 *
+	 * @param string $username
+	 *
+	 * @return void
+	 */
+	public function deleteUser($username) {
+		$userTr = $this->findUserInTable($username);
+		$deleteBtn = $userTr->find("xpath", $this->deleteUserBtnXpath);
+		if ($deleteBtn === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->deleteUserBtnXpath " .
+				"could not find delete user field "
+			);
+		}
+		$deleteBtn->click();
 	}
 }

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -93,7 +93,7 @@ class UsersPage extends OwncloudPage {
 		$userTr = $this->findUserInTable($username);
 		$selectField = $userTr->find('xpath', $this->quotaSelectXpath);
 
-		if (is_null($selectField)) {
+		if ($selectField === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->quotaSelectXpath " .
@@ -104,7 +104,7 @@ class UsersPage extends OwncloudPage {
 		$xpathLocator = "//option[@value='" . $selectField->getValue() . "']";
 		$selectField = $selectField->find('xpath', $xpathLocator);
 
-		if (is_null($selectField)) {
+		if ($selectField === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $xpathLocator " .
@@ -123,7 +123,7 @@ class UsersPage extends OwncloudPage {
 	 */
 	public function openSettingsMenu() {
 		$settingsBtn = $this->find("xpath", $this->settingsBtnXpath);
-		if (is_null($settingsBtn)) {
+		if ($settingsBtn === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->settingsBtnXpath " .
@@ -144,7 +144,7 @@ class UsersPage extends OwncloudPage {
 	 */
 	public function setSetting($setting, $value = true) {
 		$settingContent = $this->findById($this->settingContentId);
-		if (is_null($settingContent)) {
+		if ($settingContent === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" id $this->settingContentId " .
@@ -158,7 +158,7 @@ class UsersPage extends OwncloudPage {
 			// Somehow on Edge this can throw NoSuchElement even though
 			// we just found the element.
 			// TODO: Edge - if it keeps happening then find out why.
-			error_log(
+			\error_log(
 				__METHOD__
 				. " NoSuchElement while doing settingContent->isVisible()"
 				. "\n-------------------------\n"
@@ -172,9 +172,9 @@ class UsersPage extends OwncloudPage {
 			$this->openSettingsMenu();
 		}
 
-		$xpathLocator = sprintf($this->settingByTextXpath, $setting);
+		$xpathLocator = \sprintf($this->settingByTextXpath, $setting);
 		$settingLabel = $this->find("xpath", $xpathLocator);
-		if (is_null($settingLabel)) {
+		if ($settingLabel === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $xpathLocator " .
@@ -184,7 +184,7 @@ class UsersPage extends OwncloudPage {
 		//the checkbox is not visible, but we need it to find the status
 		$checkBoxId = $settingLabel->getAttribute("for");
 		$checkBox = $this->findById($checkBoxId);
-		if (is_null($checkBox)) {
+		if ($checkBox === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" could not find checkbox with the id '" . $checkBoxId . "'"
@@ -213,12 +213,12 @@ class UsersPage extends OwncloudPage {
 	) {
 		$this->fillField($this->newUserUsernameFieldId, $username);
 		$this->fillField($this->newUserPasswordFieldId, $password);
-		$this->setSetting("Send email to new user", !is_null($email));
-		if (!is_null($email)) {
+		$this->setSetting("Send email to new user", $email !== null);
+		if ($email !== null) {
 			$this->fillField($this->newUserEmailFieldId, $email);
 		}
 		$createUserBtn = $this->find("xpath", $this->createUserBtnXpath);
-		if (is_null($createUserBtn)) {
+		if ($createUserBtn === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->createUserBtnXpath " .
@@ -228,7 +228,7 @@ class UsersPage extends OwncloudPage {
 		$newUserGroupsDropDown = $this->find(
 			"xpath", $this->newUserGroupsDropDownXpath
 		);
-		if (is_null($newUserGroupsDropDown)) {
+		if ($newUserGroupsDropDown === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->newUserGroupsDropDownXpath " .
@@ -237,7 +237,7 @@ class UsersPage extends OwncloudPage {
 		}
 		$newUserGroupsDropDown->click();
 		$groupDropDownList = $this->find("xpath", $this->newUserGroupsListXpath);
-		if (is_null($groupDropDownList)) {
+		if ($groupDropDownList === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->newUserGroupsListXpath " .
@@ -256,18 +256,18 @@ class UsersPage extends OwncloudPage {
 		}
 
 		//now select all groups that we need to have
-		if (is_array($groups)) {
+		if (\is_array($groups)) {
 			foreach ($groups as $group) {
 				$groupItem = $this->find(
-					"xpath", sprintf($this->newUserGroupXpath, $group)
+					"xpath", \sprintf($this->newUserGroupXpath, $group)
 				);
-				if (!is_null($groupItem)) {
+				if ($groupItem !== null) {
 					$groupItem->click();
 				} else {
 					$newUserAddGroupBtn = $this->find(
 						"xpath", $this->newUserAddGroupBtnXpath
 					);
-					if (is_null($newUserAddGroupBtn)) {
+					if ($newUserAddGroupBtn === null) {
 						throw new ElementNotFoundException(
 							__METHOD__ .
 							" xpath $this->newUserAddGroupBtnXpath " .
@@ -278,7 +278,7 @@ class UsersPage extends OwncloudPage {
 					$createUserInput = $this->find(
 						"xpath", $this->createGroupWithNewUserInputXpath
 					);
-					if (is_null($createUserInput)) {
+					if ($createUserInput === null) {
 						throw new ElementNotFoundException(
 							__METHOD__ .
 							" xpath $this->createGroupWithNewUserInputXpath " .
@@ -311,7 +311,7 @@ class UsersPage extends OwncloudPage {
 		$userTr = $this->findUserInTable($username);
 		$selectField = $userTr->find('xpath', $this->quotaSelectXpath);
 
-		if (is_null($selectField)) {
+		if ($selectField === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->quotaSelectXpath " .
@@ -320,13 +320,13 @@ class UsersPage extends OwncloudPage {
 		}
 
 		$selectOption = $selectField->find(
-			'xpath', sprintf($this->quotaOptionXpath, $quota)
+			'xpath', \sprintf($this->quotaOptionXpath, $quota)
 		);
-		if (is_null($selectOption)) {
-			$xpathLocator = sprintf($this->quotaOptionXpath, "Other");
+		if ($selectOption === null) {
+			$xpathLocator = \sprintf($this->quotaOptionXpath, "Other");
 			$selectOption = $selectField->find('xpath', $xpathLocator);
 
-			if (is_null($selectOption)) {
+			if ($selectOption === null) {
 				throw new ElementNotFoundException(
 					__METHOD__ .
 					" xpath $xpathLocator " .
@@ -337,7 +337,7 @@ class UsersPage extends OwncloudPage {
 			$selectOption->click();
 			$manualQuotaInputElement = $this->find('xpath', $this->manualQuotaInputXpath);
 
-			if (is_null($manualQuotaInputElement)) {
+			if ($manualQuotaInputElement === null) {
 				throw new ElementNotFoundException(
 					__METHOD__ .
 					" xpath $this->manualQuotaInputXpath " .
@@ -359,7 +359,7 @@ class UsersPage extends OwncloudPage {
 	 */
 	private function getGroupListElement() {
 		$groupListElement = $this->findById($this->groupListId);
-		if (is_null($groupListElement)) {
+		if ($groupListElement === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" id $this->groupListId " .

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -1,8 +1,8 @@
 @webUI @insulated @disablePreviews
 Feature: manage user quota
-As an admin
-I want to manage user quota
-So that users can only take up a certain amount of storage space
+	As an admin
+	I want to manage user quota
+	So that users can only take up a certain amount of storage space
 
 	Background:
 		Given these users have been created but not initialized:
@@ -18,15 +18,15 @@ So that users can only take up a certain amount of storage space
 		Then the quota of user "user1" should be set to "<expected_quota>" on the webUI
 
 		Examples:
-		|start_quota|wished_quota|expected_quota|
-		|Unlimited  |5 GB        |5 GB          |
-		|1 GB       |5 GB        |5 GB          |
-		|5 GB       |Unlimited   |Unlimited     |
-		|1 GB       |Unlimited   |Unlimited     |
-		|Unlimited  |5.5 GB      |5.5 GB        |
-		|Unlimited  |5B          |5 B           |
-		|Unlimited  |55kB        |55 KB         |
-		|Unlimited  |45Kb        |45 KB         |
+			|start_quota|wished_quota|expected_quota|
+			|Unlimited  |5 GB        |5 GB          |
+			|1 GB       |5 GB        |5 GB          |
+			|5 GB       |Unlimited   |Unlimited     |
+			|1 GB       |Unlimited   |Unlimited     |
+			|Unlimited  |5.5 GB      |5.5 GB        |
+			|Unlimited  |5B          |5 B           |
+			|Unlimited  |55kB        |55 KB         |
+			|Unlimited  |45Kb        |45 KB         |
 
 	@skipOnOcV10.0.3
 	Scenario: change quota to a valid value that do not work on 10.0.3
@@ -41,10 +41,10 @@ So that users can only take up a certain amount of storage space
 		And the quota of user "user1" should be set to "Default" on the webUI
 
 		Examples:
-		|wished_quota|
-		|stupidtext  |
-		|34,54GB     |
-		|30/40GB     |
-		|30/40       |
-		|3+56 B      |
-		|-1 B        |
+			|wished_quota|
+			|stupidtext  |
+			|34,54GB     |
+			|30/40GB     |
+			|30/40       |
+			|3+56 B      |
+			|-1 B        |

--- a/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
@@ -1,8 +1,8 @@
 @webUI @insulated @disablePreviews
 Feature: Add group
-As an admin
-I would like to add a group
-So that I can share documents with other users
+	As an admin
+	I would like to add a group
+	So that I can share documents with other users
 
 	Background:
 		Given user admin has logged in using the webUI
@@ -12,5 +12,5 @@ So that I can share documents with other users
 		When the administrator adds group <groupname> using the webUI
 		Then the group name <groupname> should be listed on the webUI
 		Examples:
-		|groupname|
-		|"localuser" |
+			|groupname|
+			|"localuser" |

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -1,7 +1,7 @@
 @webUI @insulated @disablePreviews
 Feature: manage users
   As an admin
-  I want to manage users
+  I want to add users
   So that unauthorised access is impossible
 
   Background:

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -1,5 +1,5 @@
 @webUI @insulated @disablePreviews
-Feature: manage users
+Feature: add users
   As an admin
   I want to add users
   So that unauthorised access is impossible

--- a/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
@@ -13,7 +13,7 @@ Feature: delete users
 		And the administrator has browsed to the users page
 
 	Scenario: use the webUI to delete a simple user
-		When the administrator deletes the user with the username "user1" using the webUI
+		When the administrator deletes the user "user1" using the webUI
 		And the deleted user "user1" tries to login using the password "1234" using the webUI
 		Then the user should be redirected to a webUI page with the title "ownCloud"
 		When the user has browsed to the login page

--- a/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
@@ -1,0 +1,21 @@
+@webUI @insulated @disablePreviews
+Feature: delete users
+	As an admin
+	I want to delete users
+	So that I can remove users
+
+	Background:
+		Given these users have been created but not initialized:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+			|user2   |1234    |User Two   |u2@oc.com.np|
+		And user admin has logged in using the webUI
+		And the administrator has browsed to the users page
+
+	Scenario: use the webUI to delete a simple user
+		When the administrator deletes the user with the username "user1" using the webUI
+		And the deleted user "user1" tries to login using the password "1234" using the webUI
+		Then the user should be redirected to a webUI page with the title "ownCloud"
+		When the user has browsed to the login page
+		And the user logs in with username "user2" and password "1234" using the webUI
+		Then the user should be redirected to a webUI page with the title "Files - ownCloud"

--- a/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
@@ -1,8 +1,8 @@
 @webUI @insulated @disablePreviews
 Feature: manage groups
-As an admin
-I want to manage groups
-So that access to resources can be controlled more effectively
+	As an admin
+	I want to manage groups
+	So that access to resources can be controlled more effectively
 
 	Background:
 		Given user admin has logged in using the webUI
@@ -11,103 +11,103 @@ So that access to resources can be controlled more effectively
 	@skipOnOcV10.0.3
 	Scenario: delete group called "0" and "false"
 		Given these groups have been created:
-		|groupname     |
-		|do-not-delete |
-		|0             |
-		|false         |
-		|do-not-delete2|
+			|groupname     |
+			|do-not-delete |
+			|0             |
+			|false         |
+			|do-not-delete2|
 		And the administrator has browsed to the users page
 		When the administrator deletes these groups using the webUI:
-		|groupname|
-		|0        |
-		|false    |
+			|groupname|
+			|0        |
+			|false    |
 		And the administrator reloads the users page
 		Then these groups should be listed on the webUI:
-		|groupname     |
-		|do-not-delete |
-		|do-not-delete2|
+			|groupname     |
+			|do-not-delete |
+			|do-not-delete2|
 		But these groups should not be listed on the webUI:
-		|groupname|
-		|0        |
-		|false    |
+			|groupname|
+			|0        |
+			|false    |
 		And these groups should exist:
-		|groupname     |
-		|do-not-delete |
-		|do-not-delete2|
+			|groupname     |
+			|do-not-delete |
+			|do-not-delete2|
 		But these groups should not exist:
-		|groupname|
-		|0        |
-		|false    |
+			|groupname|
+			|0        |
+			|false    |
 
 	@skipOnOcV10.0.3 @skipOnOcV10.0.4 @skipOnOcV10.0.5
 	Scenario: delete groups with special characters that appear in URLs
 		Given these groups have been created:
-		|groupname     |
-		|do-not-delete |
-		|a/slash       |
-		|per%cent      |
-		|hash#char     |
-		|q?mark        |
-		|do-not-delete2|
+			|groupname     |
+			|do-not-delete |
+			|a/slash       |
+			|per%cent      |
+			|hash#char     |
+			|q?mark        |
+			|do-not-delete2|
 		And the administrator has browsed to the users page
 		When the administrator deletes these groups using the webUI:
-		|groupname     |
-		|a/slash       |
-		|per%cent      |
-		|hash#char     |
-		|q?mark        |
+			|groupname     |
+			|a/slash       |
+			|per%cent      |
+			|hash#char     |
+			|q?mark        |
 		And the administrator reloads the users page
 		Then these groups should be listed on the webUI:
-		|groupname     |
-		|do-not-delete |
-		|do-not-delete2|
+			|groupname     |
+			|do-not-delete |
+			|do-not-delete2|
 		But these groups should not be listed on the webUI:
-		|groupname     |
-		|a/slash       |
-		|per%cent      |
-		|hash#char     |
-		|q?mark        |
+			|groupname     |
+			|a/slash       |
+			|per%cent      |
+			|hash#char     |
+			|q?mark        |
 		And these groups should exist:
-		|groupname     |
-		|do-not-delete |
-		|do-not-delete2|
+			|groupname     |
+			|do-not-delete |
+			|do-not-delete2|
 		But these groups should not exist:
-		|groupname     |
-		|a/slash       |
-		|per%cent      |
-		|hash#char     |
-		|q?mark        |
+			|groupname     |
+			|a/slash       |
+			|per%cent      |
+			|hash#char     |
+			|q?mark        |
 
 	Scenario: delete groups with problematic names
 		Given these groups have been created:
-		|groupname     |
-		|do-not-delete |
-		|grp1          |
-		|quotes'       |
-		|quotes"       |
-		|do-not-delete2|
+			|groupname     |
+			|do-not-delete |
+			|grp1          |
+			|quotes'       |
+			|quotes"       |
+			|do-not-delete2|
 		And the administrator has browsed to the users page
 		When the administrator deletes these groups using the webUI:
-		|groupname|
-		|grp1     |
-		|quotes'  |
-		|quotes"  |
+			| groupname   |
+			| grp1        |
+			| quotes'     |
+			| quotes"     |
 		And the administrator reloads the users page
 		Then these groups should be listed on the webUI:
-		|groupname     |
-		|do-not-delete |
-		|do-not-delete2|
+			|groupname     |
+			|do-not-delete |
+			|do-not-delete2|
 		But these groups should not be listed on the webUI:
-		|groupname|
-		|grp1     |
-		|quotes'  |
-		|quotes"  |
+			| groupname   |
+			| grp1        |
+			| quotes'     |
+			| quotes"     |
 		And these groups should exist:
-		|groupname     |
-		|do-not-delete |
-		|do-not-delete2|
+			|groupname     |
+			|do-not-delete |
+			|do-not-delete2|
 		But these groups should not exist:
-		|groupname|
-		|grp1     |
-		|quotes'  |
-		|quotes"  |
+			| groupname   |
+			| grp1        |
+			| quotes'     |
+			| quotes"     |


### PR DESCRIPTION
Backport UI test changes that have happened in the user_management app:

1. Delete user test from https://github.com/owncloud/user_management/pull/26
2. Replace throw exception with assert in acceptance tests from https://github.com/owncloud/user_management/pull/40
3. Format and code style that happened in the user_management app
4. Make delete user acceptance test text consistent with disable user
5. Fixup addUsers feature description

This gets the code back in-sync. So it will be easier in future to make the same changes to both user_management app and to core stable10.