### PR TITLE
Log debug message for InsufficientStorage exception

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
@@ -50,6 +50,8 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 		// not available
 		'Sabre\DAV\Exception\StorageNotAvailableException' => true,
 		'OCP\Files\StorageNotAvailableException' => true,
+		//If the exception is InsufficientStorage, then log a debug message
+		'Sabre\DAV\Exception\InsufficientStorage' => true
 	];
 
 	/** @var string */

--- a/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
@@ -29,6 +29,7 @@ use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin as PluginToTest;
 use OCP\Files\ExcludeForbiddenException;
 use OCP\Files\FileContentNotAllowedException;
 use PHPUnit_Framework_MockObject_MockObject;
+use Sabre\DAV\Exception\InsufficientStorage;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Server;
 use Test\TestCase;
@@ -85,6 +86,7 @@ class ExceptionLoggerPluginTest extends TestCase {
 			[0, 'HTTP\/1.1 404 Not Found', new NotFound()],
 			[4, 'HTTP\/1.1 400 This path leads to nowhere', new InvalidPath('This path leads to nowhere')],
 			[0, '', new FileContentNotAllowedException("Testing", 0, new FileContentNotAllowedException("pervious exception", 0))],
+			[0, "HTTP\/1.1 507 Testing", new InsufficientStorage("Testing", 0, null)]
 		];
 	}
 }


### PR DESCRIPTION
Catch the insufficient storage exception and log as
debug message instead of throwing the trace.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->

## Description
<!--- Describe your changes in detail -->
Catch InsufficientStorage exception and log it as debug message.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/31284

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Catch InsufficientStorage exception and log it as debug message.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Inorder to test this tried to comment out the lines https://github.com/owncloud/core/blob/master/apps/files/js/file-upload.js#L1026-L1033
and then reloaded the web page.
- Upload a file and found this message in the log file: ```{"reqId":"Yi4GPI1j7rbrrO76v0LX","level":0,"time":"2018-07-03T08:03:32+00:00","remoteAddr":"127.0.0.1","user":"user1","app":"no app in context","method":"PUT","url":"\/testing3\/remote.php\/dav\/files\/user1\/a.txt","message":"Can not create file a.txt due to insufficient storage"}```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

