### PR TITLE
Add webDAV acceptance tests for upload-download-propfind of unusual file names

### DIFF
--- a/tests/acceptance/features/apiWebdav/webdav-related.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related.feature
@@ -165,6 +165,16 @@ Feature: webdav-related
 			| old           |
 			| new           |
 
+	Scenario Outline: download a file
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		When user "user0" downloads the file "/textfile0.txt" using the API
+		Then the downloaded content should be "ownCloud test text file" plus end-of-line
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
 	Scenario Outline: download a file with range
 		Given using <dav_version> DAV path
 		And user "user0" has been created
@@ -174,6 +184,110 @@ Feature: webdav-related
 			| dav_version   |
 			| old           |
 			| new           |
+
+	Scenario Outline: upload a file and check download content
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		When user "user0" uploads file with content "uploaded content" to "<file_name>" using the API
+		Then the content of file "<file_name>" for user "user0" should be "uploaded content"
+		Examples:
+			| dav_version | file_name         |
+			| old         | /upload.txt       |
+			| old         | /strängé file.txt |
+			| old         | /C++ file.cpp     |
+			| old         | /नेपाली.txt       |
+			| old         | /file #2.txt      |
+			| old         | /file ?2.txt      |
+			| new         | /upload.txt       |
+			| new         | /strängé file.txt |
+			| new         | /C++ file.cpp     |
+			| new         | /नेपाली.txt       |
+			| new         | /file #2.txt      |
+			| new         | /file ?2.txt      |
+
+	Scenario Outline: create a folder
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		When user "user0" creates a folder "<folder_name>" using the API
+		Then as "user0" the folder "<folder_name>" should exist
+		Examples:
+			| dav_version | folder_name     |
+			| old         | /upload         |
+			| old         | /strängé folder |
+			| old         | /C++ folder.cpp |
+			| old         | /नेपाली         |
+			| old         | /folder #2      |
+			| old         | /folder ?2      |
+			| new         | /upload         |
+			| new         | /strängé folder |
+			| new         | /C++ folder.cpp |
+			| new         | /नेपाली         |
+			| new         | /folder #2      |
+			| new         | /folder ?2      |
+
+	Scenario Outline: upload a file into a folder and check download content
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "<folder_name>"
+		When user "user0" uploads file with content "uploaded content" to "<folder_name>/<file_name>" using the API
+		Then the content of file "<folder_name>/<file_name>" for user "user0" should be "uploaded content"
+		Examples:
+			| dav_version | folder_name                      | file_name                     |
+			| old         | /upload                          | abc.txt                       |
+			| old         | /strängé folder                  | strängé file.txt              |
+			| old         | /C++ folder                      | C++ file.cpp                  |
+			| old         | /नेपाली                          | नेपाली                        |
+			| old         | /folder #2.txt                   | file #2.txt                   |
+			| old         | /folder ?2.txt                   | file ?2.txt                   |
+			| new         | /upload                          | abc.txt                       |
+			| new         | /strängé folder (duplicate #2 &) | strängé file (duplicate #2 &) |
+			| new         | /C++ folder                      | C++ file.cpp                  |
+			| new         | /नेपाली                          | नेपाली                        |
+			| new         | /folder #2.txt                   | file #2.txt                   |
+			| new         | /folder ?2.txt                   | file ?2.txt                   |
+
+	Scenario Outline: Do a PROPFIND of various file names
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		And user "user0" has uploaded file with content "uploaded content" to "<file_name>"
+		When user "user0" gets the properties of file "<file_name>" using the API
+		Then the properties response should contain an etag
+		Examples:
+			| dav_version | file_name         |
+			| old         | /upload.txt       |
+			| old         | /strängé file.txt |
+			| old         | /C++ file.cpp     |
+			| old         | /नेपाली.txt       |
+			| old         | /file #2.txt      |
+			| old         | /file ?2.txt      |
+			| new         | /upload.txt       |
+			| new         | /strängé file.txt |
+			| new         | /C++ file.cpp     |
+			| new         | /नेपाली.txt       |
+			| new         | /file #2.txt      |
+			| new         | /file ?2.txt      |
+
+	Scenario Outline: Do a PROPFIND of various folder/file names
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		And user "user0" has created a folder "<folder_name>"
+		And user "user0" has uploaded file with content "uploaded content" to "<folder_name>/<file_name>"
+		When user "user0" gets the properties of file "<folder_name>/<file_name>" using the API
+		Then the properties response should contain an etag
+		Examples:
+			| dav_version | folder_name                      | file_name                     |
+			| old         | /upload                          | abc.txt                       |
+			| old         | /strängé folder                  | strängé file.txt              |
+			| old         | /C++ folder                      | C++ file.cpp                  |
+			| old         | /नेपाली                          | नेपाली                        |
+			| old         | /folder #2.txt                   | file #2.txt                   |
+			| old         | /folder ?2.txt                   | file ?2.txt                   |
+			| new         | /upload                          | abc.txt                       |
+			| new         | /strängé folder (duplicate #2 &) | strängé file (duplicate #2 &) |
+			| new         | /C++ folder                      | C++ file.cpp                  |
+			| new         | /नेपाली                          | नेपाली                        |
+			| new         | /folder #2.txt                   | file #2.txt                   |
+			| new         | /folder ?2.txt                   | file ?2.txt                   |
 
 	Scenario Outline: Retrieving folder quota when no quota is set
 		Given using <dav_version> DAV path

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -428,6 +428,19 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then /^the downloaded content should be "([^"]*)" plus end-of-line$/
+	 *
+	 * @param string $fileName
+	 * @param string $user
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function downloadedContentShouldBePlusEndOfLine($content) {
+		$this->downloadedContentShouldBe($content . "\n");
+	}
+
+	/**
 	 * @Then /^the content of file "([^"]*)" should be "([^"]*)"$/
 	 *
 	 * @param string $fileName
@@ -576,6 +589,22 @@ trait WebDav {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" gets the properties of (?:file|folder|entry) "([^"]*)" using the API$/
+	 *
+	 * @param string $user
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function userGetsThePropertiesOfFolder(
+		$user, $path
+	) {
+		$this->response = $this->listFolder(
+			$user, $path, 0, []
+		);
+	}
+
+	/**
 	 * @When /^user "([^"]*)" gets the following properties of (?:file|folder|entry) "([^"]*)" using the API$/
 	 *
 	 * @param string $user
@@ -699,9 +728,29 @@ trait WebDav {
 	 */
 	public function asTheFileOrFolderShouldExist($user, $entry, $path) {
 		$this->response = $this->listFolder($user, $path, 0);
-		if (!\is_array($this->response) || !isset($this->response['{DAV:}getetag'])) {
+		try {
+			$this->thePropertiesResponseShouldContainAnEtag();
+		} catch (\Exception $e) {
 			throw new \Exception(
 				$entry . ' "' . $path . '" expected to exist but not found'
+			);
+		}
+	}
+
+	/**
+	 * @Then /^the properties response should contain an etag$/
+	 *
+	 * @param string $user
+	 * @param string $entry
+	 * @param string $path
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function thePropertiesResponseShouldContainAnEtag() {
+		if (!\is_array($this->response) || !isset($this->response['{DAV:}getetag'])) {
+			throw new \Exception(
+				"getetag not found in response"
 			);
 		}
 	}


### PR DESCRIPTION
## Description
Add acceptance tests that check upload, download and propfind via webDAV of files that have unusual names (regular ASCII, European special characters, other Unicode script, characters special to URLs like ``#?``

## Related Issue
#32009 
The tests cover some more combinations that might have been causing a problem for that issue. But actually these tests all pass.

## Motivation and Context
Have a broader range of webDAV tests that  check functionality with typical subsets of characters used in file and folder names.

## How Has This Been Tested?
- run acceptance tests locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] N/A Unit tests added
- [ x Acceptance tests added
- [ ] N/A Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
