### PR TITLE
Don't strip linebreaks in personal note #32036

### DIFF
--- a/core/templates/altmail.php
+++ b/core/templates/altmail.php
@@ -6,7 +6,7 @@ if (isset($_['expiration'])) {
 }
 if (isset($_['personal_note'])) {
 	// TRANSLATORS personal note in share notification email
-	print_unescaped($l->t("Personal note from the sender: %s.", [$_['personal_note']]));
+	print_unescaped($l->t("Personal note from the sender: \n %s.", $_['personal_note']));
 	print_unescaped("\n\n");
 }
 // TRANSLATORS term at the end of a mail

--- a/core/templates/mail.php
+++ b/core/templates/mail.php
@@ -20,7 +20,7 @@ if (isset($_['expiration'])) {
 
 if (isset($_['personal_note'])) {
 	// TRANSLATORS personal note in share notification email
-	p($l->t("Personal note from the sender: %s.", [$_['personal_note']]));
+	print_unescaped($l->t("Personal note from the sender: <br> %s.", $_['personal_note']));
 	print_unescaped('<br><br>');
 }
 // TRANSLATORS term at the end of a mail

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -316,7 +316,7 @@ class MailNotifications {
 		$html->assign('filename', $filename);
 		$html->assign('expiration', $formattedDate);
 		if ($personalNote !== null && $personalNote !== '') {
-			$html->assign('personal_note', $personalNote);
+			$html->assign('personal_note', \nl2br($personalNote));
 		}
 		$htmlMail = $html->fetchPage();
 

--- a/tests/lib/Share/MailNotificationsTest.php
+++ b/tests/lib/Share/MailNotificationsTest.php
@@ -157,11 +157,11 @@ class MailNotificationsTest extends TestCase {
 		$message
 			->expects($this->once())
 			->method('setHtmlBody')
-			->with($this->stringContains('personal note'));
+			->with($this->stringContains('personal note<br />'));
 		$message
 			->expects($this->once())
 			->method('setPlainBody')
-			->with($this->stringContains('personal note'));
+			->with($this->stringContains("personal note\n"));
 
 		$message
 			->expects($this->once())
@@ -195,7 +195,7 @@ class MailNotificationsTest extends TestCase {
 			$calledEvent[] = 'share.sendmail';
 			$calledEvent[] = $event;
 		});
-		$this->assertSame([], $mailNotifications->sendLinkShareMail('lukas@owncloud.com', 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600, 'personal note', ['bcc' => 'foo@bar.com,fabulous@world.com', 'cc' => 'abc@foo.com,tester@world.com']));
+		$this->assertSame([], $mailNotifications->sendLinkShareMail('lukas@owncloud.com', 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600, "personal note\n", ['bcc' => 'foo@bar.com,fabulous@world.com', 'cc' => 'abc@foo.com,tester@world.com']));
 
 		$this->assertEquals('share.sendmail', $calledEvent[0]);
 		$this->assertInstanceOf(GenericEvent::class, $calledEvent[1]);
@@ -224,11 +224,11 @@ class MailNotificationsTest extends TestCase {
 		$message
 			->expects($this->once())
 			->method('setHtmlBody')
-			->with($this->stringContains('personal note'));
+			->with($this->stringContains('personal note<br />'));
 		$message
 			->expects($this->once())
 			->method('setPlainBody')
-			->with($this->stringContains('personal note'));
+			->with($this->stringContains("personal note\n"));
 
 		$message
 			->expects($this->once())
@@ -262,7 +262,7 @@ class MailNotificationsTest extends TestCase {
 			$calledEvent[] = 'share.sendmail';
 			$calledEvent[] = $event;
 		});
-		$this->assertSame([], $mailNotifications->sendLinkShareMail('lukas@owncloud.com', 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600, 'personal note'));
+		$this->assertSame([], $mailNotifications->sendLinkShareMail('lukas@owncloud.com', 'MyFile', 'https://owncloud.com/file/?foo=bar', 3600, "personal note\n"));
 
 		$this->assertEquals('share.sendmail', $calledEvent[0]);
 		$this->assertInstanceOf(GenericEvent::class, $calledEvent[1]);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Removed the escaping of the personal note in the mail template. The content of this variable has already been sanitized by strip_tags().

Needs to be mentioned in Release Notes, that a core template file has been changed. Customers who have customized mail templates need to manually review their template file. If they don't do it, the behavior will stay the same, the line breaks will be stripped from the personal note.
## Related Issue
- Fixes #32036

## How Has This Been Tested?
- manually
- Unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Release Notes

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
