### PR TITLE
[stable10] Fixes #32090 - browser extension urls in origin header do …

### DIFF
--- a/apps/dav/lib/Connector/Sabre/CorsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CorsPlugin.php
@@ -95,8 +95,15 @@ class CorsPlugin extends ServerPlugin {
 		$this->server = $server;
 
 		$request = $this->server->httpRequest;
-		if (!$request->hasHeader('Origin') || Util::isSameDomain($request->getHeader('Origin'), $request->getAbsoluteUrl())) {
-			return false;
+		if (!$request->hasHeader('Origin')) {
+			return;
+		}
+		$originHeader = $request->getHeader('Origin');
+		if ($this->ignoreOriginHeader($originHeader)) {
+			return;
+		}
+		if (Util::isSameDomain($originHeader, $request->getAbsoluteUrl())) {
+			return;
 		}
 
 		$this->server->on('beforeMethod', [$this, 'setCorsHeaders']);
@@ -144,5 +151,22 @@ class CorsPlugin extends ServerPlugin {
 			$this->server->sapi->sendResponse($response);
 			return false;
 		}
+	}
+
+	/**
+	 * in addition to schemas used by extensions we ignore empty origin header
+	 * values as well as 'null' which is not valid by the specification but used
+	 * by some clients.
+	 * @link https://github.com/owncloud/core/pull/32120#issuecomment-407008243
+	 *
+	 * @param string $originHeader
+	 * @return bool
+	 */
+	public function ignoreOriginHeader($originHeader) {
+		if (\in_array($originHeader, ['', null, 'null'], true)) {
+			return true;
+		}
+		$schema = \parse_url($originHeader, PHP_URL_SCHEME);
+		return \in_array(\strtolower($schema), ['moz-extension', 'chrome-extension']);
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CorsPluginTest.php
@@ -57,7 +57,6 @@ class CorsPluginTest extends TestCase {
 		$this->server->sapi = $this->getMockBuilder(\stdClass::class)
 			->setMethods(['sendResponse'])
 			->getMock();
-		$this->server->sapi->expects($this->once())->method('sendResponse')->with($this->server->httpResponse);
 
 		$this->server->httpRequest->setMethod('OPTIONS');
 
@@ -262,8 +261,15 @@ class CorsPluginTest extends TestCase {
 
 	/**
 	 * @dataProvider optionsCases
+	 * @param $allowedDomains
+	 * @param $hasUser
+	 * @param $requestHeaders
+	 * @param $expectedStatus
+	 * @param array $expectedHeaders
+	 * @param bool $expectDavHeaders
 	 */
 	public function testOptionsHeaders($allowedDomains, $hasUser, $requestHeaders, $expectedStatus, array $expectedHeaders, $expectDavHeaders = false) {
+		$this->server->sapi->expects($this->once())->method('sendResponse')->with($this->server->httpResponse);
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('someuser');
 
@@ -297,5 +303,26 @@ class CorsPluginTest extends TestCase {
 
 		// if it has DAV headers, it means we did not bypass further processing
 		$this->assertEquals($expectDavHeaders, $this->server->httpResponse->hasHeader('DAV'));
+	}
+
+	/**
+	 * @dataProvider providesOriginUrls
+	 * @param $expectedValue
+	 * @param $url
+	 */
+	public function testExtensionRequests($expectedValue, $url) {
+		$plugin = new CorsPlugin($this->createMock(IUserSession::class));
+		self::assertEquals($expectedValue, $plugin->ignoreOriginHeader($url));
+	}
+
+	public function providesOriginUrls() {
+		return [
+			'Firefox extension' => [true, 'moz-extension://mgmnhfbjphngabcpbpmapnnaabhnchmi/'],
+			'Chrome extension' => [true, 'chrome-extension://mgmnhfbjphngabcpbpmapnnaabhnchmi/'],
+			'Empty Origin' => [true, ''],
+			'Null string Origin' => [true, 'null'],
+			'Null Origin' => [true, null],
+			'plain http' => [false, 'http://example.net/'],
+		];
 	}
 }


### PR DESCRIPTION
…not trigger CORS verification

backport of #32120 