### PR TITLE
[stable10] empty path has no parents

### DIFF
--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -63,6 +63,10 @@ class Propagator implements IPropagator {
 
 		$parents = $this->getParents($internalPath);
 
+		if (\count($parents) === 0) {
+			return;
+		}
+
 		if ($this->inBatch) {
 			foreach ($parents as $parent) {
 				$this->addToBatch($parent, $time, $sizeDifference);
@@ -100,6 +104,9 @@ class Propagator implements IPropagator {
 	}
 
 	protected function getParents($path) {
+		if ($path === '') {
+			return [];
+		}
 		$parts = explode('/', $path);
 		$parent = '';
 		$parents = [];

--- a/tests/lib/Files/Cache/PropagatorTest.php
+++ b/tests/lib/Files/Cache/PropagatorTest.php
@@ -81,6 +81,25 @@ class PropagatorTest extends TestCase {
 		}
 	}
 
+	public function getParentsProvider() {
+		return [
+			['', []],
+			['foo', ['']],
+			['foo/bar', ['', 'foo']],
+			['foo/bar/baz.txt', ['', 'foo', 'foo/bar']]
+		];
+	}
+
+	/**
+	 * @dataProvider getParentsProvider
+	 * @param $path
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function testGetParents($path, $expected) {
+		$propagator = $this->storage->getPropagator();
+		self::assertSame($expected, self::invokePrivate($propagator, 'getParents', [$path]));
+	}
+
 	public function testBatchedPropagation() {
 		$this->storage->mkdir('foo/baz');
 		$this->storage->mkdir('asd');


### PR DESCRIPTION
backport of https://github.com/owncloud/core/pull/31988 to stable10