### PR TITLE
[stable10] Backport of Set encrypted to zero in file cache after decr…

### DIFF
--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -264,6 +264,9 @@ class DecryptAll {
 			$this->rootView->copy($source, $target);
 			\OC\Files\Storage\Wrapper\Encryption::setDisableWriteEncryption(false);
 			$this->rootView->rename($target, $source);
+			list($storage, $internalPath) = $this->rootView->resolvePath($source);
+			//Update the encrypted column in file cache to zero, as the file is decrypted
+			$storage->getCache()->put($internalPath, ['encrypted' => 0]);
 		} catch (DecryptionFailedException $e) {
 			if ($this->rootView->file_exists($target)) {
 				$this->rootView->unlink($target);

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -27,6 +27,7 @@ use Doctrine\DBAL\Statement;
 use OC\Encryption\DecryptAll;
 use OC\Encryption\Exceptions\DecryptionFailedException;
 use OC\Encryption\Manager;
+use OC\Files\Cache\Cache;
 use OC\Files\FileInfo;
 use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\View;
@@ -521,6 +522,17 @@ class DecryptAllTest extends TestCase {
 		$this->view->expects($this->once())
 			->method('rename')
 			->with($path . '.decrypted.42.part', $path);
+		$storage = $this->createMock('\OC\Files\Storage\Storage');
+		$fileCache = $this->createMock(Cache::class);
+		$fileCache->expects($this->once())
+			->method('put')
+			->with('test.txt', ['encrypted' => 0]);
+		$storage->expects($this->once())
+			->method('getCache')
+			->willReturn($fileCache);
+		$this->view->expects($this->once())
+			->method('resolvePath')
+			->willReturn([$storage, 'test.txt']);
 
 		$this->assertTrue(
 			$this->invokePrivate($instance, 'decryptFile', [$path])


### PR DESCRIPTION
…ypt-all run on files

Set the encrypted to zero in file cache after the decrypt-all is
run on files.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The decrypt-all command never sets the encrypted value in the file cache to zero. If this value is not set to zero, the files like pdf would not be opened ( using files_pdfviewer app ). Setting this value to zero, helps fix this issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The decrypt-all command never sets the encrypted value in the file cache to zero. If this value is not set to zero, the files like pdf would not be opened ( using files_pdfviewer app ). Setting this value to zero, helps fix this issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Same as mentioned in https://github.com/owncloud/core/pull/32014#issue-200014724

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
