### PR TITLE
Tech dept/move autoloader to namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
             "OC\\Core\\": "core/",
             "OC\\Settings\\": "settings/",
             "OCP\\": "lib/public"
-        }
+        },
+        "classmap": ["lib/private/legacy"]
     },
     "require-dev": {
         "behat/behat": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         },
         "classmap": ["lib/private/legacy"]
     },
+    "autoload-dev" : {
+        "files": ["tests/lib/TestCase.php"]
+    },
     "require-dev": {
         "behat/behat": "^3.0",
         "behat/mink-extension": "^2.2",

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -75,9 +75,7 @@ class Autoloader {
 		$class = \trim($class, '\\');
 
 		$paths = [];
-		if (\strpos($class, 'OC_') === 0) {
-			$paths[] = \OC::$SERVERROOT . '/lib/private/legacy/' . \strtolower(\str_replace('_', '/', \substr($class, 3)) . '.php');
-		} elseif (\strpos($class, 'OCA\\') === 0) {
+		if (\strpos($class, 'OCA\\') === 0) {
 			list(, $app, $rest) = \explode('\\', $class, 3);
 			$app = \strtolower($app);
 			$appPath = \OC_App::getAppPath($app);

--- a/lib/base.php
+++ b/lib/base.php
@@ -54,6 +54,7 @@
  *
  */
 
+use OC\Autoloader;
 use OCP\IRequest;
 
 require_once 'public/Constants.php';
@@ -102,7 +103,7 @@ class OC {
 	public static $CLI = false;
 
 	/**
-	 * @var \OC\Autoloader $loader
+	 * @var Autoloader $loader
 	 */
 	public static $loader = null;
 
@@ -492,16 +493,6 @@ class OC {
 
 		// register autoloader
 		$loaderStart = \microtime(true);
-		require_once __DIR__ . '/autoloader.php';
-		self::$loader = new \OC\Autoloader([
-			OC::$SERVERROOT . '/lib/private/legacy',
-		]);
-		if (\defined('PHPUNIT_RUN')) {
-			self::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
-		}
-		\spl_autoload_register([self::$loader, 'load']);
-		$loaderEnd = \microtime(true);
-
 		self::$CLI = (\in_array(\php_sapi_name(), ['cli', 'phpdbg']));
 
 		// setup 3rdparty autoloader
@@ -517,6 +508,12 @@ class OC {
 			print('Composer autoloader not found!');
 			exit();
 		}
+		self::$loader = new Autoloader();
+		if (\defined('PHPUNIT_RUN')) {
+			self::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
+		}
+		\spl_autoload_register([self::$loader, 'load']);
+		$loaderEnd = \microtime(true);
 
 		try {
 			self::initPaths();

--- a/lib/private/Autoloader.php
+++ b/lib/private/Autoloader.php
@@ -49,7 +49,7 @@ class Autoloader {
 	 *
 	 * @param string[] $validRoots
 	 */
-	public function __construct(array $validRoots) {
+	public function __construct(array $validRoots = []) {
 		foreach ($validRoots as $root) {
 			$this->validRoots[$root] = true;
 		}
@@ -84,10 +84,6 @@ class Autoloader {
 				// If not found in the root of the app directory, insert '/lib' after app id and try again.
 				$paths[] = $appPath . '/lib/' . \strtolower(\str_replace('\\', '/', $rest) . '.php');
 			}
-		} elseif ($class === 'Test\\TestCase') {
-			// This File is considered public API, so we make sure that the class
-			// can still be loaded, although the PSR-4 paths have not been loaded.
-			$paths[] = \OC::$SERVERROOT . '/tests/lib/TestCase.php';
 		}
 		return $paths;
 	}

--- a/tests/lib/AutoLoaderTest.php
+++ b/tests/lib/AutoLoaderTest.php
@@ -8,51 +8,35 @@
 
 namespace Test;
 
+use OC\AutoLoader;
+
 class AutoLoaderTest extends TestCase {
 	/**
-	 * @var \OC\Autoloader $loader
+	 * @var Autoloader $loader
 	 */
 	private $loader;
 
 	protected function setUp() {
 		parent::setUp();
-		$this->loader = new \OC\AutoLoader([]);
+		$this->loader = new AutoLoader();
 	}
 
-	public function testLegacyPath() {
-		$this->assertEquals([
-			\OC::$SERVERROOT . '/lib/private/legacy/files.php',
-		], $this->loader->findClass('OC_Files'));
-	}
-
-	public function testLoadTestTestCase() {
-		$this->assertEquals([
-			\OC::$SERVERROOT . '/tests/lib/TestCase.php'
-		], $this->loader->findClass('Test\TestCase'));
-	}
-
-	public function testLoadCore() {
-		$this->assertEquals([
-			\OC::$SERVERROOT . '/lib/private/legacy/foo/bar.php',
-		], $this->loader->findClass('OC_Foo_Bar'));
-	}
-
-	public function testLoadPublicNamespace() {
+	public function testLoadPublicNamespace(): void {
 		$this->assertEquals([], $this->loader->findClass('OCP\Foo\Bar'));
 	}
 
-	public function testLoadAppNamespace() {
+	public function testLoadAppNamespace(): void {
 		$result = $this->loader->findClass('OCA\Files\Foobar');
 		$this->assertCount(2, $result);
 		$this->assertStringEndsWith('apps/files/foobar.php', $result[0]);
 		$this->assertStringEndsWith('apps/files/lib/foobar.php', $result[1]);
 	}
 
-	public function testLoadCoreNamespaceCore() {
+	public function testLoadCoreNamespaceCore(): void {
 		$this->assertEquals([], $this->loader->findClass('OC\Core\Foo\Bar'));
 	}
 
-	public function testLoadCoreNamespaceSettings() {
+	public function testLoadCoreNamespaceSettings(): void {
 		$this->assertEquals([], $this->loader->findClass('OC\Settings\Foo\Bar'));
 	}
 }


### PR DESCRIPTION
## Description
class Autoloader was not loaded via composer autoload.
This was fixed with moving the class to lib/private

## Related Issue
fixes #12573

## Motivation and Context
Housekeeping ...

## How Has This Been Tested?
- unit tests


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
