### PR TITLE
feature add exception to extraargs

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php
@@ -107,7 +107,6 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 				$level = \OCP\Util::DEBUG;
 			}
 		}
-
 		$message = $ex->getMessage();
 		if ($ex instanceof Exception) {
 			if (empty($message)) {
@@ -117,17 +116,13 @@ class ExceptionLoggerPlugin extends \Sabre\DAV\ServerPlugin {
 			$message = "HTTP/1.1 {$ex->getHTTPCode()} $message";
 		}
 
-		$user = \OC_User::getUser();
-
-		$exception = [
-			'Message' => $message,
-			'Exception' => $exceptionClass,
-			'Code' => $ex->getCode(),
-			'Trace' => $ex->getTraceAsString(),
-			'File' => $ex->getFile(),
-			'Line' => $ex->getLine(),
-			'User' => $user,
-		];
-		$this->logger->log($level, 'Exception: ' . \json_encode($exception), ['app' => $this->appName]);
+		$this->logger->logException(
+			$ex,
+			[
+				'app' 		=> $this->appName,
+				'message' 	=> 'Exception: '.$message,
+				'level' 	=> $level
+			]
+		);
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
@@ -77,16 +77,16 @@ class ExceptionLoggerPluginTest extends TestCase {
 			$this->assertNull($result);
 		} else {
 			$this->assertEquals($expectedLogLevel, $this->logger->level);
-			$this->assertStringStartsWith('Exception: {"Message":"' . $expectedMessage, $this->logger->message);
+			$this->assertStringStartsWith('Exception: ' . $expectedMessage, $this->logger->message);
 		}
 	}
 
 	public function providesExceptions() {
 		return [
-			[0, 'HTTP\/1.1 404 Not Found', new NotFound()],
-			[4, 'HTTP\/1.1 400 This path leads to nowhere', new InvalidPath('This path leads to nowhere')],
+			[0, 'HTTP/1.1 404 Not Found', new NotFound()],
+			[4, 'HTTP/1.1 400 This path leads to nowhere', new InvalidPath('This path leads to nowhere')],
 			[0, '', new FileContentNotAllowedException("Testing", 0, new FileContentNotAllowedException("pervious exception", 0))],
-			[0, "HTTP\/1.1 507 Testing", new InsufficientStorage("Testing", 0, null)]
+			[0, "HTTP/1.1 507 Testing", new InsufficientStorage("Testing", 0, null)]
 		];
 	}
 }

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -264,6 +264,12 @@ class Log implements ILogger {
 			unset($context['extraFields']);
 		}
 
+		$exception = null;
+		if (isset($context['exception'])) {
+			$exception = $context['exception'];
+			unset($context['exception']);
+		}
+
 		if (isset($context['app'])) {
 			$app = $context['app'];
 
@@ -351,6 +357,7 @@ class Log implements ILogger {
 			'formattedMessage' => $formattedMessage,
 			'context' => $context,
 			'extraFields' => $extraFields,
+			'exception' => $exception
 		];
 
 		// note: regardless of log level we let listeners receive messages
@@ -404,6 +411,7 @@ class Log implements ILogger {
 	 * @since 8.2.0
 	 */
 	public function logException($exception, array $context = []) {
+		$context['exception'] =  $exception;
 		$exception = [
 			'Exception' => \get_class($exception),
 			'Message' => $exception->getMessage(),

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -412,6 +412,11 @@ class Log implements ILogger {
 	 */
 	public function logException($exception, array $context = []) {
 		$context['exception'] =  $exception;
+		$level = Util::ERROR;
+		if (isset($context['level'])) {
+			$level = $context['level'];
+			unset($context['level']);
+		}
 		$exception = [
 			'Exception' => \get_class($exception),
 			'Message' => $exception->getMessage(),
@@ -426,6 +431,6 @@ class Log implements ILogger {
 		}
 		$msg = isset($context['message']) ? $context['message'] : 'Exception';
 		$msg .= ': ' . \json_encode($exception);
-		$this->error($msg, $context);
+		$this->log($level, $msg, $context);
 	}
 }

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -275,9 +275,26 @@ class LoggerTest extends TestCase {
 				'test' => 'replaced',
 			],
 			'extraFields' => ['extra' => 'one'],
+			'exception' => null
 		];
 
 		$this->assertEquals($expectedArgs, $beforeWriteEvent->getArguments(), 'before event arguments match');
 		$this->assertEquals($expectedArgs, $afterWriteEvent->getArguments(), 'after event arguments match');
+	}
+
+	public function testOriginalExceptionIsProvidedAsExtraField() {
+		$e = new \Exception('test');
+
+		$beforeWriteEvent = null;
+		$this->eventDispatcher->addListener(
+			'log.beforewrite',
+			function (GenericEvent $event) use (&$beforeWriteEvent) {
+				$beforeWriteEvent = $event;
+			}
+		);
+		$this->logger->logException($e);
+		$eventArguments = $beforeWriteEvent->getArguments();
+		$this->assertArrayHasKey('exception', $eventArguments, 'exception field is set');
+		$this->assertSame($e, $eventArguments['exception'], 'the original exception is passed');
 	}
 }


### PR DESCRIPTION
## Description
Forward port of #31623

## Related Issue
Forward port of #31623

## Motivation and Context
If just logging the message from ownCloud, we loose features of exception traces with parameters.

Note: 
- any app that accesses the exception, is itself responsible for handling the part of removing sensitive data. 

- the logging format for exceptions catched from sabredav will slightly change apps/dav/lib/Connector/Sabre/ExceptionLoggerPlugin.php

## How Has This Been Tested?
- [x] unit tests have been provided -> 🤖 
- [ ] manual check needs to be done

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] manual testing
