### PR TITLE
Report "Wrong current password" to user

### DIFF
--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -49,7 +49,7 @@ class Controller {
 		}
 		if ($oldPassword === $password) {
 			$l = \OC::$server->getL10NFactory()->get('settings');
-			\OC_JSON::error(["data" => ["message" => $l->t("The new password can not be the same as the previous one")]]);
+			\OC_JSON::error(["data" => ["message" => $l->t("The new password cannot be the same as the previous one")]]);
 			exit();
 		}
 		try {

--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -44,7 +44,7 @@ class Controller {
 
 		if (!\OC_User::checkPassword($username, $oldPassword)) {
 			$l = \OC::$server->getL10NFactory()->get('settings');
-			\OC_JSON::error(["data" => ["message" => $l->t("Wrong password")]]);
+			\OC_JSON::error(["data" => ["message" => $l->t("Wrong current password")]]);
 			exit();
 		}
 		if ($oldPassword === $password) {

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -68,7 +68,7 @@ So that I can give a user access to the resources of the group
 		And the HTTP status code should be "200"
 		And the API should not return any data
 
-	Scenario: a subadmin can not add users to groups the subadmin is responsible for
+	Scenario: a subadmin cannot add users to groups the subadmin is responsible for
 		Given user "subadmin" has been created
 		And user "brand-new-user" has been created
 		And group "new-group" has been created

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1145,7 +1145,7 @@ trait WebDav {
 	}
 
 	/**
-	 * asserts that a the user can or can not see a list of files/folders by propfind
+	 * asserts that a the user can or cannot see a list of files/folders by propfind
 	 *
 	 * @param string $user
 	 * @param TableNode $elements

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -19,7 +19,7 @@ So that I can login with my new password
 
 	Scenario: Password change with wrong current password
 		When the user changes the password to "passcode" entering the wrong current password using the webUI
-		Then a password error message should be displayed on the webUI with the text "Wrong password"
+		Then a password error message should be displayed on the webUI with the text "Wrong current password"
 
 	Scenario: New password is same as current password
 		When the user changes the password to "1234" using the webUI

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -23,4 +23,4 @@ So that I can login with my new password
 
 	Scenario: New password is same as current password
 		When the user changes the password to "1234" using the webUI
-		Then a password error message should be displayed on the webUI with the text "The new password can not be the same as the previous one"
+		Then a password error message should be displayed on the webUI with the text "The new password cannot be the same as the previous one"


### PR DESCRIPTION
## Description
Change message text "Wrong password" to "Wrong current password" when it is the current password that is wrong.

Change some "can not" in a message to "cannot".

## Related Issue
- Fixes #32001 

## Motivation and Context
Make the message clearer.

## How Has This Been Tested?
- Login to the webUI as any user and go to Personal General Settings.
- Enter a wrong current password, and something in "new password" and press Change Password
- See the message "Wrong current password"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
