### PR TITLE
Move common scenarios in web dav to separate file

### DIFF
--- a/tests/acceptance/features/apiWebdav/webdav-related-new-endpoint.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related-new-endpoint.feature
@@ -2,12 +2,12 @@
 Feature: webdav-related-new-endpoint
 	Background:
 		Given using API version "1"
+		And using new DAV path
+		And user "user0" has been created
 
 	## Specific Scenario Outlines for new endpoint	
 
 	Scenario: Upload chunked file asc with new chunking
-		Given using new DAV path
-		And user "user0" has been created
 		When user "user0" uploads the following chunks to "/myChunkedFile.txt" with new chunking and using the API
 			| 1 | AAAAA |
 			| 2 | BBBBB |
@@ -16,8 +16,6 @@ Feature: webdav-related-new-endpoint
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file desc with new chunking
-		Given using new DAV path
-		And user "user0" has been created
 		When user "user0" uploads the following chunks to "/myChunkedFile.txt" with new chunking and using the API
 			| 3 | CCCCC |
 			| 2 | BBBBB |
@@ -26,8 +24,6 @@ Feature: webdav-related-new-endpoint
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file random with new chunking
-		Given using new DAV path
-		And user "user0" has been created
 		When user "user0" uploads the following chunks to "/myChunkedFile.txt" with new chunking and using the API
 			| 2 | BBBBB |
 			| 3 | CCCCC |
@@ -36,9 +32,7 @@ Feature: webdav-related-new-endpoint
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Checking file id after a move overwrite using new chunking endpoint
-		Given using new DAV path
-		And user "user0" has been created
-		And user "user0" has copied file "/textfile0.txt" to "/existingFile.txt"
+		Given user "user0" has copied file "/textfile0.txt" to "/existingFile.txt"
 		And user "user0" has stored id of file "/existingFile.txt"
 		When user "user0" uploads the following chunks to "/existingFile.txt" with new chunking and using the API
 			| 1 | AAAAA |
@@ -48,9 +42,7 @@ Feature: webdav-related-new-endpoint
 		And the content of file "/existingFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Checking file id after a move between received shares
-		Given using new DAV path
-		And user "user0" has been created
-		And user "user1" has been created
+		Given user "user1" has been created
 		And user "user0" has created a folder "/folderA"
 		And user "user0" has created a folder "/folderB"
 		And user "user0" has shared folder "/folderA" with user "user1"
@@ -71,22 +63,17 @@ Feature: webdav-related-new-endpoint
 
 	Scenario: New chunked upload MKDIR using old DAV path should fail
 		Given using old DAV path
-		And user "user0" has been created
 		When user "user0" creates a new chunking upload with id "chunking-42" using the API
 		Then the HTTP status code should be "409"
 
 	Scenario: New chunked upload PUT using old DAV path should fail
-		Given using new DAV path
-		And user "user0" has been created
-		And user "user0" has created a new chunking upload with id "chunking-42"
+		Given user "user0" has created a new chunking upload with id "chunking-42"
 		When using old DAV path
 		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the API
 		Then the HTTP status code should be "404"
 
 	Scenario: New chunked upload MOVE using old DAV path should fail
-		Given using new DAV path
-		And user "user0" has been created
-		And user "user0" has created a new chunking upload with id "chunking-42"
+		Given user "user0" has created a new chunking upload with id "chunking-42"
 		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
 		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
 		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
@@ -95,15 +82,11 @@ Feature: webdav-related-new-endpoint
 		Then the HTTP status code should be "404"
 
 	Scenario: Upload to new dav path using old way should fail
-		Given using new DAV path
-		And user "user0" has been created
 		When user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt" using the API
 		Then the HTTP status code should be "503"
 
 	Scenario: Upload file via new chunking endpoint with wrong size header
-		Given using new DAV path
-		And user "user0" has been created
-		And user "user0" has created a new chunking upload with id "chunking-42"
+		Given user "user0" has created a new chunking upload with id "chunking-42"
 		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
 		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
 		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
@@ -111,9 +94,7 @@ Feature: webdav-related-new-endpoint
 		Then the HTTP status code should be "400"
 
 	Scenario: Upload file via new chunking endpoint with correct size header
