### PR TITLE
[stable10] Skip two factor challenge in account module middleware

### DIFF
--- a/core/Middleware/AccountModuleMiddleware.php
+++ b/core/Middleware/AccountModuleMiddleware.php
@@ -32,6 +32,7 @@ use OCP\Authentication\Exceptions\AccountCheckException;
 use OCP\Authentication\IAccountModuleController;
 use OCP\ILogger;
 use OCP\IUserSession;
+use OC\Core\Controller\TwoFactorChallengeController;
 
 /**
  * Class AccountModuleMiddleware
@@ -91,6 +92,11 @@ class AccountModuleMiddleware extends Middleware {
 
 		if ($controller instanceof IAccountModuleController) {
 			// Don't block any IAccountModuleController controllers
+			return;
+		}
+
+		if ($controller instanceof TwoFactorChallengeController) {
+			// Don't block two factor challenge
 			return;
 		}
 

--- a/tests/Core/Middleware/AccountModuleMiddlewareTest.php
+++ b/tests/Core/Middleware/AccountModuleMiddlewareTest.php
@@ -31,6 +31,7 @@ use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserSession;
 use Test\TestCase;
+use OC\Core\Controller\TwoFactorChallengeController;
 
 class AccountModuleMiddlewareTest extends TestCase {
 
@@ -99,6 +100,18 @@ class AccountModuleMiddlewareTest extends TestCase {
 			->method('isLoggedIn');
 
 		$controller = $this->createMock(IAccountModuleController::class);
+
+		$this->middleware->beforeController($controller, null);
+	}
+	public function testBeforeControllerSkipsTwoFactorChallengeController() {
+		$this->reflector->expects($this->once())
+			->method('hasAnnotation')
+			->with('PublicPage')
+			->will($this->returnValue(false));
+		$this->userSession->expects($this->never())
+			->method('isLoggedIn');
+
+		$controller = $this->createMock(TwoFactorChallengeController::class);
 
 		$this->middleware->beforeController($controller, null);
 	}


### PR DESCRIPTION
## Description
Fixes issue with infinite redirect when trying to access the challenge
page.

## Related Issue

- Fixes https://github.com/owncloud/password_policy/issues/32 => core issue #32059 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- test: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
