### PR TITLE
Add url parameter which open a specific details tab right away

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -87,6 +87,7 @@
 					fileActions: fileActions,
 					allowLegacyActions: true,
 					scrollTo: urlParams.scrollto,
+					detailTabId: urlParams.details,
 					filesClient: OC.Files.getClient(),
 					sorting: {
 						mode: $('#defaultFileSorting').val(),

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -256,7 +256,6 @@
 				this.$el.toggleClass('hide-hidden-files', !this._filesConfig.get('showhidden'));
 			}
 
-
 			if (_.isUndefined(options.detailsViewEnabled) || options.detailsViewEnabled) {
 				this._detailsView = new OCA.Files.DetailsView();
 				this._detailsView.$el.insertBefore(this.$el);
@@ -333,7 +332,7 @@
 
 			if (options.scrollTo) {
 				this.$fileList.one('updated', function() {
-					self.scrollTo(options.scrollTo);
+					self.scrollTo(options.scrollTo, options.detailTabId);
 				});
 			}
 
@@ -2519,9 +2518,13 @@
 			this.$el.find('.mask').remove();
 			this.$table.removeClass('hidden');
 		},
-		scrollTo:function(file) {
+		scrollTo:function(file, detailTabId) {
 			if (!_.isArray(file)) {
 				file = [file];
+			}
+			if (!_.isUndefined(detailTabId)) {
+				var filename = file[file.length - 1];
+				this.showDetailsView(filename, detailTabId);
 			}
 			this.highlightFiles(file, function($tr) {
 				$tr.addClass('searchresult');

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -143,11 +143,11 @@ class ViewController extends Controller {
 	 * @param string $fileid
 	 * @return TemplateResponse
 	 */
-	public function index($dir = '', $view = '', $fileid = null) {
+	public function index($dir = '', $view = '', $fileid = null, $details = null) {
 		$fileNotFound = false;
 		if ($fileid !== null) {
 			try {
-				return $this->showFile($fileid);
+				return $this->showFile($fileid, $details);
 			} catch (NotFoundException $e) {
 				$fileNotFound = true;
 			}
@@ -278,7 +278,7 @@ class ViewController extends Controller {
 	 * @NoCSRFRequired
 	 * @NoAdminRequired
 	 */
-	public function showFile($fileId) {
+	public function showFile($fileId, $details = null) {
 		$uid = $this->userSession->getUser()->getUID();
 		$baseFolder = $this->rootFolder->get($uid . '/files/');
 		$files = $baseFolder->getById($fileId);
@@ -307,6 +307,9 @@ class ViewController extends Controller {
 				$params['dir'] = $baseFolder->getRelativePath($file->getParent()->getPath());
 				// and scroll to the entry
 				$params['scrollto'] = $file->getName();
+			}
+			if ($details !== null) {
+				$params['details'] = $details;
 			}
 			$webUrl = $this->urlGenerator->linkToRoute('files.view.index', $params);
 

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2103,7 +2103,7 @@ trait WebDav {
 	 *
 	 * @return int
 	 */
-	private function getFileIdForPath($user, $path) {
+	public function getFileIdForPath($user, $path) {
 		try {
 			return WebDavHelper::getFileIdForPath(
 				$this->getBaseUrl(),

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -214,10 +214,14 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$this->currentFolder = '/' . \trim($folderName, '/');
 		$this->currentFile = $fileName;
 		$fileId = $this->featureContext->getFileIdForPath(
-			$this->featureContext->getCurrentUser(), $this->getCurrentFolderFilePath()
+			$this->featureContext->getCurrentUser(),
+			$this->getCurrentFolderFilePath()
 		);
-		$this->filesPage->browseToFileId($fileId, $this->currentFolder, $tabName);
+		$this->filesPage->browseToFileId(
+			$fileId, $this->currentFolder, $tabName
+		);
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
+		$this->filesPage->getDetailsDialog()->waitTillPageIsLoaded($this->getSession());
 	}
 
 	/**
@@ -232,7 +236,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		PHPUnit_Framework_Assert::assertNotNull(
 			$style,
 			'style attribute of details thumbnail is null'
-			);
+		);
 		PHPUnit_Framework_Assert::assertContains(
 			$this->getCurrentFolderFilePath(),
 			$style

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -72,6 +72,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @var ConflictDialog
 	 */
 	private $conflictDialog;
+
 	/**
 	 * Table of all files and folders that should have been deleted, stored so
 	 * that other steps can use the list to check if the deletion happened correctly
@@ -215,9 +216,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$fileId = $this->featureContext->getFileIdForPath(
 			$this->featureContext->getCurrentUser(), $this->getCurrentFolderFilePath()
 		);
-		$this->visitPath(
-			$this->featureContext->getBaseUrl() . '/index.php/apps/files/?dir=' . $folderName . '&fileid=' . $fileId . '&details=' . $tabName
-		);
+		$this->filesPage->browseToFileId($fileId, $this->currentFolder, $tabName);
 		$this->filesPage->waitTillPageIsLoaded($this->getSession());
 	}
 
@@ -228,10 +227,15 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @throws Exception
 	 */
 	public function theThumbnailShouldBeVisibleInTheDetailsPanel() {
-		$sharingDialog = $this->filesPage->getSharingDialog();
+		$detailsDialog = $this->filesPage->getDetailsDialog();
+		$style = $detailsDialog->findThumbnail()->getAttribute("style");
+		PHPUnit_Framework_Assert::assertNotNull(
+			$style,
+			'style attribute of details thumbnail is null'
+			);
 		PHPUnit_Framework_Assert::assertContains(
 			$this->getCurrentFolderFilePath(),
-			$sharingDialog->findThumbnail()->getAttribute("style")
+			$style
 		);
 	}
 
@@ -243,9 +247,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theTabNameDetailsPanelShouldBeVisible($tabName) {
-		$sharingDialog = $this->filesPage->getSharingDialog();
+		$detailsDialog = $this->filesPage->getDetailsDialog();
 		PHPUnit_Framework_Assert::assertTrue(
-			$sharingDialog->isDetailsPanelVisible($tabName),
+			$detailsDialog->isDetailsPanelVisible($tabName),
 			"the $tabName panel is not visible in the details panel"
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -25,6 +25,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\FilesPage;
+use Page\FilesPageElement\SharingDialog;
 use Page\PublicLinkFilesPage;
 use Page\SharedWithYouPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
@@ -55,6 +56,11 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @var SharedWithYouPage
 	 */
 	private $sharedWithYouPage;
+
+	/**
+	 *
+	 * @var SharingDialog
+	 */
 	private $sharingDialog;
 
 	/**
@@ -125,7 +131,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());
 		try {
-			$this->filesPage->closeSharingDialog();
+			$this->filesPage->closeDetailsDialog();
 		} catch (Exception $e) {
 			//we don't care
 		}
@@ -160,7 +166,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());
 		try {
-			$this->filesPage->closeSharingDialog();
+			$this->filesPage->closeDetailsDialog();
 		} catch (Exception $e) {
 			//we don't care
 		}
@@ -222,7 +228,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		//if there is no dialog open and we try to close it
 		//an exception will be thrown, but we do not care
 		try {
-			$this->filesPage->closeSharingDialog();
+			$this->filesPage->closeDetailsDialog();
 		} catch (Exception $e) {
 		}
 		$this->sharingDialog = $this->filesPage->openSharingDialog(
@@ -274,7 +280,8 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserClosesTheShareDialog() {
-		$this->sharingDialog->closeSharingDialog();
+		// The close button is for the whole details dialog.
+		$this->filesPage->closeDetailsDialog();
 	}
 
 	/**
@@ -619,7 +626,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		//if there is no dialog open and we try to close it
 		//an exception will be thrown, but we do not care
 		try {
-			$this->filesPage->closeSharingDialog();
+			$this->filesPage->closeDetailsDialog();
 		} catch (Exception $e) {
 		}
 		
@@ -639,9 +646,10 @@ class WebUISharingContext extends RawMinkContext implements Context {
 				"folder-shared.svg",
 				$row->findThumbnail()->getAttribute("style")
 			);
+			$detailsDialog = $this->filesPage->getDetailsDialog();
 			PHPUnit_Framework_Assert::assertContains(
 				"folder-shared.svg",
-				$sharingDialog->findThumbnail()->getAttribute("style")
+				$detailsDialog->findThumbnail()->getAttribute("style")
 			);
 		}
 		if ($sharedWithGroup !== "") {

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -23,6 +23,7 @@
 namespace Page;
 
 use Behat\Mink\Session;
+use Page\FilesPageElement\DetailsDialog;
 use Page\FilesPageElement\SharingDialog;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\UnexpectedPageException;
@@ -214,6 +215,16 @@ class FilesPage extends FilesPageBasic {
 	}
 
 	/**
+	 * gets a details dialog object
+	 *
+	 * @throws ElementNotFoundException
+	 * @return DetailsDialog
+	 */
+	public function getDetailsDialog() {
+		return $this->getPage("FilesPageElement\\DetailsDialog");
+	}
+
+	/**
 	 * gets a sharing dialog object
 	 *
 	 * @throws ElementNotFoundException
@@ -238,14 +249,15 @@ class FilesPage extends FilesPageBasic {
 	}
 
 	/**
-	 * closes an open sharing dialog
+	 * closes an open details dialog
+	 * the details dialog contains the comments, sharing, versions etc tabs
 	 *
 	 * @throws ElementNotFoundException
 	 * if no sharing dialog is open
 	 * @return void
 	 */
-	public function closeSharingDialog() {
-		$this->getPage('FilesPageElement\\SharingDialog')->closeSharingDialog();
+	public function closeDetailsDialog() {
+		$this->getDetailsDialog()->closeDetailsDialog();
 	}
 
 	/**
@@ -376,6 +388,35 @@ class FilesPage extends FilesPageBasic {
 			);
 		}
 		$this->verifyPage();
+		return $this;
+	}
+
+	/**
+	 * Browse directly to a particular file within a folder.
+	 *
+	 * The folder should open and scroll to the requested file.
+	 * If a details tab is specified, then the details panel for that file
+	 * should open with the requested tab selected.
+	 *
+	 * @param string $fileId
+	 * @param string $folderName
+	 * @param string|null $detailsTab e.g. comments, sharing, versions
+	 *
+	 * @return FilesPage
+	 */
+	public function browseToFileId(
+		$fileId, $folderName = '/', $detailsTab = null
+	) {
+		$url = \rtrim($this->getUrl(), '/');
+		$fullUrl = $url . '/?dir=' . $folderName . '&fileid=' . $fileId;
+
+		if ($detailsTab !== null) {
+			$detailsDialog = $this->getDetailsDialog();
+			$fullUrl = $fullUrl . '&details=' . $detailsDialog->getDetailsTabId($detailsTab);
+		}
+
+		$this->getDriver()->visit($fullUrl);
+
 		return $this;
 	}
 

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -214,6 +214,16 @@ class FilesPage extends FilesPageBasic {
 	}
 
 	/**
+	 * gets a sharing dialog object
+	 *
+	 * @throws ElementNotFoundException
+	 * @return SharingDialog
+	 */
+	public function getSharingDialog() {
+		return $this->getPage("FilesPageElement\\SharingDialog");
+	}
+
+	/**
 	 * opens the sharing dialog for a given file/folder name
 	 * returns the SharingDialog Object
 	 *

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @author Phil Davis <phil@jankaritech.com>
+ * @copyright Copyright (c) 2018 Phil Davis phil@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page\FilesPageElement;
+
+use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Session;
+use Page\FilesPageElement\SharingDialogElement\PublicLinkTab;
+use Page\OwncloudPage;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+
+/**
+ * The Details Dialog
+ *
+ */
+class DetailsDialog extends OwncloudPage {
+	/**
+	 *
+	 * @var string $path
+	 */
+	protected $path = '/index.php/apps/files/';
+
+	private $detailsDialogCloseXpath = "//div[@id='app-sidebar']//*[@class='close icon-close']";
+	private $thumbnailContainerXpath = ".//*[contains(@class,'thumbnailContainer')]";
+	private $thumbnailFromContainerXpath = "/a";
+	private $detailsTabId = [
+		'comments' => "commentsTabView",
+		'sharing' => "shareTabView",
+		'versions' => "versionsTabView"
+	];
+
+	/**
+	 * Lookup the id for the requested details tab.
+	 * If the id is not known, then return the passed-in parameter as the id.
+	 *
+	 * @param string $tabName e.g. comments, sharing, versions
+	 *
+	 * @return string
+	 */
+	public function getDetailsTabId($tabName) {
+		if (isset($this->detailsTabId[$tabName])) {
+			$tabId = $this->detailsTabId[$tabName];
+		} else {
+			$tabId = $tabName;
+		}
+
+		return $tabId;
+	}
+
+	/**
+	 * find the element that is the requested details tab
+	 *
+	 * @param string $tabName e.g. comments, sharing, versions
+	 *
+	 * @throws ElementNotFoundException
+	 * @return NodeElement|NULL
+	 */
+	private function _findDetailsTab($tabName) {
+		$tab = $this->findById(
+			$this->getDetailsTabId($tabName)
+		);
+		if ($tab === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" could not find details tab with id $tabName"
+			);
+		}
+		return $tab;
+	}
+
+	/**
+	 * checks if the requested tab in the details panel is visible
+	 *
+	 * @param string $tabName
+	 *
+	 * @return bool
+	 */
+	public function isDetailsPanelVisible($tabName) {
+		try {
+			$visible = $this->_findDetailsTab($tabName)->isVisible();
+		} catch (ElementNotFoundException $e) {
+			$visible = false;
+		}
+		return $visible;
+	}
+
+	/**
+	 *
+	 * @throws ElementNotFoundException
+	 * @return NodeElement of the whole container holding the thumbnail
+	 */
+	public function findThumbnailContainer() {
+		$thumbnailContainer = $this->find("xpath", $this->thumbnailContainerXpath);
+		if ($thumbnailContainer === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->thumbnailContainerXpath " .
+				"could not find thumbnailContainer"
+			);
+		}
+		return $thumbnailContainer;
+	}
+
+	/**
+	 *
+	 * @throws ElementNotFoundException
+	 * @return NodeElement
+	 */
+	public function findThumbnail() {
+		$thumbnailContainer = $this->findThumbnailContainer();
+		$thumbnail = $thumbnailContainer->find(
+			"xpath", $this->thumbnailFromContainerXpath
+		);
+		if ($thumbnail === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->thumbnailFromContainerXpath " .
+				"could not find thumbnail"
+			);
+		}
+		return $thumbnail;
+	}
+
+	/**
+	 * closes the details dialog panel
+	 *
+	 * @throws ElementNotFoundException
+	 * @return void
+	 */
+	public function closeDetailsDialog() {
+		$detailsDialogCloseButton = $this->find("xpath", $this->detailsDialogCloseXpath);
+		if ($detailsDialogCloseButton === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->detailsDialogCloseXpath " .
+				"could not find details-dialog-close-button"
+			);
+		}
+
+		try {
+			$detailsDialogCloseButton->click();
+		} catch (UnknownError $e) {
+			// Edge often throws UnknownError 'Invalid Argument' when trying to
+			// click the close button, even though the button was found above.
+			// Ignore it for now. Many tests could keep working without having
+			// closed the details dialog.
+			// TODO: Edge - if it keeps happening then find out why.
+			\error_log(
+				__METHOD__
+				. " UnknownError while doing detailsDialogCloseButton->click()"
+				. "\n-------------------------\n"
+				. $e->getMessage()
+				. "\n-------------------------\n"
+			);
+		}
+	}
+}

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -61,7 +61,7 @@ class SharingDialog extends OwncloudPage {
 	 * @throws ElementNotFoundException
 	 * @return NodeElement|NULL
 	 */
-	private function _findShareWithField() {
+	private function findShareWithField() {
 		$shareWithField = $this->find("xpath", $this->shareWithFieldXpath);
 		if ($shareWithField === null) {
 			throw new ElementNotFoundException(
@@ -79,7 +79,7 @@ class SharingDialog extends OwncloudPage {
 	 */
 	public function isShareWithFieldVisible() {
 		try {
-			$visible = $this->_findShareWithField()->isVisible();
+			$visible = $this->findShareWithField()->isVisible();
 		} catch (ElementNotFoundException $e) {
 			$visible = false;
 		}
@@ -98,7 +98,7 @@ class SharingDialog extends OwncloudPage {
 	public function fillShareWithField(
 		$input, Session $session, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
 	) {
-		$shareWithField = $this->_findShareWithField();
+		$shareWithField = $this->findShareWithField();
 		$this->fillFieldAndKeepFocus($shareWithField, $input, $session);
 		$this->waitForAjaxCallsToStartAndFinish($session, $timeout_msec);
 		return $this->getAutocompleteNodeElement();
@@ -354,7 +354,7 @@ class SharingDialog extends OwncloudPage {
 	 * @return string
 	 */
 	public function getShareWithTooltip() {
-		$shareWithField = $this->_findShareWithField();
+		$shareWithField = $this->findShareWithField();
 		$shareWithTooltip = $shareWithField->find(
 			"xpath", $this->shareWithTooltipXpath
 		);

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -45,13 +45,10 @@ class SharingDialog extends OwncloudPage {
 	private $shareWithTooltipXpath = "/..//*[@class='tooltip-inner']";
 	private $shareWithAutocompleteListXpath = ".//ul[contains(@class,'ui-autocomplete')]";
 	private $autocompleteItemsTextXpath = "//*[@class='autocomplete-item-text']";
-	private $shareWithCloseXpath = "//div[@id='app-sidebar']//*[@class='close icon-close']";
 	private $suffixToIdentifyGroups = " (group)";
 	private $suffixToIdentifyRemoteUsers = " (federated)";
 	private $sharerInformationXpath = ".//*[@class='reshare']";
 	private $sharedWithAndByRegEx = "^(?:[A-Z]\s)?Shared with you(?: and the group (.*))? by (.*)$";
-	private $thumbnailContainerXpath = ".//*[contains(@class,'thumbnailContainer')]";
-	private $thumbnailFromContainerXpath = "/a";
 	private $permissionsFieldByUserName = ".//*[@id='shareWithList']//*[@class='has-tooltip username' and .='%s']/..";
 	private $permissionLabelXpath = ".//label[@for='%s']";
 	private $showCrudsXpath = ".//*[@class='showCruds']";
@@ -73,22 +70,6 @@ class SharingDialog extends OwncloudPage {
 			);
 		}
 		return $shareWithField;
-	}
-
-	/**
-	 * checks if the requested tab in the details panel is visible
-	 *
-	 * @param string $tabName
-	 *
-	 * @return bool
-	 */
-	public function isDetailsPanelVisible($tabName) {
-		try {
-			$visible = $this->findById($tabName)->isVisible();
-		} catch (ElementNotFoundException $e) {
-			$visible = false;
-		}
-		return $visible;
 	}
 
 	/**
@@ -453,43 +434,6 @@ class SharingDialog extends OwncloudPage {
 	/**
 	 *
 	 * @throws ElementNotFoundException
-	 * @return NodeElement of the whole container holding the thumbnail
-	 */
-	public function findThumbnailContainer() {
-		$thumbnailContainer = $this->find("xpath", $this->thumbnailContainerXpath);
-		if ($thumbnailContainer === null) {
-			throw new ElementNotFoundException(
-				__METHOD__ .
-				" xpath $this->thumbnailContainerXpath " .
-				"could not find thumbnailContainer"
-			);
-		}
-		return $thumbnailContainer;
-	}
-
-	/**
-	 *
-	 * @throws ElementNotFoundException
-	 * @return NodeElement
-	 */
-	public function findThumbnail() {
-		$thumbnailContainer = $this->findThumbnailContainer();
-		$thumbnail = $thumbnailContainer->find(
-			"xpath", $this->thumbnailFromContainerXpath
-		);
-		if ($thumbnail === null) {
-			throw new ElementNotFoundException(
-				__METHOD__ .
-				" xpath $this->thumbnailFromContainerXpath " .
-				"could not find thumbnail"
-			);
-		}
-		return $thumbnail;
-	}
-
-	/**
-	 *
-	 * @throws ElementNotFoundException
 	 * @return PublicLinkTab
 	 */
 	public function openPublicShareTab() {
@@ -507,39 +451,5 @@ class SharingDialog extends OwncloudPage {
 		);
 		$publicLinkTab->initElement();
 		return $publicLinkTab;
-	}
-
-	/**
-	 * closes the sharing dialog panel
-	 *
-	 * @throws ElementNotFoundException
-	 * @return void
-	 */
-	public function closeSharingDialog() {
-		$shareDialogCloseButton = $this->find("xpath", $this->shareWithCloseXpath);
-		if ($shareDialogCloseButton === null) {
-			throw new ElementNotFoundException(
-				__METHOD__ .
-				" xpath $this->shareWithCloseXpath " .
-				"could not find share-dialog-close-button"
-			);
-		}
-
-		try {
-			$shareDialogCloseButton->click();
-		} catch (UnknownError $e) {
-			// Edge often throws UnknownError 'Invalid Argument' when trying to
-			// click the close button, even though the button was found above.
-			// Ignore it for now. Many tests could keep working without having
-			// closed the share dialog.
-			// TODO: Edge - if it keeps happening then find out why.
-			\error_log(
-				__METHOD__
-				. " UnknownError while doing shareDialogCloseButton->click()"
-				. "\n-------------------------\n"
-				. $e->getMessage()
-				. "\n-------------------------\n"
-			);
-		}
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -76,6 +76,36 @@ class SharingDialog extends OwncloudPage {
 	}
 
 	/**
+	 * checks if the requested tab in the details panel is visible
+	 *
+	 * @param string $tabName
+	 *
+	 * @return bool
+	 */
+	public function isDetailsPanelVisible($tabName) {
+		try {
+			$visible = $this->findById($tabName)->isVisible();
+		} catch (ElementNotFoundException $e) {
+			$visible = false;
+		}
+		return $visible;
+	}
+
+	/**
+	 * checks if the share-with field is visible
+	 *
+	 * @return bool
+	 */
+	public function isShareWithFieldVisible() {
+		try {
+			$visible = $this->_findShareWithField()->isVisible();
+		} catch (ElementNotFoundException $e) {
+			$visible = false;
+		}
+		return $visible;
+	}
+
+	/**
 	 * fills the "share-with" input field
 	 *
 	 * @param string $input

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -1,0 +1,40 @@
+@webUI @insulated
+Feature: browse directly to details tab
+As a user
+I want to be able to browse directly to display the details about a file
+So that I can see the details immediately without needing to click in the UI
+
+	Background:
+		Given these users have been created:
+		|username|password|displayname|email       |
+		|user1   |1234    |User One   |u1@oc.com.np|
+		And the user has browsed to the login page
+		And the user has logged in with username "user1" and password "1234" using the webUI
+
+	Scenario Outline: Browse directly to the sharing details of a file
+		When the user browses directly to display the "shareTabView" details of file "lorem.txt" in folder "<folder>"
+		Then the thumbnail should be visible in the details panel
+		And the "shareTabView" details panel should be visible
+		And the share-with field should be visible in the details panel
+		Examples:
+			| folder        |
+			| /             |
+			| simple-folder |
+
+	Scenario Outline: Browse directly to the comments details of a file
+		When the user browses directly to display the "commentsTabView" details of file "lorem.txt" in folder "<folder>"
+		Then the thumbnail should be visible in the details panel
+		And the "commentsTabView" details panel should be visible
+		Examples:
+			| folder        |
+			| /             |
+			| simple-folder |
+
+	Scenario Outline: Browse directly to the versions details of a file
+		When the user browses directly to display the "versionsTabView" details of file "lorem.txt" in folder "<folder>"
+		Then the thumbnail should be visible in the details panel
+		And the "versionsTabView" details panel should be visible
+		Examples:
+			| folder        |
+			| /             |
+			| simple-folder |

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -12,9 +12,9 @@ So that I can see the details immediately without needing to click in the UI
 		And the user has logged in with username "user1" and password "1234" using the webUI
 
 	Scenario Outline: Browse directly to the sharing details of a file
-		When the user browses directly to display the "shareTabView" details of file "lorem.txt" in folder "<folder>"
+		When the user browses directly to display the "sharing" details of file "lorem.txt" in folder "<folder>"
 		Then the thumbnail should be visible in the details panel
-		And the "shareTabView" details panel should be visible
+		And the "sharing" details panel should be visible
 		And the share-with field should be visible in the details panel
 		Examples:
 			| folder        |
@@ -22,18 +22,18 @@ So that I can see the details immediately without needing to click in the UI
 			| simple-folder |
 
 	Scenario Outline: Browse directly to the comments details of a file
-		When the user browses directly to display the "commentsTabView" details of file "lorem.txt" in folder "<folder>"
+		When the user browses directly to display the "comments" details of file "lorem.txt" in folder "<folder>"
 		Then the thumbnail should be visible in the details panel
-		And the "commentsTabView" details panel should be visible
+		And the "comments" details panel should be visible
 		Examples:
 			| folder        |
 			| /             |
 			| simple-folder |
 
 	Scenario Outline: Browse directly to the versions details of a file
-		When the user browses directly to display the "versionsTabView" details of file "lorem.txt" in folder "<folder>"
+		When the user browses directly to display the "versions" details of file "lorem.txt" in folder "<folder>"
 		Then the thumbnail should be visible in the details panel
-		And the "versionsTabView" details panel should be visible
+		And the "versions" details panel should be visible
 		Examples:
 			| folder        |
 			| /             |


### PR DESCRIPTION
## Description
This adds a url parameter to the files app which will open the details view and a specified tab for the given file in the scrollto parameter

## Motivation and Context
We need to open the share tab via url directly. Needed by the office online integration

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
![ezgif-3-aef97d1813](https://user-images.githubusercontent.com/1005065/43193307-fc3487c8-8fff-11e8-9793-af1be0bf5cd5.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
