### PR TITLE
Document security implications of enabling debug in production

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1354,6 +1354,11 @@ $CONFIG = array(
  *
  * Only enable this for local development and not in production environments
  * This will disable the minifier and outputs some additional debug information
+ *
+ * .. warning::
+ *    Be warned that, if you set this to ``true``, exceptions display
+ *    stack traces on the web interface, *including passwords*, — **in plain text!**.
+ *    We strongly encourage you never to use it in production.
  */
 'debug' => false,
 


### PR DESCRIPTION
## Description

This updates the documentation for the "debug" config option to cover the security implications of enabling it in production (or any other user-facing environment). It fixes https://github.com/owncloud/documentation/issues/4256.

## Related Issue

- Fixes https://github.com/owncloud/documentation/issues/4256

## Motivation and Context

As in description

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [X] Documentation

## Checklist:

- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [X] Docblock comment

## Open tasks:

- [X] Backport (if applicable set "backport-request" label and remove when the backport was done)