### PR TITLE
[stable10] [revived] Retry chunks in web UI on stalled uploads

### DIFF
--- a/apps/files/js/app.js
+++ b/apps/files/js/app.js
@@ -95,7 +95,9 @@
 					},
 					config: this._filesConfig,
 					enableUpload: true,
-					maxChunkSize: OC.appConfig.files && OC.appConfig.files.max_chunk_size
+					maxChunkSize: OC.appConfig.files && OC.appConfig.files.max_chunk_size,
+					uploadStallTimeout: OC.appConfig.files && OC.appConfig.files.upload_stall_timeout,
+					uploadStallRetries: OC.appConfig.files && OC.appConfig.files.upload_stall_retries
 				}
 			);
 			this.files.initialize();

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -344,7 +344,9 @@
 						fileList: this,
 						filesClient: this.filesClient,
 						dropZone: $('#content'),
-						maxChunkSize: options.maxChunkSize
+						maxChunkSize: options.maxChunkSize,
+						uploadStallTimeout: options.uploadStallTimeout,
+						uploadStallRetries: options.uploadStallRetries
 					});
 
 					this.setupUploadEvents(this._uploader);

--- a/apps/files/lib/App.php
+++ b/apps/files/lib/App.php
@@ -45,8 +45,12 @@ class App {
 
 	public static function extendJsConfig($array) {
 		$maxChunkSize = (int)(\OC::$server->getConfig()->getAppValue('files', 'max_chunk_size', (10 * 1024 * 1024)));
+		$uploadStallTimeout = (int)(\OC::$server->getConfig()->getAppValue('files', 'upload_stall_timeout', 60)); // in seconds
+		$uploadStallRetries = (int)(\OC::$server->getConfig()->getAppValue('files', 'upload_stall_retries', 100));
 		$array['array']['oc_appconfig']['files'] = [
-			'max_chunk_size' => $maxChunkSize
+			'max_chunk_size' => $maxChunkSize,
+			'upload_stall_timeout' => $uploadStallTimeout,
+			'upload_stall_retries' => $uploadStallRetries
 		];
 	}
 }

