### PR TITLE
API acceptance tests for slash in group name

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -26,11 +26,23 @@ So that I can more easily manage access to resources by groups rather than indiv
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
 			| 50%pass             | Percent sign (special escaping happens) |
 			| 50%25=0             | %25 literal looks like an escaped "%"   |
 			| 50%2Eagle           | %2E literal looks like an escaped "."   |
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
+
+	# A group name must not end in "/subadmins" because that would create ambiguity
+	# with the endpoint for getting the subadmins of a group
+	Scenario: admin tries to create a group with name ending in "/subadmins"
+		Given group "new-group" has been created
+		When the administrator tries to send a group creation request for group "priv/subadmins" using the API
+		Then the OCS status code should be "101"
+		And the HTTP status code should be "200"
+		And group "priv/subadmins" should not exist
 
 	Scenario: admin tries to create a group that already exists
 		Given group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -28,6 +28,9 @@ So that I can give a user access to the resources of the group
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
 			| 50%pass             | Percent sign (special escaping happens) |
 			| 50%25=0             | %25 literal looks like an escaped "%"   |
 			| 50%2Eagle           | %2E literal looks like an escaped "."   |

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -27,6 +27,9 @@ So that I can remove unnecessary groups
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
 			| 50%pass             | Percent sign (special escaping happens) |
 			| 50%25=0             | %25 literal looks like an escaped "%"   |
 			| 50%2Eagle           | %2E literal looks like an escaped "."   |

--- a/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
@@ -15,11 +15,15 @@ So that I can manage group membership
 		And group "Admin & Finance (NP)" has been created
 		And group "admin:Pokhara@Nepal" has been created
 		And group "नेपाली" has been created
+		And group "Mgmt/Sydney" has been created
+		And group "priv/subadmins/1" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "brand-new-user" has been added to group "0"
 		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
 		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
 		And user "brand-new-user" has been added to group "नेपाली"
+		And user "brand-new-user" has been added to group "Mgmt/Sydney"
+		And user "brand-new-user" has been added to group "priv/subadmins/1"
 		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user/groups"
 		Then the groups returned by the API should be
 			| new-group            |
@@ -27,6 +31,8 @@ So that I can manage group membership
 			| Admin & Finance (NP) |
 			| admin:Pokhara@Nepal  |
 			| नेपाली               |
+			| Mgmt/Sydney          |
+			| priv/subadmins/1     |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
 

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -30,6 +30,9 @@ So that I can manage user access to group resources
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
 			| 50%pass             | Percent sign (special escaping happens) |
 			| 50%25=0             | %25 literal looks like an escaped "%"   |
 			| 50%2Eagle           | %2E literal looks like an escaped "."   |

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -26,11 +26,23 @@ So that I can more easily manage access to resources by groups rather than indiv
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
 			| 50%pass             | Percent sign (special escaping happens) |
 			| 50%25=0             | %25 literal looks like an escaped "%"   |
 			| 50%2Eagle           | %2E literal looks like an escaped "."   |
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
+
+	# A group name must not end in "/subadmins" because that would create ambiguity
+	# with the endpoint for getting the subadmins of a group
+	Scenario: admin tries to create a group with name ending in "/subadmins"
+		Given group "new-group" has been created
+		When the administrator tries to send a group creation request for group "priv/subadmins" using the API
+		Then the OCS status code should be "400"
+		And the HTTP status code should be "400"
+		And group "priv/subadmins" should not exist
 
 	Scenario: admin tries to create a group that already exists
 		Given group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -28,6 +28,9 @@ So that I can give a user access to the resources of the group
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
 			| 50%pass             | Percent sign (special escaping happens) |
 			| 50%25=0             | %25 literal looks like an escaped "%"   |
 			| 50%2Eagle           | %2E literal looks like an escaped "."   |

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -27,6 +27,9 @@ So that I can remove unnecessary groups
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
 			| 50%pass             | Percent sign (special escaping happens) |
 			| 50%25=0             | %25 literal looks like an escaped "%"   |
 			| 50%2Eagle           | %2E literal looks like an escaped "."   |

--- a/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
@@ -15,11 +15,15 @@ So that I can manage group membership
 		And group "Admin & Finance (NP)" has been created
 		And group "admin:Pokhara@Nepal" has been created
 		And group "नेपाली" has been created
+		And group "Mgmt/Sydney" has been created
+		And group "priv/subadmins/1" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "brand-new-user" has been added to group "0"
 		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
 		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
 		And user "brand-new-user" has been added to group "नेपाली"
+		And user "brand-new-user" has been added to group "Mgmt/Sydney"
+		And user "brand-new-user" has been added to group "priv/subadmins/1"
 		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user/groups"
 		Then the groups returned by the API should be
 			| new-group            |
@@ -27,6 +31,8 @@ So that I can manage group membership
 			| Admin & Finance (NP) |
 			| admin:Pokhara@Nepal  |
 			| नेपाली               |
+			| Mgmt/Sydney          |
+			| priv/subadmins/1     |
 		And the OCS status code should be "200"
 		And the HTTP status code should be "200"
 

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -30,6 +30,9 @@ So that I can manage user access to group resources
 			| maint+eng           | Plus sign                               |
 			| $x<=>[y*z^2]!       | Maths symbols                           |
 			| Mgmt\Middle         | Backslash                               |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
 			| 50%pass             | Percent sign (special escaping happens) |
 			| 50%25=0             | %25 literal looks like an escaped "%"   |
 			| 50%2Eagle           | %2E literal looks like an escaped "."   |

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -934,6 +934,18 @@ trait Provisioning {
 	}
 
 	/**
+	 * @When /^the administrator tries to send a group creation request for group "([^"]*)" using the API$/
+	 *
+	 * @param string $group
+	 *
+	 * @return void
+	 */
+	public function adminTriesToSendGroupCreationRequestUsingTheAPI($group) {
+		$this->adminSendsGroupCreationRequestUsingTheAPI($group);
+		$this->rememberThatGroupIsNotExpectedToExist($group);
+	}
+
+	/**
 	 * creates a single group
 	 *
 	 * @param string $group


### PR DESCRIPTION
Run this set of new/changed tests from PR #31463 without any actual back-end code changes. 
Lets see if any of these group-names-containing-slash are working now, after other recent changes in ``master``