### PR TITLE
Remove string parameter type from testSendLinkShareMailException parameter

### DIFF
--- a/tests/lib/Share/MailNotificationsTest.php
+++ b/tests/lib/Share/MailNotificationsTest.php
@@ -357,7 +357,7 @@ class MailNotificationsTest extends TestCase {
 	 * @param string $bcc
 	 * @param string $expectedRecipientErrorList
 	 */
-	public function testSendLinkShareMailException($to, $cc, $bcc, string $expectedRecipientErrorList) {
+	public function testSendLinkShareMailException($to, $cc, $bcc, $expectedRecipientErrorList) {
 		$this->setupMailerMock('TestUser shared »MyFile« with you', [$to]);
 
 		$mailNotifications = new MailNotifications(


### PR DESCRIPTION
Forward port of 2nd commit of ``stable10`` PR #31935 
