### PR TITLE
Fixes 32012 - read the correct translations

### DIFF
--- a/lib/private/Helper/LocaleHelper.php
+++ b/lib/private/Helper/LocaleHelper.php
@@ -104,7 +104,7 @@ class LocaleHelper {
 
 		$availableCodes = $langFactory->findAvailableLanguages();
 		foreach ($availableCodes as $languageCode) {
-			$l = $langFactory->get('settings', $languageCode);
+			$l = $langFactory->get('lib', $languageCode);
 
 			// TRANSLATORS this is a self-name of your language for the language switcher
 			$endonym = (string)$l->t('__language_name__');


### PR DESCRIPTION
## Description
Read translations from the correct location

## Related Issue
- Fixes #32012 

## How Has This Been Tested?
## Screenshots (if appropriate):
- manually: open settings and see the real language names not the codes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