--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -24,6 +24,8 @@ describe('OC.Upload tests', function() {
 	var testFile;
 	var uploader;
 	var failStub;
+	var currentUserStub;
+	var getFolderContentsStub;
 
 	beforeEach(function() {
 		testFile = {
@@ -37,6 +39,7 @@ describe('OC.Upload tests', function() {
 			'<input type="file" id="file_upload_start" name="files[]" multiple="multiple">' +
 			'<input type="hidden" id="free_space" name="free_space" value="50000000">' + // 50 MB
 			// TODO: handlebars!
+			'<div id="uploadprogressbar"></div>' +
 			'<div id="new">' +
 			'<a>New</a>' +
 			'<ul>' +
@@ -48,10 +51,17 @@ describe('OC.Upload tests', function() {
 		uploader = new OC.Uploader($dummyUploader);
 		failStub = sinon.stub();
 		uploader.on('fail', failStub);
+
+		currentUserStub = sinon.stub(OC, 'getCurrentUser').returns({uid: 'current@user'});
+		getFolderContentsStub = sinon.stub(OC.Files.Client.prototype, 'getFolderContents');
 	});
 	afterEach(function() {
 		$dummyUploader = undefined;
 		failStub = undefined;
+		currentUserStub.restore();
+		getFolderContentsStub.restore();
+		uploader.clear();
+		uploader = null;
 	});
 
 	/**
@@ -67,7 +77,8 @@ describe('OC.Upload tests', function() {
 				files: [file],
 				jqXHR: jqXHR,
 				response: sinon.stub.returns(jqXHR),
-				submit: sinon.stub()
+				submit: sinon.stub(),
+				abort: sinon.stub()
 			};
 			if (uploader.fileUploadParam.add.call(
 					$dummyUploader[0],
@@ -274,15 +285,16 @@ describe('OC.Upload tests', function() {
 		});
 	});
 	describe('submitting uploads', function() {
-		describe('headers', function() {
-			function testHeaders(fileData) {
+		describe('headers', function () {
+			function testHeaders (fileData) {
 				var uploadData = addFiles(uploader, [
 					fileData
 				]);
 
 				return uploadData[0].headers;
 			}
-			it('sets request token', function() {
+
+			it('sets request token', function () {
 				var oldToken = OC.requestToken;
 				OC.requestToken = 'abcd';
 				var headers = testHeaders({
@@ -292,7 +304,7 @@ describe('OC.Upload tests', function() {
 				expect(headers['requesttoken']).toEqual('abcd');
 				OC.requestToken = oldToken;
 			});
-			it('sets the mtime header when lastModifiedDate is set', function() {
+			it('sets the mtime header when lastModifiedDate is set', function () {
 				var headers = testHeaders({
 					name: 'mtimetest.txt',
 					lastModifiedDate: new Date(Date.UTC(2018, 7, 26, 14, 55, 22, 500))
@@ -300,7 +312,7 @@ describe('OC.Upload tests', function() {
 
 				expect(headers['X-OC-Mtime']).toEqual('1535295322.5');
 			});
-			it('sets the mtime header when lastModified is set', function() {
+			it('sets the mtime header when lastModified is set', function () {
 				var headers = testHeaders({
 					name: 'mtimetest.txt',
 					lastModified: 1535295322500
@@ -308,6 +320,137 @@ describe('OC.Upload tests', function() {
 
 				expect(headers['X-OC-Mtime']).toEqual('1535295322.5');
 			});
+		});
+	});
+	describe('Chunked upload', function() {
+		it('rewires data url when uploading chunks', function() {
+			var result = addFiles(uploader, [testFile]);
+			var upload = uploader.getUpload(result[0]);
+			expect(result[0]).not.toEqual(null);
+			expect(result[0].submit.calledOnce).toEqual(true);
+
+			result[0].contentRange = 'bytes 100-250/150';
+			result[0].headers['Content-Range'] = 'bytes 100-250/150';
+			result[0].retries = 3;
+
+			$dummyUploader.trigger('fileuploadchunksend', result[0]);
+
+			expect(result[0].contentRange).not.toBeDefined();
+			expect(result[0].headers['Content-Range']).not.toBeDefined();
+			expect(result[0].url)
+				.toEqual(OC.getRootPath() + '/remote.php/dav/uploads/current%40user/' + upload.getId() + '/100');
+			expect(result[0].retries).toEqual(0);
+		});
+
+		it('retries stalled chunk on failure', function() {
+			var clock = sinon.useFakeTimers();
+
+			uploader = new OC.Uploader($dummyUploader, {
+				maxChunkSize: 150
+			});
+			uploader.on('fail', failStub);
+
+			var result = addFiles(uploader, [testFile]);
+			var upload = uploader.getUpload(result[0]);
+
+			// chunk upload doesn't call "submit" initially
+			expect(result[0].submit.notCalled).toEqual(true);
+
+			upload.data.stalled = true;
+
+			result[0].headers['If-None-Match'] = '*';
+
+			result[0].uploadedBytes = 300; // less than expected
+
+			uploader.fileUploadParam.fail.call($dummyUploader[0], {}, result[0]);
+
+			expect(upload.data.retries).toEqual(1);
+			expect(failStub.notCalled).toEqual(true);
+
+			expect(getFolderContentsStub.notCalled).toEqual(true);
+
+			var deferred = $.Deferred();
+			getFolderContentsStub.returns(deferred.promise());
+
+			// trigger retry
+			clock.tick(10000);
+
+			expect(getFolderContentsStub.calledOnce).toEqual(true);
+			expect(getFolderContentsStub.getCall(0).args[0]).toEqual('uploads/current@user/' + upload.getId());
+
+			deferred.resolve(207, [
+				{
+					name: '0',
+					size: 150
+				},
+				{
+					name: '150',
+					size: 150
+				},
+				// this chunk is smaller and needs to be retried
+				{
+					name: '300',
+					size: 100
+				},
+				// ignored
+				{
+					name: '.file',
+					size: 10000
+				}
+			]);
+
+			// uploaded bytes was set to the sum of all chunk sizes
+			expect(result[0].uploadedBytes).toEqual(300);
+			expect(result[0].data).toBeFalsy();
+
+			// header was cleared for overwriting
+			expect(result[0].headers['If-None-Match']).not.toBeDefined();
+
+			expect(result[0].submit.calledOnce).toEqual(true);
+
+			clock.restore();
+		});
+
+		it('stalled progress will set stalled flag after a while', function() {
+			var clock = sinon.useFakeTimers();
+
+			uploader = new OC.Uploader($dummyUploader, {
+				uploadStallTimeout: 10
+			});
+
+			var result = addFiles(uploader, [testFile]);
+			var upload = uploader.getUpload(result[0]);
+
+			$dummyUploader.trigger('fileuploadstart', result[0]);
+
+			result[0].uploadedBytes = 300;
+
+			expect(upload.data.stalled).toBeFalsy();
+
+			$dummyUploader.trigger('fileuploadprogressall', {loaded: 300, total: 5000});
+			clock.tick(5000);
+
+			expect(upload.data.stalled).toBeFalsy();
+
+			result[0].uploadedBytes = 400; // some progress, no stall
+
+			$dummyUploader.trigger('fileuploadprogressall', {loaded: 400, total: 5000});
+			clock.tick(10000);
+
+			expect(upload.data.stalled).toBeFalsy();
+
+			expect(result[0].abort.notCalled).toEqual(true);
+
+			// no progress, stalled
+			$dummyUploader.trigger('fileuploadprogressall', {loaded: 400, total: 5000});
+
+			clock.tick(10000);
+
+			expect(upload.data.stalled).toEqual(true);
+
+			expect(result[0].abort.calledOnce).toEqual(true);
+
+			clock.restore();
 		});
 	});
 });


### PR DESCRIPTION
Reverts owncloud/core#31185, bringing back https://github.com/owncloud/core/pull/31005.
Second chance to make it right

Setup instructions for testing here:
- ~~old and wrong results: https://github.com/owncloud/core/pull/30776#issue-174952506~~
- patch for DAV endpoint: https://gist.github.com/PVince81/2978ed02a21876fd9e58f74beda7e5c0 (or in the future, use https://github.com/owncloud/core/issues/32183)
- `occ config:app:set files max_chunk_size --value 1024`
- `occ config:app:set files upload_stall_timeout --value 3`

Fixes https://github.com/owncloud/core/issues/30770

- [x] debug issue => it was the testing code...
