### PR TITLE
[stable10] Backport of Remove user from the storage setting or storag…

### DIFF
--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -24,11 +24,11 @@ namespace OCA\Files_External\Lib\Backend;
 
 use OCA\Files_External\Lib\Auth\AmazonS3\AccessKey;
 use OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
-use OCP\Files\External\Backend\Backend;
+use OCP\Files\External\Backend\Backend as ExternalBackend;
 use OCP\Files\External\DefinitionParameter;
 use OCP\IL10N;
 
-class AmazonS3 extends Backend {
+class AmazonS3 extends ExternalBackend {
 
 	use LegacyDependencyCheckPolyfill;
 

--- a/apps/files_external/lib/Lib/Backend/DAV.php
+++ b/apps/files_external/lib/Lib/Backend/DAV.php
@@ -24,11 +24,11 @@ namespace OCA\Files_External\Lib\Backend;
 
 use OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 use OCP\Files\External\Auth\AuthMechanism;
-use OCP\Files\External\Backend\Backend;
+use OCP\Files\External\Backend\Backend as ExternalBackend;
 use OCP\Files\External\DefinitionParameter;
 use OCP\IL10N;
 
-class DAV extends Backend {
+class DAV extends ExternalBackend {
 
 	use LegacyDependencyCheckPolyfill;
 

--- a/apps/files_external/lib/Lib/Backend/Google.php
+++ b/apps/files_external/lib/Lib/Backend/Google.php
@@ -25,10 +25,10 @@ namespace OCA\Files_External\Lib\Backend;
 use OCP\IL10N;
 use OCP\Files\External\DefinitionParameter;
 use OCP\Files\External\Auth\AuthMechanism;
-use OCP\Files\External\Backend\Backend;
+use OCP\Files\External\Backend\Backend as ExternalBackend;
 use OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 
-class Google extends Backend {
+class Google extends ExternalBackend {
 
 	use LegacyDependencyCheckPolyfill;
 

--- a/apps/files_external/lib/Lib/Backend/Local.php
+++ b/apps/files_external/lib/Lib/Backend/Local.php
@@ -23,12 +23,12 @@
 namespace OCA\Files_External\Lib\Backend;
 
 use OCP\Files\External\Auth\AuthMechanism;
-use OCP\Files\External\Backend\Backend;
+use OCP\Files\External\Backend\Backend as ExternalBackend;
 use OCP\Files\External\DefinitionParameter;
 use OCP\Files\External\IStoragesBackendService;
 use OCP\IL10N;
 
-class Local extends Backend {
+class Local extends ExternalBackend {
 
 	public function __construct(IL10N $l) {
 		$this

--- a/apps/files_external/lib/Lib/Backend/OwnCloud.php
+++ b/apps/files_external/lib/Lib/Backend/OwnCloud.php
@@ -23,11 +23,11 @@
 namespace OCA\Files_External\Lib\Backend;
 
 use OCP\Files\External\Auth\AuthMechanism;
-use OCP\Files\External\Backend\Backend;
+use OCP\Files\External\Backend\Backend as ExternalBackend;
 use OCP\Files\External\DefinitionParameter;
 use OCP\IL10N;
 
-class OwnCloud extends Backend {
+class OwnCloud extends ExternalBackend {
 
 	public function __construct(IL10N $l) {
 		$this

--- a/apps/files_external/lib/Lib/Backend/SFTP.php
+++ b/apps/files_external/lib/Lib/Backend/SFTP.php
@@ -23,11 +23,11 @@
 namespace OCA\Files_External\Lib\Backend;
 
 use OCP\Files\External\Auth\AuthMechanism;
-use OCP\Files\External\Backend\Backend;
+use OCP\Files\External\Backend\Backend as ExternalBackend;
 use OCP\Files\External\DefinitionParameter;
 use OCP\IL10N;
 
-class SFTP extends Backend {
+class SFTP extends ExternalBackend {
 
 	public function __construct(IL10N $l) {
 		$this

--- a/apps/files_external/lib/Lib/Backend/SFTP_Key.php
+++ b/apps/files_external/lib/Lib/Backend/SFTP_Key.php
@@ -23,11 +23,11 @@
 namespace OCA\Files_External\Lib\Backend;
 
 use OCP\Files\External\Auth\AuthMechanism;
-use OCP\Files\External\Backend\Backend;
+use OCP\Files\External\Backend\Backend as ExternalBackend;
 use OCP\Files\External\DefinitionParameter;
 use OCP\IL10N;
 
-class SFTP_Key extends Backend {
+class SFTP_Key extends ExternalBackend {
 
 	public function __construct(IL10N $l, SFTP $sftpBackend) {
 		$this

--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -24,13 +24,13 @@ namespace OCA\Files_External\Lib\Backend;
 
 use OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 use OCP\Files\External\Auth\AuthMechanism;
-use OCP\Files\External\Backend\Backend;
+use OCP\Files\External\Backend\Backend as ExternalBackend;
 use OCP\Files\External\DefinitionParameter;
 use OCP\Files\External\IStorageConfig;
 use OCP\IL10N;
 use OCP\IUser;
 
-class SMB extends Backend {
+class SMB extends ExternalBackend {
 
 	use LegacyDependencyCheckPolyfill;
 

--- a/apps/files_external/lib/Lib/Backend/SMB_OC.php
+++ b/apps/files_external/lib/Lib/Backend/SMB_OC.php
@@ -24,7 +24,7 @@ namespace OCA\Files_External\Lib\Backend;
 
 use OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 use OCP\Files\External\Auth\AuthMechanism;
-use OCP\Files\External\Backend\Backend;
+use OCP\Files\External\Backend\Backend as ExternalBackend;
 use OCP\Files\External\DefinitionParameter;
 use OCP\Files\External\IStorageConfig;
 use OCP\Files\External\IStoragesBackendService;
@@ -34,7 +34,7 @@ use OCP\IUser;
 /**
  * Deprecated SMB_OC class - use SMB with the password::sessioncredentials auth mechanism
  */
-class SMB_OC extends Backend {
+class SMB_OC extends ExternalBackend {
 
 	use LegacyDependencyCheckPolyfill;
 

--- a/apps/files_external/lib/Lib/Backend/Swift.php
+++ b/apps/files_external/lib/Lib/Backend/Swift.php
@@ -24,11 +24,11 @@ namespace OCA\Files_External\Lib\Backend;
 
 use OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 use OCP\Files\External\Auth\AuthMechanism;
-use OCP\Files\External\Backend\Backend;
+use OCP\Files\External\Backend\Backend as ExternalBackend;
 use OCP\Files\External\DefinitionParameter;
 use OCP\IL10N;
 
-class Swift extends Backend {
+class Swift extends ExternalBackend {
 
 	use LegacyDependencyCheckPolyfill;
 

--- a/lib/private/Files/External/Service/UserStoragesService.php
+++ b/lib/private/Files/External/Service/UserStoragesService.php
@@ -27,6 +27,7 @@ namespace OC\Files\External\Service;
 use OC\Files\Filesystem;
 
 use OCP\Files\Config\IUserMountCache;
+use OCP\IUser;
 use OCP\IUserSession;
 
 use OCP\Files\External\IStorageConfig;
@@ -56,6 +57,7 @@ class UserStoragesService extends StoragesService implements IUserStoragesServic
 		IUserMountCache $userMountCache
 	) {
 		$this->userSession = $userSession;
+		$this->userMountCache = $userMountCache;
 		parent::__construct($backendService, $dbConfig, $userMountCache);
 	}
 
@@ -139,5 +141,23 @@ class UserStoragesService extends StoragesService implements IUserStoragesServic
 
 	protected function isApplicable(IStorageConfig $config) {
 		return ($config->getApplicableUsers() === [$this->getUser()->getUID()]) && $config->getType() === IStorageConfig::MOUNT_TYPE_PERSONAl;
+	}
+
+	/**
+	 * Deletes the storages mounted to a user
+	 * @param IUser $user
+	 * @return bool
+	 */
+	public function deleteAllMountsForUser(IUser $user) {
+		$getUserMounts = $this->userMountCache->getMountsForUser($user);
+		$result = false;
+		if (\count($getUserMounts) > 0) {
+			foreach ($getUserMounts as $userMount) {
+				$id = $userMount->getStorageId();
+				$this->userMountCache->removeUserStorageMount($id, $user->getUID());
+				$result = true;
+			}
+		}
+		return $result;
 	}
 }

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -43,7 +43,6 @@ use OCP\IConfig;
 use OCP\IUserBackend;
 use OCP\IUserSession;
 use OCP\User\IChangePasswordBackend;
-use OCP\UserInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -226,6 +225,11 @@ class User implements IUser {
 		}
 		// Delete the user's keys in preferences
 		\OC::$server->getConfig()->deleteAllUserValues($this->getUID());
+
+		// Delete all mount points for user
+		\OC::$server->getUserStoragesService()->deleteAllMountsForUser($this);
+		//Delete external storage or remove user from applicableUsers list
+		\OC::$server->getGlobalStoragesService()->deleteAllForUser($this);
 
 		// Delete user files in /data/
 		if ($homePath !== false) {

--- a/lib/public/Files/External/Service/IGlobalStoragesService.php
+++ b/lib/public/Files/External/Service/IGlobalStoragesService.php
@@ -35,4 +35,12 @@ interface IGlobalStoragesService extends IStoragesService {
 	 * @since 10.0
 	 */
 	public function getStorageForAllUsers();
+
+	/**
+	 * Deletes the external storages mounted to the user
+	 * @param \OCP\IUser $user
+	 * @return bool
+	 * @since 10.0.10
+	 */
+	public function deleteAllForUser($user);
 }

--- a/lib/public/Files/External/Service/IUserStoragesService.php
+++ b/lib/public/Files/External/Service/IUserStoragesService.php
@@ -28,5 +28,11 @@ namespace OCP\Files\External\Service;
  * @since 10.0
  */
 interface IUserStoragesService extends IStoragesService {
-
+	/**
+	 * Deletes the storages mounted to a user
+	 * @param \OCP\IUser $user
+	 * @return bool
+	 * @since 10.0.10
+	 */
+	public function deleteAllMountsForUser(\OCP\IUser $user);
 }

--- a/tests/lib/Files/External/Service/GlobalStoragesServiceDeleteUserTest.php
+++ b/tests/lib/Files/External/Service/GlobalStoragesServiceDeleteUserTest.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace Test\Files\External\Service;
+
+use OC\Files\Config\UserMountCache;
+use OC\Files\External\Service\DBConfigService;
+use OC\Files\External\Service\GlobalStoragesService;
+use OC\Files\External\StoragesBackendService;
+use OCA\Files_External\Lib\Backend\Backend;
+use OCP\IUser;
+use Test\TestCase;
+
+/**
+ * Class GlobalStoragesServiceDeleteUser
+ *
+ * @group DB
+ * @package Test\Files\External\Service
+ */
+class GlobalStoragesServiceDeleteUserTest extends TestCase {
+	public function setUp() {
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		//Remove all global storages created
+		$globalStorageService = \OC::$server->getGlobalStoragesService();
+		foreach ($globalStorageService->getAllStorages() as $storage) {
+			$storageId = $storage->getId();
+			$globalStorageService->removeStorage($storageId);
+		}
+	}
+
+	public function providesDeleteAllUser() {
+		return [
+			[
+				[
+					[
+						'applicableUsers' => ['user1', 'user2'],
+						'applicableGroups' => ['group1'],
+						'priority' => 12,
+						'authMechanism' => 'identifier:\Auth\Mechanism',
+						'storageClass' => 'OC\Files\Storage\DAV',
+						'backendIdentifier' => 'identifier:\Test\Files\External\Backend\DummyBackend',
+						'backendOptions' => [
+							'host' => 'http://localhost',
+							'root' => 'test',
+							'secure' => 'false',
+							'user' => 'foo',
+							'password' => 'foo'
+						]
+					],
+					[
+						'applicableUsers' => ['user1', 'user3'],
+						'applicableGroups' => [],
+						'priority' => 13,
+						'authMechanism' => 'identifier:\Auth\Mechanism',
+						'storageClass' => 'OC\Files\Storage\DAV',
+						'backendIdentifier' => 'identifier:\Test\Files\External\Backend\DummyBackend2',
+						'backendOptions' => [
+							'host' => 'http://localhost',
+							'root' => 'test1',
+							'secure' => 'false',
+							'user' => 'foo',
+							'password' => 'foo'
+						]
+					],
+					[
+						'applicableUsers' => ['user1', 'user4'],
+						'applicableGroups' => [],
+						'priority' => 14,
+						'storageClass' => 'OC\Files\Storage\DAV',
+						'authMechanism' => 'identifier:\Auth\Mechanism',
+						'backendIdentifier' => 'identifier:\Test\Files\External\Backend\DummyBackend2',
+						'backendOptions' => [
+							'host' => 'http://localhost',
+							'root' => 'test2',
+							'secure' => 'false',
+							'user' => 'foo',
+							'password' => 'foo'
+						]
+					],
+					//This storage shouldn't be available
+					[
+						'applicableUsers' => ['user1'],
+						'applicableGroups' => [],
+						'priority' => 15,
+						'authMechanism' => 'identifier:\Auth\Mechanism',
+						'storageClass' => 'OC\Files\Storage\DAV',
+						'backendIdentifier' => 'identifier:\Test\Files\External\Backend\DummyBackend2',
+						'backendOptions' => [
+							'host' => 'http://localhost',
+							'root' => 'test3',
+							'secure' => 'false',
+							'user' => 'foo',
+							'password' => 'foo'
+						]
+					],
+				], 'user1'
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider providesDeleteAllUser
+	 * @param $storageParams
+	 */
+	public function testDeleteAllForUser($storageParams, $userId) {
+		$backendService = new StoragesBackendService(\OC::$server->getConfig());
+		$dbConfigService = new DBConfigService(\OC::$server->getDatabaseConnection(), \OC::$server->getCrypto());
+		$userManager = \OC::$server->getUserManager();
+		$userMountCache = new UserMountCache(\OC::$server->getDatabaseConnection(), $userManager, \OC::$server->getLogger());
+		$service = new GlobalStoragesService($backendService, $dbConfigService, $userMountCache);
+
+		$storageIds = [];
+		foreach ($storageParams as $storageParam) {
+			$backend = new Backend();
+			$backend->setIdentifier($storageParam['backendIdentifier']);
+			$backendService->registerBackend($backend);
+			$storageConfig = $service->createStorage('/foo/',
+				$storageParam['backendIdentifier'], $storageParam['authMechanism'],
+				$storageParam['backendOptions'], null,
+				$storageParam['applicableUsers'], $storageParam['applicableGroups'],
+				$storageParam['priority']);
+			$storageConfig->setBackend($backend);
+			$backend->setStorageClass($storageParam['storageClass']);
+
+			$newStorage = $service->addStorage($storageConfig);
+			$storageIds[] = $newStorage->getId();
+		}
+
+		$user = $this->createMock(IUser::class);
+		$user->expects($this->once())
+			->method('getUID')
+			->willReturn($userId);
+
+		$this->assertTrue($service->deleteAllForUser($user));
+
+		$storages = $service->getStorages();
+		$newStorageIds = [];
+		foreach ($storages as $storage) {
+			$users = $storage->getApplicableUsers();
+			$this->assertFalse(\in_array($userId, $users, true));
+			$this->assertTrue(\in_array($storage->getId(), $storageIds, true));
+			$newStorageIds[] = $storage->getId();
+		}
+		$missingStorageId = \array_pop($storageIds);
+		$this->assertFalse(\in_array($missingStorageId, $newStorageIds, true));
+	}
+}


### PR DESCRIPTION
…e when user is deleted

Remove user from the storage if there are multiple
users associated with the storage during deletion
of the user. Else remove the storage when user is
deleted, since the storage is only associated with
the user being deleted.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Remove user from the external storage list when there are multiple users applicable users for the storage, during deletion of user. Else remove the storage as the user which is being deleted is the only storage associated with the user.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/30694

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change would help to clean up the external storage when a user is being deleted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create 2 users `admin` and `user1`
- As `admin` user, create 3 external storages SFTP ( as root at /tmp/a), SFTP1 ( root at /tmp/b), SFTP2 ( root at /tmp/c) and ownCloud
- SFTP is available for all users. No users are selected from drop down
- SFTP1 is available for `admin` and `user1`.
- SFTP2 is available for `user1` only.
- ownCloud is available `user1` and `admin`.
- Now delete `user1`.
- Create `user1` again.
- Only `SFTP` is available. This is because of `admin` configuration, as it is available to all users. Verified in the `Storages` section in the settings.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
