### PR TITLE
Reword "using the API" and related steps

### DIFF
--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -42,7 +42,7 @@ class AppConfigHelper {
 	 *                                 "testing"
 	 * @param boolean $testingState the on|off state the parameter must be set to for the test
 	 * @param string $savedCapabilitiesXml the original capabilities in XML format
-	 * @param int $apiVersion (1|2)
+	 * @param int $ocsApiVersion (1|2)
 	 *
 	 * @return array of the original state of the capability set
 	 */
@@ -56,7 +56,7 @@ class AppConfigHelper {
 		$testingParameter,
 		$testingState,
 		$savedCapabilitiesXml,
-		$apiVersion = 1
+		$ocsApiVersion = 1
 	) {
 		$originalState = self::wasCapabilitySet(
 			$capabilitiesApp,
@@ -75,7 +75,7 @@ class AppConfigHelper {
 			$testingApp,
 			$testingParameter,
 			$testingState ? 'yes' : 'no',
-			$apiVersion
+			$ocsApiVersion
 		);
 		
 		return [
@@ -95,7 +95,7 @@ class AppConfigHelper {
 	 *                                 ['testingParameter'] the parameter name as understood by "testing"
 	 *                                 ['testingState'] boolean|string that the parameter must be set to for the test
 	 * @param string $savedCapabilitiesXml the original capabilities in XML format
-	 * @param int $apiVersion (1|2)
+	 * @param int $ocsApiVersion (1|2)
 	 *
 	 * @return array of the original state of each capability set
 	 */
@@ -105,7 +105,7 @@ class AppConfigHelper {
 		$password,
 		$capabilitiesArray,
 		$savedCapabilitiesXml,
-		$apiVersion = 1
+		$ocsApiVersion = 1
 	) {
 		$appParameterValues = [];
 		$originalCapabilities = [];
@@ -152,7 +152,7 @@ class AppConfigHelper {
 			$user,
 			$password,
 			$appParameterValues,
-			$apiVersion
+			$ocsApiVersion
 		);
 
 		return $originalCapabilities;
@@ -244,14 +244,14 @@ class AppConfigHelper {
 	 * @param string $app
 	 * @param string $parameter
 	 * @param string $value
-	 * @param int $apiVersion (1|2)
+	 * @param int $ocsApiVersion (1|2)
 	 *
 	 * @return void
 	 */
 	public static function modifyServerConfig(
 		$baseUrl,
 		$user,
-		$password, $app, $parameter, $value, $apiVersion = 2
+		$password, $app, $parameter, $value, $ocsApiVersion = 2
 	) {
 		$body = ['value' => $value];
 		$response = OcsApiHelper::sendRequest(
@@ -261,10 +261,10 @@ class AppConfigHelper {
 			'post',
 			"/apps/testing/api/v1/app/{$app}/{$parameter}",
 			$body,
-			$apiVersion
+			$ocsApiVersion
 		);
 		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
-		if ($apiVersion === 1) {
+		if ($ocsApiVersion === 1) {
 			PHPUnit_Framework_Assert::assertEquals(
 				"100", self::getOCSResponse($response)
 			);
@@ -276,14 +276,14 @@ class AppConfigHelper {
 	 * @param string $user
 	 * @param string $password
 	 * @param array $appParameterValues 'appid' 'configkey' and 'value'
-	 * @param int $apiVersion (1|2)
+	 * @param int $ocsApiVersion (1|2)
 	 *
 	 * @return void
 	 */
 	public static function modifyServerConfigs(
 		$baseUrl,
 		$user,
-		$password, $appParameterValues, $apiVersion = 2
+		$password, $appParameterValues, $ocsApiVersion = 2
 	) {
 		$body = ['values' => $appParameterValues];
 		$response = OcsApiHelper::sendRequest(
@@ -293,10 +293,10 @@ class AppConfigHelper {
 			'post',
 			"/apps/testing/api/v1/apps",
 			$body,
-			$apiVersion
+			$ocsApiVersion
 		);
 		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
-		if ($apiVersion === 1) {
+		if ($ocsApiVersion === 1) {
 			PHPUnit_Framework_Assert::assertEquals(
 				"100", self::getOCSResponse($response)
 			);

--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -39,19 +39,19 @@ class OcsApiHelper {
 	 * @param string $method HTTP Method
 	 * @param string $path
 	 * @param array $body array of key, value pairs e.g ['value' => 'yes']
-	 * @param int $apiVersion (1|2) default 2
+	 * @param int $ocsApiVersion (1|2) default 2
 	 *
 	 * @return ResponseInterface
 	 * @throws ClientException
 	 */
 	public static function sendRequest(
-		$baseUrl, $user, $password, $method, $path, $body = [], $apiVersion = 2
+		$baseUrl, $user, $password, $method, $path, $body = [], $ocsApiVersion = 2
 	) {
 		$fullUrl = $baseUrl;
 		if (\substr($fullUrl, -1) !== '/') {
 			$fullUrl .= '/';
 		}
-		$fullUrl .= "ocs/v{$apiVersion}.php" . $path;
+		$fullUrl .= "ocs/v{$ocsApiVersion}.php" . $path;
 		$client = new Client();
 		$options = [];
 		if ($user !== null) {

--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -60,7 +60,7 @@ class SharingHelper {
 	 *                                An expire date for public link shares.
 	 *                                This argument expects a date string
 	 *                                in the format 'YYYY-MM-DD'.
-	 * @param int $apiVersion
+	 * @param int $ocsApiVersion
 	 * @param int $sharingApiVersion
 	 *
 	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
@@ -77,7 +77,7 @@ class SharingHelper {
 		$permissions = null,
 		$linkName = null,
 		$expireDate = null, // unused, to be implemented
-		$apiVersion = 1,
+		$ocsApiVersion = 1,
 		$sharingApiVersion = 1
 	) {
 		$fd = [];
@@ -137,11 +137,16 @@ class SharingHelper {
 			}
 			$fd['permissions'] = $permissionSum;
 		}
-		if (!\in_array($apiVersion, [1, 2], true)
-			|| !\in_array($sharingApiVersion, [1,2], true)
-		) {
+
+		if (!\in_array($ocsApiVersion, [1, 2], true)) {
 			throw new \InvalidArgumentException(
-				"invalid apiVersion/sharingApiVersion"
+				"invalid ocsApiVersion ($ocsApiVersion)"
+			);
+		}
+
+		if (!\in_array($sharingApiVersion, [1, 2], true)) {
+			throw new \InvalidArgumentException(
+				"invalid sharingApiVersion ($sharingApiVersion)"
 			);
 		}
 
@@ -149,7 +154,7 @@ class SharingHelper {
 		if (\substr($fullUrl, -1) !== '/') {
 			$fullUrl .= '/';
 		}
-		$fullUrl .= "ocs/v{$apiVersion}.php/apps/files_sharing/api/v{$sharingApiVersion}/shares";
+		$fullUrl .= "ocs/v{$ocsApiVersion}.php/apps/files_sharing/api/v{$sharingApiVersion}/shares";
 		$client = new GClient();
 		$options['auth'] = [$user, $password];
 		$fd['path'] = $path;

--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -107,12 +107,12 @@ class UserHelper {
 	 * @param string $userName
 	 * @param string $adminUser
 	 * @param string $adminPassword
-	 * @param int $apiVersion
+	 * @param int $ocsApiVersion
 	 *
 	 * @return ResponseInterface
 	 */
 	public static function deleteUser(
-		$baseUrl, $userName, $adminUser, $adminPassword, $apiVersion = 2
+		$baseUrl, $userName, $adminUser, $adminPassword, $ocsApiVersion = 2
 	) {
 		return OcsApiHelper::sendRequest(
 			$baseUrl,
@@ -121,7 +121,7 @@ class UserHelper {
 			"DELETE",
 			"/cloud/users/" . $userName,
 			[],
-			$apiVersion
+			$ocsApiVersion
 		);
 	}
 
@@ -149,17 +149,17 @@ class UserHelper {
 	 * @param string $group
 	 * @param string $adminUser
 	 * @param string $adminPassword
-	 * @param int $apiVersion
+	 * @param int $ocsApiVersion
 	 *
 	 * @return ResponseInterface
 	 */
 	public static function deleteGroup(
-		$baseUrl, $group, $adminUser, $adminPassword, $apiVersion = 2
+		$baseUrl, $group, $adminUser, $adminPassword, $ocsApiVersion = 2
 	) {
 		$group = \rawurlencode($group);
 		return OcsApiHelper::sendRequest(
 			$baseUrl, $adminUser, $adminPassword,
-			"DELETE", "/cloud/groups/" . $group, [], $apiVersion
+			"DELETE", "/cloud/groups/" . $group, [], $ocsApiVersion
 		);
 	}
 

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -1,36 +1,36 @@
 @api
 Feature: capabilities
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And as user "admin"
 
 	Scenario: Check that the sharing API can be enabled
 		Given parameter "shareapi_enabled" of app "core" has been set to "no"
 		And the capabilities setting of "files_sharing" path "api_enabled" has been confirmed to be ""
-		When the administrator sets parameter "shareapi_enabled" of app "core" to "yes" using the API
+		When the administrator sets parameter "shareapi_enabled" of app "core" to "yes"
 		Then the capabilities setting of "files_sharing" path "api_enabled" should be "1"
 
 	Scenario: Check that the sharing API can be disabled
 		Given parameter "shareapi_enabled" of app "core" has been set to "yes"
 		And the capabilities setting of "files_sharing" path "api_enabled" has been confirmed to be "1"
-		When the administrator sets parameter "shareapi_enabled" of app "core" to "no" using the API
+		When the administrator sets parameter "shareapi_enabled" of app "core" to "no"
 		Then the capabilities setting of "files_sharing" path "api_enabled" should be ""
 
 	Scenario: Check that group sharing can be enabled
 		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
 		And the capabilities setting of "files_sharing" path "group_sharing" has been confirmed to be ""
 
-		When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "yes" using the API
+		When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "yes"
 		Then the capabilities setting of "files_sharing" path "group_sharing" should be "1"
 
 	Scenario: Check that group sharing can be disabled
 		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "yes"
 		And the capabilities setting of "files_sharing" path "group_sharing" has been confirmed to be "1"
-		When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "no" using the API
+		When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "no"
 		Then the capabilities setting of "files_sharing" path "group_sharing" should be ""
 
 	Scenario: getting capabilities with admin user
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                       | value             |
 			| core          | pollinterval                          | 60                |
@@ -54,7 +54,7 @@ Feature: capabilities
 
 	Scenario: Changing public upload
 		Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                       | value             |
 			| core          | pollinterval                          | 60                |
@@ -78,7 +78,7 @@ Feature: capabilities
 
 	Scenario: Disabling share api
 		Given parameter "shareapi_enabled" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element       | value             |
 			| core          | pollinterval          | 60                |
@@ -96,7 +96,7 @@ Feature: capabilities
 
 	Scenario: Disabling public links
 		Given parameter "shareapi_allow_links" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                       | value             |
 			| core          | pollinterval                          | 60                |
@@ -118,7 +118,7 @@ Feature: capabilities
 
 	Scenario: Changing resharing
 		Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                       | value             |
 			| core          | pollinterval                          | 60                |
@@ -142,7 +142,7 @@ Feature: capabilities
 
 	Scenario: Changing federation outgoing
 		Given parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                       | value             |
 			| core          | pollinterval                          | 60                |
@@ -166,7 +166,7 @@ Feature: capabilities
 
 	Scenario: Changing federation incoming
 		Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                       | value             |
 			| core          | pollinterval                          | 60                |
@@ -190,7 +190,7 @@ Feature: capabilities
 
 	Scenario: Changing "password enforced for read-only public link shares"
 		Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                                | value             |
 			| core          | pollinterval                                   | 60                |
@@ -217,7 +217,7 @@ Feature: capabilities
 
 	Scenario: Changing "password enforced for read-write public link shares"
 		Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                                | value             |
 			| core          | pollinterval                                   | 60                |
@@ -244,7 +244,7 @@ Feature: capabilities
 
 	Scenario: Changing "password enforced for write-only public link shares"
 		Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                                | value             |
 			| core          | pollinterval                                   | 60                |
@@ -271,7 +271,7 @@ Feature: capabilities
 
 	Scenario: Changing public notifications
 		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                       | value             |
 			| core          | pollinterval                          | 60                |
@@ -295,7 +295,7 @@ Feature: capabilities
 
 	Scenario: Changing public social share
 		Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                       | value             |
 			| core          | pollinterval                          | 60                |
@@ -319,7 +319,7 @@ Feature: capabilities
 
 	Scenario: Changing expire date
 		Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                       | value             |
 			| core          | pollinterval                          | 60                |
@@ -345,7 +345,7 @@ Feature: capabilities
 	Scenario: Changing expire date enforcing
 		Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
 		And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                       | value             |
 			| core          | pollinterval                          | 60                |
@@ -371,7 +371,7 @@ Feature: capabilities
 
 	Scenario: Changing group sharing allowed
 		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                       | value             |
 			| core          | pollinterval                          | 60                |
@@ -395,7 +395,7 @@ Feature: capabilities
 
 	Scenario: Changing only share with group member
 		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                       | value             |
 			| core          | pollinterval                          | 60                |
@@ -419,7 +419,7 @@ Feature: capabilities
 
 	Scenario: Changing allow share dialog user enumeration
 		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element               | value             |
 			| core          | pollinterval                  | 60                |
@@ -442,7 +442,7 @@ Feature: capabilities
 
 	Scenario: Changing allow share dialog user enumeration for group members only
 		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                       | value             |
 			| core          | pollinterval                          | 60                |
@@ -470,7 +470,7 @@ Feature: capabilities
 		And group "hash#group" has been created
 		And group "group-3" has been created
 		And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                           | value             |
 			| core          | pollinterval                              | 60                |
@@ -502,7 +502,7 @@ Feature: capabilities
 		And user "user0" has been added to group "hash#group"
 		And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
 		And as user "user0"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                           | value             |
 			| core          | pollinterval                              | 60                |
@@ -534,7 +534,7 @@ Feature: capabilities
 		And user "user0" has been added to group "ordinary-group"
 		And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
 		And as user "user0"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                           | value             |
 			| core          | pollinterval                              | 60                |
@@ -567,7 +567,7 @@ Feature: capabilities
 		And user "user0" has been added to group "ordinary-group"
 		And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1","hash#group","group-3"]'
 		And as user "user0"
-		When the user retrieves the capabilities using the API
+		When the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                           | value             |
 			| core          | pollinterval                              | 60                |

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -1,7 +1,7 @@
 @api
 Feature: federated
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And parameter "shareapi_enabled" of app "core" has been set to "yes"
 		And parameter "shareapi_allow_resharing" of app "core" has been set to "yes"
 		And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "yes"
@@ -12,7 +12,7 @@ Feature: federated
 		And user "user1" has been created
 		And using server "LOCAL"
 		And user "user0" has been created
-		When user "user0" from server "LOCAL" shares "/textfile0.txt" with user "user1" from server "REMOTE" using the API
+		When user "user0" from server "LOCAL" shares "/textfile0.txt" with user "user1" from server "REMOTE" using the sharing API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
@@ -37,7 +37,7 @@ Feature: federated
 		And user "user0" has been created
 		And using server "REMOTE"
 		And user "user1" has been created
-		When user "user1" from server "REMOTE" shares "/textfile0.txt" with user "user0" from server "LOCAL" using the API
+		When user "user1" from server "REMOTE" shares "/textfile0.txt" with user "user0" from server "LOCAL" using the sharing API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
@@ -64,7 +64,7 @@ Feature: federated
 		And user "user0" has been created
 		And user "user0" from server "LOCAL" has shared "/textfile0.txt" with user "user1" from server "REMOTE"
 		And using server "REMOTE"
-		When user "user1" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/remote_shares/pending"
+		When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/pending"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
@@ -84,7 +84,7 @@ Feature: federated
 		And using server "LOCAL"
 		And user "user0" has been created
 		And user "user0" from server "LOCAL" has shared "/textfile0.txt" with user "user1" from server "REMOTE"
-		When user "user1" from server "REMOTE" accepts the last pending share using the API
+		When user "user1" from server "REMOTE" accepts the last pending share using the sharing API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
@@ -97,7 +97,7 @@ Feature: federated
 		And user "user0" from server "LOCAL" has shared "/textfile0.txt" with user "user1" from server "REMOTE"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		When user "user1" creates a share using the API with settings
+		When user "user1" creates a share using the sharing API with settings
 			| path        | /textfile0 (2).txt |
 			| shareType   | 0                  |
 			| shareWith   | user2              |
@@ -130,7 +130,7 @@ Feature: federated
 		And user "user0" from server "LOCAL" has shared "/textfile0.txt" with user "user1" from server "REMOTE"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		When user "user1" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the API
+		When user "user1" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
 		And using server "LOCAL"
 		Then the content of file "/textfile0.txt" for user "user0" should be "BLABLABLA" plus end-of-line
 
@@ -143,7 +143,7 @@ Feature: federated
 		And user "user0" from server "LOCAL" has shared "/PARENT" with user "user1" from server "REMOTE"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		When user "user1" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the API
+		When user "user1" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
 		And using server "LOCAL"
 		Then the content of file "/PARENT/textfile0.txt" for user "user0" should be "BLABLABLA" plus end-of-line
 
@@ -156,7 +156,7 @@ Feature: federated
 		And user "user0" from server "LOCAL" has shared "/textfile0.txt" with user "user1" from server "REMOTE"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		When user "user1" uploads the following "3" chunks to "/textfile0 (2).txt" with old chunking and using the API
+		When user "user1" uploads the following "3" chunks to "/textfile0 (2).txt" with old chunking and using the WebDAV API
 			| 1 | AAAAA |
 			| 2 | BBBBB |
 			| 3 | CCCCC |
@@ -171,7 +171,7 @@ Feature: federated
 		And user "user0" from server "LOCAL" has shared "/PARENT" with user "user1" from server "REMOTE"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		When user "user1" uploads the following "3" chunks to "/PARENT (2)/textfile0.txt" with old chunking and using the API
+		When user "user1" uploads the following "3" chunks to "/PARENT (2)/textfile0.txt" with old chunking and using the WebDAV API
 			| 1 | AAAAA |
 			| 2 | BBBBB |
 			| 3 | CCCCC |
@@ -179,8 +179,8 @@ Feature: federated
 
 	Scenario: Trusted server handshake does not require authenticated requests - we force 403 by sending an empty body
 		Given using server "LOCAL"
-		And using API version "2"
-		When user "UNAUTHORIZED_USER" sends HTTP method "POST" to API endpoint "/apps/federation/api/v1/request-shared-secret"
+		And using OCS API version "2"
+		When user "UNAUTHORIZED_USER" sends HTTP method "POST" to OCS API endpoint "/apps/federation/api/v1/request-shared-secret"
 		Then the HTTP status code should be "403"
 
 	Scenario: Overwrite a federated shared folder as recipient propagates etag for recipient
@@ -193,7 +193,7 @@ Feature: federated
 		And using server "REMOTE"
 		And user "user1" has stored etag of element "/PARENT (2)"
 		And using server "LOCAL"
-		When user "user0" uploads file "data/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the API
+		When user "user0" uploads file "data/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the WebDAV API
 		Then using server "REMOTE"
 		And the etag of element "/PARENT (2)" of user "user1" should have changed
 
@@ -206,7 +206,7 @@ Feature: federated
 		And user "user0" has stored etag of element "/PARENT"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		When user "user1" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the API
+		When user "user1" uploads file "data/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
 		Then using server "LOCAL"
 		And the etag of element "/PARENT" of user "user0" should have changed
 
@@ -219,7 +219,7 @@ Feature: federated
 		And user "user0" from server "LOCAL" has shared "/PARENT" with user "user1" from server "REMOTE"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		When user "user1" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms using the API
+		When user "user1" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
 		Then the HTTP status code of all upload responses should be "201"
 		And using server "LOCAL"
 		And as "user0" the files uploaded to "/PARENT/testquota.txt" with all mechanisms should exist
@@ -233,6 +233,6 @@ Feature: federated
 		And user "user0" from server "LOCAL" has shared "/PARENT" with user "user1" from server "REMOTE"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		And using server "REMOTE"
-		When user "user1" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms using the API
+		When user "user1" uploads file "data/textfile.txt" to "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
 		Then the HTTP status code of all upload responses should be "507"
 

--- a/tests/acceptance/features/apiMain/caldav.feature
+++ b/tests/acceptance/features/apiMain/caldav.feature
@@ -6,7 +6,7 @@ Feature: caldav
 
 	@caldav
 	Scenario: Accessing a not existing calendar of another user
-		When user "admin" requests calendar "user0/MyCalendar" using the API
+		When user "admin" requests calendar "user0/MyCalendar" using the new WebDAV API
 		Then the CalDAV HTTP status code should be "404"
 		And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
 		And the CalDAV error message should be "Node with name 'MyCalendar' could not be found"
@@ -14,14 +14,14 @@ Feature: caldav
 	@caldav
 	Scenario: Accessing a not shared calendar of another user
 		And user "admin" has successfully created a calendar named "MyCalendar"
-		When user "user0" requests calendar "admin/MyCalendar" using the API
+		When user "user0" requests calendar "admin/MyCalendar" using the new WebDAV API
 		Then the CalDAV HTTP status code should be "404"
 		And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
 		And the CalDAV error message should be "Node with name 'MyCalendar' could not be found"
 
 	@caldav
 	Scenario: Accessing a not existing calendar of myself
-		When user "user0" requests calendar "admin/MyCalendar" using the API
+		When user "user0" requests calendar "admin/MyCalendar" using the new WebDAV API
 		Then the CalDAV HTTP status code should be "404"
 		And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
 		And the CalDAV error message should be "Node with name 'MyCalendar' could not be found"
@@ -29,5 +29,5 @@ Feature: caldav
 	@caldav
 	Scenario: Creating a new calendar
 		Given user "user0" has successfully created a calendar named "MyCalendar"
-		When user "user0" requests calendar "user0/MyCalendar" using the API
+		When user "user0" requests calendar "user0/MyCalendar" using the new WebDAV API
 		Then the CalDAV HTTP status code should be "200"

--- a/tests/acceptance/features/apiMain/caldav.feature
+++ b/tests/acceptance/features/apiMain/caldav.feature
@@ -13,7 +13,7 @@ Feature: caldav
 
 	@caldav
 	Scenario: Accessing a not shared calendar of another user
-		And user "admin" has successfully created a calendar named "MyCalendar"
+		Given user "admin" has successfully created a calendar named "MyCalendar"
 		When user "user0" requests calendar "admin/MyCalendar" using the new WebDAV API
 		Then the CalDAV HTTP status code should be "404"
 		And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"

--- a/tests/acceptance/features/apiMain/carddav.feature
+++ b/tests/acceptance/features/apiMain/carddav.feature
@@ -6,7 +6,7 @@ Feature: carddav
 
   @carddav
   Scenario: Accessing a not existing addressbook of another user
-    When user "admin" requests address book "user0/MyAddressbook" using the API
+    When user "admin" requests address book "user0/MyAddressbook" using the new WebDAV API
     Then the CardDAV HTTP status code should be "404"
     And the CardDAV exception should be "Sabre\DAV\Exception\NotFound"
     And the CardDAV error message should be "Addressbook with name 'MyAddressbook' could not be found"
@@ -14,14 +14,14 @@ Feature: carddav
   @carddav
   Scenario: Accessing a not shared addressbook of another user
     And user "admin" has successfully created an address book named "MyAddressbook"
-    When user "user0" requests address book "admin/MyAddressbook" using the API
+    When user "user0" requests address book "admin/MyAddressbook" using the new WebDAV API
     Then the CardDAV HTTP status code should be "404"
     And the CardDAV exception should be "Sabre\DAV\Exception\NotFound"
     And the CardDAV error message should be "Addressbook with name 'MyAddressbook' could not be found"
 
   @carddav
   Scenario: Accessing a not existing addressbook of myself
-    When user "user0" requests address book "admin/MyAddressbook" using the API
+    When user "user0" requests address book "admin/MyAddressbook" using the new WebDAV API
     Then the CardDAV HTTP status code should be "404"
     And the CardDAV exception should be "Sabre\DAV\Exception\NotFound"
     And the CardDAV error message should be "Addressbook with name 'MyAddressbook' could not be found"
@@ -29,5 +29,5 @@ Feature: carddav
   @carddav
   Scenario: Creating a new addressbook
     Given user "user0" has successfully created an address book named "MyAddressbook"
-    When user "user0" requests address book "user0/MyAddressbook" using the API
+    When user "user0" requests address book "user0/MyAddressbook" using the new WebDAV API
     Then the CardDAV HTTP status code should be "200"

--- a/tests/acceptance/features/apiMain/carddav.feature
+++ b/tests/acceptance/features/apiMain/carddav.feature
@@ -13,7 +13,7 @@ Feature: carddav
 
   @carddav
   Scenario: Accessing a not shared addressbook of another user
-    And user "admin" has successfully created an address book named "MyAddressbook"
+    Given user "admin" has successfully created an address book named "MyAddressbook"
     When user "user0" requests address book "admin/MyAddressbook" using the new WebDAV API
     Then the CardDAV HTTP status code should be "404"
     And the CardDAV exception should be "Sabre\DAV\Exception\NotFound"

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -6,7 +6,7 @@ Feature: checksums
 
   Scenario Outline: Uploading a file with checksum should work
     Given using <dav_version> DAV path
-    When user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the API
+    When user "user0" uploads file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the WebDAV API
     Then the webdav response should have a status code "201"
     Examples:
 			| dav_version   |
@@ -26,7 +26,7 @@ Feature: checksums
   Scenario Outline: Uploading a file with checksum should return the checksum in the download header
     Given using <dav_version> DAV path
     And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" downloads the file "/myChecksumFile.txt" using the API
+    When user "user0" downloads the file "/myChecksumFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
 			| dav_version   |
@@ -36,7 +36,7 @@ Feature: checksums
   Scenario Outline: Moving a file with checksum should return the checksum in the propfind
     Given using <dav_version> DAV path
     And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the API
+    When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the WebDAV API
     And user "user0" requests the checksum of "/myMovedChecksumFile.txt" via propfind
     Then the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     Examples:
@@ -47,8 +47,8 @@ Feature: checksums
   Scenario: Downloading a file with checksum should return the checksum in the download header
     Given using old DAV path
     And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the API
-    And user "user0" downloads the file "/myMovedChecksumFile.txt" using the API
+    When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the WebDAV API
+    And user "user0" downloads the file "/myMovedChecksumFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
 
   Scenario: Uploading a chunked file with checksum should return the checksum in the propfind
@@ -64,7 +64,7 @@ Feature: checksums
     And user "user0" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
     And user "user0" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
     And user "user0" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
-    When user "user0" downloads the file "/myChecksumFile.txt" using the API
+    When user "user0" downloads the file "/myChecksumFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8"
 
   @local_storage
@@ -73,9 +73,9 @@ Feature: checksums
     # Create the file directly in local storage, bypassing ownCloud
     And file "prueba_cksum.txt" with text "Test file for checksums" has been created in local storage
     # Do a first download, which will trigger ownCloud to calculate a checksum for the file
-    And user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the API
+    And user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the WebDAV API
     # Now do a download that is expected to have a checksum with it
-    When user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the API
+    When user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the WebDAV API
     Then the header checksum should match "SHA1:a35b7605c8f586d735435535c337adc066c2ccb6"
     Examples:
 			| dav_version   |
@@ -85,8 +85,8 @@ Feature: checksums
   Scenario Outline: Moving file with checksum should return the checksum in the download header
     Given using <dav_version> DAV path
     And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the API
-    And user "user0" downloads the file "/myMovedChecksumFile.txt" using the API
+    When user "user0" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the WebDAV API
+    And user "user0" downloads the file "/myMovedChecksumFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
 			| dav_version   |
@@ -96,37 +96,37 @@ Feature: checksums
   Scenario: Copying a file with checksum should return the checksum in the propfind using new DAV path
     Given using new DAV path
     And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt" using the API
+    When user "user0" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt" using the WebDAV API
     And user "user0" requests the checksum of "/myChecksumFileCopy.txt" via propfind
     Then the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
 
   Scenario: Copying file with checksum should return the checksum in the download header using new DAV path
     Given using new DAV path
     And user "user0" has uploaded file "data/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "user0" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt" using the API
-    And user "user0" downloads the file "/myChecksumFileCopy.txt" using the API
+    When user "user0" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt" using the WebDAV API
+    And user "user0" downloads the file "/myChecksumFileCopy.txt" using the WebDAV API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
 
   Scenario: Upload new dav chunked file where checksum matches
     Given using new DAV path
-    When user "user0" creates a new chunking upload with id "chunking-42" using the API
-    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
-    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the API
-    And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the API
+    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
     Then the HTTP status code should be "201"
 
   Scenario: Upload new dav chunked file where checksum does not match
     Given using new DAV path
-    When user "user0" creates a new chunking upload with id "chunking-42" using the API
-    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
-    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the API
-    And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:f005ba11" using the API
+    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:f005ba11" using the WebDAV API
     Then the HTTP status code should be "400"
 
   Scenario Outline: Upload a file where checksum does not match
     Given using <dav_version> DAV path
     And file "/chksumtst.txt" has been deleted for user "user0"
-    When user "user0" uploads file with checksum "SHA1:f005ba11" and content "Some Text" to "/chksumtst.txt" using the API
+    When user "user0" uploads file with checksum "SHA1:f005ba11" and content "Some Text" to "/chksumtst.txt" using the WebDAV API
     Then the HTTP status code should be "400"
     Examples:
 			| dav_version   |
@@ -136,7 +136,7 @@ Feature: checksums
   Scenario Outline: Upload a file where checksum does match
     Given using <dav_version> DAV path
     And file "/chksumtst.txt" has been deleted for user "user0"
-    When user "user0" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt" using the API
+    When user "user0" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     Examples:
 			| dav_version   |
@@ -147,7 +147,7 @@ Feature: checksums
     Given using <dav_version> DAV path
     And file "/chksumtst.txt" has been deleted for user "user0"
     And user "user0" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt"
-    When user "user0" downloads the file "/chksumtst.txt" using the API
+    When user "user0" downloads the file "/chksumtst.txt" using the WebDAV API
     Then the following headers should be set
       | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
     Examples:
@@ -160,7 +160,7 @@ Feature: checksums
     Given using <dav_version> DAV path
     And file "/local_storage/chksumtst.txt" has been deleted for user "user0"
     And user "user0" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/local_storage/chksumtst.txt"
-    When user "user0" downloads the file "/local_storage/chksumtst.txt" using the API
+    When user "user0" downloads the file "/local_storage/chksumtst.txt" using the WebDAV API
     Then the following headers should be set
       | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
     Examples:
@@ -173,5 +173,5 @@ Feature: checksums
 
   Scenario: Uploading an old method chunked file with checksum should fail using new DAV path
     Given using new DAV path
-    When user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e" using the API
+    When user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e" using the WebDAV API
     Then the HTTP status code should be "503"

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -73,9 +73,9 @@ Feature: checksums
     # Create the file directly in local storage, bypassing ownCloud
     And file "prueba_cksum.txt" with text "Test file for checksums" has been created in local storage
     # Do a first download, which will trigger ownCloud to calculate a checksum for the file
-    And user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the WebDAV API
-    # Now do a download that is expected to have a checksum with it
     When user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the WebDAV API
+    # Now do a download that is expected to have a checksum with it
+    And user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the WebDAV API
     Then the header checksum should match "SHA1:a35b7605c8f586d735435535c337adc066c2ccb6"
     Examples:
 			| dav_version   |

--- a/tests/acceptance/features/apiMain/comments.feature
+++ b/tests/acceptance/features/apiMain/comments.feature
@@ -6,7 +6,7 @@ Feature: Comments
   Scenario: Creating a comment on a file belonging to myself
     Given user "user0" has been created
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
-    When user "user0" comments with content "My first comment" on file "/myFileToComment.txt" using the API
+    When user "user0" comments with content "My first comment" on file "/myFileToComment.txt" using the WebDAV API
     Then user "user0" should have the following comments on file "/myFileToComment.txt"
       | user0 | My first comment |
 
@@ -15,8 +15,8 @@ Feature: Comments
     And user "user1" has been created
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
     And user "user0" has shared file "/myFileToComment.txt" with user "user1"
-    When user "user1" comments with content "A comment from sharee" on file "/myFileToComment.txt" using the API
-    And user "user0" comments with content "A comment from sharer" on file "/myFileToComment.txt" using the API
+    When user "user1" comments with content "A comment from sharee" on file "/myFileToComment.txt" using the WebDAV API
+    And user "user0" comments with content "A comment from sharer" on file "/myFileToComment.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "user1" should have the following comments on file "/myFileToComment.txt"
       | user1 | A comment from sharee |
@@ -26,7 +26,7 @@ Feature: Comments
     Given user "user0" has been created
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
     And user "user0" has commented with content "My first comment" on file "/myFileToComment.txt"
-    When user "user0" deletes the last created comment using the API
+    When user "user0" deletes the last created comment using the WebDAV API
     Then the HTTP status code should be "204"
     And user "user0" should have 0 comments on file "/myFileToComment.txt"
 
@@ -37,7 +37,7 @@ Feature: Comments
     And user "user0" has commented with content "My second comment" on file "/myFileToComment.txt"
     And user "user0" has commented with content "My third comment" on file "/myFileToComment.txt"
     And user "user0" has commented with content "My fourth comment" on file "/myFileToComment.txt"
-    When user "user0" deletes the last created comment using the API
+    When user "user0" deletes the last created comment using the WebDAV API
     Then the HTTP status code should be "204"
     And user "user0" should have 3 comments on file "/myFileToComment.txt"
 
@@ -51,7 +51,7 @@ Feature: Comments
     And user "user1" should have the following comments on file "/myFileToComment.txt"
       | user0 | File owner comment |
       | user1 | Sharee comment     |
-    When user "user1" deletes the last created comment using the API
+    When user "user1" deletes the last created comment using the WebDAV API
     Then the HTTP status code should be "204"
     And user "user1" should have 1 comments on file "/myFileToComment.txt"
 
@@ -59,7 +59,7 @@ Feature: Comments
     Given user "user0" has been created
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
     And user "user0" has commented with content "File owner comment" on file "/myFileToComment.txt"
-    When user "user0" edits the last created comment with content "My edited comment" using the API
+    When user "user0" edits the last created comment with content "My edited comment" using the WebDAV API
     Then the HTTP status code should be "207"
     And user "user0" should have the following comments on file "/myFileToComment.txt"
       | user0 | My edited comment |
@@ -70,7 +70,7 @@ Feature: Comments
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
     And user "user0" has shared file "/myFileToComment.txt" with user "user1"
     And user "user1" has commented with content "Sharee comment" on file "/myFileToComment.txt"
-    When user "user1" edits the last created comment with content "My edited comment" using the API
+    When user "user1" edits the last created comment with content "My edited comment" using the WebDAV API
     Then the HTTP status code should be "207"
     And user "user1" should have the following comments on file "/myFileToComment.txt"
       | user1 | My edited comment |
@@ -83,7 +83,7 @@ Feature: Comments
     And user "user1" has commented with content "Sharee comment" on file "/myFileToComment.txt"
     And user "user0" should have the following comments on file "/myFileToComment.txt"
       | user1 | Sharee comment |
-    When user "user0" edits the last created comment with content "User1 edited comment" using the API
+    When user "user0" edits the last created comment with content "User1 edited comment" using the WebDAV API
     Then the HTTP status code should be "403"
     And user "user0" should have the following comments on file "/myFileToComment.txt"
       | user1 | Sharee comment |
@@ -94,7 +94,7 @@ Feature: Comments
     And user "user0" has commented with content "My first comment" on file "/myFileToComment.txt"
     And user "user0" should have the following comments on file "/myFileToComment.txt"
       | user0 | My first comment |
-    When user "user0" gets the following properties of folder "/myFileToComment.txt" using the API
+    When user "user0" gets the following properties of folder "/myFileToComment.txt" using the WebDAV API
       | {http://owncloud.org/ns}comments-href   |
       | {http://owncloud.org/ns}comments-count  |
       | {http://owncloud.org/ns}comments-unread |
@@ -109,7 +109,7 @@ Feature: Comments
 		And user "user1" has been added to group "sharinggroup"
 		And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
 		And user "user0" has shared file "/myFileToComment.txt" with group "sharinggroup"
-		When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the API
+		When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 		And user "user0" should have the following comments on file "/myFileToComment.txt"
 			| user1 | Comment from sharee |
@@ -125,7 +125,7 @@ Feature: Comments
 			| shareType   | 0                    |
 			| shareWith   | user1                |
 			| permissions | 1                    |
-		When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the API
+		When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 		And user "user0" should have the following comments on file "/myFileToComment.txt"
 			| user1 | Comment from sharee |
@@ -141,13 +141,13 @@ Feature: Comments
 			| shareType   | 0                    |
 			| shareWith   | user1                |
 			| permissions | 4                    |
-		When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the API
+		When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API
 		Then the HTTP status code should be "501"
 		And user "user0" should have 0 comments on file "/myFileToComment.txt"
 
   Scenario: Creating a comment on a folder belonging to myself
     Given user "user0" has been created
-    When user "user0" comments with content "My first comment" on folder "/FOLDER" using the API
+    When user "user0" comments with content "My first comment" on folder "/FOLDER" using the WebDAV API
     Then user "user0" should have the following comments on folder "/FOLDER"
       | user0 | My first comment |
 
@@ -156,8 +156,8 @@ Feature: Comments
     And user "user1" has been created
     And user "user0" has created a folder "/FOLDER_TO_SHARE"
     And user "user0" has shared folder "/FOLDER_TO_SHARE" with user "user1"
-    When user "user1" comments with content "A comment from sharee" on folder "/FOLDER_TO_SHARE" using the API
-    And user "user0" comments with content "A comment from sharer" on folder "/FOLDER_TO_SHARE" using the API
+    When user "user1" comments with content "A comment from sharee" on folder "/FOLDER_TO_SHARE" using the WebDAV API
+    And user "user0" comments with content "A comment from sharer" on folder "/FOLDER_TO_SHARE" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "user1" should have the following comments on file "/FOLDER_TO_SHARE"
       | user1 | A comment from sharee |
@@ -167,7 +167,7 @@ Feature: Comments
 		Given user "user0" has been created
 		And user "user0" has created a folder "/FOLDER_TO_COMMENT_AND_DELETE"
 		And user "user0" has commented with content "My first comment" on folder "/FOLDER_TO_COMMENT_AND_DELETE"
-		When user "user0" deletes the last created comment using the API
+		When user "user0" deletes the last created comment using the WebDAV API
 		Then the HTTP status code should be "204"
 		And user "user0" should have 0 comments on folder "/FOLDER_TO_COMMENT_AND_DELETE"
 
@@ -178,7 +178,7 @@ Feature: Comments
 		And user "user0" has commented with content "My second comment" on folder "/FOLDER_TO_COMMENT"
 		And user "user0" has commented with content "My third comment" on folder "/FOLDER_TO_COMMENT"
 		And user "user0" has commented with content "My fourth comment" on folder "/FOLDER_TO_COMMENT"
-		When user "user0" deletes the last created comment using the API
+		When user "user0" deletes the last created comment using the WebDAV API
 		Then the HTTP status code should be "204"
 		And user "user0" should have 3 comments on folder "/FOLDER_TO_COMMENT"
 
@@ -192,7 +192,7 @@ Feature: Comments
 		And user "user1" should have the following comments on folder "/FOLDER_TO_COMMENT"
 			| user0 | Folder owner comment |
 			| user1 | Sharee comment     |
-		When user "user1" deletes the last created comment using the API
+		When user "user1" deletes the last created comment using the WebDAV API
 		Then the HTTP status code should be "204"
 		And user "user1" should have 1 comments on folder "/FOLDER_TO_COMMENT"
 
@@ -200,7 +200,7 @@ Feature: Comments
 		Given user "user0" has been created
 		And user "user0" has created a folder "/FOLDER_TO_COMMENT"
 		And user "user0" has commented with content "Folder owner comment" on folder "/FOLDER_TO_COMMENT"
-		When user "user0" edits the last created comment with content "My edited comment" using the API
+		When user "user0" edits the last created comment with content "My edited comment" using the WebDAV API
 		Then the HTTP status code should be "207"
 		And user "user0" should have the following comments on folder "/FOLDER_TO_COMMENT"
 			| user0 | My edited comment |
@@ -212,7 +212,7 @@ Feature: Comments
 		And user "user1" has been added to group "sharinggroup"
 		And user "user0" has created a folder "/FOLDER_TO_COMMENT"
 		And user "user0" has shared folder "/FOLDER_TO_COMMENT" with group "sharinggroup"
-		When user "user1" comments with content "Comment from sharee" on folder "/FOLDER_TO_COMMENT" using the API
+		When user "user1" comments with content "Comment from sharee" on folder "/FOLDER_TO_COMMENT" using the WebDAV API
 		Then the HTTP status code should be "201"
 		And user "user0" should have the following comments on folder "/FOLDER_TO_COMMENT"
 			| user1 | Comment from sharee |
@@ -220,9 +220,9 @@ Feature: Comments
 	Scenario: deleting a folder removes existing comments on the folder
 		Given user "user0" has been created
 		And user "user0" has created a folder "/FOLDER_TO_DELETE"
-		When user "user0" comments with content "This should be deleted" on folder "/FOLDER_TO_DELETE" using the API
+		When user "user0" comments with content "This should be deleted" on folder "/FOLDER_TO_DELETE" using the WebDAV API
 		Then user "user0" should have 1 comments on folder "/FOLDER_TO_DELETE"
-		When user "user0" deletes folder "/FOLDER_TO_DELETE" using the API
+		When user "user0" deletes folder "/FOLDER_TO_DELETE" using the WebDAV API
 		And user "user0" has created a folder "/FOLDER_TO_DELETE"
 		Then user "user0" should have 0 comments on folder "/FOLDER_TO_DELETE"
 
@@ -245,5 +245,5 @@ Feature: Comments
 		And user "user0" has commented with content "Comment from owner" on folder "/FOLDER_TO_COMMENT"
 		And user "user0" has been deleted
 		And user "user0" has been created
-		When user "user0" creates a folder "/FOLDER_TO_COMMENT" using the API
+		When user "user0" creates a folder "/FOLDER_TO_COMMENT" using the WebDAV API
 		Then user "user0" should have 0 comments on folder "/FOLDER_TO_COMMENT"

--- a/tests/acceptance/features/apiMain/comments.feature
+++ b/tests/acceptance/features/apiMain/comments.feature
@@ -236,7 +236,7 @@ Feature: Comments
 			| user1 | Comment from sharee |
 		And user "user1" has been deleted
 		Then user "user0" should have 1 comments on folder "/FOLDER_TO_COMMENT"
-		Then user "user0" should have the following comments on folder "/FOLDER_TO_COMMENT"
+		And user "user0" should have the following comments on folder "/FOLDER_TO_COMMENT"
 			| deleted_users | Comment from sharee |
 
 	Scenario: deleting a content owner deletes the comment

--- a/tests/acceptance/features/apiMain/dav-versions.feature
+++ b/tests/acceptance/features/apiMain/dav-versions.feature
@@ -1,18 +1,18 @@
 @api
 Feature: dav-versions
   Background:
-    Given using API version "2"
+    Given using OCS API version "2"
     And using new DAV path
     And user "user0" has been created
     And file "/davtest.txt" has been deleted for user "user0"
 
   Scenario: Upload file and no version is available
-    When user "user0" uploads file "data/davtest.txt" to "/davtest.txt" using the API
+    When user "user0" uploads file "data/davtest.txt" to "/davtest.txt" using the WebDAV API
     Then the version folder of file "/davtest.txt" for user "user0" should contain "0" elements
 
   Scenario: Upload a file twice and versions are available
-    When user "user0" uploads file "data/davtest.txt" to "/davtest.txt" using the API
-    And user "user0" uploads file "data/davtest.txt" to "/davtest.txt" using the API
+    When user "user0" uploads file "data/davtest.txt" to "/davtest.txt" using the WebDAV API
+    And user "user0" uploads file "data/davtest.txt" to "/davtest.txt" using the WebDAV API
     Then the version folder of file "/davtest.txt" for user "user0" should contain "1" element
     And the content length of file "/davtest.txt" with version index "1" for user "user0" in versions folder should be "8"
 
@@ -21,14 +21,14 @@ Feature: dav-versions
     And user "user0" has uploaded file "data/davtest.txt" to "/davtest.txt"
     And the version folder of file "/davtest.txt" for user "user0" should contain "1" element
     And user "user0" has deleted file "/davtest.txt"
-    When user "user0" uploads file "data/davtest.txt" to "/davtest.txt" using the API
+    When user "user0" uploads file "data/davtest.txt" to "/davtest.txt" using the WebDAV API
     Then the version folder of file "/davtest.txt" for user "user0" should contain "0" elements
 
   Scenario: Restore a file and check, if the content is now in the current file
     Given user "user0" has uploaded file with content "123" to "/davtest.txt"
     And user "user0" has uploaded file with content "12345" to "/davtest.txt"
     And the version folder of file "/davtest.txt" for user "user0" should contain "1" element
-    When user "user0" restores version index "1" of file "/davtest.txt" using the API
+    When user "user0" restores version index "1" of file "/davtest.txt" using the WebDAV API
     Then the content of file "/davtest.txt" for user "user0" should be "123"
 
   Scenario: User cannot access meta folder of a file which is owned by somebody else
@@ -43,7 +43,7 @@ Feature: dav-versions
     And user "user0" has uploaded file with content "123" to "/davtest.txt"
     And user "user0" has uploaded file with content "456789" to "/davtest.txt"
     And we save it into "FILEID"
-    When user "user0" creates a share using the API with settings
+    When user "user0" creates a share using the sharing API with settings
       | path        | /davtest.txt |
       | shareType   | 0            |
       | shareWith   | user1        |
@@ -65,7 +65,7 @@ Feature: dav-versions
 		And user "user0" has uploaded file with content "user0 content" to "sharefile.txt"
 		And user "user0" has shared file "sharefile.txt" with user "user1"
 		And user "user1" has uploaded file with content "user1 content" to "/sharefile.txt"
-		When user "user0" restores version index "1" of file "/sharefile.txt" using the API
+		When user "user0" restores version index "1" of file "/sharefile.txt" using the WebDAV API
 		Then the HTTP status code should be "204"
 		And the content of file "/sharefile.txt" for user "user0" should be "user0 content"
 		And the content of file "/sharefile.txt" for user "user1" should be "user0 content"
@@ -77,7 +77,7 @@ Feature: dav-versions
 		And user "user0" has shared folder "/sharingfolder" with user "user1"
 		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
 		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
-		When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the API
+		When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
 		Then the HTTP status code should be "204"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user0 content"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
@@ -89,7 +89,7 @@ Feature: dav-versions
 		And user "user0" has shared folder "/sharingfolder" with user "user1"
 		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
 		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
-		When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the API
+		When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
 		Then the HTTP status code should be "204"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user0 content"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
@@ -101,7 +101,7 @@ Feature: dav-versions
 		And user "user0" has shared folder "/sharingfolder" with user "user1"
 		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
 		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
-		When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the API
+		When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
 		Then the HTTP status code should be "204"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user1 content"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user1 content"
@@ -113,7 +113,7 @@ Feature: dav-versions
 		And user "user0" has shared folder "/sharingfolder" with user "user1"
 		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
 		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
-		When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the API
+		When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
 		Then the HTTP status code should be "204"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user1 content"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user1 content"
@@ -125,7 +125,7 @@ Feature: dav-versions
 		And user "user0" has shared folder "/sharingfolder" with user "user1"
 		And user "user1" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
 		And user "user1" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
-		When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the API
+		When user "user0" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
 		Then the HTTP status code should be "204"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "old content"
@@ -137,7 +137,7 @@ Feature: dav-versions
 		And user "user0" has shared folder "/sharingfolder" with user "user1"
 		And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
 		And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
-		When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the API
+		When user "user1" restores version index "1" of file "/sharingfolder/sharefile.txt" using the WebDAV API
 		Then the HTTP status code should be "204"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "old content"
@@ -151,7 +151,7 @@ Feature: dav-versions
 		And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
 		And user "user1" has created a folder "/received"
 		And user "user1" has moved folder "/sharingfolder" to "/received/sharingfolder"
-		When user "user1" restores version index "1" of file "/received/sharingfolder/sharefile.txt" using the API
+		When user "user1" restores version index "1" of file "/received/sharingfolder/sharefile.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
 		And the content of file "/received/sharingfolder/sharefile.txt" for user "user1" should be "old content"
@@ -164,7 +164,7 @@ Feature: dav-versions
 		And user "user0" has shared file "/sharefile.txt" with user "user1"
 		And user "user1" has created a folder "/received"
 		And user "user1" has moved file "/sharefile.txt" to "/received/sharefile.txt"
-		When user "user1" restores version index "1" of file "/received/sharefile.txt" using the API
+		When user "user1" restores version index "1" of file "/received/sharefile.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 		And the content of file "/sharefile.txt" for user "user0" should be "old content"
 		And the content of file "/received/sharefile.txt" for user "user1" should be "old content"
@@ -178,7 +178,7 @@ Feature: dav-versions
 		And user "user0" has shared file "/sharingfolder/sharefile.txt" with user "user1"
 		And user "user1" has created a folder "/received"
 		And user "user1" has moved file "/sharefile.txt" to "/received/sharefile.txt"
-		When user "user1" restores version index "1" of file "/received/sharefile.txt" using the API
+		When user "user1" restores version index "1" of file "/received/sharefile.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "old content"
 		And the content of file "/received/sharefile.txt" for user "user1" should be "old content"
@@ -195,7 +195,7 @@ Feature: dav-versions
 		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
 		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
 		And user "user2" has uploaded file with content "user2 content" to "/sharingfolder/sharefile.txt"
-		When user "user0" restores version index "2" of file "/sharingfolder/sharefile.txt" using the API
+		When user "user0" restores version index "2" of file "/sharingfolder/sharefile.txt" using the WebDAV API
 		Then the HTTP status code should be "204"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user0" should be "user0 content"
 		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -1,7 +1,7 @@
 @api
 Feature: external-storage
   Background:
-    Given using API version "1"
+    Given using OCS API version "1"
     And using old DAV path
 
   # TODO: change to @no_default_encryption once all this works with master key
@@ -13,7 +13,7 @@ Feature: external-storage
     And user "user0" has created a folder "/local_storage/foo"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo/textfile0.txt"
     And user "user0" has shared folder "/local_storage/foo" with user "user1"
-    When user "user1" creates a share using the API with settings
+    When user "user1" creates a share using the sharing API with settings
       | path      | foo |
       | shareType | 3   |
     Then the OCS status code should be "100"
@@ -30,7 +30,7 @@ Feature: external-storage
     Given user "user0" has been created
     And user "user1" has been created
     And user "user0" has created a folder "/local_storage/foo1"
-    When user "user0" moves file "/textfile0.txt" to "/local_storage/foo1/textfile0.txt" using the API
+    When user "user0" moves file "/textfile0.txt" to "/local_storage/foo1/textfile0.txt" using the WebDAV API
     Then as "user1" the file "/local_storage/foo1/textfile0.txt" should exist
     And as "user0" the file "/local_storage/foo1/textfile0.txt" should exist
 
@@ -41,7 +41,7 @@ Feature: external-storage
     And user "user1" has been created
     And user "user0" has created a folder "/local_storage/foo2"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo2/textfile0.txt"
-    When user "user1" moves file "/local_storage/foo2/textfile0.txt" to "/local.txt" using the API
+    When user "user1" moves file "/local_storage/foo2/textfile0.txt" to "/local.txt" using the WebDAV API
     Then as "user1" the file "/local_storage/foo2/textfile0.txt" should not exist
     And as "user0" the file "/local_storage/foo2/textfile0.txt" should not exist
     And as "user1" the file "/local.txt" should exist
@@ -51,7 +51,7 @@ Feature: external-storage
     And user "user0" has created a folder "/local_storage/foo3"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo3/textfile0.txt"
     And file "foo3/textfile0.txt" has been deleted in local storage
-    When user "user0" downloads the file "local_storage/foo3/textfile0.txt" using the API
+    When user "user0" downloads the file "local_storage/foo3/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "404"
     And as "user0" the file "local_storage/foo3/textfile0.txt" should not exist
 
@@ -59,6 +59,6 @@ Feature: external-storage
   Scenario: Upload a file to external storage while quota is set on home storage
     Given user "user0" has been created
     And the quota of user "user0" has been set to "1 B"
-    When user "user0" uploads file "data/textfile.txt" to "/local_storage/testquota.txt" with all mechanisms using the API
+    When user "user0" uploads file "data/textfile.txt" to "/local_storage/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
     And as "user0" the files uploaded to "/local_storage/testquota.txt" with all mechanisms should exist

--- a/tests/acceptance/features/apiMain/favorites.feature
+++ b/tests/acceptance/features/apiMain/favorites.feature
@@ -1,13 +1,13 @@
 @api
 Feature: favorite
     Background:
-        Given using API version "1"
+        Given using OCS API version "1"
 
     Scenario Outline: Favorite a folder
         Given using <dav_version> DAV path
         And user "user0" has been created
-        When user "user0" favorites element "/FOLDER" using the API
-        And user "user0" gets the following properties of folder "/FOLDER" using the API
+        When user "user0" favorites element "/FOLDER" using the WebDAV API
+        And user "user0" gets the following properties of folder "/FOLDER" using the WebDAV API
             |{http://owncloud.org/ns}favorite|
         Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
         Examples:
@@ -18,9 +18,9 @@ Feature: favorite
     Scenario Outline: Favorite and unfavorite a folder
         Given using <dav_version> DAV path
         And user "user0" has been created
-        When user "user0" favorites element "/FOLDER" using the API
-        And user "user0" unfavorites element "/FOLDER" using the API
-        And user "user0" gets the following properties of folder "/FOLDER" using the API
+        When user "user0" favorites element "/FOLDER" using the WebDAV API
+        And user "user0" unfavorites element "/FOLDER" using the WebDAV API
+        And user "user0" gets the following properties of folder "/FOLDER" using the WebDAV API
             |{http://owncloud.org/ns}favorite|
         Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
         Examples:
@@ -31,8 +31,8 @@ Feature: favorite
     Scenario Outline: Favorite a file
         Given using <dav_version> DAV path
         And user "user0" has been created
-        When user "user0" favorites element "/textfile0.txt" using the API
-        And user "user0" gets the following properties of file "/textfile0.txt" using the API
+        When user "user0" favorites element "/textfile0.txt" using the WebDAV API
+        And user "user0" gets the following properties of file "/textfile0.txt" using the WebDAV API
             |{http://owncloud.org/ns}favorite|
         Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
         Examples:
@@ -43,9 +43,9 @@ Feature: favorite
     Scenario Outline: Favorite and unfavorite a file
         Given using <dav_version> DAV path
         And user "user0" has been created
-        When user "user0" favorites element "/textfile0.txt" using the API
-        And user "user0" unfavorites element "/textfile0.txt" using the API
-        And user "user0" gets the following properties of file "/textfile0.txt" using the API
+        When user "user0" favorites element "/textfile0.txt" using the WebDAV API
+        And user "user0" unfavorites element "/textfile0.txt" using the WebDAV API
+        And user "user0" gets the following properties of file "/textfile0.txt" using the WebDAV API
             |{http://owncloud.org/ns}favorite|
         Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
         Examples:
@@ -56,9 +56,9 @@ Feature: favorite
     Scenario Outline: Get favorited elements of a folder
         Given using <dav_version> DAV path
         And user "user0" has been created
-        When user "user0" favorites element "/FOLDER" using the API
-        And user "user0" favorites element "/textfile0.txt" using the API
-        And user "user0" favorites element "/textfile1.txt" using the API
+        When user "user0" favorites element "/FOLDER" using the WebDAV API
+        And user "user0" favorites element "/textfile0.txt" using the WebDAV API
+        And user "user0" favorites element "/textfile1.txt" using the WebDAV API
         Then user "user0" in folder "/" should have favorited the following elements
             | /FOLDER        |
             | /textfile0.txt |
@@ -75,10 +75,10 @@ Feature: favorite
         And user "user0" has moved file "/textfile0.txt" to "/subfolder/textfile0.txt"
         And user "user0" has moved file "/textfile1.txt" to "/subfolder/textfile1.txt"
         And user "user0" has moved file "/textfile2.txt" to "/subfolder/textfile2.txt"
-        When user "user0" favorites element "/subfolder/textfile0.txt" using the API
-        And user "user0" favorites element "/subfolder/textfile1.txt" using the API
-        And user "user0" favorites element "/subfolder/textfile2.txt" using the API
-        And user "user0" unfavorites element "/subfolder/textfile1.txt" using the API
+        When user "user0" favorites element "/subfolder/textfile0.txt" using the WebDAV API
+        And user "user0" favorites element "/subfolder/textfile1.txt" using the WebDAV API
+        And user "user0" favorites element "/subfolder/textfile2.txt" using the WebDAV API
+        And user "user0" unfavorites element "/subfolder/textfile1.txt" using the WebDAV API
         Then user "user0" in folder "/subfolder" should have favorited the following elements
             | /subfolder/textfile0.txt |
             | /subfolder/textfile2.txt |
@@ -95,7 +95,7 @@ Feature: favorite
         And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
         And user "user0" has shared folder "/shared" with user "user1"
         And user "user1" has favorited element "/shared/shared_file.txt"
-        When user "user1" moves file "/shared/shared_file.txt" to "/taken_out.txt" using the API
+        When user "user1" moves file "/shared/shared_file.txt" to "/taken_out.txt" using the WebDAV API
         Then user "user1" in folder "/" should have favorited the following elements
             | /taken_out.txt |
         Examples:
@@ -113,12 +113,12 @@ Feature: favorite
         And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile3.txt"
         And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile4.txt"
         And user "user0" has copied file "/textfile0.txt" to "/subfolder/textfile5.txt"
-        When user "user0" favorites element "/subfolder/textfile0.txt" using the API
-        And user "user0" favorites element "/subfolder/textfile1.txt" using the API
-        And user "user0" favorites element "/subfolder/textfile2.txt" using the API
-        And user "user0" favorites element "/subfolder/textfile3.txt" using the API
-        And user "user0" favorites element "/subfolder/textfile4.txt" using the API
-        And user "user0" favorites element "/subfolder/textfile5.txt" using the API
+        When user "user0" favorites element "/subfolder/textfile0.txt" using the WebDAV API
+        And user "user0" favorites element "/subfolder/textfile1.txt" using the WebDAV API
+        And user "user0" favorites element "/subfolder/textfile2.txt" using the WebDAV API
+        And user "user0" favorites element "/subfolder/textfile3.txt" using the WebDAV API
+        And user "user0" favorites element "/subfolder/textfile4.txt" using the WebDAV API
+        And user "user0" favorites element "/subfolder/textfile5.txt" using the WebDAV API
         Then user "user0" in folder "/subfolder" should have favorited the following elements from offset 3 and limit 2
             | /subfolder/textfile2.txt |
             | /subfolder/textfile3.txt |
@@ -133,8 +133,8 @@ Feature: favorite
 		And user "user1" has been created
 		And user "user0" has moved file "/textfile0.txt" to "/favoriteFile.txt"
 		And user "user0" has shared file "/favoriteFile.txt" with user "user1"
-		When user "user0" favorites element "/favoriteFile.txt" using the API
-		And user "user1" gets the following properties of file "/favoriteFile.txt" using the API
+		When user "user0" favorites element "/favoriteFile.txt" using the WebDAV API
+		And user "user1" gets the following properties of file "/favoriteFile.txt" using the WebDAV API
 			|{http://owncloud.org/ns}favorite|
 		Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
 		Examples:
@@ -148,8 +148,8 @@ Feature: favorite
 		And user "user1" has been created	
 		And user "user0" has moved file "/textfile0.txt" to "/favoriteFile.txt"	
 		And user "user0" has shared file "/favoriteFile.txt" with user "user1"	
-		When user "user1" favorites element "/favoriteFile.txt" using the API	
-		And user "user0" gets the following properties of file "/favoriteFile.txt" using the API	
+		When user "user1" favorites element "/favoriteFile.txt" using the WebDAV API
+		And user "user0" gets the following properties of file "/favoriteFile.txt" using the WebDAV API
 			|{http://owncloud.org/ns}favorite|	
 		Then the single response should contain a property "{http://owncloud.org/ns}favorite" with value "0"
 		Examples:
@@ -160,8 +160,8 @@ Feature: favorite
 	Scenario Outline: favoriting a folder does not change the favorite state of elements inside the folder
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" favorites element "/PARENT/parent.txt" using the API
-		And user "user0" favorites element "/PARENT" using the API
+		When user "user0" favorites element "/PARENT/parent.txt" using the WebDAV API
+		And user "user0" favorites element "/PARENT" using the WebDAV API
 		Then user "user0" in folder "/" should have favorited the following elements
 			| /PARENT            |
 			| /PARENT/parent.txt |

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -1,7 +1,7 @@
 @api
 Feature: quota
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	# Owner
 
@@ -9,7 +9,7 @@ Feature: quota
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And the quota of user "user0" has been set to "10 MB"
-		When user "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the API
+		When user "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
 		Then the HTTP status code of all upload responses should be "201"
 		Examples:
 			| dav_version   |
@@ -20,7 +20,7 @@ Feature: quota
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And the quota of user "user0" has been set to "20 B"
-		When user "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the API
+		When user "user0" uploads file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
 		Then the HTTP status code of all upload responses should be "507"
 		And as "user0" the file "/testquota.txt" should not exist
 		Examples:
@@ -33,7 +33,7 @@ Feature: quota
 		And user "user0" has been created
 		And the quota of user "user0" has been set to "10 MB"
 		And user "user0" has uploaded file with content "test" to "/testquota.txt"
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the API
+		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
 		Then the HTTP status code of all upload responses should be "204"
 		Examples:
 			| dav_version   |
@@ -45,7 +45,7 @@ Feature: quota
 		And user "user0" has been created
 		And the quota of user "user0" has been set to "20 B"
 		And user "user0" has uploaded file with content "test" to "/testquota.txt"
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the API
+		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
 		Then the HTTP status code of all upload responses should be "507"
 		And as "user0" the file "/testquota.txt" should not exist
 		Examples:
@@ -63,7 +63,7 @@ Feature: quota
 		And the quota of user "user1" has been set to "10 MB"
 		And user "user1" has created a folder "/testquota"
 		And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
-		When user "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the API
+		When user "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
 		Then the HTTP status code of all upload responses should be "201"
 		Examples:
 			| dav_version   |
@@ -78,7 +78,7 @@ Feature: quota
 		And the quota of user "user1" has been set to "20 B"
 		And user "user1" has created a folder "/testquota"
 		And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
-		When user "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the API
+		When user "user0" uploads file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
 		Then the HTTP status code of all upload responses should be "507"
 		And as "user0" the file "/testquota/testquota.txt" should not exist
 		Examples:
@@ -95,7 +95,7 @@ Feature: quota
 		And user "user1" has created a folder "/testquota"
 		And user "user1" has uploaded file with content "test" to "/testquota/testquota.txt"
 		And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the API
+		When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
 		Then the HTTP status code of all upload responses should be "204"
 		Examples:
 			| dav_version   |
@@ -111,7 +111,7 @@ Feature: quota
 		And user "user1" has created a folder "/testquota"
 		And user "user1" has uploaded file with content "test" to "/testquota/testquota.txt"
 		And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the API
+		When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
 		Then the HTTP status code of all upload responses should be "507"
 		And as "user0" the file "/testquota/testquota.txt" should not exist
 		Examples:
@@ -129,7 +129,7 @@ Feature: quota
 		And the quota of user "user1" has been set to "10 MB"
 		And user "user1" has uploaded file with content "test" to "/testquota.txt"
 		And user "user1" has shared file "/testquota.txt" with user "user0" with permissions 19
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the API
+		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
 		Then the HTTP status code of all upload responses should be "204"
 		Examples:
 			| dav_version   |
@@ -144,7 +144,7 @@ Feature: quota
 		And the quota of user "user1" has been set to "20 B"
 		And user "user1" has moved file "/textfile0.txt" to "/testquota.txt"
 		And user "user1" has shared file "/testquota.txt" with user "user0" with permissions 19
-		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the API
+		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
 		Then the HTTP status code of all upload responses should be "507"
 		Examples:
 			| dav_version   |

--- a/tests/acceptance/features/apiMain/recreatemasterkey.feature
+++ b/tests/acceptance/features/apiMain/recreatemasterkey.feature
@@ -6,8 +6,8 @@ Feature: recreate-master-key
 		Given user "admin" has been created
 		And user "admin" has uploaded file "data/textfile.txt" to "/somefile.txt"
 		When the administrator successfully recreates the encryption masterkey using the occ command
-		And user "admin" logs in to a web-style session using the API
-		And user "admin" logs in to a web-style session using the API
+		And user "admin" logs in to a web-style session
+		And user "admin" logs in to a web-style session
 		Then the downloaded content when downloading file "/somefile.txt" for user "admin" with range "bytes=0-6" should be "This is"
 
 	@masterkey_encryption
@@ -15,8 +15,8 @@ Feature: recreate-master-key
 		Given user "user0" has been created
 		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
 		When the administrator successfully recreates the encryption masterkey using the occ command
-		And user "admin" logs in to a web-style session using the API
-		And user "user0" logs in to a web-style session using the API
-		And user "user0" uploads chunk file "1" of "1" with "AA" to "/somefile.txt" using the API
+		And user "admin" logs in to a web-style session
+		And user "user0" logs in to a web-style session
+		And user "user0" uploads chunk file "1" of "1" with "AA" to "/somefile.txt" using the WebDAV API
 		Then the downloaded content when downloading file "/somefile.txt" for user "user0" with range "bytes=0-3" should be "AA"
 

--- a/tests/acceptance/features/apiMain/status.feature
+++ b/tests/acceptance/features/apiMain/status.feature
@@ -2,7 +2,7 @@
 Feature: Status
 
   Scenario: Status.php is correct
-      When the admin requests status.php using the API
+      When the admin requests status.php
       Then the status.php response should match with
       """
       {"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"$CURRENT_VERSION","versionstring":"$CURRENT_VERSION_STRING","edition":"Community","productname":"ownCloud"}

--- a/tests/acceptance/features/apiMain/tags.feature
+++ b/tests/acceptance/features/apiMain/tags.feature
@@ -3,7 +3,7 @@ Feature: tags
   
   Scenario Outline: Creating a normal tag as regular user should work
     Given user "user0" has been created
-    When user "user0" creates a "normal" tag with name "<tag_name>" using the API
+    When user "user0" creates a "normal" tag with name "<tag_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And the following tags should exist for "admin"
       |<tag_name>|normal|
@@ -17,32 +17,32 @@ Feature: tags
 
   Scenario: Creating a not user-assignable tag as regular user should fail
     Given user "user0" has been created
-    When user "user0" creates a "not user-assignable" tag with name "JustARegularTagName" using the API
+    When user "user0" creates a "not user-assignable" tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Creating a not user-visible tag as regular user should fail
     Given user "user0" has been created
-    When user "user0" creates a "not user-visible" tag with name "JustARegularTagName" using the API
+    When user "user0" creates a "not user-visible" tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Creating a not user-assignable tag with groups as admin should work
     Given user "user0" has been created
-    When user "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the API
+    When user "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
     Then the HTTP status code should be "201"
     And the "not user-assignable" tag with name "TagWithGroups" should have the groups "group1|group2"
 
   Scenario: Creating a normal tag with groups as regular user should fail
     Given user "user0" has been created
-    When user "user0" creates a "normal" tag with name "JustARegularTagName" and groups "group1|group2" using the API
+    When user "user0" creates a "normal" tag with name "JustARegularTagName" and groups "group1|group2" using the WebDAV API
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for "user0"
 
   Scenario Outline: Renaming a normal tag as regular user should work
     Given user "user0" has been created
     And user "admin" has created a "normal" tag with name "<tag_name>"
-    When user "user0" edits the tag with name "<tag_name>" and sets its name to "AnotherTagName" using the API
+    When user "user0" edits the tag with name "<tag_name>" and sets its name to "AnotherTagName" using the WebDAV API
     Then the following tags should exist for "admin"
       | AnotherTagName | normal |
 
@@ -54,40 +54,40 @@ Feature: tags
   Scenario: Renaming a not user-assignable tag as regular user should fail
     Given user "user0" has been created
     And user "admin" has created a "not user-assignable" tag with name "JustARegularTagName"
-    When user "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the API
+    When user "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the WebDAV API
     Then the following tags should exist for "admin"
       | JustARegularTagName | not user-assignable |
 
   Scenario: Renaming a not user-visible tag as regular user should fail
     Given user "user0" has been created
     And user "admin" has created a "not user-visible" tag with name "JustARegularTagName"
-    When user "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the API
+    When user "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the WebDAV API
     Then the following tags should exist for "admin"
       | JustARegularTagName | not user-visible |
 
   Scenario: Editing tag groups as admin should work
     Given user "user0" has been created
     And user "admin" has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
-    When user "admin" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the API
+    When user "admin" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the WebDAV API
     Then the "not user-assignable" tag with name "TagWithGroups" should have the groups "group1|group3"
 
   Scenario: Editing tag groups as regular user should fail
     Given user "user0" has been created
     And user "admin" has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
-    When user "user0" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the API
+    When user "user0" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the WebDAV API
     Then the "not user-assignable" tag with name "TagWithGroups" should have the groups "group1|group2"
 
   Scenario: Deleting a normal tag as regular user should work
     Given user "user0" has been created
     And user "admin" has created a "normal" tag with name "JustARegularTagName"
-    When user "user0" deletes the tag with name "JustARegularTagName" using the API
+    When user "user0" deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Deleting a not user-assignable tag as regular user should fail
     Given user "user0" has been created
     And user "admin" has created a "not user-assignable" tag with name "JustARegularTagName"
-    When user "user0" deletes the tag with name "JustARegularTagName" using the API
+    When user "user0" deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "403"
     And the following tags should exist for "admin"
       | JustARegularTagName | not user-assignable |
@@ -95,20 +95,20 @@ Feature: tags
   Scenario: Deleting a not user-visible tag as regular user should fail
     Given user "user0" has been created
     And user "admin" has created a "not user-visible" tag with name "JustARegularTagName"
-    When user "user0" deletes the tag with name "JustARegularTagName" using the API
+    When user "user0" deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "404"
     And the following tags should exist for "admin"
       | JustARegularTagName | not user-visible |
 
   Scenario: Deleting a not user-assignable tag as admin should work
     Given user "admin" has created a "not user-assignable" tag with name "JustARegularTagName"
-    When user "admin" deletes the tag with name "JustARegularTagName" using the API
+    When user "admin" deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for "admin"
 
   Scenario: Deleting a not user-visible tag as admin should work
     Given user "admin" has created a "not user-visible" tag with name "JustARegularTagName"
-    When user "admin" deletes the tag with name "JustARegularTagName" using the API
+    When user "admin" deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for "admin"
 
@@ -118,7 +118,7 @@ Feature: tags
     And user "admin" has created a "normal" tag with name "JustARegularTagName"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0" using the API
+    When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags
       | JustARegularTagName | normal |
@@ -129,8 +129,8 @@ Feature: tags
     And user "admin" has created a "normal" tag with name "MyFirstTag"
     And user "admin" has created a "normal" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
-    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the API
-    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" owned by "user0" using the API
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
+    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
     And file "/myFileToTag.txt" owned by "user0" should have the following tags
       | MyFirstTag | normal |
@@ -142,8 +142,8 @@ Feature: tags
     And user "admin" has created a "not user-assignable" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the API
-    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the API
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
+    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "403"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags
       | MyFirstTag | normal |
@@ -156,7 +156,7 @@ Feature: tags
     And user "admin" has created a "not user-assignable" tag with name "JustARegularTagName" and groups "group1"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0" using the API
+    When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags
       | JustARegularTagName | not user-assignable |
@@ -168,8 +168,8 @@ Feature: tags
     And user "admin" has created a "not user-visible" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
-    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the API
-    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the API
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
+    And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "412"
     And file "/myFileToTag.txt" shared by "user0" should have the following tags
       | MyFirstTag | normal |
@@ -182,8 +182,8 @@ Feature: tags
     And user "another_admin" has created a "not user-visible" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
-    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the API
-    And user "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the API
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
+    And user "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" should have the following tags for user "another_admin"
       | MyFirstTag  | normal           |
@@ -199,8 +199,8 @@ Feature: tags
     And user "another_admin" has created a "not user-assignable" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
-    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0" using the API
-    And user "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the API
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    And user "another_admin" adds the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "201"
     And file "/myFileToTag.txt" should have the following tags for user "another_admin"
       | MyFirstTag  | normal              |
@@ -218,7 +218,7 @@ Feature: tags
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
     And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" owned by "user0"
-    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
+    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "204"
     And file "/myFileToTag.txt" should have the following tags for user "user0"
       | MySecondTag | normal |
@@ -231,7 +231,7 @@ Feature: tags
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
+    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
     And file "/myFileToTag.txt" should have the following tags for user "user0"
       | MyFirstTag  | normal |
@@ -249,7 +249,7 @@ Feature: tags
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
     And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
+    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
     And file "/myFileToTag.txt" should have the following tags for user "user0"
       | MySecondTag | normal |
@@ -269,7 +269,7 @@ Feature: tags
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
     And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
+    When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "204"
     And file "/myFileToTag.txt" should have the following tags for user "user0"
       | MySecondTag | normal |
@@ -289,7 +289,7 @@ Feature: tags
     And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     And user "user0" has removed all shares from the file named "/myFileToTag.txt"
-    When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
+    When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
 
   Scenario: Unassigning a not user-assignable tag from a file shared by someone else as regular user should fail
@@ -304,7 +304,7 @@ Feature: tags
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
     And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
+    When user "user1" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "403"
     And file "/myFileToTag.txt" should have the following tags for user "user0"
       | MyFirstTag  | not user-assignable |
@@ -325,7 +325,7 @@ Feature: tags
     And user "user0" has shared file "/myFileToTag.txt" with user "another_admin"
     And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
-    When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
+    When user "another_admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "204"
     And file "/myFileToTag.txt" should have the following tags for user "user0"
       | MySecondTag | normal |
@@ -345,23 +345,23 @@ Feature: tags
     And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     And user "user0" has removed all shares from the file named "/myFileToTag.txt"
-    When user "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the API
+    When user "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
 
   Scenario: Overwriting existing normal tags should fail
     Given user "user0" has been created
     And user "user0" has created a "normal" tag with name "MyFirstTag"
-    When user "user0" creates a "normal" tag with name "MyFirstTag" using the API
+    When user "user0" creates a "normal" tag with name "MyFirstTag" using the WebDAV API
     Then the HTTP status code should be "409"
 
   Scenario: Overwriting existing not user-assignable tags should fail
     Given user "admin" has created a "not user-assignable" tag with name "MyFirstTag"
-    When user "admin" creates a "not user-assignable" tag with name "MyFirstTag" using the API
+    When user "admin" creates a "not user-assignable" tag with name "MyFirstTag" using the WebDAV API
     Then the HTTP status code should be "409"
 
   Scenario: Overwriting existing not user-visible tags should fail
     Given user "admin" has created a "not user-visible" tag with name "MyFirstTag"
-    When user "admin" creates a "not user-visible" tag with name "MyFirstTag" using the API
+    When user "admin" creates a "not user-visible" tag with name "MyFirstTag" using the WebDAV API
     Then the HTTP status code should be "409"
 
   Scenario: Getting tags only works with access to the file
@@ -369,7 +369,7 @@ Feature: tags
     And user "user1" has been created
     And user "admin" has created a "normal" tag with name "MyFirstTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
-    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0" using the API
+    When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then file "/myFileToTag.txt" should have the following tags for user "user0"
       | MyFirstTag | normal |
     And file "/myFileToTag.txt" should have the following tags for user "user1"
@@ -379,12 +379,12 @@ Feature: tags
     Given user "user0" has been created
     And group "group1" has been created
     And user "user0" has been added to group "group1"
-    When user "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the API
+    When user "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
     Then the HTTP status code should be "201"
     And the user "user0" should be able to assign the "not user-assignable" tag with name "TagWithGroups"
 
   Scenario: User cannot assign tags when not in the tag's groups
     Given user "user0" has been created
-    When user "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the API
+    When user "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
     Then the HTTP status code should be "201"
     And the user "user0" should not be able to assign the "not user-assignable" tag with name "TagWithGroups"

--- a/tests/acceptance/features/apiMain/tokenAuth.feature
+++ b/tests/acceptance/features/apiMain/tokenAuth.feature
@@ -2,7 +2,7 @@
 Feature: tokenAuth
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And these users have been created:
 			| username    | password | displayname  | email                 |
 			| user1       | 1234     | User One     | u1@oc.com.np          |
@@ -10,13 +10,13 @@ Feature: tokenAuth
 
 	Scenario: creating a user with basic auth should be blocked when token auth is enforced
 		Given user "brand-new-user" has been deleted
-		When the administrator sends a user creation request for user "brand-new-user" password "456firstpwd" using the API
+		When the administrator sends a user creation request for user "brand-new-user" password "456firstpwd" using the provisioning API
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 
 	Scenario: moving a file should be blocked when token auth is enforced
 		Given using new DAV path
-		When user "user1" moves file "/textfile0.txt" to "/renamed_textfile0.txt" using the API
+		When user "user1" moves file "/textfile0.txt" to "/renamed_textfile0.txt" using the WebDAV API
 		Then the HTTP status code should be "401"
 
 	Scenario: can access files app with an app password when token auth is enforced

--- a/tests/acceptance/features/apiMain/transfer-ownership.feature
+++ b/tests/acceptance/features/apiMain/transfer-ownership.feature
@@ -16,7 +16,7 @@ Feature: transfer-ownership
 		Given user "user0" has been created
 		And user "user1" has been created
 		And user "user0" has uploaded file "data/file_to_overwrite.txt" to "/PARENT/textfile0.txt"
-		And user "user0" has uploaded the following "3" chunks to "/PARENT/textfile0.txt" with old chunking and using the API
+		And user "user0" has uploaded the following "3" chunks to "/PARENT/textfile0.txt" with old chunking
 			| 1 | AA |
 			| 2 | BB |
 			| 3 | CC |
@@ -184,9 +184,9 @@ Feature: transfer-ownership
 		And user "user1" has been created
 		And user "user2" has been created
 		And user "user0" has created a folder "/test"
-		And user "user0" uploads file "data/textfile.txt" to "/test/somefile.txt" using the API
+		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
 		And user "user0" has shared folder "/test" with user "user2" with permissions 31
-		And user "user1" creates a share using the API with settings
+		And user "user1" creates a share using the sharing API with settings
 			| path      | /test/somefile.txt |
 			| shareType | 3                  |
 		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
@@ -252,11 +252,11 @@ Feature: transfer-ownership
 		And user "user0" has created a folder "/test"
 		And user "user0" has created a folder "/test/foo"
 		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
-		And user "user0" creates a share using the API with settings
+		And user "user0" creates a share using the sharing API with settings
 			| path      | /test/somefile.txt |
 			| shareType | 3                  |
 		And user "user0" has shared file "/test" with user "user1" with permissions 31
-		And user "user1" creates a share using the API with settings
+		And user "user1" creates a share using the sharing API with settings
 			| path      | /test |
 			| shareType | 3                  |
 		When the administrator transfers ownership from "user0" to "user1" using the occ command
@@ -297,7 +297,7 @@ Feature: transfer-ownership
 	Scenario: transferring ownership fails with empty files
 		Given user "user0" has been created
 		And user "user1" has been created
-		And user "user0" deletes everything from folder "/" using the API
+		And user "user0" deletes everything from folder "/" using the WebDAV API
 		When the administrator transfers ownership from "user0" to "user1" using the occ command
 		Then the command output should contain the text "No files/folders to transfer"
 		And the command should have failed with exit code 1

--- a/tests/acceptance/features/apiMain/transfer-ownership.feature
+++ b/tests/acceptance/features/apiMain/transfer-ownership.feature
@@ -186,7 +186,7 @@ Feature: transfer-ownership
 		And user "user0" has created a folder "/test"
 		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
 		And user "user0" has shared folder "/test" with user "user2" with permissions 31
-		And user "user1" creates a share using the sharing API with settings
+		And user "user1" has created a share with settings
 			| path      | /test/somefile.txt |
 			| shareType | 3                  |
 		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
@@ -297,7 +297,7 @@ Feature: transfer-ownership
 	Scenario: transferring ownership fails with empty files
 		Given user "user0" has been created
 		And user "user1" has been created
-		And user "user0" deletes everything from folder "/" using the WebDAV API
+		And user "user0" has deleted everything from folder "/"
 		When the administrator transfers ownership from "user0" to "user1" using the occ command
 		Then the command output should contain the text "No files/folders to transfer"
 		And the command should have failed with exit code 1

--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -5,10 +5,10 @@ I want to be able to add groups
 So that I can more easily manage access to resources by groups rather than individual users
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario Outline: admin creates a group
-		Given the administrator sends a group creation request for group "<group_id>" using the API
+		Given the administrator sends a group creation request for group "<group_id>" using the provisioning API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And group "<group_id>" should exist
@@ -34,14 +34,14 @@ So that I can more easily manage access to resources by groups rather than indiv
 
 	Scenario: admin tries to create a group that already exists
 		Given group "new-group" has been created
-		When the administrator sends a group creation request for group "new-group" using the API
+		When the administrator sends a group creation request for group "new-group" using the provisioning API
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
 		And group "new-group" should exist
 
 	Scenario: normal user tries to create a group
 		Given user "brand-new-user" has been created
-		When user "brand-new-user" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
+		When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
 			| groupid   | new-group   |
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
@@ -51,7 +51,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
+		And user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
 			| groupid   | another-group   |
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -8,7 +8,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 		Given using OCS API version "1"
 
 	Scenario Outline: admin creates a group
-		Given the administrator sends a group creation request for group "<group_id>" using the provisioning API
+		When the administrator sends a group creation request for group "<group_id>" using the provisioning API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And group "<group_id>" should exist
@@ -51,7 +51,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
+		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
 			| groupid   | another-group   |
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -5,12 +5,12 @@ I want to be able to add users to a group
 So that I can give a user access to the resources of the group
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario Outline: adding a user to a group
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -36,7 +36,7 @@ So that I can give a user access to the resources of the group
 
 	Scenario: normal user tries to add himself to a group
 		Given user "brand-new-user" has been created
-		When user "brand-new-user" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
@@ -45,7 +45,7 @@ So that I can give a user access to the resources of the group
 	Scenario: admin tries to add user to a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | not-group |
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
@@ -53,7 +53,7 @@ So that I can give a user access to the resources of the group
 
 	Scenario: admin tries to add user to a group without sending the group
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid |  |
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
@@ -62,7 +62,7 @@ So that I can give a user access to the resources of the group
 	Scenario: admin tries to add a user which does not exist to a group
 		Given user "not-user" has been deleted
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/not-user/groups" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "103"
 		And the HTTP status code should be "200"
@@ -73,7 +73,7 @@ So that I can give a user access to the resources of the group
 		And user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "104"
 		And the HTTP status code should be "200"
@@ -85,7 +85,7 @@ So that I can give a user access to the resources of the group
 		And group "new-group" has been created
 		And group "other-group" has been created
 		And user "other-subadmin" has been made a subadmin of group "other-group"
-		When user "other-subadmin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "other-subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "104"
 		And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -5,18 +5,18 @@ I want to be able to add users
 So that I can give people controlled individual access to resources on the ownCloud server
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin creates a user
 		Given user "brand-new-user" has been deleted
-		When the administrator sends a user creation request for user "brand-new-user" password "456firstpwd" using the API
+		When the administrator sends a user creation request for user "brand-new-user" password "456firstpwd" using the provisioning API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "brand-new-user" should exist
 
 	Scenario: admin tries to create an existing user
 		Given user "brand-new-user" has been created
-		When the administrator sends a user creation request for user "brand-new-user" password "456newpwd" using the API
+		When the administrator sends a user creation request for user "brand-new-user" password "456newpwd" using the provisioning API
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
 		And the API should not return any data
@@ -24,14 +24,14 @@ So that I can give people controlled individual access to resources on the ownCl
 	Scenario: admin tries to create an existing disabled user
 		Given user "brand-new-user" has been created
 		And user "brand-new-user" has been disabled
-		When the administrator sends a user creation request for user "brand-new-user" password "456newpwd" using the API
+		When the administrator sends a user creation request for user "brand-new-user" password "456newpwd" using the provisioning API
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
 		And the API should not return any data
 
 	Scenario: Admin creates a new user and adds him directly to a group
 		Given group "newgroup" has been created
-		When the administrator sends a user creation request for user "newuser" password "456firstpwd" group "newgroup" using the API
+		When the administrator sends a user creation request for user "newuser" password "456firstpwd" group "newgroup" using the provisioning API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "newuser" should belong to group "newgroup"

--- a/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
@@ -4,7 +4,7 @@ As an ownCloud user
 I want to be able to use the provisioning API with an app password
 So that I can make a client app or script for provisioning users/groups that can use an app password instead of my real password.
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin deletes the user
 		Given user "brand-new-user" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -5,12 +5,12 @@ I want to be able to make a user the subadmin of a group
 So that I can give administrative privilege of a group to a user
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin creates a subadmin
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -19,7 +19,7 @@ So that I can give administrative privilege of a group to a user
 	Scenario: admin tries to create a subadmin using a user which does not exist
 		Given user "not-user" has been deleted
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/not-user/subadmins" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
@@ -28,7 +28,7 @@ So that I can give administrative privilege of a group to a user
 	Scenario: admin tries to create a subadmin using a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | not-group |
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
@@ -39,9 +39,9 @@ So that I can give administrative privilege of a group to a user
 		And user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "admin" has sent HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		And user "admin" has sent HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
-		When user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -5,11 +5,11 @@ I want to be able to delete groups
 So that I can remove unnecessary groups
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario Outline: admin deletes a group
 		Given group "<group_id>" has been created
-		When the administrator deletes group "<group_id>" using the API
+		When the administrator deletes group "<group_id>" using the provisioning API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And group "<group_id>" should not exist
@@ -37,7 +37,7 @@ So that I can remove unnecessary groups
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
-		When user "brand-new-user" sends HTTP method "DELETE" to API endpoint "/cloud/groups/new-group"
+		When user "brand-new-user" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And group "new-group" should exist
@@ -46,7 +46,7 @@ So that I can remove unnecessary groups
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subamin" sends HTTP method "DELETE" to API endpoint "/cloud/groups/new-group"
+		When user "subamin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And group "new-group" should exist

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -5,11 +5,11 @@ I want to be able to delete users
 So that I can remove user from ownCloud
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: Delete a user
 		Given user "brand-new-user" has been created
-		When the administrator sends a user deletion request for user "brand-new-user" using the API
+		When the administrator sends a user deletion request for user "brand-new-user" using the provisioning API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "brand-new-user" should not exist
@@ -20,7 +20,7 @@ So that I can remove user from ownCloud
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When the subadmin "subadmin" sends a user deletion request for user "brand-new-user" using the API
+		When the subadmin "subadmin" sends a user deletion request for user "brand-new-user" using the provisioning API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "brand-new-user" should not exist
@@ -28,7 +28,7 @@ So that I can remove user from ownCloud
 	Scenario: normal user tries to delete a user
 		Given user "user1" has been created
 		And user "user2" has been created
-		When user "user1" sends HTTP method "DELETE" to API endpoint "/cloud/users/user2"
+		When user "user1" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/user2"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And user "user2" should exist

--- a/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
@@ -5,7 +5,7 @@ I want to be able to disable an enabled app
 So that I can stop the app features being used
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: Admin disables an app
 		Given the app "comments" has been enabled

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -5,11 +5,11 @@ I want to be able to disable a user
 So that I can remove access to files and resources for a user, without actually deleting the files and resources
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin disables an user
 		Given user "user1" has been created
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/user1/disable"
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "user1" should be disabled
@@ -21,7 +21,7 @@ So that I can remove access to files and resources for a user, without actually 
 		And user "subadmin" has been added to group "new-group"
 		And user "user1" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/user1/disable"
+		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "user1" should be disabled
@@ -34,7 +34,7 @@ So that I can remove access to files and resources for a user, without actually 
 		And user "subadmin" has been added to group "new-group"
 		And user "user1" has been added to group "another-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/user1/disable"
+		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And user "user1" should be enabled
@@ -47,7 +47,7 @@ So that I can remove access to files and resources for a user, without actually 
 		And user "subadmin" has been added to group "new-group"
 		And user "another-admin" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/disable"
+		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And user "another-admin" should be enabled
@@ -55,7 +55,7 @@ So that I can remove access to files and resources for a user, without actually 
 	Scenario: Admin can disable another admin user
 		Given user "another-admin" has been created
 		And user "another-admin" has been added to group "admin"
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/disable"
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "another-admin" should be disabled
@@ -66,7 +66,7 @@ So that I can remove access to files and resources for a user, without actually 
 		And user "subadmin" has been added to group "new-group"
 		And user "admin" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/subadmin/disable"
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "subadmin" should be disabled
@@ -74,7 +74,7 @@ So that I can remove access to files and resources for a user, without actually 
 	Scenario: Admin user cannot disable himself
 		Given user "another-admin" has been created
 		And user "another-admin" has been added to group "admin"
-		When user "another-admin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/disable"
+		When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
 		And user "another-admin" should be enabled
@@ -82,7 +82,7 @@ So that I can remove access to files and resources for a user, without actually 
 	Scenario: disable an user with a regular user
 		Given user "user1" has been created
 		And user "user2" has been created
-		When user "user1" sends HTTP method "PUT" to API endpoint "/cloud/users/user2/disable"
+		When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/disable"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And user "user2" should be enabled
@@ -92,7 +92,7 @@ So that I can remove access to files and resources for a user, without actually 
 		And group "new-group" has been created
 		And user "subadmin" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/subadmin/disable"
+		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
 		And user "subadmin" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -5,11 +5,11 @@ I want to be able to edit a user
 So that I can change user information
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: Edit a user
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | quota                    |
 			| value | 12MB                     |
 			| key   | email                    |
@@ -20,17 +20,17 @@ So that I can change user information
 
 	Scenario: Override existing user email
 		Given user "brand-new-user" has been created
-		And user "admin" has sent HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
+		And user "admin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | email                    |
 			| value | brand-new-user@gmail.com |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "admin" has sent HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
+		And user "admin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | email                      |
 			| value | brand-new-user@example.com |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the user attributes returned by the API should include
@@ -42,13 +42,13 @@ So that I can change user information
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "subadmin" has sent HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
+		And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | quota                      |
 			| value | 12MB                       |
-		And user "subadmin" has sent HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
+		And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | email                      |
 			| value | brand-new-user@example.com |
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the user attributes returned by the API should include
@@ -57,7 +57,7 @@ So that I can change user information
 
 	Scenario: normal user should not be able to change their quota
 		Given user "brand-new-user" has been created
-		When user "brand-new-user" sends HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
+		When user "brand-new-user" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | quota                      |
 			| value | 12MB                       |
 		Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -5,7 +5,7 @@ I want to be able to enable a disabled app
 So that I can use the app features again
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: Admin enables an app
 		Given the app "comments" has been disabled

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -5,12 +5,12 @@ I want to be able to enable a user
 So that I can give a user access to their files and resources again if they are now authorized for that
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin enables an user
 		Given user "user1" has been created
 		And user "user1" has been disabled
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/user1/enable"
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/enable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "user1" should be enabled
@@ -19,7 +19,7 @@ So that I can give a user access to their files and resources again if they are 
 		Given user "another-admin" has been created
 		And user "another-admin" has been added to group "admin"
 		And user "another-admin" has been disabled
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/enable"
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "another-admin" should be enabled
@@ -30,7 +30,7 @@ So that I can give a user access to their files and resources again if they are 
 		And user "subadmin" has been added to group "new-group"
 		And user "admin" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/subadmin/disable"
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "subadmin" should be disabled
@@ -39,14 +39,14 @@ So that I can give a user access to their files and resources again if they are 
 		And user "another-admin" has been created
 		And user "another-admin" has been added to group "admin"
 		And user "another-admin" has been disabled
-		When user "another-admin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/enable"
+		When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
 		Then user "another-admin" should be disabled
 
 	Scenario: normal user tries to enable other user
 		Given user "user1" has been created
 		And user "user2" has been created
 		And user "user2" has been disabled
-		When user "user1" sends HTTP method "PUT" to API endpoint "/cloud/users/user2/enable"
+		When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/enable"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And user "user2" should be disabled
@@ -57,7 +57,7 @@ So that I can give a user access to their files and resources again if they are 
 		And user "subadmin" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "subadmin" has been disabled
-		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/subadmin/enabled"
+		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/enabled"
 		And user "subadmin" should be disabled
 
 	Scenario: Making a web request with an enabled user

--- a/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
@@ -5,10 +5,10 @@ I want to be able to get app info
 So that I can get the information of a specific application
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin gets app info
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/apps/files"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/apps/files"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the XML "data" "id" value should be "files"

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -5,11 +5,11 @@ I want to be able to get the list of apps on my ownCloud
 So that I can manage apps
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	@no_encryption
 	Scenario: admin gets enabled apps
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/apps?filter=enabled"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the apps returned by the API should include

--- a/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
@@ -5,7 +5,7 @@ I want to be able to get group details
 So that I can know which users are in a group
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin gets users in the group
 		Given user "brand-new-user" has been created
@@ -13,7 +13,7 @@ So that I can know which users are in a group
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "123" has been added to group "new-group"
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the users returned by the API should be
@@ -22,7 +22,7 @@ So that I can know which users are in a group
 
 	Scenario: admin tries to get users in the empty group
 		Given group "new-group" has been created
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the list of users returned by the API should be empty
@@ -35,7 +35,7 @@ So that I can know which users are in a group
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "user1" has been added to group "new-group"
 		And user "user2" has been added to group "new-group"
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the users returned by the API should be
@@ -47,13 +47,13 @@ So that I can know which users are in a group
 		And group "new-group" has been created
 		And group "another-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/groups/another-group"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/another-group"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 
 	Scenario: normal user tries to get users in his group
 		Given user "newuser" has been created
 		And group "new-group" has been created
-		When user "newuser" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
+		When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
@@ -5,14 +5,14 @@ I want to be able to get groups
 So that I can see all the groups in my ownCloud
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin gets all the groups
 		Given group "0" has been created
 		And group "new-group" has been created
 		And group "admin" has been created
 		And group "España" has been created
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
 		Then the groups returned by the API should be
 			| España    |
 			| admin     |

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdminGroups.feature
@@ -5,13 +5,13 @@ I want to be able to get the groups in which the user is subadmin
 So that I can know in which groups the user has administrative rights
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin gets subadmin groups of a user
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user/subadmins"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/subadmins"
 		Then the subadmin groups returned by the API should be
 			| new-group |
 		And the OCS status code should be "100"
@@ -20,7 +20,7 @@ So that I can know in which groups the user has administrative rights
 	Scenario: admin tries to get subadmin groups of a user which do not exist
 		Given user "not-user" has been deleted
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/not-user/subadmins"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/not-user/subadmins"
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
 		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -5,13 +5,13 @@ I want to be able to get the list of subadmins of a group
 So that I can manage subadmins of a group
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin gets subadmin users of a group
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group/subadmins"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
 		Then the subadmin users returned by the API should be
 			| brand-new-user |
 		And the OCS status code should be "100"
@@ -20,7 +20,7 @@ So that I can manage subadmins of a group
 	Scenario: admin tries to get subadmin users of a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/not-group/subadmins"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/not-group/subadmins"
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
 		And the API should not return any data
@@ -31,7 +31,7 @@ So that I can manage subadmins of a group
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "newsubadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group/subadmins"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And the API should not return any data
@@ -41,7 +41,7 @@ So that I can manage subadmins of a group
 		And user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "newuser" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group/subadmins"
+		When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -4,17 +4,17 @@ As an admin
 I want to be able to get user
 So that I can get information about user
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin gets existing user
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the display name returned by the API should be "brand-new-user"
 
 	Scenario: admin tries to get a not existing user
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/test"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
 		Then the OCS status code should be "998"
 		And the HTTP status code should be "200"
 		And the API should not return any data
@@ -25,7 +25,7 @@ So that I can get information about user
 		And group "newgroup" has been created
 		And user "newuser" has been added to group "newgroup"
 		And user "subadmin" has been made a subadmin of group "newgroup"
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/users/newuser"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the display name returned by the API should be "newuser"
@@ -35,7 +35,7 @@ So that I can get information about user
 		And user "newuser" has been created
 		And group "newgroup" has been created
 		And user "subadmin" has been made a subadmin of group "newgroup"
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/users/newuser"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And the API should not return any data
@@ -43,14 +43,14 @@ So that I can get information about user
 	Scenario: normal user tries to get information of another user
 		Given user "newuser" has been created
 		And user "anotheruser" has been created
-		When user "anotheruser" sends HTTP method "GET" to API endpoint "/cloud/users/newuser"
+		When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And the API should not return any data
 
 	Scenario: normal user gets his own information
 		Given user "newuser" has been created
-		When user "newuser" sends HTTP method "GET" to API endpoint "/cloud/users/newuser"
+		When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the display name returned by the API should be "newuser"

--- a/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
@@ -5,7 +5,7 @@ I want to be able to get groups
 So that I can manage group membership
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin gets groups of an user
 		Given user "brand-new-user" has been created
@@ -20,7 +20,7 @@ So that I can manage group membership
 		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
 		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
 		And user "brand-new-user" has been added to group "नेपाली"
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user/groups"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
 		Then the groups returned by the API should be
 			| new-group            |
 			| 0                    |
@@ -38,7 +38,7 @@ So that I can manage group membership
 		And user "subadmin" has been made a subadmin of group "newgroup"
 		And user "newuser" has been added to group "newgroup"
 		And user "newuser" has been added to group "anothergroup"
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/users/newuser/groups"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
 		Then the groups returned by the API should include "newgroup"
 		And the groups returned by the API should not include "anothergroup"
 		And the OCS status code should be "100"
@@ -49,7 +49,7 @@ So that I can manage group membership
 		And user "anotheruser" has been created
 		And group "newgroup" has been created
 		And user "newuser" has been added to group "newgroup"
-		When user "anotheruser" sends HTTP method "GET" to API endpoint "/cloud/users/newuser/groups"
+		When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And the API should not return any data
@@ -57,7 +57,7 @@ So that I can manage group membership
 	Scenario: admin gets groups of an user who is not in any groups
 		Given user "brand-new-user" has been created
 		And group "unused-group" has been created
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user/groups"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the list of groups returned by the API should be empty

--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -5,12 +5,12 @@ I want to be able to list the users that exist
 So that I can see who has access to ownCloud
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin gets all users
 		Given user "brand-new-user" has been created
 		And user "admin" has been created
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the users returned by the API should be
@@ -23,7 +23,7 @@ So that I can see who has access to ownCloud
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "brand-new-user" sends HTTP method "GET" to API endpoint "/cloud/users"
+		When user "brand-new-user" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
 		Then the users returned by the API should be
 			| brand-new-user |
 		And the OCS status code should be "100"
@@ -32,7 +32,7 @@ So that I can see who has access to ownCloud
 	Scenario: normal user tries to get other users
 		Given user "normaluser" has been created
 		And user "newuser" has been created
-		When user "normaluser" sends HTTP method "GET" to API endpoint "/cloud/users"
+		When user "normaluser" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
 		And the OCS status code should be "997"
 		And the HTTP status code should be "401"
 		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -5,13 +5,13 @@ I want to be able to remove a user from a group
 So that I can manage user access to group resources
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario Outline: admin removes a user from a group
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
 		And user "brand-new-user" has been added to group "<group_id>"
-		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200" 
@@ -39,7 +39,7 @@ So that I can manage user access to group resources
 	Scenario: admin tries to remove a user from a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | not-group |
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
@@ -51,7 +51,7 @@ So that I can manage user access to group resources
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -64,7 +64,7 @@ So that I can manage user access to group resources
 		And group "other-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "other-subadmin" has been made a subadmin of group "other-group"
-		When user "other-subadmin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "other-subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "104"
 		And the HTTP status code should be "200"
@@ -76,7 +76,7 @@ So that I can manage user access to group resources
 		And group "new-group" has been created
 		And user "newuser" has been added to group "new-group"
 		And user "anotheruser" has been added to group "new-group"
-		When user "newuser" sends HTTP method "DELETE" to API endpoint "/cloud/users/anotheruser/groups" with body
+		When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/anotheruser/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
@@ -5,13 +5,13 @@ I want to be able to remove subadmin rights to a user from a group
 So that I cam manage administrative access rights for groups
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario: admin removes subadmin from a group
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -23,7 +23,7 @@ So that I cam manage administrative access rights for groups
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "newsubadmin" has been created
 		And user "newsubadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "DELETE" to API endpoint "/cloud/users/newsubadmin/subadmins" with body
+		When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/newsubadmin/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
@@ -35,7 +35,7 @@ So that I cam manage administrative access rights for groups
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "newuser" has been added to group "new-group"
-		When user "newuser" sends HTTP method "DELETE" to API endpoint "/cloud/users/subadmin/subadmins" with body
+		When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/subadmin/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -5,10 +5,10 @@ I want to be able to add groups
 So that I can more easily manage access to resources by groups rather than individual users
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario Outline: admin creates a group
-		Given the administrator sends a group creation request for group "<group_id>" using the API
+		Given the administrator sends a group creation request for group "<group_id>" using the provisioning API
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And group "<group_id>" should exist
@@ -34,7 +34,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 
 	Scenario: admin tries to create a group that already exists
 		Given group "new-group" has been created
-		When the administrator sends a group creation request for group "new-group" using the API
+		When the administrator sends a group creation request for group "new-group" using the provisioning API
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
 		And group "new-group" should exist
@@ -42,7 +42,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 	@skip @issue-31276
 	Scenario: normal user tries to create a group
 		Given user "brand-new-user" has been created
-		When user "brand-new-user" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
+		When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
 			| groupid   | new-group   |
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
@@ -52,7 +52,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/groups" with body
+		And user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
 			| groupid   | another-group   |
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -8,7 +8,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 		Given using OCS API version "2"
 
 	Scenario Outline: admin creates a group
-		Given the administrator sends a group creation request for group "<group_id>" using the provisioning API
+		When the administrator sends a group creation request for group "<group_id>" using the provisioning API
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And group "<group_id>" should exist
@@ -52,7 +52,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
+		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/groups" with body
 			| groupid   | another-group   |
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -5,12 +5,12 @@ I want to be able to add users to a group
 So that I can give a user access to the resources of the group
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario Outline: adding a user to a group
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
@@ -37,7 +37,7 @@ So that I can give a user access to the resources of the group
 	@skip @issue-31276
 	Scenario: normal user tries to add himself to a group
 		Given user "brand-new-user" has been created
-		When user "brand-new-user" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
@@ -46,7 +46,7 @@ So that I can give a user access to the resources of the group
 	Scenario: admin tries to add user to a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | not-group |
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
@@ -54,7 +54,7 @@ So that I can give a user access to the resources of the group
 
 	Scenario: admin tries to add user to a group without sending the group
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid |  |
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
@@ -63,7 +63,7 @@ So that I can give a user access to the resources of the group
 	Scenario: admin tries to add a user which does not exist to a group
 		Given user "not-user" has been deleted
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/not-user/groups" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
@@ -74,7 +74,7 @@ So that I can give a user access to the resources of the group
 		And user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "403"
 		And the HTTP status code should be "403"
@@ -86,7 +86,7 @@ So that I can give a user access to the resources of the group
 		And group "new-group" has been created
 		And group "other-group" has been created
 		And user "other-subadmin" has been made a subadmin of group "other-group"
-		When user "other-subadmin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "other-subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "403"
 		And the HTTP status code should be "403"

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -5,18 +5,18 @@ I want to be able to add users
 So that I can give people controlled individual access to resources on the ownCloud server
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: Create a user
 		Given user "brand-new-user" has been deleted
-		When the administrator sends a user creation request for user "brand-new-user" password "456firstpwd" using the API
+		When the administrator sends a user creation request for user "brand-new-user" password "456firstpwd" using the provisioning API
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "brand-new-user" should exist
 
 	Scenario: admin tries to create an existing user
 		Given user "brand-new-user" has been created
-		When the administrator sends a user creation request for user "brand-new-user" password "456newpwd" using the API
+		When the administrator sends a user creation request for user "brand-new-user" password "456newpwd" using the provisioning API
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
 		And the API should not return any data
@@ -24,14 +24,14 @@ So that I can give people controlled individual access to resources on the ownCl
 	Scenario: admin tries to create an existing disabled user
 		Given user "brand-new-user" has been created
 		And user "brand-new-user" has been disabled
-		When the administrator sends a user creation request for user "brand-new-user" password "456newpwd" using the API
+		When the administrator sends a user creation request for user "brand-new-user" password "456newpwd" using the provisioning API
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
 		And the API should not return any data
 
 	Scenario: Admin creates a new user and adds him directly to a group
 		Given group "newgroup" has been created
-		When the administrator sends a user creation request for user "newuser" password "456firstpwd" group "newgroup" using the API
+		When the administrator sends a user creation request for user "newuser" password "456firstpwd" group "newgroup" using the provisioning API
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "newuser" should belong to group "newgroup"

--- a/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
@@ -4,7 +4,7 @@ As an ownCloud user
 I want to be able to use the provisioning API with an app password
 So that I can make a client app or script for provisioning users/groups that can use an app password instead of my real password.
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: admin deletes the user
 		Given user "brand-new-user" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -5,12 +5,12 @@ I want to be able to make a user the subadmin of a group
 So that I can give administrative privilege of a group to a user
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: admin creates a subadmin
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
@@ -19,7 +19,7 @@ So that I can give administrative privilege of a group to a user
 	Scenario: admin tries to create a subadmin using a user which does not exist
 		Given user "not-user" has been deleted
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/not-user/subadmins" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
@@ -28,7 +28,7 @@ So that I can give administrative privilege of a group to a user
 	Scenario: admin tries to create a subadmin using a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | not-group |
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
@@ -39,9 +39,9 @@ So that I can give administrative privilege of a group to a user
 		And user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "admin" has sent HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		And user "admin" has sent HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
-		When user "subadmin" sends HTTP method "POST" to API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -5,11 +5,11 @@ I want to be able to delete groups
 So that I can remove unnecessary groups
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario Outline: admin deletes a group
 		Given group "<group_id>" has been created
-		When the administrator deletes group "<group_id>" using the API
+		When the administrator deletes group "<group_id>" using the provisioning API
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And group "<group_id>" should not exist
@@ -38,7 +38,7 @@ So that I can remove unnecessary groups
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
-		When user "brand-new-user" sends HTTP method "DELETE" to API endpoint "/cloud/groups/new-group"
+		When user "brand-new-user" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
 		And group "new-group" should exist
@@ -48,7 +48,7 @@ So that I can remove unnecessary groups
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subamin" sends HTTP method "DELETE" to API endpoint "/cloud/groups/new-group"
+		When user "subamin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
 		And group "new-group" should exist

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -5,11 +5,11 @@ I want to be able to delete users
 So that I can remove user from ownCloud
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: Delete a user
 		Given user "brand-new-user" has been created
-		When the administrator sends a user deletion request for user "brand-new-user" using the API
+		When the administrator sends a user deletion request for user "brand-new-user" using the provisioning API
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "brand-new-user" should not exist
@@ -20,7 +20,7 @@ So that I can remove user from ownCloud
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When the subadmin "subadmin" sends a user deletion request for user "brand-new-user" using the API
+		When the subadmin "subadmin" sends a user deletion request for user "brand-new-user" using the provisioning API
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "brand-new-user" should not exist
@@ -29,7 +29,7 @@ So that I can remove user from ownCloud
 	Scenario: normal user tries to delete a user
 		Given user "user1" has been created
 		And user "user2" has been created
-		When user "user1" sends HTTP method "DELETE" to API endpoint "/cloud/users/user2"
+		When user "user1" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/user2"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
 		And user "user2" should exist

--- a/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
@@ -5,7 +5,7 @@ I want to be able to disable an enabled app
 So that I can stop the app features being used
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: Admin disables an app
 		Given the app "comments" has been enabled

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -5,11 +5,11 @@ I want to be able to disable a user
 So that I can remove access to files and resources for a user, without actually deleting the files and resources
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: admin disables an user
 		Given user "user1" has been created
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/user1/disable"
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "user1" should be disabled
@@ -21,7 +21,7 @@ So that I can remove access to files and resources for a user, without actually 
 		And user "subadmin" has been added to group "new-group"
 		And user "user1" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/user1/disable"
+		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "user1" should be disabled
@@ -35,7 +35,7 @@ So that I can remove access to files and resources for a user, without actually 
 		And user "subadmin" has been added to group "new-group"
 		And user "user1" has been added to group "another-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/user1/disable"
+		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
 		And user "user1" should be enabled
@@ -49,7 +49,7 @@ So that I can remove access to files and resources for a user, without actually 
 		And user "subadmin" has been added to group "new-group"
 		And user "another-admin" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/disable"
+		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
 		And user "another-admin" should be enabled
@@ -57,7 +57,7 @@ So that I can remove access to files and resources for a user, without actually 
 	Scenario: Admin can disable another admin user
 		Given user "another-admin" has been created
 		And user "another-admin" has been added to group "admin"
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/disable"
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "another-admin" should be disabled
@@ -68,7 +68,7 @@ So that I can remove access to files and resources for a user, without actually 
 		And user "subadmin" has been added to group "new-group"
 		And user "admin" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/subadmin/disable"
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "subadmin" should be disabled
@@ -76,7 +76,7 @@ So that I can remove access to files and resources for a user, without actually 
 	Scenario: Admin user cannot disable himself
 		Given user "another-admin" has been created
 		And user "another-admin" has been added to group "admin"
-		When user "another-admin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/disable"
+		When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
 		And user "another-admin" should be enabled
@@ -85,7 +85,7 @@ So that I can remove access to files and resources for a user, without actually 
 	Scenario: disable an user with a regular user
 		Given user "user1" has been created
 		And user "user2" has been created
-		When user "user1" sends HTTP method "PUT" to API endpoint "/cloud/users/user2/disable"
+		When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/disable"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
 		And user "user2" should be enabled
@@ -95,7 +95,7 @@ So that I can remove access to files and resources for a user, without actually 
 		And group "new-group" has been created
 		And user "subadmin" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/subadmin/disable"
+		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
 		And user "subadmin" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -5,11 +5,11 @@ I want to be able to edit a user
 So that I can change user information
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: Edit a user
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | quota                    |
 			| value | 12MB                     |
 			| key   | email                    |
@@ -20,17 +20,17 @@ So that I can change user information
 
 	Scenario: Override existing user email
 		Given user "brand-new-user" has been created
-		And user "admin" has sent HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
+		And user "admin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | email                    |
 			| value | brand-new-user@gmail.com |
 		And the OCS status code should be "200"
 		And the HTTP status code should be "200"
-		And user "admin" has sent HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
+		And user "admin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | email                      |
 			| value | brand-new-user@example.com |
 		And the OCS status code should be "200"
 		And the HTTP status code should be "200"
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the user attributes returned by the API should include
@@ -42,13 +42,13 @@ So that I can change user information
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "subadmin" has sent HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
+		And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | quota                      |
 			| value | 12MB                       |
-		And user "subadmin" has sent HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
+		And user "subadmin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | email                      |
 			| value | brand-new-user@example.com |
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the user attributes returned by the API should include
@@ -58,7 +58,7 @@ So that I can change user information
 	@skip @issue-31276
 	Scenario: normal user should not be able to change their quota
 		Given user "brand-new-user" has been created
-		When user "brand-new-user" sends HTTP method "PUT" to API endpoint "/cloud/users/brand-new-user" with body
+		When user "brand-new-user" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | quota                      |
 			| value | 12MB                       |
 		Then the OCS status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -5,7 +5,7 @@ I want to be able to enable a disabled app
 So that I can use the app features again
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: Admin enables an app
 		Given the app "comments" has been disabled

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -5,12 +5,12 @@ I want to be able to enable a user
 So that I can give a user access to their files and resources again if they are now authorized for that
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: admin enables an user
 		Given user "user1" has been created
 		And user "user1" has been disabled
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/user1/enable"
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/enable"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "user1" should be enabled
@@ -19,7 +19,7 @@ So that I can give a user access to their files and resources again if they are 
 		Given user "another-admin" has been created
 		And user "another-admin" has been added to group "admin"
 		And user "another-admin" has been disabled
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/enable"
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "another-admin" should be enabled
@@ -30,7 +30,7 @@ So that I can give a user access to their files and resources again if they are 
 		And user "subadmin" has been added to group "new-group"
 		And user "admin" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "PUT" to API endpoint "/cloud/users/subadmin/disable"
+		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "subadmin" should be disabled
@@ -39,7 +39,7 @@ So that I can give a user access to their files and resources again if they are 
 		And user "another-admin" has been created
 		And user "another-admin" has been added to group "admin"
 		And user "another-admin" has been disabled
-		When user "another-admin" sends HTTP method "PUT" to API endpoint "/cloud/users/another-admin/enable"
+		When user "another-admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
 		Then user "another-admin" should be disabled
 
 	@skip @issue-31276
@@ -47,7 +47,7 @@ So that I can give a user access to their files and resources again if they are 
 		Given user "user1" has been created
 		And user "user2" has been created
 		And user "user2" has been disabled
-		When user "user1" sends HTTP method "PUT" to API endpoint "/cloud/users/user2/enable"
+		When user "user1" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user2/enable"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
 		And user "user2" should be disabled
@@ -58,7 +58,7 @@ So that I can give a user access to their files and resources again if they are 
 		And user "subadmin" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "subadmin" has been disabled
-		When user "subadmin" sends HTTP method "PUT" to API endpoint "/cloud/users/subadmin/enabled"
+		When user "subadmin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/enabled"
 		And user "subadmin" should be disabled
 
 	Scenario: Making a web request with an enabled user

--- a/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
@@ -5,10 +5,10 @@ I want to be able to get app info
 So that I can get the information of a specific application
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: admin gets app info
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/apps/files"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/apps/files"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the XML "data" "id" value should be "files"

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -5,11 +5,11 @@ I want to be able to get the list of apps on my ownCloud
 So that I can manage apps
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	@no_encryption
 	Scenario: admin gets enabled apps
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/apps?filter=enabled"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the apps returned by the API should include

--- a/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
@@ -5,7 +5,7 @@ I want to be able to get group details
 So that I can know which users are in a group
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: admin gets users in the group
 		Given user "brand-new-user" has been created
@@ -13,7 +13,7 @@ So that I can know which users are in a group
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "123" has been added to group "new-group"
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the users returned by the API should be
@@ -22,7 +22,7 @@ So that I can know which users are in a group
 
 	Scenario: admin tries to get users in the empty group
 		Given group "new-group" has been created
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the list of users returned by the API should be empty
@@ -35,7 +35,7 @@ So that I can know which users are in a group
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "user1" has been added to group "new-group"
 		And user "user2" has been added to group "new-group"
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the users returned by the API should be
@@ -48,7 +48,7 @@ So that I can know which users are in a group
 		And group "new-group" has been created
 		And group "another-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/groups/another-group"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/another-group"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
 
@@ -56,6 +56,6 @@ So that I can know which users are in a group
 	Scenario: normal user tries to get users in his group
 		Given user "newuser" has been created
 		And group "new-group" has been created
-		When user "newuser" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group"
+		When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
@@ -5,14 +5,14 @@ I want to be able to get groups
 So that I can see all the groups in my ownCloud
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: admin gets all the groups
 		Given group "0" has been created
 		And group "new-group" has been created
 		And group "admin" has been created
 		And group "España" has been created
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
 		Then the groups returned by the API should be
 			| España    |
 			| admin     |

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdminGroups.feature
@@ -5,13 +5,13 @@ I want to be able to get the groups in which the user is subadmin
 So that I can know in which groups the user has administrative rights
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: admin gets subadmin groups of a user
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user/subadmins"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/subadmins"
 		Then the subadmin groups returned by the API should be
 			| new-group |
 		And the OCS status code should be "200"
@@ -20,7 +20,7 @@ So that I can know in which groups the user has administrative rights
 	Scenario: admin tries to get subadmin groups of a user which do not exist
 		Given user "not-user" has been deleted
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/not-user/subadmins"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/not-user/subadmins"
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
 		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -5,13 +5,13 @@ I want to be able to get the list of subadmins of a group
 So that I can manage subadmins of a group
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: admin gets subadmin users of a group
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group/subadmins"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
 		Then the subadmin users returned by the API should be
 			| brand-new-user |
 		And the OCS status code should be "200"
@@ -20,7 +20,7 @@ So that I can manage subadmins of a group
 	Scenario: admin tries to get subadmin users of a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/groups/not-group/subadmins"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/not-group/subadmins"
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
 		And the API should not return any data
@@ -32,7 +32,7 @@ So that I can manage subadmins of a group
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "newsubadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group/subadmins"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
 		And the API should not return any data
@@ -43,7 +43,7 @@ So that I can manage subadmins of a group
 		And user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "newuser" sends HTTP method "GET" to API endpoint "/cloud/groups/new-group/subadmins"
+		When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
 		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -4,17 +4,17 @@ As an admin
 I want to be able to get user
 So that I can get information about user
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: admin gets an existing user
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the display name returned by the API should be "brand-new-user"
 
 	Scenario: admin tries to get a not existing user
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/test"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "404"
 		And the API should not return any data
@@ -25,7 +25,7 @@ So that I can get information about user
 		And group "newgroup" has been created
 		And user "newuser" has been added to group "newgroup"
 		And user "subadmin" has been made a subadmin of group "newgroup"
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/users/newuser"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the display name returned by the API should be "newuser"
@@ -36,7 +36,7 @@ So that I can get information about user
 		And user "newuser" has been created
 		And group "newgroup" has been created
 		And user "subadmin" has been made a subadmin of group "newgroup"
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/users/newuser"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
 		And the API should not return any data
@@ -45,14 +45,14 @@ So that I can get information about user
 	Scenario: normal user tries to get information of another user
 		Given user "newuser" has been created
 		And user "anotheruser" has been created
-		When user "anotheruser" sends HTTP method "GET" to API endpoint "/cloud/users/newuser"
+		When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
 		And the API should not return any data
 
 	Scenario: normal user gets his own information
 		Given user "newuser" has been created
-		When user "newuser" sends HTTP method "GET" to API endpoint "/cloud/users/newuser"
+		When user "newuser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the display name returned by the API should be "newuser"

--- a/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
@@ -5,7 +5,7 @@ I want to be able to get groups
 So that I can manage group membership
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: admin gets groups of an user
 		Given user "brand-new-user" has been created
@@ -20,7 +20,7 @@ So that I can manage group membership
 		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
 		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
 		And user "brand-new-user" has been added to group "नेपाली"
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users/brand-new-user/groups"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
 		Then the groups returned by the API should be
 			| new-group            |
 			| 0                    |
@@ -38,7 +38,7 @@ So that I can manage group membership
 		And user "subadmin" has been made a subadmin of group "newgroup"
 		And user "newuser" has been added to group "newgroup"
 		And user "newuser" has been added to group "anothergroup"
-		When user "subadmin" sends HTTP method "GET" to API endpoint "/cloud/users/newuser/groups"
+		When user "subadmin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
 		Then the groups returned by the API should include "newgroup"
 		And the groups returned by the API should not include "anothergroup"
 		And the OCS status code should be "200"
@@ -50,7 +50,7 @@ So that I can manage group membership
 		And user "anotheruser" has been created
 		And group "newgroup" has been created
 		And user "newuser" has been added to group "newgroup"
-		When user "anotheruser" sends HTTP method "GET" to API endpoint "/cloud/users/newuser/groups"
+		When user "anotheruser" sends HTTP method "GET" to OCS API endpoint "/cloud/users/newuser/groups"
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
 		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -5,12 +5,12 @@ I want to be able to list the users that exist
 So that I can see who has access to ownCloud
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: admin gets all users
 		Given user "brand-new-user" has been created
 		And user "admin" has been created
-		When user "admin" sends HTTP method "GET" to API endpoint "/cloud/users"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the users returned by the API should be
@@ -23,7 +23,7 @@ So that I can see who has access to ownCloud
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "brand-new-user" sends HTTP method "GET" to API endpoint "/cloud/users"
+		When user "brand-new-user" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
 		Then the users returned by the API should be
 			| brand-new-user |
 		And the OCS status code should be "200"
@@ -33,7 +33,7 @@ So that I can see who has access to ownCloud
 	Scenario: normal user tries to get other users
 		Given user "normaluser" has been created
 		And user "newuser" has been created
-		When user "normaluser" sends HTTP method "GET" to API endpoint "/cloud/users"
+		When user "normaluser" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
 		And the OCS status code should be "401"
 		And the HTTP status code should be "401"
 		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -5,13 +5,13 @@ I want to be able to remove a user from a group
 So that I can manage user access to group resources
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario Outline: admin removes a user from a group
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
 		And user "brand-new-user" has been added to group "<group_id>"
-		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
@@ -39,7 +39,7 @@ So that I can manage user access to group resources
 		Scenario: admin tries to remove a user from a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | not-group |
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
@@ -51,7 +51,7 @@ So that I can manage user access to group resources
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
@@ -64,7 +64,7 @@ So that I can manage user access to group resources
 		And group "other-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "other-subadmin" has been made a subadmin of group "other-group"
-		When user "other-subadmin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "other-subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "403"
 		And the HTTP status code should be "403"
@@ -77,7 +77,7 @@ So that I can manage user access to group resources
 		And group "new-group" has been created
 		And user "newuser" has been added to group "new-group"
 		And user "anotheruser" has been added to group "new-group"
-		When user "newuser" sends HTTP method "DELETE" to API endpoint "/cloud/users/anotheruser/groups" with body
+		When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/anotheruser/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -5,13 +5,13 @@ I want to be able to remove subadmin rights to a user from a group
 So that I cam manage administrative access rights for groups
 
 	Background:
-		Given using API version "2"
+		Given using OCS API version "2"
 
 	Scenario: admin removes subadmin from a group
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "DELETE" to API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
@@ -24,7 +24,7 @@ So that I cam manage administrative access rights for groups
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "newsubadmin" has been created
 		And user "newsubadmin" has been made a subadmin of group "new-group"
-		When user "subadmin" sends HTTP method "DELETE" to API endpoint "/cloud/users/newsubadmin/subadmins" with body
+		When user "subadmin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/newsubadmin/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "401"
 		And the HTTP status code should be "401"
@@ -37,7 +37,7 @@ So that I cam manage administrative access rights for groups
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
 		And user "newuser" has been added to group "new-group"
-		When user "newuser" sends HTTP method "DELETE" to API endpoint "/cloud/users/subadmin/subadmins" with body
+		When user "newuser" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/subadmin/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -1,7 +1,7 @@
 @api
 Feature: sharees
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And user "test" has been created
 		And user "Sharee1" has been created
 		And group "ShareeGroup" has been created
@@ -9,7 +9,7 @@ Feature: sharees
 		And user "test" has been added to group "ShareeGroup2"
 
 	Scenario: Search without exact match
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | Sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
@@ -25,7 +25,7 @@ Feature: sharees
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Search without exact match not-exact casing
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
@@ -42,7 +42,7 @@ Feature: sharees
 
 	Scenario: Search only with group members - denied
 		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
@@ -59,7 +59,7 @@ Feature: sharees
 	Scenario: Search only with group members - allowed
 		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
 		And user "Sharee1" has been added to group "ShareeGroup2"
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
@@ -77,7 +77,7 @@ Feature: sharees
 	Scenario: Search only with group members - no group as non-member
 		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
 		And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-		When user "Sharee1" gets the sharees using the API with parameters
+		When user "Sharee1" gets the sharees using the sharing API with parameters
 			| search   | sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
@@ -91,7 +91,7 @@ Feature: sharees
 
 	Scenario: Search only with membership groups - denied
 		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-		When user "Sharee1" gets the sharees using the API with parameters
+		When user "Sharee1" gets the sharees using the sharing API with parameters
 			| search   | ShareeGroup |
 			| itemType | file        |
 		Then the OCS status code should be "100"
@@ -105,7 +105,7 @@ Feature: sharees
 
 	Scenario: Search only with membership groups - denied but users match
 		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-		When user "Sharee1" gets the sharees using the API with parameters
+		When user "Sharee1" gets the sharees using the sharing API with parameters
 			| search   | sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
@@ -120,7 +120,7 @@ Feature: sharees
 
 	Scenario: Search only with membership groups - allowed
 		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | ShareeGroup |
 			| itemType | file        |
 		Then the OCS status code should be "100"
@@ -135,7 +135,7 @@ Feature: sharees
 
 	Scenario: Search only with membership groups - allowed including users
 		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | Sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
@@ -151,7 +151,7 @@ Feature: sharees
 
 	Scenario: Search without exact match no iteration allowed
 		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | Sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
@@ -165,7 +165,7 @@ Feature: sharees
 
 	Scenario: Search with exact match no iteration allowed
 		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | Sharee1 |
 			| itemType | file    |
 		Then the OCS status code should be "100"
@@ -180,7 +180,7 @@ Feature: sharees
 
 	Scenario: Search with exact match group no iteration allowed
 		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | ShareeGroup |
 			| itemType | file        |
 		Then the OCS status code should be "100"
@@ -194,7 +194,7 @@ Feature: sharees
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Search with exact match
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | Sharee1 |
 			| itemType | file    |
 		Then the OCS status code should be "100"
@@ -208,7 +208,7 @@ Feature: sharees
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Search with exact match not-exact casing
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | sharee1 |
 			| itemType | file    |
 		Then the OCS status code should be "100"
@@ -222,7 +222,7 @@ Feature: sharees
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Search with exact match not-exact casing group
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | shareegroup2 |
 			| itemType | file         |
 		Then the OCS status code should be "100"
@@ -236,7 +236,7 @@ Feature: sharees
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Search with "self"
-		When user "Sharee1" gets the sharees using the API with parameters
+		When user "Sharee1" gets the sharees using the sharing API with parameters
 			| search   | Sharee1 |
 			| itemType | file    |
 		Then the OCS status code should be "100"
@@ -250,7 +250,7 @@ Feature: sharees
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Remote sharee for files
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | test@localhost |
 			| itemType | file           |
 		Then the OCS status code should be "100"
@@ -264,7 +264,7 @@ Feature: sharees
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Remote sharee for calendars not allowed
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | test@localhost |
 			| itemType | calendar       |
 		Then the OCS status code should be "100"
@@ -278,7 +278,7 @@ Feature: sharees
 
 	Scenario: Group sharees not returned when group sharing is disabled
 		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
@@ -295,7 +295,7 @@ Feature: sharees
 		Given user "Another" has been created
 		And user "Another" has been added to group "ShareeGroup2"
 		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | anot  |
 			| itemType | file |
 		Then the OCS status code should be "100"
@@ -310,7 +310,7 @@ Feature: sharees
 
 	Scenario: Enumerate only group members - accept exact match from non-member groups
 		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | Sharee1 |
 			| itemType | file    |
 		Then the OCS status code should be "100"
@@ -325,7 +325,7 @@ Feature: sharees
 
 	Scenario: Enumerate only group members - only show partial results from member groups
 		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | ShareeG |
 			| itemType | file    |
 		Then the OCS status code should be "100"
@@ -341,7 +341,7 @@ Feature: sharees
 	Scenario: Enumerate only group members - only accept exact group match from non-memberships
 		Given group "ShareeGroupNonMember" has been created
 		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the API with parameters
+		When user "test" gets the sharees using the sharing API with parameters
 			| search   | ShareeGroupNonMember |
 			| itemType | file                 |
 		Then the OCS status code should be "100"

--- a/tests/acceptance/features/apiSharees/sharees_provisioningapiv2.feature
+++ b/tests/acceptance/features/apiSharees/sharees_provisioningapiv2.feature
@@ -1,7 +1,7 @@
 @api
 Feature: sharees_provisioningapiv2
   Background:
-    Given using API version "2"
+    Given using OCS API version "2"
     And user "test" has been created
     And user "Sharee1" has been created
     And group "ShareeGroup" has been created
@@ -9,7 +9,7 @@ Feature: sharees_provisioningapiv2
     And user "test" has been added to group "ShareeGroup2"
 
   Scenario: Search without exact match
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | Sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
@@ -25,7 +25,7 @@ Feature: sharees_provisioningapiv2
     And the "remotes" sharees returned should be empty
 
   Scenario: Search without exact match not-exact casing
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
@@ -42,7 +42,7 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search only with group members - denied
     Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
@@ -59,7 +59,7 @@ Feature: sharees_provisioningapiv2
   Scenario: Search only with group members - allowed
     Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     And user "Sharee1" has been added to group "ShareeGroup2"
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
@@ -77,7 +77,7 @@ Feature: sharees_provisioningapiv2
   Scenario: Search only with group members - no group as non-member
     Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    When user "Sharee1" gets the sharees using the API with parameters
+    When user "Sharee1" gets the sharees using the sharing API with parameters
       | search   | sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
@@ -91,7 +91,7 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search only with membership groups - denied
     Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    When user "Sharee1" gets the sharees using the API with parameters
+    When user "Sharee1" gets the sharees using the sharing API with parameters
       | search   | ShareeGroup |
       | itemType | file        |
     Then the OCS status code should be "200"
@@ -105,7 +105,7 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search only with membership groups - denied but users match
     Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    When user "Sharee1" gets the sharees using the API with parameters
+    When user "Sharee1" gets the sharees using the sharing API with parameters
       | search   | sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
@@ -120,7 +120,7 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search only with membership groups - allowed
     Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | ShareeGroup |
       | itemType | file        |
     Then the OCS status code should be "200"
@@ -135,7 +135,7 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search only with membership groups - allowed including users
     Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | Sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
@@ -151,7 +151,7 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search without exact match no iteration allowed
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | Sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
@@ -165,7 +165,7 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search with exact match no iteration allowed
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | Sharee1 |
       | itemType | file    |
     Then the OCS status code should be "200"
@@ -180,7 +180,7 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search with exact match group no iteration allowed
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | ShareeGroup |
       | itemType | file        |
     Then the OCS status code should be "200"
@@ -194,7 +194,7 @@ Feature: sharees_provisioningapiv2
     And the "remotes" sharees returned should be empty
 
   Scenario: Search with exact match
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | Sharee1 |
       | itemType | file    |
     Then the OCS status code should be "200"
@@ -208,7 +208,7 @@ Feature: sharees_provisioningapiv2
     And the "remotes" sharees returned should be empty
 
   Scenario: Search with exact match not-exact casing
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | sharee1 |
       | itemType | file    |
     Then the OCS status code should be "200"
@@ -222,7 +222,7 @@ Feature: sharees_provisioningapiv2
     And the "remotes" sharees returned should be empty
 
   Scenario: Search with exact match not-exact casing group
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | shareegroup2 |
       | itemType | file         |
     Then the OCS status code should be "200"
@@ -236,7 +236,7 @@ Feature: sharees_provisioningapiv2
     And the "remotes" sharees returned should be empty
 
   Scenario: Search with "self"
-    When user "Sharee1" gets the sharees using the API with parameters
+    When user "Sharee1" gets the sharees using the sharing API with parameters
       | search   | Sharee1 |
       | itemType | file    |
     Then the OCS status code should be "200"
@@ -250,7 +250,7 @@ Feature: sharees_provisioningapiv2
     And the "remotes" sharees returned should be empty
 
   Scenario: Remote sharee for files
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | test@localhost |
       | itemType | file           |
     Then the OCS status code should be "200"
@@ -264,7 +264,7 @@ Feature: sharees_provisioningapiv2
     And the "remotes" sharees returned should be empty
 
   Scenario: Remote sharee for calendars not allowed
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | test@localhost |
       | itemType | calendar       |
     Then the OCS status code should be "200"
@@ -278,7 +278,7 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Group sharees not returned when group sharing is disabled
     Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-    When user "test" gets the sharees using the API with parameters
+    When user "test" gets the sharees using the sharing API with parameters
       | search   | sharee |
       | itemType | file   |
     Then the OCS status code should be "200"

--- a/tests/acceptance/features/apiSharing/acceptShares.feature
+++ b/tests/acceptance/features/apiSharing/acceptShares.feature
@@ -5,7 +5,7 @@ Feature: accept/decline shares coming from internal users
 	So that I can keep my file system clean
 
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And using new DAV path
 		And user "user0" has been created
 		And user "user1" has been created
@@ -16,8 +16,8 @@ Feature: accept/decline shares coming from internal users
 
 	Scenario: share a file & folder with another internal user when auto accept is enabled
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		When user "user0" shares folder "/PARENT" with user "user1" using the API
-		And user "user0" shares file "/textfile0.txt" with user "user1" using the API
+		When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
+		And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
 		Then user "user1" should see the following elements
 			| /FOLDER/                 |
 			| /PARENT/                 |
@@ -25,15 +25,15 @@ Feature: accept/decline shares coming from internal users
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0.txt           |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user1" that these shares are in the accepted state
+		And the sharing API should report to user "user1" that these shares are in the accepted state
 			| path                     |
 			| /PARENT (2)/             |
 			| /textfile0 (2).txt       |
 
 	Scenario: share a file & folder with internal group when auto accept is enabled
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the API
-		And user "user0" shares file "/textfile0.txt" with group "grp1" using the API
+		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+		And user "user0" shares file "/textfile0.txt" with group "grp1" using the sharing API
 		Then user "user1" should see the following elements
 			| /FOLDER/                 |
 			| /PARENT/                 |
@@ -41,7 +41,7 @@ Feature: accept/decline shares coming from internal users
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0.txt           |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user1" that these shares are in the accepted state
+		And the sharing API should report to user "user1" that these shares are in the accepted state
 			| path                     |
 			| /PARENT (2)/             |
 			| /textfile0 (2).txt       |
@@ -52,7 +52,7 @@ Feature: accept/decline shares coming from internal users
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0.txt           |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user2" that these shares are in the accepted state
+		And the sharing API should report to user "user2" that these shares are in the accepted state
 			| path                     |
 			| /PARENT (2)/             |
 			| /textfile0 (2).txt       |
@@ -61,13 +61,13 @@ Feature: accept/decline shares coming from internal users
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
 		And user "user0" has shared folder "/PARENT" with user "user1"
 		And user "user0" has shared file "/textfile0.txt" with user "user1"
-		When user "user1" declines the share "/PARENT (2)" offered by user "user0" using the API
-		And user "user1" declines the share "/textfile0 (2).txt" offered by user "user0" using the API
+		When user "user1" declines the share "/PARENT (2)" offered by user "user0" using the sharing API
+		And user "user1" declines the share "/textfile0 (2).txt" offered by user "user0" using the sharing API
 		Then user "user1" should not see the following elements
 			| /PARENT%20(2)/           |
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user1" that these shares are in the declined state
+		And the sharing API should report to user "user1" that these shares are in the declined state
 			| path                     |
 			| /PARENT/                 |
 			| /textfile0.txt           |
@@ -78,13 +78,13 @@ Feature: accept/decline shares coming from internal users
 		And user "user0" has shared file "/textfile0.txt" with user "user1"
 		And user "user1" has declined the share "/PARENT (2)" offered by user "user0"
 		And user "user1" has declined the share "/textfile0 (2).txt" offered by user "user0"
-		When user "user1" accepts the share "/PARENT" offered by user "user0" using the API
-		And user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the API
+		When user "user1" accepts the share "/PARENT" offered by user "user0" using the sharing API
+		And user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the sharing API
 		Then user "user1" should see the following elements
 			| /PARENT%20(2)/           |
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user1" that these shares are in the accepted state
+		And the sharing API should report to user "user1" that these shares are in the accepted state
 			| path                     |
 			| /PARENT (2)/             |
 			| /textfile0 (2).txt       |
@@ -93,13 +93,13 @@ Feature: accept/decline shares coming from internal users
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
 		And user "user0" has shared folder "/PARENT" with user "user1"
 		And user "user0" has shared file "/textfile0.txt" with user "user1"
-		When user "user1" unshares folder "/PARENT (2)" using the API
-		And user "user1" unshares file "/textfile0 (2).txt" using the API
+		When user "user1" unshares folder "/PARENT (2)" using the WebDAV API
+		And user "user1" unshares file "/textfile0 (2).txt" using the WebDAV API
 		Then user "user1" should not see the following elements
 			| /PARENT%20(2)/           |
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user1" that these shares are in the declined state
+		And the sharing API should report to user "user1" that these shares are in the declined state
 			| path                     |
 			| /PARENT/                 |
 			| /textfile0.txt           |
@@ -108,13 +108,13 @@ Feature: accept/decline shares coming from internal users
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
 		And user "user0" has shared folder "/PARENT" with group "grp1"
 		And user "user0" has shared file "/textfile0.txt" with group "grp1"
-		When user "user1" unshares folder "/PARENT (2)" using the API
-		And user "user1" unshares file "/textfile0 (2).txt" using the API
+		When user "user1" unshares folder "/PARENT (2)" using the WebDAV API
+		And user "user1" unshares file "/textfile0 (2).txt" using the WebDAV API
 		Then user "user1" should not see the following elements
 			| /PARENT%20(2)/           |
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user1" that these shares are in the declined state
+		And the sharing API should report to user "user1" that these shares are in the declined state
 			| path                     |
 			| /PARENT/                 |
 			| /textfile0.txt           |
@@ -122,7 +122,7 @@ Feature: accept/decline shares coming from internal users
 			| /PARENT%20(2)/           |
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user2" that these shares are in the accepted state
+		And the sharing API should report to user "user2" that these shares are in the accepted state
 			| path                     |
 			| /PARENT (2)/             |
 			| /textfile0 (2).txt       |
@@ -130,12 +130,12 @@ Feature: accept/decline shares coming from internal users
 	Scenario: rename accepted share, decline it
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
 		And user "user0" has shared folder "/PARENT" with user "user1"
-		When user "user1" moves folder "/PARENT (2)" to "/PARENT-renamed" using the API
-		And user "user1" declines the share "/PARENT-renamed" offered by user "user0" using the API
+		When user "user1" moves folder "/PARENT (2)" to "/PARENT-renamed" using the WebDAV API
+		And user "user1" declines the share "/PARENT-renamed" offered by user "user0" using the sharing API
 		Then user "user1" should not see the following elements
 			| /PARENT%20(2)/           |
 			| /PARENT-renamed/         |
-		And the API should report to user "user1" that these shares are in the declined state
+		And the sharing API should report to user "user1" that these shares are in the declined state
 			| path                     |
 			| /PARENT/                 |
 
@@ -143,12 +143,12 @@ Feature: accept/decline shares coming from internal users
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
 		And user "user0" has shared folder "/PARENT" with user "user1"
 		And user "user1" has moved folder "/PARENT (2)" to "/PARENT-renamed"
-		When user "user1" declines the share "/PARENT-renamed" offered by user "user0" using the API
-		And user "user1" accepts the share "/PARENT" offered by user "user0" using the API
+		When user "user1" declines the share "/PARENT-renamed" offered by user "user0" using the sharing API
+		And user "user1" accepts the share "/PARENT" offered by user "user0" using the sharing API
 		Then user "user1" should see the following elements
 			| /PARENT/                 |
 			| /PARENT-renamed/         |
-		And the API should report to user "user1" that these shares are in the accepted state
+		And the sharing API should report to user "user1" that these shares are in the accepted state
 			| path                     |
 			| /PARENT-renamed/         |
 
@@ -157,13 +157,13 @@ Feature: accept/decline shares coming from internal users
 		And user "user0" has created a folder "/shared"
 		And user "user0" has shared folder "/shared" with user "user1"
 		And user "user1" has moved folder "/shared" to "/PARENT/shared"
-		When user "user1" declines the share "/PARENT/shared" offered by user "user0" using the API
-		And user "user1" accepts the share "/shared" offered by user "user0" using the API
+		When user "user1" declines the share "/PARENT/shared" offered by user "user0" using the sharing API
+		And user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
 		Then user "user1" should not see the following elements
 			| /shared/                 |
 		But user "user1" should see the following elements
 			| /PARENT/shared/          |
-		And the API should report to user "user1" that these shares are in the accepted state
+		And the sharing API should report to user "user1" that these shares are in the accepted state
 			| path                     |
 			| /PARENT/shared/          |
 
@@ -172,14 +172,14 @@ Feature: accept/decline shares coming from internal users
 		And user "user0" has created a folder "/shared"
 		And user "user0" has shared folder "/shared" with user "user1"
 		And user "user1" has moved folder "/shared" to "/PARENT/shared"
-		When user "user1" declines the share "/PARENT/shared" offered by user "user0" using the API
-		And user "user1" deletes folder "/PARENT" using the API
-		And user "user1" accepts the share "/shared" offered by user "user0" using the API
+		When user "user1" declines the share "/PARENT/shared" offered by user "user0" using the sharing API
+		And user "user1" deletes folder "/PARENT" using the WebDAV API
+		And user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
 		Then user "user1" should not see the following elements
 			| /PARENT/                 |
 		But user "user1" should see the following elements
 			| /shared/                 |
-		And the API should report to user "user1" that these shares are in the accepted state
+		And the sharing API should report to user "user1" that these shares are in the accepted state
 			| path                     |
 			| /shared/                 |
 
@@ -189,20 +189,20 @@ Feature: accept/decline shares coming from internal users
 		And user "user0" has created a folder "/shared/user0"
 		And user "user1" has created a folder "/shared"
 		And user "user1" has created a folder "/shared/user1"
-		When user "user0" shares folder "/shared" with user "user2" using the API
-		And user "user1" shares folder "/shared" with user "user2" using the API
+		When user "user0" shares folder "/shared" with user "user2" using the sharing API
+		And user "user1" shares folder "/shared" with user "user2" using the sharing API
 		Then user "user2" should see the following elements
 			| /shared/user0/           |
 			| /shared%20(2)/user1/     |
-		And the API should report to user "user2" that these shares are in the accepted state
+		And the sharing API should report to user "user2" that these shares are in the accepted state
 			| path                     |
 			| /shared/                 |
 			| /shared (2)/             |
 
 	Scenario: share a file & folder with another internal user when auto accept is disabled
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the API
-		And user "user0" shares file "/textfile0.txt" with group "grp1" using the API
+		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+		And user "user0" shares file "/textfile0.txt" with group "grp1" using the sharing API
 		Then user "user1" should see the following elements
 			| /FOLDER/                 |
 			| /PARENT/                 |
@@ -211,7 +211,7 @@ Feature: accept/decline shares coming from internal users
 			| /PARENT%20(2)/           |
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user1" that these shares are in the pending state
+		And the sharing API should report to user "user1" that these shares are in the pending state
 			| path                     |
 			| /PARENT/                 |
 			| /textfile0.txt           |
@@ -223,15 +223,15 @@ Feature: accept/decline shares coming from internal users
 			| /PARENT%20(2)/           |
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user2" that these shares are in the pending state
+		And the sharing API should report to user "user2" that these shares are in the pending state
 			| path                     |
 			| /PARENT/                 |
 			| /textfile0.txt           |
 
 	Scenario: share a file & folder with another internal user when auto accept is disabled
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with user "user1" using the API
-		And user "user0" shares file "/textfile0.txt" with user "user1" using the API
+		When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
+		And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
 		Then user "user1" should see the following elements
 			| /FOLDER/                 |
 			| /PARENT/                 |
@@ -240,7 +240,7 @@ Feature: accept/decline shares coming from internal users
 			| /PARENT%20(2)/           |
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user1" that these shares are in the pending state
+		And the sharing API should report to user "user1" that these shares are in the pending state
 			| path                     |
 			| /PARENT/                 |
 			| /textfile0.txt           |
@@ -249,8 +249,8 @@ Feature: accept/decline shares coming from internal users
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
 		And user "user0" has shared folder "/PARENT" with user "user1"
 		And user "user0" has shared file "/textfile0.txt" with user "user1"
-		When user "user1" accepts the share "/PARENT" offered by user "user0" using the API
-		And user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the API
+		When user "user1" accepts the share "/PARENT" offered by user "user0" using the sharing API
+		And user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the sharing API
 		Then user "user1" should see the following elements
 			| /FOLDER/                 |
 			| /PARENT/                 |
@@ -258,7 +258,7 @@ Feature: accept/decline shares coming from internal users
 			| /PARENT%20(2)/           |
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user1" that these shares are in the accepted state
+		And the sharing API should report to user "user1" that these shares are in the accepted state
 			| path                     |
 			| /PARENT (2)/             |
 			| /textfile0 (2).txt       |
@@ -267,11 +267,11 @@ Feature: accept/decline shares coming from internal users
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
 		And user "user0" has created a folder "/shared"
 		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user1" accepts the share "/shared" offered by user "user0" using the API
-		And user "user1" accepts the share "/shared" offered by user "user0" using the API
+		When user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
+		And user "user1" accepts the share "/shared" offered by user "user0" using the sharing API
 		Then user "user1" should see the following elements
 			| /shared/    |
-		And the API should report to user "user1" that these shares are in the accepted state
+		And the sharing API should report to user "user1" that these shares are in the accepted state
 			| path        |
 			| /shared/    |
 
@@ -279,8 +279,8 @@ Feature: accept/decline shares coming from internal users
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
 		And user "user0" has shared folder "/PARENT" with user "user1"
 		And user "user0" has shared file "/textfile0.txt" with user "user1"
-		When user "user1" declines the share "/PARENT" offered by user "user0" using the API
-		And user "user1" declines the share "/textfile0.txt" offered by user "user0" using the API
+		When user "user1" declines the share "/PARENT" offered by user "user0" using the sharing API
+		And user "user1" declines the share "/textfile0.txt" offered by user "user0" using the sharing API
 		Then user "user1" should see the following elements
 			| /FOLDER/                 |
 			| /PARENT/                 |
@@ -289,7 +289,7 @@ Feature: accept/decline shares coming from internal users
 			| /PARENT%20(2)/           |
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user1" that these shares are in the declined state
+		And the sharing API should report to user "user1" that these shares are in the declined state
 			| path                     |
 			| /PARENT/                 |
 			| /textfile0.txt           |
@@ -300,13 +300,13 @@ Feature: accept/decline shares coming from internal users
 		And user "user0" has shared file "/textfile0.txt" with user "user1"
 		And user "user1" has accepted the share "/PARENT" offered by user "user0"
 		And user "user1" has accepted the share "/textfile0.txt" offered by user "user0"
-		When user "user1" declines the share "/PARENT (2)" offered by user "user0" using the API
-		And user "user1" declines the share "/textfile0 (2).txt" offered by user "user0" using the API
+		When user "user1" declines the share "/PARENT (2)" offered by user "user0" using the sharing API
+		And user "user1" declines the share "/textfile0 (2).txt" offered by user "user0" using the sharing API
 		Then user "user1" should not see the following elements
 			| /PARENT%20(2)/           |
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user1" that these shares are in the declined state
+		And the sharing API should report to user "user1" that these shares are in the declined state
 			| path                     |
 			| /PARENT/                 |
 			| /textfile0.txt           |
@@ -315,21 +315,21 @@ Feature: accept/decline shares coming from internal users
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
 		And user "user0" has shared folder "/PARENT" with user "user1"
 		And user "user0" has shared file "/textfile0.txt" with user "user1"
-		When user "user0" deletes folder "/PARENT" using the API
-		And user "user0" deletes file "/textfile0.txt" using the API
-		Then the API should report that no shares are shared with user "user1"
+		When user "user0" deletes folder "/PARENT" using the WebDAV API
+		And user "user0" deletes file "/textfile0.txt" using the WebDAV API
+		Then the sharing API should report that no shares are shared with user "user1"
 
 	Scenario: only one user in a group accepts a share
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
 		And user "user0" has shared folder "/PARENT" with group "grp1"
 		And user "user0" has shared file "/textfile0.txt" with group "grp1"
-		When user "user1" accepts the share "/PARENT" offered by user "user0" using the API
-		And user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the API
+		When user "user1" accepts the share "/PARENT" offered by user "user0" using the sharing API
+		And user "user1" accepts the share "/textfile0.txt" offered by user "user0" using the sharing API
 		Then user "user2" should not see the following elements
 			| /PARENT%20(2)/           |
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user2" that these shares are in the pending state
+		And the sharing API should report to user "user2" that these shares are in the pending state
 			| path                     |
 			| /PARENT/                 |
 			| /textfile0.txt           |
@@ -337,7 +337,7 @@ Feature: accept/decline shares coming from internal users
 			| /PARENT%20(2)/           |
 			| /PARENT%20(2)/parent.txt |
 			| /textfile0%20(2).txt     |
-		And the API should report to user "user1" that these shares are in the accepted state
+		And the sharing API should report to user "user1" that these shares are in the accepted state
 			| path                     |
 			| /PARENT (2)/             |
 			| /textfile0 (2).txt       |
@@ -350,20 +350,20 @@ Feature: accept/decline shares coming from internal users
 		And user "user1" has created a folder "/shared/user1"
 		And user "user0" has shared folder "/shared" with user "user2"
 		And user "user1" has shared folder "/shared" with user "user2"
-		When user "user2" accepts the share "/shared" offered by user "user1" using the API
-		And user "user2" accepts the share "/shared" offered by user "user0" using the API
+		When user "user2" accepts the share "/shared" offered by user "user1" using the sharing API
+		And user "user2" accepts the share "/shared" offered by user "user0" using the sharing API
 		Then user "user2" should see the following elements
 			| /shared/user1/           |
 			| /shared%20(2)/user0/     |
-		And the API should report to user "user2" that these shares are in the accepted state
+		And the sharing API should report to user "user2" that these shares are in the accepted state
 			| path                     |
 			| /shared/                 |
 			| /shared (2)/             |
 
 	Scenario: share with a group that you are part of yourself
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the API
-		Then the API should report to user "user1" that these shares are in the pending state
+		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+		Then the sharing API should report to user "user1" that these shares are in the pending state
 			| path                     |
 			| /PARENT/                 |
-		And the API should report that no shares are shared with user "user0"
+		And the sharing API should report that no shares are shared with user "user0"

--- a/tests/acceptance/features/apiSharing/accessToShare.feature
+++ b/tests/acceptance/features/apiSharing/accessToShare.feature
@@ -6,9 +6,9 @@ Feature: sharing
 		And user "user1" has been created
 
 	Scenario Outline: Sharee can see the share
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has shared file "textfile0.txt" with user "user1"
-		When user "user1" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+		When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the last share_id should be included in the response
@@ -18,10 +18,10 @@ Feature: sharing
 		|2              |200            |
 
 	Scenario Outline: Sharee can see the filtered share
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has shared file "textfile0.txt" with user "user1"
 		And user "user0" has shared file "textfile1.txt" with user "user1"
-		When user "user1" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile1 (2).txt"
+		When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile1 (2).txt"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the last share_id should be included in the response
@@ -31,10 +31,10 @@ Feature: sharing
 		|2              |200            |
 
 	Scenario Outline: Sharee can't see the share that is filtered out
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has shared file "textfile0.txt" with user "user1"
 		And user "user0" has shared file "textfile1.txt" with user "user1"
-		When user "user1" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile0 (2).txt"
+		When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true&path=textfile0 (2).txt"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the last share_id should not be included in the response
@@ -44,11 +44,11 @@ Feature: sharing
 		|2              |200            |
 
 	Scenario Outline: Sharee can see the group share
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And group "group0" has been created
 		And user "user1" has been added to group "group0"
 		And user "user0" has shared file "textfile0.txt" with group "group0"
-		When user "user1" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+		When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the last share_id should be included in the response

--- a/tests/acceptance/features/apiSharing/changingFilesShare.feature
+++ b/tests/acceptance/features/apiSharing/changingFilesShare.feature
@@ -1,7 +1,7 @@
 @api
 Feature: sharing
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And using old DAV path
 		And user "user0" has been created
 		And user "user1" has been created
@@ -9,7 +9,7 @@ Feature: sharing
 	Scenario: moving a file into a share as recipient
 		Given user "user0" has created a folder "/shared"
 		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user1" moves file "/textfile0.txt" to "/shared/shared_file.txt" using the API
+		When user "user1" moves file "/textfile0.txt" to "/shared/shared_file.txt" using the WebDAV API
 		Then as "user1" the file "/shared/shared_file.txt" should exist
 		And as "user0" the file "/shared/shared_file.txt" should exist
 
@@ -18,7 +18,7 @@ Feature: sharing
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
 		And user "user0" has shared file "/shared" with user "user1"
 		And user "user1" has moved folder "/shared" to "/shared_renamed"
-		When user "user1" moves file "/shared_renamed/shared_file.txt" to "/taken_out.txt" using the API
+		When user "user1" moves file "/shared_renamed/shared_file.txt" to "/taken_out.txt" using the WebDAV API
 		Then as "user1" the file "/taken_out.txt" should exist
 		And as "user0" the file "/shared/shared_file.txt" should not exist
 		And as "user0" the file "/shared_file.txt" should exist in trash
@@ -29,7 +29,7 @@ Feature: sharing
 		And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
 		And user "user0" has shared file "/shared" with user "user1"
 		And user "user1" has moved folder "/shared" to "/shared_renamed"
-		When user "user1" moves folder "/shared_renamed/sub" to "/taken_out" using the API
+		When user "user1" moves folder "/shared_renamed/sub" to "/taken_out" using the WebDAV API
 		Then as "user1" the file "/taken_out" should exist
 		And as "user0" the folder "/shared/sub" should not exist
 		And as "user0" the folder "/sub" should exist in trash

--- a/tests/acceptance/features/apiSharing/createShare.feature
+++ b/tests/acceptance/features/apiSharing/createShare.feature
@@ -5,9 +5,9 @@ Feature: sharing
 		And user "user0" has been created
 
 	Scenario Outline: Creating a new share with user
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
-		When user "user0" shares file "welcome.txt" with user "user1" using the API
+		When user "user0" shares file "welcome.txt" with user "user1" using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
@@ -22,10 +22,10 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a share with a group
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And group "sharing-group" has been created
-		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
+		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path      | welcome.txt   |
 			| shareWith | sharing-group |
 			| shareType | 1             |
@@ -43,12 +43,12 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a new share with user who already received a share through their group
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And group "sharing-group" has been created
 		And user "user1" has been added to group "sharing-group"
 		And user "user0" has shared file "welcome.txt" with group "sharing-group"
-		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
+		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path      | welcome.txt |
 			| shareWith | user1       |
 			| shareType | 0           |
@@ -66,8 +66,8 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a new public share of a file
-		Given using API version "<ocs_api_version>"
-		When user "user0" creates a share using the API with settings
+		Given using OCS API version "<ocs_api_version>"
+		When user "user0" creates a share using the sharing API with settings
 			| path      | welcome.txt |
 			| shareType | 3           |
 		Then the OCS status code should be "<ocs_status_code>"
@@ -79,8 +79,8 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a new public share of a file with password
-		Given using API version "<ocs_api_version>"
-		When user "user0" creates a share using the API with settings
+		Given using OCS API version "<ocs_api_version>"
+		When user "user0" creates a share using the sharing API with settings
 			| path      | welcome.txt |
 			| shareType | 3           |
 			| password  | publicpw    |
@@ -93,8 +93,8 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Trying to create a new public share of a file with edit permissions results in a read-only share
-		Given using API version "<ocs_api_version>"
-		When user "user0" creates a share using the API with settings
+		Given using OCS API version "<ocs_api_version>"
+		When user "user0" creates a share using the sharing API with settings
 			| path        | welcome.txt |
 			| shareType   | 3           |
 			| permissions | 31          |
@@ -114,8 +114,8 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a new public share of a folder
-		Given using API version "<ocs_api_version>"
-		When user "user0" creates a share using the API with settings
+		Given using OCS API version "<ocs_api_version>"
+		When user "user0" creates a share using the sharing API with settings
 			| path      | PARENT   |
 			| shareType | 3        |
 			| password  | publicpw |
@@ -128,10 +128,10 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a new share with a disabled user
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And user "user0" has been disabled
-		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
+		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path      | welcome.txt |
 			| shareWith | user1       |
 			| shareType | 0           |
@@ -143,10 +143,10 @@ Feature: sharing
 
 	@skip @issue-32068
 	Scenario: Creating a new share with a disabled user
-		Given using API version "2"
+		Given using OCS API version "2"
 		And user "user1" has been created
 		And user "user0" has been disabled
-		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
+		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path      | welcome.txt |
 			| shareWith | user1       |
 			| shareType | 0           |
@@ -154,9 +154,9 @@ Feature: sharing
 		And the HTTP status code should be "401"
 
 	Scenario Outline: Creating a link share with no specified permissions defaults to read permissions
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has created a folder "/afolder"
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path      | /afolder |
 			| shareType | 3        |
 		Then the OCS status code should be "<ocs_status_code>"
@@ -171,10 +171,10 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
 		And user "user0" has created a folder "/afolder"
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path      | /afolder |
 			| shareType | 3        |
 		Then the OCS status code should be "<ocs_status_code>"
@@ -189,9 +189,9 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a link share with edit permissions keeps it
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has created a folder "/afolder"
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path        | /afolder |
 			| shareType   | 3        |
 			| permissions | 15       |
@@ -207,12 +207,12 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Share of folder and sub-folder to same user - core#20645
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And group "group0" has been created
 		And user "user1" has been added to group "group0"
-		When user "user0" shares file "/PARENT" with user "user1" using the API
-		And user "user0" shares file "/PARENT/CHILD" with group "group0" using the API
+		When user "user0" shares file "/PARENT" with user "user1" using the sharing API
+		And user "user0" shares file "/PARENT/CHILD" with group "group0" using the sharing API
 		Then user "user1" should see the following elements
 			| /FOLDER/                 |
 			| /PARENT/                 |
@@ -229,13 +229,13 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Share of folder to a group
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And user "user2" has been created
 		And group "group0" has been created
 		And user "user1" has been added to group "group0"
 		And user "user2" has been added to group "group0"
-		And user "user0" shares file "/PARENT" with group "group0" using the API
+		And user "user0" shares file "/PARENT" with group "group0" using the sharing API
 		Then user "user1" should see the following elements
 			| /FOLDER/                 |
 			| /PARENT/                 |
@@ -258,8 +258,8 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Do not allow sharing of the root
-		Given using API version "<ocs_api_version>"
-		When user "user0" creates a share using the API with settings
+		Given using OCS API version "<ocs_api_version>"
+		When user "user0" creates a share using the sharing API with settings
 			| path      | / |
 			| shareType | 3 |
 		Then the OCS status code should be "<ocs_status_code>"
@@ -269,36 +269,36 @@ Feature: sharing
 			|2              |403            |
 
 	Scenario: Only allow 1 link share per file/folder
-		Given using API version "1"
+		Given using OCS API version "1"
 		And as user "user0"
 		And the user has created a share with settings
 			| path      | welcome.txt |
 			| shareType | 3           |
 		And the last share id has been remembered
-		When the user creates a share using the API with settings
+		When the user creates a share using the sharing API with settings
 			| path      | welcome.txt |
 			| shareType | 3           |
 		Then the share ids should match
 
 	Scenario: unique target names for incoming shares
-		Given using API version "1"
+		Given using OCS API version "1"
 		And user "user1" has been created
 		And user "user2" has been created
 		And user "user0" has created a folder "/foo"
 		And user "user1" has created a folder "/foo"
-		When user "user0" shares file "/foo" with user "user2" using the API
-		And user "user1" shares file "/foo" with user "user2" using the API
+		When user "user0" shares file "/foo" with user "user2" using the sharing API
+		And user "user1" shares file "/foo" with user "user2" using the sharing API
 		Then user "user2" should see the following elements
 			| /foo/       |
 			| /foo%20(2)/ |
 
 	Scenario Outline: sharing again an own file while belonging to a group
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And group "sharing-group" has been created
 		And user "user0" has been added to group "sharing-group"
 		And user "user0" has shared file "welcome.txt" with group "sharing-group"
 		And user "user0" has deleted the last share
-		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
+		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path      | welcome.txt   |
 			| shareWith | sharing-group |
 			| shareType | 1             |
@@ -310,13 +310,13 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: sharing subfolder when parent already shared
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And group "sharing-group" has been created
 		And user "user0" has created a folder "/test"
 		And user "user0" has created a folder "/test/sub"
 		And user "user0" has shared file "/test" with group "sharing-group"
-		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
+		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path      | /test/sub |
 			| shareWith | user1     |
 			| shareType | 0         |
@@ -329,14 +329,14 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: sharing subfolder when parent already shared with group of sharer
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And group "sharing-group" has been created
 		And user "user0" has been added to group "sharing-group"
 		And user "user0" has created a folder "/test"
 		And user "user0" has created a folder "/test/sub"
 		And user "user0" has shared file "/test" with group "sharing-group"
-		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
+		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path      | /test/sub |
 			| shareWith | user1     |
 			| shareType | 0         |
@@ -349,7 +349,7 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: sharing subfolder of already shared folder, GET result is correct
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And user "user2" has been created
 		And user "user3" has been created
@@ -361,13 +361,13 @@ Feature: sharing
 		And user "user0" has shared file "/folder1/folder2" with user "user3"
 		And user "user0" has shared file "/folder1/folder2" with user "user4"
 		And as user "user0"
-		When the user sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares"
+		When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the response should contain 4 entries
 		And file "/folder1" should be included as path in the response
 		And file "/folder1/folder2" should be included as path in the response
-		And the user sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
+		And the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
 		And the response should contain 2 entries
 		And file "/folder1" should not be included as path in the response
 		And file "/folder1/folder2" should be included as path in the response
@@ -377,9 +377,9 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Cannot create share with zero permissions
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
-		When user "user0" sends HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
+		When user "user0" sends HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path        | welcome.txt |
 			| shareWith   | user1       |
 			| shareType   | 0           |

--- a/tests/acceptance/features/apiSharing/deleteShare.feature
+++ b/tests/acceptance/features/apiSharing/deleteShare.feature
@@ -6,13 +6,13 @@ Feature: sharing
 		And user "user1" has been created
 
 	Scenario Outline: Delete all group shares
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And group "group1" has been created
 		And user "user1" has been added to group "group1"
 		And user "user0" has shared file "textfile0.txt" with group "group1"
 		And user "user1" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
-		When user "user0" deletes the last share using the API
-		And user "user1" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+		When user "user0" deletes the last share using the sharing API
+		And user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the last share_id should not be included in the response
@@ -22,9 +22,9 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: delete a share
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has shared file "textfile0.txt" with user "user1"
-		When user "user0" deletes the last share using the API
+		When user "user0" deletes the last share using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the last share_id should not be included in the response
@@ -34,17 +34,17 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario: orphaned shares
-		Given using API version "1"
+		Given using OCS API version "1"
 		And a new browser session for "user0" has been started
 		And user "user0" has created a folder "/common"
 		And user "user0" has created a folder "/common/sub"
 		And user "user0" has shared folder "/common/sub" with user "user1"
-		When user "user0" deletes folder "/common" using the API
+		When user "user0" deletes folder "/common" using the WebDAV API
 		Then the HTTP status code should be "204"
 		And as "user1" the folder "/sub" should not exist
 
 	Scenario Outline: sharing subfolder of already shared folder, GET result is correct
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user2" has been created
 		And user "user3" has been created
 		And user "user4" has been created
@@ -55,13 +55,13 @@ Feature: sharing
 		And user "user0" has shared file "/folder1/folder2" with user "user3"
 		And user "user0" has shared file "/folder1/folder2" with user "user4"
 		And as user "user0"
-		When the user sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares"
+		When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the response should contain 4 entries
 		And file "/folder1" should be included as path in the response
 		And file "/folder1/folder2" should be included as path in the response
-		When the user sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
+		When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the response should contain 2 entries
@@ -73,11 +73,11 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario: deleting a file out of a share as recipient creates a backup for the owner
-		Given using API version "1"
+		Given using OCS API version "1"
 		And user "user0" has created a folder "/shared"
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
 		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user1" deletes file "/shared/shared_file.txt" using the API
+		When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
 		Then the HTTP status code should be "204"
 		And as "user1" the file "/shared/shared_file.txt" should not exist
 		And as "user0" the file "/shared/shared_file.txt" should not exist
@@ -85,12 +85,12 @@ Feature: sharing
 		And as "user1" the file "/shared_file.txt" should exist in trash
 
 	Scenario: deleting a folder out of a share as recipient creates a backup for the owner
-		Given using API version "1"
+		Given using OCS API version "1"
 		And user "user0" has created a folder "/shared"
 		And user "user0" has created a folder "/shared/sub"
 		And user "user0" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
 		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user1" deletes folder "/shared/sub" using the API
+		When user "user1" deletes folder "/shared/sub" using the WebDAV API
 		Then the HTTP status code should be "204"
 		And as "user1" the folder "/shared/sub" should not exist
 		And as "user0" the folder "/shared/sub" should not exist
@@ -100,14 +100,14 @@ Feature: sharing
 		And as "user1" the file "/sub/shared_file.txt" should exist in trash
 
 	Scenario Outline: unshare from self
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And group "sharing-group" has been created
 		And user "user0" has been added to group "sharing-group"
 		And user "user1" has been added to group "sharing-group"
 		And user "user0" has shared file "/PARENT/parent.txt" with group "sharing-group"
 		And user "user0" has stored etag of element "/PARENT"
 		And user "user1" has stored etag of element "/"
-		When user "user1" deletes the last share using the API
+		When user "user1" deletes the last share using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the etag of element "/" of user "user1" should have changed
@@ -118,40 +118,40 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario: sharee of a read-only share folder tries to delete the shared folder
-		Given using API version "1"
+		Given using OCS API version "1"
 		And user "user0" has created a folder "/shared"
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has sent HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
+		And user "user0" has sent HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path        | shared |
 			| shareWith   | user1  |
 			| shareType   | 0      |
 			| permissions | 1      |
-		When user "user1" deletes file "/shared/shared_file.txt" using the API
+		When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
 		Then the HTTP status code should be "403"
 		And as "user1" the file "/shared/shared_file.txt" should exist
 
 	Scenario: sharee of a upload-only shared folder tries to delete a file in the shared folder
-		Given using API version "1"
+		Given using OCS API version "1"
 		And user "user0" has created a folder "/shared"
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has sent HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
+		And user "user0" has sent HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path        | shared |
 			| shareWith   | user1  |
 			| shareType   | 0      |
 			| permissions | 4      |
-		When user "user1" deletes file "/shared/shared_file.txt" using the API
+		When user "user1" deletes file "/shared/shared_file.txt" using the WebDAV API
 		Then the HTTP status code should be "403"
 		And as "user0" the file "/shared/shared_file.txt" should exist
 
 	Scenario: sharee of a upload-only share folder tries to delete his file in the folder
-		Given using API version "1"
+		Given using OCS API version "1"
 		And user "user0" has created a folder "/shared"
-		And user "user0" has sent HTTP method "POST" to API endpoint "/apps/files_sharing/api/v1/shares" with body
+		And user "user0" has sent HTTP method "POST" to OCS API endpoint "/apps/files_sharing/api/v1/shares" with body
 			| path        | shared |
 			| shareWith   | user1  |
 			| shareType   | 0      |
 			| permissions | 4      |
-		When user "user1" uploads file "data/textfile.txt" to "shared/textfile.txt" using the API
-		And user "user1" deletes file "/shared/textfile.txt" using the API
+		When user "user1" uploads file "data/textfile.txt" to "shared/textfile.txt" using the WebDAV API
+		And user "user1" deletes file "/shared/textfile.txt" using the WebDAV API
 		Then the HTTP status code should be "403"
 		And as "user0" the file "/shared/textfile.txt" should exist

--- a/tests/acceptance/features/apiSharing/disableSharing.feature
+++ b/tests/acceptance/features/apiSharing/disableSharing.feature
@@ -10,9 +10,9 @@ So that ownCloud users cannot share file or folder
 		And user "user1" has been created
 
 	Scenario Outline: user tries to share a file with another user when the sharing api has been disabled
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to share file "welcome.txt" with user "user1" using the API
+		Then user "user0" should not be able to share file "welcome.txt" with user "user1" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -21,9 +21,9 @@ So that ownCloud users cannot share file or folder
 			|2              |404             |
 
 	Scenario Outline: user tries to share a folder with another user when the sharing api has been disabled
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to share folder "/FOLDER" with user "user1" using the API
+		Then user "user0" should not be able to share folder "/FOLDER" with user "user1" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -32,11 +32,11 @@ So that ownCloud users cannot share file or folder
 			|2              |404             |
 
 	Scenario Outline: user tries to share a file with group when the sharing api has been disabled
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And group "sharinggroup" has been created
 		And user "user1" has been added to group "sharinggroup"
 		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to share file "welcome.txt" with group "sharinggroup" using the API
+		Then user "user0" should not be able to share file "welcome.txt" with group "sharinggroup" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -45,11 +45,11 @@ So that ownCloud users cannot share file or folder
 			|2              |404             |
 
 	Scenario Outline: user tries to share a folder with group when the sharing api has been disabled
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And group "sharinggroup" has been created
 		And user "user1" has been added to group "sharinggroup"
 		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to share folder "/FOLDER" with group "sharinggroup" using the API
+		Then user "user0" should not be able to share folder "/FOLDER" with group "sharinggroup" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -58,9 +58,9 @@ So that ownCloud users cannot share file or folder
 			|2              |404             |
 
 	Scenario Outline: user tries to create public share of a file when the sharing api has been disabled
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to create public share of file "welcome.txt" using the API
+		Then user "user0" should not be able to create a public share of file "welcome.txt" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -69,9 +69,9 @@ So that ownCloud users cannot share file or folder
 			|2              |404             |
 
 	Scenario Outline: user tries to create public share of a folder when the sharing api has been disabled
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to create public share of folder "/FOLDER" using the API
+		Then user "user0" should not be able to create a public share of folder "/FOLDER" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -80,11 +80,11 @@ So that ownCloud users cannot share file or folder
 			|2              |404             |
 
 	Scenario Outline: user tries to share a file with user who is not in his group when sharing outside the group has been restricted
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And group "sharinggroup" has been created
 		And user "user0" has been added to group "sharinggroup"
 		When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		Then user "user0" should not be able to share file "welcome.txt" with user "user1" using the API
+		Then user "user0" should not be able to share file "welcome.txt" with user "user1" using the sharing API
 		And the OCS status code should be "403"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -93,12 +93,12 @@ So that ownCloud users cannot share file or folder
 			|2              |403             |
 
 	Scenario Outline: user shares a file with user who is in his group when sharing outside the group has been restricted
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And group "sharinggroup" has been created
 		And user "user0" has been added to group "sharinggroup"
 		And user "user1" has been added to group "sharinggroup"
 		When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		Then user "user0" should be able to share file "welcome.txt" with user "user1" using the API
+		Then user "user0" should be able to share file "welcome.txt" with user "user1" using the sharing API
 		And the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		Examples:
@@ -107,13 +107,13 @@ So that ownCloud users cannot share file or folder
 			|2              |200            |
 
 	Scenario Outline: user shares a file with the group he is not member of when sharing outside the group has been restricted
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And group "sharinggroup" has been created
 		And group "anothersharinggroup" has been created
 		And user "user0" has been added to group "sharinggroup"
 		And user "user1" has been added to group "anothersharinggroup"
 		When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		Then user "user0" should be able to share file "welcome.txt" with group "anothersharinggroup" using the API
+		Then user "user0" should be able to share file "welcome.txt" with group "anothersharinggroup" using the sharing API
 		And the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		Examples:
@@ -122,11 +122,11 @@ So that ownCloud users cannot share file or folder
 			|2              |200            |
 
 	Scenario Outline: user who is not a member of a group tries to share a file in the group when group sharing has been disabled
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And group "sharinggroup" has been created
 		And user "user1" has been added to group "sharinggroup"
 		When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		Then user "user0" should not be able to share file "welcome.txt" with group "sharinggroup" using the API
+		Then user "user0" should not be able to share file "welcome.txt" with group "sharinggroup" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -135,12 +135,12 @@ So that ownCloud users cannot share file or folder
 			|2              |404             |
 
 	Scenario Outline: user who is a member of a group tries to share a file in the group when group sharing has been disabled
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And group "sharinggroup" has been created
 		And user "user0" has been added to group "sharinggroup"
 		And user "user1" has been added to group "sharinggroup"
 		When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		Then user "user0" should not be able to share file "welcome.txt" with group "sharinggroup" using the API
+		Then user "user0" should not be able to share file "welcome.txt" with group "sharinggroup" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:

--- a/tests/acceptance/features/apiSharing/downloadFromShare.feature
+++ b/tests/acceptance/features/apiSharing/downloadFromShare.feature
@@ -1,13 +1,13 @@
 @api
 Feature: sharing
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And using old DAV path
 		And user "user0" has been created
 
 	Scenario: Downloading from upload-only share is forbidden
 		Given user "user0" has moved file "/textfile0.txt" to "/FOLDER/test.txt"
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path        | FOLDER |
 			| shareType   | 3      |
 			| permissions | 4      |
@@ -26,8 +26,8 @@ Feature: sharing
 		And user "user1" has shared file "textfile0.txt" with user "user2"
 		And user "user1" has moved file "/textfile0.txt" to "/common/textfile0.txt"
 		And user "user1" has moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
-		When user "user2" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the API
-		And user "user2" downloads file "/common/sub/textfile0.txt" with range "bytes=0-8" using the API
+		When user "user2" uploads file "data/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
+		And user "user2" downloads file "/common/sub/textfile0.txt" with range "bytes=0-8" using the WebDAV API
 		Then the downloaded content should be "BLABLABLA"
 		And the downloaded content when downloading file "/textfile0 (2).txt" for user "user2" with range "bytes=0-8" should be "BLABLABLA"
 		And user "user2" should see the following elements
@@ -36,21 +36,21 @@ Feature: sharing
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with default permissions
 		Given user "user1" has been created
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path      | PARENT     |
 			| shareType | 0          |
 			| shareWith | user1      |
-		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the API
+		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with default permissions
 		Given user "user1" has been created
 		And group "sharegroup" has been created
 		And user "user1" has been added to group "sharegroup"
 		When user "user0" has shared folder "PARENT" with group "sharegroup"
-		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the API
+		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with public with default permissions
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path         | PARENT   |
 			| shareType    | 3        |
 			| password     | publicpw |
@@ -58,26 +58,26 @@ Feature: sharing
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read/Write permission 
 		Given user "user1" has been created
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path        | PARENT |
 			| shareType   | 0      |
 			| shareWith   | user1  |
 			| permissions | 15     |
-		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the API
+		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read/Write permission 
 		Given user "user1" has been created
 		And group "sharegroup" has been created
 		And user "user1" has been added to group "sharegroup"
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path        | PARENT      |
 			| shareType   | 1           |
 			| shareWith   | sharegroup  |
 			| permissions | 15          |
-		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the API
+		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read/Write permission 
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path         | PARENT   |
 			| shareType    | 3        |
 			| password     | publicpw |
@@ -86,26 +86,26 @@ Feature: sharing
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read only permission 
 		Given user "user1" has been created
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path        | PARENT |
 			| shareType   | 0      |
 			| shareWith   | user1  |
 			| permissions | 1      |
-		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the API
+		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read only permission 
 		Given user "user1" has been created
 		And group "sharegroup" has been created
 		And user "user1" has been added to group "sharegroup"
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path        | PARENT      |
 			| shareType   | 1           |
 			| shareWith   | sharegroup  |
 			| permissions | 1           |
-		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the API
+		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read only permission 
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path         | PARENT   |
 			| shareType    | 3        |
 			| password     | publicpw |

--- a/tests/acceptance/features/apiSharing/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiSharing/getWebDAVSharePermissions.feature
@@ -1,21 +1,21 @@
 @api
 Feature: sharing
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And using old DAV path
 		And user "user0" has been created
 		And user "user1" has been created
 
 	Scenario: Correct webdav share-permissions for owned file
 		Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
-		When user "user0" gets the following properties of file "/tmp.txt" using the API
+		When user "user0" gets the following properties of file "/tmp.txt" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
 
 	Scenario: Correct webdav share-permissions for received file with edit and reshare permissions
 		Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
 		And user "user0" has shared file "/tmp.txt" with user "user1"
-		When user "user1" gets the following properties of file "/tmp.txt" using the API
+		When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
 
@@ -28,16 +28,16 @@ Feature: sharing
 			| shareType   | 1          |
 			| permissions | 19         |
 			| shareWith   | sharegroup |
-		When user "user1" gets the following properties of file "/tmp.txt" using the API
+		When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
 
 	Scenario: Correct webdav share-permissions for received file with edit permissions but no reshare permissions
 		Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
 		And user "user0" has shared file "tmp.txt" with user "user1"
-		When user "user0" updates the last share using the API with
+		When user "user0" updates the last share using the sharing API with
 			| permissions | 3 |
-		And user "user1" gets the following properties of file "/tmp.txt" using the API
+		And user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
 
@@ -50,16 +50,16 @@ Feature: sharing
 			| shareType   | 1          |
 			| permissions | 3          |
 			| shareWith   | sharegroup |
-		When user "user1" gets the following properties of file "/tmp.txt" using the API
+		When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
 
 	Scenario: Correct webdav share-permissions for received file with reshare permissions but no edit permissions
 		Given user "user0" has uploaded file with content "foo" to "/tmp.txt"
 		And user "user0" has shared file "tmp.txt" with user "user1"
-		When user "user0" updates the last share using the API with
+		When user "user0" updates the last share using the sharing API with
 			| permissions | 17 |
-		And user "user1" gets the following properties of file "/tmp.txt" using the API
+		And user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
 
@@ -72,20 +72,20 @@ Feature: sharing
 			| shareType   | 1          |
 			| permissions | 17         |
 			| shareWith   | sharegroup |
-		When user "user1" gets the following properties of file "/tmp.txt" using the API
+		When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
 
 	Scenario: Correct webdav share-permissions for owned folder
 		Given user "user0" has created a folder "/tmp"
-		When user "user0" gets the following properties of folder "/" using the API
+		When user "user0" gets the following properties of folder "/" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
 
 	Scenario: Correct webdav share-permissions for received folder with all permissions
 		Given user "user0" has created a folder "/tmp"
 		And user "user0" has shared file "/tmp" with user "user1"
-		When user "user1" gets the following properties of folder "/tmp" using the API
+		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
 
@@ -97,16 +97,16 @@ Feature: sharing
 			| path        | tmp        |
 			| shareType   | 1          |
 			| shareWith   | sharegroup |
-		When user "user1" gets the following properties of folder "/tmp" using the API
+		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
 
 	Scenario: Correct webdav share-permissions for received folder with all permissions but edit
 		Given user "user0" has created a folder "/tmp"
 		And user "user0" has shared file "/tmp" with user "user1"
-		When user "user0" updates the last share using the API with
+		When user "user0" updates the last share using the sharing API with
 			| permissions | 29 |
-		And user "user1" gets the following properties of folder "/tmp" using the API
+		And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
 
@@ -119,16 +119,16 @@ Feature: sharing
 			| shareType   | 1          |
 			| shareWith   | sharegroup |
 			| permissions | 29         |
-		When user "user1" gets the following properties of folder "/tmp" using the API
+		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
 
 	Scenario: Correct webdav share-permissions for received folder with all permissions but create
 		Given user "user0" has created a folder "/tmp"
 		And user "user0" has shared file "/tmp" with user "user1"
-		When user "user0" updates the last share using the API with
+		When user "user0" updates the last share using the sharing API with
 			| permissions | 27 |
-		And user "user1" gets the following properties of folder "/tmp" using the API
+		And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
 
@@ -141,16 +141,16 @@ Feature: sharing
 			| shareType   | 1          |
 			| shareWith   | sharegroup |
 			| permissions | 27         |
-		When user "user1" gets the following properties of folder "/tmp" using the API
+		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
 
 	Scenario: Correct webdav share-permissions for received folder with all permissions but delete
 		Given user "user0" has created a folder "/tmp"
 		And user "user0" has shared file "/tmp" with user "user1"
-		When user "user0" updates the last share using the API with
+		When user "user0" updates the last share using the sharing API with
 			| permissions | 23 |
-		And user "user1" gets the following properties of folder "/tmp" using the API
+		And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
 
@@ -163,16 +163,16 @@ Feature: sharing
 			| shareType   | 1          |
 			| shareWith   | sharegroup |
 			| permissions | 23         |
-		When user "user1" gets the following properties of folder "/tmp" using the API
+		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
 
 	Scenario: Correct webdav share-permissions for received folder with all permissions but share
 		Given user "user0" has created a folder "/tmp"
 		And user "user0" has shared file "/tmp" with user "user1"
-		When user "user0" updates the last share using the API with
+		When user "user0" updates the last share using the sharing API with
 			| permissions | 15 |
-		And user "user1" gets the following properties of folder "/tmp" using the API
+		And user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"
 
@@ -185,6 +185,6 @@ Feature: sharing
 			| shareType   | 1          |
 			| shareWith   | sharegroup |
 			| permissions | 15         |
-		When user "user1" gets the following properties of folder "/tmp" using the API
+		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"

--- a/tests/acceptance/features/apiSharing/gettingShares.feature
+++ b/tests/acceptance/features/apiSharing/gettingShares.feature
@@ -6,10 +6,10 @@ Feature: sharing
 		And user "user1" has been created
 
 	Scenario Outline: getting all shares of a user using that user
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has moved file "/textfile0.txt" to "/file_to_share.txt"
 		And user "user0" has shared file "file_to_share.txt" with user "user1"
-		When user "user0" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares"
+		When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And file "file_to_share.txt" should be included in the response
@@ -19,9 +19,9 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: getting all shares of a user using another user
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has shared file "textfile0.txt" with user "user1"
-		When user "admin" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And file "textfile0.txt" should not be included in the response
@@ -31,12 +31,12 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: getting all shares of a file
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user2" has been created
 		And user "user3" has been created
 		And user "user0" has shared file "textfile0.txt" with user "user1"
 		And user "user0" has shared file "textfile0.txt" with user "user2"
-		When user "user0" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?path=textfile0.txt"
+		When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=textfile0.txt"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And user "user1" should be included in the response
@@ -48,12 +48,12 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: getting all shares of a file with reshares
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user2" has been created
 		And user "user3" has been created
 		And user "user0" has shared file "textfile0.txt" with user "user1"
 		And user "user1" has shared file "textfile0 (2).txt" with user "user2"
-		When user "user0" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?reshares=true&path=textfile0.txt"
+		When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?reshares=true&path=textfile0.txt"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And user "user1" should be included in the response
@@ -65,14 +65,14 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: User's own shares reshared to him don't appear when getting "shared with me" shares
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And group "group0" has been created
 		And user "user0" has been added to group "group0"
 		And user "user0" has created a folder "/shared"
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
 		And user "user0" has shared folder "/shared" with user "user1"
 		And user "user1" has shared folder "/shared" with group "group0"
-		When user "user0" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+		When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the last share_id should not be included in the response
@@ -82,10 +82,10 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: getting share info of a share
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has moved file "/textfile0.txt" to "/file_to_share.txt"
 		And user "user0" has shared file "file_to_share.txt" with user "user1"
-		When user "user0" gets the info of the last share using the API
+		When user "user0" gets the info of the last share using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
@@ -112,10 +112,10 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Get a share with a user that didn't receive the share
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user2" has been created
 		And user "user0" has shared file "textfile0.txt" with user "user1"
-		When user "user2" gets the info of the last share using the API
+		When user "user2" gets the info of the last share using the sharing API
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -124,13 +124,13 @@ Feature: sharing
 			|2              |404             |
 
 	Scenario: Share of folder to a group, remove user from that group
-		Given using API version "1"
+		Given using OCS API version "1"
 		And user "user2" has been created
 		And group "group0" has been created
 		And user "user1" has been added to group "group0"
 		And user "user2" has been added to group "group0"
-		And user "user0" shares file "/PARENT" with group "group0" using the API
-		And the administrator removes user "user2" from group "group0" using the API
+		And user "user0" shares file "/PARENT" with group "group0" using the sharing API
+		And the administrator removes user "user2" from group "group0" using the provisioning API
 		Then user "user1" should see the following elements
 			| /FOLDER/                 |
 			| /PARENT/                 |
@@ -146,9 +146,9 @@ Feature: sharing
 			| /PARENT%20(2)/parent.txt |
 
 	Scenario Outline: getting all the shares inside the folder
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has shared file "PARENT/parent.txt" with user "user1"
-		When user "user0" sends HTTP method "GET" to API endpoint "/apps/files_sharing/api/v1/shares?path=PARENT&subfiles=true"
+		When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=PARENT&subfiles=true"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And file "parent.txt" should be included in the response

--- a/tests/acceptance/features/apiSharing/mergeShare.feature
+++ b/tests/acceptance/features/apiSharing/mergeShare.feature
@@ -1,7 +1,7 @@
 @api
 Feature: sharing
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And using old DAV path
 		And user "user0" has been created
 		And user "user1" has been created
@@ -10,16 +10,16 @@ Feature: sharing
 
 	Scenario: Merging shares for recipient when shared from outside with group and member
 		Given user "user0" has created a folder "/merge-test-outside"
-		When user "user0" shares folder "/merge-test-outside" with group "group1" using the API
-		And user "user0" shares folder "/merge-test-outside" with user "user1" using the API
+		When user "user0" shares folder "/merge-test-outside" with group "group1" using the sharing API
+		And user "user0" shares folder "/merge-test-outside" with user "user1" using the sharing API
 		Then as "user1" the folder "/merge-test-outside" should exist
 		And as "user1" the folder "/merge-test-outside (2)" should not exist
 
 	Scenario: Merging shares for recipient when shared from outside with group and member with different permissions
 		Given user "user0" has created a folder "/merge-test-outside-perms"
-		When user "user0" shares folder "/merge-test-outside-perms" with group "group1" with permissions 1 using the API
-		And user "user0" shares folder "/merge-test-outside-perms" with user "user1" with permissions 31 using the API
-		And user "user1" gets the following properties of folder "/merge-test-outside-perms" using the API
+		When user "user0" shares folder "/merge-test-outside-perms" with group "group1" with permissions 1 using the sharing API
+		And user "user0" shares folder "/merge-test-outside-perms" with user "user1" with permissions 31 using the sharing API
+		And user "user1" gets the following properties of folder "/merge-test-outside-perms" using the WebDAV API
 			|{http://owncloud.org/ns}permissions|
 		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
 		And as "user1" the folder "/merge-test-outside-perms (2)" should not exist
@@ -28,8 +28,8 @@ Feature: sharing
 		Given group "group2" has been created
 		And user "user1" has been added to group "group2"
 		And user "user0" has created a folder "/merge-test-outside-twogroups"
-		When user "user0" shares folder "/merge-test-outside-twogroups" with group "group1" using the API
-		And user "user0" shares folder "/merge-test-outside-twogroups" with group "group2" using the API
+		When user "user0" shares folder "/merge-test-outside-twogroups" with group "group1" using the sharing API
+		And user "user0" shares folder "/merge-test-outside-twogroups" with group "group2" using the sharing API
 		Then as "user1" the folder "/merge-test-outside-twogroups" should exist
 		And as "user1" the folder "/merge-test-outside-twogroups (2)" should not exist
 
@@ -37,9 +37,9 @@ Feature: sharing
 		Given group "group2" has been created
 		And user "user1" has been added to group "group2"
 		And user "user0" has created a folder "/merge-test-outside-twogroups-perms"
-		When user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "group1" with permissions 1 using the API
-		And user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "group2" with permissions 31 using the API
-		And user "user1" gets the following properties of folder "/merge-test-outside-twogroups-perms" using the API
+		When user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "group1" with permissions 1 using the sharing API
+		And user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "group2" with permissions 31 using the sharing API
+		And user "user1" gets the following properties of folder "/merge-test-outside-twogroups-perms" using the WebDAV API
 			|{http://owncloud.org/ns}permissions|
 		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
 		And as "user1" the folder "/merge-test-outside-twogroups-perms (2)" should not exist
@@ -48,17 +48,17 @@ Feature: sharing
 		Given group "group2" has been created
 		And user "user1" has been added to group "group2"
 		And user "user0" has created a folder "/merge-test-outside-twogroups-member-perms"
-		When user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "group1" with permissions 1 using the API
-		And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "group2" with permissions 31 using the API
-		And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with user "user1" with permissions 1 using the API
-		And user "user1" gets the following properties of folder "/merge-test-outside-twogroups-member-perms" using the API
+		When user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "group1" with permissions 1 using the sharing API
+		And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "group2" with permissions 31 using the sharing API
+		And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with user "user1" with permissions 1 using the sharing API
+		And user "user1" gets the following properties of folder "/merge-test-outside-twogroups-member-perms" using the WebDAV API
 			|{http://owncloud.org/ns}permissions|
 		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
 		And as "user1" the folder "/merge-test-outside-twogroups-member-perms (2)" should not exist
 
 	Scenario: Merging shares for recipient when shared from inside with group
 		Given user "user1" has created a folder "/merge-test-inside-group"
-		When user "user1" shares folder "/merge-test-inside-group" with group "group1" using the API
+		When user "user1" shares folder "/merge-test-inside-group" with group "group1" using the sharing API
 		Then as "user1" the folder "/merge-test-inside-group" should exist
 		And as "user1" the folder "/merge-test-inside-group (2)" should not exist
 
@@ -66,8 +66,8 @@ Feature: sharing
 		Given group "group2" has been created
 		And user "user1" has been added to group "group2"
 		And user "user1" has created a folder "/merge-test-inside-twogroups"
-		When user "user1" shares folder "/merge-test-inside-twogroups" with group "group1" using the API
-		And user "user1" shares folder "/merge-test-inside-twogroups" with group "group2" using the API
+		When user "user1" shares folder "/merge-test-inside-twogroups" with group "group1" using the sharing API
+		And user "user1" shares folder "/merge-test-inside-twogroups" with group "group2" using the sharing API
 		Then as "user1" the folder "/merge-test-inside-twogroups" should exist
 		And as "user1" the folder "/merge-test-inside-twogroups (2)" should not exist
 		And as "user1" the folder "/merge-test-inside-twogroups (3)" should not exist
@@ -76,9 +76,9 @@ Feature: sharing
 		Given group "group2" has been created
 		And user "user1" has been added to group "group2"
 		And user "user1" has created a folder "/merge-test-inside-twogroups-perms"
-		When user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "group1" using the API
-		And user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "group2" using the API
-		And user "user1" gets the following properties of folder "/merge-test-inside-twogroups-perms" using the API
+		When user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "group1" using the sharing API
+		And user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "group2" using the sharing API
+		And user "user1" gets the following properties of folder "/merge-test-inside-twogroups-perms" using the WebDAV API
 			|{http://owncloud.org/ns}permissions|
 		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK" or with value "RMDNVCK"
 		And as "user1" the folder "/merge-test-inside-twogroups-perms (2)" should not exist
@@ -87,20 +87,20 @@ Feature: sharing
 	@skip @issue-29016
 	Scenario: Merging shares for recipient when shared from outside with group then user and recipient renames in between
 		Given user "user0" has created a folder "/merge-test-outside-groups-renamebeforesecondshare"
-		When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "group1" using the API
-		And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the API
-		And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the API
-		And user "user1" gets the following properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the API
+		When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "group1" using the sharing API
+		And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
+		And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
+		And user "user1" gets the following properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
 			|{http://owncloud.org/ns}permissions|
 		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
 		And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist
 
 	Scenario: Merging shares for recipient when shared from outside with user then group and recipient renames in between
 		Given user "user0" has created a folder "/merge-test-outside-groups-renamebeforesecondshare"
-		When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the API
-		And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the API
-		And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "group1" using the API
-		And user "user1" gets the following properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the API
+		When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
+		And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
+		And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "group1" using the sharing API
+		And user "user1" gets the following properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
 			|{http://owncloud.org/ns}permissions|
 		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
 		And as "user1" the folder "/merge-test-outside-groups-renamebeforesecondshare" should not exist

--- a/tests/acceptance/features/apiSharing/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiSharing/moveReceivedShare.feature
@@ -1,7 +1,7 @@
 @api
 Feature: sharing
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And using old DAV path
 		And user "user0" has been created
 		And user "user1" has been created
@@ -12,10 +12,10 @@ Feature: sharing
 		And user "user1" has been added to group "group"
 		And user "user2" has been added to group "group"
 		And user "user0" has created a folder "/TMP"
-		When user "user0" shares folder "TMP" with group "group" using the API
-		And user "user1" creates a folder "/myFOLDER" using the API
-		And user "user1" moves folder "/TMP" to "/myFOLDER/myTMP" using the API
-		And the administrator deletes user "user2" using the API
+		When user "user0" shares folder "TMP" with group "group" using the sharing API
+		And user "user1" creates a folder "/myFOLDER" using the WebDAV API
+		And user "user1" moves folder "/TMP" to "/myFOLDER/myTMP" using the WebDAV API
+		And the administrator deletes user "user2" using the provisioning API
 		Then user "user1" should see the following elements
 			| /myFOLDER/myTMP/ |
 
@@ -23,7 +23,7 @@ Feature: sharing
 		Given user "user0" has uploaded file with content "foo" to "/sharefile.txt"
 		And user "user0" has shared file "/sharefile.txt" with user "user1"
 		And user "user0" has shared file "/sharefile.txt" with user "user2"
-		When user "user2" moves file "/sharefile.txt" to "/renamedsharefile.txt" using the API
+		When user "user2" moves file "/sharefile.txt" to "/renamedsharefile.txt" using the WebDAV API
 		Then as "user2" the file "/renamedsharefile.txt" should exist
 		And as "user0" the file "/sharefile.txt" should exist
 		And as "user1" the file "/sharefile.txt" should exist
@@ -33,7 +33,7 @@ Feature: sharing
 		And user "user0" has shared file "/sharefile.txt" with user "user1"
 		And user "user0" has shared file "/sharefile.txt" with user "user2"
 		And user "user2" has created a folder "newfolder"
-		When user "user2" moves file "/sharefile.txt" to "/newfolder/sharefile.txt" using the API
+		When user "user2" moves file "/sharefile.txt" to "/newfolder/sharefile.txt" using the WebDAV API
 		Then as "user2" the file "/newfolder/sharefile.txt" should exist
 		And as "user0" the file "/sharefile.txt" should exist
 		And as "user1" the file "/sharefile.txt" should exist

--- a/tests/acceptance/features/apiSharing/multilinksharing.feature
+++ b/tests/acceptance/features/apiSharing/multilinksharing.feature
@@ -7,7 +7,7 @@ Feature: multilinksharing
 		And as user "user0"
 
 	Scenario Outline: Creating three public shares of a folder
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And the user has created a share with settings
 			| path         | FOLDER      |
 			| shareType    | 3           |
@@ -32,7 +32,7 @@ Feature: multilinksharing
 			| publicUpload | true        |
 			| permissions  | 15          |
 			| name         | sharedlink3 |
-		When the user updates the last share using the API with
+		When the user updates the last share using the sharing API with
 			| permissions | 1 |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
@@ -46,7 +46,7 @@ Feature: multilinksharing
 			|2              |200            |
 
 	Scenario Outline: Creating three public shares of a file
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And the user has created a share with settings
 			| path        | textfile0.txt |
 			| shareType   | 3             |
@@ -68,7 +68,7 @@ Feature: multilinksharing
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink3   |
-		When the user updates the last share using the API with
+		When the user updates the last share using the sharing API with
 			| permissions | 1 |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
@@ -82,7 +82,7 @@ Feature: multilinksharing
 			|2              |200            |
 
 	Scenario Outline: Check that updating password doesn't remove name of links
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And the user has created a share with settings
 			| path         | FOLDER      |
 			| shareType    | 3           |
@@ -99,7 +99,7 @@ Feature: multilinksharing
 			| publicUpload | true        |
 			| permissions  | 15          |
 			| name         | sharedlink2 |
-		When the user updates the last share using the API with
+		When the user updates the last share using the sharing API with
 			| password | newpassword |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
@@ -112,7 +112,7 @@ Feature: multilinksharing
 			|2              |200            |
 
 	Scenario: Deleting a file deletes also its public links
-		Given using API version "1"
+		Given using OCS API version "1"
 		And the user has created a share with settings
 			| path        | textfile0.txt |
 			| shareType   | 3             |
@@ -129,13 +129,13 @@ Feature: multilinksharing
 			| name        | sharedlink2   |
 		And user "user0" has deleted file "/textfile0.txt"
 		And the HTTP status code should be "204"
-		When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt" using the API
+		When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 		And as user "user0" the public shares of file "/textfile0.txt" should be
 			| | | |
 
 	Scenario Outline: Deleting one public share of a file doesn't affect the rest
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And the user has created a share with settings
 			| path        | textfile0.txt |
 			| shareType   | 3             |
@@ -157,7 +157,7 @@ Feature: multilinksharing
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink3   |
-		When user "user0" deletes public share named "sharedlink2" in file "/textfile0.txt" using the API
+		When user "user0" deletes public share named "sharedlink2" in file "/textfile0.txt" using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And as user "user0" the public shares of file "/textfile0.txt" should be
@@ -169,7 +169,7 @@ Feature: multilinksharing
 			|2              |200            |
 
 	Scenario: Overwriting a file doesn't remove its public shares
-		Given using API version "1"
+		Given using OCS API version "1"
 		And the user has created a share with settings
 			| path        | textfile0.txt |
 			| shareType   | 3             |
@@ -184,13 +184,13 @@ Feature: multilinksharing
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink2   |
-		When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt" using the API
+		When user "user0" uploads file "data/textfile.txt" to "/textfile0.txt" using the WebDAV API
 		Then as user "user0" the public shares of file "/textfile0.txt" should be
 			| /textfile0.txt | 1 | sharedlink1 |
 			| /textfile0.txt | 1 | sharedlink2 |
 
 	Scenario: Renaming a folder doesn't remove its public shares
-		Given using API version "1"
+		Given using OCS API version "1"
 		And the user has created a share with settings
 			| path         | FOLDER      |
 			| shareType    | 3           |
@@ -207,7 +207,7 @@ Feature: multilinksharing
 			| publicUpload | true        |
 			| permissions  | 15          |
 			| name         | sharedlink2 |
-		When user "user0" moves folder "/FOLDER" to "/FOLDER_RENAMED" using the API
+		When user "user0" moves folder "/FOLDER" to "/FOLDER_RENAMED" using the WebDAV API
 		Then as user "user0" the public shares of file "/FOLDER_RENAMED" should be
 			| /FOLDER_RENAMED | 15 | sharedlink1 |
 			| /FOLDER_RENAMED | 15 | sharedlink2 |

--- a/tests/acceptance/features/apiSharing/reShare.feature
+++ b/tests/acceptance/features/apiSharing/reShare.feature
@@ -6,14 +6,14 @@ Feature: sharing
 		And user "user1" has been created
 
 	Scenario Outline: User is not allowed to reshare file
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user2" has been created
 		And user "user0" has created a share with settings
 			| path        | /textfile0.txt |
 			| shareType   | 0              |
 			| shareWith   | user1          |
 			| permissions | 8              |
-		When user "user1" creates a share using the API with settings
+		When user "user1" creates a share using the sharing API with settings
 			| path        | /textfile0 (2).txt |
 			| shareType   | 0                  |
 			| shareWith   | user2              |
@@ -26,14 +26,14 @@ Feature: sharing
 			|2              |404             |
 
 	Scenario Outline: User is not allowed to reshare file with more permissions
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user2" has been created
 		And user "user0" has created a share with settings
 			| path        | /textfile0.txt |
 			| shareType   | 0              |
 			| shareWith   | user1          |
 			| permissions | 16             |
-		When user "user1" creates a share using the API with settings
+		When user "user1" creates a share using the sharing API with settings
 			| path        | /textfile0 (2).txt |
 			| shareType   | 0                  |
 			| shareWith   | user2              |
@@ -46,7 +46,7 @@ Feature: sharing
 			|2              |404             |
 
 	Scenario Outline: Do not allow reshare to exceed permissions
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user2" has been created
 		And user "user0" has created a folder "/TMP"
 		And user "user0" has created a share with settings
@@ -60,7 +60,7 @@ Feature: sharing
 			| shareType   | 0     |
 			| shareWith   | user2 |
 			| permissions | 21    |
-		When the user updates the last share using the API with
+		When the user updates the last share using the sharing API with
 			| permissions | 31 |
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
@@ -76,15 +76,15 @@ Feature: sharing
 		And user "user1" has moved file "/textfile0 (2).txt" to "/textfile0_shared.txt"
 		And user "user1" has shared file "textfile0_shared.txt" with user "user2"
 		And user "user2" has shared file "textfile0_shared.txt" with user "user3"
-		When user "user1" deletes file "/textfile0_shared.txt" using the API
-		And user "user3" downloads file "/textfile0_shared.txt" with range "bytes=1-7" using the API
+		When user "user1" deletes file "/textfile0_shared.txt" using the WebDAV API
+		And user "user3" downloads file "/textfile0_shared.txt" with range "bytes=1-7" using the WebDAV API
 		Then the downloaded content should be "wnCloud"
 
 	Scenario Outline: resharing using a public link with read only permissions is not allowed
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 1
-		When user "user1" creates a share using the API with settings
+		When user "user1" creates a share using the sharing API with settings
 			| path         | /test |
 			| shareType    | 3     |
 			| publicUpload | false |
@@ -96,10 +96,10 @@ Feature: sharing
 			|2              |404             |
 
 	Scenario Outline: resharing using a public link with read and write permissions only is not allowed
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 15
-		When user "user1" creates a share using the API with settings
+		When user "user1" creates a share using the sharing API with settings
 			| path         | /test |
 			| shareType    | 3     |
 			| publicUpload | false |
@@ -111,7 +111,7 @@ Feature: sharing
 			|2              |404             |
 
 	Scenario Outline: resharing a file is not allowed when allow resharing has been disabled
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user2" has been created
 		And user "user0" has created a share with settings
 			| path        | /textfile0.txt |
@@ -119,7 +119,7 @@ Feature: sharing
 			| shareWith   | user1          |
 			| permissions | 31             |
 		And parameter "shareapi_allow_resharing" of app "core" has been set to "no"
-		When user "user1" creates a share using the API with settings
+		When user "user1" creates a share using the sharing API with settings
 			| path        | /textfile0 (2).txt |
 			| shareType   | 0                  |
 			| shareWith   | user2              |

--- a/tests/acceptance/features/apiSharing/updateShare.feature
+++ b/tests/acceptance/features/apiSharing/updateShare.feature
@@ -1,18 +1,18 @@
 @api
 Feature: sharing
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And using old DAV path
 		And user "user0" has been created
 
 	Scenario Outline: Allow modification of reshare
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And user "user2" has been created
 		And user "user0" has created a folder "/TMP"
 		And user "user0" has shared file "TMP" with user "user1"
 		And user "user1" has shared file "TMP" with user "user2"
-		When user "user1" updates the last share using the API with
+		When user "user1" updates the last share using the sharing API with
 			| permissions | 1 |
 		Then the OCS status code should be "<ocs_status_code>"
 		Examples:
@@ -21,14 +21,14 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a new public share, updating its expiration date and getting its info
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And as user "user0"
-		When the user creates a share using the API with settings
+		When the user creates a share using the sharing API with settings
 			| path      | FOLDER |
 			| shareType | 3      |
-		And the user updates the last share using the API with
+		And the user updates the last share using the sharing API with
 			| expireDate | +3 days |
-		And the user gets the info of the last share using the API
+		And the user gets the info of the last share using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
@@ -55,13 +55,13 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a new public share with password and adding an expiration date
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And as user "user0"
-		When the user creates a share using the API with settings
+		When the user creates a share using the sharing API with settings
 			| path      | welcome.txt |
 			| shareType | 3           |
 			| password  | publicpw    |
-		And the user updates the last share using the API with
+		And the user updates the last share using the sharing API with
 			| expireDate | +3 days |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
@@ -72,14 +72,14 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a new public share, updating its expiration date and getting its info
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And as user "user0"
-		When the user creates a share using the API with settings
+		When the user creates a share using the sharing API with settings
 			| path      | FOLDER |
 			| shareType | 3      |
-		And the user updates the last share using the API with
+		And the user updates the last share using the sharing API with
 			| expireDate | +3 days |
-		And the user gets the info of the last share using the API
+		And the user gets the info of the last share using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
@@ -106,14 +106,14 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a new public share, updating its password and getting its info
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And as user "user0"
-		When the user creates a share using the API with settings
+		When the user creates a share using the sharing API with settings
 			| path      | FOLDER |
 			| shareType | 3      |
-		And the user updates the last share using the API with
+		And the user updates the last share using the sharing API with
 			| password | publicpw |
-		And the user gets the info of the last share using the API
+		And the user gets the info of the last share using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
@@ -139,14 +139,14 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a new public share, updating its permissions and getting its info
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And as user "user0"
-		When the user creates a share using the API with settings
+		When the user creates a share using the sharing API with settings
 			| path      | FOLDER |
 			| shareType | 3      |
-		And the user updates the last share using the API with
+		And the user updates the last share using the sharing API with
 			| permissions | 7 |
-		And the user gets the info of the last share using the API
+		And the user gets the info of the last share using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
@@ -172,14 +172,14 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Creating a new public share, updating publicUpload option and getting its info
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And as user "user0"
-		When the user creates a share using the API with settings
+		When the user creates a share using the sharing API with settings
 			| path      | FOLDER |
 			| shareType | 3      |
-		And the user updates the last share using the API with
+		And the user updates the last share using the sharing API with
 			| publicUpload | true |
-		And the user gets the info of the last share using the API
+		And the user gets the info of the last share using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
@@ -205,16 +205,16 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: keep group permissions in sync
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And group "group1" has been created
 		And user "user1" has been added to group "group1"
 		And user "user0" has shared file "textfile0.txt" with group "group1"
 		And user "user1" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
 		And as user "user0"
-		When the user updates the last share using the API with
+		When the user updates the last share using the sharing API with
 			| permissions | 1 |
-		And the user gets the info of the last share using the API
+		And the user gets the info of the last share using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
@@ -238,7 +238,7 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 17
@@ -247,7 +247,7 @@ Feature: sharing
 			| path         | /test |
 			| shareType    | 3     |
 			| publicUpload | false |
-		When the user updates the last share using the API with
+		When the user updates the last share using the sharing API with
 			| publicUpload | true |
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
@@ -257,14 +257,14 @@ Feature: sharing
 			|2              |404             |
 
 	Scenario Outline: Cannot set permissions to zero
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And group "new-group" has been created
 		And user "user0" has been added to group "new-group"
 		And user "user1" has been added to group "new-group"
 		And user "user0" has been made a subadmin of group "new-group"
 		And user "user0" has shared folder "/FOLDER" with group "new-group"
-		When user "user0" updates the last share using the API with
+		When user "user0" updates the last share using the sharing API with
 			| permissions | 0 |
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "<http_status_code>"
@@ -281,8 +281,8 @@ Feature: sharing
 		And user "user1" has created a folder "/moved-out"
 		And user "user0" has shared folder "/folder1" with user "user1" with permissions 31
 		And user "user1" has shared folder "/folder1/folder2" with user "user2" with permissions 31
-		When user "user1" moves folder "/folder1/folder2" to "/moved-out/folder2" using the API
-		And user "user1" gets the info of the last share using the API
+		When user "user1" moves folder "/folder1/folder2" to "/moved-out/folder2" using the WebDAV API
+		And user "user1" gets the info of the last share using the sharing API
 		Then the share fields of the last share should include
 			| id                | A_NUMBER             |
 			| item_type         | folder               |
@@ -309,8 +309,8 @@ Feature: sharing
 		And user "user2" has created a folder "/user2-folder"
 		And user "user0" has shared folder "/user0-folder" with user "user1" with permissions 31
 		And user "user2" has shared folder "/user2-folder" with user "user1" with permissions 31
-		When user "user1" moves folder "/user0-folder/folder2" to "/user2-folder/folder2" using the API
-		And user "user1" gets the info of the last share using the API
+		When user "user1" moves folder "/user0-folder/folder2" to "/user2-folder/folder2" using the WebDAV API
+		And user "user1" gets the info of the last share using the sharing API
 		Then the share fields of the last share should include
 			| id                | A_NUMBER             |
 			| item_type         | folder               |
@@ -330,7 +330,7 @@ Feature: sharing
 		And as "user2" the folder "/user2-folder/folder2" should exist
 
 	Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 31
@@ -339,7 +339,7 @@ Feature: sharing
 			| path         | /test |
 			| shareType    | 3     |
 			| publicUpload | false |
-		When the user updates the last share using the API with
+		When the user updates the last share using the sharing API with
 			| publicUpload | true |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
@@ -349,7 +349,7 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 17
@@ -358,7 +358,7 @@ Feature: sharing
 			| path        | /test |
 			| shareType   | 3     |
 			| permissions | 1     |
-		When the user updates the last share using the API with
+		When the user updates the last share using the sharing API with
 			| permissions | 15 |
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
@@ -368,7 +368,7 @@ Feature: sharing
 			|2              |404             |
 
 	Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 31
@@ -377,7 +377,7 @@ Feature: sharing
 			| path        | /test |
 			| shareType   | 3     |
 			| permissions | 1     |
-		When the user updates the last share using the API with
+		When the user updates the last share using the sharing API with
 			| permissions | 15 |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
@@ -387,7 +387,7 @@ Feature: sharing
 			|2              |200            |
 
 	Scenario Outline: Increasing permissions is allowed for owner
-		Given using API version "<ocs_api_version>"
+		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
 		And group "new-group" has been created
 		And user "user0" has been added to group "new-group"
@@ -397,7 +397,7 @@ Feature: sharing
 		And the user has shared folder "/FOLDER" with group "new-group"
 		And the user has updated the last share with
 			| permissions | 1 |
-		When the user updates the last share using the API with
+		When the user updates the last share using the sharing API with
 			| permissions | 31 |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiSharing/uploadToShare.feature
+++ b/tests/acceptance/features/apiSharing/uploadToShare.feature
@@ -1,7 +1,7 @@
 @api
 Feature: sharing
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And using old DAV path
 		And user "user0" has been created
 
@@ -11,8 +11,8 @@ Feature: sharing
 			| path        | FOLDER |
 			| shareType   | 3      |
 			| permissions | 4      |
-		When the public uploads file "test.txt" with content "test" using the API
-		And the public uploads file "test.txt" with content "test2" with autorename mode using the API
+		When the public uploads file "test.txt" with content "test" using the old WebDAV API
+		And the public uploads file "test.txt" with content "test2" with autorename mode using the old WebDAV API
 		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 		And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
 
@@ -21,12 +21,12 @@ Feature: sharing
 			| path        | FOLDER |
 			| shareType   | 3      |
 			| permissions | 4      |
-		When user "user0" deletes file "/FOLDER" using the API
+		When user "user0" deletes file "/FOLDER" using the WebDAV API
 		Then publicly uploading a file should not work
 		And the HTTP status code should be "404"
 
 	Scenario: Uploading file to a public read-only share folder does not work
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path        | FOLDER |
 			| shareType   | 3      |
 			| permissions | 1      |
@@ -40,7 +40,7 @@ Feature: sharing
 			| shareType   | 0      |
 			| permissions | 1      |
 			| shareWith   | user1  |
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the API
+		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
 		Then the HTTP status code should be "403"
 
 	Scenario: Uploading file to a group read-only share folder does not work
@@ -52,7 +52,7 @@ Feature: sharing
 			| shareType   | 1          |
 			| permissions | 1          |
 			| shareWith   | sharegroup |
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the API
+		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
 		Then the HTTP status code should be "403"
 
 	Scenario: Uploading to a public upload-only share
@@ -61,7 +61,7 @@ Feature: sharing
 			| path        | FOLDER |
 			| shareType   | 3      |
 			| permissions | 4      |
-		When the public uploads file "test.txt" with content "test" using the API
+		When the public uploads file "test.txt" with content "test" using the old WebDAV API
 		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
 	Scenario: Uploading to a public upload-only share with password
@@ -71,7 +71,7 @@ Feature: sharing
 			| shareType   | 3        |
 			| password    | publicpw |
 			| permissions | 4        |
-		When the public uploads file "test.txt" with password "publicpw" and content "test" using the API
+		When the public uploads file "test.txt" with password "publicpw" and content "test" using the old WebDAV API
 		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
 	Scenario: Uploading file to a user upload-only share folder works
@@ -81,7 +81,7 @@ Feature: sharing
 			| shareType   | 0      |
 			| permissions | 4      |
 			| shareWith   | user1  |
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the API
+		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 
 	Scenario: Uploading file to a group upload-only share folder works
@@ -93,7 +93,7 @@ Feature: sharing
 			| shareType   | 1          |
 			| permissions | 4          |
 			| shareWith   | sharegroup |
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the API
+		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 
 	Scenario: Uploading to a public read/write share with password
@@ -103,7 +103,7 @@ Feature: sharing
 			| shareType   | 3        |
 			| password    | publicpw |
 			| permissions | 15       |
-		When the public uploads file "test.txt" with password "publicpw" and content "test" using the API
+		When the public uploads file "test.txt" with password "publicpw" and content "test" using the old WebDAV API
 		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
 	Scenario: Uploading file to a user read/write share folder works
@@ -113,7 +113,7 @@ Feature: sharing
 			| shareType   | 0      |
 			| permissions | 15     |
 			| shareWith   | user1  |
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the API
+		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 
 	Scenario: Uploading file to a group read/write share folder works
@@ -125,7 +125,7 @@ Feature: sharing
 			| shareType   | 1          |
 			| permissions | 15         |
 			| shareWith   | sharegroup |
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the API
+		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 
 	Scenario: Check quota of owners parent directory of a shared file
@@ -133,7 +133,7 @@ Feature: sharing
 		And the quota of user "user1" has been set to "0"
 		And user "user0" has moved file "/welcome.txt" to "/myfile.txt"
 		And user "user0" has shared file "myfile.txt" with user "user1"
-		When user "user1" uploads file "data/textfile.txt" to "/myfile.txt" using the API
+		When user "user1" uploads file "data/textfile.txt" to "/myfile.txt" using the WebDAV API
 		Then the HTTP status code should be "204"
 
 	Scenario: Uploading to a public read/write share with password
@@ -143,7 +143,7 @@ Feature: sharing
 			| shareType   | 3        |
 			| password    | publicpw |
 			| permissions | 15       |
-		When the public uploads file "test.txt" with password "publicpw" and content "test" using the API
+		When the public uploads file "test.txt" with password "publicpw" and content "test" using the old WebDAV API
 		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
 	Scenario: Uploading to a user shared folder with read/write permission when the sharer has unsufficient quota does not work
@@ -154,7 +154,7 @@ Feature: sharing
 			| permissions | 15         |
 			| shareWith   | user1      |
 		And the quota of user "user0" has been set to "0"
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the API
+		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
 		Then the HTTP status code should be "507"
 
 	Scenario: Uploading to a group shared folder with read/write permission when the sharer has unsufficient quota does not work
@@ -167,11 +167,11 @@ Feature: sharing
 			| permissions | 15           |
 			| shareWith   | sharinggroup |
 		And the quota of user "user0" has been set to "0"
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the API
+		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
 		Then the HTTP status code should be "507"
 
 	Scenario: Uploading file to a public shared folder with read/write permission when the sharer has unsufficient quota does not work
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path        | FOLDER |
 			| shareType   | 3      |
 			| permissions | 15      |
@@ -187,7 +187,7 @@ Feature: sharing
 			| permissions | 4         |
 			| shareWith   | user1      |
 		And the quota of user "user0" has been set to "0"
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the API
+		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
 		Then the HTTP status code should be "507"
 
 	Scenario: Uploading to a group shared folder with upload-only permission when the sharer has unsufficient quota does not work
@@ -200,11 +200,11 @@ Feature: sharing
 			| permissions | 4           |
 			| shareWith   | sharinggroup |
 		And the quota of user "user0" has been set to "0"
-		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the API
+		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
 		Then the HTTP status code should be "507"
 
 	Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has unsufficient quota does not work
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path        | FOLDER |
 			| shareType   | 3      |
 			| permissions | 4      |
@@ -217,7 +217,7 @@ Feature: sharing
 			| path        | FOLDER |
 			| shareType   | 3      |
 			| permissions | 4      |
-		When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "no" using the API
+		When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "no"
 		Then publicly uploading a file should not work
 		And the HTTP status code should be "403"
 
@@ -227,7 +227,7 @@ Feature: sharing
 			| path        | FOLDER |
 			| shareType   | 3      |
 			| permissions | 31      |
-		When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "yes" using the API
+		When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "yes"
 		Then publicly uploading a file should not work
 		And the HTTP status code should be "403"
 
@@ -238,5 +238,5 @@ Feature: sharing
 			| permissions | 4      |
 		And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
 		And parameter "shareapi_allow_public_upload" of app "core" has been set to "yes"
-		When the public uploads file "test.txt" with content "test" using the API
+		When the public uploads file "test.txt" with content "test" using the old WebDAV API
 		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"

--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -6,7 +6,7 @@ Feature: Display notifications when receiving a share
 
 	Background:
 		Given the app "notifications" has been enabled
-		And using API version "1"
+		And using OCS API version "1"
 		And using new DAV path
 		And user "user0" has been created
 		And user "user1" has been created
@@ -19,8 +19,8 @@ Feature: Display notifications when receiving a share
 
 	Scenario: share to user sends notification
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with user "user1" using the API
-		And user "user0" shares file "/textfile0.txt" with user "user1" using the API
+		When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
+		And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
 		Then user "user1" should have 2 notifications
 		And the last notification of user "user1" should match these regular expressions
 			| app         | /^files_sharing$/                       |
@@ -31,8 +31,8 @@ Feature: Display notifications when receiving a share
 
 	Scenario: share to group sends notification to every member
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the API
-		And user "user0" shares file "/textfile0.txt" with group "grp1" using the API
+		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+		And user "user0" shares file "/textfile0.txt" with group "grp1" using the sharing API
 		Then user "user1" should have 2 notifications
 		And the last notification of user "user1" should match these regular expressions
 			| app         | /^files_sharing$/                       |
@@ -50,20 +50,20 @@ Feature: Display notifications when receiving a share
 
 	Scenario: when auto-accepting is enabled no notifications are sent
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
-		When user "user0" shares folder "/PARENT" with user "user1" using the API
-		And user "user0" shares file "/textfile0.txt" with user "user1" using the API
+		When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
+		And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
 		Then user "user1" should have 0 notifications
 
 	Scenario: discard notification if target user is not member of the group anymore
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the API
-		And the administrator removes user "user1" from group "grp1" using the API
+		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+		And the administrator removes user "user1" from group "grp1" using the provisioning API
 		Then user "user1" should have 0 notifications
 		Then user "user2" should have 1 notification
 
 	Scenario: discard notification if group is deleted
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-		When user "user0" shares folder "/PARENT" with group "grp1" using the API
-		And the administrator deletes group "grp1" using the API
+		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
+		And the administrator deletes group "grp1" using the provisioning API
 		Then user "user1" should have 0 notifications
 		Then user "user2" should have 0 notifications

--- a/tests/acceptance/features/apiTrashbin/trashbin-new-endpoint.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbin-new-endpoint.feature
@@ -1,26 +1,26 @@
 @api
 Feature: trashbin-new-endpoint
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And using new DAV path
 		And as user "admin"
 
 	Scenario: deleting a file moves it to trashbin
 		Given user "user0" has been created
-		When user "user0" deletes file "/textfile0.txt" using the API
+		When user "user0" deletes file "/textfile0.txt" using the WebDAV API
 		Then as "user0" the file "/textfile0.txt" should exist in trash
 
 	Scenario: deleting a folder moves it to trashbin
 		Given user "user0" has been created
 		And user "user0" has created a folder "/tmp"
-		When user "user0" deletes folder "/tmp" using the API
+		When user "user0" deletes folder "/tmp" using the WebDAV API
 		Then as "user0" the folder "/tmp" should exist in trash
 
 	Scenario: deleting a file in a folder moves it to the trashbin root
 		Given user "user0" has been created
 		And user "user0" has created a folder "/new-folder"
 		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
-		When user "user0" deletes file "/new-folder/new-file.txt" using the API
+		When user "user0" deletes file "/new-folder/new-file.txt" using the WebDAV API
 		Then as "user0" the file with original path "/new-folder/new-file.txt" should exist in trash
 		And as "user0" the file "/new-file.txt" should exist in trash
 		But as "user0" the file "/new-folder/new-file.txt" should not exist
@@ -31,7 +31,7 @@ Feature: trashbin-new-endpoint
 		And user "user0" has created a folder "/shared"
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
 		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user0" deletes file "/shared/shared_file.txt" using the API
+		When user "user0" deletes file "/shared/shared_file.txt" using the WebDAV API
 		Then as "user0" the file with original path "/shared/shared_file.txt" should exist in trash
 		And as "user0" the file "/shared_file.txt" should exist in trash
 		But as "user0" the file "/shared/shared_file.txt" should not exist
@@ -42,7 +42,7 @@ Feature: trashbin-new-endpoint
 		And user "user0" has created a folder "/shared"
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
 		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user0" deletes folder "/shared" using the API
+		When user "user0" deletes folder "/shared" using the WebDAV API
 		Then as "user0" the folder with original path "/shared" should exist in trash
 
 	Scenario: deleting a received folder doesn't move it to trashbin
@@ -52,7 +52,7 @@ Feature: trashbin-new-endpoint
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
 		And user "user0" has shared folder "/shared" with user "user1"
 		And user "user1" has moved folder "/shared" to "/renamed_shared"
-		When user "user1" deletes folder "/renamed_shared" using the API
+		When user "user1" deletes folder "/renamed_shared" using the WebDAV API
 		Then as "user1" the folder with original path "/renamed_shared" should not exist in trash
 
 	Scenario: deleting a file in a received folder moves it to trashbin
@@ -62,7 +62,7 @@ Feature: trashbin-new-endpoint
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
 		And user "user0" has shared folder "/shared" with user "user1"
 		And user "user1" has moved file "/shared" to "/renamed_shared"
-		When user "user1" deletes file "/renamed_shared/shared_file.txt" using the API
+		When user "user1" deletes file "/renamed_shared/shared_file.txt" using the WebDAV API
 		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should exist in trash
 
 	Scenario: deleting a file in a received folder when restored it comes back to the original path
@@ -73,8 +73,8 @@ Feature: trashbin-new-endpoint
 		And user "user0" has shared folder "/shared" with user "user1"
 		And user "user1" has moved file "/shared" to "/renamed_shared"
 		And user "user1" has deleted file "/renamed_shared/shared_file.txt"
-		And user "user1" has logged in to a web-style session using the API
-		When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the API
+		And user "user1" has logged in to a web-style session
+		When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the trashbin API
 		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
 		And user "user1" should see the following elements
 			| /renamed_shared/                |
@@ -87,7 +87,7 @@ Feature: trashbin-new-endpoint
 		And user "user0" has deleted file "/textfile1.txt"
 		And as "user0" the file "/textfile0.txt" should exist in trash
 		And as "user0" the file "/textfile1.txt" should exist in trash
-		When user "user0" empties the trashbin using the API
+		When user "user0" empties the trashbin using the trashbin API
 		Then as "user0" the file with original path "/textfile0.txt" should not exist in trash
 		And as "user0" the file with original path "/textfile1.txt" should not exist in trash
 
@@ -95,8 +95,8 @@ Feature: trashbin-new-endpoint
 		Given user "user0" has been created
 		And user "user0" has deleted file "/textfile0.txt"
 		And as "user0" the file "/textfile0.txt" should exist in trash
-		And user "user0" has logged in to a web-style session using the API
-		When user "user0" restores the folder with original path "/textfile0.txt" using the API
+		And user "user0" has logged in to a web-style session
+		When user "user0" restores the folder with original path "/textfile0.txt" using the trashbin API
 		Then as "user0" the folder with original path "/textfile0.txt" should not exist in trash
 		And user "user0" should see the following elements
 			| /FOLDER/           |
@@ -113,8 +113,8 @@ Feature: trashbin-new-endpoint
 		And user "user0" has created a folder "/new-folder"
 		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
 		And user "user0" has deleted file "/new-folder/new-file.txt"
-		And user "user0" has logged in to a web-style session using the API
-		When user "user0" restores the file with original path "/new-folder/new-file.txt" using the API
+		And user "user0" has logged in to a web-style session
+		When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
 		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
 		And as "user0" the file "/new-folder/new-file.txt" should exist
 
@@ -124,8 +124,8 @@ Feature: trashbin-new-endpoint
 		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
 		And user "user0" has deleted file "/new-folder/new-file.txt"
 		And user "user0" has deleted folder "/new-folder"
-		And user "user0" has logged in to a web-style session using the API
-		When user "user0" restores the file with original path "/new-folder/new-file.txt" using the API
+		And user "user0" has logged in to a web-style session
+		When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
 		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
 		And as "user0" the file "/new-file.txt" should exist
 
@@ -135,9 +135,9 @@ Feature: trashbin-new-endpoint
 		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
 		And user "user0" has deleted file "/new-folder/new-file.txt"
 		And user "user0" has deleted folder "/new-folder"
-		And user "user0" has logged in to a web-style session using the API
-		When user "user0" restores the folder with original path "/new-folder" using the API
-		And user "user0" restores the file with original path "/new-folder/new-file.txt" using the API
+		And user "user0" has logged in to a web-style session
+		When user "user0" restores the folder with original path "/new-folder" using the trashbin API
+		And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
 		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
 		And as "user0" the file "/new-folder/new-file.txt" should exist
 
@@ -147,9 +147,9 @@ Feature: trashbin-new-endpoint
 		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
 		And user "user0" has deleted file "/new-folder/new-file.txt"
 		And user "user0" has deleted folder "/new-folder"
-		And user "user0" has logged in to a web-style session using the API
-		When user "user0" creates a folder "/new-folder" using the API
-		And user "user0" restores the file with original path "/new-folder/new-file.txt" using the API
+		And user "user0" has logged in to a web-style session
+		When user "user0" creates a folder "/new-folder" using the WebDAV API
+		And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
 		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
 		And as "user0" the file "/new-folder/new-file.txt" should exist
 
@@ -160,9 +160,9 @@ Feature: trashbin-new-endpoint
 		And user "user0" has created a folder "/folderB"
 		And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
 		And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
-		When user "user0" deletes file "/folderA/textfile0.txt" using the API
-		And user "user0" deletes file "/folderB/textfile0.txt" using the API
-		And user "user0" deletes file "/textfile0.txt" using the API
+		When user "user0" deletes file "/folderA/textfile0.txt" using the WebDAV API
+		And user "user0" deletes file "/folderB/textfile0.txt" using the WebDAV API
+		And user "user0" deletes file "/textfile0.txt" using the WebDAV API
 		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
 		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
 		And as "user0" the folder with original path "/textfile0.txt" should exist in trash
@@ -173,9 +173,9 @@ Feature: trashbin-new-endpoint
 		And user "user0" has created a folder "/folderB"
 		And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
 		And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
-		When user "user0" waits and deletes file "/folderA/textfile0.txt" using the API
-		And user "user0" waits and deletes file "/folderB/textfile0.txt" using the API
-		And user "user0" waits and deletes file "/textfile0.txt" using the API
+		When user "user0" waits and deletes file "/folderA/textfile0.txt" using the WebDAV API
+		And user "user0" waits and deletes file "/folderB/textfile0.txt" using the WebDAV API
+		And user "user0" waits and deletes file "/textfile0.txt" using the WebDAV API
 		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
 		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
 		And as "user0" the folder with original path "/textfile0.txt" should exist in trash
@@ -188,7 +188,7 @@ Feature: trashbin-new-endpoint
 		And user "user0" has been created
 		And user "user0" has created a folder "/local_storage/tmp"
 		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
-		When user "user0" deletes folder "/local_storage/tmp" using the API
+		When user "user0" deletes folder "/local_storage/tmp" using the WebDAV API
 		Then as "user0" the folder with original path "/local_storage/tmp" should exist in trash
 
 	@local_storage
@@ -201,8 +201,8 @@ Feature: trashbin-new-endpoint
 		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
 		And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
 		And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
-		And user "user0" has logged in to a web-style session using the API
-		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the API
+		And user "user0" has logged in to a web-style session
+		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
 		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
 		And user "user0" should see the following elements
 			| /local_storage/                  |

--- a/tests/acceptance/features/apiTrashbin/trashbin-old-endpoint.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbin-old-endpoint.feature
@@ -1,26 +1,26 @@
 @api
 Feature: trashbin-new-endpoint
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And using old DAV path
 		And as user "admin"
 
 	Scenario: deleting a file moves it to trashbin
 		Given user "user0" has been created
-		When user "user0" deletes file "/textfile0.txt" using the API
+		When user "user0" deletes file "/textfile0.txt" using the WebDAV API
 		Then as "user0" the file "/textfile0.txt" should exist in trash
 
 	Scenario: deleting a folder moves it to trashbin
 		Given user "user0" has been created
 		And user "user0" has created a folder "/tmp"
-		When user "user0" deletes folder "/tmp" using the API
+		When user "user0" deletes folder "/tmp" using the WebDAV API
 		Then as "user0" the folder "/tmp" should exist in trash
 
 	Scenario: deleting a file in a folder moves it to the trashbin root
 		Given user "user0" has been created
 		And user "user0" has created a folder "/new-folder"
 		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
-		When user "user0" deletes file "/new-folder/new-file.txt" using the API
+		When user "user0" deletes file "/new-folder/new-file.txt" using the WebDAV API
 		Then as "user0" the file with original path "/new-folder/new-file.txt" should exist in trash
 		And as "user0" the file "/new-file.txt" should exist in trash
 		But as "user0" the file "/new-folder/new-file.txt" should not exist
@@ -31,7 +31,7 @@ Feature: trashbin-new-endpoint
 		And user "user0" has created a folder "/shared"
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
 		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user0" deletes file "/shared/shared_file.txt" using the API
+		When user "user0" deletes file "/shared/shared_file.txt" using the WebDAV API
 		Then as "user0" the file with original path "/shared/shared_file.txt" should exist in trash
 		And as "user0" the file "/shared_file.txt" should exist in trash
 		But as "user0" the file "/shared/shared_file.txt" should not exist
@@ -42,7 +42,7 @@ Feature: trashbin-new-endpoint
 		And user "user0" has created a folder "/shared"
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
 		And user "user0" has shared folder "/shared" with user "user1"
-		When user "user0" deletes folder "/shared" using the API
+		When user "user0" deletes folder "/shared" using the WebDAV API
 		Then as "user0" the folder with original path "/shared" should exist in trash
 
 	Scenario: deleting a received folder doesn't move it to trashbin
@@ -52,7 +52,7 @@ Feature: trashbin-new-endpoint
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
 		And user "user0" has shared folder "/shared" with user "user1"
 		And user "user1" has moved folder "/shared" to "/renamed_shared"
-		When user "user1" deletes folder "/renamed_shared" using the API
+		When user "user1" deletes folder "/renamed_shared" using the WebDAV API
 		Then as "user1" the folder with original path "/renamed_shared" should not exist in trash
 
 	Scenario: deleting a file in a received folder moves it to trashbin
@@ -62,7 +62,7 @@ Feature: trashbin-new-endpoint
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
 		And user "user0" has shared folder "/shared" with user "user1"
 		And user "user1" has moved file "/shared" to "/renamed_shared"
-		When user "user1" deletes file "/renamed_shared/shared_file.txt" using the API
+		When user "user1" deletes file "/renamed_shared/shared_file.txt" using the WebDAV API
 		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should exist in trash
 
 	Scenario: deleting a file in a received folder when restored it comes back to the original path
@@ -73,8 +73,8 @@ Feature: trashbin-new-endpoint
 		And user "user0" has shared folder "/shared" with user "user1"
 		And user "user1" has moved file "/shared" to "/renamed_shared"
 		And user "user1" has deleted file "/renamed_shared/shared_file.txt"
-		And user "user1" has logged in to a web-style session using the API
-		When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the API
+		And user "user1" has logged in to a web-style session
+		When user "user1" restores the file with original path "/renamed_shared/shared_file.txt" using the trashbin API
 		Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
 		And user "user1" should see the following elements
 			| /renamed_shared/                |
@@ -87,7 +87,7 @@ Feature: trashbin-new-endpoint
 		And user "user0" has deleted file "/textfile1.txt"
 		And as "user0" the file "/textfile0.txt" should exist in trash
 		And as "user0" the file "/textfile1.txt" should exist in trash
-		When user "user0" empties the trashbin using the API
+		When user "user0" empties the trashbin using the trashbin API
 		Then as "user0" the file with original path "/textfile0.txt" should not exist in trash
 		And as "user0" the file with original path "/textfile1.txt" should not exist in trash
 
@@ -95,8 +95,8 @@ Feature: trashbin-new-endpoint
 		Given user "user0" has been created
 		And user "user0" has deleted file "/textfile0.txt"
 		And as "user0" the file "/textfile0.txt" should exist in trash
-		And user "user0" has logged in to a web-style session using the API
-		When user "user0" restores the folder with original path "/textfile0.txt" using the API
+		And user "user0" has logged in to a web-style session
+		When user "user0" restores the folder with original path "/textfile0.txt" using the trashbin API
 		Then as "user0" the folder with original path "/textfile0.txt" should not exist in trash
 		And user "user0" should see the following elements
 			| /FOLDER/           |
@@ -113,8 +113,8 @@ Feature: trashbin-new-endpoint
 		And user "user0" has created a folder "/new-folder"
 		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
 		And user "user0" has deleted file "/new-folder/new-file.txt"
-		And user "user0" has logged in to a web-style session using the API
-		When user "user0" restores the file with original path "/new-folder/new-file.txt" using the API
+		And user "user0" has logged in to a web-style session
+		When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
 		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
 		And as "user0" the file "/new-folder/new-file.txt" should exist
 
@@ -124,8 +124,8 @@ Feature: trashbin-new-endpoint
 		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
 		And user "user0" has deleted file "/new-folder/new-file.txt"
 		And user "user0" has deleted folder "/new-folder"
-		And user "user0" has logged in to a web-style session using the API
-		When user "user0" restores the file with original path "/new-folder/new-file.txt" using the API
+		And user "user0" has logged in to a web-style session
+		When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
 		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
 		And as "user0" the file "/new-file.txt" should exist
 
@@ -135,9 +135,9 @@ Feature: trashbin-new-endpoint
 		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
 		And user "user0" has deleted file "/new-folder/new-file.txt"
 		And user "user0" has deleted folder "/new-folder"
-		And user "user0" has logged in to a web-style session using the API
-		When user "user0" restores the folder with original path "/new-folder" using the API
-		And user "user0" restores the file with original path "/new-folder/new-file.txt" using the API
+		And user "user0" has logged in to a web-style session
+		When user "user0" restores the folder with original path "/new-folder" using the trashbin API
+		And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
 		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
 		And as "user0" the file "/new-folder/new-file.txt" should exist
 
@@ -147,9 +147,9 @@ Feature: trashbin-new-endpoint
 		And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
 		And user "user0" has deleted file "/new-folder/new-file.txt"
 		And user "user0" has deleted folder "/new-folder"
-		And user "user0" has logged in to a web-style session using the API
-		When user "user0" creates a folder "/new-folder" using the API
-		And user "user0" restores the file with original path "/new-folder/new-file.txt" using the API
+		And user "user0" has logged in to a web-style session
+		When user "user0" creates a folder "/new-folder" using the WebDAV API
+		And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
 		Then as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
 		And as "user0" the file "/new-folder/new-file.txt" should exist
 
@@ -160,9 +160,9 @@ Feature: trashbin-new-endpoint
 		And user "user0" has created a folder "/folderB"
 		And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
 		And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
-		When user "user0" deletes file "/folderA/textfile0.txt" using the API
-		And user "user0" deletes file "/folderB/textfile0.txt" using the API
-		And user "user0" deletes file "/textfile0.txt" using the API
+		When user "user0" deletes file "/folderA/textfile0.txt" using the WebDAV API
+		And user "user0" deletes file "/folderB/textfile0.txt" using the WebDAV API
+		And user "user0" deletes file "/textfile0.txt" using the WebDAV API
 		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
 		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
 		And as "user0" the folder with original path "/textfile0.txt" should exist in trash
@@ -173,9 +173,9 @@ Feature: trashbin-new-endpoint
 		And user "user0" has created a folder "/folderB"
 		And user "user0" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
 		And user "user0" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
-		When user "user0" waits and deletes file "/folderA/textfile0.txt" using the API
-		And user "user0" waits and deletes file "/folderB/textfile0.txt" using the API
-		And user "user0" waits and deletes file "/textfile0.txt" using the API
+		When user "user0" waits and deletes file "/folderA/textfile0.txt" using the WebDAV API
+		And user "user0" waits and deletes file "/folderB/textfile0.txt" using the WebDAV API
+		And user "user0" waits and deletes file "/textfile0.txt" using the WebDAV API
 		Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
 		And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
 		And as "user0" the folder with original path "/textfile0.txt" should exist in trash
@@ -188,7 +188,7 @@ Feature: trashbin-new-endpoint
 		And user "user0" has been created
 		And user "user0" has created a folder "/local_storage/tmp"
 		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
-		When user "user0" deletes folder "/local_storage/tmp" using the API
+		When user "user0" deletes folder "/local_storage/tmp" using the WebDAV API
 		Then as "user0" the folder with original path "/local_storage/tmp" should exist in trash
 
 	@local_storage
@@ -201,8 +201,8 @@ Feature: trashbin-new-endpoint
 		And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
 		And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
 		And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
-		And user "user0" has logged in to a web-style session using the API
-		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the API
+		And user "user0" has logged in to a web-style session
+		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
 		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
 		And user "user0" should see the following elements
 			| /local_storage/                  |
@@ -220,7 +220,7 @@ Feature: trashbin-new-endpoint
 		And user "user0" has uploaded chunk file "1" of "1" with "AA" to "/local_storage/tmp/textfile0.txt"
 		And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
 		And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
-		And user "user0" has logged in to a web-style session using the API
-		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the API
+		And user "user0" has logged in to a web-style session
+		When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
 		Then as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
 		And the downloaded content when downloading file "/local_storage/tmp/textfile0.txt" for user "user0" with range "bytes=0-1" should be "AA"

--- a/tests/acceptance/features/apiWebdav/webdav-related-new-endpoint.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related-new-endpoint.feature
@@ -1,14 +1,14 @@
 @api
 Feature: webdav-related-new-endpoint
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And using new DAV path
 		And user "user0" has been created
 
 	## Specific Scenario Outlines for new endpoint	
 
 	Scenario: Upload chunked file asc with new chunking
-		When user "user0" uploads the following chunks to "/myChunkedFile.txt" with new chunking and using the API
+		When user "user0" uploads the following chunks to "/myChunkedFile.txt" with new chunking and using the WebDAV API
 			| 1 | AAAAA |
 			| 2 | BBBBB |
 			| 3 | CCCCC |
@@ -16,7 +16,7 @@ Feature: webdav-related-new-endpoint
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file desc with new chunking
-		When user "user0" uploads the following chunks to "/myChunkedFile.txt" with new chunking and using the API
+		When user "user0" uploads the following chunks to "/myChunkedFile.txt" with new chunking and using the WebDAV API
 			| 3 | CCCCC |
 			| 2 | BBBBB |
 			| 1 | AAAAA |
@@ -24,7 +24,7 @@ Feature: webdav-related-new-endpoint
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file random with new chunking
-		When user "user0" uploads the following chunks to "/myChunkedFile.txt" with new chunking and using the API
+		When user "user0" uploads the following chunks to "/myChunkedFile.txt" with new chunking and using the WebDAV API
 			| 2 | BBBBB |
 			| 3 | CCCCC |
 			| 1 | AAAAA |
@@ -34,7 +34,7 @@ Feature: webdav-related-new-endpoint
 	Scenario: Checking file id after a move overwrite using new chunking endpoint
 		Given user "user0" has copied file "/textfile0.txt" to "/existingFile.txt"
 		And user "user0" has stored id of file "/existingFile.txt"
-		When user "user0" uploads the following chunks to "/existingFile.txt" with new chunking and using the API
+		When user "user0" uploads the following chunks to "/existingFile.txt" with new chunking and using the WebDAV API
 			| 1 | AAAAA |
 			| 2 | BBBBB |
 			| 3 | CCCCC |
@@ -50,7 +50,7 @@ Feature: webdav-related-new-endpoint
 		And user "user1" has created a folder "/folderA/ONE"
 		And user "user1" has stored id of file "/folderA/ONE"
 		And user "user1" has created a folder "/folderA/ONE/TWO"
-		When user "user1" moves folder "/folderA/ONE" to "/folderB/ONE" using the API
+		When user "user1" moves folder "/folderA/ONE" to "/folderB/ONE" using the WebDAV API
 		Then as "user1" the folder "/folderA" should exist
 		And as "user1" the folder "/folderA/ONE" should not exist
 		# yes, a weird bug used to make this one fail
@@ -63,13 +63,13 @@ Feature: webdav-related-new-endpoint
 
 	Scenario: New chunked upload MKDIR using old DAV path should fail
 		Given using old DAV path
-		When user "user0" creates a new chunking upload with id "chunking-42" using the API
+		When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
 		Then the HTTP status code should be "409"
 
 	Scenario: New chunked upload PUT using old DAV path should fail
 		Given user "user0" has created a new chunking upload with id "chunking-42"
 		When using old DAV path
-		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the API
+		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
 		Then the HTTP status code should be "404"
 
 	Scenario: New chunked upload MOVE using old DAV path should fail
@@ -78,11 +78,11 @@ Feature: webdav-related-new-endpoint
 		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
 		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
 		When using old DAV path
-		And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" using the API
+		And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" using the WebDAV API
 		Then the HTTP status code should be "404"
 
 	Scenario: Upload to new dav path using old way should fail
-		When user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt" using the API
+		When user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt" using the WebDAV API
 		Then the HTTP status code should be "503"
 
 	Scenario: Upload file via new chunking endpoint with wrong size header
@@ -90,7 +90,7 @@ Feature: webdav-related-new-endpoint
 		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
 		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
 		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
-		When user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with size 5 using the API
+		When user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with size 5 using the WebDAV API
 		Then the HTTP status code should be "400"
 
 	Scenario: Upload file via new chunking endpoint with correct size header
@@ -98,17 +98,17 @@ Feature: webdav-related-new-endpoint
 		And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
 		And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
 		And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
-		When user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with size 15 using the API
+		When user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with size 15 using the WebDAV API
 		Then the HTTP status code should be "201"
 		And as "user0" the file "/myChunkedFile.txt" should exist
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario Outline: Upload files with difficult names using new chunking
-		When user "user0" creates a new chunking upload with id "chunking-42" using the API
-		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the API
-		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
-		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the API
-		And user "user0" moves new chunk file with id "chunking-42" to "/<file-name>" using the API
+		When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
+		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+		And user "user0" moves new chunk file with id "chunking-42" to "/<file-name>" using the WebDAV API
 		Then as "user0" the file "/<file-name>" should exist
 		And the content of file "/<file-name>" for user "user0" should be "AAAAABBBBBCCCCC"
 		Examples:
@@ -119,10 +119,10 @@ Feature: webdav-related-new-endpoint
 	#this test should be integrated into the previous Scenario after fixing the issue
 	@skip @issue-29599
 	Scenario: Upload a file called "0" using new chunking
-		When user "user0" creates a new chunking upload with id "chunking-42" using the API
-		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the API
-		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the API
-		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the API
-		And user "user0" moves new chunk file with id "chunking-42" to "/0" using the API
+		When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+		And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
+		And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+		And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+		And user "user0" moves new chunk file with id "chunking-42" to "/0" using the WebDAV API
 		And as "user0" the file "/0" should exist
 		And the content of file "/0" for user "user0" should be "AAAAABBBBBCCCCC"

--- a/tests/acceptance/features/apiWebdav/webdav-related-old-endpoint.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related-old-endpoint.feature
@@ -1,7 +1,7 @@
 @api
 Feature: webdav-related-old-endpoint
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 		And using old DAV path
 		And user "user0" has been created
 
@@ -15,7 +15,7 @@ Feature: webdav-related-old-endpoint
 	### Scenarios specific to old endpoint
 
 	Scenario: Upload chunked file asc
-		When user "user0" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the API
+		When user "user0" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the WebDAV API
 			| 1 | AAAAA |
 			| 2 | BBBBB |
 			| 3 | CCCCC |
@@ -23,7 +23,7 @@ Feature: webdav-related-old-endpoint
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file desc
-		When user "user0" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the API
+		When user "user0" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the WebDAV API
 			| 3 | CCCCC |
 			| 2 | BBBBB |
 			| 1 | AAAAA |
@@ -31,7 +31,7 @@ Feature: webdav-related-old-endpoint
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario: Upload chunked file random
-		When user "user0" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the API
+		When user "user0" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the WebDAV API
 			| 2 | BBBBB |
 			| 3 | CCCCC |
 			| 1 | AAAAA |
@@ -39,7 +39,7 @@ Feature: webdav-related-old-endpoint
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
 
 	Scenario Outline: Chunked upload files with difficult name
-		When user "user0" uploads the following "3" chunks to "/<file-name>" with old chunking and using the API
+		When user "user0" uploads the following "3" chunks to "/<file-name>" with old chunking and using the WebDAV API
 			| 1 | AAAAA |
 			| 2 | BBBBB |
 			| 3 | CCCCC |

--- a/tests/acceptance/features/apiWebdav/webdav-related.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related.feature
@@ -1,11 +1,11 @@
 @api
 Feature: webdav-related
 	Background:
-		Given using API version "1"
+		Given using OCS API version "1"
 
 	Scenario Outline: Unauthenticated call
 		Given using <dav_version> DAV path
-		When an unauthenticated client connects to the dav endpoint using the API
+		When an unauthenticated client connects to the dav endpoint using the WebDAV API
 		Then the HTTP status code should be "401"
 		And there should be no duplicate headers
 		And the following headers should be set
@@ -18,7 +18,7 @@ Feature: webdav-related
 	Scenario Outline: Moving a file
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" moves file "/welcome.txt" to "/FOLDER/welcome.txt" using the API
+		When user "user0" moves file "/welcome.txt" to "/FOLDER/welcome.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 		And the downloaded content when downloading file "/FOLDER/welcome.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 		Examples:
@@ -29,7 +29,7 @@ Feature: webdav-related
 	Scenario Outline: Moving and overwriting a file
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" moves file "/welcome.txt" to "/textfile0.txt" using the API
+		When user "user0" moves file "/welcome.txt" to "/textfile0.txt" using the WebDAV API
 		Then the HTTP status code should be "204"
 		And the downloaded content when downloading file "/textfile0.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 		Examples:
@@ -47,9 +47,9 @@ Feature: webdav-related
 			| shareType   | 0         |
 			| permissions | 1         |
 			| shareWith   | user0     |
-		When user "user0" moves file "/textfile0.txt" to "/testshare/textfile0.txt" using the API
+		When user "user0" moves file "/textfile0.txt" to "/testshare/textfile0.txt" using the WebDAV API
 		Then the HTTP status code should be "403"
-		When user "user0" downloads the file "/testshare/textfile0.txt" using the API
+		When user "user0" downloads the file "/testshare/textfile0.txt" using the WebDAV API
  		Then the HTTP status code should be "404"
  		Examples:
 			| dav_version   |
@@ -67,7 +67,7 @@ Feature: webdav-related
 			| permissions | 1         |
 			| shareWith   | user0     |
 		And user "user1" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"
-		When user "user0" moves file "/textfile0.txt" to "/testshare/overwritethis.txt" using the API
+		When user "user0" moves file "/textfile0.txt" to "/testshare/overwritethis.txt" using the WebDAV API
 		Then the HTTP status code should be "403"
 		And the downloaded content when downloading file "/testshare/overwritethis.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 		Examples:
@@ -78,7 +78,7 @@ Feature: webdav-related
 	Scenario Outline: move file into a not-existing folder
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" moves file "/welcome.txt" to "/not-existing/welcome.txt" using the API
+		When user "user0" moves file "/welcome.txt" to "/not-existing/welcome.txt" using the WebDAV API
 		Then the HTTP status code should be "409"
 		Examples:
 			| dav_version   |
@@ -88,7 +88,7 @@ Feature: webdav-related
 	Scenario Outline: rename a file into an invalid filename
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" moves file "/welcome.txt" to "/a\\a" using the API
+		When user "user0" moves file "/welcome.txt" to "/a\\a" using the WebDAV API
 		Then the HTTP status code should be "400"
 		Examples:
 			| dav_version   |
@@ -98,7 +98,7 @@ Feature: webdav-related
 	Scenario Outline: rename a file into a banned filename
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" moves file "/welcome.txt" to "/.htaccess" using the API
+		When user "user0" moves file "/welcome.txt" to "/.htaccess" using the WebDAV API
 		Then the HTTP status code should be "403"
 		Examples:
 			| dav_version   |
@@ -108,7 +108,7 @@ Feature: webdav-related
 	Scenario Outline: Copying a file
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" copies file "/welcome.txt" to "/FOLDER/welcome.txt" using the API
+		When user "user0" copies file "/welcome.txt" to "/FOLDER/welcome.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 		And the downloaded content when downloading file "/FOLDER/welcome.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 		Examples:
@@ -119,7 +119,7 @@ Feature: webdav-related
 	Scenario Outline: Copying and overwriting a file
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" copies file "/welcome.txt" to "/textfile1.txt" using the API
+		When user "user0" copies file "/welcome.txt" to "/textfile1.txt" using the WebDAV API
 		Then the HTTP status code should be "204"
 		And the downloaded content when downloading file "/textfile1.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 		Examples:
@@ -137,9 +137,9 @@ Feature: webdav-related
 			| shareType   | 0         |
 			| permissions | 1         |
 			| shareWith   | user0     |
-		When user "user0" copies file "/textfile0.txt" to "/testshare/textfile0.txt" using the API
+		When user "user0" copies file "/textfile0.txt" to "/testshare/textfile0.txt" using the WebDAV API
 		Then the HTTP status code should be "403"
-		And user "user0" downloads the file "/testshare/textfile0.txt" using the API
+		And user "user0" downloads the file "/testshare/textfile0.txt" using the WebDAV API
 		And the HTTP status code should be "404"
 		Examples:
 			| dav_version   |
@@ -157,7 +157,7 @@ Feature: webdav-related
 			| permissions | 1         |
 			| shareWith   | user0     |
 		And user "user1" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"
-		When user "user0" copies file "/textfile0.txt" to "/testshare/overwritethis.txt" using the API
+		When user "user0" copies file "/textfile0.txt" to "/testshare/overwritethis.txt" using the WebDAV API
 		Then the HTTP status code should be "403"
 		And the downloaded content when downloading file "/testshare/overwritethis.txt" for user "user0" with range "bytes=0-6" should be "Welcome"
 		Examples:
@@ -168,7 +168,7 @@ Feature: webdav-related
 	Scenario Outline: download a file
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" downloads the file "/textfile0.txt" using the API
+		When user "user0" downloads the file "/textfile0.txt" using the WebDAV API
 		Then the downloaded content should be "ownCloud test text file" plus end-of-line
 		Examples:
 			| dav_version   |
@@ -178,7 +178,7 @@ Feature: webdav-related
 	Scenario Outline: download a file with range
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" downloads file "/welcome.txt" with range "bytes=51-77" using the API
+		When user "user0" downloads file "/welcome.txt" with range "bytes=51-77" using the WebDAV API
 		Then the downloaded content should be "example file for developers"
 		Examples:
 			| dav_version   |
@@ -188,7 +188,7 @@ Feature: webdav-related
 	Scenario Outline: upload a file and check download content
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" uploads file with content "uploaded content" to "<file_name>" using the API
+		When user "user0" uploads file with content "uploaded content" to "<file_name>" using the WebDAV API
 		Then the content of file "<file_name>" for user "user0" should be "uploaded content"
 		Examples:
 			| dav_version | file_name         |
@@ -208,7 +208,7 @@ Feature: webdav-related
 	Scenario Outline: create a folder
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" creates a folder "<folder_name>" using the API
+		When user "user0" creates a folder "<folder_name>" using the WebDAV API
 		Then as "user0" the folder "<folder_name>" should exist
 		Examples:
 			| dav_version | folder_name     |
@@ -229,7 +229,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user0" has created a folder "<folder_name>"
-		When user "user0" uploads file with content "uploaded content" to "<folder_name>/<file_name>" using the API
+		When user "user0" uploads file with content "uploaded content" to "<folder_name>/<file_name>" using the WebDAV API
 		Then the content of file "<folder_name>/<file_name>" for user "user0" should be "uploaded content"
 		Examples:
 			| dav_version | folder_name                      | file_name                     |
@@ -250,7 +250,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user0" has uploaded file with content "uploaded content" to "<file_name>"
-		When user "user0" gets the properties of file "<file_name>" using the API
+		When user "user0" gets the properties of file "<file_name>" using the WebDAV API
 		Then the properties response should contain an etag
 		Examples:
 			| dav_version | file_name         |
@@ -272,7 +272,7 @@ Feature: webdav-related
 		And user "user0" has been created
 		And user "user0" has created a folder "<folder_name>"
 		And user "user0" has uploaded file with content "uploaded content" to "<folder_name>/<file_name>"
-		When user "user0" gets the properties of file "<folder_name>/<file_name>" using the API
+		When user "user0" gets the properties of file "<folder_name>/<file_name>" using the WebDAV API
 		Then the properties response should contain an etag
 		Examples:
 			| dav_version | folder_name                      | file_name                     |
@@ -292,8 +292,8 @@ Feature: webdav-related
 	Scenario Outline: Retrieving folder quota when no quota is set
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When the administrator gives unlimited quota to user "user0" using the API
-		And user "user0" gets the following properties of folder "/" using the API
+		When the administrator gives unlimited quota to user "user0" using the provisioning API
+		And user "user0" gets the following properties of folder "/" using the WebDAV API
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "-3"
 		Examples:
@@ -304,8 +304,8 @@ Feature: webdav-related
 	Scenario Outline: Retrieving folder quota when quota is set
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When the administrator sets the quota of user "user0" to "10 MB" using the API
-		And user "user0" gets the following properties of folder "/" using the API
+		When the administrator sets the quota of user "user0" to "10 MB" using the provisioning API
+		And user "user0" gets the following properties of folder "/" using the WebDAV API
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
 		Examples:
@@ -325,7 +325,7 @@ Feature: webdav-related
 			| shareType   | 0         |
 			| permissions | 31        |
 			| shareWith   | user0     |
-		When user "user0" gets the following properties of folder "/testquota" using the API
+		When user "user0" gets the following properties of folder "/testquota" using the WebDAV API
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "10485358"
 		Examples:
@@ -338,7 +338,7 @@ Feature: webdav-related
 		And user "user0" has been created
 		And the quota of user "user0" has been set to "1 KB"
 		And user "user0" has added file "/prueba.txt" of 93 bytes
-		When user "user0" gets the following properties of folder "/" using the API
+		When user "user0" gets the following properties of folder "/" using the WebDAV API
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "529"
 		Examples:
@@ -353,7 +353,7 @@ Feature: webdav-related
 		And the quota of user "user1" has been set to "1 KB"
 		And user "user0" has added file "/user0.txt" of 93 bytes
 		And user "user0" has shared file "user0.txt" with user "user1"
-		When user "user1" gets the following properties of folder "/" using the API
+		When user "user1" gets the following properties of folder "/" using the WebDAV API
 		  |{DAV:}quota-available-bytes|
 		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "622"
 		Examples:
@@ -364,10 +364,10 @@ Feature: webdav-related
 	Scenario Outline: download a public shared file with range
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path      | welcome.txt |
 			| shareType | 3           |
-		And the public downloads the last public shared file with range "bytes=51-77" using the API
+		And the public downloads the last public shared file with range "bytes=51-77" using the old WebDAV API
 		Then the downloaded content should be "example file for developers"
 		Examples:
 			| dav_version   |
@@ -377,10 +377,10 @@ Feature: webdav-related
 	Scenario Outline: download a public shared file inside a folder with range
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" creates a share using the API with settings
+		When user "user0" creates a share using the sharing API with settings
 			| path      | PARENT |
 			| shareType | 3      |
-		And the public downloads file "/parent.txt" from inside the last public shared folder with range "bytes=1-7" using the API
+		And the public downloads file "/parent.txt" from inside the last public shared folder with range "bytes=1-7" using the old WebDAV API
 		Then the downloaded content should be "wnCloud"
 		Examples:
 			| dav_version   |
@@ -390,7 +390,7 @@ Feature: webdav-related
 	Scenario Outline: Downloading a file should serve security headers
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" downloads the file "/welcome.txt" using the API
+		When user "user0" downloads the file "/welcome.txt" using the WebDAV API
 		Then the following headers should be set
 			| Content-Disposition               | attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt" |
 			| Content-Security-Policy           | default-src 'none';                                              |
@@ -410,7 +410,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user0" has created a folder "/test"
-		When user "user0" gets the following properties of folder "/test" using the API
+		When user "user0" gets the following properties of folder "/test" using the WebDAV API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain an empty property "{http://owncloud.org/ns}share-types"
 		Examples:
@@ -428,7 +428,7 @@ Feature: webdav-related
 			| shareType   | 0     |
 			| permissions | 31    |
 			| shareWith   | user1 |
-		When user "user0" gets the following properties of folder "/test" using the API
+		When user "user0" gets the following properties of folder "/test" using the WebDAV API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
 			| 0 |
@@ -447,7 +447,7 @@ Feature: webdav-related
 			| shareType   | 1      |
 			| permissions | 31     |
 			| shareWith   | group1 |
-		When user "user0" gets the following properties of folder "/test" using the API
+		When user "user0" gets the following properties of folder "/test" using the WebDAV API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
 			| 1 |
@@ -464,7 +464,7 @@ Feature: webdav-related
 			| path        | test |
 			| shareType   | 3    |
 			| permissions | 31   |
-		When user "user0" gets the following properties of folder "/test" using the API
+		When user "user0" gets the following properties of folder "/test" using the WebDAV API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
 			| 3 |
@@ -493,7 +493,7 @@ Feature: webdav-related
 			| path        | test  |
 			| shareType   | 3     |
 			| permissions | 31    |
-		When user "user0" gets the following properties of folder "/test" using the API
+		When user "user0" gets the following properties of folder "/test" using the WebDAV API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
 			| 0 |
@@ -508,7 +508,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "userToBeDisabled" has been created
 		And user "userToBeDisabled" has been disabled
-		When user "userToBeDisabled" downloads the file "/welcome.txt" using the API
+		When user "userToBeDisabled" downloads the file "/welcome.txt" using the WebDAV API
 		Then the HTTP status code should be "401"
 		Examples:
 			| dav_version   |
@@ -519,7 +519,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user0" has created a folder "/test_folder"
-		When user "user0" gets the following properties of folder "/test_folder" using the API
+		When user "user0" gets the following properties of folder "/test_folder" using the WebDAV API
 		  |{DAV:}resourcetype|
 		Then the single response should contain a property "{DAV:}resourcetype" with value "{DAV:}collection"
 		Examples:
@@ -531,7 +531,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user0" has created a folder "/test_folder:5"
-		When user "user0" gets the following properties of folder "/test_folder:5" using the API
+		When user "user0" gets the following properties of folder "/test_folder:5" using the WebDAV API
 		  |{DAV:}resourcetype|
 		Then the single response should contain a property "{DAV:}resourcetype" with value "{DAV:}collection"
 		Examples:
@@ -545,7 +545,7 @@ Feature: webdav-related
 		And user "user0" has moved file "/welcome.txt" to "/FOLDER/welcome.txt"
 		And user "user0" has created a folder "/FOLDER/SUBFOLDER"
 		And user "user0" has copied file "/textfile0.txt" to "/FOLDER/SUBFOLDER/testfile0.txt"
-		When user "user0" deletes everything from folder "/FOLDER/" using the API
+		When user "user0" deletes everything from folder "/FOLDER/" using the WebDAV API
 		Then user "user0" should see the following elements
 			| /FOLDER/           |
 			| /PARENT/           |
@@ -568,7 +568,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user0" has stored id of file "/textfile0.txt"
-		When user "user0" moves file "/textfile0.txt" to "/FOLDER/textfile0.txt" using the API
+		When user "user0" moves file "/textfile0.txt" to "/FOLDER/textfile0.txt" using the WebDAV API
 		Then user "user0" file "/FOLDER/textfile0.txt" should have the previously stored id
 		And user "user0" should not see the following elements
 			| /textfile0.txt |
@@ -581,7 +581,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user0" has created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/%5C" using the API
+		When user "user0" moves folder "/testshare" to "/%5C" using the WebDAV API
 		Then the HTTP status code should be "400"
 		And user "user0" should see the following elements
 			| /testshare/ |
@@ -594,7 +594,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user0" has created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/%5Ctestshare" using the API
+		When user "user0" moves folder "/testshare" to "/%5Ctestshare" using the WebDAV API
 		Then the HTTP status code should be "400"
 		And user "user0" should see the following elements
 			| /testshare/ |
@@ -607,7 +607,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user0" has created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/hola%5Chola" using the API
+		When user "user0" moves folder "/testshare" to "/hola%5Chola" using the WebDAV API
 		Then the HTTP status code should be "400"
 		And user "user0" should see the following elements
 			| /testshare/ |
@@ -620,7 +620,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user0" has created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/.htaccess" using the API
+		When user "user0" moves folder "/testshare" to "/.htaccess" using the WebDAV API
 		Then the HTTP status code should be "403"
 		And user "user0" should see the following elements
 			| /testshare/ |
@@ -633,7 +633,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user0" has created a folder "/testshare"
-		When user "user0" moves folder "/testshare" to "/not-existing/testshare" using the API
+		When user "user0" moves folder "/testshare" to "/not-existing/testshare" using the WebDAV API
 		Then the HTTP status code should be "409"
 		And user "user0" should see the following elements
 			| /testshare/ |
@@ -645,7 +645,7 @@ Feature: webdav-related
 	Scenario Outline: Downloading a file should serve security headers
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" downloads the file "/welcome.txt" using the API
+		When user "user0" downloads the file "/welcome.txt" using the WebDAV API
 		Then the following headers should be set
 			| Content-Disposition               | attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt" |
 			| Content-Security-Policy           | default-src 'none';                                              |
@@ -664,8 +664,8 @@ Feature: webdav-related
 	Scenario Outline: Doing a GET with a web login should work without CSRF token on the new backend
 		Given user "user0" has been created
 		And using <dav_version> DAV path
-		And user "user0" has logged in to a web-style session using the API
-		When the client sends a "GET" to "/remote.php/dav/files/user0/welcome.txt" without requesttoken using the API
+		And user "user0" has logged in to a web-style session
+		When the client sends a "GET" to "/remote.php/dav/files/user0/welcome.txt" without requesttoken
 		Then the downloaded content should start with "Welcome to your ownCloud account!"
 		And the HTTP status code should be "200"
 		Examples:
@@ -676,8 +676,8 @@ Feature: webdav-related
 	Scenario Outline: Doing a GET with a web login should work with CSRF token on the new backend
 		Given user "user0" has been created
 		And using <dav_version> DAV path
-		And user "user0" has logged in to a web-style session using the API
-		When the client sends a "GET" to "/remote.php/dav/files/user0/welcome.txt" with requesttoken using the API
+		And user "user0" has logged in to a web-style session
+		When the client sends a "GET" to "/remote.php/dav/files/user0/welcome.txt" with requesttoken
 		Then the downloaded content should start with "Welcome to your ownCloud account!"
 		And the HTTP status code should be "200"
 		Examples:
@@ -688,8 +688,8 @@ Feature: webdav-related
 	Scenario Outline: Doing a PROPFIND with a web login should work with CSRF token on the new backend
 		Given user "user0" has been created
 		And using <dav_version> DAV path
-		And user "user0" has logged in to a web-style session using the API
-		When the client sends a "PROPFIND" to "/remote.php/dav/files/user0/welcome.txt" with requesttoken using the API
+		And user "user0" has logged in to a web-style session
+		When the client sends a "PROPFIND" to "/remote.php/dav/files/user0/welcome.txt" with requesttoken
 		Then the HTTP status code should be "207"
 		Examples:
 			| dav_version   |
@@ -763,7 +763,7 @@ Feature: webdav-related
 		And user "user1" has created a folder "/folderA/ONE"
 		And user "user1" has stored id of file "/folderA/ONE"
 		And user "user1" has created a folder "/folderA/ONE/TWO"
-		When user "user1" moves folder "/folderA/ONE" to "/folderB/ONE" using the API
+		When user "user1" moves folder "/folderA/ONE" to "/folderB/ONE" using the WebDAV API
 		Then as "user1" the folder "/folderA" should exist
 		And as "user1" the folder "/folderA/ONE" should not exist
 		# yes, a weird bug used to make this one fail
@@ -780,7 +780,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
-		When user "user0" gets the following properties of file "/somefile.txt" using the API
+		When user "user0" gets the following properties of file "/somefile.txt" using the WebDAV API
 			|{http://owncloud.org/ns}privatelink|
 		Then the single response should contain a property "{http://owncloud.org/ns}privatelink" with value like "%(/(index.php/)?f/[0-9]*)%"
 		Examples:
@@ -791,7 +791,7 @@ Feature: webdav-related
 	Scenario Outline: Copying file to a path with extension .part should not be possible
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" copies file "/welcome.txt" to "/welcome.part" using the API
+		When user "user0" copies file "/welcome.txt" to "/welcome.part" using the WebDAV API
 		Then the HTTP status code should be "400"
 		And user "user0" should see the following elements
 			| /welcome.txt |
@@ -817,7 +817,7 @@ Feature: webdav-related
 	Scenario Outline: Renaming a file to a path with extension .part should not be possible
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" moves file "/welcome.txt" to "/welcome.part" using the API
+		When user "user0" moves file "/welcome.txt" to "/welcome.part" using the WebDAV API
 		Then the HTTP status code should be "400"
 		And user "user0" should see the following elements
 			| /welcome.txt |
@@ -831,7 +831,7 @@ Feature: webdav-related
 	Scenario Outline: Creating a directory which contains .part should not be possible
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" creates a folder "/folder.with.ext.part" using the API
+		When user "user0" creates a folder "/folder.with.ext.part" using the WebDAV API
 		Then the HTTP status code should be "400"
 		And user "user0" should not see the following elements
 			| /folder.with.ext.part |
@@ -844,7 +844,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
-		When user "user0" gets the following properties of file "/somefile.txt" using the API
+		When user "user0" gets the following properties of file "/somefile.txt" using the WebDAV API
 			|{http://owncloud.org/ns}privatelink|
 		Then the single response should contain a property "{http://owncloud.org/ns}privatelink" with value like "%(/(index.php/)?f/[0-9]*)%"
 		Examples:
@@ -855,7 +855,7 @@ Feature: webdav-related
 	Scenario Outline: Copying file to a path with extension .part should not be possible
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" copies file "/welcome.txt" to "/welcome.part" using the API
+		When user "user0" copies file "/welcome.txt" to "/welcome.part" using the WebDAV API
 		Then the HTTP status code should be "400"
 		And user "user0" should see the following elements
 			| /welcome.txt |
@@ -869,7 +869,7 @@ Feature: webdav-related
 	Scenario Outline: Uploading file to path with extension .part should not be possible
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" uploads file "data/textfile.txt" to "/textfile.part" using the API
+		When user "user0" uploads file "data/textfile.txt" to "/textfile.part" using the WebDAV API
 		Then the HTTP status code should be "400"
 		And user "user0" should not see the following elements
 			| /textfile.part |
@@ -881,7 +881,7 @@ Feature: webdav-related
 	Scenario Outline: Renaming a file to a path with extension .part should not be possible
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" moves file "/welcome.txt" to "/welcome.part" using the API
+		When user "user0" moves file "/welcome.txt" to "/welcome.part" using the WebDAV API
 		Then the HTTP status code should be "400"
 		And user "user0" should see the following elements
 			| /welcome.txt |
@@ -895,7 +895,7 @@ Feature: webdav-related
 	Scenario Outline: Creating a directory which contains .part should not be possible
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		When user "user0" creates a folder "/folder.with.ext.part" using the API
+		When user "user0" creates a folder "/folder.with.ext.part" using the WebDAV API
 		Then the HTTP status code should be "400"
 		And user "user0" should not see the following elements
 			| /folder.with.ext.part |

--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -53,7 +53,7 @@ trait AppConfiguration {
 	 *
 	 * @return void
 	 */
-	abstract public function sendingTo($verb, $url);
+	abstract public function theUserSendsToOcsApiEndpoint($verb, $url);
 
 	/**
 	 * @param string $verb
@@ -62,7 +62,7 @@ trait AppConfiguration {
 	 *
 	 * @return void
 	 */
-	abstract public function sendingToWith($verb, $url, $body);
+	abstract public function theUserSendsToOcsApiEndpointWithBody($verb, $url, $body);
 
 	/**
 	 * @param mixed $statusCode
@@ -79,7 +79,7 @@ trait AppConfiguration {
 	abstract public function theHTTPStatusCodeShouldBe($statusCode);
 
 	/**
-	 * @When /^the administrator sets parameter "([^"]*)" of app "([^"]*)" to "([^"]*)" using the API$/
+	 * @When /^the administrator sets parameter "([^"]*)" of app "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $parameter
 	 * @param string $app
@@ -152,12 +152,12 @@ trait AppConfiguration {
 	}
 
 	/**
-	 * @When the user retrieves the capabilities using the API
+	 * @When the user retrieves the capabilities using the capabilities API
 	 *
 	 * @return void
 	 */
 	public function getCapabilitiesCheckResponse() {
-		$this->sendingTo('GET', '/cloud/capabilities');
+		$this->theUserSendsToOcsApiEndpoint('GET', '/cloud/capabilities');
 		PHPUnit_Framework_Assert::assertEquals(
 			200, $this->response->getStatusCode()
 		);
@@ -295,7 +295,7 @@ trait AppConfiguration {
 			$app,
 			$parameter,
 			$value,
-			$this->apiVersion
+			$this->ocsApiVersion
 		);
 	}
 
@@ -310,7 +310,7 @@ trait AppConfiguration {
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
 			$appParameterValues,
-			$this->apiVersion
+			$this->ocsApiVersion
 		);
 	}
 
@@ -321,13 +321,15 @@ trait AppConfiguration {
 	 * @return void
 	 */
 	protected function setStatusTestingApp($enabled) {
-		$this->sendingTo(($enabled ? 'post' : 'delete'), '/cloud/apps/testing');
+		$this->theUserSendsToOcsApiEndpoint(
+			($enabled ? 'post' : 'delete'), '/cloud/apps/testing'
+		);
 		$this->theHTTPStatusCodeShouldBe('200');
-		if ($this->apiVersion == 1) {
+		if ($this->ocsApiVersion == 1) {
 			$this->theOCSStatusCodeShouldBe('100');
 		}
 
-		$this->sendingTo('get', '/cloud/apps?filter=enabled');
+		$this->theUserSendsToOcsApiEndpoint('get', '/cloud/apps?filter=enabled');
 		$this->theHTTPStatusCodeShouldBe('200');
 		if ($enabled) {
 			PHPUnit_Framework_Assert::assertContains(

--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -107,7 +107,7 @@ trait Auth {
 	}
 
 	/**
-	 * @When the user generates a new app password named :name using the API
+	 * Use the private API to generate an app password
 	 *
 	 * @param string $name
 	 *
@@ -144,7 +144,7 @@ trait Auth {
 	}
 
 	/**
-	 * @When user :user generates a new client token using the API
+	 * @When user :user generates a new client token using the token API
 	 * @Given a new client token for :user has been generated
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -87,7 +87,7 @@ trait BasicStructure {
 	 * The base URL of the local server under test,
 	 * without any terminating slash
 	 * e.g. http://localhost:8080
-	 *
+	 *ocsApiVersion
 	 * @var string
 	 */
 	private $localBaseUrl = '';
@@ -104,7 +104,7 @@ trait BasicStructure {
 	/**
 	 * @var int
 	 */
-	private $apiVersion = 1;
+	private $ocsApiVersion = 1;
 
 	/**
 	 * @var ResponseInterface
@@ -259,14 +259,14 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @Given /^using (?:api|API) version "([^"]*)"$/
+	 * @Given /^using OCS API version "([^"]*)"$/
 	 *
 	 * @param string $version
 	 *
 	 * @return void
 	 */
-	public function usingApiVersion($version) {
-		$this->apiVersion = (int) $version;
+	public function usingOcsApiVersion($version) {
+		$this->ocsApiVersion = (int) $version;
 	}
 
 	/**
@@ -317,20 +317,20 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When /^the user sends HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
-	 * @Given /^the user has sent HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
+	 * @When /^the user sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)"$/
+	 * @Given /^the user has sent HTTP method "([^"]*)" to OCS API endpoint "([^"]*)"$/
 	 *
 	 * @param string $verb
 	 * @param string $url
 	 *
 	 * @return void
 	 */
-	public function sendingTo($verb, $url) {
-		$this->sendingToWith($verb, $url, null);
+	public function theUserSendsToOcsApiEndpoint($verb, $url) {
+		$this->theUserSendsToOcsApiEndpointWithBody($verb, $url, null);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
+	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)"$/
 	 * @Given /^user "([^"]*)" has sent HTTP method "([^"]*)" to API endpoint "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -339,8 +339,8 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	public function userSendingTo($user, $verb, $url) {
-		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+	public function userSendsToOcsApiEndpoint($user, $verb, $url) {
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			$verb,
 			$url,
@@ -433,8 +433,8 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When /^the user sends HTTP method "([^"]*)" to API endpoint "([^"]*)" with body$/
-	 * @Given /^the user has sent HTTP method "([^"]*)" to API endpoint "([^"]*)" with body$/
+	 * @When /^the user sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with body$/
+	 * @Given /^the user has sent HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with body$/
 	 *
 	 * @param string $verb
 	 * @param string $url
@@ -442,8 +442,8 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	public function sendingToWith($verb, $url, $body) {
-		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+	public function theUserSendsToOcsApiEndpointWithBody($verb, $url, $body) {
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$this->currentUser,
 			$verb,
 			$url,
@@ -452,8 +452,8 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to API endpoint "([^"]*)" with body$/
-	 * @Given /^user "([^"]*)" has sent HTTP method "([^"]*)" to API endpoint "([^"]*)" with body$/
+	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with body$/
+	 * @Given /^user "([^"]*)" has sent HTTP method "([^"]*)" to OCS API endpoint "([^"]*)" with body$/
 	 *
 	 * @param string $user
 	 * @param string $verb
@@ -462,7 +462,7 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	public function userSendsHTTPMethodToAPIEndpointWithBody(
+	public function userSendsHTTPMethodToOcsApiEndpointWithBody(
 		$user, $verb, $url, $body
 	) {
 
@@ -486,7 +486,7 @@ trait BasicStructure {
 
 		$this->response = OcsApiHelper::sendRequest(
 			$this->getBaseUrl(),
-			$user, $password, $verb, $url, $bodyArray, $this->apiVersion
+			$user, $password, $verb, $url, $bodyArray, $this->ocsApiVersion
 		);
 	}
 
@@ -665,8 +665,8 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" logs in to a web-style session using the API$/
-	 * @Given /^user "([^"]*)" has logged in to a web-style session using the API$/
+	 * @When /^user "([^"]*)" logs in to a web-style session$/
+	 * @Given /^user "([^"]*)" has logged in to a web-style session$/
 	 *
 	 * @param string $user
 	 *
@@ -702,7 +702,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When the client sends a :method to :url with requesttoken using the API
+	 * @When the client sends a :method to :url with requesttoken
 	 * @Given the client has sent a :method to :url with requesttoken
 	 *
 	 * @param string $method
@@ -728,7 +728,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When the client sends a :method to :url without requesttoken using the API
+	 * @When the client sends a :method to :url without requesttoken
 	 * @Given the client has sent a :method to :url without requesttoken
 	 *
 	 * @param string $method
@@ -891,7 +891,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When the admin requests status.php using the API
+	 * @When the admin requests status.php
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -84,7 +84,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @When user :user requests calendar :calendar using the API
+	 * @When user :user requests calendar :calendar using the new WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $calendar

--- a/tests/acceptance/features/bootstrap/CardDavContext.php
+++ b/tests/acceptance/features/bootstrap/CardDavContext.php
@@ -84,7 +84,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @When user :user requests address book :addressBook using the API
+	 * @When user :user requests address book :addressBook using the new WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $addressBook

--- a/tests/acceptance/features/bootstrap/Checksums.php
+++ b/tests/acceptance/features/bootstrap/Checksums.php
@@ -29,7 +29,7 @@ use GuzzleHttp\Client;
 trait Checksums {
 
 	/**
-	 * @When user :user uploads file :source to :destination with checksum :checksum using the API
+	 * @When user :user uploads file :source to :destination with checksum :checksum using the WebDAV API
 	 * @Given user :user has uploaded file :source to :destination with checksum :checksum
 	 *
 	 * @param string $user
@@ -176,7 +176,7 @@ trait Checksums {
 	}
 
 	/**
-	 * @When user :user uploads chunk file :num of :total with :data to :destination with checksum :checksum using the API
+	 * @When user :user uploads chunk file :num of :total with :data to :destination with checksum :checksum using the WebDAV API
 	 * @Given user :user has uploaded chunk file :num of :total with :data to :destination with checksum :checksum
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/bootstrap/Comments.php
+++ b/tests/acceptance/features/bootstrap/Comments.php
@@ -40,7 +40,7 @@ trait Comments {
 	private $lastFileId;
 
 	/**
-	 * @When /^user "([^"]*)" comments with content "([^"]*)" on (?:file|folder) "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" comments with content "([^"]*)" on (?:file|folder) "([^"]*)" using the WebDAV API$/
 	 * @Given /^user "([^"]*)" has commented with content "([^"]*)" on (?:file|folder) "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -177,7 +177,7 @@ trait Comments {
 	}
 
 	/**
-	 * @When user :user deletes the last created comment using the API
+	 * @When user :user deletes the last created comment using the WebDAV API
 	 * @Given user :user has deleted the last created comment
 	 *
 	 * @param string $user
@@ -262,7 +262,7 @@ trait Comments {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" edits the last created comment with content "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" edits the last created comment with content "([^"]*)" using the WebDAV API$/
 	 * @Given /^user "([^"]*)" has edited the last created comment with content "([^"]*)"$/
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -40,7 +40,7 @@ class FederationContext implements Context {
 	private $featureContext;
 
 	/**
-	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" shares "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)" using the API$/
+	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" shares "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)" using the sharing API$/
 	 * @Given /^user "([^"]*)" from server "(LOCAL|REMOTE)" has shared "([^"]*)" with user "([^"]*)" from server "(LOCAL|REMOTE)"$/
 	 *
 	 * @param string $sharerUser
@@ -76,7 +76,7 @@ class FederationContext implements Context {
 	}
 	
 	/**
-	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" accepts the last pending share using the API$/
+	 * @When /^user "([^"]*)" from server "(LOCAL|REMOTE)" accepts the last pending share using the sharing API$/
 	 * @Given /^user "([^"]*)" from server "(LOCAL|REMOTE)" has accepted the last pending share$/
 	 *
 	 * @param string $user
@@ -87,7 +87,7 @@ class FederationContext implements Context {
 	public function acceptLastPendingShare($user, $server) {
 		$previous = $this->featureContext->usingServer($server);
 		$this->featureContext->asUser($user);
-		$this->featureContext->sendingToWith(
+		$this->featureContext->theUserSendsToOcsApiEndpointWithBody(
 			'GET',
 			"/apps/files_sharing/api/v1/remote_shares/pending",
 			null
@@ -100,7 +100,7 @@ class FederationContext implements Context {
 		 */
 		$response = $this->featureContext->getResponse();
 		$share_id = $response->xml()->data[0]->element[0]->id;
-		$this->featureContext->sendingToWith(
+		$this->featureContext->theUserSendsToOcsApiEndpointWithBody(
 			'POST',
 			"/apps/files_sharing/api/v1/remote_shares/pending/{$share_id}",
 			null

--- a/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
@@ -109,7 +109,7 @@ class NotificationsCoreContext implements Context {
 	 * @return void
 	 */
 	public function userNumNotifications($user, $numNotifications, $missingLast) {
-		$this->featureContext->userSendingTo(
+		$this->featureContext->userSendsToOcsApiEndpoint(
 			$user, 'GET', '/apps/notifications/api/v1/notifications?format=json'
 		);
 		PHPUnit_Framework_Assert::assertEquals(
@@ -188,7 +188,7 @@ class NotificationsCoreContext implements Context {
 			$notificationId = \end($lastNotifications);
 		}
 
-		$this->featureContext->userSendingTo(
+		$this->featureContext->userSendsToOcsApiEndpoint(
 			$user, 'GET', '/apps/notifications/api/v1/notifications/' .
 			$notificationId . '?format=json'
 		);

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -211,7 +211,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator creates the user "([^"]*)" using the API$/
+	 * @When /^the administrator creates the user "([^"]*)" using the provisioning API$/
 	 * @Given /^user "([^"]*)" has been created$/
 	 *
 	 * @param string $user
@@ -219,7 +219,7 @@ trait Provisioning {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function adminCreatesUserUsingTheAPI($user) {
+	public function adminCreatesUserUsingTheProvisioningApi($user) {
 		if (!$this->userExists($user)) {
 			$password = $this->getPasswordForUser($user);
 			$this->createUser($user, $password, null, null, true, 'api');
@@ -272,7 +272,7 @@ trait Provisioning {
 	 */
 	public function userEnablesOrDisablesApp($user, $action, $app) {
 		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/cloud/apps/" . $app;
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/apps/" . $app;
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser($user);
 		try {
@@ -320,16 +320,16 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator sends a user creation request for user "([^"]*)" password "([^"]*)" using the API$/
+	 * @When /^the administrator sends a user creation request for user "([^"]*)" password "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $user
 	 * @param string $password
 	 *
 	 * @return void
 	 */
-	public function adminSendsUserCreationRequestUsingTheAPI($user, $password) {
+	public function adminSendsUserCreationRequestUsingTheProvisioningApi($user, $password) {
 		$bodyTable = new TableNode([['userid', $user], ['password', $password]]);
-		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$this->getAdminUsername(),
 			"POST",
 			"/cloud/users",
@@ -339,7 +339,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator sends a user creation request for user "([^"]*)" password "([^"]*)" group "([^"]*)" using the API$/
+	 * @When /^the administrator sends a user creation request for user "([^"]*)" password "([^"]*)" group "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $user
 	 * @param string $password
@@ -347,13 +347,13 @@ trait Provisioning {
 	 *
 	 * @return void
 	 */
-	public function theAdministratorCreatesUserPasswordGroupUsingTheApi(
+	public function theAdministratorCreatesUserPasswordGroupUsingTheProvisioningApi(
 		$user, $password, $group
 	) {
 		$bodyTable = new TableNode(
 			[['userid', $user], ['password', $password], ['groups[]', $group]]
 		);
-		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$this->getAdminUsername(),
 			"POST",
 			"/cloud/users",
@@ -363,20 +363,20 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator sends a user deletion request for user "([^"]*)" using the API$/
+	 * @When /^the administrator sends a user deletion request for user "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theAdminDeletesTheUserUsingAPI($user) {
-		$this->deleteTheUserUsingTheAPI($user);
+	public function theAdminDeletesTheUserUsingTheProvisioningApi($user) {
+		$this->deleteTheUserUsingTheProvisioningApi($user);
 		$this->rememberThatUserIsNotExpectedToExist($user);
 	}
 
 	/**
-	 * @When /^the subadmin "([^"]*)" sends a user deletion request for user "([^"]*)" using the API$/
+	 * @When /^the subadmin "([^"]*)" sends a user deletion request for user "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $subadmin
 	 * @param string $user
@@ -384,13 +384,13 @@ trait Provisioning {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theSubAdminDeletesTheUser($subadmin, $user) {
+	public function theSubAdminDeletesTheUserUsingTheProvisioningApi($subadmin, $user) {
 		$this->response = UserHelper::deleteUser(
 			$this->getBaseUrl(),
 			$user,
 			$subadmin,
 			$this->getUserPassword($subadmin),
-			$this->apiVersion
+			$this->ocsApiVersion
 		);
 		$this->rememberThatUserIsNotExpectedToExist($user);
 	}
@@ -477,7 +477,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator deletes user "([^"]*)" using the API$/
+	 * @When /^the administrator deletes user "([^"]*)" using the provisioning API$/
 	 * @Given /^user "([^"]*)" has been deleted$/
 	 *
 	 * @param string $user
@@ -485,9 +485,9 @@ trait Provisioning {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function adminDeletesUserUsingTheAPI($user) {
+	public function adminDeletesUserUsingTheProvisioningApi($user) {
 		if ($this->userExists($user)) {
-			$this->deleteTheUserUsingTheAPI($user);
+			$this->deleteTheUserUsingTheProvisioningApi($user);
 		}
 		$this->userShouldNotExist($user);
 	}
@@ -521,7 +521,7 @@ trait Provisioning {
 	 */
 	public function initializeUser($user, $password) {
 		$url = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/cloud/users/" . $user;
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/" . $user;
 		$client = new Client();
 		$options = [
 			'auth' => [$user, $password],
@@ -652,7 +652,7 @@ trait Provisioning {
 	 * @throws \Exception
 	 */
 	public function deleteUser($user) {
-		$this->deleteTheUserUsingTheAPI($user);
+		$this->deleteTheUserUsingTheProvisioningApi($user);
 		$this->userShouldNotExist($user);
 	}
 
@@ -668,7 +668,7 @@ trait Provisioning {
 	 */
 	public function cleanupGroup($group) {
 		try {
-			$this->deleteTheGroupUsingTheAPI($group);
+			$this->deleteTheGroupUsingTheProvisioningApi($group);
 		} catch (BadResponseException $e) {
 			$this->response = $e->getResponse();
 			\error_log(
@@ -777,7 +777,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator adds user "([^"]*)" to group "([^"]*)" using the API$/
+	 * @When /^the administrator adds user "([^"]*)" to group "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -785,7 +785,7 @@ trait Provisioning {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function adminAddsUserToGroupUsingTheAPI($user, $group) {
+	public function adminAddsUserToGroupUsingTheProvisioningApi($user, $group) {
 		if (!$this->userBelongsToGroup($user, $group)) {
 			$this->userHasBeenAddedToGroup($user, $group);
 		}
@@ -885,7 +885,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator creates group "([^"]*)" using the API$/
+	 * @When /^the administrator creates group "([^"]*)" using the provisioning API$/
 	 * @Given /^group "([^"]*)" has been created$/
 	 *
 	 * @param string $group
@@ -893,7 +893,7 @@ trait Provisioning {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function adminCreatesGroupUsingTheAPI($group) {
+	public function adminCreatesGroupUsingTheProvisioningApi($group) {
 		if (!$this->groupExists($group)) {
 			$this->createTheGroup($group, 'api');
 		}
@@ -916,15 +916,15 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator sends a group creation request for group "([^"]*)" using the API$/
+	 * @When /^the administrator sends a group creation request for group "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $group
 	 *
 	 * @return void
 	 */
-	public function adminSendsGroupCreationRequestUsingTheAPI($group) {
+	public function adminSendsGroupCreationRequestUsingTheProvisioningApi($group) {
 		$bodyTable = new TableNode([['groupid', $group]]);
-		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$this->getAdminUsername(),
 			"POST",
 			"/cloud/groups",
@@ -993,16 +993,16 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator disables user "([^"]*)" using the API$/
+	 * @When /^the administrator disables user "([^"]*)" using the provisioning API$/
 	 * @Given /^user "([^"]*)" has been disabled$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
-	public function adminDisablesUserUsingTheAPI($user) {
+	public function adminDisablesUserUsingTheProvisioningApi($user) {
 		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/cloud/users/$user/disable";
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$user/disable";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
@@ -1018,14 +1018,14 @@ trait Provisioning {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function deleteTheUserUsingTheAPI($user) {
+	public function deleteTheUserUsingTheProvisioningApi($user) {
 		// Always try to delete the user
 		$this->response = UserHelper::deleteUser(
 			$this->getBaseUrl(),
 			$user,
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
-			$this->apiVersion
+			$this->ocsApiVersion
 		);
 
 		// Only log a message if the test really expected the user to have been
@@ -1052,28 +1052,28 @@ trait Provisioning {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function groupHasBeenDeletedUsingTheAPI($group) {
+	public function groupHasBeenDeletedUsingTheProvisioningApi($group) {
 		if ($this->groupExists($group)) {
-			$this->deleteTheGroupUsingTheAPI($group);
+			$this->deleteTheGroupUsingTheProvisioningApi($group);
 		}
 		$this->groupShouldNotExist($group);
 	}
 
 	/**
-	 * @When /^the administrator deletes group "([^"]*)" using the API$/
+	 * @When /^the administrator deletes group "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $group
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function deleteTheGroupUsingTheAPI($group) {
+	public function deleteTheGroupUsingTheProvisioningApi($group) {
 		$this->response = UserHelper::deleteGroup(
 			$this->getBaseUrl(),
 			$group,
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
-			$this->apiVersion
+			$this->ocsApiVersion
 		);
 
 		if ($this->theGroupShouldExist($group)
@@ -1110,7 +1110,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When the administrator removes user :user from group :group using the API
+	 * @When the administrator removes user :user from group :group using the provisioning API
 	 * @Given user :user has been removed from group :group
 	 *
 	 * @param string $user
@@ -1118,7 +1118,7 @@ trait Provisioning {
 	 *
 	 * @return void
 	 */
-	public function adminRemovesUserFromGroupUsingTheAPI($user, $group) {
+	public function adminRemovesUserFromGroupUsingTheProvisioningApi($user, $group) {
 		$this->response = UserHelper::removeUserFromGroup(
 			$this->getBaseUrl(),
 			$user,
@@ -1160,7 +1160,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator makes user "([^"]*)" a subadmin of group "([^"]*)" using the API$/
+	 * @When /^the administrator makes user "([^"]*)" a subadmin of group "([^"]*)" using the provisioning API$/
 	 * @Given /^user "([^"]*)" has been made a subadmin of group "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -1168,9 +1168,11 @@ trait Provisioning {
 	 *
 	 * @return void
 	 */
-	public function adminMakesUserSubadminOfGroupUsingTheAPI($user, $group) {
+	public function adminMakesUserSubadminOfGroupUsingTheProvisioningApi(
+		$user, $group
+	) {
 		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/cloud/users/$user/subadmins";
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$user/subadmins";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
@@ -1186,7 +1188,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When /^the administrator makes user "([^"]*)" not a subadmin of group "([^"]*)" using the API$/
+	 * @When /^the administrator makes user "([^"]*)" not a subadmin of group "([^"]*)" using the provisioning API$/
 	 * @Given /^user "([^"]*)" has been made not a subadmin of group "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -1194,7 +1196,9 @@ trait Provisioning {
 	 *
 	 * @return void
 	 */
-	public function adminMakesUserNotSubadminOfGroupUsingTheAPI($user, $group) {
+	public function adminMakesUserNotSubadminOfGroupUsingTheProvisioningApi(
+		$user, $group
+	) {
 		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/groups/$group/subadmins";
 		$client = new Client();
 		$options = [];
@@ -1494,7 +1498,7 @@ trait Provisioning {
 	 */
 	public function userShouldBeDisabled($user) {
 		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/cloud/users/$user";
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
@@ -1514,7 +1518,7 @@ trait Provisioning {
 	 */
 	public function useShouldBeEnabled($user) {
 		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/cloud/users/$user";
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
@@ -1526,7 +1530,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When the administrator sets the quota of user :user to :quota using the API
+	 * @When the administrator sets the quota of user :user to :quota using the provisioning API
 	 * @Given the quota of user :user has been set to :quota
 	 *
 	 * @param string $user
@@ -1534,7 +1538,7 @@ trait Provisioning {
 	 *
 	 * @return void
 	 */
-	public function adminSetsUserQuotaToUsingTheAPI($user, $quota) {
+	public function adminSetsUserQuotaToUsingTheProvisioningApi($user, $quota) {
 		$body
 			= [
 				'key' => 'quota',
@@ -1557,15 +1561,15 @@ trait Provisioning {
 	}
 
 	/**
-	 * @When the administrator gives unlimited quota to user :user using the API
+	 * @When the administrator gives unlimited quota to user :user using the provisioning API
 	 * @Given user :user has been given unlimited quota
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
-	public function adminGivesUnlimitedQuotaToUserUsingTheAPI($user) {
-		$this->adminSetsUserQuotaToUsingTheAPI($user, 'none');
+	public function adminGivesUnlimitedQuotaToUserUsingTheProvisioningApi($user) {
+		$this->adminSetsUserQuotaToUsingTheProvisioningApi($user, 'none');
 	}
 
 	/**
@@ -1577,7 +1581,7 @@ trait Provisioning {
 	 */
 	public function getUserHome($user) {
 		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/cloud/users/$user";
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$user";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForAdmin();
@@ -1617,7 +1621,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function checkAttributesForUser($user, $body) {
-		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$this->getAdminUsername(), "GET", "/cloud/users/$user",
 			null
 		);

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -41,7 +41,7 @@ class ShareesContext implements Context {
 	private $featureContext;
 
 	/**
-	 * @When /^the user gets the sharees using the API with parameters$/
+	 * @When /^the user gets the sharees using the sharing API with parameters$/
 	 *
 	 * @param TableNode $body
 	 *
@@ -54,7 +54,7 @@ class ShareesContext implements Context {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the sharees using the API with parameters$/
+	 * @When /^user "([^"]*)" gets the sharees using the sharing API with parameters$/
 	 *
 	 * @param string $user
 	 * @param TableNode $body
@@ -73,7 +73,7 @@ class ShareesContext implements Context {
 			}
 		}
 
-		$this->featureContext->userSendsHTTPMethodToAPIEndpointWithBody(
+		$this->featureContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, 'GET', $url, null
 		);
 	}

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -76,7 +76,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a share using the API with settings$/
+	 * @When /^user "([^"]*)" creates a share using the sharing API with settings$/
 	 * @Given /^user "([^"]*)" has created a share with settings$/
 	 *
 	 * @param string $user
@@ -86,7 +86,7 @@ trait Sharing {
 	 */
 	public function userCreatesAShareWithSettings($user, $body) {
 		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
+			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser($user);
@@ -112,7 +112,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^the user creates a share using the API with settings$/
+	 * @When /^the user creates a share using the sharing API with settings$/
 	 *
 	 * @param TableNode|null $body
 	 *
@@ -164,7 +164,7 @@ trait Sharing {
 				$permissions,
 				null, // linkName
 				null, // expireDate
-				$this->apiVersion,
+				$this->ocsApiVersion,
 				$this->sharingApiVersion
 			);
 		} catch (BadResponseException $e) {
@@ -176,7 +176,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)" using the sharing API$/
 	 * @Given /^user "([^"]*)" has created a public share of (?:file|folder) "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -189,7 +189,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^the user creates a public share of (?:file|folder) "([^"]*)" using the API$/
+	 * @When /^the user creates a public share of (?:file|folder) "([^"]*)" using the sharing API$/
 	 * @Given /^the user has created a public share of (?:file|folder) "([^"]*)"$/
 	 *
 	 * @param string $path
@@ -200,7 +200,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)" using the API with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 * @When /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)" using the sharing API with (read|update|create|delete|change|share|all) permission(?:s|)$/
 	 * @Given /^user "([^"]*)" has created a public share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|share|all) permission(?:s|)$/
 	 *
 	 * @param string $user
@@ -216,7 +216,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^the user creates a public share of (?:file|folder) "([^"]*)" using the API with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 * @When /^the user creates a public share of (?:file|folder) "([^"]*)" using the sharing API with (read|update|create|delete|change|share|all) permission(?:s|)$/
 	 * @Given /^the user has created a public share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|share|all) permission(?:s|)$/
 	 *
 	 * @param string $path
@@ -289,14 +289,14 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^the user "([^"]*)" should be able to download the file "([^"]*)" using the API$/
+	 * @Then /^the user "([^"]*)" should be able to download the file "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $path
 	 *
 	 * @return void
 	 */
-	public function theUserShouldBeAbleToDownloadTheFileUsingTheApi($user, $path) {
+	public function theUserShouldBeAbleToDownloadTheFileUsingTheSharingApi($user, $path) {
 		$path = \ltrim($path, "/");
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser($user);
@@ -374,7 +374,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When the public uploads file ":filename" with content ":body" using the API
+	 * @When the public uploads file ":filename" with content ":body" using the old WebDAV API
 	 * @Given the public has uploaded file ":filename" with content ":body"
 	 *
 	 * @param string $filename target file name
@@ -387,7 +387,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When the public overwrites file ":filename" with content ":body" using the API
+	 * @When the public overwrites file ":filename" with content ":body" using the old WebDAV API
 	 * @Given the public has overwritten file ":filename" with content ":body"
 	 *
 	 * @param string $filename target file name
@@ -400,7 +400,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When the public uploads file ":filename" with password ":password" and content ":body" using the API
+	 * @When the public uploads file ":filename" with password ":password" and content ":body" using the old WebDAV API
 	 * @Given the public has uploaded file ":filename" with password ":password" and content ":body"
 	 *
 	 * @param string $filename target file name
@@ -416,7 +416,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When the public uploads file ":filename" with content ":body" with autorename mode using the API
+	 * @When the public uploads file ":filename" with content ":body" with autorename mode using the old WebDAV API
 	 * @Given the public has uploaded file ":filename" with content ":body" with autorename mode
 	 *
 	 * @param string $filename target file name
@@ -429,7 +429,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When the public uploads file ":filename" using the API
+	 * @When the public uploads file ":filename" using the old WebDAV API
 	 * @Given the public has uploaded file ":filename"
 	 *
 	 * @param string $source target file name
@@ -442,7 +442,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should not be able to create public share of (?:file|folder) "([^"]*)" using the API$/
+	 * @Then /^user "([^"]*)" should not be able to create a public share of (?:file|folder) "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $sharer
 	 * @param string $filepath
@@ -514,7 +514,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^the user adds an expiration date to the last share using the API$/
+	 * @When /^the user adds an expiration date to the last share using the sharing API$/
 	 * @Given /^the user has added an expiration date to the last share$/
 	 *
 	 * @return void
@@ -522,7 +522,7 @@ trait Sharing {
 	public function theUserAddsExpirationDateToLastShare() {
 		$share_id = (string) $this->lastShareData->data[0]->id;
 		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
+			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser($this->currentUser);
@@ -538,7 +538,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^the user updates the last share using the API with$/
+	 * @When /^the user updates the last share using the sharing API with$/
 	 * @Given /^the user has updated the last share with$/
 	 *
 	 * @param TableNode|null $body
@@ -550,7 +550,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" updates the last share using the API with$/
+	 * @When /^user "([^"]*)" updates the last share using the sharing API with$/
 	 * @Given /^user "([^"]*)" has updated the last share with$/
 	 *
 	 * @param string $user
@@ -561,7 +561,7 @@ trait Sharing {
 	public function userUpdatesTheLastShareWith($user, $body) {
 		$share_id = (string) $this->lastShareData->data[0]->id;
 		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
+			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser($user);
@@ -619,7 +619,7 @@ trait Sharing {
 				$permissions,
 				$linkName,
 				null, //expireDate
-				$this->apiVersion,
+				$this->ocsApiVersion,
 				$this->sharingApiVersion
 			);
 			$this->lastShareData = $this->response->xml();
@@ -777,7 +777,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions ([\d]*))? using the API$/
+	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
 	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with user "([^"]*)"(?: with permissions ([\d]*))?$/
 	 *
 	 * @param string $user1
@@ -787,11 +787,11 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
-	public function userSharesFileWithUserUsingTheAPI(
+	public function userSharesFileWithUserUsingTheSharingApi(
 		$user1, $filepath, $user2, $permissions = null
 	) {
 		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
+			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser($user1);
@@ -819,7 +819,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^the user shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))? using the API$/
+	 * @When /^the user shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
 	 * @Given /^the user has shared (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))?$/
 	 *
 	 * @param string $filepath
@@ -828,16 +828,16 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
-	public function theUserSharesFileWithGroupUsingTheAPI(
+	public function theUserSharesFileWithGroupUsingTheSharingApi(
 		$filepath, $group, $permissions = null
 	) {
-		$this->userSharesFileWithGroupUsingTheAPI(
+		$this->userSharesFileWithGroupUsingTheSharingApi(
 			$this->currentUser, $filepath, $group, $permissions
 		);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))? using the API$/
+	 * @When /^user "([^"]*)" shares (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
 	 * @Given /^user "([^"]*)" has shared (?:file|folder|entry) "([^"]*)" with group "([^"]*)"(?: with permissions ([\d]*))?$/
 	 *
 	 * @param string $user
@@ -847,11 +847,11 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
-	public function userSharesFileWithGroupUsingTheAPI(
+	public function userSharesFileWithGroupUsingTheSharingApi(
 		$user, $filepath, $group, $permissions = null
 	) {
 		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
+			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" . "?path=$filepath";
 		$client = new Client();
 		$options = [];
 		$options['auth'] = $this->getAuthOptionForUser($user);
@@ -871,7 +871,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should not be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)"(?: with permissions ([\d]*))? using the API$/
+	 * @Then /^user "([^"]*)" should not be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
 	 *
 	 * @param string $sharer
 	 * @param string $filepath
@@ -881,7 +881,7 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
-	public function userTriesToShareFileUsingTheApi($sharer, $filepath, $userOrGroup, $sharee, $permissions = null) {
+	public function userTriesToShareFileUsingTheSharingApi($sharer, $filepath, $userOrGroup, $sharee, $permissions = null) {
 		$shareType = ($userOrGroup === "user" ? 0 : 1);
 		$time = \time();
 		if ($this->lastShareTime !== null && $time - $this->lastShareTime < 1) {
@@ -902,7 +902,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)"(?: with permissions ([\d]*))? using the API$/
+	 * @Then /^user "([^"]*)" should be able to share (?:file|folder|entry) "([^"]*)" with (user|group) "([^"]*)"(?: with permissions ([\d]*))? using the sharing API$/
 	 *
 	 * @param string $sharer
 	 * @param string $filepath
@@ -912,7 +912,7 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
-	public function userShouldBeAbleToShareUsingTheApi(
+	public function userShouldBeAbleToShareUsingTheSharingApi(
 		$sharer, $filepath, $userOrGroup, $sharee, $permissions = null
 	) {
 		$shareType = ($userOrGroup === "user" ? 0 : 1);
@@ -934,51 +934,51 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^the user deletes the last share using the API$/
+	 * @When /^the user deletes the last share using the sharing API$/
 	 * @Given /^the user has deleted the last share$/
 	 *
 	 * @return void
 	 */
-	public function theUserDeletesLastShareUsingTheAPI() {
-		$this->userDeletesLastShareUsingTheAPI($this->currentUser);
+	public function theUserDeletesLastShareUsingTheSharingAPI() {
+		$this->userDeletesLastShareUsingTheSharingApi($this->currentUser);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes the last share using the API$/
+	 * @When /^user "([^"]*)" deletes the last share using the sharing API$/
 	 * @Given /^user "([^"]*)" has deleted the last share$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
-	public function userDeletesLastShareUsingTheAPI($user) {
+	public function userDeletesLastShareUsingTheSharingApi($user) {
 		$share_id = $this->lastShareData->data[0]->id;
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
-		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, "DELETE", $url, null
 		);
 	}
 
 	/**
-	 * @When /^the user gets the info of the last share using the API$/
+	 * @When /^the user gets the info of the last share using the sharing API$/
 	 *
 	 * @return void
 	 */
-	public function theUserGetsInfoOfLastShareUsingTheAPI() {
-		$this->userGetsInfoOfLastShareUsingTheAPI($this->currentUser);
+	public function theUserGetsInfoOfLastShareUsingTheSharingApi() {
+		$this->userGetsInfoOfLastShareUsingTheSharingApi($this->currentUser);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the info of the last share using the API$/
+	 * @When /^user "([^"]*)" gets the info of the last share using the sharing API$/
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 */
-	public function userGetsInfoOfLastShareUsingTheAPI($user) {
+	public function userGetsInfoOfLastShareUsingTheSharingApi($user) {
 		$share_id = $this->lastShareData->data[0]->id;
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
-		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, "GET", $url, null
 		);
 	}
@@ -1069,7 +1069,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When user :user removes all shares from the file named :fileName using the API
+	 * @When user :user removes all shares from the file named :fileName using the sharing API
 	 * @Given user :user has removed all shares from the file named :fileName
 	 *
 	 * @param string $user
@@ -1080,7 +1080,7 @@ trait Sharing {
 	 */
 	public function userRemovesAllSharesFromTheFileNamed($user, $fileName) {
 		$url = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares?format=json";
+			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares?format=json";
 		$client = new \GuzzleHttp\Client();
 		$res = $client->get(
 			$url,
@@ -1098,7 +1098,7 @@ trait Sharing {
 				$id = $data['id'];
 				$client->delete(
 					$this->getBaseUrl()
-					. "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/{$id}",
+					. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/{$id}",
 					[
 						'auth' => $this->getAuthOptionForUser($user),
 						'headers' => [
@@ -1148,7 +1148,7 @@ trait Sharing {
 	 */
 	public function getShares($user, $path) {
 		$fullUrl = $this->getBaseUrl()
-			. "/ocs/v{$this->apiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
+			. "/ocs/v{$this->ocsApiVersion}.php/apps/files_sharing/api/v{$this->sharingApiVersion}/shares";
 		$fullUrl = $fullUrl . '?path=' . $path;
 
 		$client = new Client();
@@ -1224,7 +1224,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes public share named "([^"]*)" in (?:file|folder) "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" deletes public share named "([^"]*)" in (?:file|folder) "([^"]*)" using the sharing API$/
 	 * @Given /^user "([^"]*)" has deleted public share named "([^"]*)" in (?:file|folder) "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -1233,16 +1233,16 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
-	public function userDeletesPublicShareNamedUsingTheAPI(
+	public function userDeletesPublicShareNamedUsingTheSharingApi(
 		$user, $name, $path
 	) {
 		$share_id = $this->getPublicShareIDByName($user, $path, $name);
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares/$share_id";
-		$this->sendingToWith("DELETE", $url, null);
+		$this->theUserSendsToOcsApiEndpointWithBody("DELETE", $url, null);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (declines|accepts) the share "([^"]*)" offered by user "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" (declines|accepts) the share "([^"]*)" offered by user "([^"]*)" using the sharing API$/
 	 * @Given /^user "([^"]*)" has (declined|accepted) the share "([^"]*)" offered by user "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -1277,7 +1277,7 @@ trait Sharing {
 			$httpRequestMethod = "POST";
 		}
 		
-		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, $httpRequestMethod, $url, null
 		);
 		if ($this->response->getStatusCode() !== 200) {
@@ -1289,7 +1289,7 @@ trait Sharing {
 
 	/**
 	 *
-	 * @Then /^the API should report to user "([^"]*)" that these shares are in the (pending|accepted|declined) state$/
+	 * @Then /^the sharing API should report to user "([^"]*)" that these shares are in the (pending|accepted|declined) state$/
 	 *
 	 * @param string $user
 	 * @param string $state
@@ -1323,7 +1323,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then the API should report that no shares are shared with user :user
+	 * @Then the sharing API should report that no shares are shared with user :user
 	 *
 	 * @param string $user
 	 *
@@ -1370,7 +1370,7 @@ trait Sharing {
 		
 		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}/shares" .
 			   "?format=json&shared_with_me=true&state=$stateCode";
-		$this->userSendsHTTPMethodToAPIEndpointWithBody(
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user, "GET", $url, null
 		);
 		if ($this->response->getStatusCode() !== 200) {

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -87,7 +87,7 @@ trait Tags {
 	}
 
 	/**
-	 * @When user :user creates a :type tag with name :name using the API
+	 * @When user :user creates a :type tag with name :name using the WebDAV API
 	 * @Given user :user has created a :type tag with name :name
 	 *
 	 * @param string $user
@@ -107,7 +107,7 @@ trait Tags {
 	}
 
 	/**
-	 * @When user :user creates a :type tag with name :name and groups :groups using the API
+	 * @When user :user creates a :type tag with name :name and groups :groups using the WebDAV API
 	 * @Given user :user has created a :type tag with name :name and groups :groups
 	 *
 	 * @param string $user
@@ -315,7 +315,7 @@ trait Tags {
 	}
 
 	/**
-	 * @When user :user edits the tag with name :oldName and sets its name to :newName using the API
+	 * @When user :user edits the tag with name :oldName and sets its name to :newName using the WebDAV API
 	 * @Given user :user has edited the tag with name :oldName and set its name to :newName
 	 *
 	 * @param string $user
@@ -333,7 +333,7 @@ trait Tags {
 	}
 
 	/**
-	 * @When user :user edits the tag with name :oldName and sets its groups to :groups using the API
+	 * @When user :user edits the tag with name :oldName and sets its groups to :groups using the WebDAV API
 	 * @Given user :user has edited the tag with name :oldName and set its groups to :groups
 	 *
 	 * @param string $user
@@ -351,7 +351,7 @@ trait Tags {
 	}
 
 	/**
-	 * @When user :user deletes the tag with name :name using the API
+	 * @When user :user deletes the tag with name :name using the WebDAV API
 	 * @Given user :user has deleted the tag with name :name
 	 *
 	 * @param string $user
@@ -434,7 +434,7 @@ trait Tags {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" adds the tag "([^"]*)" to "([^"]*)" (?:shared|owned) by "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" adds the tag "([^"]*)" to "([^"]*)" (?:shared|owned) by "([^"]*)" using the WebDAV API$/
 	 * @Given /^user "([^"]*)" has added the tag "([^"]*)" to "([^"]*)" (?:shared|owned) by "([^"]*)"$/
 	 *
 	 * @param string $taggingUser
@@ -534,7 +534,7 @@ trait Tags {
 	}
 
 	/**
-	 * @When user :user removes the tag :tagName from :fileName shared by :shareUser using the API
+	 * @When user :user removes the tag :tagName from :fileName shared by :shareUser using the WebDAV API
 	 * @Given user :user has removed the tag :tagName from :fileName shared by :shareUser
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/bootstrap/Trashbin.php
+++ b/tests/acceptance/features/bootstrap/Trashbin.php
@@ -27,7 +27,7 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
 trait Trashbin {
 
 	/**
-	 * @When user :user empties the trashbin using the API
+	 * @When user :user empties the trashbin using the trashbin API
 	 * @Given user :user has emptied the trashbin
 	 *
 	 * @param string $user user
@@ -188,7 +188,7 @@ trait Trashbin {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" restores the (?:file|folder|entry) with original path "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" restores the (?:file|folder|entry) with original path "([^"]*)" using the trashbin API$/
 	 * @Given /^user "([^"]*)" has restored the (?:file|folder|entry) with original path "([^"]*)"$/
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -250,7 +250,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" moves (?:file|folder|entry) "([^"]*)" to "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" moves (?:file|folder|entry) "([^"]*)" to "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $fileSource
@@ -273,7 +273,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" copies file "([^"]*)" to "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" copies file "([^"]*)" to "([^"]*)" using the WebDAV API$/
 	 * @Given /^user "([^"]*)" has copied file "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -297,7 +297,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^the user downloads file "([^"]*)" with range "([^"]*)" using the API$/
+	 * @When /^the user downloads file "([^"]*)" with range "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $fileSource
 	 * @param string $range
@@ -311,7 +311,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" downloads file "([^"]*)" with range "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" downloads file "([^"]*)" with range "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $fileSource
@@ -327,7 +327,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^the public downloads the last public shared file with range "([^"]*)" using the API$/
+	 * @When /^the public downloads the last public shared file with range "([^"]*)" using the old WebDAV API$/
 	 *
 	 * @param string $range
 	 *
@@ -349,7 +349,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with range "([^"]*)" using the API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with range "([^"]*)" using the old WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $range
@@ -371,7 +371,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with password "([^"]*)" with range "([^"]*)" using the API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with password "([^"]*)" with range "([^"]*)" using the old WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $password
@@ -514,7 +514,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When the user downloads the file :fileName using the API
+	 * @When the user downloads the file :fileName using the WebDAV API
 	 *
 	 * @param string $fileName
 	 *
@@ -525,7 +525,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user downloads the file :fileName using the API
+	 * @When user :user downloads the file :fileName using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $fileName
@@ -589,7 +589,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the properties of (?:file|folder|entry) "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" gets the properties of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -605,7 +605,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the following properties of (?:file|folder|entry) "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" gets the following properties of (?:file|folder|entry) "([^"]*)" using the WebDAV API$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -648,7 +648,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sets property "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" sets property "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)" using the WebDAV API$/
 	 * @Given /^user "([^"]*)" has set property "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -1187,7 +1187,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads file :source to :destination using the API
+	 * @When user :user uploads file :source to :destination using the WebDAV API
 	 * @Given user :user has uploaded file :source to :destination
 	 *
 	 * @param string $user
@@ -1209,7 +1209,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads file :source to :destination with chunks using the API
+	 * @When user :user uploads file :source to :destination with chunks using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -1268,7 +1268,7 @@ trait WebDav {
 	/**
 	 * Uploading with old/new dav and chunked/non-chunked.
 	 *
-	 * @When user :user uploads file :source to :destination with all mechanisms using the API
+	 * @When user :user uploads file :source to :destination with all mechanisms using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -1287,7 +1287,7 @@ trait WebDav {
 	/**
 	 * Overwriting with old/new dav and chunked/non-chunked.
 	 *
-	 * @When user :user overwrites file :source to :destination with all mechanisms using the API
+	 * @When user :user overwrites file :source to :destination with all mechanisms using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $source
@@ -1432,7 +1432,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads file with content :content to :destination using the API
+	 * @When user :user uploads file with content :content to :destination using the WebDAV API
 	 * @Given user :user has uploaded file with content :content to :destination
 	 *
 	 * @param string $user
@@ -1468,7 +1468,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads file with checksum :checksum and content :content to :destination using the API
+	 * @When user :user uploads file with checksum :checksum and content :content to :destination using the WebDAV API
 	 * @Given user :user has uploaded file with checksum :checksum and content :content to :destination
 	 *
 	 * @param string $user
@@ -1513,7 +1513,7 @@ trait WebDav {
 	 * entries with the same timestamp. Only use this step to avoid the problem
 	 * in core issue 23151 when wanting to demonstrate other correct behavior
 	 *
-	 * @When /^user "([^"]*)" waits and deletes (?:file|folder) "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" waits and deletes (?:file|folder) "([^"]*)" using the WebDAV API$/
 	 * @Given /^user "([^"]*)" has waited and deleted (?:file|folder) "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -1530,7 +1530,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (?:deletes|unshares) (?:file|folder) "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" (?:deletes|unshares) (?:file|folder) "([^"]*)" using the WebDAV API$/
 	 * @Given /^user "([^"]*)" has (?:deleted|unshared) (?:file|folder) "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -1548,7 +1548,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user creates a folder :destination using the API
+	 * @When user :user creates a folder :destination using the WebDAV API
 	 * @Given user :user has created a folder :destination
 	 *
 	 * @param string $user
@@ -1571,8 +1571,8 @@ trait WebDav {
 	/**
 	 * Old style chunking upload
 	 *
-	 * @When user :user uploads the following :total chunks to :file with old chunking and using the API
-	 * @Given user :user has uploaded the following :total chunks to :file with old chunking and using the API
+	 * @When user :user uploads the following :total chunks to :file with old chunking and using the WebDAV API
+	 * @Given user :user has uploaded the following :total chunks to :file with old chunking
 	 *
 	 * @param string $user
 	 * @param string $total
@@ -1598,8 +1598,8 @@ trait WebDav {
 	/**
 	 * Old style chunking upload
 	 *
-	 * @When user :user uploads the following chunks to :file with old chunking and using the API
-	 * @Given user :user has uploaded the following chunks to :file with old chunking and using the API
+	 * @When user :user uploads the following chunks to :file with old chunking and using the WebDAV API
+	 * @Given user :user has uploaded the following chunks to :file with old chunking
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -1623,7 +1623,7 @@ trait WebDav {
 	/**
 	 * Old style chunking upload
 	 *
-	 * @When user :user uploads chunk file :num of :total with :data to :destination using the API
+	 * @When user :user uploads chunk file :num of :total with :data to :destination using the WebDAV API
 	 * @Given user :user has uploaded chunk file :num of :total with :data to :destination
 	 *
 	 * @param string $user
@@ -1652,8 +1652,8 @@ trait WebDav {
 	/**
 	 * New style chunking upload
 	 *
-	 * @When user :user uploads the following chunks to :file with new chunking and using the API
-	 * @Given user :user has uploaded the following chunks to :file with new chunking and using the API
+	 * @When user :user uploads the following chunks to :file with new chunking and using the WebDAV API
+	 * @Given user :user has uploaded the following chunks to :file with new chunking
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -1696,7 +1696,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user creates a new chunking upload with id :id using the API
+	 * @When user :user creates a new chunking upload with id :id using the WebDAV API
 	 * @Given user :user has created a new chunking upload with id :id
 	 *
 	 * @param string $user
@@ -1716,7 +1716,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads new chunk file :num with :data to id :id using the API
+	 * @When user :user uploads new chunk file :num with :data to id :id using the WebDAV API
 	 * @Given user :user has uploaded new chunk file :num with :data to id :id
 	 *
 	 * @param string $user
@@ -1739,7 +1739,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user moves new chunk file with id :id to :dest using the API
+	 * @When user :user moves new chunk file with id :id to :dest using the WebDAV API
 	 * @Given user :user has moved new chunk file with id :id to :dest
 	 *
 	 * @param string $user
@@ -1755,7 +1755,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user cancels chunking-upload with id :id using the API
+	 * @When user :user cancels chunking-upload with id :id using the WebDAV API
 	 * @Given user :user has canceled new chunking-upload with id :id
 	 *
 	 * @param string $user
@@ -1770,7 +1770,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user moves new chunk file with id :id to :dest with size :size using the API
+	 * @When user :user moves new chunk file with id :id to :dest with size :size using the WebDAV API
 	 * @Given user :user has moved new chunk file with id :id to :dest with size :size
 	 *
 	 * @param string $user
@@ -1789,7 +1789,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user moves new chunk file with id :id to :dest with checksum :checksum using the API
+	 * @When user :user moves new chunk file with id :id to :dest with checksum :checksum using the WebDAV API
 	 * @Given user :user has moved new chunk file with id :id to :dest with checksum :checksum
 	 *
 	 * @param string $user
@@ -1866,7 +1866,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user favorites element :path using the API
+	 * @When user :user favorites element :path using the WebDAV API
 	 * @Given user :user has favorited element :path
 	 *
 	 * @param string $user
@@ -1883,7 +1883,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user unfavorites element :path using the API
+	 * @When user :user unfavorites element :path using the WebDAV API
 	 * @Given user :user has unfavorited element :path
 	 *
 	 * @param string $user
@@ -1929,7 +1929,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user stores etag of element :path using the API
+	 * @When user :user stores etag of element :path using the WebDAV API
 	 * @Given user :user has stored etag of element :path
 	 *
 	 * @param string $user
@@ -1983,8 +1983,8 @@ trait WebDav {
 	}
 
 	/**
-	 * @When an unauthenticated client connects to the dav endpoint using the API
-	 * @Given an unauthenticated client has connected to the dav endpoint using the API
+	 * @When an unauthenticated client connects to the dav endpoint using the WebDAV API
+	 * @Given an unauthenticated client has connected to the dav endpoint
 	 *
 	 * @return void
 	 */
@@ -2066,7 +2066,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes everything from folder "([^"]*)" using the API$/
+	 * @When /^user "([^"]*)" deletes everything from folder "([^"]*)" using the WebDAV API$/
 	 * @Given /^user "([^"]*)" has deleted everything from folder "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -2136,7 +2136,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user restores version index :versionIndex of file :path using the API
+	 * @When user :user restores version index :versionIndex of file :path using the WebDAV API
 	 * @Given user :user has restored version index :versionIndex of file :path
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -7,7 +7,7 @@ Feature: admin sharing settings
 	Scenario: disable share API
 		Given the admin has browsed to the admin sharing settings page
 		When the admin disables the share API using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value |
 			| files_sharing | api_enabled     | EMPTY |
@@ -15,7 +15,7 @@ Feature: admin sharing settings
 	Scenario: disable public sharing
 		Given the admin has browsed to the admin sharing settings page
 		When the admin disables share via link using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element  | value |
 			| files_sharing | public@@@enabled | EMPTY |
@@ -23,7 +23,7 @@ Feature: admin sharing settings
 	Scenario: disable public upload
 		Given the admin has browsed to the admin sharing settings page
 		When the admin disables public uploads using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value |
 			| files_sharing | public@@@upload | EMPTY |
@@ -31,7 +31,7 @@ Feature: admin sharing settings
 	Scenario: enable mail notification on public share
 		Given the admin has browsed to the admin sharing settings page
 		When the admin enables mail notification on public share using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element    | value |
 			| files_sharing | public@@@send_mail | 1     |
@@ -39,7 +39,7 @@ Feature: admin sharing settings
 	Scenario: disable social media share on public share
 		Given the admin has browsed to the admin sharing settings page
 		When the admin disables social media share on public share using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element       | value |
 			| files_sharing | public@@@social_share | EMPTY |
@@ -47,7 +47,7 @@ Feature: admin sharing settings
 	Scenario: enable enforce password protection for read-only links
 		Given the admin has browsed to the admin sharing settings page
 		When the admin enables enforce password protection for read-only links using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                              | value |
 			| files_sharing | public@@@password@@@enforced_for@@@read_only | 1     |
@@ -55,7 +55,7 @@ Feature: admin sharing settings
 	Scenario: enable enforce password protection for read and write links
 		Given the admin has browsed to the admin sharing settings page
 		When the admin enables enforce password protection for read and write links using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                               | value |
 			| files_sharing | public@@@password@@@enforced_for@@@read_write | 1     |
@@ -63,7 +63,7 @@ Feature: admin sharing settings
 	Scenario: enable enforce password protection for upload-only links
 		Given the admin has browsed to the admin sharing settings page
 		When the admin enables enforce password protection for upload only links using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                                | value |
 			| files_sharing | public@@@password@@@enforced_for@@@upload_only | 1     |
@@ -71,7 +71,7 @@ Feature: admin sharing settings
 	Scenario: disable resharing
 		Given the admin has browsed to the admin sharing settings page
 		When the admin disables resharing using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value     |
 			| files_sharing | resharing       | EMPTY     |
@@ -79,7 +79,7 @@ Feature: admin sharing settings
 	Scenario: disable sharing with groups
 		Given the admin has browsed to the admin sharing settings page
 		When the admin disables sharing with groups using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value     |
 			| files_sharing | group_sharing   | EMPTY     |
@@ -87,7 +87,7 @@ Feature: admin sharing settings
 	Scenario: enable restrict users to only share with users in their groups
 		Given the admin has browsed to the admin sharing settings page
 		When the admin enables restrict users to only share with their group members using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element               | value |
 			| files_sharing | share_with_group_members_only | 1     |
@@ -96,7 +96,7 @@ Feature: admin sharing settings
 		Given parameter "shareapi_enabled" of app "core" has been set to "no"
 		And the admin has browsed to the admin sharing settings page
 		When the admin enables the share API using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value |
 			| files_sharing | api_enabled     | 1     |
@@ -105,7 +105,7 @@ Feature: admin sharing settings
 		Given parameter "shareapi_allow_links" of app "core" has been set to "no"
 		And the admin has browsed to the admin sharing settings page
 		When the admin enables share via link using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element  | value |
 			| files_sharing | public@@@enabled | 1     |
@@ -114,7 +114,7 @@ Feature: admin sharing settings
 		Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
 		And the admin has browsed to the admin sharing settings page
 		When the admin enables public uploads using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value |
 			| files_sharing | public@@@upload | 1     |
@@ -123,7 +123,7 @@ Feature: admin sharing settings
 		Given parameter "shareapi_allow_public_send_mail" of app "core" has been set to "no"
 		And the admin has browsed to the admin sharing settings page
 		When the admin disables mail notification on public share using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element    | value |
 			| files_sharing | public@@@send_mail | EMPTY |
@@ -132,7 +132,7 @@ Feature: admin sharing settings
 		Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
 		And the admin has browsed to the admin sharing settings page
 		When the admin enables social media share on public share using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element       | value |
 			| files_sharing | public@@@social_share | 1     |
@@ -141,7 +141,7 @@ Feature: admin sharing settings
 		Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
 		And the admin has browsed to the admin sharing settings page
 		When the admin disables enforce password protection for read-only links using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                              | value |
 			| files_sharing | public@@@password@@@enforced_for@@@read_only | EMPTY |
@@ -150,7 +150,7 @@ Feature: admin sharing settings
 		Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "no"
 		And the admin has browsed to the admin sharing settings page
 		When the admin disables enforce password protection for read and write links using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                               | value |
 			| files_sharing | public@@@password@@@enforced_for@@@read_write | EMPTY |
@@ -159,7 +159,7 @@ Feature: admin sharing settings
 		Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "no"
 		And the admin has browsed to the admin sharing settings page
 		When the admin disables enforce password protection for upload only links using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                                | value |
 			| files_sharing | public@@@password@@@enforced_for@@@upload_only | EMPTY |
@@ -168,7 +168,7 @@ Feature: admin sharing settings
 		Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
 		And the admin has browsed to the admin sharing settings page
 		When the admin enables resharing using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value |
 			| files_sharing | resharing       | 1     |
@@ -177,7 +177,7 @@ Feature: admin sharing settings
 		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
 		And the admin has browsed to the admin sharing settings page
 		When the admin enables sharing with groups using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value |
 			| files_sharing | group_sharing   | 1     |
@@ -186,7 +186,7 @@ Feature: admin sharing settings
 		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
 		And the admin has browsed to the admin sharing settings page
 		When the admin disables restrict users to only share with their group members using the webUI
-		And the user retrieves the capabilities using the API
+		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element               | value |
 			| files_sharing | share_with_group_members_only | EMPTY |


### PR DESCRIPTION
## Description
1) Change ``Given using API version`` to ``Given using OCS API version``
2) Change other ``using the API`` to more specific ``using the xxx API``

## Motivation and Context
There are OCS API versions, and within that a sharing API version. That makes this step confusing:
```
Given using API version "1"
```
as it is not clear what "API" it is.

Similarly other test step text that says ``using the API`` can sometimes be unclear, because maybe there can be multiple ways to do something using an API endpoint(s). So be specific about the various APIs that exist - ``sharing API`` ``trashbin API`` ``webDAV API`` and so on.

## How Has This Been Tested?
- CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [x] Acceptance tests added

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
