### PR TITLE
 use remote occ as much as possible 

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -191,7 +191,7 @@ class WebDavHelper {
 	 */
 	public static function getSabreClient($baseUrl, $user, $password) {
 		$settings = [
-				'baseUri' => $baseUrl,
+				'baseUri' => $baseUrl . "/",
 				'userName' => $user,
 				'password' => $password,
 				'authType' => SClient::AUTH_BASIC

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -259,7 +259,7 @@ trait CommandLine {
 			}
 		);
 
-		$davPath = \rtrim($this->getDavFilesPath($targetUser), '/');
+		$davPath = \rtrim($this->getFullDavFilesPath($targetUser), '/');
 
 		$foundPath = \end($foundPaths)['path'];
 		// strip dav path

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -149,6 +149,20 @@ trait WebDav {
 	}
 
 	/**
+	 * gives the dav path of a file including the subfolder of the webserver
+	 * e.g. when the server runs in `http://localhost/owncloud/`
+	 * this function will return `owncloud/remote.php/webdav/prueba.txt`
+	 *
+	 * @param string $user
+	 *
+	 * @return string
+	 */
+	public function getFullDavFilesPath($user) {
+		$basePath = \ltrim(\parse_url($this->getBaseUrl(), PHP_URL_PATH), "/");
+		return \ltrim($basePath . "/" . $this->getDavFilesPath($user), "/");
+	}
+
+	/**
 	 * Select a suitable dav path version number.
 	 * Some endpoints have only existed since a certain point in time, so for
 	 * those make sure to return a DAV path version that works for that endpoint.
@@ -1167,7 +1181,7 @@ trait WebDav {
 		$elementRows = $elements->getRows();
 		$elementsSimplified = $this->simplifyArray($elementRows);
 		foreach ($elementsSimplified as $expectedElement) {
-			$webdavPath = "/" . $this->getDavFilesPath($user) . $expectedElement;
+			$webdavPath = "/" . $this->getFullDavFilesPath($user) . $expectedElement;
 			if (!\array_key_exists($webdavPath, $elementList) && $expectedToBeListed) {
 				PHPUnit_Framework_Assert::fail(
 					"$webdavPath" . " is not in propfind answer but should"
@@ -2049,7 +2063,7 @@ trait WebDav {
 			$elementRows = $expectedElements->getRows();
 			$elementsSimplified = $this->simplifyArray($elementRows);
 			foreach ($elementsSimplified as $expectedElement) {
-				$webdavPath = "/" . $this->getDavFilesPath($user) . $expectedElement;
+				$webdavPath = "/" . $this->getFullDavFilesPath($user) . $expectedElement;
 				if (!\array_key_exists($webdavPath, $elementList)) {
 					PHPUnit_Framework_Assert::fail(
 						"$webdavPath" . " is not in report answer"
@@ -2073,7 +2087,7 @@ trait WebDav {
 		if (\is_array($elementList) && \count($elementList)) {
 			$elementListKeys = \array_keys($elementList);
 			\array_shift($elementListKeys);
-			$davPrefix = "/" . $this->getDavFilesPath($user);
+			$davPrefix = "/" . $this->getFullDavFilesPath($user);
 			foreach ($elementListKeys as $element) {
 				if (\substr($element, 0, \strlen($davPrefix)) == $davPrefix) {
 					$element = \substr($element, \strlen($davPrefix));

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -175,10 +175,15 @@ fi
 
 if [ "${TEST_WITH_PHPDEVSERVER}" != "true" ]
 then
-    echo "Not using php inbuilt server for running scenario ..."
-    echo "Updating .htaccess for proper rewrites"
-    ${OCC} config:system:set htaccess.RewriteBase --value /
-    ${OCC} maintenance:update:htaccess
+	echo "Not using php inbuilt server for running scenario ..."
+	echo "Updating .htaccess for proper rewrites"
+	
+	#get the sub path of the webserver and set the correct RewriteBase
+	PROTOCOL="$(echo ${TEST_SERVER_URL} | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+	URL="$(echo ${TEST_SERVER_URL/$PROTOCOL/})"
+	WEBSERVER_PATH="$(echo ${URL} | grep / | cut -d/ -f2-)"
+	${OCC} config:system:set htaccess.RewriteBase --value /${WEBSERVER_PATH}/
+	${OCC} maintenance:update:htaccess
 else
 	echo "Using php inbuilt server for running scenario ..."
 


### PR DESCRIPTION
## Description
make `./occ` commands to run through the testing-app as much as possible

depends on #32160

## Related Issue
working towards https://github.com/owncloud/QA/issues/538

## Motivation and Context
we want to be able to test remote instances, so we cannot rely `occ` being available locally

## How Has This Been Tested?
ran some acceptance tests locally, now hoping that drone will do the rest
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
