### PR TITLE
Bugfix/sanitize path on node api

### DIFF
--- a/lib/private/Files/Node/File.php
+++ b/lib/private/Files/Node/File.php
@@ -112,17 +112,17 @@ class File extends Node implements \OCP\Files\File, IPreviewNode {
 	}
 
 	public function delete() {
-		if ($this->checkPermissions(\OCP\Constants::PERMISSION_DELETE)) {
-			$this->sendHooks(['preDelete']);
-			$fileInfo = $this->getFileInfo();
-			$this->view->unlink($this->path);
-			$nonExisting = new NonExistingFile($this->root, $this->view, $this->path, $fileInfo);
-			$this->root->emit('\OC\Files', 'postDelete', [$nonExisting]);
-			$this->exists = false;
-			$this->fileInfo = null;
-		} else {
+		if (!$this->checkPermissions(\OCP\Constants::PERMISSION_DELETE)) {
 			throw new NotPermittedException();
 		}
+
+		$this->sendHooks(['preDelete']);
+		$fileInfo = $this->getFileInfo();
+		$this->view->unlink($this->path);
+		$nonExisting = new NonExistingFile($this->root, $this->view, $this->path, $fileInfo);
+		$this->root->emit('\OC\Files', 'postDelete', [$nonExisting]);
+		$this->exists = false;
+		$this->fileInfo = null;
 	}
 
 	/**

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -104,8 +104,10 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @param string $path
 	 * @param FileInfo $info
 	 * @return File|Folder
+	 * @throws \OCP\Files\InvalidPathException
 	 */
 	protected function createNode($path, FileInfo $info = null) {
+		$this->view->verifyPath($this->path, $path);
 		if ($info === null) {
 			$isDir = $this->view->is_dir($path);
 		} else {
@@ -145,10 +147,12 @@ class Folder extends Node implements \OCP\Files\Folder {
 	/**
 	 * @param string $path
 	 * @return \OC\Files\Node\Folder
-	 * @throws \OCP\Files\NotPermittedException
+	 * @throws NotPermittedException
+	 * @throws \OCP\Files\InvalidPathException
 	 */
 	public function newFolder($path) {
 		if ($this->checkPermissions(\OCP\Constants::PERMISSION_CREATE)) {
+			$this->view->verifyPath($this->path, $path);
 			$fullPath = $this->getFullPath($path);
 			$nonExisting = new NonExistingFolder($this->root, $this->view, $fullPath);
 			$this->root->emit('\OC\Files', 'preWrite', [$nonExisting]);
@@ -158,18 +162,20 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$this->root->emit('\OC\Files', 'postWrite', [$node]);
 			$this->root->emit('\OC\Files', 'postCreate', [$node]);
 			return $node;
-		} else {
-			throw new NotPermittedException('No create permission for folder ' . $this->getFullPath($path));
 		}
+
+		throw new NotPermittedException('No create permission for folder ' . $this->getFullPath($path));
 	}
 
 	/**
 	 * @param string $path
 	 * @return \OC\Files\Node\File
 	 * @throws \OCP\Files\NotPermittedException
+	 * @throws \OCP\Files\InvalidPathException
 	 */
 	public function newFile($path) {
 		if ($this->checkPermissions(\OCP\Constants::PERMISSION_CREATE)) {
+			$this->view->verifyPath($this->path, $path);
 			$fullPath = $this->getFullPath($path);
 			$nonExisting = new NonExistingFile($this->root, $this->view, $fullPath);
 			$this->root->emit('\OC\Files', 'preWrite', [$nonExisting]);
@@ -179,9 +185,9 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$this->root->emit('\OC\Files', 'postWrite', [$node]);
 			$this->root->emit('\OC\Files', 'postCreate', [$node]);
 			return $node;
-		} else {
-			throw new NotPermittedException('No create permission for path ' . $this->getFullPath($path));
 		}
+
+		throw new NotPermittedException('No create permission for path ' . $this->getFullPath($path));
 	}
 
 	/**

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -928,6 +928,8 @@ class View {
 						$this->emit_file_hooks_pre($exists, $path2, $run);
 					}
 					if ($run) {
+						$this->verifyPath(\dirname($path2), \basename($path2));
+
 						$mount1 = $this->getMount($path1);
 						$mount2 = $this->getMount($path2);
 						$storage1 = $mount1->getStorage();

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -14,7 +14,15 @@ use OC\Files\Mount\MountPoint;
 use OC\Files\Node\Folder;
 use OC\Files\Node\Node;
 use OCP\Constants;
+use OCP\Files\InvalidPathException;
 use OCP\Files\NotFoundException;
+use OC\Files\Node\Root;
+use OC\Files\View;
+use OC\Files\Mount\Manager;
+use OC\Files\Storage\Storage;
+use OCP\Files\Mount\IMountPoint;
+use OC\Files\Node\File;
+use OC\Files\Node\NonExistingFolder;
 
 /**
  * Class FolderTest
@@ -25,20 +33,20 @@ use OCP\Files\NotFoundException;
  */
 class FolderTest extends NodeTest {
 	public $viewDeleteMethod = 'rmdir';
-	public $nodeClass = '\OC\Files\Node\Folder';
-	public $nonExistingNodeClass = '\OC\Files\Node\NonExistingFolder';
+	public $nodeClass = Folder::class;
+	public $nonExistingNodeClass = NonExistingFolder::class;
 
 	protected function createTestNode($root, $view, $path) {
-		return new \OC\Files\Node\Folder($root, $view, $path);
+		return new Folder($root, $view, $path);
 	}
 
 	public function testGetDirectoryContent() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
@@ -56,8 +64,8 @@ class FolderTest extends NodeTest {
 		$node = new Folder($root, $view, '/bar/foo');
 		$children = $node->getDirectoryListing();
 		$this->assertCount(2, $children);
-		$this->assertInstanceOf('\OC\Files\Node\File', $children[0]);
-		$this->assertInstanceOf('\OC\Files\Node\Folder', $children[1]);
+		$this->assertInstanceOf(File::class, $children[0]);
+		$this->assertInstanceOf(Folder::class, $children[1]);
 		$this->assertEquals('asd', $children[0]->getName());
 		$this->assertEquals('qwerty', $children[1]->getName());
 		$this->assertEquals(2, $children[0]->getId());
@@ -65,12 +73,12 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testGet() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
@@ -86,12 +94,12 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testNodeExists() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
@@ -110,12 +118,12 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testNodeExistsNotExists() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
@@ -132,12 +140,12 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testNewFolder() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
@@ -156,7 +164,7 @@ class FolderTest extends NodeTest {
 
 		$node = new Folder($root, $view, '/bar/foo');
 		$child = new Folder($root, $view, '/bar/foo/asd');
-		$result = $node->newFolder('asd');
+		$result = $node->newFolder("as\td");
 		$this->assertEquals($child, $result);
 	}
 
@@ -164,12 +172,12 @@ class FolderTest extends NodeTest {
 	 * @expectedException \OCP\Files\NotPermittedException
 	 */
 	public function testNewFolderNotPermitted() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
@@ -186,12 +194,12 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testNewFile() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
@@ -218,12 +226,12 @@ class FolderTest extends NodeTest {
 	 * @expectedException \OCP\Files\NotPermittedException
 	 */
 	public function testNewFileNotPermitted() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
@@ -240,12 +248,12 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testGetFreeSpace() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
@@ -262,19 +270,19 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testSearch() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->createMock('\OC\Files\Storage\Storage');
-		$cache = $this->getMockBuilder('\OC\Files\Cache\Cache')
+		$storage = $this->createMock(Storage::class);
+		$cache = $this->getMockBuilder(Cache::class)
 			->setConstructorArgs([''])
 			->getMock();
 
@@ -282,7 +290,7 @@ class FolderTest extends NodeTest {
 			->method('getCache')
 			->will($this->returnValue($cache));
 
-		$mount = $this->createMock('\OCP\Files\Mount\IMountPoint');
+		$mount = $this->createMock(IMountPoint::class);
 		$mount->expects($this->once())
 			->method('getStorage')
 			->will($this->returnValue($storage));
@@ -314,12 +322,12 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testSearchInRoot() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setMethods(['getUser', 'getMountsIn', 'getMount'])
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
@@ -327,12 +335,12 @@ class FolderTest extends NodeTest {
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->createMock('\OC\Files\Storage\Storage');
-		$cache = $this->getMockBuilder('\OC\Files\Cache\Cache')
+		$storage = $this->createMock(Storage::class);
+		$cache = $this->getMockBuilder(Cache::class)
 			->setConstructorArgs([''])
 			->getMock();
 
-		$mount = $this->createMock('\OCP\Files\Mount\IMountPoint');
+		$mount = $this->createMock(IMountPoint::class);
 		$mount->expects($this->once())
 			->method('getStorage')
 			->will($this->returnValue($storage));
@@ -368,21 +376,21 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testSearchInStorageRoot() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->createMock('\OC\Files\Storage\Storage');
+		$storage = $this->createMock(Storage::class);
 		$cache = $this->createMock(Cache::class);
 
-		$mount = $this->createMock('\OCP\Files\Mount\IMountPoint');
+		$mount = $this->createMock(IMountPoint::class);
 		$mount->expects($this->once())
 			->method('getStorage')
 			->will($this->returnValue($storage));
@@ -418,22 +426,22 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testSearchByTag() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setMethods(['getUser', 'getMountsIn', 'getMount'])
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->createMock('\OC\Files\Storage\Storage');
+		$storage = $this->createMock(Storage::class);
 		$cache = $this->createMock(Cache::class);
 
-		$mount = $this->createMock('\OCP\Files\Mount\IMountPoint');
+		$mount = $this->createMock(IMountPoint::class);
 		$mount->expects($this->once())
 			->method('getStorage')
 			->will($this->returnValue($storage));
@@ -469,25 +477,25 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testSearchSubStorages() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setMethods(['getUser', 'getMountsIn', 'getMount'])
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->createMock('\OC\Files\Storage\Storage');
+		$storage = $this->createMock(Storage::class);
 		$cache = $this->createMock(Cache::class);
 		$subCache = $this->createMock(Cache::class);
-		$subStorage = $this->createMock('\OC\Files\Storage\Storage');
-		$subMount = $this->createMock('\OC\Files\Mount\MountPoint', [], [null, '']);
+		$subStorage = $this->createMock(Storage::class);
+		$subMount = $this->createMock(MountPoint::class);
 
-		$mount = $this->createMock('\OCP\Files\Mount\IMountPoint');
+		$mount = $this->createMock(IMountPoint::class);
 		$mount->expects($this->once())
 			->method('getStorage')
 			->will($this->returnValue($storage));
@@ -551,12 +559,12 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testGetById() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setMethods(['getUser', 'getMountsIn', 'getMount'])
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
@@ -564,7 +572,7 @@ class FolderTest extends NodeTest {
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->createMock('\OC\Files\Storage\Storage');
+		$storage = $this->createMock(Storage::class);
 		$mount = new MountPoint($storage, '/bar');
 		$cache = $this->createMock(Cache::class);
 
@@ -598,19 +606,19 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testGetByIdOutsideFolder() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setMethods(['getUser', 'getMountsIn', 'getMount'])
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->createMock('\OC\Files\Storage\Storage');
+		$storage = $this->createMock(Storage::class);
 		$mount = new MountPoint($storage, '/bar');
 		$cache = $this->createMock(Cache::class);
 
@@ -639,19 +647,19 @@ class FolderTest extends NodeTest {
 	}
 
 	public function testGetByIdMultipleStorages() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setMethods(['getUser', 'getMountsIn', 'getMount'])
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 		$root->expects($this->any())
 			->method('getUser')
 			->will($this->returnValue($this->user));
-		$storage = $this->createMock('\OC\Files\Storage\Storage');
+		$storage = $this->createMock(Storage::class);
 		$mount1 = new MountPoint($storage, '/bar');
 		$mount2 = new MountPoint($storage, '/bar/foo/asd');
 		$cache = $this->createMock(Cache::class);
@@ -697,15 +705,19 @@ class FolderTest extends NodeTest {
 
 	/**
 	 * @dataProvider uniqueNameProvider
+	 * @param $name
+	 * @param $existingFiles
+	 * @param $expected
+	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function testGetUniqueName($name, $existingFiles, $expected) {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+		$manager = $this->createMock(Manager::class);
 		$folderPath = '/bar/foo';
 		/**
 		 * @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setMethods(['getUser', 'getMountsIn', 'getMount'])
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
@@ -723,5 +735,26 @@ class FolderTest extends NodeTest {
 
 		$node = new Folder($root, $view, $folderPath);
 		$this->assertEquals($expected, $node->getNonExistingName($name));
+	}
+
+	/**
+	 * @expectedException \OCP\Files\InvalidPathException
+	 */
+	public function testInvalidFolderName() {
+		$view = $this->createMock(View::class);
+		$root = $this->createMock(Root::class);
+		$fileInfo = $this->createMock(FileInfo::class);
+		$fileInfo->method('getPermissions')
+			->willReturn(Constants::PERMISSION_ALL);
+
+		$view
+			->method('getFileInfo')
+			->willReturn($fileInfo);
+		$view->expects(self::once())
+			->method('verifyPath')
+			->willThrowException(new InvalidPathException());
+
+		$node = new Folder($root, $view, '/file');
+		$node->newFile("ab\tcd");
 	}
 }


### PR DESCRIPTION
## Description
Path verification on node api methods was completly missing.

## How Has This Been Tested?
- create a folder with a tab character via the node api
- try to access the folder via webdav
-> BEFORE this patch: exception
-> AFTER this patch: creating the folder is denied

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
