### PR TITLE
map the webhook to the value which slack plugin expects

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -275,7 +275,9 @@ pipeline:
   notify:
     image: plugins/slack:1
     pull: true
-    secrets: [ slack_webhook_public ]
+    secrets:
+      - source: slack_webhook_public
+        target: slack_webhook
     channel: server
     when:
       status: [ failure, changed ]


### PR DESCRIPTION
## Description
With #31976 notifications have been added - however the secret was not mapped correctly. This fixes it


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
