### PR TITLE
#32221 Set permissions on log file creation instead of every write.

### DIFF
--- a/lib/private/Log/Owncloud.php
+++ b/lib/private/Log/Owncloud.php
@@ -51,14 +51,8 @@ class Owncloud {
 		 * Fall back to default log file if specified logfile does not exist
 		 * and can not be created.
 		 */
-		if (!\file_exists(self::$logFile)) {
-			if (!\is_writable(\dirname(self::$logFile))) {
-				self::$logFile = $defaultLogFile;
-			} else {
-				if (!\touch(self::$logFile)) {
-					self::$logFile = $defaultLogFile;
-				}
-			}
+		if (!self::createLogFile(self::$logFile)) {
+			self::$logFile = $defaultLogFile;
 		}
 	}
 
@@ -125,11 +119,11 @@ class Owncloud {
 			if ($conditionalLogFile[0] !== '/') {
 				$conditionalLogFile = \OC::$server->getConfig()->getSystemValue('datadirectory') . "/" . $conditionalLogFile;
 			}
+			self::createLogFile($conditionalLogFile);
 			$handle = @\fopen($conditionalLogFile, 'a');
-			@\chmod($conditionalLogFile, 0640);
 		} else {
+			self::createLogFile(self::$logFile);
 			$handle = @\fopen(self::$logFile, 'a');
-			@\chmod(self::$logFile, 0640);
 		}
 		if ($handle) {
 			\fwrite($handle, $entry."\n");
@@ -143,6 +137,23 @@ class Owncloud {
 		}
 	}
 
+	/**
+	 * create a log file and chmod it to the correct permissions
+	 * @param string $logFile
+	 * @return boolean
+	 */
+	public static function createLogFile($logFile) {
+		if (\file_exists($logFile) ) {
+			return true;
+		} else {
+			if (\is_writable(\dirname($logFile)) && \touch($logFile)) {
+				@\chmod($logFile, 0640);
+				return true;
+			}
+		}
+		return false;
+	}
+	
 	/**
 	 * @return string
 	 */

--- a/lib/private/Log/Owncloud.php
+++ b/lib/private/Log/Owncloud.php
@@ -143,13 +143,12 @@ class Owncloud {
 	 * @return boolean
 	 */
 	public static function createLogFile($logFile) {
-		if (\file_exists($logFile) ) {
+		if (\file_exists($logFile)) {
 			return true;
-		} else {
-			if (\is_writable(\dirname($logFile)) && \touch($logFile)) {
-				@\chmod($logFile, 0640);
-				return true;
-			}
+		}
+		if (\is_writable(\dirname($logFile)) && \touch($logFile)) {
+			@\chmod($logFile, 0640);
+			return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
## Description
Moves the chmod for the log files to a file creation method so that it is only run on file creation rather than every write. This allows the administrator of the ownCloud instance to set their own permissions if required.

## Related Issue
- Fixes #32221

## Motivation and Context
To allow other applications to read the file without having to provide that application permissions to all files that are owned by the web server.

## How Has This Been Tested?
No.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
