### PR TITLE
Use envrironment vars for recovery and oc password

### DIFF
--- a/core/Command/Encryption/DecryptAll.php
+++ b/core/Command/Encryption/DecryptAll.php
@@ -32,6 +32,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
@@ -117,9 +118,27 @@ class DecryptAll extends Command {
 			'User for whom you want to decrypt all files (optional).',
 			''
 		);
+		$this->addOption(
+			'method',
+			'm',
+			InputOption::VALUE_OPTIONAL,
+			'Use recovery or password. If recovery method is chosen then the recovery password will be used to decrypt files. If password method is chosen then individual user passwords will be used to decrypt files.'
+		);
+		$this->addOption(
+			'continue',
+			'c',
+			InputOption::VALUE_OPTIONAL,
+			'Provide yes or no. Whether to ask for permission to continue.'
+		);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		$confirmed = $input->getOption('continue');
+		if (($confirmed !== 'yes') && ($confirmed !== 'no')) {
+			$output->writeln('Continue can accept either yes or no');
+			return null;
+		}
+
 		try {
 			if ($this->encryptionManager->isEnabled() === true) {
 				$output->write('Disable server side encryption... ');
@@ -144,7 +163,7 @@ class DecryptAll extends Command {
 			$output->writeln('Please make sure that no user access his files during this process!');
 			$output->writeln('');
 			$question = new ConfirmationQuestion('Do you really want to continue? (y/n) ', false);
-			if ($this->questionHelper->ask($input, $output, $question)) {
+			if (($confirmed === 'yes') || $this->questionHelper->ask($input, $output, $question)) {
 				$this->forceSingleUserAndTrashbin();
 				$user = $input->getArgument('user');
 				$result = $this->decryptAll->decryptAll($input, $output, $user);

--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -112,8 +112,13 @@ class DecryptAll {
 		} else {
 			$this->output->writeln('Files for following users couldn\'t be decrypted, ');
 			$this->output->writeln('maybe the user is not set up in a way that supports this operation: ');
-			foreach ($this->failed as $uid => $paths) {
+			foreach ($this->failed as $uid => $data) {
 				$this->output->writeln('    ' . $uid);
+				foreach ($data as $failure) {
+					$path = $failure['path'];
+					$message = $failure['exception']->getMessage();
+					$this->output->writeLn("           $path - $message");
+				}
 			}
 			$this->output->writeln('');
 		}
@@ -242,9 +247,9 @@ class DecryptAll {
 							'app' => __CLASS__
 						]);
 						if (isset($this->failed[$uid])) {
-							$this->failed[$uid][] = $path;
+							$this->failed[$uid][] = ['path' => $path, 'exception' => $e];
 						} else {
-							$this->failed[$uid] = [$path];
+							$this->failed[$uid] = [['path' => $path, 'exception' => $e]];
 						}
 					}
 				}

--- a/lib/private/Helper/EnvironmentHelper.php
+++ b/lib/private/Helper/EnvironmentHelper.php
@@ -55,4 +55,13 @@ class EnvironmentHelper {
 	public function getAppsRoots() {
 		return \OC::$APPSROOTS;
 	}
+
+	/**
+	 * Get the environment variable
+	 * @param $envVar
+	 * @return array|false|string
+	 */
+	public function getEnvVar($envVar) {
+		return \getenv($envVar);
+	}
 }

--- a/tests/Core/Command/Encryption/DecryptAllTest.php
+++ b/tests/Core/Command/Encryption/DecryptAllTest.php
@@ -125,6 +125,11 @@ class DecryptAllTest extends TestCase {
 			$this->questionHelper
 		);
 
+		$this->consoleInput->expects($this->once())
+			->method('getOption')
+			->with('continue')
+			->willReturn('no');
+
 		$this->encryptionManager->expects($this->once())
 			->method('isEnabled')
 			->willReturn($encryptionEnabled);
@@ -181,6 +186,11 @@ class DecryptAllTest extends TestCase {
 			$this->questionHelper
 		);
 
+		$this->consoleInput->expects($this->once())
+			->method('getOption')
+			->with('continue')
+			->willReturn('no');
+
 		$this->config->expects($this->at(0))
 			->method('setAppValue')
 			->with('core', 'encryption_enabled', 'no');
@@ -211,5 +221,39 @@ class DecryptAllTest extends TestCase {
 			});
 
 		$this->invokePrivate($instance, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+
+	public function providesConfirmVal() {
+		return [
+			['yes'],
+			['no'],
+			['foo']
+		];
+	}
+
+	/**
+	 * @dataProvider providesConfirmVal
+	 * @param $confirmVal
+	 */
+
+	public function testExecuteConfirm($confirmVal) {
+		$instance = new DecryptAll(
+			$this->encryptionManager,
+			$this->appManager,
+			$this->config,
+			$this->decryptAll,
+			$this->questionHelper
+		);
+
+		$this->consoleInput->expects($this->once())
+			->method('getOption')
+			->with('continue')
+			->willReturn($confirmVal);
+
+		$this->encryptionManager->expects($this->any())
+			->method('isEnabled')
+			->willReturn(true);
+
+		$this->assertNull($this->invokePrivate($instance, 'execute', [$this->consoleInput, $this->consoleOutput]));
 	}
 }

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -110,6 +110,28 @@ class DecryptAllTest extends TestCase {
 		$this->invokePrivate($this->instance, 'output', [$this->outputInterface]);
 	}
 
+	public function testDecryptAllFailsToDecrypt() {
+		/** @var DecryptAll | \PHPUnit_Framework_MockObject_MockObject |  $instance */
+		$instance = $this->getMockBuilder(DecryptAll::class)
+			->setConstructorArgs(
+				[
+					$this->encryptionManager,
+					$this->userManager,
+					$this->view,
+					$this->logger
+				]
+			)
+			->setMethods(['prepareEncryptionModules', 'decryptAllUsersFiles'])
+			->getMock();
+
+		$instance->expects($this->once())
+			->method('decryptAllUsersFiles')
+			->with('user1');
+
+		$this->invokePrivate($instance, 'failed', [['user1' => [['path' => 'a.txt', 'exception' => new \Exception('Missing file')]]]]);
+		$this->assertTrue($instance->decryptAll($this->inputInterface, $this->outputInterface, 'user1'));
+	}
+
 	public function dataDecryptAll() {
 		return [
 			[true, 'user1', true],
@@ -436,6 +458,7 @@ class DecryptAllTest extends TestCase {
 		return[
 			['called', \OC\Files\Storage\Local::class],
 			['exception', \OC\Files\Storage\Local::class],
+			['exception2', \OC\Files\Storage\Local::class],
 			['skip', SharedStorage::class],
 			['skip', \OCA\Files_Sharing\External\Storage::class],
 		];
@@ -489,11 +512,14 @@ class DecryptAllTest extends TestCase {
 				}
 			);
 
-		if ($decryptBehavior === 'exception') {
+		if (($decryptBehavior === 'exception') || ($decryptBehavior === 'exception2')) {
 			$instance->expects($this->at(0))
 				->method('decryptFile')
 				->with('/user1/files/bar')
 				->willThrowException(new \Exception());
+			if ($decryptBehavior === 'exception2') {
+				$this->invokePrivate($instance, 'failed', [['user1' => [['path' => 'a.txt', 'exception' => new \Exception('Missing file')]]]]);
+			}
 		} elseif ($decryptBehavior === 'skip') {
 			$instance->expects($this->never())
 				->method('decryptFile');

--- a/tests/lib/Helper/EnvironmentHelperTest.php
+++ b/tests/lib/Helper/EnvironmentHelperTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Helper;
+
+use OC\Helper\EnvironmentHelper;
+use Test\TestCase;
+
+class EnvironmentHelperTest extends TestCase {
+	private $environmentHelper;
+
+	public function setUp() {
+		$this->environmentHelper = new EnvironmentHelper();
+		parent::setUp();
+	}
+
+	public function testGetWebRoot() {
+		$this->assertEquals(\OC::$WEBROOT, $this->environmentHelper->getWebRoot());
+	}
+
+	public function testGetServerRoot() {
+		$this->assertEquals(\OC::$SERVERROOT, $this->environmentHelper->getServerRoot());
+	}
+
+	public function testGetAppsRoots() {
+		$this->assertEquals(\OC::$APPSROOTS, $this->environmentHelper->getAppsRoots());
+	}
+
+	public function testGetEnvVar() {
+		\putenv('foo=bar');
+		$this->assertEquals('bar', $this->environmentHelper->getEnvVar('foo'));
+	}
+}


### PR DESCRIPTION
Instead of providing password for all the users, be
it recovery or oc password, its better to read it
from the environment variable. This change helps
users to read it from the environment variable.
If user wishes to provide oc password for each user,
that option is also available.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- create 2 users `admin` and `user1`
- Enable encryption with user-keys. Login as `admin` and `user1`.
- Now try to run decrypt-all command as follows:
1. `./occ encryption:decrypt-all -c yes` - This will decrypt both `admin` and `user1`. Confirmation questions will be asked, like whether to continue or like enter login password. This step shows us that old behaviour of entering oc password is preserved. Here is the console output log:
```
➜  owncloud3 git:(recovery_passwd-and-oc_passwd-from-env) ✗ ./occ encryption:decrypt-all -c yes            
Cannot load Xdebug - it was already loaded
Disable server side encryption... done.


You are about to start to decrypt all files stored in your ownCloud.
It will depend on the encryption module and your setup if this is possible.
Depending on the number and size of your files this can take some time
Please make sure that no user access his files during this process!

prepare encryption modules...
 done.


 starting to decrypt files... 
 [->--------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
Please enter the user: admin login password: 
 decrypt files for user admin (1 of 2): /admin/files/welcome.txt 
 [-->-------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
Please enter the user: user1 login password: 
 decrypt files for user user1 (2 of 2): /user1/files/welcome.txt 
 [--->------------------------]

 starting to decrypt files... finished 
 [============================]


all files could be decrypted successfully!
➜  owncloud3 git:(recovery_passwd-and-oc_passwd-from-env) ✗
```
2. Make some modification to `welcome.txt` files of both user and enable recovery password for both users, and observe the console log  
```
➜  owncloud3 git:(recovery_passwd-and-oc_passwd-from-env) ✗ ./occ encryption:decrypt-all -c yes -m recovery
Cannot load Xdebug - it was already loaded
Disable server side encryption... done.


You are about to start to decrypt all files stored in your ownCloud.
It will depend on the encryption module and your setup if this is possible.
Depending on the number and size of your files this can take some time
Please make sure that no user access his files during this process!

prepare encryption modules...
 done.


 starting to decrypt files... 
 [->--------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
Attempting to use recovery key from environment: OC_RECOVERY_PASSWORD
 decrypt files for user admin (1 of 2): /admin/files/welcome.txt 
 [-->-------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
Attempting to use recovery key from environment: OC_RECOVERY_PASSWORD
 decrypt files for user user1 (2 of 2): /user1/files/welcome.txt 
 [--->------------------------]

 starting to decrypt files... finished 
 [============================]


all files could be decrypted successfully!
➜  owncloud3 git:(recovery_passwd-and-oc_passwd-from-env) ✗
```
Now the files are observed decrypted.
3. Make some modification to `welcome.txt` files of both user, and observe the console log:
```
➜  owncloud3 git:(recovery_passwd-and-oc_passwd-from-env) ✗ ./occ encryption:decrypt-all -c yes -m password user1
Cannot load Xdebug - it was already loaded
Disable server side encryption... done.


You are about to start to decrypt all files stored in user1's account.
It will depend on the encryption module and your setup if this is possible.
Depending on the number and size of your files this can take some time
Please make sure that no user access his files during this process!

prepare encryption modules...
 done.


 starting to decrypt files... 
 [->--------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
Attempting to use users password from environment: OC_PASSWORD
 decrypt files for user user1 (1 of 1): /user1/files/welcome.txt 
 [-->-------------------------]

 starting to decrypt files... finished 
 [============================]


all files could be decrypted successfully!
Server side encryption remains enabled
➜  owncloud3 git:(recovery_passwd-and-oc_passwd-from-env) ✗ 
```
4. Make some modification to `welcome.txt` files of both user, and observe the console log:
```
➜  owncloud3 git:(recovery_passwd-and-oc_passwd-from-env) ✗ ./occ encryption:decrypt-all -c yes -m password      
Cannot load Xdebug - it was already loaded
Disable server side encryption... done.


You are about to start to decrypt all files stored in your ownCloud.
It will depend on the encryption module and your setup if this is possible.
Depending on the number and size of your files this can take some time
Please make sure that no user access his files during this process!

 aborted.

In DecryptAll.php line 172:
                                                            
  Password method cannot be used for decrypting all users.  
                                                            

encryption:decrypt-all [-m|--method [METHOD]] [-c|--continue [CONTINUE]] [--] [<user>]

➜  owncloud3 git:(recovery_passwd-and-oc_passwd-from-env) ✗
```
5. Make some modification to `welcome.txt` files of both user and disable recovery password for `user1`, and observe the console log:
```
➜  owncloud3 git:(recovery_passwd-and-oc_passwd-from-env) ✗ ./occ encryption:decrypt-all -c yes -m recovery
Cannot load Xdebug - it was already loaded
Disable server side encryption... done.


You are about to start to decrypt all files stored in your ownCloud.
It will depend on the encryption module and your setup if this is possible.
Depending on the number and size of your files this can take some time
Please make sure that no user access his files during this process!

prepare encryption modules...
 done.


 starting to decrypt files... 
 [->--------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
Attempting to use recovery key from environment: OC_RECOVERY_PASSWORD
 decrypt files for user admin (1 of 2): /admin/files/welcome.txt 
 [-->-------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
Password recovery is not enabled for user1
Module "Default encryption module" does not support the functionality to decrypt all files again or the initialization of the module failed!


 starting to decrypt files... finished 
 [============================]


all files could be decrypted successfully!
➜  owncloud3 git:(recovery_passwd-and-oc_passwd-from-env) ✗
```
For testing recovery `OC_RECOVERY_PASSWORD=xxx` and for password `OC_PASSWORD=xxx` is exported in the shell.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] REQUIRES: https://github.com/owncloud/encryption/pull/40
- [x] This PR was taken from https://github.com/owncloud/core/pull/28569, made minor modifications and added unit tests. Basically trying to take an approach of creating PR in the master branch first and then backport.

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
