### PR TITLE
[stable10] FileTest::testPutWithModifyRun is testing a wrong behavior

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -223,6 +223,10 @@ class File extends Node implements IFile, IFileNode {
 			$view = \OC\Files\Filesystem::getView();
 			if ($view) {
 				$run = $this->emitPreHooks($exists);
+				if ($run === false) {
+					$view->unlockFile($this->path, ILockingProvider::LOCK_SHARED);
+					return null;
+				}
 			} else {
 				$run = true;
 			}

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -183,7 +183,7 @@ class File extends Node implements IFile, IFileNode {
 		list($storage, $internalPath) = $this->fileView->resolvePath($this->path);
 		try {
 			$target = $partStorage->fopen($internalPartPath, 'wb');
-			if ($target === false) {
+			if (!\is_resource($target)) {
 				\OCP\Util::writeLog('webdav', '\OC\Files\Filesystem::fopen() failed', \OCP\Util::ERROR);
 				// because we have no clue about the cause we can only throw back a 500/Internal Server Error
 				throw new Exception('Could not write file contents');

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -296,8 +296,6 @@ class FileTest extends TestCase {
 	 * value in the listener. Once it is modified check the exception returned
 	 * from main function. The reason for exception is put from Sabre/File.php
 	 * throws exception
-	 *
-	 * @expectedException \Sabre\DAV\Exception
 	 */
 	public function testPutWithModifyRun() {
 		$calledUploadAllowed = [];
@@ -312,6 +310,8 @@ class FileTest extends TestCase {
 			->setMethods(['fopen'])
 			->setConstructorArgs([['datadir' => \OC::$server->getTempManager()->getTemporaryFolder()]])
 			->getMock();
+		$storage->method('fopen')
+			->willReturn($this->getStream('qwertz'));
 		Filesystem::mount($storage, [], $this->user . '/');
 		/** @var View | \PHPUnit_Framework_MockObject_MockObject $view */
 		$view = $this->getMockBuilder(View::class)
@@ -337,7 +337,7 @@ class FileTest extends TestCase {
 
 		$file = new File($view, $info);
 
-		$file->put('test data');
+		$file->put($this->getStream('test data'));
 
 		$this->assertInstanceOf(GenericEvent::class, $calledUploadAllowed[1]);
 		$this->assertArrayHasKey('run', $calledUploadAllowed[1]);


### PR DESCRIPTION
## Description
Due to the (as I assume) false annotation about the expected exception the real desired functionality is not tested (as show it is not working)

## How Has This Been Tested?
Run unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
