### PR TITLE
[stable10] provisioning API tests for group with comma

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -16,6 +16,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली                                   | Unicode group name                       |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -18,6 +18,7 @@ So that I can give a user access to the resources of the group
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली              | Unicode group name                      |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -17,6 +17,7 @@ So that I can remove unnecessary groups
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली              | Unicode group name                      |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -20,6 +20,7 @@ So that I can manage user access to group resources
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली              | Unicode group name                      |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -16,6 +16,7 @@ So that I can more easily manage access to resources by groups rather than indiv
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली                                   | Unicode group name                       |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -18,6 +18,7 @@ So that I can give a user access to the resources of the group
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली              | Unicode group name                      |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -17,6 +17,7 @@ So that I can remove unnecessary groups
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली              | Unicode group name                      |
 			| 0                   | The "false" group                       |

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -20,6 +20,7 @@ So that I can manage user access to group resources
 			| group_id            | comment                                 |
 			| new-group           | dash                                    |
 			| the.group           | dot                                     |
+			| left,right          | comma                                   |
 			| España              | special European characters             |
 			| नेपाली              | Unicode group name                      |
 			| 0                   | The "false" group                       |

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1632,6 +1632,15 @@ class ManagerTest extends \Test\TestCase {
 		// New list only groups in common
 		$data[] = ['yes', \json_encode(['group1', 'group2']), null, ['group2'], true];
 
+		// New list partly in common, group names containing comma
+		$data[] = ['yes', \json_encode(['group1,a', 'group2']), null, ['group1,a', 'group3'], true];
+		$data[] = ['yes', \json_encode(['group1,a', 'group2,b']), null, ['group1,a', 'group3'], true];
+		$data[] = ['yes', \json_encode(['group1,a', 'group2']), null, ['group1,a', 'group3,c'], true];
+
+		// New list only groups in common, group names containing comma
+		$data[] = ['yes', \json_encode(['group1', 'group2,a']), null, ['group2,a'], true];
+		$data[] = ['yes', \json_encode(['group1,a', 'group2,a']), null, ['group2,a'], true];
+
 		return $data;
 	}
 


### PR DESCRIPTION
Backport of commits from #31719 that:

1) add acceptance test scenarios for using the Provisioning API with groups that have a comma in the group name.
2) add unit test cases for groups that have a comma in the group name.

There are commits in that PR which modify the ``files:scan`` command to allow for group names containing a comma. Those changes are a backward-compatibility break, so are NOT backported.