### PR TITLE
check the comment URL correctly when SUT runs in subfolder

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -214,6 +214,17 @@ trait BasicStructure {
 	}
 
 	/**
+	 * returns the path of the base URL
+	 * e.g. owncloud-core/10 if the baseUrl is http://localhost/owncloud-core/10
+	 * the path is without a slash at the end and without a slash at the beginning
+	 *
+	 * @return string
+	 */
+	public function getBasePath() {
+		return \ltrim(\parse_url($this->getBaseUrl(), PHP_URL_PATH), "/");
+	}
+
+	/**
 	 * returns the base URL but without "http(s)://" in front of it
 	 *
 	 * @return string

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -158,8 +158,9 @@ trait WebDav {
 	 * @return string
 	 */
 	public function getFullDavFilesPath($user) {
-		$basePath = \ltrim(\parse_url($this->getBaseUrl(), PHP_URL_PATH), "/");
-		return \ltrim($basePath . "/" . $this->getDavFilesPath($user), "/");
+		return \ltrim(
+			$this->getBasePath() . "/" . $this->getDavFilesPath($user), "/"
+		);
 	}
 
 	/**
@@ -811,7 +812,9 @@ trait WebDav {
 		}
 
 		if ($expectedValue === "a_comment_url") {
-			if (\preg_match("#^/remote.php/dav/comments/files/([0-9]+)$#", $value)) {
+			$basePath = \ltrim($this->getBasePath() . "/", "/");
+			$expected = "#^/" . $basePath . "remote.php/dav/comments/files/([0-9]+)$#";
+			if (\preg_match($expected, $value)) {
 				return;
 			} else {
 				throw new \Exception(


### PR DESCRIPTION
## Description
the expected comments url was not correct when system-under-test ran in a subfolder e.g. `http://localhost/owncloud/`

## Motivation and Context
make tests more general

## How Has This Been Tested?
ran comments acceptance tests with a server installed in a sub-folder

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
