### PR TITLE
Remove unused modifyTextOfFile

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -765,23 +765,6 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When user :user modifies text of :filename with text :text using the API
-	 * @Given user :user has modified text of :filename with text :text
-	 *
-	 * @param string $user
-	 * @param string $filename
-	 * @param string $text
-	 *
-	 * @return void
-	 */
-	public function modifyTextOfFile($user, $filename, $text) {
-		self::removeFile($this->getUserHome($user) . "/files", "$filename");
-		\file_put_contents(
-			$this->getUserHome($user) . "/files" . "$filename", "$text"
-		);
-	}
-
-	/**
 	 * @param string $name
 	 * @param string $size
 	 *


### PR DESCRIPTION
## Description
Remove unusued ``modifyTextOfFile`` method in acceptance tests.

## Motivation and Context
Cleanup unused stuff.
This method was trying to delete a file ffrom a user's local storage "underneath" ownCloud. It depended on the test code running on the same system with the same view of the file-system as the system-under-test. We do not want to depend on that anyway. If a step like this is required in future, then it will have to request the testing app to do its dirty work.

## How Has This Been Tested?
- CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
