### PR TITLE
Fix decrypt of single user in decrypt-all command

### DIFF
--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -180,6 +180,14 @@ class DecryptAll {
 				$userNo++;
 			});
 		} else {
+			if (\OC::$server->getConfig()->getAppValue('encryption', 'userSpecificKey', '0') !== '0') {
+				$userObject = $this->userManager->get($user);
+				if ($userObject !== null) {
+					if ($this->prepareEncryptionModules($userObject->getUID()) === false) {
+						return false;
+					}
+				}
+			}
 			$this->decryptUsersFiles($user, $progress, "$user (1 of 1)");
 		}
 

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -263,7 +263,7 @@ class DecryptAllTest extends TestCase {
 					$this->logger
 				]
 			)
-			->setMethods(['decryptUsersFiles'])
+			->setMethods(['decryptUsersFiles', 'prepareEncryptionModules'])
 			->getMock();
 
 		$this->invokePrivate($instance, 'input', [$this->inputInterface]);
@@ -286,14 +286,36 @@ class DecryptAllTest extends TestCase {
 			$instance->expects($this->at(1))
 				->method('decryptUsersFiles')
 				->with('user2');
+			\OC::$server->getConfig()->setAppValue('encryption', 'userSpecificKey', '0');
 		} else {
-			$instance->expects($this->once())
-				->method('decryptUsersFiles')
-				->with($user);
+			\OC::$server->getConfig()->setAppValue('encryption', 'userSpecificKey', '1');
+			$iUser = $this->createMock(IUser::class);
+			$iUser->expects($this->once())
+				->method('getUID')
+				->willReturn($user);
+			$this->userManager->expects($this->once())
+				->method('get')
+				->willReturn($iUser);
+			if ($user === 'userfails') {
+				$instance->expects($this->once())
+					->method('prepareEncryptionModules')
+					->willReturn(false);
+			} else {
+				$instance->expects($this->once())
+					->method('decryptUsersFiles')
+					->with($user);
+				$instance->expects($this->once())
+					->method('prepareEncryptionModules')
+					->willReturn(true);
+			}
 		}
 
 		$result = $this->invokePrivate($instance, 'decryptAllUsersFiles', [$user]);
-		$this->assertEquals(true, $result);
+		if ($user !== 'userfails') {
+			$this->assertEquals(true, $result);
+		} else {
+			$this->assertFalse($result);
+		}
 	}
 
 	public function providerDecryptAllUsersFilesUsersSeen() {
@@ -405,6 +427,7 @@ class DecryptAllTest extends TestCase {
 	public function dataTestDecryptAllUsersFiles() {
 		return [
 			['user1'],
+			['userfails'],
 			['']
 		];
 	}


### PR DESCRIPTION
When a user is passed as an argument to decrypt-all
command the decryption was failing. This change helps
to fix the issue.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When a user is passed as an argument to `decrypt-all` command the decryption was not happening. The root cause of the issue found was `prepareEncryptionModules()` was not called when single user is passed to `decrypt-all` command.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/32161

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When a user is passed as an argument to `decrypt-all` command the decryption was not happening.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: master branch of core + master branch of encryption app
- create 2 users `admin` and `user1`
- Try to enable encryption with user keys. And then login to both `admin` and `user1`
- Now try to run `decrypt-all` command with `user1`
- The files under `user1` are decrypted.
- This is also tested with masterkey encryption.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
