### PR TITLE
Make sure limit is respected

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesSearchReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesSearchReportPlugin.php
@@ -165,9 +165,13 @@ class FilesSearchReportPlugin extends ServerPlugin {
 		$propFindType = $requestedProps ? PropFind::NORMAL : PropFind::ALLPROPS;
 
 		// make sure we limit the results
-		$nodes = \array_slice($nodes, 0, $maxResults, true);
+		$returnedElements = 0;
 
 		foreach ($nodes as $path => $node) {
+			if ($returnedElements >= $maxResults) {
+				break;
+			}
+
 			$propFind = new PropFind(
 				$path,
 				$requestedProps,
@@ -179,6 +183,8 @@ class FilesSearchReportPlugin extends ServerPlugin {
 			$result = $propFind->getResultForMultiStatus();
 			$result['href'] = $propFind->getPath();
 			yield $result;
+
+			$returnedElements++;
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Ensure we're sending a maximum number of elements according to the limit

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/32080

## Motivation and Context
Having multiple search providers might trigger the issue, so we could be sending more elements than requested. The PR patches this behaviour ensuring we return the number of elements requested.

In addition, elements returned by different providers will be unified, so no duplicate will be send to the client (unintentional good behaviour)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested with search_elastic app (with minor patch to not remove the default search provider)
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)