### PR TITLE
notify on build failures when pushed/tagged on core

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -272,6 +272,15 @@ pipeline:
       matrix:
         TEST_SUITE: phpunit
 
+  notify:
+    image: plugins/slack:1
+    pull: true
+    secrets: [ slack_webhook_public ]
+    channel: server
+    when:
+      status: [ failure, changed ]
+      event: [ push, tag ]
+
 services:
   mariadb:
     image: mariadb:10.2


### PR DESCRIPTION
## Description

Send slack notifications, when a push/tag to `master` branch leads to a build failure

## Motivation and Context
We want to know instantly when our master branch is in 🔴 

## How Has This Been Tested?
🤖 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] CI improvement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

