### PR TITLE
Workaround mink selenium2 driver regressions

### DIFF
--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -27,6 +27,7 @@ use Page\FilesPageElement\SharingDialog;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\UnexpectedPageException;
 use WebDriver\Exception\NoSuchElement;
+use WebDriver\Exception\StaleElementReference;
 use WebDriver\Key;
 
 /**
@@ -138,6 +139,12 @@ class FilesPage extends FilesPageBasic {
 			// this seems to be a bug in MinkSelenium2Driver.
 			// Used to work fine in 1.3.1 but now throws this exception
 			// Actually all that we need does happen, so we just don't do anything
+		} catch (StaleElementReference $e) {
+			// At the end of processing setValue, MinkSelenium2Driver tries to blur
+			// away from the element. But we pressed enter which has already
+			// made the element go away. So we do not care about this exception.
+			// This issue started happening due to:
+			// https://github.com/minkphp/MinkSelenium2Driver/pull/286
 		}
 		$timeoutMsec = (int) $timeoutMsec;
 		$currentTime = \microtime(true);

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -88,7 +88,7 @@ class SharingDialog extends OwncloudPage {
 		$input, Session $session, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
 	) {
 		$shareWithField = $this->_findShareWithField();
-		$shareWithField->setValue($input);
+		$this->fillFieldAndKeepFocus($shareWithField, $input, $session);
 		$this->waitForAjaxCallsToStartAndFinish($session, $timeout_msec);
 		return $this->getAutocompleteNodeElement();
 	}

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -684,6 +684,29 @@ class OwncloudPage extends Page {
 	}
 
 	/**
+	 * Fill an element with a text value and keep focus on the element.
+	 *
+	 * The existing fillField and setValue methods have a problem. They blur out
+	 * of the field after entering the data. This is a problem when the focus
+	 * should remain in the field, e.g. for auto-complete fields. It is also a
+	 * problem for fields where we send an enter at the end of the field.
+	 * Regression caused by:
+	 * https://github.com/minkphp/MinkSelenium2Driver/pull/286
+	 *
+	 * @param NodeElement $element
+	 * @param string $value
+	 * @param Session $session
+	 *
+	 * @throws \Exception
+	 */
+	public function fillFieldAndKeepFocus(NodeElement $element, $value, $session) {
+		$driver = $session->getDriver();
+		$element = $driver->getWebDriverSession()->element('xpath', $element->getXpath());
+		$value = \str_repeat(Key::BACKSPACE . Key::DELETE, \strlen($element->attribute('value'))) . $value;
+		$element->postValue(['value' => [$value]]);
+	}
+
+	/**
 	 * Edge often returns whitespace before or after element text.
 	 * This is a convenient wrapper to ensure that text is trimmed
 	 * before using it in tests.


### PR DESCRIPTION
## Description
1) Catch ``StaleElementReference`` that is now thrown (unfortunately/wrongly) by ``fillField``
2) Implement our own code that will do a ``setValue`` because the existing code in ``MinkSelenium2Driver`` does not work in auto-complete fields.

## Related Issue
- Fixes #32143 

## Motivation and Context
Fix webUI tests that are broken by a regression in the ``MinkSelenium2Driver``

## How Has This Been Tested?
- run failing tests locally
- CI will check it all

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
