### PR TITLE
[stable10] Backport of Use envrironment vars for recovery and oc password

### DIFF
--- a/apps/encryption/lib/AppInfo/Application.php
+++ b/apps/encryption/lib/AppInfo/Application.php
@@ -24,6 +24,7 @@ namespace OCA\Encryption\AppInfo;
 
 
 use OC\Files\View;
+use OC\Helper\EnvironmentHelper;
 use OCA\Encryption\Controller\RecoveryController;
 use OCA\Encryption\Controller\SettingsController;
 use OCA\Encryption\Controller\StatusController;
@@ -260,7 +261,8 @@ class Application extends \OCP\AppFramework\App {
 					$c->query('Crypt'),
 					$c->query('Session'),
 					$c->getServer()->getUserManager(),
-					new QuestionHelper()
+					new QuestionHelper(),
+					new EnvironmentHelper()
 				);
 			}
 		);

--- a/apps/encryption/lib/Crypto/DecryptAll.php
+++ b/apps/encryption/lib/Crypto/DecryptAll.php
@@ -23,6 +23,7 @@
 namespace OCA\Encryption\Crypto;
 
 
+use OC\Helper\EnvironmentHelper;
 use OC\User\LoginException;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Session;
@@ -42,6 +43,9 @@ class DecryptAll {
 	/** @var QuestionHelper  */
 	protected $questionHelper;
 
+	/** @var EnvironmentHelper  */
+	protected $environmentHelper;
+
 	/** @var  Crypt */
 	protected $crypt;
 
@@ -55,11 +59,15 @@ class DecryptAll {
 	protected $userManager;
 
 	/**
+	 * DecryptAll constructor.
+	 *
 	 * @param Util $util
 	 * @param KeyManager $keyManager
 	 * @param Crypt $crypt
 	 * @param Session $session
+	 * @param IUserManager $userManager
 	 * @param QuestionHelper $questionHelper
+	 * @param EnvironmentHelper $environmentHelper
 	 */
 	public function __construct(
 		Util $util,
@@ -67,7 +75,8 @@ class DecryptAll {
 		Crypt $crypt,
 		Session $session,
 		IUserManager $userManager,
-		QuestionHelper $questionHelper
+		QuestionHelper $questionHelper,
+		EnvironmentHelper $environmentHelper
 	) {
 		$this->util = $util;
 		$this->keyManager = $keyManager;
@@ -75,70 +84,124 @@ class DecryptAll {
 		$this->session = $session;
 		$this->userManager = $userManager;
 		$this->questionHelper = $questionHelper;
+		$this->environmentHelper = $environmentHelper;
 	}
 
 	/**
 	 * prepare encryption module to decrypt all files
+	 *
+	 * - The value of $user (when called from decrypt-all command ) is as follows:
+	 *   the uid of user passed, if the oC filesystem is encrypted using user-keys
+	 *   the empty string '', if the oC filesystem is encrypted using master-key
 	 *
 	 * - Throws LoginException when user login fails either recovery password fails
 	 *   or if the user password fails
 	 *
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @param $user
+	 * @param string|null $user The uid of the user ( a non empty string ) for user-keys, or empty or null string for masterkey decryption
 	 * @return bool
 	 * @throws LoginException
 	 */
 	public function prepare(InputInterface $input, OutputInterface $output, $user) {
+		// We need to setup the module with everything it needs in order to decrypt user data
+		// This could be using master key or user key encryption
+		// and could also be for a single user or multiple users
 
-		$question = new Question('Please enter the recovery key password: ');
-
-		if($this->util->isMasterKeyEnabled()) {
-			$output->writeln('Use master key to decrypt all files');
+		/**
+		 * Try to stop decrypting process if password method is used for decrypting all users.
+		 * If the decrypt-all command doesn't provide a user, which means decryption of oC
+		 * filesystem. And if the method provided is password then it should stop decryption
+		 * process, because same password can not be used for every user. Even though the
+		 * input user is empty the $user can have value of each user(s) in oC.
+		 */
+		if (($input->getArgument('user') === '') && ($input->getOption('method') === 'password')) {
+			$output->writeln('Password method can not be used for decrypting all users.');
+			$output->writeln('Aborting the decryption process');
+			return false;
+		}
+		// First lets work out the mode
+		if ($this->util->isMasterKeyEnabled()) {
+			$output->writeln('Using master key for decryption');
 			$user = $this->keyManager->getMasterKeyId();
-			$password =$this->keyManager->getMasterKeyPassword();
+			$password = $this->keyManager->getMasterKeyPassword();
 		} else {
-			$recoveryKeyId = $this->keyManager->getRecoveryKeyId();
-			if (!empty($user)) {
-				$output->writeln('You can only decrypt the users files if you know');
-				$output->writeln('the users password or if he activated the recovery key.');
-				$output->writeln('');
-				$questionUseLoginPassword = new ConfirmationQuestion(
-					'Do you want to use the user: ' . $user . ' login password to decrypt all files? (y/n) ',
-					false
-				);
-				$useLoginPassword = $this->questionHelper->ask($input, $output, $questionUseLoginPassword);
-				if ($useLoginPassword) {
-					$question = new Question('Please enter the user\'s login password: ');
-				} else if ($this->util->isRecoveryEnabledForUser($user) === false) {
-					$output->writeln('No recovery key available for user ' . $user);
-					return false;
+			$throwLoginException = false;
+			$output->writeln("Configuring encryption module for decryption with user based keys");
+			// We must be using user key - now finish the prep
+			// Must either be using recovery keys, or just decrypting one user and know their password
+
+			// Check a method has been passed
+			if(!$input->hasOption('method') && !in_array($input->getOption('method'),['recovery', 'password'])) {
+				$output->writeln('A method must be supplied when decrypting from user-key state');
+				return false;
+			}
+			if (empty($user)) {
+				// all users, so only recovery is possible
+				if ($input->getOption('method') === 'recovery' &&
+					(($this->environmentHelper->getEnvVar('OC_RECOVERY_PASSWORD') !== ''))) {
+					// Then we can attempt to use this for all of the users
+					$output->writeln('Attempting to use recovery key from environment for all users. Users must have enabled recovery keys for this to work.');
+					$password = $this->environmentHelper->getEnvVar('OC_RECOVERY_PASSWORD');
 				} else {
-					$user = $recoveryKeyId;
+					$output->writeLn('Recovery key is the only supported method for decrypting all users in one command. The key is read from OC_RECOVERY_PASSWORD.');
+					return false;
 				}
 			} else {
-				$output->writeln('You can only decrypt the files of all users if the');
-				$output->writeln('recovery key is enabled by the admin and activated by the users.');
-				$output->writeln('');
-				$user = $recoveryKeyId;
-			}
+				// Specific user, password is an option here
+				if ($input->getOption('method') === 'recovery' &&
+					($this->environmentHelper->getEnvVar('OC_RECOVERY_PASSWORD') !== '')) {
+					if ($this->util->isRecoveryEnabledForUser($user) === false) {
+						$output->writeln('Password recovery is not enabled for ' . $user);
+						return false;
+					}
+					// Then we can attempt to use this for all of the users
+					$output->writeln('Attempting to use recovery key from environment: OC_RECOVERY_PASSWORD');
+					$password = $this->environmentHelper->getEnvVar('OC_RECOVERY_PASSWORD');
 
-			$question->setHidden(true);
-			$question->setHiddenFallback(false);
-			$password = $this->questionHelper->ask($input, $output, $question);
-
-
-			$throwLoginException = false;
-			if ($recoveryKeyId === $user) {
-				try {
-					if ($this->keyManager->checkRecoveryPassword($password) === false) {
+					try {
+						if ($this->keyManager->checkRecoveryPassword($password) === false) {
+							$throwLoginException = true;
+						}
+					} catch (\Exception $e) {
 						$throwLoginException = true;
 					}
-				} catch (\Exception $e) {
-					$throwLoginException = true;
+
+					$recoveryKeyId = $this->keyManager->getRecoveryKeyId();
+					$user = $recoveryKeyId;
+				} elseif ($input->getOption('method') === 'password' && ($this->environmentHelper->getEnvVar('OC_PASSWORD') !== '')) {
+					$output->writeln('Attempting to use users password from environment: OC_PASSWORD');
+					// Then we want to use the users password and it has been supplied
+					$password = $this->environmentHelper->getEnvVar('OC_PASSWORD');
+
+					if ($this->userManager->checkPassword($user, $password) === false) {
+						$throwLoginException = true;
+					}
+				} elseif ($input->getOption('method') === null) {
+					//Grab user specific password
+					$question = new Question('Please enter the login password for user: ' . $user);
+					$question->setHidden(true);
+					$question->setHiddenFallback(false);
+					$password = $this->questionHelper->ask($input, $output, $question);
+
+					if ($this->userManager->checkPassword($user, $password) === false) {
+						throw new LoginException('Invalid credentials provided');
+					}
+				} else {
+					//If method or password is used and the environment is not set, then trigger LoginException
+					if (($input->getOption('method') === 'recovery') || ($input->getOption('method') === 'password')) {
+						if (($this->environmentHelper->getEnvVar('OC_RECOVERY_PASSWORD') === false) ||
+							($this->environmentHelper->getEnvVar('OC_RECOVERY_PASSWORD') === '')) {
+							$output->writeln('Recovery password not set in the envrironment');
+							$throwLoginException = true;
+						} elseif (($this->environmentHelper->getEnvVar('OC_PASSWORD') === false) ||
+							($this->environmentHelper->getEnvVar('OC_PASSWORD') === '')) {
+							$output->writeln('OC password not set in the envrironment');
+							$throwLoginException = true;
+						}
 				}
-			} elseif ($this->userManager->checkPassword($user, $password) === false) {
-				$throwLoginException = true;
+
+				}
 			}
 
 			if ($throwLoginException === true) {
@@ -153,7 +216,6 @@ class DecryptAll {
 		} else {
 			$output->writeln('Could not decrypt private key, maybe you entered the wrong password?');
 		}
-
 
 		return false;
 	}

--- a/core/Command/Encryption/DecryptAll.php
+++ b/core/Command/Encryption/DecryptAll.php
@@ -32,6 +32,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
@@ -117,9 +118,27 @@ class DecryptAll extends Command {
 			'User for whom you want to decrypt all files (optional).',
 			''
 		);
+		$this->addOption(
+			'method',
+			'm',
+			InputOption::VALUE_OPTIONAL,
+			'Use recovery or password. If recovery method is chosen then the recovery password will be used to decrypt files. If password method is chosen then individual user passwords will be used to decrypt files.'
+		);
+		$this->addOption(
+			'continue',
+			'c',
+			InputOption::VALUE_OPTIONAL,
+			'Provide yes or no. Whether to ask for permission to continue.'
+		);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		$confirmed = $input->getOption('continue');
+		if (($confirmed !== 'yes') && ($confirmed !== 'no')) {
+			$output->writeln('Continue can accept either yes or no');
+			return null;
+		}
+
 		try {
 			if ($this->encryptionManager->isEnabled() === true) {
 				$output->write('Disable server side encryption... ');
@@ -144,7 +163,7 @@ class DecryptAll extends Command {
 			$output->writeln('Please make sure that no user access his files during this process!');
 			$output->writeln('');
 			$question = new ConfirmationQuestion('Do you really want to continue? (y/n) ', false);
-			if ($this->questionHelper->ask($input, $output, $question)) {
+			if (($confirmed === 'yes') || $this->questionHelper->ask($input, $output, $question)) {
 				$this->forceSingleUserAndTrashbin();
 				$user = $input->getArgument('user');
 				$result = $this->decryptAll->decryptAll($input, $output, $user);

--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -112,8 +112,13 @@ class DecryptAll {
 		} else {
 			$this->output->writeln('Files for following users couldn\'t be decrypted, ');
 			$this->output->writeln('maybe the user is not set up in a way that supports this operation: ');
-			foreach ($this->failed as $uid => $paths) {
+			foreach ($this->failed as $uid => $data) {
 				$this->output->writeln('    ' . $uid);
+				foreach ($data as $failure) {
+					$path = $failure['path'];
+					$message = $failure['exception']->getMessage();
+					$this->output->writeLn("           $path - $message");
+				}
 			}
 			$this->output->writeln('');
 		}
@@ -242,9 +247,9 @@ class DecryptAll {
 							'app' => __CLASS__
 						]);
 						if (isset($this->failed[$uid])) {
-							$this->failed[$uid][] = $path;
+							$this->failed[$uid][] = ['path' => $path, 'exception' => $e];
 						} else {
-							$this->failed[$uid] = [$path];
+							$this->failed[$uid] = [['path' => $path, 'exception' => $e]];
 						}
 					}
 				}

--- a/lib/private/Helper/EnvironmentHelper.php
+++ b/lib/private/Helper/EnvironmentHelper.php
@@ -55,4 +55,13 @@ class EnvironmentHelper {
 	public function getAppsRoots() {
 		return \OC::$APPSROOTS;
 	}
+
+	/**
+	 * Get the environment variable
+	 * @param $envVar
+	 * @return array|false|string
+	 */
+	public function getEnvVar($envVar) {
+		return \getenv($envVar);
+	}
 }

--- a/tests/Core/Command/Encryption/DecryptAllTest.php
+++ b/tests/Core/Command/Encryption/DecryptAllTest.php
@@ -125,6 +125,11 @@ class DecryptAllTest extends TestCase {
 			$this->questionHelper
 		);
 
+		$this->consoleInput->expects($this->once())
+			->method('getOption')
+			->with('continue')
+			->willReturn('no');
+
 		$this->encryptionManager->expects($this->once())
 			->method('isEnabled')
 			->willReturn($encryptionEnabled);
@@ -181,6 +186,11 @@ class DecryptAllTest extends TestCase {
 			$this->questionHelper
 		);
 
+		$this->consoleInput->expects($this->once())
+			->method('getOption')
+			->with('continue')
+			->willReturn('no');
+
 		$this->config->expects($this->at(0))
 			->method('setAppValue')
 			->with('core', 'encryption_enabled', 'no');
@@ -211,5 +221,39 @@ class DecryptAllTest extends TestCase {
 			});
 
 		$this->invokePrivate($instance, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+
+	public function providesConfirmVal() {
+		return [
+			['yes'],
+			['no'],
+			['foo']
+		];
+	}
+
+	/**
+	 * @dataProvider providesConfirmVal
+	 * @param $confirmVal
+	 */
+
+	public function testExecuteConfirm($confirmVal) {
+		$instance = new DecryptAll(
+			$this->encryptionManager,
+			$this->appManager,
+			$this->config,
+			$this->decryptAll,
+			$this->questionHelper
+		);
+
+		$this->consoleInput->expects($this->once())
+			->method('getOption')
+			->with('continue')
+			->willReturn($confirmVal);
+
+		$this->encryptionManager->expects($this->any())
+			->method('isEnabled')
+			->willReturn(true);
+
+		$this->assertNull($this->invokePrivate($instance, 'execute', [$this->consoleInput, $this->consoleOutput]));
 	}
 }

--- a/tests/lib/Helper/EnvironmentHelperTest.php
+++ b/tests/lib/Helper/EnvironmentHelperTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2017, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Helper;
+
+use OC\Helper\EnvironmentHelper;
+use Test\TestCase;
+
+class EnvironmentHelperTest extends TestCase {
+	private $environmentHelper;
+
+	public function setUp() {
+		$this->environmentHelper = new EnvironmentHelper();
+		parent::setUp();
+	}
+
+	public function testGetWebRoot() {
+		$this->assertEquals(\OC::$WEBROOT, $this->environmentHelper->getWebRoot());
+	}
+
+	public function testGetServerRoot() {
+		$this->assertEquals(\OC::$SERVERROOT, $this->environmentHelper->getServerRoot());
+	}
+
+	public function testGetAppsRoots() {
+		$this->assertEquals(\OC::$APPSROOTS, $this->environmentHelper->getAppsRoots());
+	}
+
+	public function testGetEnvVar() {
+		\putenv('foo=bar');
+		$this->assertEquals('bar', $this->environmentHelper->getEnvVar('foo'));
+	}
+}


### PR DESCRIPTION
Instead of providing password for all the users, be
it recovery or oc password, its better to read it
from the environment variable. This change helps
users to read it from the environment variable.
If user wishes to provide oc password for each user,
that option is also available.

Co-authored-by: Tom Needham <tom@owncloud.com>

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Use environment variables to read the password. This helps admin when the decrypt-all is run against entire users in oC. It helps in automation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Use environment variables to read the password. This helps admin when the decrypt-all is run against entire users in oC. It helps in automation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested as per the steps mentioned at https://github.com/owncloud/core/pull/32172#issue-204198207.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
