### PR TITLE
Disable jQuery's globalEval function

### DIFF
--- a/core/js/jquery-migration-helper.js
+++ b/core/js/jquery-migration-helper.js
@@ -1,0 +1,16 @@
+/**
+ * This file is tasked with making the migration from jQuery 2.1.4 to 3.x as 
+ * painless as is possible.
+ */
+
+/** 
+ * Disable the use of globalEval in jQuery 2.1.4.
+ * This is required for API compatibility, yet should not be available all the
+ * same.
+ *
+ * @see https://github.com/jquery/jquery/issues/2432 for further details.
+ */ 
+(function ($) {
+    $.fn.globalEval = function(){};
+})(jQuery);
+

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -150,6 +150,7 @@ class OC_Template extends \OC\Template\Base {
 			OC_Util::addScript("l10n", null, true);
 			OC_Util::addScript("js", null, true);
 			OC_Util::addScript("oc-dialogs", null, true);
+			OC_Util::addScript("jquery-migration-helper.js", null, true);
 			OC_Util::addScript("jquery.ocdialog", null, true);
 			OC_Util::addStyle("jquery.ocdialog");
 			OC_Util::addScript('files/fileinfo');


### PR DESCRIPTION
## Description

Begin migrating from 2.1.4 to the 3.x series.

## Related Issue

https://github.com/owncloud/enterprise/issues/2701

## Motivation and Context

This is intended to start the migration from jQuery 2.1.4 to the 3.x branch. There's a promise to maintain backward compatibility to the 1.x jQuery API, so this method needs to be retained, yet deprecated.

## How Has This Been Tested?

It hasn't been, yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
