### PR TITLE
Revert "Add exclude_groups_from_sharing to capabilities"

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -65,19 +65,6 @@ class Capabilities implements ICapability {
 	}
 
 	/**
-	 * Returns whether the currently logged in user is an administrator
-	 *
-	 * @return bool true if the user is an admin
-	 */
-	private function isAdmin() {
-		$user = $this->userSession->getUser();
-		if ($user !== null) {
-			return $this->groupManager->isAdmin($user->getUID());
-		}
-		return false;
-	}
-
-	/**
 	 * Return this classes capabilities
 	 *
 	 * @return array
@@ -137,14 +124,6 @@ class Capabilities implements ICapability {
 				$res['can_share'] = false;
 			} else {
 				$res['can_share'] = true;
-			}
-
-			if ($this->isAdmin()) {
-				$res['exclude_groups_from_sharing'] = $this->config->getAppValue('core', 'shareapi_exclude_groups', 'yes') === 'yes';
-
-				if ($res['exclude_groups_from_sharing']) {
-					$res['groups_excluded_from_sharing'] = \json_decode($this->config->getAppValue('core', 'shareapi_exclude_groups_list', '[]'), true);
-				}
 			}
 
 			$user_enumeration = [];

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -378,24 +378,6 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertTrue($result['share_with_membership_groups_only']);
 	}
 
-	public function testNoExcludeGroupsFromSharingWhenNotAdmin() {
-		$map = [
-			['core', 'shareapi_enabled', 'yes', 'yes'],
-			['core', 'shareapi_exclude_groups', 'yes', 'no'],
-		];
-		$result = $this->getResults($map);
-		$this->assertArrayNotHasKey('exclude_groups_from_sharing', $result);
-	}
-
-	public function testExcludeGroupsFromSharingWhenNotAdmin() {
-		$map = [
-			['core', 'shareapi_enabled', 'yes', 'yes'],
-			['core', 'shareapi_exclude_groups', 'yes', 'yes'],
-		];
-		$result = $this->getResults($map);
-		$this->assertArrayNotHasKey('exclude_groups_from_sharing', $result);
-	}
-
 	public function testNoUserEnumeration() {
 		$map = [
 			['core', 'shareapi_enabled', 'yes', 'yes'],

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -46,7 +46,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                 | 1                 |
 			| files_sharing | group_sharing                         | 1                 |
 			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing           | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled            | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
 			| files         | bigfilechunking                       | 1                 |
@@ -71,7 +70,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                 | 1                 |
 			| files_sharing | group_sharing                         | 1                 |
 			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing           | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled            | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
 			| files         | bigfilechunking                       | 1                 |
@@ -112,7 +110,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                 | 1                 |
 			| files_sharing | group_sharing                         | 1                 |
 			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing           | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled            | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
 			| files         | bigfilechunking                       | 1                 |
@@ -137,7 +134,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                 | 1                 |
 			| files_sharing | group_sharing                         | 1                 |
 			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing           | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled            | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
 			| files         | bigfilechunking                       | 1                 |
@@ -162,7 +158,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                 | 1                 |
 			| files_sharing | group_sharing                         | 1                 |
 			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing           | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled            | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
 			| files         | bigfilechunking                       | 1                 |
@@ -187,7 +182,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                 | EMPTY             |
 			| files_sharing | group_sharing                         | 1                 |
 			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing           | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled            | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
 			| files         | bigfilechunking                       | 1                 |
@@ -215,7 +209,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                          | 1                 |
 			| files_sharing | group_sharing                                  | 1                 |
 			| files_sharing | share_with_group_members_only                  | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing                    | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled                     | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
 			| files         | bigfilechunking                                | 1                 |
@@ -243,7 +236,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                          | 1                 |
 			| files_sharing | group_sharing                                  | 1                 |
 			| files_sharing | share_with_group_members_only                  | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing                    | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled                     | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
 			| files         | bigfilechunking                                | 1                 |
@@ -271,7 +263,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                          | 1                 |
 			| files_sharing | group_sharing                                  | 1                 |
 			| files_sharing | share_with_group_members_only                  | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing                    | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled                     | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
 			| files         | bigfilechunking                                | 1                 |
@@ -296,7 +287,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                 | 1                 |
 			| files_sharing | group_sharing                         | 1                 |
 			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing           | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled            | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
 			| files         | bigfilechunking                       | 1                 |
@@ -321,7 +311,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                 | 1                 |
 			| files_sharing | group_sharing                         | 1                 |
 			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing           | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled            | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
 			| files         | bigfilechunking                       | 1                 |
@@ -347,7 +336,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                 | 1                 |
 			| files_sharing | group_sharing                         | 1                 |
 			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing           | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled            | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
 			| files         | bigfilechunking                       | 1                 |
@@ -375,7 +363,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                 | 1                 |
 			| files_sharing | group_sharing                         | 1                 |
 			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing           | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled            | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
 			| files         | bigfilechunking                       | 1                 |
@@ -400,7 +387,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                 | 1                 |
 			| files_sharing | group_sharing                         | EMPTY             |
 			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing           | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled            | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
 			| files         | bigfilechunking                       | 1                 |
@@ -425,7 +411,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                 | 1                 |
 			| files_sharing | group_sharing                         | 1                 |
 			| files_sharing | share_with_group_members_only         | 1                 |
-			| files_sharing | exclude_groups_from_sharing           | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled            | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only | EMPTY             |
 			| files         | bigfilechunking                       | 1                 |
@@ -450,7 +435,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming         | 1                 |
 			| files_sharing | group_sharing                 | 1                 |
 			| files_sharing | share_with_group_members_only | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing   | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled    | EMPTY             |
 			| files         | bigfilechunking               | 1                 |
 			| files         | undelete                      | 1                 |
@@ -474,7 +458,6 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                 | 1                 |
 			| files_sharing | group_sharing                         | 1                 |
 			| files_sharing | share_with_group_members_only         | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing           | EMPTY             |
 			| files_sharing | user_enumeration@@@enabled            | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only | 1                 |
 			| files         | bigfilechunking                       | 1                 |
@@ -503,17 +486,13 @@ Feature: capabilities
 			| files_sharing | federation@@@incoming                     | 1                 |
 			| files_sharing | group_sharing                             | 1                 |
 			| files_sharing | share_with_group_members_only             | EMPTY             |
-			| files_sharing | exclude_groups_from_sharing               | 1                 |
-			| files_sharing | groups_excluded_from_sharing@@@element[0] | grp1              |
-			| files_sharing | groups_excluded_from_sharing@@@element[1] | hash#group        |
-			| files_sharing | groups_excluded_from_sharing@@@element[2] | group-3           |
 			| files_sharing | user_enumeration@@@enabled                | 1                 |
 			| files_sharing | user_enumeration@@@group_members_only     | EMPTY             |
 			| files         | bigfilechunking                           | 1                 |
 			| files         | undelete                                  | 1                 |
 			| files         | versioning                                | 1                 |
 
-	Scenario: When in a group that is excluded from sharing, can_share is off and "exclude groups from sharing" details are not reported
+	Scenario: When in a group that is excluded from sharing, can_share is off
 		Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
 		And user "user0" has been created
 		And group "grp1" has been created
@@ -544,14 +523,8 @@ Feature: capabilities
 			| files         | bigfilechunking                           | 1                 |
 			| files         | undelete                                  | 1                 |
 			| files         | versioning                                | 1                 |
-		And the capabilities should not contain
-			| capability    | path_to_element                           |
-			| files_sharing | exclude_groups_from_sharing               |
-			| files_sharing | groups_excluded_from_sharing@@@element[0] |
-			| files_sharing | groups_excluded_from_sharing@@@element[1] |
-			| files_sharing | groups_excluded_from_sharing@@@element[2] |
 
-	Scenario: When not in any group that is excluded from sharing, can_share is on and "exclude groups from sharing" details are not reported
+	Scenario: When not in any group that is excluded from sharing, can_share is on
 		Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
 		And user "user0" has been created
 		And group "grp1" has been created
@@ -582,50 +555,8 @@ Feature: capabilities
 			| files         | bigfilechunking                           | 1                 |
 			| files         | undelete                                  | 1                 |
 			| files         | versioning                                | 1                 |
-		And the capabilities should not contain
-			| capability    | path_to_element                           |
-			| files_sharing | exclude_groups_from_sharing               |
-			| files_sharing | groups_excluded_from_sharing@@@element[0] |
-			| files_sharing | groups_excluded_from_sharing@@@element[1] |
-			| files_sharing | groups_excluded_from_sharing@@@element[2] |
 
-	Scenario: When not in any group at all, can_share is on and "exclude groups from sharing" details are not reported
-		Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-		And group "grp1" has been created
-		And group "hash#group" has been created
-		And group "group-3" has been created
-		And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
-		And user "user0" has been created
-		And as user "user0"
-		When the user retrieves the capabilities using the API
-		Then the capabilities should contain
-			| capability    | path_to_element                           | value             |
-			| core          | pollinterval                              | 60                |
-			| core          | webdav-root                               | remote.php/webdav |
-			| files_sharing | api_enabled                               | 1                 |
-			| files_sharing | can_share                                 | 1                 |
-			| files_sharing | public@@@enabled                          | 1                 |
-			| files_sharing | public@@@upload                           | 1                 |
-			| files_sharing | public@@@send_mail                        | EMPTY             |
-			| files_sharing | public@@@social_share                     | 1                 |
-			| files_sharing | resharing                                 | 1                 |
-			| files_sharing | federation@@@outgoing                     | 1                 |
-			| files_sharing | federation@@@incoming                     | 1                 |
-			| files_sharing | group_sharing          			        | 1                 |
-			| files_sharing | share_with_group_members_only             | EMPTY             |
-			| files_sharing | user_enumeration@@@enabled                | 1                 |
-			| files_sharing | user_enumeration@@@group_members_only     | EMPTY             |
-			| files         | bigfilechunking                           | 1                 |
-			| files         | undelete                                  | 1                 |
-			| files         | versioning                                | 1                 |
-		And the capabilities should not contain
-			| capability    | path_to_element                           |
-			| files_sharing | exclude_groups_from_sharing               |
-			| files_sharing | groups_excluded_from_sharing@@@element[0] |
-			| files_sharing | groups_excluded_from_sharing@@@element[1] |
-			| files_sharing | groups_excluded_from_sharing@@@element[2] |
-
-	Scenario: When in a group that is excluded from sharing and in another group, can_share is off and "exclude groups from sharing" details are not reported
+	Scenario: When in a group that is excluded from sharing and in another group, can_share is off
 		Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
 		And user "user0" has been created
 		And group "grp1" has been created
@@ -657,9 +588,3 @@ Feature: capabilities
 			| files         | bigfilechunking                           | 1                 |
 			| files         | undelete                                  | 1                 |
 			| files         | versioning                                | 1                 |
-		And the capabilities should not contain
-			| capability    | path_to_element                           |
-			| files_sharing | exclude_groups_from_sharing               |
-			| files_sharing | groups_excluded_from_sharing@@@element[0] |
-			| files_sharing | groups_excluded_from_sharing@@@element[1] |
-			| files_sharing | groups_excluded_from_sharing@@@element[2] |


### PR DESCRIPTION
Reverts owncloud/core#31580 that was merged by mistake due to me being too eager to merge and not paying enough attention