-		Given using new DAV path
-		And user "user0" has been created
-		And user "user0" has created a new chunking upload with id "chunking-42"
+		Given user "user0" has created a new chunking upload with id "chunking-42"
 		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
 		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
 		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
@@ -123,8 +104,6 @@ Feature: webdav-related-new-endpoint
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario Outline: Upload files with difficult names using new chunking
-		Given using new DAV path
-		And user "user0" has been created
 		When user "user0" creates a new chunking upload with id "chunking-42" using the API
 		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the API
 		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
@@ -140,8 +119,6 @@ Feature: webdav-related-new-endpoint
 	#this test should be integrated into the previous Scenario after fixing the issue
 	@skip @issue-29599
 	Scenario: Upload a file called "0" using new chunking
-		Given using new DAV path
-		And user "user0" has been created
 		When user "user0" creates a new chunking upload with id "chunking-42" using the API
 		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the API
 		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
@@ -149,47 +126,3 @@ Feature: webdav-related-new-endpoint
 		And user "user0" moves new chunk file with id "chunking-42" to "/0" using the API
 		And as "user0" the file "/0" should exist
 		And the content of file "/0" for user "user0" should be "AAAAABBBBBCCCCC"
-
-	Scenario: Retrieving private link
-		Given using new DAV path
-		And user "user0" has been created
-		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
-		When user "user0" gets the following properties of file "/somefile.txt" using the API
-			|{http://owncloud.org/ns}privatelink|
-		Then the single response should contain a property "{http://owncloud.org/ns}privatelink" with value like "%(/(index.php/)?f/[0-9]*)%"
-
-	Scenario: Copying file to a path with extension .part should not be possible
-		Given using new DAV path
-		And user "user0" has been created
-		When user "user0" copies file "/welcome.txt" to "/welcome.part" using the API
-		Then the HTTP status code should be "400"
-		And user "user0" should see the following elements
-			| /welcome.txt |
-		But user "user0" should not see the following elements
-			| /welcome.part |
-
-	Scenario: Uploading file to path with extension .part should not be possible
-		Given using new DAV path
-		And user "user0" has been created
-		When user "user0" uploads file "data/textfile.txt" to "/textfile.part" using the API
-		Then the HTTP status code should be "400"
-		And user "user0" should not see the following elements
-			| /textfile.part |
-
-	Scenario: Renaming a file to a path with extension .part should not be possible
-		Given using new DAV path
-		And user "user0" has been created
-		When user "user0" moves file "/welcome.txt" to "/welcome.part" using the API
-		Then the HTTP status code should be "400"
-		And user "user0" should see the following elements
-			| /welcome.txt |
-		But user "user0" should not see the following elements
-			| /welcome.part |
-
-	Scenario: Creating a directory which contains .part should not be possible
-		Given using new DAV path
-		And user "user0" has been created
-		When user "user0" creates a folder "/folder.with.ext.part" using the API
-		Then the HTTP status code should be "400"
-		And user "user0" should not see the following elements
-			| /folder.with.ext.part |

--- a/tests/acceptance/features/apiWebdav/webdav-related-old-endpoint.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related-old-endpoint.feature
@@ -2,11 +2,11 @@
 Feature: webdav-related-old-endpoint
 	Background:
 		Given using API version "1"
+		And using old DAV path
+		And user "user0" has been created
 
 	Scenario: Setting custom DAV property using an old endpoint and reading it using a new endpoint
-		Given using old DAV path
-		And user "user0" has been created
-		And user "user0" has uploaded file "data/textfile.txt" to "/testoldnew.txt"
+		Given user "user0" has uploaded file "data/textfile.txt" to "/testoldnew.txt"
 		And user "user0" has set property "{http://whatever.org/ns}very-custom-prop" of file "/testoldnew.txt" to "constant"
 		And using new DAV path
 		When user "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testoldnew.txt"
@@ -15,7 +15,6 @@ Feature: webdav-related-old-endpoint
 	### Scenarios specific to old endpoint
 
 	Scenario: Upload chunked file asc
-		Given user "user0" has been created
 		When user "user0" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the API
 			| 1 | AAAAA |
 			| 2 | BBBBB |
@@ -24,7 +23,6 @@ Feature: webdav-related-old-endpoint
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file desc
-		Given user "user0" has been created
 		When user "user0" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the API
 			| 3 | CCCCC |
 			| 2 | BBBBB |
@@ -33,7 +31,6 @@ Feature: webdav-related-old-endpoint
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file random
-		Given user "user0" has been created
 		When user "user0" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the API
 			| 2 | BBBBB |
 			| 3 | CCCCC |
@@ -42,7 +39,6 @@ Feature: webdav-related-old-endpoint
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario Outline: Chunked upload files with difficult name
-		Given user "user0" has been created
 		When user "user0" uploads the following "3" chunks to "/<file-name>" with old chunking and using the API
 			| 1 | AAAAA |
 			| 2 | BBBBB |
@@ -54,68 +50,3 @@ Feature: webdav-related-old-endpoint
 			| 0         |
 			| &#?       |
 			| TIÄFÜ     |
-
-	Scenario: Checking file id after a move between received shares
-		Given using old DAV path
-		And user "user0" has been created
-		And user "user1" has been created
-		And user "user0" has created a folder "/folderA"
-		And user "user0" has created a folder "/folderB"
-		And user "user0" has shared folder "/folderA" with user "user1"
-		And user "user0" has shared folder "/folderB" with user "user1"
-		And user "user1" has created a folder "/folderA/ONE"
-		And user "user1" has stored id of file "/folderA/ONE"
-		And user "user1" has created a folder "/folderA/ONE/TWO"
-		When user "user1" moves folder "/folderA/ONE" to "/folderB/ONE" using the API
-		Then as "user1" the folder "/folderA" should exist
-		And as "user1" the folder "/folderA/ONE" should not exist
-		# yes, a weird bug used to make this one fail
-		And as "user1" the folder "/folderA/ONE/TWO" should not exist
-		And as "user1" the folder "/folderB/ONE" should exist
-		And as "user1" the folder "/folderB/ONE/TWO" should exist
-		And user "user1" file "/folderB/ONE" should have the previously stored id
-
-	Scenario: Retrieving private link
-		Given using old DAV path
-		And user "user0" has been created
-		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
-		When user "user0" gets the following properties of file "/somefile.txt" using the API
-			|{http://owncloud.org/ns}privatelink|
-		Then the single response should contain a property "{http://owncloud.org/ns}privatelink" with value like "%(/(index.php/)?f/[0-9]*)%"
-
-	Scenario: Copying file to a path with extension .part should not be possible
-		Given using old DAV path
-		And user "user0" has been created
-		When user "user0" copies file "/welcome.txt" to "/welcome.part" using the API
-		Then the HTTP status code should be "400"
-		And user "user0" should see the following elements
-			| /welcome.txt |
-		But user "user0" should not see the following elements
-			| /welcome.part |
-
-	Scenario: Uploading file to path with extension .part should not be possible
-		Given using old DAV path
-		And user "user0" has been created
-		And user "user0" has uploaded file "data/textfile.txt" to "/textfile.part"
-		Then the HTTP status code should be "400"
-		And user "user0" should not see the following elements
-			| /textfile.part |
-
-	Scenario: Renaming a file to a path with extension .part should not be possible
-		Given using old DAV path
-		And user "user0" has been created
-		When user "user0" moves file "/welcome.txt" to "/welcome.part" using the API
-		Then the HTTP status code should be "400"
-		And user "user0" should see the following elements
-			| /welcome.txt |
-		But user "user0" should not see the following elements
-			| /welcome.part |
-
-	Scenario: Creating a directory which contains .part should not be possible
-		Given using new DAV path
-		And user "user0" has been created
-		When user "user0" creates a folder "/folder.with.ext.part" using the API
-		Then the HTTP status code should be "400"
-		And user "user0" should not see the following elements
-			| /folder.with.ext.part |
-

--- a/tests/acceptance/features/apiWebdav/webdav-related.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related.feature
@@ -751,3 +751,155 @@ Feature: webdav-related
 		| action_dav_version | other_dav_version |
 		| old                | new               |
 		| new                | old               |
+
+	Scenario Outline: Checking file id after a move between received shares
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		And user "user1" has been created
+		And user "user0" has created a folder "/folderA"
+		And user "user0" has created a folder "/folderB"
+		And user "user0" has shared folder "/folderA" with user "user1"
+		And user "user0" has shared folder "/folderB" with user "user1"
+		And user "user1" has created a folder "/folderA/ONE"
+		And user "user1" has stored id of file "/folderA/ONE"
+		And user "user1" has created a folder "/folderA/ONE/TWO"
+		When user "user1" moves folder "/folderA/ONE" to "/folderB/ONE" using the API
+		Then as "user1" the folder "/folderA" should exist
+		And as "user1" the folder "/folderA/ONE" should not exist
+		# yes, a weird bug used to make this one fail
+		And as "user1" the folder "/folderA/ONE/TWO" should not exist
+		And as "user1" the folder "/folderB/ONE" should exist
+		And as "user1" the folder "/folderB/ONE/TWO" should exist
+		And user "user1" file "/folderB/ONE" should have the previously stored id
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
+	Scenario Outline: Retrieving private link
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
+		When user "user0" gets the following properties of file "/somefile.txt" using the API
+			|{http://owncloud.org/ns}privatelink|
+		Then the single response should contain a property "{http://owncloud.org/ns}privatelink" with value like "%(/(index.php/)?f/[0-9]*)%"
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
+	Scenario Outline: Copying file to a path with extension .part should not be possible
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		When user "user0" copies file "/welcome.txt" to "/welcome.part" using the API
+		Then the HTTP status code should be "400"
+		And user "user0" should see the following elements
+			| /welcome.txt |
+		But user "user0" should not see the following elements
+			| /welcome.part |
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
+	Scenario Outline: Uploading file to path with extension .part should not be possible
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/textfile.part"
+		Then the HTTP status code should be "400"
+		And user "user0" should not see the following elements
+			| /textfile.part |
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
+	Scenario Outline: Renaming a file to a path with extension .part should not be possible
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/welcome.part" using the API
+		Then the HTTP status code should be "400"
+		And user "user0" should see the following elements
+			| /welcome.txt |
+		But user "user0" should not see the following elements
+			| /welcome.part |
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
+	Scenario Outline: Creating a directory which contains .part should not be possible
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		When user "user0" creates a folder "/folder.with.ext.part" using the API
+		Then the HTTP status code should be "400"
+		And user "user0" should not see the following elements
+			| /folder.with.ext.part |
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
+	Scenario Outline: Retrieving private link
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
+		When user "user0" gets the following properties of file "/somefile.txt" using the API
+			|{http://owncloud.org/ns}privatelink|
+		Then the single response should contain a property "{http://owncloud.org/ns}privatelink" with value like "%(/(index.php/)?f/[0-9]*)%"
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
+	Scenario Outline: Copying file to a path with extension .part should not be possible
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		When user "user0" copies file "/welcome.txt" to "/welcome.part" using the API
+		Then the HTTP status code should be "400"
+		And user "user0" should see the following elements
+			| /welcome.txt |
+		But user "user0" should not see the following elements
+			| /welcome.part |
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
+	Scenario Outline: Uploading file to path with extension .part should not be possible
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		When user "user0" uploads file "data/textfile.txt" to "/textfile.part" using the API
+		Then the HTTP status code should be "400"
+		And user "user0" should not see the following elements
+			| /textfile.part |
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
+	Scenario Outline: Renaming a file to a path with extension .part should not be possible
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/welcome.txt" to "/welcome.part" using the API
+		Then the HTTP status code should be "400"
+		And user "user0" should see the following elements
+			| /welcome.txt |
+		But user "user0" should not see the following elements
+			| /welcome.part |
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
+	Scenario Outline: Creating a directory which contains .part should not be possible
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		When user "user0" creates a folder "/folder.with.ext.part" using the API
+		Then the HTTP status code should be "400"
+		And user "user0" should not see the following elements
+			| /folder.with.ext.part |
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |


### PR DESCRIPTION
## Description
Some scenarios which work for both old and new webDAV are moved to separate file.

## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Acceptance test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.