### PR TITLE
Trigger mountConfigLoaded event properly, and initialize events after

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -788,7 +788,6 @@ MountConfigListView.prototype = _.extend({
 	 */
 	_executeCallbackWhenFinished: function(deferreds, callback) {
 		var self = this;
-		var pendingDeferreds = [];
 
 		$.when.apply($, deferreds).always(function() {
 			var pendingDeferreds = [];
@@ -980,7 +979,7 @@ MountConfigListView.prototype = _.extend({
 
 		if (this._isPersonal) {
 			// load userglobal storages
-			var personalRequest = $.ajax({
+			var fixedStoragesRequest = $.ajax({
 				type: 'GET',
 				url: OC.generateUrl('apps/files_external/userglobalstorages'),
 				data: {'testOnly' : true},
@@ -1020,12 +1019,12 @@ MountConfigListView.prototype = _.extend({
 					onCompletion.resolve();
 				}
 			});
-			ajaxRequests.push(personalRequest);
+			ajaxRequests.push(fixedStoragesRequest);
 		}
 
 		var url = this._storageConfigClass.prototype._url;
 
-		var globalRequest = $.ajax({
+		var changeableStoragesRequest = $.ajax({
 			type: 'GET',
 			url: OC.generateUrl(url),
 			contentType: 'application/json',
@@ -1041,7 +1040,7 @@ MountConfigListView.prototype = _.extend({
 				onCompletion.resolve();
 			}
 		});
-		ajaxRequests.push(globalRequest);
+		ajaxRequests.push(changeableStoragesRequest);
 
 		this._executeCallbackWhenFinished(ajaxRequests, function() {
 			$('#body-settings').trigger('mountConfigLoaded');

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -50,7 +50,7 @@ describe('OCA.External.Settings tests', function() {
 			'</tr>' +
 			'</tbody>' +
 			'</table>'
-		);
+		).append('<div id="body-settings"></div>');
 		// these are usually appended into the data attribute
 		// within the DOM by the server template
 		$('#externalStorage .selectBackend:first').data('configurations', {
@@ -423,23 +423,17 @@ describe('OCA.External.Settings tests', function() {
 	describe('mountConfigLoaded event is triggered', function() {
 		var view;
 		var $bodySettings;
-		var fakeServer;
 
 		beforeEach(function() {
-			// add the body-settings for the mountConfigLoaded event
-			$('#testArea').append('<div id="body-settings"></div>');
-
 			var $el = $('#externalStorage');
 			view = new OCA.External.Settings.MountConfigListView($el, {encryptionEnabled: false});
 			$bodySettings = $('#body-settings');
-			fakeServer = sinon.fakeServer.create();
 		});
 
 		afterEach(function() {
 			view = null;
 			$bodySettings.off('mountConfigLoaded');
 			$bodySettings.remove();
-			fakeServer.restore();
 		});
 
 		it('only for not personal mounts', function() {

--- a/apps/files_external/tests/js/settingsSpec.js
+++ b/apps/files_external/tests/js/settingsSpec.js
@@ -152,6 +152,7 @@ describe('OCA.External.Settings tests', function() {
 		beforeEach(function() {
 			var $el = $('#externalStorage');
 			view = new OCA.External.Settings.MountConfigListView($el, {encryptionEnabled: false});
+			view._initEvents();
 		});
 		afterEach(function() {
 			view = null;
@@ -417,5 +418,150 @@ describe('OCA.External.Settings tests', function() {
 	});
 	describe('allow user mounts section', function() {
 		// TODO: test allowUserMounting section
+	});
+
+	describe('mountConfigLoaded event is triggered', function() {
+		var view;
+		var $bodySettings;
+		var fakeServer;
+
+		beforeEach(function() {
+			// add the body-settings for the mountConfigLoaded event
+			$('#testArea').append('<div id="body-settings"></div>');
+
+			var $el = $('#externalStorage');
+			view = new OCA.External.Settings.MountConfigListView($el, {encryptionEnabled: false});
+			$bodySettings = $('#body-settings');
+			fakeServer = sinon.fakeServer.create();
+		});
+
+		afterEach(function() {
+			view = null;
+			$bodySettings.off('mountConfigLoaded');
+			$bodySettings.remove();
+			fakeServer.restore();
+		});
+
+		it('only for not personal mounts', function() {
+			view._isPersonal = false;
+			var callbackStub = sinon.stub();
+
+			view.loadStorages();
+
+			expect(fakeServer.requests.length).toEqual(1);
+			var request = fakeServer.requests[0];
+
+			$bodySettings.on('mountConfigLoaded', callbackStub);
+
+			expect(callbackStub.called).toEqual(false);
+			request.respond(200, {'Content-Type': 'application/json'}, JSON.stringify({}));
+
+			expect(callbackStub.called).toEqual(true);
+		});
+
+		it('only for not personal mounts including failure', function() {
+			view._isPersonal = false;
+			var callbackStub = sinon.stub();
+
+			view.loadStorages();
+
+			expect(fakeServer.requests.length).toEqual(1);
+			var request = fakeServer.requests[0];
+
+			$bodySettings.on('mountConfigLoaded', callbackStub);
+
+			expect(callbackStub.called).toEqual(false);
+			request.respond(403, {'Content-Type': 'application/json'}, JSON.stringify({}));
+
+			expect(callbackStub.called).toEqual(true);
+		});
+
+		it('all kind of mounts included', function() {
+			view._isPersonal = true;
+			var callbackStub = sinon.stub();
+
+			view.loadStorages();
+
+			expect(fakeServer.requests.length).toEqual(2);
+			var request1 = fakeServer.requests[0];
+			var request2 = fakeServer.requests[1];
+
+			$bodySettings.on('mountConfigLoaded', callbackStub);
+
+			expect(callbackStub.called).toEqual(false);
+			request1.respond(200, {'Content-Type': 'application/json'}, JSON.stringify({}));
+
+			// mountConfigLoaded event shouldn't have been triggered yet
+			expect(callbackStub.called).toEqual(false);
+			request2.respond(200, {'Content-Type': 'application/json'}, JSON.stringify({}));
+
+			expect(callbackStub.called).toEqual(true);
+		});
+
+		it('all kind of mounts included, but non-userglobal failed', function() {
+			view._isPersonal = true;
+			var callbackStub = sinon.stub();
+
+			view.loadStorages();
+
+			expect(fakeServer.requests.length).toEqual(2);
+			var request1 = fakeServer.requests[0];
+			var request2 = fakeServer.requests[1];
+
+			$bodySettings.on('mountConfigLoaded', callbackStub);
+
+			expect(callbackStub.called).toEqual(false);
+			request1.respond(200, {'Content-Type': 'application/json'}, JSON.stringify({}));
+
+			// mountConfigLoaded event shouldn't have been triggered yet
+			expect(callbackStub.called).toEqual(false);
+			request2.respond(403, {'Content-Type': 'application/json'}, JSON.stringify({}));
+
+			expect(callbackStub.called).toEqual(true);
+		});
+
+		it('all kind of mounts included, but userglobal failed', function() {
+			view._isPersonal = true;
+			var callbackStub = sinon.stub();
+
+			view.loadStorages();
+
+			expect(fakeServer.requests.length).toEqual(2);
+			var request1 = fakeServer.requests[0];
+			var request2 = fakeServer.requests[1];
+
+			$bodySettings.on('mountConfigLoaded', callbackStub);
+
+			expect(callbackStub.called).toEqual(false);
+			request1.respond(403, {'Content-Type': 'application/json'}, JSON.stringify({}));
+
+			// mountConfigLoaded event shouldn't have been triggered yet
+			expect(callbackStub.called).toEqual(false);
+			request2.respond(200, {'Content-Type': 'application/json'}, JSON.stringify({}));
+
+			expect(callbackStub.called).toEqual(true);
+		});
+
+		it('all kind of mounts included, but all failing', function() {
+			view._isPersonal = true;
+			var callbackStub = sinon.stub();
+
+			view.loadStorages();
+
+			expect(fakeServer.requests.length).toEqual(2);
+			var request1 = fakeServer.requests[0];
+			var request2 = fakeServer.requests[1];
+
+			$bodySettings.on('mountConfigLoaded', callbackStub);
+
+			expect(callbackStub.called).toEqual(false);
+			request1.respond(403, {'Content-Type': 'application/json'}, JSON.stringify({}));
+
+			// mountConfigLoaded event shouldn't have been triggered yet
+			expect(callbackStub.called).toEqual(false);
+			request2.respond(403, {'Content-Type': 'application/json'}, JSON.stringify({}));
+
+			expect(callbackStub.called).toEqual(true);
+		});
 	});
 });


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
Trigger the mountConfigLoaded event only once in the personal page, and initialize the mountConfig events after the storage information is loaded in the page.

## Related Issue
https://github.com/owncloud/core/issues/31814


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
