### PR TITLE
Revert "Revert "Remove old unused private utility method isSharingDisabledForUser""

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -22,8 +22,6 @@ namespace OCA\Files_Sharing;
 
 use OCP\Capabilities\ICapability;
 use OCP\IConfig;
-use OCP\IGroupManager;
-use OCP\IUserSession;
 use OCP\Util\UserSearch;
 
 /**
@@ -42,26 +40,14 @@ class Capabilities implements ICapability {
 	private $userSearch;
 
 	/**
-	 * @var IUserSession
-	 */
-	private $userSession;
-
-	/**
-	 * @var IGroupManager
-	 */
-	private $groupManager;
-
-	/**
 	 * Capabilities constructor.
 	 *
 	 * @param IConfig $config
 	 * @param UserSearch $userSearch
 	 */
-	public function __construct(IConfig $config, UserSearch $userSearch, IUserSession $userSession, IGroupManager $groupManager) {
+	public function __construct(IConfig $config, UserSearch $userSearch) {
 		$this->config = $config;
 		$this->userSearch = $userSearch;
-		$this->userSession = $userSession;
-		$this->groupManager = $groupManager;
 	}
 
 	/**
@@ -120,7 +106,7 @@ class Capabilities implements ICapability {
 			$res['share_with_group_members_only'] = $this->config->getAppValue('core', 'shareapi_only_share_with_group_members', 'yes') === 'yes';
 			$res['share_with_membership_groups_only'] = $this->config->getAppValue('core', 'shareapi_only_share_with_membership_groups', 'yes') === 'yes';
 
-			if (\OC_Util::isSharingDisabledForUser($this->config, $this->groupManager, $this->userSession->getUser())) {
+			if (\OCP\Util::isSharingDisabledForUser()) {
 				$res['can_share'] = false;
 			} else {
 				$res['can_share'] = true;

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -36,26 +36,12 @@ class CapabilitiesTest extends \Test\TestCase {
 	 */
 	protected $userSearch;
 
-	/** @var \OCP\IUserSession|\PHPUnit_Framework_MockObject_MockObject */
-	protected $session;
-
-	/** @var \OCP\IGroupManager|\PHPUnit_Framework_MockObject_MockObject */
-	protected $groupManager;
-
 	/**
 	 *
 	 */
 	protected function setUp() {
 		parent::setUp();
 		$this->userSearch = $this->getMockBuilder(\OCP\Util\UserSearch::class)
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->session = $this->getMockBuilder(\OCP\IUserSession::class)
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->groupManager = $this->getMockBuilder(\OCP\IGroupManager::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -87,7 +73,7 @@ class CapabilitiesTest extends \Test\TestCase {
 	private function getResults(array $map) {
 		$stub = $this->getMockBuilder('\OCP\IConfig')->disableOriginalConstructor()->getMock();
 		$stub->method('getAppValue')->will($this->returnValueMap($map));
-		$cap = new Capabilities($stub, $this->userSearch, $this->session, $this->groupManager);
+		$cap = new Capabilities($stub, $this->userSearch);
 		$result = $this->getFilesSharingPart($cap->getCapabilities());
 		return $result;
 	}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1481,8 +1481,6 @@ class Manager implements IManager {
 	/**
 	 * Copied from \OC_Util::isSharingDisabledForUser
 	 *
-	 * TODO: Deprecate function from OC_Util
-	 *
 	 * @param string $userId
 	 * @return bool
 	 */

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -315,32 +315,6 @@ class OC_Util {
 	}
 
 	/**
-	 * check if sharing is disabled for the current user
-	 * @param IConfig $config
-	 * @param IGroupManager $groupManager
-	 * @param IUser|null $user
-	 * @return bool
-	 */
-	public static function isSharingDisabledForUser(IConfig $config, IGroupManager $groupManager, $user) {
-		if ($config->getAppValue('core', 'shareapi_exclude_groups', 'no') === 'yes') {
-			$groupsList = $config->getAppValue('core', 'shareapi_exclude_groups_list', '');
-			$excludedGroups = \json_decode($groupsList);
-			if ($excludedGroups === null) {
-				$excludedGroups = \explode(',', $groupsList);
-				$newValue = \json_encode($excludedGroups);
-				$config->setAppValue('core', 'shareapi_exclude_groups_list', $newValue);
-			}
-			$usersGroups = $groupManager->getUserGroupIds($user);
-			$matchingGroups = \array_intersect($usersGroups, $excludedGroups);
-			if (!empty($matchingGroups)) {
-				// If the user is a member of any of the excluded groups they cannot use sharing
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
 	 * check if share API enforces a default expire date
 	 *
 	 * @return boolean

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -248,53 +248,6 @@ class UtilTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataProviderForTestIsSharingDisabledForUser
-	 * @param array $groups existing groups
-	 * @param array $membership groups the user belong to
-	 * @param array $excludedGroups groups which should be excluded from sharing
-	 * @param bool $expected expected result
-	 */
-	public function testIsSharingDisabledForUser($groups, $membership, $excludedGroups, $expected) {
-		$config = $this->getMockBuilder('OCP\IConfig')->disableOriginalConstructor()->getMock();
-		$groupManager = $this->getMockBuilder('OCP\IGroupManager')->disableOriginalConstructor()->getMock();
-		$user = $this->getMockBuilder('OCP\IUser')->disableOriginalConstructor()->getMock();
-
-		$config
-				->expects($this->at(0))
-				->method('getAppValue')
-				->with('core', 'shareapi_exclude_groups', 'no')
-				->will($this->returnValue('yes'));
-		$config
-				->expects($this->at(1))
-				->method('getAppValue')
-				->with('core', 'shareapi_exclude_groups_list')
-				->will($this->returnValue(\json_encode($excludedGroups)));
-
-		$groupManager
-				->expects($this->at(0))
-				->method('getUserGroupIds')
-				->with($user)
-				->will($this->returnValue($membership));
-
-		$result = \OC_Util::isSharingDisabledForUser($config, $groupManager, $user);
-
-		$this->assertSame($expected, $result);
-	}
-
-	public function dataProviderForTestIsSharingDisabledForUser() {
-		return [
-			// existing groups, groups the user belong to, groups excluded from sharing, expected result
-			[['g1', 'g2', 'g3'], [], ['g1'], false],
-			[['g1', 'g2', 'g3'], [], [], false],
-			[['g1', 'g2', 'g3'], ['g2'], ['g1'], false],
-			[['g1', 'g2', 'g3'], ['g2'], [], false],
-			[['g1', 'g2', 'g3'], ['g1', 'g2'], ['g1'], true],
-			[['g1', 'g2', 'g3'], ['g1', 'g2'], ['g1', 'g2'], true],
-			[['g1', 'g2', 'g3'], ['g1', 'g2'], ['g1', 'g2', 'g3'], true],
-		];
-	}
-
-	/**
 	 * Test default apps
 	 *
 	 * @dataProvider defaultAppsProvider


### PR DESCRIPTION
Reverts the revert owncloud/core#31936

The clash observed on master was due to another PR https://github.com/owncloud/core/pull/31580 that was still using the IUserSession. The latter is reverted in https://github.com/owncloud/core/pull/31937

- [x] requires https://github.com/owncloud/core/pull/31937 to be merged first
- [x] and rebase this on top of new master