### PR TITLE
empty path has no parents

### DIFF
--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -62,6 +62,10 @@ class Propagator implements IPropagator {
 
 		$parents = $this->getParents($internalPath);
 
+		if (\count($parents) === 0) {
+			return;
+		}
+
 		if ($this->inBatch) {
 			foreach ($parents as $parent) {
 				$this->addToBatch($parent, $time, $sizeDifference);
@@ -99,6 +103,9 @@ class Propagator implements IPropagator {
 	}
 
 	protected function getParents($path) {
+		if ($path === '') {
+			return [];
+		}
 		$parts = \explode('/', $path);
 		$parent = '';
 		$parents = [];

--- a/tests/lib/Files/Cache/PropagatorTest.php
+++ b/tests/lib/Files/Cache/PropagatorTest.php
@@ -81,6 +81,25 @@ class PropagatorTest extends TestCase {
 		}
 	}
 
+	public function getParentsProvider() {
+		return [
+			['', []],
+			['foo', ['']],
+			['foo/bar', ['', 'foo']],
+			['foo/bar/baz.txt', ['', 'foo', 'foo/bar']]
+		];
+	}
+
+	/**
+	 * @dataProvider getParentsProvider
+	 * @param $path
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function testGetParents($path, $expected) {
+		$propagator = $this->storage->getPropagator();
+		self::assertSame($expected, self::invokePrivate($propagator, 'getParents', [$path]));
+	}
+
 	public function testBatchedPropagation() {
 		$this->storage->mkdir('foo/baz');
 		$this->storage->mkdir('asd');


### PR DESCRIPTION
what can I say ... :disappointed: 

Without this a public share, mounted as a federated share in the root of a users home will hav its etag overwritten with a uniqeid on every propfind, causing endless downloads.

How to reproduce:

1. as user admin create a 1 byte txt file.
2. share it as public link
3. log out
4. open the link 
5. add to the same oc instance
6. log in as user test
7. accept incoming share
8. do a propfind against user test like
```
curl 'http://core/remote.php/dav/files/test/' -X PROPFIND --data-binary $'<?xml version="1.0"?>\n<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">\n <d:prop>\n <d:getetag />\n <oc:fileid />\n <oc:permissions />\n <oc:size />\n </d:prop>\n</d:propfind>' --compressed -k -u test:123 -H 'Cookie: XDEBUG_SESSION=PHPSTORM' | xml_pp
```

Expected behavior:
multiple PROPFINDS give the same md5 etag

Actual behavior:
every propfind returns a new uniqueid