### PR TITLE
Remove deprecated \OCP\User::getUser

### DIFF
--- a/apps/dav/lib/HookManager.php
+++ b/apps/dav/lib/HookManager.php
@@ -27,7 +27,6 @@ use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\SyncService;
 use OCP\IL10N;
 use OCP\IUser;
-use OCP\User;
 use OCP\IUserManager;
 use OCP\Util;
 use OC\Files\View;
@@ -165,7 +164,10 @@ class HookManager {
 	}
 
 	public function deleteZsyncMetadata($params) {
-		$view = new View('/'.User::getUser());
+		if (\OC::$server->getUserSession() === null || \OC::$server->getUserSession()->getUser() === null) {
+			return;
+		}
+		$view = new View('/' . \OC::$server->getUserSession()->getUser()->getUID());
 		$path = $params[\OC\Files\Filesystem::signal_param_path];
 		$path = 'files/' . \ltrim($path, '/');
 
@@ -196,7 +198,10 @@ class HookManager {
 	}
 
 	public function copyZsyncMetadata($params) {
-		$view = new View('/'.User::getUser());
+		if (\OC::$server->getUserSession() === null || \OC::$server->getUserSession()->getUser() === null) {
+			return;
+		}
+		$view = new View('/' . \OC::$server->getUserSession()->getUser()->getUID());
 		$from = $params[\OC\Files\Filesystem::signal_param_oldpath];
 		$from = 'files/' . \ltrim($from, '/');
 		$to = $params[\OC\Files\Filesystem::signal_param_newpath];

--- a/apps/dav/tests/unit/DAV/HookManagerTest.php
+++ b/apps/dav/tests/unit/DAV/HookManagerTest.php
@@ -31,6 +31,7 @@ use OCA\DAV\CardDAV\SyncService;
 use OCA\DAV\HookManager;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use Test\TestCase;
 
 class HookManagerTest extends TestCase {
@@ -41,7 +42,7 @@ class HookManagerTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->l10n = $this->getMockBuilder('OC\L10N\L10N')
+		$this->l10n = $this->getMockBuilder(L10N::class)
 			->disableOriginalConstructor()->getMock();
 		$this->l10n
 			->expects($this->any())

--- a/apps/dav/tests/unit/DAV/HookManagerZsyncTest.php
+++ b/apps/dav/tests/unit/DAV/HookManagerZsyncTest.php
@@ -18,10 +18,8 @@
  */
 namespace OCA\DAV\Tests\unit\DAV;
 
+use OCP\IUserSession;
 use Test\TestCase;
-use OCP\Files\NotFoundException;
-use OC\L10N\L10N;
-use OCA\DAV\CalDAV\BirthdayService;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\SyncService;
@@ -110,6 +108,9 @@ class HookManagerZsyncTest extends TestCase {
 		$card = $this->getMockBuilder(CardDavBackend::class)
 			->disableOriginalConstructor()
 			->getMock();
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn(self::TEST_ZSYNC_HOOKS_USER);
 
 		$hm = new HookManager($userManager, $syncService, $cal, $card, $l10n);
 		$hm->setup();

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -166,7 +166,7 @@ class Helper {
 		Filesystem::initMountPoints($owner);
 		$info = Filesystem::getFileInfo($target);
 		$ownerView = new View('/'.$owner.'/files');
-		if ($owner != User::getUser()) {
+		if ($owner != self::getUser()) {
 			$path = $ownerView->getPath($info['fileid']);
 		} else {
 			$path = $target;
@@ -212,10 +212,10 @@ class Helper {
 		// to a remote user with a federated cloud ID we use the current logged-in
 		// user. We need a valid local user to create the share
 		if (!$userManager->userExists($uid)) {
-			$uid = User::getUser();
+			$uid = self::getUser();
 		}
 		Filesystem::initMountPoints($uid);
-		if ($uid != User::getUser()) {
+		if ($uid != self::getUser()) {
 			$info = Filesystem::getFileInfo($filename);
 			$ownerView = new View('/'.$uid.'/files');
 			try {
@@ -303,5 +303,13 @@ class Helper {
 	 */
 	public static function setShareFolder($shareFolder) {
 		\OC::$server->getConfig()->setSystemValue('share_folder', $shareFolder);
+	}
+
+	public static function getUser() {
+		$user = \OC::$server->getUserSession() ? \OC::$server->getUserSession()->getUser() : null;
+		if ($user === null) {
+			return null;
+		}
+		return $user->getUID();
 	}
 }

--- a/apps/files_sharing/lib/Updater.php
+++ b/apps/files_sharing/lib/Updater.php
@@ -93,11 +93,11 @@ class Updater {
 	 * @param string $newPath new path relative to data/user/files
 	 */
 	private static function renameChildren($oldPath, $newPath) {
-		$absNewPath =  \OC\Files\Filesystem::normalizePath('/' . \OCP\User::getUser() . '/files/' . $newPath);
-		$absOldPath =  \OC\Files\Filesystem::normalizePath('/' . \OCP\User::getUser() . '/files/' . $oldPath);
+		$absNewPath =  \OC\Files\Filesystem::normalizePath('/' . Helper::getUser() . '/files/' . $newPath);
+		$absOldPath =  \OC\Files\Filesystem::normalizePath('/' . Helper::getUser() . '/files/' . $oldPath);
 
 		$mountManager = \OC\Files\Filesystem::getMountManager();
-		$mountedShares = $mountManager->findIn('/' . \OCP\User::getUser() . '/files/' . $oldPath);
+		$mountedShares = $mountManager->findIn('/' . Helper::getUser() . '/files/' . $oldPath);
 		foreach ($mountedShares as $mount) {
 			if ($mount->getStorage()->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
 				$mountPoint = $mount->getMountPoint();

--- a/apps/files_trashbin/ajax/delete.php
+++ b/apps/files_trashbin/ajax/delete.php
@@ -62,7 +62,8 @@ foreach ($list as $file) {
 		$timestamp = null;
 	}
 
-	OCA\Files_Trashbin\Trashbin::delete($filename, \OCP\User::getUser(), $timestamp);
+	$userId = \OC::$server->getUserSession()->getUser()->getUID();
+	OCA\Files_Trashbin\Trashbin::delete($filename, $userId, $timestamp);
 	if (OCA\Files_Trashbin\Trashbin::file_exists($filename, $timestamp)) {
 		$error[] = $filename;
 		\OCP\Util::writeLog('trashbin', 'can\'t delete ' . $filename . ' permanently.', \OCP\Util::ERROR);

--- a/apps/files_trashbin/ajax/isEmpty.php
+++ b/apps/files_trashbin/ajax/isEmpty.php
@@ -26,6 +26,7 @@ OCP\JSON::checkLoggedIn();
 OCP\JSON::callCheck();
 \OC::$server->getSession()->close();
 
-$trashStatus = OCA\Files_Trashbin\Trashbin::isEmpty(OCP\User::getUser());
+$userId = \OC::$server->getUserSession()->getUser()->getUID();
+$trashStatus = OCA\Files_Trashbin\Trashbin::isEmpty($userId);
 
-OCP\JSON::success(["data" => ["isEmpty" => $trashStatus]]);
+OCP\JSON::success(['data' => ['isEmpty' => $trashStatus]]);

--- a/apps/files_trashbin/ajax/list.php
+++ b/apps/files_trashbin/ajax/list.php
@@ -32,9 +32,10 @@ $data = [];
 
 // make filelist
 try {
-	$files = \OCA\Files_Trashbin\Helper::getTrashFiles($dir, \OCP\User::getUser(), $sortAttribute, $sortDirection);
+	$userId = \OC::$server->getUserSession()->getUser()->getUID();
+	$files = \OCA\Files_Trashbin\Helper::getTrashFiles($dir, $userId, $sortAttribute, $sortDirection);
 } catch (Exception $e) {
-	\header("HTTP/1.0 404 Not Found");
+	\header('HTTP/1.0 404 Not Found');
 	exit();
 }
 

--- a/apps/files_trashbin/ajax/undelete.php
+++ b/apps/files_trashbin/ajax/undelete.php
@@ -43,7 +43,8 @@ if (isset($_POST['allfiles']) && (string)$_POST['allfiles'] === 'true') {
 	if ($dir === '' || $dir === '/') {
 		$dirListing = false;
 	}
-	foreach (OCA\Files_Trashbin\Helper::getTrashFiles($dir, \OCP\User::getUser()) as $file) {
+	$userId = \OC::$server->getUserSession()->getUser()->getUID();
+	foreach (OCA\Files_Trashbin\Helper::getTrashFiles($dir, $userId) as $file) {
 		$fileName = $file['name'];
 		if (!$dirListing) {
 			$fileName .= '.d' . $file['mtime'];

--- a/apps/files_trashbin/lib/Hooks.php
+++ b/apps/files_trashbin/lib/Hooks.php
@@ -44,10 +44,13 @@ class Hooks {
 		}
 	}
 
-	public static function post_write_hook($params) {
-		$user = \OCP\User::getUser();
-		if (!empty($user)) {
-			Trashbin::resizeTrash($user);
+	public static function post_write_hook() {
+		if (\OC::$server->getUserSession() === null || \OC::$server->getUserSession()->getUser() === null) {
+			return;
+		}
+		$userId = \OC::$server->getUserSession()->getUser()->getUID();
+		if (!empty($userId)) {
+			Trashbin::resizeTrash($userId);
 		}
 	}
 }

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -113,14 +113,15 @@ class Trashbin {
 		// to a remote user with a federated cloud ID we use the current logged-in
 		// user. We need a valid local user to move the file to the right trash bin
 		if (!$userManager->userExists($uid)) {
-			$uid = User::getUser();
+			$user = \OC::$server->getUserSession()->getUser();
+			$uid= $user ? $user->getUID() : null;
 		}
 		if (!$uid) {
 			// no owner, usually because of share link from ext storage
 			return [null, null];
 		}
 		Filesystem::initMountPoints($uid);
-		if ($uid != User::getUser()) {
+		if ($uid != \OC::$server->getUserSession()->getUser()->getUID()) {
 			$info = Filesystem::getFileInfo($filename);
 			$ownerView = new View('/' . $uid . '/files');
 			try {
@@ -392,7 +393,7 @@ class Trashbin {
 				$copyKeysResult = $sourceStorage->retainKeys($filename, $owner, $ownerPath, $timestamp, $sourceStorage);
 			}
 
-			$user = User::getUser();
+			$user = \OC::$server->getUserSession()->getUser()->getUID();
 			$rootView = new View('/');
 
 			if ($rootView->is_dir($owner . '/files_versions/' . $ownerPath)) {
@@ -475,7 +476,7 @@ class Trashbin {
 	 * @return bool true on success, false otherwise
 	 */
 	public static function restore($file, $filename, $timestamp) {
-		$user = User::getUser();
+		$user = \OC::$server->getUserSession()->getUser()->getUID();
 		$view = new View('/' . $user);
 
 		$location = '';
@@ -543,7 +544,7 @@ class Trashbin {
 	 */
 	private static function restoreVersions(View $view, $file, $filename, $uniqueFilename, $location, $timestamp) {
 		if (\OCP\App::isEnabled('files_versions')) {
-			$user = User::getUser();
+			$user = \OC::$server->getUserSession()->getUser()->getUID();
 			$rootView = new View('/');
 
 			$target = Filesystem::normalizePath('/' . $location . '/' . $uniqueFilename);
@@ -579,7 +580,7 @@ class Trashbin {
 	 * delete all files from the trash
 	 */
 	public static function deleteAll() {
-		$user = User::getUser();
+		$user = \OC::$server->getUserSession()->getUser()->getUID();
 		$view = new View('/' . $user);
 		$fileInfos = $view->getDirectoryContent('files_trashbin/files');
 
@@ -705,7 +706,7 @@ class Trashbin {
 	 * @return bool true if file exists, otherwise false
 	 */
 	public static function file_exists($filename, $timestamp = null) {
-		$user = User::getUser();
+		$user = \OC::$server->getUserSession()->getUser()->getUID();
 		$view = new View('/' . $user);
 
 		if ($timestamp) {

--- a/apps/files_versions/lib/Hooks.php
+++ b/apps/files_versions/lib/Hooks.php
@@ -134,7 +134,8 @@ class Hooks {
 
 			// if we rename a movable mount point, then the versions don't have
 			// to be renamed
-			$absOldPath = \OC\Files\Filesystem::normalizePath('/' . \OCP\User::getUser() . '/files' . $params['oldpath']);
+			$userId = \OC::$server->getUserSession()->getUser()->getUID();
+			$absOldPath = \OC\Files\Filesystem::normalizePath('/' . $userId . '/files' . $params['oldpath']);
 			$manager = \OC\Files\Filesystem::getMountManager();
 			$mount = $manager->find($absOldPath);
 			$internalPath = $mount->getInternalPath($absOldPath);
@@ -142,7 +143,7 @@ class Hooks {
 				return;
 			}
 
-			$view = new \OC\Files\View(\OCP\User::getUser() . '/files');
+			$view = new \OC\Files\View($userId . '/files');
 			if ($view->file_exists($params['newpath'])) {
 				Storage::store($params['newpath']);
 			} else {

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -96,11 +96,12 @@ class Storage {
 		// if the user with the UID doesn't exists, e.g. because the UID points
 		// to a remote user with a federated cloud ID we use the current logged-in
 		// user. We need a valid local user to create the versions
+		$sessionUserId = \OC_User::getUser();
 		if (!$userManager->userExists($uid)) {
-			$uid = User::getUser();
+			$uid = $sessionUserId;
 		}
 		Filesystem::initMountPoints($uid);
-		if ($uid != User::getUser()) {
+		if ($uid != $sessionUserId) {
 			$info = Filesystem::getFileInfo($filename);
 			$ownerView = new View('/'.$uid.'/files');
 			try {

--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -117,9 +117,10 @@ if (isset($_POST['action'], $_POST['itemType'], $_POST['itemSource'])) {
 				$recipientList = $group->searchUsers('');
 			}
 			// don't send a mail to the user who shared the file
-			$recipientList = \array_filter($recipientList, function ($user) {
+			$sessionUser = \OC::$server->getUserSession()->getUser()->getUID();
+			$recipientList = \array_filter($recipientList, function ($user) use ($sessionUser) {
 				/** @var IUser $user */
-				return $user->getUID() !== \OCP\User::getUser();
+				return $user->getUID() !== $sessionUser;
 			});
 
 			$mailNotification = new \OC\Share\MailNotifications(

--- a/lib/private/AppFramework/Core/API.php
+++ b/lib/private/AppFramework/Core/API.php
@@ -52,7 +52,7 @@ class API implements IApi {
 	 * @deprecated Use \OC::$server->getUserSession()->getUser()->getUID()
 	 */
 	public function getUserId() {
-		return \OCP\User::getUser();
+		return \OC::$server->getUserSession()->getUser()->getUID();
 	}
 
 	/**

--- a/lib/private/Files/External/LegacyUtil.php
+++ b/lib/private/Files/External/LegacyUtil.php
@@ -190,8 +190,9 @@ class LegacyUtil {
 		if (self::$skipTest) {
 			return StorageNotAvailableException::STATUS_SUCCESS;
 		}
+		$sessionUserId = \OC::$server->getUserSession()->getUser()->getUID();
 		foreach ($options as $key => $option) {
-			$options[$key] = self::setUserVars(\OCP\User::getUser(), $option);
+			$options[$key] = self::setUserVars($sessionUserId, $option);
 		}
 		if (\class_exists($class)) {
 			try {

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -2163,7 +2163,8 @@ class View {
 			throw new NotFoundException($this->getAbsolutePath($filename) . ' not found');
 		}
 		$uid = $info->getOwner()->getUID();
-		if ($uid != \OCP\User::getUser()) {
+		$sessionUserId = \OC::$server->getUserSession()->getUser()->getUID();
+		if ($uid != $sessionUserId) {
 			Filesystem::initMountPoints($uid);
 			$ownerView = new View('/' . $uid . '/files');
 			try {

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -1011,8 +1011,7 @@ class Share extends Constants {
 	 */
 	public static function unshareFromSelf($itemType, $itemOrigin, $originIsSource = false) {
 		$originType = ($originIsSource) ? 'source' : 'target';
-		$uid = \OCP\User::getUser();
-
+		$uid = \OC::$server->getUserSession()->getUser()->getUID();
 		if ($itemType === 'file' || $itemType === 'folder') {
 			$statement = 'SELECT * FROM `*PREFIX*share` WHERE `item_type` = ? and `file_' . $originType . '` = ?';
 		} else {
@@ -1954,7 +1953,8 @@ class Share extends Constants {
 		}
 
 		// group items if we are looking for items shared with the current user
-		if (isset($shareWith) && $shareWith === \OCP\User::getUser()) {
+		$sessionUserId = \OC::$server->getUserSession()->getUser()->getUID();
+		if (isset($shareWith) && $shareWith === $sessionUserId) {
 			$items = self::groupItems($items, $itemType);
 		}
 
@@ -2151,9 +2151,10 @@ class Share extends Constants {
 			} else {
 				$users = self::usersInGroup($shareWith['group']);
 			}
+			$sessionUserId = \OC::$server->getUserSession()->getUser()->getUID();
 			// remove current user from list
-			if (\in_array(\OCP\User::getUser(), $users)) {
-				unset($users[\array_search(\OCP\User::getUser(), $users)]);
+			if (\in_array($sessionUserId, $users)) {
+				unset($users[\array_search($sessionUserId, $users)]);
 			}
 			$groupItemTarget = Helper::generateTarget($itemType, $itemSource,
 				$shareType, $shareWith['group'], $uidOwner, $suggestedItemTarget);

--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -603,7 +603,8 @@ class OC_Helper {
 			$sourceStorage = $storage->getSourceStorage();
 		}
 		if ($includeExtStorage) {
-			$quota = OC_Util::getUserQuota(\OCP\User::getUser());
+			$sessionUserId = \OC::$server->getUserSession()->getUser()->getUID();
+			$quota = OC_Util::getUserQuota($sessionUserId);
 			if ($quota !== \OCP\Files\FileInfo::SPACE_UNLIMITED) {
 				// always get free space / total space from root + mount points
 				return self::getGlobalStorageInfo();
@@ -655,7 +656,8 @@ class OC_Helper {
 	 * @return array
 	 */
 	private static function getGlobalStorageInfo() {
-		$quota = OC_Util::getUserQuota(\OCP\User::getUser());
+		$sessionUserId = \OC::$server->getUserSession()->getUser()->getUID();
+		$quota = OC_Util::getUserQuota($sessionUserId);
 
 		$rootInfo = \OC\Files\Filesystem::getFileInfo('', 'ext');
 		$used = $rootInfo['size'];

--- a/lib/public/User.php
+++ b/lib/public/User.php
@@ -45,15 +45,6 @@ namespace OCP;
  * @since 5.0.0
  */
 class User {
-	/**
-	 * Get the user id of the user currently logged in.
-	 * @return string uid or false
-	 * @deprecated 8.0.0 Use \OC::$server->getUserSession()->getUser()->getUID()
-	 * @since 5.0.0
-	 */
-	public static function getUser() {
-		return \OC_User::getUser();
-	}
 
 	/**
 	 * Get a list of all users


### PR DESCRIPTION
## Description
 \OCP\User::getUser was deprecated in ownCloud 8 - time to say good bye

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
