### PR TITLE
fix restoring settings to original state after testrun

### DIFF
--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -171,7 +171,9 @@ class AppConfigHelper {
 		$pathToElement = \explode('@@@', $capabilitiesPath);
 		$answeredValue = $xml->{$capabilitiesApp};
 		for ($i = 0; $i < \count($pathToElement); $i++) {
-			$answeredValue = $answeredValue->{$pathToElement[$i]};
+			if (\gettype($answeredValue) === "object") {
+				$answeredValue = $answeredValue->{$pathToElement[$i]};
+			}
 		}
 		return (string)$answeredValue;
 	}

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -2,11 +2,7 @@
 Feature: federated
 	Background:
 		Given using OCS API version "1"
-		And parameter "shareapi_enabled" of app "core" has been set to "yes"
-		And parameter "shareapi_allow_resharing" of app "core" has been set to "yes"
-		And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "yes"
-		And parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "yes"
-
+		
 	Scenario: Federate share a file with another server
 		Given using server "REMOTE"
 		And user "user1" has been created

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1540,15 +1540,15 @@ trait Sharing {
 				'testingState' => false
 			],
 			[
-				'capabilitiesApp' => 'federation',
-				'capabilitiesParameter' => 'outgoing',
+				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'federation@@@outgoing',
 				'testingApp' => 'files_sharing',
 				'testingParameter' => 'outgoing_server2server_share_enabled',
 				'testingState' => true
 			],
 			[
-				'capabilitiesApp' => 'federation',
-				'capabilitiesParameter' => 'incoming',
+				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'federation@@@incoming',
 				'testingApp' => 'files_sharing',
 				'testingParameter' => 'incoming_server2server_share_enabled',
 				'testingState' => true


### PR DESCRIPTION
## Description
1. in `AppConfigHelper.php` if ` $answeredValue` wasn't an object but a string or empty the function and so the tests would fail
2. `capabilitiesParameter` and `capabilitiesApp` were wrong for fed-sharing
3. no need to set the settings in `Given` that are already set by default

## Motivation and Context
trying to reset the settings correctly when running fed. sharing on different servers and found this issue

## How Has This Been Tested?
set setting, run tests, see if original sharing settings being restored

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
