### PR TITLE
Run fed tests on different srv

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,6 +10,41 @@ clone:
     depth: 50
 
 pipeline:
+  install-fed-server:
+    image: owncloudci/core
+    pull: true
+    version: ${FEDERATION_OC_VERSION}
+    core_path: /drone/fed-server
+    when:
+      matrix:
+        USE_FEDERATED_SERVER: true
+
+  configure-federation-server:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - cd /drone/fed-server
+      - php occ a:l
+      - php occ a:e testing
+      - php occ a:l
+      - php occ config:system:set trusted_domains 1 --value=server
+      - php occ config:system:set trusted_domains 2 --value=federated
+      - php occ log:manage --level 0
+      - php occ config:list
+      - echo "export TEST_SERVER_FED_URL=http://federated" > /drone/saved-settings.sh
+    when:
+      matrix:
+        USE_FEDERATED_SERVER: true
+
+  fix-permissions-federation-server:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - chown www-data /drone/fed-server -R
+    when:
+      matrix:
+        USE_FEDERATED_SERVER: true
+
   restore:
     image: plugins/s3-cache:1
     pull: true
@@ -222,13 +257,25 @@ pipeline:
       matrix:
         OWNCLOUD_LOG: true
 
+  federated-log:
+    image: owncloud/ubuntu:16.04
+    detach: true
+    pull: true
+    commands:
+      - tail -f /drone/fed-server/data/owncloud.log
+    when:
+      matrix:
+        OWNCLOUD_LOG: true
+        USE_FEDERATED_SERVER: true
+
   api-acceptance-tests:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
       - TEST_SERVER_URL=http://server
-      - TEST_SERVER_FED_URL=http://federated
     commands:
+      - touch /drone/saved-settings.sh
+      - . /drone/saved-settings.sh
       - ./tests/drone/test-acceptance.sh
     when:
       matrix:
@@ -242,11 +289,12 @@ pipeline:
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
       - TEST_SERVER_URL=http://server
-      - TEST_SERVER_FED_URL=http://federated
       - SKELETON_DIR=/drone/src/tests/acceptance/webUISkeleton
       - PLATFORM=Linux
       - MAILHOG_HOST=email
     commands:
+      - touch /drone/saved-settings.sh
+      - . /drone/saved-settings.sh
       - ./tests/drone/test-acceptance.sh --remote
     when:
       matrix:
@@ -355,7 +403,7 @@ services:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-      - APACHE_WEBROOT=/drone/src/
+      - APACHE_WEBROOT=/drone/fed-server/
     command: [ "/usr/local/bin/apachectl", "-e", "debug" , "-D", "FOREGROUND" ]
     when:
       matrix:
@@ -582,6 +630,7 @@ matrix:
       DB_TYPE: mariadb
       USE_SERVER: true
       USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
