### PR TITLE
allow public uploads to fail when expected

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -450,17 +450,16 @@ trait Sharing {
 	 * @return void
 	 */
 	public function publiclyUploadingShouldNotWork() {
-		try {
-			$this->publicUploadContent('whateverfilefortesting.txt', '', 'test');
-			PHPUnit_Framework_Assert::fail('Publicly uploading must fail');
-		} catch (BadResponseException $e) {
-			// expected
-			PHPUnit_Framework_Assert::assertTrue(
-				($e->getCode() == 507) || (($e->getCode() >= 400) && ($e->getCode() <= 499)),
-				"upload should have failed but passed with code" . $e->getCode()
-			);
-			$this->response = $e->getResponse();
-		}
+		$this->publicUploadContent('whateverfilefortesting.txt', '', 'test');
+
+		PHPUnit_Framework_Assert::assertTrue(
+			($this->response->getStatusCode() == 507)
+			|| (
+				($this->response->getStatusCode() >= 400)
+				&& ($this->response->getStatusCode() <= 499)
+			),
+			"upload should have failed but passed with code " . $this->response->getStatusCode()
+		);
 	}
 
 	/**
@@ -492,18 +491,14 @@ trait Sharing {
 		}
 
 		$client = new Client();
-		$this->response = $client->send(
-			$client->createRequest('PUT', $url, $options)
-		);
-		if ($overwriting) {
-			$expectedStatus = 204;
-		} else {
-			$expectedStatus = 201;
+		try {
+			$this->response = $client->send(
+				$client->createRequest('PUT', $url, $options)
+			);
+		} catch (BadResponseException $e) {
+			// 4xx and 5xx responses cause an exception
+			$this->response = $e->getResponse();
 		}
-		PHPUnit_Framework_Assert::assertEquals(
-			$expectedStatus,
-			$this->response->getStatusCode()
-		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
the expected status code should not be checked in `publicUploadContent()` because:
1. this function is mostly called by When and Given steps
2. it does limit the usability
3. every scenario that cares about the status code should check it in a Then step

So its better to catch the bad codes there and to set `$this->response`, the way its done in other places also

## Motivation and Context
make the function be more general and more useful

## How Has This Been Tested?
made antivirus tests where public uploads should not be possible

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
