### PR TITLE
Properly reset the checksum if the file data has changed

### DIFF
--- a/apps/files/tests/Command/VerifyChecksumsTest.php
+++ b/apps/files/tests/Command/VerifyChecksumsTest.php
@@ -135,10 +135,10 @@ class VerifyChecksumsTest extends TestCase {
 
 	private function assertChecksumsAreCorrect(array $files) {
 		foreach ($files as $key => $file) {
-			/** @var File $f */
-			$f = $files[$key]['file'];
 			$expectedChecksums = $files[$key]['expectedChecksums'];
 			$this->refreshFileInfo($files[$key]['file']);
+			/** @var File $f */
+			$f = $files[$key]['file'];
 			$this->assertSame(
 				$expectedChecksums(),
 				$f->getChecksum()

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -205,9 +205,12 @@ class Scanner extends BasicEmitter implements IScanner {
 					}
 					if (!empty($newData)) {
 						// Only reset checksum on file change
-						foreach (\array_intersect_key($newData, $data) as $key => $value) {
-							if (\in_array($key, ['size', 'storage_mtime', 'mtime', 'etag']) && $data[$key] != $newData[$key]) {
-								$newData['checksum'] = '';
+						if ($fileId > 0 && !isset($newData['checksum'])) {
+							foreach (['size', 'storage_mtime', 'mtime', 'etag'] as $dataKey) {
+								if (isset($newData[$dataKey])) {
+									$newData['checksum'] = '';
+									break;
+								}
 							}
 						}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Properly reset the checksum if the file has changed

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/2561

## Motivation and Context
Checksum wasn't being reset in that scenario. The previous condition was wrong

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested with the scenario described in the issue
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)