### PR TITLE
#32217 Change the file locking on large uploads

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -217,7 +217,9 @@ class FileTest extends TestCase {
 		// action
 		$caughtException = null;
 		try {
+			$file->acquireLock(ILockingProvider::LOCK_SHARED);
 			$file->put('test data');
+			$file->releaseLock(ILockingProvider::LOCK_SHARED);
 		} catch (\Exception $e) {
 			$caughtException = $e;
 		}
@@ -288,7 +290,9 @@ class FileTest extends TestCase {
 		);
 
 		$file = new File($view, $info);
+		$file->acquireLock(ILockingProvider::LOCK_SHARED);
 		$file->put('Look at me failing');
+		$file->releaseLock(ILockingProvider::LOCK_SHARED);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
When uploading large files >10GB, the assembly process on the server runs very long (>5minutes). This causes a timeout on the client side (Version 2.4.2). The setup is a clustered web server behind a F5 load balancer.
New move Requests by the client, let the running assembly processes fail.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #32217 

## Motivation and Context
Created PR to test if we can make the file locking process more robust

## How Has This Been Tested?
- test environment: Local docker images with Desktop client 2.4.2
- test case 1: Upload 10GB file, while slowing down the assembly process (sleep()) to produce timout at the client side

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Changed Unit Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