@@ -758,6 +807,7 @@ matrix:
       DB_TYPE: mariadb
       USE_SERVER: true
       USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -141,7 +141,6 @@ trait BasicStructure {
 		$this->adminPassword = $adminPassword;
 		$this->regularUserPassword = $regularUserPassword;
 		$this->localBaseUrl = $this->baseUrl;
-		$this->remoteBaseUrl = $this->baseUrl;
 		$this->currentServer = 'LOCAL';
 		$this->cookieJar = new \GuzzleHttp\Cookie\CookieJar();
 		$this->ocPath = $ocPath;
@@ -157,6 +156,8 @@ trait BasicStructure {
 		$testRemoteServerUrl = \getenv('TEST_SERVER_FED_URL');
 		if ($testRemoteServerUrl !== false) {
 			$this->remoteBaseUrl = \rtrim($testRemoteServerUrl, '/');
+		} else {
+			$this->remoteBaseUrl = $this->localBaseUrl;
 		}
 
 		// get the admin username from the environment (if defined)

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -37,7 +37,7 @@ class FeatureContext extends BehatVariablesContext {
 	protected function resetAppConfigs() {
 		// Remember the current capabilities
 		$this->getCapabilitiesCheckResponse();
-		$this->savedCapabilitiesXml = $this->getCapabilitiesXml();
+		$this->savedCapabilitiesXml[$this->getBaseUrl()] = $this->getCapabilitiesXml();
 		// Set the required starting values for testing
 		$this->setCapabilities($this->getCommonSharingConfigs());
 	}

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -287,6 +287,24 @@ trait WebDav {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" on "(LOCAL|REMOTE)" moves (?:file|folder|entry) "([^"]*)" to "([^"]*)" using the WebDAV API$/
+	 *
+	 * @param string $user
+	 * @param string $server
+	 * @param string $fileSource
+	 * @param string $fileDestination
+	 *
+	 * @return void
+	 */
+	public function userOnMovesFileUsingTheAPI(
+		$user, $server, $fileSource, $fileDestination
+	) {
+		$previousServer = $this->usingServer($server);
+		$this->userMovesFileUsingTheAPI($user, $fileSource, $fileDestination);
+		$this->usingServer($previousServer);
+	}
+
+	/**
 	 * @When /^user "([^"]*)" copies file "([^"]*)" to "([^"]*)" using the WebDAV API$/
 	 * @Given /^user "([^"]*)" has copied file "([^"]*)" to "([^"]*)"$/
 	 *
@@ -1217,6 +1235,22 @@ trait WebDav {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" on "(LOCAL|REMOTE)" uploads file "([^"]*)" to "([^"]*)" using the WebDAV API$/
+	 *
+	 * @param string $user
+	 * @param string $server
+	 * @param string $source
+	 * @param string $destination
+	 *
+	 * @return void
+	 */
+	public function userOnUploadsAFileTo($user, $server, $source, $destination) {
+		$previousServer = $this->usingServer($server);
+		$this->userUploadsAFileTo($user, $source, $destination);
+		$this->usingServer($previousServer);
+	}
+	
+	/**
 	 * @When user :user uploads file :source to :destination with chunks using the WebDAV API
 	 *
 	 * @param string $user
@@ -1553,6 +1587,22 @@ trait WebDav {
 			// 4xx and 5xx responses cause an exception
 			$this->response = $e->getResponse();
 		}
+	}
+
+	/**
+	 * @When /^user "([^"]*)" on "(LOCAL|REMOTE)" (?:deletes|unshares) (?:file|folder) "([^"]*)" using the WebDAV API$/
+	 * @Given /^user "([^"]*)" on "(LOCAL|REMOTE)" has (?:deleted|unshared) (?:file|folder) "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $server
+	 * @param string $file
+	 *
+	 * @return void
+	 */
+	public function userOnDeletesFile($user, $server, $file) {
+		$previousServer = $this->usingServer($server);
+		$this->userDeletesFile($user, $file);
+		$this->usingServer($previousServer);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -400,7 +400,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			$capability['testingApp'],
 			$capability['testingParameter'],
 			$value,
-			$this->getSavedCapabilitiesXml()
+			$this->getSavedCapabilitiesXml()[$this->featureContext->getBaseUrl()]
 		);
 		$this->addToSavedCapabilitiesChanges($change);
 	}
@@ -507,9 +507,10 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword()
 		);
-		$this->savedCapabilitiesXml = AppConfigHelper::getCapabilitiesXml(
-			$response
-		);
+		$this->savedCapabilitiesXml[$this->featureContext->getBaseUrl()] =
+			AppConfigHelper::getCapabilitiesXml(
+				$response
+			);
 		if ($this->oldCSRFSetting === null) {
 			$oldCSRFSetting = SetupHelper::runOcc(
 				['config:system:get', 'csrf.disabled']

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -125,6 +125,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user logs in with username :username and password :password to :server using the webUI
+	 * @Given the user has logged in with username :username and password :password to :server using the webUI
 	 *
 	 * @param string $username
 	 * @param string $password

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -911,7 +911,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword(),
 			$settings,
-			$this->webUIGeneralContext->getSavedCapabilitiesXml()
+			$this->webUIGeneralContext->getSavedCapabilitiesXml()[$this->featureContext->getBaseUrl()]
 		);
 		$this->webUIGeneralContext->addToSavedCapabilitiesChanges($change);
 	}

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -5,39 +5,61 @@ I want to share files with any users on other cloud storages
 So that other users have access to these files
 
 	Background:
-		Given the administrator has allowed http fallback for federation sharing
+		Given using server "REMOTE"
 		And these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
-		|user2   |1234    |User Two   |u2@oc.com.np|
-		|user3   |1234    |User Two   |u2@oc.com.np|
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+		And using server "LOCAL"
+		And these users have been created:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
 		And the user has browsed to the login page
-		And the user has logged in with username "user2" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "1234" using the webUI
 
-	Scenario: test the single steps of federation sharing
+	Scenario: test the single steps of sharing a folder to a remote server
 		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
 		And the user shares the folder "simple-empty-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
 		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+		And the user accepts the offered remote shares using the webUI
+		And using server "REMOTE"
+		Then as "user1" the folder "/simple-folder (2)" should exist
+		And as "user1" the file "/simple-folder (2)/lorem.txt" should exist
+		And as "user1" the folder "/simple-empty-folder (2)" should exist
+
+	Scenario: test the single steps of receiving a federation share
+		Given using server "REMOTE"
+		And these users have been created:
+			|username|password|displayname|email       |
+			|user2   |1234    |User Two   |u2@oc.com.np|
+			|user3   |1234    |User Two   |u2@oc.com.np|
+		And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+		And user "user2" from server "REMOTE" has shared "simple-empty-folder" with user "user1" from server "LOCAL"
+		And user "user3" from server "REMOTE" has shared "lorem.txt" with user "user1" from server "LOCAL"
+		And the user has reloaded the current page of the webUI
 		Then dialogs should be displayed on the webUI
-		| title        | content                                                                              |
-		| Remote share | Do you want to add the remote share /simple-folder from user2@%local_server_without_scheme%/?       |
-		| Remote share | Do you want to add the remote share /simple-empty-folder from user2@%local_server_without_scheme%/? |
+			| title        | content                                                                                              |
+			| Remote share | Do you want to add the remote share /simple-folder from user1@%remote_server_without_scheme%/?       |
+			| Remote share | Do you want to add the remote share /simple-empty-folder from user2@%remote_server_without_scheme%/? |
+			| Remote share | Do you want to add the remote share /lorem.txt from user3@%remote_server_without_scheme%/?           |
 		When the user accepts the offered remote shares using the webUI
-		Then the folder "simple-folder (2)" should be listed on the webUI
+		Then the file "lorem (2).txt" should be listed on the webUI
+		And the content of "lorem (2).txt" on the local server should be the same as the original "lorem.txt"
+		And the folder "simple-folder (2)" should be listed on the webUI
 		And the file "lorem.txt" should be listed in the folder "simple-folder (2)" on the webUI
-		And the content of "lorem.txt" on the remote server should be the same as the original "simple-folder/lorem.txt"
+		And the content of "lorem.txt" on the local server should be the same as the original "simple-folder/lorem.txt"
+		And the file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
 		And the folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
 		And the folder "simple-empty-folder (2)" should be listed in the shared-with-you page on the webUI
 
 	Scenario: declining a federation share on the webUI
-		Given user "user1" from server "LOCAL" has shared "/lorem.txt" with user "user2" from server "REMOTE"
+		Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
 		And the user has reloaded the current page of the webUI
 		When the user declines the offered remote shares using the webUI
 		Then the file "lorem (2).txt" should not be listed on the webUI
 		And the file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
 
 	@skipOnMICROSOFTEDGE
-	Scenario: share a folder with an remote user and prohibit deleting
+	Scenario: share a folder with an remote user and prohibit deleting - local server shares - remote server receives
 		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
 		And the user sets the sharing permissions of "user1@%remote_server_without_scheme% (federated)" for "simple-folder" using the webUI to
 		| delete | no |
@@ -46,53 +68,104 @@ So that other users have access to these files
 		And the user opens the folder "simple-folder (2)" using the webUI
 		Then it should not be possible to delete the file "lorem.txt" using the webUI
 
-	Scenario: overwrite a file in a received share
-		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+	@skipOnMICROSOFTEDGE
+	Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
+		When the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+		And the user shares the folder "simple-folder" with the remote user "user1@%local_server_without_scheme%" using the webUI
+		And the user sets the sharing permissions of "user1@%local_server_without_scheme% (federated)" for "simple-folder" using the webUI to
+		| delete | no |
+		And the user re-logs in with username "user1" and password "1234" to "%local_server%" using the webUI
 		And the user accepts the offered remote shares using the webUI
 		And the user opens the folder "simple-folder (2)" using the webUI
-		And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-		And the user re-logs in with username "user2" and password "1234" to "%local_server%" using the webUI
+		Then it should not be possible to delete the file "lorem.txt" using the webUI
+
+	Scenario: overwrite a file in a received share - local server shares - remote server receives
+		Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+		And user "user1" from server "REMOTE" has accepted the last pending share
+		When user "user1" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/lorem.txt" using the WebDAV API
+		And the user re-logs in with username "user1" and password "1234" to "%local_server%" using the webUI
 		And the user opens the folder "simple-folder" using the webUI
 		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" on the local server should be the same as the local "lorem.txt"
 
-	Scenario: upload a new file in a received share
-		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
-		And the user accepts the offered remote shares using the webUI
+	Scenario: overwrite a file in a received share - remote server shares - local server receives
+		Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+		And the user has reloaded the current page of the webUI
+		When the user accepts the offered remote shares using the webUI
 		And the user opens the folder "simple-folder (2)" using the webUI
-		And the user uploads the file "new-lorem.txt" using the webUI
-		And the user re-logs in with username "user2" and password "1234" to "%local_server%" using the webUI
+		And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
+		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+		And the user opens the folder "simple-folder" using the webUI
+		Then the file "lorem.txt" should be listed on the webUI
+		And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
+
+	Scenario: upload a new file in a received share - local server shares - remote server receives
+		Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+		And user "user1" from server "REMOTE" has accepted the last pending share
+		When user "user1" on "REMOTE" uploads file "filesForUpload/new-lorem.txt" to "simple-folder (2)/new-lorem.txt" using the WebDAV API
+		And the user re-logs in with username "user1" and password "1234" to "%local_server%" using the webUI
 		And the user opens the folder "simple-folder" using the webUI
 		Then the file "new-lorem.txt" should be listed on the webUI
 		And the content of "new-lorem.txt" on the local server should be the same as the local "new-lorem.txt"
 
-	Scenario: rename a file in a received share
-		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
-		And the user accepts the offered remote shares using the webUI
+	Scenario: upload a new file in a received share - remote server shares - local server receives
+		Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+		And the user has reloaded the current page of the webUI
+		When the user accepts the offered remote shares using the webUI
 		And the user opens the folder "simple-folder (2)" using the webUI
-		And the user renames the file "lorem-big.txt" to "renamed file.txt" using the webUI
-		And the user re-logs in with username "user2" and password "1234" to "%local_server%" using the webUI
+		And the user uploads the file "new-lorem.txt" using the webUI
+		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+		And the user opens the folder "simple-folder" using the webUI
+		Then the file "new-lorem.txt" should be listed on the webUI
+		And the content of "new-lorem.txt" on the remote server should be the same as the local "new-lorem.txt"
+
+	Scenario: rename a file in a received share - local server shares - remote server receives
+		Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+		And user "user1" from server "REMOTE" has accepted the last pending share
+		When user "user1" on "REMOTE" moves file "/simple-folder%20(2)/lorem-big.txt" to "/simple-folder%20(2)/renamed%20file.txt" using the WebDAV API
+		When the user re-logs in with username "user1" and password "1234" to "%local_server%" using the webUI
 		And the user opens the folder "simple-folder" using the webUI
 		Then the file "renamed file.txt" should be listed on the webUI
+		But the file "lorem-big.txt" should not be listed on the webUI
 		And the content of "renamed file.txt" on the local server should be the same as the original "simple-folder/lorem-big.txt"
+
+	Scenario: rename a file in a received share - remote server shares - local server receives
+		Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+		And the user has reloaded the current page of the webUI
+		When the user accepts the offered remote shares using the webUI
+		When the user opens the folder "simple-folder (2)" using the webUI
+		And the user renames the file "lorem-big.txt" to "renamed file.txt" using the webUI
+		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+		And the user opens the folder "simple-folder" using the webUI
+		Then the file "renamed file.txt" should be listed on the webUI
+		And the content of "renamed file.txt" on the remote server should be the same as the original "simple-folder/lorem-big.txt"
 		But the file "lorem-big.txt" should not be listed on the webUI
 
-	Scenario: delete a file in a received share
-		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
-		And the user accepts the offered remote shares using the webUI
+	Scenario: delete a file in a received share - local server shares - remote server receives
+		Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
+		And user "user1" from server "REMOTE" has accepted the last pending share
+		When user "user1" on "REMOTE" deletes file "simple-folder (2)/data.zip" using the WebDAV API
+		And the user re-logs in with username "user1" and password "1234" to "%local_server%" using the webUI
+		And the user opens the folder "simple-folder" using the webUI
+		Then the file "data.zip" should not be listed on the webUI
+
+	Scenario: delete a file in a received share - remote server shares - local server receives
+		Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+		And the user has reloaded the current page of the webUI
+		When the user accepts the offered remote shares using the webUI
 		And the user opens the folder "simple-folder (2)" using the webUI
 		And the user deletes the file "data.zip" using the webUI
-		And the user re-logs in with username "user2" and password "1234" to "%local_server%" using the webUI
+		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
 		And the user opens the folder "simple-folder" using the webUI
 		Then the file "data.zip" should not be listed on the webUI
 
 	Scenario: receive same name federation share from two users
-		Given user "user1" from server "LOCAL" has shared "/lorem.txt" with user "user2" from server "REMOTE"
-		And user "user3" from server "LOCAL" has shared "/lorem.txt" with user "user2" from server "REMOTE"
+		Given using server "REMOTE"
+		And these users have been created:
+			|username|password|displayname|email       |
+			|user2   |1234    |User Two   |u2@oc.com.np|
+		And user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
+		And user "user2" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
 		And the user has reloaded the current page of the webUI
 		When the user accepts the offered remote shares using the webUI
 		Then the file "lorem (2).txt" should be listed on the webUI
@@ -101,8 +174,8 @@ So that other users have access to these files
 		And the file "lorem (3).txt" should be listed in the shared-with-you page on the webUI
 
 	Scenario: unshare a federation share
-		Given user "user1" from server "LOCAL" has shared "/lorem.txt" with user "user2" from server "REMOTE"
-		And user "user2" from server "REMOTE" has accepted the last pending share
+		Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
+		And user "user1" from server "LOCAL" has accepted the last pending share
 		And the user has reloaded the current page of the webUI
 		When the user unshares the file "lorem (2).txt" using the webUI
 		Then the file "lorem (2).txt" should not be listed on the webUI
@@ -111,9 +184,9 @@ So that other users have access to these files
 		And the file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
 
 	Scenario: unshare a federation share from "share-with-you" page
-		Given user "user1" from server "LOCAL" has shared "/lorem.txt" with user "user2" from server "REMOTE"
-		And user "user2" from server "REMOTE" has accepted the last pending share
-		And the user has browsed to the shared-with-you page
+		Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
+		And user "user1" from server "LOCAL" has accepted the last pending share
+		And the user has reloaded the current page of the webUI
 		When the user unshares the file "lorem (2).txt" using the webUI
 		Then the file "lorem (2).txt" should not be listed on the webUI
 		And the file "lorem (2).txt" should not be listed in the files page on the webUI

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -43,7 +43,8 @@ So that public sharing is limited according to organization policy
 
 	@skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue_30392
 	Scenario: mount public link
-		Given these users have been created:
+		Given using server "REMOTE"
+		And these users have been created:
 		|username|password|displayname|email       |
 		|user2   |1234    |User One   |u1@oc.com.np|
 		When the user creates a new public link for the folder "simple-folder" using the webUI
@@ -59,7 +60,8 @@ So that public sharing is limited according to organization policy
 
 	@skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue_30392
 	Scenario: mount public link and overwrite file
-		Given these users have been created:
+		Given using server "REMOTE"
+		And these users have been created:
 		|username|password|displayname|email       |
 		|user2   |1234    |User One   |u1@oc.com.np|
 		When the user creates a new public link for the folder "simple-folder" using the webUI with


### PR DESCRIPTION
## Description
so far we used the same server when running federation tests, it was just available on different URLs
to make the tests more realistic, the two servers should be independent (not sharing data or database)

what was done in detail:
- everywhere the 'local' server is the current PR, the 'remote' server is currently the stable10-qa tarball
- refactored `run.sh` to set settings on both servers (including enable / disable apps and revert settings after test-run)
- refactor `@BeforeScenario` to set and remember settings on both servers
- refactor `@AfterScenario` to revert settings after test-run on both servers
- adjust federation sharing features
  - in the first place we want to test the 'LOCAL' server, that is the SUT
  - where needed doubled the tests, so shares came from local to remote and vice versa 
  - where needed reversed LOCAL & REMOTE, so we test results on LOCAL

## Related Issue
https://github.com/owncloud/QA/issues/538
and #32053 

## Motivation and Context
test what you fly, fly what you test :rocket: 

## How Has This Been Tested?
- ran various tests with php built-in server
- ran various tests with two separate servers
- ran tests in drone

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
