### PR TITLE
[stable10] Fix Cache:update() to reset columns on oracle

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -35,6 +35,7 @@
 
 namespace OC\Files\Cache;
 
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use \OCP\Files\IMimeTypeLoader;
@@ -306,6 +307,16 @@ class Cache implements ICache {
 		// once for the SET part, once in the WHERE clause
 		$params = array_merge($params, $params);
 		$params[] = $id;
+
+		// Oracle does not support empty string values so we convert them to nulls
+		// https://github.com/owncloud/core/issues/31692
+		if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+			foreach ($data as $param => $value) {
+				if ($value === '') {
+					$data[$param] = null;
+				}
+			}
+		}
 
 		// don't update if the data we try to set is the same as the one in the record
 		// some databases (Postgres) don't like superfluous updates

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -671,6 +671,15 @@ class CacheTest extends TestCase {
 		}
 	}
 
+	public function testUpdateClearsCacheColumn() {
+		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'text/plain', 'checksum' => 'abc'];
+		$this->cache->put('somefile.txt', $data);
+
+		$this->cache->update($this->cache->getId('somefile.txt'), ['mtime' => 0,'checksum' => '']);
+		$entry = $this->cache->get('somefile.txt');
+		$this->assertEmpty($entry['checksum']);
+	}
+
 	protected function tearDown() {
 		if ($this->cache) {
 			$this->cache->clear();


### PR DESCRIPTION
Backport of #31989 