### PR TITLE
Delete excess phpdoc public upload content

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -480,7 +480,6 @@ trait Sharing {
 	 * @param string $password
 	 * @param string $body
 	 * @param bool $autorename
-	 * @param bool $overwriting the upload is expected to overwrite an existing file
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -430,8 +430,6 @@ trait WebDav {
 	/**
 	 * @Then /^the downloaded content should be "([^"]*)" plus end-of-line$/
 	 *
-	 * @param string $fileName
-	 * @param string $user
 	 * @param string $content
 	 *
 	 * @return void
@@ -739,10 +737,6 @@ trait WebDav {
 
 	/**
 	 * @Then /^the properties response should contain an etag$/
-	 *
-	 * @param string $user
-	 * @param string $entry
-	 * @param string $path
 	 *
 	 * @return void
 	 * @throws \Exception

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -44,7 +44,6 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	 * WebUIAdminSharingSettingsContext constructor.
 	 *
 	 * @param AdminSharingSettingsPage $adminSharingSettingsPage
-	 * @param LoginPage $loginPage
 	 */
 	public function __construct(
 		AdminSharingSettingsPage $adminSharingSettingsPage

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -537,7 +537,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			foreach ($elementArray as $internalName => $displayName) {
 				// Matching should be case-insensitive on the internal or display name
 				if (((\stripos($internalName, $requiredString) !== false)
-						|| (\stripos($displayName, $requiredString) !== false))
+					|| (\stripos($displayName, $requiredString) !== false))
 					&& ($displayName !== $notToBeListed)
 					&& ($displayName !== $this->featureContext->getCurrentUser())
 					&& ($displayName !== $this->featureContext->getCurrentUserDisplayName())


### PR DESCRIPTION
## Description
Remove excess PHPdoc and other things found by ``phpcs`` from acceptance test code.

## Related Issue
PR #32118 

## Motivation and Context
PR above did not quite delete everything it could.

## How Has This Been Tested?
- CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
