### PR TITLE
files:scan add number of items per second on printed result table

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -429,7 +429,7 @@ class Scan extends Base {
 		$output->writeln("");
 
 		$headers = [
-			'Folders', 'Files', 'Elapsed time'
+			'Folders', 'Files', 'Elapsed time', 'Items per second'
 		];
 
 		$this->showSummary($headers, null, $output);
@@ -444,11 +444,13 @@ class Scan extends Base {
 	 */
 	protected function showSummary($headers, $rows, OutputInterface $output) {
 		$niceDate = $this->formatExecTime();
+		$itemsPerSecond = $this->getItemsPerSecond();
 		if (!$rows) {
 			$rows = [
 				$this->foldersCounter,
 				$this->filesCounter,
 				$niceDate,
+				$itemsPerSecond
 			];
 		}
 		$table = new Table($output);
@@ -456,6 +458,22 @@ class Scan extends Base {
 			->setHeaders($headers)
 			->setRows([$rows]);
 		$table->render();
+	}
+
+	/**
+	 * Get items per second processed, no fractions
+	 *
+	 * @return string
+	 */
+	protected function getItemsPerSecond() {
+		$items = $this->foldersCounter + $this->filesCounter;
+		if ($this->execTime === 0) {
+			// catch div by 0
+			$itemsPerSecond = 0;
+		} else {
+			$itemsPerSecond = $items / $this->execTime;
+		}
+		return \sprintf("%.0f", $itemsPerSecond);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR adds to the table printout of files:scan the items per second processed

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #32085 ([Feature Request] Improve console output for files scan command)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prints a calculated performance.
Note: on low number of seconds the result may differ a bit because fractions of a second are calculated but only seconds are shown in the table

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
sudo -uwww-data ./occ files:scan --path="user_1/files/mount_folder_1"

Scanning files for 1 users
Starting scan for user 1 out of 1 (user_1)

+---------+-------+--------------+------------------+
| Folders | Files | Elapsed time | Items per second |
+---------+-------+--------------+------------------+
| 60      | 863   | 00:00:06     | 149              |
+---------+-------+--------------+------------------+

sudo -uwww-data ./occ files:scan --path="user_1/files/mount_folder_2"

Scanning files for 1 users
Starting scan for user 1 out of 1 (user_1)

+---------+-------+--------------+------------------+
| Folders | Files | Elapsed time | Items per second |
+---------+-------+--------------+------------------+
| 1027    | 14903 | 00:02:57     | 169              |
+---------+-------+--------------+------------------+
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
