### PR TITLE
Remove sensitive shared_secret data from occ config:list output

### DIFF
--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -166,7 +166,7 @@ class SystemConfig {
 					 * Remove any sensitive values from all actual entries.
 					 */
 					foreach ($value as $valueKey => $valueData) {
-						if (is_int($valueKey) && ($valueKey >= 0)) {
+						if (\is_int($valueKey) && ($valueKey >= 0)) {
 							$value[$valueKey] = $this->removeSensitiveValue($valueToRemove, $value[$valueKey]);
 						}
 					}

--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -50,7 +50,14 @@ class SystemConfig {
 		'proxyuserpwd' => true,
 		'marketplace.key' => true,
 		'log.condition' => [
+			[
 			'shared_secret' => true,
+			]
+		],
+		'log.conditions' => [
+			[
+			'shared_secret' => true,
+			]
 		],
 		'license-key' => true,
 		'redis' => [
@@ -152,8 +159,21 @@ class SystemConfig {
 
 		if (\is_array($value)) {
 			foreach ($keysToRemove as $keyToRemove => $valueToRemove) {
-				if (isset($value[$keyToRemove])) {
-					$value[$keyToRemove] = $this->removeSensitiveValue($valueToRemove, $value[$keyToRemove]);
+				if ($keyToRemove === 0) {
+					/*
+					 * The 0 key in keysToRemove indicates a possibly repeating
+					 * array of actual entries 0,1,2,3...
+					 * Remove any sensitive values from all actual entries.
+					 */
+					foreach ($value as $valueKey => $valueData) {
+						if (is_int($valueKey) && ($valueKey >= 0)) {
+							$value[$valueKey] = $this->removeSensitiveValue($valueToRemove, $value[$valueKey]);
+						}
+					}
+				} else {
+					if (isset($value[$keyToRemove])) {
+						$value[$keyToRemove] = $this->removeSensitiveValue($valueToRemove, $value[$keyToRemove]);
+					}
 				}
 			}
 		}

--- a/tests/lib/SystemConfigTest.php
+++ b/tests/lib/SystemConfigTest.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Phil Davis <phil@jankaritech.com>
+ * @copyright Copyright (c) 2018 Phil Davis phil@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test;
+
+/**
+ * Class SystemConfigTest
+ *
+ * @group DB
+ *
+ * @package Test
+ */
+class SystemConfigTest extends TestCase {
+	const TESTCONTENT =
+		'<?php $CONFIG=array("instanceid"=>"random123", ' .
+		'"passwordsalt"=>"saltstring111", ' .
+		'"secret"=>"abiglongsecretstring222", ' .
+		'"trusted_domains" => array("localhost", "example.com"), ' .
+		'"redis" => array("password" => "theRedisPassphrase", "other" => "another setting"), ' .
+		'"dbtype"=>"mysql", ' .
+		'"dbname"=>"owncloud", ' .
+		'"dbhost"=>"localhost", ' .
+		'"dbuser"=>"owncloud", ' .
+		'"dbpassword"=>"dev123pwd", ' .
+		'"license-key"=>"Company-license-key-string", ' .
+		'"installed" => true, ' .
+		'"log.conditions" => [' .
+		'["shared_secret" => "randomString1", "users" => ["user1"], "apps" => ["files_texteditor"], "logfile" => "/tmp/texteditor.log"], ' .
+		'["shared_secret" => "randomString2", "users" => ["user2"], "apps" => ["gallery"], "logfile" => "/tmp/gallery.log"], ' .
+		'["shared_secret" => "randomString3", "users" => ["user3"], "apps" => ["comments"], "logfile" => "/tmp/comments.log"], ' .
+		'],' .
+		'"objectstore" => ["arguments" => [' .
+		'"password" => "theObjectStorePassword", ' .
+		'"options" => ["other" => "stuff", "credentials" => ["key" => "specialKeyValue", "secret" => "secretCredential"]]' .
+		']]' .
+		');';
+
+	/** @var array */
+	private $initialConfig = [
+		'instanceid' => 'random123',
+		'passwordsalt' => 'saltstring111',
+		'secret' => 'abiglongsecretstring222',
+		'trusted_domains' => [
+				0 => 'localhost',
+				1 => 'example.com',
+			],
+		'redis' => [
+			'password' => 'theRedisPassphrase',
+			'other' => 'another setting'
+		],
+		'dbtype' => 'mysql',
+		'dbname' => 'owncloud',
+		'dbhost' => 'localhost',
+		'dbuser' => 'owncloud',
+		'dbpassword' => 'dev123pwd',
+		'license-key' => 'Company-license-key-string',
+		'installed' => true,
+		'log.conditions' => [
+			[
+				'shared_secret' => 'randomString1',
+				'users' => ['user1'],
+				'apps' => ['files_texteditor'],
+				'logfile' => '/tmp/texteditor.log'
+			],
+			[
+				'shared_secret' => 'randomString2',
+				'users' => ['user2'],
+				'apps' => ['gallery'],
+				'logfile' => '/tmp/gallery.log'
+			],
+			[
+				'shared_secret' => 'randomString3',
+				'users' => ['user3'],
+				'apps' => ['comments'],
+				'logfile' => '/tmp/comments.log'
+			],
+		],
+		'objectstore' => [
+			'arguments' => [
+				'password' => 'theObjectStorePassword',
+				'options' => [
+					'other' => 'stuff',
+					'credentials' => [
+						'key' => 'specialKeyValue',
+						'secret' => 'secretCredential',
+					],
+				],
+			],
+		],
+	];
+
+	/** @var string */
+	private $configFile;
+	/** @var \OC\Config */
+	private $config;
+	/** @var string */
+	private $randomTmpDir;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->randomTmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$this->configFile = $this->randomTmpDir.'testconfig.php';
+		\file_put_contents($this->configFile, self::TESTCONTENT);
+		$this->config = new \OC\Config($this->randomTmpDir, 'testconfig.php');
+	}
+
+	protected function tearDown() {
+		\unlink($this->configFile);
+		parent::tearDown();
+	}
+
+	public function testSetValue() {
+		$systemConfig = new \OC\SystemConfig($this->config);
+		$systemConfig->setValue('dbtype', 'otherDb');
+		$expectedConfig = $this->initialConfig;
+		$expectedConfig['dbtype'] = 'otherDb';
+		$this->assertAttributeEquals($expectedConfig, 'cache', $this->config);
+	}
+
+	public function testSetValues() {
+		$systemConfig = new \OC\SystemConfig($this->config);
+		$this->assertStringEqualsFile($this->configFile, self::TESTCONTENT);
+
+		// Changing configs to existing values and deleting non-existing ones
+		// should not rewrite the config.php
+		$systemConfig->setValues([
+			'dbtype'		=> 'mysql',
+			'not_exists'	=> null,
+		]);
+
+		$this->assertAttributeEquals($this->initialConfig, 'cache', $this->config);
+		$this->assertStringEqualsFile($this->configFile, self::TESTCONTENT);
+
+		$systemConfig->setValues([
+			'dbtype'		=> 'otherDb',
+			'license-key'	=> null,
+		]);
+		$expectedConfig = $this->initialConfig;
+		$expectedConfig['dbtype'] = 'otherDb';
+		unset($expectedConfig['license-key']);
+		$this->assertAttributeEquals($expectedConfig, 'cache', $this->config);
+	}
+
+	public function dataGetValue() {
+		return [
+			['dbtype', null, 'mysql'],
+			['non_existent_key', null, ''],
+			['installed', 'someBogusValue', true],
+			['trusted_domains', 'someBogusValue', [0 => 'localhost', 1 => 'example.com']],
+			['trusted_domains', null, [0 => 'localhost', 1 => 'example.com']],
+			['redis', null, ['password' => 'theRedisPassphrase', 'other' => 'another setting']],
+			['dbpassword', null, 'dev123pwd'],
+			['license-key', null, 'Company-license-key-string'],
+			['log.conditions', null, [
+				[
+					'shared_secret' => 'randomString1',
+					'users' => ['user1'],
+					'apps' => ['files_texteditor'],
+					'logfile' => '/tmp/texteditor.log'
+				],
+				[
+					'shared_secret' => 'randomString2',
+					'users' => ['user2'],
+					'apps' => ['gallery'],
+					'logfile' => '/tmp/gallery.log'
+				],
+				[
+					'shared_secret' => 'randomString3',
+					'users' => ['user3'],
+					'apps' => ['comments'],
+					'logfile' => '/tmp/comments.log'
+				],
+			]],
+			['objectstore', null, [
+				'arguments' => [
+					'password' => 'theObjectStorePassword',
+					'options' => [
+						'other' => 'stuff',
+						'credentials' => [
+							'key' => 'specialKeyValue',
+							'secret' => 'secretCredential',
+						],
+					],
+				],
+			]],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetValue
+	 * @param string $key
+	 * @param mixed $default
+	 * @param mixed $expectedValue
+	 */
+	public function testGetValue($key, $default, $expectedValue) {
+		$systemConfig = new \OC\SystemConfig($this->config);
+		if ($default === null) {
+			$actualValue = $systemConfig->getValue($key);
+		} else {
+			$actualValue = $systemConfig->getValue($key, $default);
+		}
+		$this->assertSame(
+			$expectedValue,
+			$actualValue
+		);
+	}
+
+	public function dataGetFilteredValue() {
+		return [
+			['dbtype', null, 'mysql'],
+			['non_existent_key', null, ''],
+			['installed', 'someBogusValue', true],
+			['trusted_domains', 'someBogusValue', [0 => 'localhost', 1 => 'example.com']],
+			['trusted_domains', null, [0 => 'localhost', 1 => 'example.com']],
+			['redis', null, ['password' => '***REMOVED SENSITIVE VALUE***', 'other' => 'another setting']],
+			['dbpassword', null, '***REMOVED SENSITIVE VALUE***'],
+			['license-key', null, '***REMOVED SENSITIVE VALUE***'],
+			['log.conditions', null, [
+				[
+					'shared_secret' => '***REMOVED SENSITIVE VALUE***',
+					'users' => ['user1'],
+					'apps' => ['files_texteditor'],
+					'logfile' => '/tmp/texteditor.log'
+				],
+				[
+					'shared_secret' => '***REMOVED SENSITIVE VALUE***',
+					'users' => ['user2'],
+					'apps' => ['gallery'],
+					'logfile' => '/tmp/gallery.log'
+				],
+				[
+					'shared_secret' => '***REMOVED SENSITIVE VALUE***',
+					'users' => ['user3'],
+					'apps' => ['comments'],
+					'logfile' => '/tmp/comments.log'
+				],
+			]],
+			['objectstore', null, [
+				'arguments' => [
+					'password' => '***REMOVED SENSITIVE VALUE***',
+					'options' => [
+						'other' => 'stuff',
+						'credentials' => [
+							'key' => '***REMOVED SENSITIVE VALUE***',
+							'secret' => '***REMOVED SENSITIVE VALUE***',
+						],
+					],
+				],
+			]],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetFilteredValue
+	 * @param string $key
+	 * @param mixed $default
+	 * @param mixed $expectedValue
+	 */
+	public function testGetFilteredValue($key, $default, $expectedValue) {
+		$systemConfig = new \OC\SystemConfig($this->config);
+		if ($default === null) {
+			$actualValue = $systemConfig->getFilteredValue($key);
+		} else {
+			$actualValue = $systemConfig->getFilteredValue($key, $default);
+		}
+		$this->assertSame(
+			$expectedValue,
+			$actualValue
+		);
+	}
+
+	public function testDeleteValue() {
+		$systemConfig = new \OC\SystemConfig($this->config);
+		$systemConfig->deleteValue('dbtype');
+		$expectedConfig = $this->initialConfig;
+		unset($expectedConfig['dbtype']);
+		$this->assertAttributeEquals($expectedConfig, 'cache', $this->config);
+	}
+
+	public function testIsReadOnly() {
+		$systemConfig = new \OC\SystemConfig($this->config);
+		$this->assertFalse($systemConfig->isReadOnly(), 'Config is read-only but should not be');
+	}
+}


### PR DESCRIPTION
## Description

This PR applies a patch from @phil-davis, that ensures that `log.condition` `shared_secret` sensitive data is removed from calls to `occ config:list` output.

## Motivation and Context

```php
'log.condition' => [
        [
            'shared_secret' => '57b58edb6637fe3059b3595cf9c41b9',
            'users' => ['user1'],
            'apps' => ['files_texteditor'],
            'logfile' => '/tmp/test.log'
        ],
    ],
```

If you had the above configuration in `config/config.php`, then the `shared_secret` information would not be stripped, from the output of a call to `occ config:list`. However, with the PR applied, the output would appear as follows:

```php
"log.condition": [
      {
          "shared_secret": "***REMOVED SENSITIVE VALUE***",
           "users": [
               "user1"
           ],
           "apps": [
               "files_texteditor"
           ],
           "logfile": "\/tmp\/test.log"
      },
]
```

## How Has This Been Tested?

Currently, it's only been manually tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised:

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [X] Backport (if applicable set "backport-request" label and remove when the backport was done)