### PR TITLE
[stable10] return all failed recipients in sendLinkShareMailFromBody

### DIFF
--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -253,8 +253,28 @@ class MailNotifications {
 
 			return $this->mailer->send($message);
 		} catch (\Exception $e) {
-			$this->logger->error("Can't send mail with public link to $recipient: ".$e->getMessage(), ['app' => 'sharing']);
-			return [$recipient];
+			$allRecipientsArr = [];
+			if ($recipient !== null && $recipient !== '') {
+				$allRecipientsArr = \explode(',', $recipient);
+			}
+			if (isset($options['cc']) && $options['cc'] !== '') {
+				$allRecipientsArr = \array_merge(
+					$allRecipientsArr,
+					\explode(',', $options['cc'])
+				);
+			}
+			if (isset($options['bcc']) && $options['bcc'] !== '') {
+				$allRecipientsArr = \array_merge(
+					$allRecipientsArr,
+					\explode(',', $options['bcc'])
+				);
+			}
+			$allRecipients = \implode(',', $allRecipientsArr);
+			$this->logger->error(
+				"Can't send mail with public link to $allRecipients: ".$e->getMessage(),
+				['app' => 'sharing']
+			);
+			return [$allRecipients];
 		}
 	}
 

--- a/tests/lib/Share/MailNotificationsTest.php
+++ b/tests/lib/Share/MailNotificationsTest.php
@@ -350,7 +350,7 @@ class MailNotificationsTest extends TestCase {
 	 * @param string $bcc
 	 * @param string $expectedRecipientErrorList
 	 */
-	public function testSendLinkShareMailException($to, $cc, $bcc, string $expectedRecipientErrorList) {
+	public function testSendLinkShareMailException($to, $cc, $bcc, $expectedRecipientErrorList) {
 		$this->setupMailerMock('TestUser shared »MyFile« with you', [$to]);
 
 		$mailNotifications = new MailNotifications(

--- a/tests/lib/Share/MailNotificationsTest.php
+++ b/tests/lib/Share/MailNotificationsTest.php
@@ -331,8 +331,27 @@ class MailNotificationsTest extends TestCase {
 		$this->assertSame([], $mailNotifications->sendLinkShareMail($to, 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600));
 	}
 
-	public function testSendLinkShareMailException() {
-		$this->setupMailerMock('TestUser shared »MyFile« with you', ['lukas@owncloud.com']);
+	public function dataSendLinkShareMailException() {
+		return [
+			['lukas@owncloud.com', '', '', 'lukas@owncloud.com'],
+			['you@owncloud.com', 'cc1@example.com,cc2@example.com', '', 'you@owncloud.com,cc1@example.com,cc2@example.com'],
+			['you@owncloud.com', '', 'phil@example.com,jim@example.com.np', 'you@owncloud.com,phil@example.com,jim@example.com.np'],
+			['you@owncloud.com', 'cc1@example.com,cc2@example.com', 'phil@example.com,jim@example.com.np', 'you@owncloud.com,cc1@example.com,cc2@example.com,phil@example.com,jim@example.com.np'],
+			['', 'cc1@example.com,cc2@example.com', '', 'cc1@example.com,cc2@example.com'],
+			['', '', 'phil@example.com,jim@example.com.np', 'phil@example.com,jim@example.com.np'],
+			['', 'cc1@example.com,cc2@example.com', 'phil@example.com,jim@example.com.np', 'cc1@example.com,cc2@example.com,phil@example.com,jim@example.com.np'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataSendLinkShareMailException
+	 * @param string $to
+	 * @param string $cc
+	 * @param string $bcc
+	 * @param string $expectedRecipientErrorList
+	 */
+	public function testSendLinkShareMailException($to, $cc, $bcc, string $expectedRecipientErrorList) {
+		$this->setupMailerMock('TestUser shared »MyFile« with you', [$to]);
 
 		$mailNotifications = new MailNotifications(
 			$this->user,
@@ -344,7 +363,20 @@ class MailNotificationsTest extends TestCase {
 			$this->eventDispatcher
 		);
 
-		$this->assertSame(['lukas@owncloud.com'], $mailNotifications->sendLinkShareMail('lukas@owncloud.com', 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600));
+		$options = [];
+
+		if ($cc !== '') {
+			$options['cc'] = $cc;
+		}
+
+		if ($bcc !== '') {
+			$options['bcc'] = $bcc;
+		}
+
+		$this->assertSame(
+			[$expectedRecipientErrorList],
+			$mailNotifications->sendLinkShareMail($to, 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600, null, $options)
+		);
 	}
 
 	public function testSendInternalShareMail() {


### PR DESCRIPTION
Backport #31847 