### PR TITLE
separate given step to create user from when step

### DIFF
--- a/tests/acceptance/features/apiMain/dav-versions.feature
+++ b/tests/acceptance/features/apiMain/dav-versions.feature
@@ -51,8 +51,7 @@ Feature: dav-versions
     Then the version folder of fileId "<<FILEID>>" for user "user1" should contain "1" element
 
 	Scenario: sharer of a file can see the old version information when the sharee changes the content of the file
-		Given user "user0" has been created
-		And user "user1" has been created
+		Given user "user1" has been created
 		And user "user0" has uploaded file with content "user0 content" to "sharefile.txt"
 		And user "user0" has shared file "sharefile.txt" with user "user1"
 		When user "user1" has uploaded file with content "user1 content" to "/sharefile.txt"
@@ -60,8 +59,7 @@ Feature: dav-versions
 		And the version folder of file "/sharefile.txt" for user "user0" should contain "1" element
 
 	Scenario: sharer of a file can restore the original content of a shared file after the file has been modified by the sharee
-		Given user "user0" has been created
-		And user "user1" has been created
+		Given user "user1" has been created
 		And user "user0" has uploaded file with content "user0 content" to "sharefile.txt"
 		And user "user0" has shared file "sharefile.txt" with user "user1"
 		And user "user1" has uploaded file with content "user1 content" to "/sharefile.txt"
@@ -71,8 +69,7 @@ Feature: dav-versions
 		And the content of file "/sharefile.txt" for user "user1" should be "user0 content"
 
 	Scenario: sharer can restore a file inside a shared folder modified by sharee
-		Given user "user0" has been created
-		And user "user1" has been created
+		Given user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
 		And user "user0" has shared folder "/sharingfolder" with user "user1"
 		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
@@ -83,8 +80,7 @@ Feature: dav-versions
 		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
 
 	Scenario: sharee can restore a file inside a shared folder modified by sharee
-		Given user "user0" has been created
-		And user "user1" has been created
+		Given user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
 		And user "user0" has shared folder "/sharingfolder" with user "user1"
 		And user "user0" has uploaded file with content "user0 content" to "/sharingfolder/sharefile.txt"
@@ -95,8 +91,7 @@ Feature: dav-versions
 		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user0 content"
 
 	Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharer
-		Given user "user0" has been created
-		And user "user1" has been created
+		Given user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
 		And user "user0" has shared folder "/sharingfolder" with user "user1"
 		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
@@ -107,8 +102,7 @@ Feature: dav-versions
 		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user1 content"
 
 	Scenario: sharee can restore a file inside a shared folder created by sharee and modified by sharer
-		Given user "user0" has been created
-		And user "user1" has been created
+		Given user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
 		And user "user0" has shared folder "/sharingfolder" with user "user1"
 		And user "user1" has uploaded file with content "user1 content" to "/sharingfolder/sharefile.txt"
@@ -119,8 +113,7 @@ Feature: dav-versions
 		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "user1 content"
 
 	Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharee
-		Given user "user0" has been created
-		And user "user1" has been created
+		Given user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
 		And user "user0" has shared folder "/sharingfolder" with user "user1"
 		And user "user1" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
@@ -131,8 +124,7 @@ Feature: dav-versions
 		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "old content"
 
 	Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer
-		Given user "user0" has been created
-		And user "user1" has been created
+		Given user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
 		And user "user0" has shared folder "/sharingfolder" with user "user1"
 		And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
@@ -143,8 +135,7 @@ Feature: dav-versions
 		And the content of file "/sharingfolder/sharefile.txt" for user "user1" should be "old content"
 
 	Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer, when the folder has been moved by the sharee
-		Given user "user0" has been created
-		And user "user1" has been created
+		Given user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
 		And user "user0" has shared folder "/sharingfolder" with user "user1"
 		And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
@@ -157,8 +148,7 @@ Feature: dav-versions
 		And the content of file "/received/sharingfolder/sharefile.txt" for user "user1" should be "old content"
 
 	Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is at the top level of the sharer)
-		Given user "user0" has been created
-		And user "user1" has been created
+		Given user "user1" has been created
 		And user "user0" has uploaded file with content "old content" to "/sharefile.txt"
 		And user "user0" has uploaded file with content "new content" to "/sharefile.txt"
 		And user "user0" has shared file "/sharefile.txt" with user "user1"
@@ -170,8 +160,7 @@ Feature: dav-versions
 		And the content of file "/received/sharefile.txt" for user "user1" should be "old content"
 
 	Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is inside a folder of the sharer)
-		Given user "user0" has been created
-		And user "user1" has been created
+		Given user "user1" has been created
 		And user "user0" has created a folder "/sharingfolder"
 		And user "user0" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
 		And user "user0" has uploaded file with content "new content" to "/sharingfolder/sharefile.txt"
@@ -184,8 +173,7 @@ Feature: dav-versions
 		And the content of file "/received/sharefile.txt" for user "user1" should be "old content"
 
 	Scenario: sharer can restore a file inside a group shared folder modified by sharee
-		Given user "user0" has been created
-		And user "user1" has been created
+		Given user "user1" has been created
 		And user "user2" has been created
 		And group "newgroup" has been created
 		And user "user1" has been added to group "newgroup"

--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -9,7 +9,6 @@ So that I can see who has access to ownCloud
 
 	Scenario: admin gets all users
 		Given user "brand-new-user" has been created
-		And user "admin" has been created
 		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -9,7 +9,6 @@ So that I can see who has access to ownCloud
 
 	Scenario: admin gets all users
 		Given user "brand-new-user" has been created
-		And user "admin" has been created
 		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -212,7 +212,6 @@ trait Provisioning {
 
 	/**
 	 * @When /^the administrator creates the user "([^"]*)" using the provisioning API$/
-	 * @Given /^user "([^"]*)" has been created$/
 	 *
 	 * @param string $user
 	 *
@@ -225,6 +224,20 @@ trait Provisioning {
 			$this->createUser($user, $password, null, null, true, 'api');
 		}
 		$this->userShouldExist($user);
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has been created$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function userHasBeenCreated($user) {
+		$this->createUser(
+			$user, $this->getPasswordForUser($user), null, null, true
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
- Given steps should not been forced to use a specific way (API/OCC/webUI) to achieve a specific state
- Given steps don't need to be checked, we assume they work

## Motivation and Context
when using this step for LDAP tests it fails because in LDAP we do not create users, but skip the user creation and believe they exist. Still the given step should work and not throw an exception.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
