### PR TITLE
allow the public to upload a file from source in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -429,6 +429,19 @@ trait Sharing {
 	}
 
 	/**
+	 * @When the public uploads file ":filename" using the API
+	 * @Given the public has uploaded file ":filename"
+	 *
+	 * @param string $source target file name
+	 *
+	 * @return void
+	 */
+	public function publiclyUploadingFile($source) {
+		$file = \GuzzleHttp\Stream\Stream::factory(\fopen($source, 'r'));
+		$this->publicUploadContent(\basename($source), '', $file->getContents());
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" should not be able to create public share of (?:file|folder) "([^"]*)" using the API$/
 	 *
 	 * @param string $sharer


### PR DESCRIPTION
## Description
step to be able to upload a file from the filesystem as "public upload" in acceptance tests

## Related Issue
https://github.com/owncloud/files_antivirus/issues/228

## Motivation and Context
in the antivirus tests we want to try upload a virus file

## How Has This Been Tested?
made tests that using this step

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
