### PR TITLE
Protect debug statement in token invalidation code

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -776,6 +776,28 @@ class Session implements IUserSession, Emitter {
 
 		if ($this->manager->checkPassword($dbToken->getLoginName(), $pwd) === false
 			|| ($this->activeUser !== null && !$this->activeUser->isEnabled())) {
+
+			// FIXME: protect debug statement this way to avoid regressions
+			if ($this->activeUser !== null) {
+				$this->logger->debug(
+					'user uid {uid}, email {email}, displayName {displayName} was disabled or password changed',
+					[
+						'app' => __METHOD__,
+						'uid' => $this->activeUser->getUID(),
+						'email' => $this->activeUser->getEMailAddress(),
+						'displayName' => $this->activeUser->getDisplayName(),
+					]
+				);
+			} else {
+				$this->logger->debug(
+					'user with login name {loginName} was disabled or password changed (no activeUser)',
+					[
+						'app' => __METHOD__,
+						'loginName' => $dbToken->getLoginName(),
+					]
+				);
+			}
+
 			$this->tokenProvider->invalidateToken($token);
 			// Password has changed or user was disabled -> log user out
 			return false;


### PR DESCRIPTION
When a password got changed and before invalidating tokens, the log
statement might access a null activeUser. This change protects it.

## Description
Protect debug statement

## Related Issue
Fixes https://github.com/owncloud/core/issues/32038

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
See steps in ticket. After the fix the app password gets invalidated properly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
