### PR TITLE
throw exception when json_decode of log fails

### DIFF
--- a/tests/acceptance/features/bootstrap/Logging.php
+++ b/tests/acceptance/features/bootstrap/Logging.php
@@ -59,6 +59,9 @@ trait Logging {
 		$lineNo = 0;
 		foreach ($expectedLogEntries as $expectedLogEntry) {
 			$logEntry = \json_decode($logLines[$lineNo], true);
+			if ($logEntry === null) {
+				throw new \Exception("the logline :\n" . $logLines[$lineNo] . " is not valid JSON");
+			}
 			foreach (\array_keys($expectedLogEntry) as $attribute) {
 				$expectedLogEntry[$attribute]
 					= $this->featureContext->substituteInLineCodes(
@@ -112,6 +115,9 @@ trait Logging {
 		$logLines = \file(LoggingHelper::getLogFilePath());
 		foreach ($logLines as $logLine) {
 			$logEntry = \json_decode($logLine, true);
+			if ($logEntry === null) {
+				throw new \Exception("the logline :\n" . $logLine . " is not valid JSON");
+			}
 			foreach ($logEntriesExpectedNotToExist as $logEntryExpectedNotToExist) {
 				$match = true; // start by assuming the worst, we match the unwanted log entry
 				foreach (\array_keys($logEntryExpectedNotToExist) as $attribute) {


### PR DESCRIPTION
## Description
throw exception when json_decode of log fails

## Motivation and Context
I had an empty line in the log file and wandered why tests failed, this would prevent that issue

## How Has This Been Tested?
created tests using it for an other PR

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
