### PR TITLE
show a short list of mount infos: files_external:list --short

### DIFF
--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -167,14 +167,14 @@ class ListCommand extends Base {
 				}
 			}
 		}
-		
+
 		if ($outputType === self::OUTPUT_FORMAT_JSON || $outputType === self::OUTPUT_FORMAT_JSON_PRETTY) {
 			$keys = \array_map(function ($header) {
 				return \strtolower(\str_replace(' ', '_', $header));
 			}, $headers);
 
 			if ($shortView) {
-				$pairs = \array_map(function (IStorageConfig $config) use ($keys, $userId) {
+				$pairs = \array_map(function (IStorageConfig $config) use ($keys) {
 					$values = [
 							$config->getId(),
 							$config->getMountPoint(),

--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -91,6 +91,11 @@ class ListCommand extends Base {
 				'a',
 				InputOption::VALUE_NONE,
 				'show both system wide mounts and all personal mounts'
+			)->addOption(
+				'short',
+				's',
+				InputOption::VALUE_NONE,
+				'show only a reduced mount info'
 			);
 		parent::configure();
 	}
@@ -119,6 +124,8 @@ class ListCommand extends Base {
 	 */
 	public function listMounts($userId, array $mounts, InputInterface $input, OutputInterface $output) {
 		$outputType = $input->getOption('output');
+		$shortView = $input->getOption('short');
+
 		if (\count($mounts) === 0) {
 			if ($outputType === self::OUTPUT_FORMAT_JSON || $outputType === self::OUTPUT_FORMAT_JSON_PRETTY) {
 				$output->writeln('[]');
@@ -134,58 +141,78 @@ class ListCommand extends Base {
 			return;
 		}
 
-		$headers = ['Mount ID', 'Mount Point', 'Storage', 'Authentication Type', 'Configuration', 'Options'];
+		if ($shortView) {
+			$headers = ['Mount ID', 'Mount Point', 'Type'];
+		} else {
+			$headers = ['Mount ID', 'Mount Point', 'Storage', 'Authentication Type', 'Configuration', 'Options'];
 
-		if (!$userId || $userId === self::ALL) {
-			$headers[] = 'Applicable Users';
-			$headers[] = 'Applicable Groups';
-		}
-		if ($userId === self::ALL) {
-			$headers[] = 'Type';
-		}
+			if (!$userId || $userId === self::ALL) {
+				$headers[] = 'Applicable Users';
+				$headers[] = 'Applicable Groups';
+			}
 
-		if (!$input->getOption('show-password')) {
-			$hideKeys = ['password', 'refresh_token', 'token', 'client_secret', 'public_key', 'private_key'];
-			foreach ($mounts as $mount) {
-				$config = $mount->getBackendOptions();
-				foreach ($config as $key => $value) {
-					if (\in_array($key, $hideKeys)) {
-						$mount->setBackendOption($key, '***');
+			if ($userId === self::ALL) {
+				$headers[] = 'Type';
+			}
+
+			if (!$input->getOption('show-password')) {
+				$hideKeys = ['password', 'refresh_token', 'token', 'client_secret', 'public_key', 'private_key'];
+				foreach ($mounts as $mount) {
+					$config = $mount->getBackendOptions();
+					foreach ($config as $key => $value) {
+						if (\in_array($key, $hideKeys)) {
+							$mount->setBackendOption($key, '***');
+						}
 					}
 				}
 			}
 		}
-
+		
 		if ($outputType === self::OUTPUT_FORMAT_JSON || $outputType === self::OUTPUT_FORMAT_JSON_PRETTY) {
 			$keys = \array_map(function ($header) {
 				return \strtolower(\str_replace(' ', '_', $header));
 			}, $headers);
 
-			$pairs = \array_map(function (IStorageConfig $config) use ($keys, $userId) {
-				$values = [
-					$config->getId(),
-					$config->getMountPoint(),
-					$config->getBackend()->getStorageClass(),
-					$config->getAuthMechanism()->getIdentifier(),
-					$config->getBackendOptions(),
-					$config->getMountOptions()
-				];
-				if (!$userId || $userId === self::ALL) {
-					$values[] = $config->getApplicableUsers();
-					$values[] = $config->getApplicableGroups();
-				}
-				if ($userId === self::ALL) {
-					$values[] = $config->getType() === IStorageConfig::MOUNT_TYPE_ADMIN ? 'admin' : 'personal';
-				}
+			if ($shortView) {
+				$pairs = \array_map(function (IStorageConfig $config) use ($keys, $userId) {
+					$values = [
+							$config->getId(),
+							$config->getMountPoint(),
+							$config->getType() === IStorageConfig::MOUNT_TYPE_ADMIN ? 'admin' : 'personal'
+						];
 
-				return \array_combine($keys, $values);
-			}, $mounts);
+					return \array_combine($keys, $values);
+				}, $mounts);
+			} else {
+				$pairs = \array_map(function (IStorageConfig $config) use ($keys, $userId) {
+					$values = [
+							$config->getId(),
+							$config->getMountPoint(),
+							$config->getBackend()->getStorageClass(),
+							$config->getAuthMechanism()->getIdentifier(),
+							$config->getBackendOptions(),
+							$config->getMountOptions()
+						];
+					if (!$userId || $userId === self::ALL) {
+						$values[] = $config->getApplicableUsers();
+						$values[] = $config->getApplicableGroups();
+					}
+					if ($userId === self::ALL) {
+						$values[] = $config->getType() === IStorageConfig::MOUNT_TYPE_ADMIN ? 'admin' : 'personal';
+					}
+
+					return \array_combine($keys, $values);
+				}, $mounts);
+			}
+
 			if ($outputType === self::OUTPUT_FORMAT_JSON) {
 				$output->writeln(\json_encode(\array_values($pairs)));
 			} else {
 				$output->writeln(\json_encode(\array_values($pairs), JSON_PRETTY_PRINT));
 			}
 		} else {
+
+			// default output style
 			$full = $input->getOption('full');
 			$defaultMountOptions = [
 				'encrypt' => true,
@@ -195,7 +222,9 @@ class ListCommand extends Base {
 				'encoding_compatibility' => false
 			];
 			$countInvalid = 0;
-			$rows = \array_map(function (IStorageConfig $config) use ($userId, $defaultMountOptions, $full, &$countInvalid) {
+			// In case adding array elements, add them only after the first two (Mount ID / Mount Point)
+			// and before the last one entry (Type). Necessary for option -s
+			$rows = \array_map(function (IStorageConfig $config) use ($shortView, $userId, $defaultMountOptions, $full, &$countInvalid) {
 				if ($config->getBackend() instanceof InvalidBackend || $config->getAuthMechanism() instanceof InvalidAuth) {
 					$countInvalid++;
 				}
@@ -251,7 +280,8 @@ class ListCommand extends Base {
 					$values[] = $applicableUsers;
 					$values[] = $applicableGroups;
 				}
-				if ($userId === self::ALL) {
+				// This MUST stay the last entry
+				if ($shortView || $userId === self::ALL) {
 					$values[] = $config->getType() === IStorageConfig::MOUNT_TYPE_ADMIN ? 'Admin' : 'Personal';
 				}
 
@@ -260,7 +290,7 @@ class ListCommand extends Base {
 
 			$table = new Table($output);
 			$table->setHeaders($headers);
-			$table->setRows($rows);
+			$table->setRows($this->getColumns($shortView, $rows));
 			$table->render();
 
 			if ($countInvalid > 0) {
@@ -273,6 +303,32 @@ class ListCommand extends Base {
 		}
 	}
 
+	// Removes all unused columns for option -s.
+	// Only the first two (Mount ID / Mount Point) and the last column (Mount Type) is kept.
+	protected function getColumns($shortView, $rows) {
+		if ($shortView) {
+			$newRows = [];
+			// $subArr is a copy of $rows anyways...
+			foreach ($rows as $subArr) {
+				$c = \count($subArr) - 1;
+				$u = false;
+				foreach ($subArr as $key => $val) {
+					if ((int)$key > 1 && (int)$key < $c) {
+						unset($subArr[$key]);
+						$u = true;
+					}
+				}
+				if ($u) {
+					$subArr = \array_values($subArr);
+				}
+				$newRows[] = $subArr;
+			}
+			return $newRows;
+		} else {
+			return $rows;
+		}
+	}
+	
 	protected function getStorageService($userId) {
 		if (!empty($userId)) {
 			$user = $this->userManager->get($userId);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->
This is a new PR for https://github.com/owncloud/core/pull/32098 because of a push problem killing the commit.

## Description
This PR adds an option ``-s --short`` to ``sudo -uwww-data ./occ files_external:list user_id`` 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/32084 ([Feature Request] Improve files_external:list to show a short list of mounts for a given user)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current output of ``./occ files_external:list user_id`` is quite big and for some purposes hard to read. This short view helps when using in conjunction of ``files:scan`` with option ``--path=`` to identify easily the scannable paths for a user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
sudo -uwww-data ./occ files_external:list user_1 --short
+----------+------------------+----------+
| Mount ID | Mount Point      | Type     |
+----------+------------------+----------+
| 1        | /mount_1         | Personal |
| 2        | /mount_2         | Personal |
+----------+------------------+----------+
```
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)

@PVince81 I added the changes requested from the original PR