### PR TITLE
[stable10] Cleanup the encryption keys after file deletion

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -415,7 +415,8 @@ class Trashbin {
 			}
 
 			if ($copyKeysResult === true) {
-				$sourceStorage->deleteAllFileKeys($filename);
+				$filePath = $rootView->getAbsolutePath('/files/' . $ownerPath);
+				$sourceStorage->deleteAllFileKeys($filePath);
 			}
 		}
 	}

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -35,6 +35,7 @@ use OC\Files\View;
 use OCA\Files_Sharing\AppInfo\Application;
 use OCA\Files_Trashbin\Expiration;
 use OCA\Files_Trashbin\Helper;
+use OCA\Files_Trashbin\Storage;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\Constants;
 use OCP\Files\File;
@@ -737,6 +738,20 @@ class TrashbinTest extends TestCase {
 
 		$this->assertEquals('/owncloud/index.php/apps/files/?view=trashbin&dir=/test.d1462861890/sub&scrollto=somefile.txt', $event->getArgument('resolvedWebLink'));
 		$this->assertNull($event->getArgument('resolvedDavLink'));
+	}
+
+	public function testDeleteKeys() {
+		$sourceStorage = $this->getMockBuilder(Storage::class)
+			->setConstructorArgs([['mountPoint' => 'test', 'storage' => 'Encryption']])
+			->setMethods(['retainKeys', 'deleteAllFileKeys'])->getMock();
+
+		$sourceStorage->expects($this->once())
+			->method('retainKeys')
+			->willReturn(true);
+		$sourceStorage->expects($this->once())
+			->method('deleteAllFileKeys')
+			->with('//files/file1.txt');
+		$this->invokePrivate(Trashbin::class, 'retainVersions', ['file1.txt', 'test-trashbin-user1', 'file1.txt', 1529567106, $sourceStorage]);
 	}
 
 	/**


### PR DESCRIPTION
The encryption keys were not deleted even after
files were deleted from the file system. The
reason for this is because of the wrong path
shared. Instead of filename, the relative path
from the files should be shared.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
The encryption keys should be deleted or removed once the files are deleted from the trashbin.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The encryption keys should be deleted or removed once the files are deleted from the trashbin.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Created a user admin and login as admin user
- Now create a file a.txt and try to update it so that versions are also created.
- Before deletion of a.txt this is how the console output of tree command would look like
```
➜  owncloud3 git:(fix-encryptionkey-trashbin) ✗ tree data -I "thumbnails"
data
├── admin
│   ├── cache
│   ├── files
│   │   ├── a.txt
│   │   ├── foo
│   │   │   └── f.txt
│   │   └── welcome.txt
│   ├── files_encryption
│   │   └── keys
│   │       └── files
│   │           ├── a.txt
│   │           │   └── OC_DEFAULT_MODULE
│   │           │       ├── fileKey
│   │           │       └── master_fea6d2f9.shareKey
│   │           ├── foo
│   │           │   └── f.txt
│   │           │       └── OC_DEFAULT_MODULE
│   │           │           ├── fileKey
│   │           │           └── master_fea6d2f9.shareKey
│   │           └── welcome.txt
│   │               └── OC_DEFAULT_MODULE
│   │                   ├── fileKey
│   │                   └── master_fea6d2f9.shareKey
│   ├── files_versions
│   │   ├── a.txt.v1529496454
│   │   ├── a.txt.v1529496457
│   │   ├── a.txt.v1529496458
│   │   └── foo
│   │       ├── f.txt.v1529496435
│   │       ├── f.txt.v1529496438
│   │       └── f.txt.v1529496439
│   └── files_zsync
├── avatars
│   ├── 21
│   │   └── 23
│   │       └── 2f297a57a5a743894a0e4a801fc3
│   └── 24
│       └── c9
│           └── e15e52afc47c225b757e7bee1f9d
├── files_encryption
│   └── OC_DEFAULT_MODULE
│       ├── master_fea6d2f9.privateKey
│       ├── master_fea6d2f9.publicKey
│       ├── pubShare_fea6d2f9.privateKey
│       └── pubShare_fea6d2f9.publicKey
├── index.html
├── owncloud.db
└── owncloud.log

26 directories, 22 files
➜  owncloud3 git:(fix-encryptionkey-trashbin) ✗
```
- Now delete a.txt so that file moves to trashbin and after this operation the tree command would show us:
```
➜  owncloud3 git:(fix-encryptionkey-trashbin) ✗ tree data -I "thumbnails"
data
├── admin
│   ├── cache
│   ├── files
│   │   ├── foo
│   │   │   └── f.txt
│   │   └── welcome.txt
│   ├── files_encryption
│   │   └── keys
│   │       ├── files
│   │       │   ├── foo
│   │       │   │   └── f.txt
│   │       │   │       └── OC_DEFAULT_MODULE
│   │       │   │           ├── fileKey
│   │       │   │           └── master_fea6d2f9.shareKey
│   │       │   └── welcome.txt
│   │       │       └── OC_DEFAULT_MODULE
│   │       │           ├── fileKey
│   │       │           └── master_fea6d2f9.shareKey
│   │       └── files_trashbin
│   │           └── files
│   │               └── a.txt.d1529496497
│   │                   └── OC_DEFAULT_MODULE
│   │                       ├── fileKey
│   │                       └── master_fea6d2f9.shareKey
│   ├── files_trashbin
│   │   ├── files
│   │   │   └── a.txt.d1529496497
│   │   ├── keys
│   │   └── versions
│   │       ├── a.txt.v1529496454.d1529496497
│   │       ├── a.txt.v1529496457.d1529496497
│   │       └── a.txt.v1529496458.d1529496497
│   ├── files_versions
│   │   └── foo
│   │       ├── f.txt.v1529496435
│   │       ├── f.txt.v1529496438
│   │       └── f.txt.v1529496439
│   └── files_zsync
├── avatars
│   ├── 21
│   │   └── 23
│   │       └── 2f297a57a5a743894a0e4a801fc3
│   └── 24
│       └── c9
│           └── e15e52afc47c225b757e7bee1f9d
├── files_encryption
│   └── OC_DEFAULT_MODULE
│       ├── master_fea6d2f9.privateKey
│       ├── master_fea6d2f9.publicKey
│       ├── pubShare_fea6d2f9.privateKey
│       └── pubShare_fea6d2f9.publicKey
├── index.html
├── owncloud.db
└── owncloud.log

32 directories, 22 files
➜  owncloud3 git:(fix-encryptionkey-trashbin) ✗
```
- Now delete the file a.txt from the trashbin. And after this operation the kesy should be deleted. Below is the output which justifies the same:
```
➜  owncloud3 git:(fix-encryptionkey-trashbin) ✗ tree data -I "thumbnails"
data
├── admin
│   ├── cache
│   ├── files
│   │   ├── foo
│   │   │   └── f.txt
│   │   └── welcome.txt
│   ├── files_encryption
│   │   └── keys
│   │       └── files
│   │           ├── foo
│   │           │   └── f.txt
│   │           │       └── OC_DEFAULT_MODULE
│   │           │           ├── fileKey
│   │           │           └── master_fea6d2f9.shareKey
│   │           └── welcome.txt
│   │               └── OC_DEFAULT_MODULE
│   │                   ├── fileKey
│   │                   └── master_fea6d2f9.shareKey
│   ├── files_trashbin
│   │   └── files
│   ├── files_versions
│   │   └── foo
│   │       ├── f.txt.v1529496435
│   │       ├── f.txt.v1529496438
│   │       └── f.txt.v1529496439
│   └── files_zsync
├── avatars
│   ├── 21
│   │   └── 23
│   │       └── 2f297a57a5a743894a0e4a801fc3
│   └── 24
│       └── c9
│           └── e15e52afc47c225b757e7bee1f9d
├── files_encryption
│   └── OC_DEFAULT_MODULE
│       ├── master_fea6d2f9.privateKey
│       ├── master_fea6d2f9.publicKey
│       ├── pubShare_fea6d2f9.privateKey
│       └── pubShare_fea6d2f9.publicKey
├── index.html
├── owncloud.db
└── owncloud.log

26 directories, 16 files
➜  owncloud3 git:(fix-encryptionkey-trashbin) ✗ 
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

