### PR TITLE
[stable10] Read mtime from both properties

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -114,6 +114,17 @@ OC.FileUpload.prototype = {
 		return this.getFile().name;
 	},
 
+	getLastModified: function() {
+		var file = this.getFile();
+		if (file.lastModifiedDate) {
+			return file.lastModifiedDate.getTime() / 1000;
+		}
+		if (file.lastModified) {
+			return file.lastModified / 1000;
+		}
+		return null;
+	},
+
 	setTargetFolder: function(targetFolder) {
 		this._targetFolder = targetFolder;
 	},
@@ -238,9 +249,10 @@ OC.FileUpload.prototype = {
 			this.data.headers['OC-Autorename'] = '1';
 		}
 
-		if (file.lastModified) {
+		var lastModified = this.getLastModified();
+		if (lastModified) {
 			// preserve timestamp
-			this.data.headers['X-OC-Mtime'] = file.lastModified / 1000;
+			this.data.headers['X-OC-Mtime'] = '' + lastModified;
 		}
 
 		var userName = this.uploader.davClient.getUserName();
@@ -287,11 +299,11 @@ OC.FileUpload.prototype = {
 		}
 
 		var uid = OC.getCurrentUser().uid;
-		var mtime = this.getFile().lastModified;
+		var mtime = this.getLastModified();
 		var size = this.getFile().size;
 		var headers = {};
 		if (mtime) {
-			headers['X-OC-Mtime'] = mtime / 1000;
+			headers['X-OC-Mtime'] = mtime;
 		}
 		if (size) {
 			headers['OC-Total-Length'] = size;

--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -273,4 +273,41 @@ describe('OC.Upload tests', function() {
 			expect(upload.data.headers['OC-Autorename']).toEqual('1');
 		});
 	});
+	describe('submitting uploads', function() {
+		describe('headers', function() {
+			function testHeaders(fileData) {
+				var uploadData = addFiles(uploader, [
+					fileData
+				]);
+
+				return uploadData[0].headers;
+			}
+			it('sets request token', function() {
+				var oldToken = OC.requestToken;
+				OC.requestToken = 'abcd';
+				var headers = testHeaders({
+					name: 'headerstest.txt'
+				});
+
+				expect(headers['requesttoken']).toEqual('abcd');
+				OC.requestToken = oldToken;
+			});
+			it('sets the mtime header when lastModifiedDate is set', function() {
+				var headers = testHeaders({
+					name: 'mtimetest.txt',
+					lastModifiedDate: new Date(Date.UTC(2018, 7, 26, 14, 55, 22, 500))
+				});
+
+				expect(headers['X-OC-Mtime']).toEqual('1535295322.5');
+			});
+			it('sets the mtime header when lastModified is set', function() {
+				var headers = testHeaders({
+					name: 'mtimetest.txt',
+					lastModified: 1535295322500
+				});
+
+				expect(headers['X-OC-Mtime']).toEqual('1535295322.5');
+			});
+		});
+	});
 });


### PR DESCRIPTION
## Description
See https://stackoverflow.com/questions/44115976/files-properties-lastmodified-vs-lastmodifieddate

## Related Issue


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] upload small file with Chrome => mtime preserved
- [x] upload big file > 10mb with Chrome => mtime preserved
- [ ] upload small file with IE11 => mtime preserved
- [ ] upload big file > 10mb with IE11 => mtime preserved
- [ ] upload small file with MS Edge => mtime preserved
- [ ] upload big file > 10mb with MS Edge => mtime preserved

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
