### PR TITLE
Standardize acceptance test ocPath to always go through testing app

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -268,6 +268,7 @@ class SetupHelper {
 	 *                    For example: "files:transfer-ownership"
 	 *
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
+	 * @throws Exception if ocPath has not been set yet or the testing app is not enabled
 	 */
 	public static function runOcc($args) {
 		if (self::$adminUsername === null

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -266,24 +266,65 @@ class SetupHelper {
 	 *
 	 * @param array $args anything behind "occ".
 	 *                    For example: "files:transfer-ownership"
+	 * @param string|null $adminUsername
+	 * @param string|null $adminPassword
+	 * @param string|null $baseUrl
+	 * @param string|null $ocPath
 	 *
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
-	 * @throws Exception if ocPath has not been set yet or the testing app is not enabled
+	 * @throws Exception if parameters have not been provided yet or the testing app is not enabled
 	 */
-	public static function runOcc($args) {
+	public static function runOcc(
+		$args,
+		$adminUsername = null,
+		$adminPassword = null,
+		$baseUrl = null,
+		$ocPath = null
+	) {
 		if (self::$adminUsername === null
-			|| self::$adminPassword === null
-			|| self::$baseUrl === null
-			|| self::$ocPath === null
+			&& $adminUsername === null
 		) {
 			throw new Exception(
-				"runOcc called before init"
+				"runOcc called without adminUsername - pass the username or call SetupHelper::init"
 			);
+		}
+		if (self::$adminPassword === null
+			&& $adminPassword === null
+		) {
+			throw new Exception(
+				"runOcc called without adminPassword - pass the password or call SetupHelper::init"
+			);
+		}
+		if (self::$baseUrl === null
+			&& $baseUrl === null
+		) {
+			throw new Exception(
+				"runOcc called without baseUrl - pass the baseUrl or call SetupHelper::init"
+			);
+		}
+		if (self::$ocPath === null
+			&& $ocPath === null
+		) {
+			throw new Exception(
+				"runOcc called without ocPath - pass the ocPath or call SetupHelper::init"
+			);
+		}
+		if ($adminUsername === null) {
+			$adminUsername = self::$adminUsername;
+		}
+		if ($adminPassword === null) {
+			$adminPassword = self::$adminPassword;
+		}
+		if ($baseUrl === null) {
+			$baseUrl = self::$baseUrl;
+		}
+		if ($ocPath === null) {
+			$ocPath = self::$ocPath;
 		}
 		try {
 			$result = OcsApiHelper::sendRequest(
-				self::$baseUrl, self::$adminUsername,
-				self::$adminPassword, "POST", self::$ocPath,
+				$baseUrl, $adminUsername,
+				$adminPassword, "POST", $ocPath,
 				['command' => \implode(' ', $args)]
 			);
 		} catch (ServerException $e) {

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -11,7 +11,7 @@ default:
             adminUsername: admin
             adminPassword: admin
             regularUserPassword: 123456
-            ocPath: ../../
+            ocPath: apps/testing/api/v1/occ
         - CardDavContext:
         - CalDavContext:
         - AppManagementContext:
@@ -71,9 +71,6 @@ default:
     webUILogin:
       paths:
         - %paths.base%/../features/webUILogin
-      context: &common_webui_suite_context
-        parameters:
-          ocPath: apps/testing/api/v1/occ
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -85,7 +82,6 @@ default:
     apiWebdav:
       paths:
         - %paths.base%/../features/apiWebdav
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
@@ -93,7 +89,6 @@ default:
     webUIAdminSettings:
       paths:
         - %paths.base%/../features/webUIAdminSettings
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIAdminSharingSettingsContext:
@@ -105,7 +100,6 @@ default:
     webUIFiles:
       paths:
         - %paths.base%/../features/webUIFiles
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -115,7 +109,6 @@ default:
     webUIMoveFilesFolders:
       paths:
         - %paths.base%/../features/webUIMoveFilesFolders
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -125,7 +118,6 @@ default:
     webUIRenameFiles:
       paths:
         - %paths.base%/../features/webUIRenameFiles
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -135,7 +127,6 @@ default:
     webUIRenameFolders:
       paths:
         - %paths.base%/../features/webUIRenameFolders
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -145,7 +136,6 @@ default:
     webUITrashbin:
       paths:
         - %paths.base%/../features/webUITrashbin
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -155,7 +145,6 @@ default:
     webUISharingInternalGroups:
       paths:
         - %paths.base%/../features/webUISharingInternalGroups
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -166,7 +155,6 @@ default:
     webUISharingInternalUsers:
       paths:
         - %paths.base%/../features/webUISharingInternalUsers
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -177,7 +165,6 @@ default:
     webUISharingExternal:
       paths:
         - %paths.base%/../features/webUISharingExternal
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -189,7 +176,6 @@ default:
     webUIUpload:
       paths:
         - %paths.base%/../features/webUIUpload
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -199,7 +185,6 @@ default:
     webUIRestrictSharing:
       paths:
         - %paths.base%/../features/webUIRestrictSharing
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -210,7 +195,6 @@ default:
     webUIFavorites:
       paths:
         - %paths.base%/../features/webUIFavorites
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -220,7 +204,6 @@ default:
     webUIPersonalSettings:
       paths:
         - %paths.base%/../features/webUIPersonalSettings
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebUIGeneralContext:
@@ -233,7 +216,6 @@ default:
     webUISharingNotifications:
       paths:
         - %paths.base%/../features/webUISharingNotifications
-      context: *common_webui_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - NotificationsCoreContext:

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -206,6 +206,13 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getOcPath() {
+		return (string) $this->ocPath;
+	}
+
+	/**
 	 * returns the base URL (which is without a slash at the end)
 	 *
 	 * @return string
@@ -929,7 +936,8 @@ trait BasicStructure {
 		$jsonExpectedDecoded = \json_decode($jsonExpected->getRaw(), true);
 		$jsonRespondedEncoded
 			= \json_encode(\json_decode($this->response->getBody(), true));
-		if ($this->runOcc(['status']) === 0) {
+		$runOccStatus = $this->runOcc(['status']);
+		if ($runOccStatus === 0) {
 			$output = \explode("- ", $this->lastStdOut);
 			$version = \explode(": ", $output[3]);
 			PHPUnit_Framework_Assert::assertEquals(
@@ -946,7 +954,9 @@ trait BasicStructure {
 				$jsonExpectedEncoded, $jsonRespondedEncoded
 			);
 		} else {
-			PHPUnit_Framework_Assert::fail('Cannot get version variables from occ');
+			PHPUnit_Framework_Assert::fail(
+				"Cannot get version variables from occ - status $runOccStatus"
+			);
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -44,13 +44,23 @@ trait CommandLine {
 	 * Invokes an OCC command
 	 *
 	 * @param array $args of the occ command
+	 * @param string|null $adminUsername
+	 * @param string|null $adminPassword
+	 * @param string|null $baseUrl
+	 * @param string|null $ocPath
 	 *
 	 * @return int exit code
 	 * @throws Exception if ocPath has not been set yet or the testing app is not enabled
 	 */
-	public function runOcc($args = []) {
+	public function runOcc(
+		$args = [],
+		$adminUsername = null,
+		$adminPassword = null,
+		$baseUrl = null,
+		$ocPath = null
+	) {
 		$args[] = '--no-ansi';
-		$return = SetupHelper::runOcc($args);
+		$return = SetupHelper::runOcc($args, $adminUsername, $adminPassword, $baseUrl, $ocPath);
 		$this->lastStdOut = $return['stdOut'];
 		$this->lastStdErr = $return['stdErr'];
 		$this->lastCode = (int) $return['code'];

--- a/tests/acceptance/features/bootstrap/LoggingContext.php
+++ b/tests/acceptance/features/bootstrap/LoggingContext.php
@@ -49,12 +49,11 @@ class LoggingContext implements Context {
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
-		$suiteParameters = SetupHelper::getSuiteParameters($scope);
 		SetupHelper::init(
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword(),
 			$this->featureContext->getBaseUrl(),
-			$suiteParameters['ocPath']
+			$this->featureContext->getOcPath()
 		);
 	}
 }

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -494,12 +494,11 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			//to include FilesContext
 		}
 
-		$suiteParameters = SetupHelper::getSuiteParameters($scope);
 		SetupHelper::init(
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword(),
 			$this->featureContext->getBaseUrl(),
-			$suiteParameters['ocPath']
+			$this->featureContext->getOcPath()
 		);
 		
 		$response = AppConfigHelper::getCapabilities(


### PR DESCRIPTION
## Description
1) Use a common ``ocPath`` in behat that points to the testing app.
2) Make the ``CommandLine.php`` ``runOcc()`` method call the ``SetupHelper::runOcc()`` method, which is the one that gets the testing app to do the work.

Item (2) maintains the ``CommandLine.php`` ``runOcc()`` method so that callers from app acceptance tests etc. should still work the same.

## Motivation and Context
1) Methods in API test contexts use a ``runOcc`` that directly runs an occ command.
2) Methods in webUI test contexts use a ``runOccc`` that sends a request to the testing app, and the testing app runs the ``occ`` command and returns the status and output.

Method (1) only works if the test script is running on/in the same system as the SUT.
Method (2) is more general - and we require the testing app to be available anyway for other setup and teardown stuff in scenarios.

Do things the same way in API and webUI tests.

## How Has This Been Tested?
Some loca; API nad webUI test runs. Let CI run the whole suite of tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
