### PR TITLE
make sharing tests work correctly with ocs api v2

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -551,30 +551,44 @@ trait BasicStructure {
 	/**
 	 * @Then /^the OCS status code should be "([^"]*)"$/
 	 *
-	 * @param int $statusCode
+	 * @param int|int[] $statusCode
 	 * @param string $message
 	 *
 	 * @return void
 	 */
 	public function theOCSStatusCodeShouldBe($statusCode, $message = "") {
-		PHPUnit_Framework_Assert::assertEquals(
-			$statusCode, $this->getOCSResponseStatusCode($this->response),
-			$message
-		);
+		if (\is_array($statusCode)) {
+			PHPUnit_Framework_Assert::assertContains(
+				$this->getOCSResponseStatusCode($this->response), $statusCode,
+				$message
+			);
+		} else {
+			PHPUnit_Framework_Assert::assertEquals(
+				$statusCode, $this->getOCSResponseStatusCode($this->response),
+				$message
+			);
+		}
 	}
 
 	/**
 	 * @Then /^the HTTP status code should be "([^"]*)"$/
 	 *
-	 * @param int $statusCode
+	 * @param int|int[] $statusCode
 	 * @param string $message
 	 *
 	 * @return void
 	 */
 	public function theHTTPStatusCodeShouldBe($statusCode, $message = "") {
-		PHPUnit_Framework_Assert::assertEquals(
-			$statusCode, $this->response->getStatusCode(), $message
-		);
+		if (\is_array($statusCode)) {
+			PHPUnit_Framework_Assert::assertContains(
+				$this->response->getStatusCode(), $statusCode,
+				$message
+			);
+		} else {
+			PHPUnit_Framework_Assert::assertEquals(
+				$statusCode, $this->response->getStatusCode(), $message
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
this allows the sharing tests to work correctly with `v2.php`

## Related Issue
#32040

## Motivation and Context
`v2.php` does map the OCS status codes to the corresponding HTTP codes, so some expectation in the code does not work for `v2.php`

## How Has This Been Tested?
run some of the corresponding tests locally, :robot: will do the rest

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
