### PR TITLE
Remove unneeded steps in recreate master key feature

### DIFF
--- a/tests/acceptance/features/apiMain/recreatemasterkey.feature
+++ b/tests/acceptance/features/apiMain/recreatemasterkey.feature
@@ -6,8 +6,6 @@ Feature: recreate-master-key
 		Given user "admin" has been created
 		And user "admin" has uploaded file "data/textfile.txt" to "/somefile.txt"
 		When the administrator successfully recreates the encryption masterkey using the occ command
-		And user "admin" logs in to a web-style session
-		And user "admin" logs in to a web-style session
 		Then the downloaded content when downloading file "/somefile.txt" for user "admin" with range "bytes=0-6" should be "This is"
 
 	@masterkey_encryption
@@ -15,8 +13,6 @@ Feature: recreate-master-key
 		Given user "user0" has been created
 		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"
 		When the administrator successfully recreates the encryption masterkey using the occ command
-		And user "admin" logs in to a web-style session
-		And user "user0" logs in to a web-style session
 		And user "user0" uploads chunk file "1" of "1" with "AA" to "/somefile.txt" using the WebDAV API
 		Then the downloaded content when downloading file "/somefile.txt" for user "user0" with range "bytes=0-3" should be "AA"
 

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -665,7 +665,6 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" logs in to a web-style session$/
 	 * @Given /^user "([^"]*)" has logged in to a web-style session$/
 	 *
 	 * @param string $user


### PR DESCRIPTION
## Description
Remove useless web-style session acceptance test steps

## Motivation and Context
Acceptance tests for recreating the master key check that the new master key works OK by checking that upload and download still works. The upload and download steps use WebDAV and do not need to have a web-style session. So the steps that setup the web-style session are not needed.

## How Has This Been Tested?
- locally install encryption and enable masterkey
- run the feature, including these scenarios tagged ``masterkey_encryption``
they pass

Note: these scenarios are not run in a regular drone API acceptance test run.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [x] Acceptance tests added

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
