### PR TITLE
[Stable10]  Fix warning in logs while moving FutureFile after chunk assembly

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -205,30 +205,26 @@ class Server {
 					)
 				);
 
-				$filePropertiesPlugin = new FileCustomPropertiesPlugin(
-					new FileCustomPropertiesBackend(
-						$this->server->tree,
-						\OC::$server->getDatabaseConnection(),
-						\OC::$server->getUserSession()->getUser()
-					)
-				);
-				$filePropertiesPlugin->pathFilter = function ($path) {
-					// oh yes, we could set custom properties on the user's storage root
-					return \strpos($path, 'files/') === 0;
-				};
-				$this->server->addPlugin($filePropertiesPlugin);
-
-				$miscPropertiesPlugin = new \Sabre\DAV\PropertyStorage\Plugin(
-					new MiscCustomPropertiesBackend(
-						$this->server->tree,
-						\OC::$server->getDatabaseConnection(),
-						\OC::$server->getUserSession()->getUser()
-					)
-				);
-				$miscPropertiesPlugin->pathFilter = function ($path) {
-					return \strpos($path, 'files/') !== 0;
-				};
-				$this->server->addPlugin($miscPropertiesPlugin);
+				if ($this->isRequestForSubtree(['files', 'uploads'])) {
+					//For files only
+					$filePropertiesPlugin = new FileCustomPropertiesPlugin(
+						new FileCustomPropertiesBackend(
+							$this->server->tree,
+							\OC::$server->getDatabaseConnection(),
+							\OC::$server->getUserSession()->getUser()
+						)
+					);
+					$this->server->addPlugin($filePropertiesPlugin);
+				} else {
+					$miscPropertiesPlugin = new \Sabre\DAV\PropertyStorage\Plugin(
+						new MiscCustomPropertiesBackend(
+							$this->server->tree,
+							\OC::$server->getDatabaseConnection(),
+							\OC::$server->getUserSession()->getUser()
+						)
+					);
+					$this->server->addPlugin($miscPropertiesPlugin);
+				}
 
 				if ($view !== null) {
 					$this->server->addPlugin(

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -61,12 +61,6 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
 
-    apiWebdav:
-      paths:
-        - %paths.base%/../features/apiWebdav
-      contexts:
-        - FeatureContext: *common_feature_context_params
-
     apiSharingNotifications:
       paths:
         - %paths.base%/../features/apiSharingNotifications
@@ -87,6 +81,14 @@ default:
         - WebUIFilesContext:
         - WebUIPersonalGeneralSettingsContext:
         - EmailContext:
+
+    apiWebdav:
+      paths:
+        - %paths.base%/../features/apiWebdav
+      context: *common_webui_suite_context
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - LoggingContext:
 
     webUIAdminSettings:
       paths:

--- a/tests/acceptance/features/apiWebdav/webdav-related-new-endpoint.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related-new-endpoint.feature
@@ -4,6 +4,8 @@ Feature: webdav-related-new-endpoint
 		Given using OCS API version "1"
 		And using new DAV path
 		And user "user0" has been created
+		And the owncloud log level has been set to debug
+		And the owncloud log has been cleared
 
 	## Specific Scenario Outlines for new endpoint	
 
@@ -14,6 +16,9 @@ Feature: webdav-related-new-endpoint
 			| 3 | CCCCC |
 		Then as "user0" the file "/myChunkedFile.txt" should exist
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
+		And the log file should not contain any log-entries containing these attributes:
+			| app |
+			| dav |
 
 	Scenario: Upload chunked file desc with new chunking
 		When user "user0" uploads the following chunks to "/myChunkedFile.txt" with new chunking and using the WebDAV API
@@ -22,6 +27,9 @@ Feature: webdav-related-new-endpoint
 			| 1 | AAAAA |
 		Then as "user0" the file "/myChunkedFile.txt" should exist
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
+		And the log file should not contain any log-entries containing these attributes:
+			| app |
+			| dav |
 
 	Scenario: Upload chunked file random with new chunking
 		When user "user0" uploads the following chunks to "/myChunkedFile.txt" with new chunking and using the WebDAV API
@@ -30,6 +38,9 @@ Feature: webdav-related-new-endpoint
 			| 1 | AAAAA |
 		Then as "user0" the file "/myChunkedFile.txt" should exist
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
+		And the log file should not contain any log-entries containing these attributes:
+			| app |
+			| dav |
 
 	Scenario: Checking file id after a move overwrite using new chunking endpoint
 		Given user "user0" has copied file "/textfile0.txt" to "/existingFile.txt"
@@ -40,6 +51,9 @@ Feature: webdav-related-new-endpoint
 			| 3 | CCCCC |
 		Then user "user0" file "/existingFile.txt" should have the previously stored id
 		And the content of file "/existingFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
+		And the log file should not contain any log-entries containing these attributes:
+			| app |
+			| dav |
 
 	Scenario: Checking file id after a move between received shares
 		Given user "user1" has been created
@@ -102,6 +116,9 @@ Feature: webdav-related-new-endpoint
 		Then the HTTP status code should be "201"
 		And as "user0" the file "/myChunkedFile.txt" should exist
 		And the content of file "/myChunkedFile.txt" for user "user0" should be "AAAAABBBBBCCCCC"
+		And the log file should not contain any log-entries containing these attributes:
+			| app |
+			| dav |
 
 	Scenario Outline: Upload files with difficult names using new chunking
 		When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
@@ -111,6 +128,9 @@ Feature: webdav-related-new-endpoint
 		And user "user0" moves new chunk file with id "chunking-42" to "/<file-name>" using the WebDAV API
 		Then as "user0" the file "/<file-name>" should exist
 		And the content of file "/<file-name>" for user "user0" should be "AAAAABBBBBCCCCC"
+		And the log file should not contain any log-entries containing these attributes:
+			| app |
+			| dav |
 		Examples:
 			| file-name |
 			| &#?       |

--- a/tests/acceptance/features/bootstrap/LoggingContext.php
+++ b/tests/acceptance/features/bootstrap/LoggingContext.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use TestHelpers\SetupHelper;
+
+require_once 'bootstrap.php';
+
+/**
+ * Context to make the Logging steps available
+ */
+class LoggingContext implements Context {
+	use Logging;
+
+	/**
+	 * @var FeatureContext
+	 */
+	private $featureContext;
+
+	/**
+	 * @BeforeScenario
+	 *
+	 * @param BeforeScenarioScope $scope
+	 *
+	 * @return void
+	 */
+	public function setUpScenario(BeforeScenarioScope $scope) {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->featureContext = $environment->getContext('FeatureContext');
+		$suiteParameters = SetupHelper::getSuiteParameters($scope);
+		SetupHelper::init(
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->featureContext->getBaseUrl(),
+			$suiteParameters['ocPath']
+		);
+	}
+}


### PR DESCRIPTION
backport of https://github.com/owncloud/core/pull/31890

## Description
Register FileCustomPropertiesBackend for `files/`  and `uploads/` 
 MiscCustomPropertiesBackend for everything else

## Related Issue
Fixes https://github.com/owncloud/core/issues/31631

## Motivation and Context
Extra log entry

## How Has This Been Tested?
1. By uploading big files
also 
2. 
`cd tests/acceptance; ./run.sh ./run.sh features/apiWebdav/webdav-related-new-endpoint.feature:38`
`grep 'Could not get node for path' ../../data/owncloud.log` 
#### expected:
nothing
#### actual
```
{"reqId":"YsWCEJL9CwgkRKFVOAnr","level":2,"time":"2018-07-04T14:24:39+00:00","remoteAddr":"127.0.0.1","user":"user0","app":"dav","method":"MOVE","url":"\/remote.php\/dav\/uploads\/user0\/chunking-42\/.file","message":"Could not get node for path: \"uploads\/user0\/chunking-42\/.file\" : File with name \/\/chunking-42 could not be located"}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

