### PR TITLE
Fixes #32090 - browser extension urls in origin header do not trigger…

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CorsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CorsPlugin.php
@@ -97,8 +97,15 @@ class CorsPlugin extends ServerPlugin {
 		$this->server = $server;
 
 		$request = $this->server->httpRequest;
-		if (!$request->hasHeader('Origin') || Util::isSameDomain($request->getHeader('Origin'), $request->getAbsoluteUrl())) {
-			return false;
+		if (!$request->hasHeader('Origin')) {
+			return;
+		}
+		$originHeader = $request->getHeader('Origin');
+		if ($this->ignoreOriginHeader($originHeader)) {
+			return;
+		}
+		if (Util::isSameDomain($originHeader, $request->getAbsoluteUrl())) {
+			return;
 		}
 
 		$this->server->on('beforeMethod', [$this, 'setCorsHeaders']);
@@ -146,5 +153,22 @@ class CorsPlugin extends ServerPlugin {
 			$this->server->sapi->sendResponse($response);
 			return false;
 		}
+	}
+
+	/**
+	 * in addition to schemas used by extensions we ignore empty origin header
+	 * values as well as 'null' which is not valid by the specification but used
+	 * by some clients.
+	 * @link https://github.com/owncloud/core/pull/32120#issuecomment-407008243
+	 *
+	 * @param string $originHeader
+	 * @return bool
+	 */
+	public function ignoreOriginHeader($originHeader) {
+		if (\in_array($originHeader, ['', null, 'null'], true)) {
+			return true;
+		}
+		$schema = \parse_url($originHeader, PHP_URL_SCHEME);
+		return \in_array(\strtolower($schema), ['moz-extension', 'chrome-extension']);
 	}
 }


### PR DESCRIPTION
… CORS verification

## Description
Browser extension send an Origin header with an url which has the schema moz-extension or chromw-extension. We shall no perform CORS verification on these requests since they come from non-websites.

## Related Issue
- Fixes #32090 

## How Has This Been Tested?
- ~not tested personally with an extension~
- tested with firefox extension 'buttercup' - https://addons.mozilla.org/en-US/firefox/addon/buttercup-pw/?src=search
- maybe @julianpoemp can help testing if extensions work now

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
