### PR TITLE
Move oc-backbone-webdav loading to core

### DIFF
--- a/apps/comments/appinfo/app.php
+++ b/apps/comments/appinfo/app.php
@@ -24,7 +24,6 @@ $eventDispatcher = \OC::$server->getEventDispatcher();
 $eventDispatcher->addListener(
 	'OCA\Files::loadAdditionalScripts',
 	function () {
-		\OCP\Util::addScript('oc-backbone-webdav');
 		\OCP\Util::addScript('comments', 'app');
 		\OCP\Util::addScript('comments', 'commentmodel');
 		\OCP\Util::addScript('comments', 'commentcollection');

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -133,6 +133,7 @@ class OC_Template extends \OC\Template\Base {
 				\OC_Util::addScript('placeholder', null, true);
 			}
 
+			OC_Util::addScript('oc-backbone-webdav', null, true);
 			OC_Util::addScript('oc-backbone', null, true);
 			OC_Util::addVendorScript('core', 'backbone/backbone', true);
 			OC_Util::addVendorScript('core', 'select2/select2', true);


### PR DESCRIPTION
## Description
Because other apps like files_versions need it but only worked because
it was indirectly loaded by the comments app.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/32117

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- [x] test that comments app still works: can post a message
- [x] test that versions app works when comments app is disabled: panel appears

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added => not possible to test loading order
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
