### PR TITLE
[stable10] Follow license file name change for stable10 branch

### DIFF
--- a/COPYING-README
+++ b/COPYING-README
@@ -1,5 +1,5 @@
 Files in ownCloud are licensed under the Affero General Public License version 3,
-the text of which can be found in COPYING-AGPL, or any later version of the AGPL,
+the text of which can be found in COPYING, or any later version of the AGPL,
 unless otherwise noted.
 
 Licensing of components:


### PR DESCRIPTION
## Description
The old COPYRIGHT-AGPL file is renamed to COPYRIGHT.

## Related Issue
Same as #31860

## Motivation and Context
This change follows license file name change.

## How Has This Been Tested?
Not tested.

## Screenshots (if appropriate):
None.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
