### PR TITLE
mark API tests that should also run on LDAP

### DIFF
--- a/tests/acceptance/features/apiMain/auth.feature
+++ b/tests/acceptance/features/apiMain/auth.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: auth
 
 	Background:

--- a/tests/acceptance/features/apiMain/caldav.feature
+++ b/tests/acceptance/features/apiMain/caldav.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: caldav
 
 	Background:

--- a/tests/acceptance/features/apiMain/carddav.feature
+++ b/tests/acceptance/features/apiMain/carddav.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: carddav
 
   Background:

--- a/tests/acceptance/features/apiMain/comments.feature
+++ b/tests/acceptance/features/apiMain/comments.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: Comments
   Background:
     Given using new DAV path
@@ -105,10 +105,10 @@ Feature: Comments
 	Scenario: sharee comments on a group shared file
 		Given user "user0" has been created
 		And user "user1" has been created
-		And group "sharinggroup" has been created
-		And user "user1" has been added to group "sharinggroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
-		And user "user0" has shared file "/myFileToComment.txt" with group "sharinggroup"
+		And user "user0" has shared file "/myFileToComment.txt" with group "grp1"
 		When user "user1" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 		And user "user0" should have the following comments on file "/myFileToComment.txt"
@@ -117,8 +117,6 @@ Feature: Comments
 	Scenario: sharee comments on read-only shared file
 		Given user "user0" has been created
 		And user "user1" has been created
-		And group "sharinggroup" has been created
-		And user "user1" has been added to group "sharinggroup"
 		And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
 		And user "user0" has created a share with settings
 			| path        | /myFileToComment.txt |
@@ -133,8 +131,6 @@ Feature: Comments
 	Scenario: sharee comments on upload-only shared file
 		Given user "user0" has been created
 		And user "user1" has been created
-		And group "sharinggroup" has been created
-		And user "user1" has been added to group "sharinggroup"
 		And user "user0" has uploaded file "data/textfile.txt" to "/myFileToComment.txt"
 		And user "user0" has created a share with settings
 			| path        | /myFileToComment.txt |
@@ -208,10 +204,10 @@ Feature: Comments
 	Scenario: sharee comments on a group shared folder
 		Given user "user0" has been created
 		And user "user1" has been created
-		And group "sharinggroup" has been created
-		And user "user1" has been added to group "sharinggroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has created a folder "/FOLDER_TO_COMMENT"
-		And user "user0" has shared folder "/FOLDER_TO_COMMENT" with group "sharinggroup"
+		And user "user0" has shared folder "/FOLDER_TO_COMMENT" with group "grp1"
 		When user "user1" comments with content "Comment from sharee" on folder "/FOLDER_TO_COMMENT" using the WebDAV API
 		Then the HTTP status code should be "201"
 		And user "user0" should have the following comments on folder "/FOLDER_TO_COMMENT"

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -1,22 +1,24 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharees
 	Background:
 		Given using OCS API version "1"
-		And user "test" has been created
-		And user "Sharee1" has been created
+		And these users have been created: 
+			|username|displayname|
+			|user1   |User One   |
+			|sharee1 |Sharee One |
 		And group "ShareeGroup" has been created
 		And group "ShareeGroup2" has been created
-		And user "test" has been added to group "ShareeGroup2"
+		And user "user1" has been added to group "ShareeGroup2"
 
 	Scenario: Search without exact match
-		When user "test" gets the sharees using the sharing API with parameters
-			| search   | Sharee |
+		When user "user1" gets the sharees using the sharing API with parameters
+			| search   | sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
 		And the "users" sharees returned should be
-			| Sharee1 | 0 | Sharee1 |
+			| Sharee One | 0 | sharee1 |
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be
 			| ShareeGroup  | 1 | ShareeGroup  |
@@ -25,14 +27,14 @@ Feature: sharees
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Search without exact match not-exact casing
-		When user "test" gets the sharees using the sharing API with parameters
-			| search   | sharee |
+		When user "user1" gets the sharees using the sharing API with parameters
+			| search   | sHaRee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
 		And the "users" sharees returned should be
-			| Sharee1 | 0 | Sharee1 |
+			| Sharee One | 0 | sharee1 |
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be
 			| ShareeGroup  | 1 | ShareeGroup  |
@@ -42,7 +44,7 @@ Feature: sharees
 
 	Scenario: Search only with group members - denied
 		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
@@ -56,17 +58,18 @@ Feature: sharees
 		And the "exact remotes" sharees returned should be empty
 		And the "remotes" sharees returned should be empty
 
+	@skipOnLDAP
 	Scenario: Search only with group members - allowed
 		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
 		And user "Sharee1" has been added to group "ShareeGroup2"
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
 		And the "users" sharees returned should be
-			| Sharee1 | 0 | Sharee1 |
+			| Sharee One | 0 | sharee1 |
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be
 			| ShareeGroup  | 1 | ShareeGroup  |
@@ -112,7 +115,7 @@ Feature: sharees
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
 		And the "users" sharees returned should be
-			| Sharee1 | 0 | Sharee1 |
+			| Sharee One | 0 | sharee1 |
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be empty
 		And the "exact remotes" sharees returned should be empty
@@ -120,7 +123,7 @@ Feature: sharees
 
 	Scenario: Search only with membership groups - allowed
 		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | ShareeGroup |
 			| itemType | file        |
 		Then the OCS status code should be "100"
@@ -135,14 +138,14 @@ Feature: sharees
 
 	Scenario: Search only with membership groups - allowed including users
 		Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | Sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
 		And the "users" sharees returned should be
-			| Sharee1 | 0 | Sharee1 |
+			| Sharee One | 0 | sharee1 |
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be
 			| ShareeGroup2 | 1 | ShareeGroup2 |
@@ -151,7 +154,7 @@ Feature: sharees
 
 	Scenario: Search without exact match no iteration allowed
 		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | Sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
@@ -165,13 +168,13 @@ Feature: sharees
 
 	Scenario: Search with exact match no iteration allowed
 		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | Sharee1 |
 			| itemType | file    |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be
-			| Sharee1 | 0 | Sharee1 |
+			| Sharee One | 0 | sharee1 |
 		And the "users" sharees returned should be empty
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be empty
@@ -180,7 +183,7 @@ Feature: sharees
 
 	Scenario: Search with exact match group no iteration allowed
 		Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | ShareeGroup |
 			| itemType | file        |
 		Then the OCS status code should be "100"
@@ -194,13 +197,13 @@ Feature: sharees
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Search with exact match
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | Sharee1 |
 			| itemType | file    |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be
-			| Sharee1 | 0 | Sharee1 |
+			| Sharee One | 0 | sharee1 |
 		And the "users" sharees returned should be empty
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be empty
@@ -208,13 +211,13 @@ Feature: sharees
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Search with exact match not-exact casing
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | sharee1 |
 			| itemType | file    |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be
-			| Sharee1 | 0 | Sharee1 |
+			| Sharee One | 0 | sharee1 |
 		And the "users" sharees returned should be empty
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be empty
@@ -222,7 +225,7 @@ Feature: sharees
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Search with exact match not-exact casing group
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | shareegroup2 |
 			| itemType | file         |
 		Then the OCS status code should be "100"
@@ -242,7 +245,7 @@ Feature: sharees
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be
-			| Sharee1 | 0 | Sharee1 |
+			| Sharee One | 0 | sharee1 |
 		And the "users" sharees returned should be empty
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be empty
@@ -250,7 +253,7 @@ Feature: sharees
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Remote sharee for files
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | test@localhost |
 			| itemType | file           |
 		Then the OCS status code should be "100"
@@ -264,7 +267,7 @@ Feature: sharees
 		And the "remotes" sharees returned should be empty
 
 	Scenario: Remote sharee for calendars not allowed
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | test@localhost |
 			| itemType | calendar       |
 		Then the OCS status code should be "100"
@@ -278,24 +281,25 @@ Feature: sharees
 
 	Scenario: Group sharees not returned when group sharing is disabled
 		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | sharee |
 			| itemType | file   |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be empty
 		And the "users" sharees returned should be
-			| Sharee1 | 0 | Sharee1 |
+			| Sharee One | 0 | sharee1 |
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be empty
 		And the "exact remotes" sharees returned should be empty
 		And the "remotes" sharees returned should be empty
 
+	@skipOnLDAP
 	Scenario: Enumerate only group members - only show partial results from member groups
 		Given user "Another" has been created
 		And user "Another" has been added to group "ShareeGroup2"
 		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | anot  |
 			| itemType | file |
 		Then the OCS status code should be "100"
@@ -310,13 +314,13 @@ Feature: sharees
 
 	Scenario: Enumerate only group members - accept exact match from non-member groups
 		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | Sharee1 |
 			| itemType | file    |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the "exact users" sharees returned should be
-			| Sharee1 | 0 | Sharee1 |
+			| Sharee One | 0 | sharee1 |
 		And the "users" sharees returned should be empty
 		And the "exact groups" sharees returned should be empty
 		And the "groups" sharees returned should be empty
@@ -325,7 +329,7 @@ Feature: sharees
 
 	Scenario: Enumerate only group members - only show partial results from member groups
 		Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | ShareeG |
 			| itemType | file    |
 		Then the OCS status code should be "100"
@@ -338,10 +342,11 @@ Feature: sharees
 		And the "exact remotes" sharees returned should be empty
 		And the "remotes" sharees returned should be empty
 
+	@skipOnLDAP
 	Scenario: Enumerate only group members - only accept exact group match from non-memberships
 		Given group "ShareeGroupNonMember" has been created
 		And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
-		When user "test" gets the sharees using the sharing API with parameters
+		When user "user1" gets the sharees using the sharing API with parameters
 			| search   | ShareeGroupNonMember |
 			| itemType | file                 |
 		Then the OCS status code should be "100"

--- a/tests/acceptance/features/apiSharees/sharees_provisioningapiv2.feature
+++ b/tests/acceptance/features/apiSharees/sharees_provisioningapiv2.feature
@@ -1,22 +1,24 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharees_provisioningapiv2
   Background:
     Given using OCS API version "2"
-    And user "test" has been created
-    And user "Sharee1" has been created
+    And these users have been created: 
+      |username|displayname|
+      |user1   |User One   |
+      |sharee1 |Sharee One |
     And group "ShareeGroup" has been created
     And group "ShareeGroup2" has been created
-    And user "test" has been added to group "ShareeGroup2"
+    And user "user1" has been added to group "ShareeGroup2"
 
   Scenario: Search without exact match
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | Sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
     And the "users" sharees returned should be
-      | Sharee1 | 0 | Sharee1 |
+      | Sharee One | 0 | sharee1 |
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be
       | ShareeGroup  | 1 | ShareeGroup  |
@@ -25,14 +27,14 @@ Feature: sharees_provisioningapiv2
     And the "remotes" sharees returned should be empty
 
   Scenario: Search without exact match not-exact casing
-    When user "test" gets the sharees using the sharing API with parameters
-      | search   | sharee |
+    When user "user1" gets the sharees using the sharing API with parameters
+      | search   | sHaRee |
       | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
     And the "users" sharees returned should be
-      | Sharee1 | 0 | Sharee1 |
+      | Sharee One | 0 | sharee1 |
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be
       | ShareeGroup  | 1 | ShareeGroup  |
@@ -42,7 +44,7 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search only with group members - denied
     Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
@@ -56,17 +58,18 @@ Feature: sharees_provisioningapiv2
     And the "exact remotes" sharees returned should be empty
     And the "remotes" sharees returned should be empty
 
+  @skipOnLDAP
   Scenario: Search only with group members - allowed
     Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     And user "Sharee1" has been added to group "ShareeGroup2"
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
     And the "users" sharees returned should be
-      | Sharee1 | 0 | Sharee1 |
+      | Sharee One | 0 | sharee1 |
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be
       | ShareeGroup  | 1 | ShareeGroup  |
@@ -112,7 +115,7 @@ Feature: sharees_provisioningapiv2
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
     And the "users" sharees returned should be
-      | Sharee1 | 0 | Sharee1 |
+      | Sharee One | 0 | sharee1 |
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be empty
     And the "exact remotes" sharees returned should be empty
@@ -120,7 +123,7 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search only with membership groups - allowed
     Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | ShareeGroup |
       | itemType | file        |
     Then the OCS status code should be "200"
@@ -135,14 +138,14 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search only with membership groups - allowed including users
     Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | Sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
     And the "users" sharees returned should be
-      | Sharee1 | 0 | Sharee1 |
+      | Sharee One | 0 | sharee1 |
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be
       | ShareeGroup2 | 1 | ShareeGroup2 |
@@ -151,7 +154,7 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search without exact match no iteration allowed
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | Sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
@@ -165,13 +168,13 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search with exact match no iteration allowed
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | Sharee1 |
       | itemType | file    |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be
-      | Sharee1 | 0 | Sharee1 |
+      | Sharee One | 0 | sharee1 |
     And the "users" sharees returned should be empty
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be empty
@@ -180,7 +183,7 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Search with exact match group no iteration allowed
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | ShareeGroup |
       | itemType | file        |
     Then the OCS status code should be "200"
@@ -194,13 +197,13 @@ Feature: sharees_provisioningapiv2
     And the "remotes" sharees returned should be empty
 
   Scenario: Search with exact match
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | Sharee1 |
       | itemType | file    |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be
-      | Sharee1 | 0 | Sharee1 |
+      | Sharee One | 0 | sharee1 |
     And the "users" sharees returned should be empty
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be empty
@@ -208,13 +211,13 @@ Feature: sharees_provisioningapiv2
     And the "remotes" sharees returned should be empty
 
   Scenario: Search with exact match not-exact casing
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | sharee1 |
       | itemType | file    |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be
-      | Sharee1 | 0 | Sharee1 |
+      | Sharee One | 0 | sharee1 |
     And the "users" sharees returned should be empty
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be empty
@@ -222,7 +225,7 @@ Feature: sharees_provisioningapiv2
     And the "remotes" sharees returned should be empty
 
   Scenario: Search with exact match not-exact casing group
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | shareegroup2 |
       | itemType | file         |
     Then the OCS status code should be "200"
@@ -242,7 +245,7 @@ Feature: sharees_provisioningapiv2
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be
-      | Sharee1 | 0 | Sharee1 |
+      | Sharee One | 0 | sharee1 |
     And the "users" sharees returned should be empty
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be empty
@@ -250,7 +253,7 @@ Feature: sharees_provisioningapiv2
     And the "remotes" sharees returned should be empty
 
   Scenario: Remote sharee for files
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | test@localhost |
       | itemType | file           |
     Then the OCS status code should be "200"
@@ -264,7 +267,7 @@ Feature: sharees_provisioningapiv2
     And the "remotes" sharees returned should be empty
 
   Scenario: Remote sharee for calendars not allowed
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | test@localhost |
       | itemType | calendar       |
     Then the OCS status code should be "200"
@@ -278,14 +281,14 @@ Feature: sharees_provisioningapiv2
 
   Scenario: Group sharees not returned when group sharing is disabled
     Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-    When user "test" gets the sharees using the sharing API with parameters
+    When user "user1" gets the sharees using the sharing API with parameters
       | search   | sharee |
       | itemType | file   |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And the "exact users" sharees returned should be empty
     And the "users" sharees returned should be
-      | Sharee1 | 0 | Sharee1 |
+      | Sharee One | 0 | sharee1 |
     And the "exact groups" sharees returned should be empty
     And the "groups" sharees returned should be empty
     And the "exact remotes" sharees returned should be empty

--- a/tests/acceptance/features/apiSharing/acceptShares.feature
+++ b/tests/acceptance/features/apiSharing/acceptShares.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: accept/decline shares coming from internal users
 	As a user
 	I want to have control of which received shares I accept

--- a/tests/acceptance/features/apiSharing/accessToShare.feature
+++ b/tests/acceptance/features/apiSharing/accessToShare.feature
@@ -1,10 +1,10 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharing
 	Background:
 		Given using old DAV path
 		And user "user0" has been created
 		And user "user1" has been created
-
+	
 	Scenario Outline: Sharee can see the share
 		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has shared file "textfile0.txt" with user "user1"
@@ -45,9 +45,9 @@ Feature: sharing
 
 	Scenario Outline: Sharee can see the group share
 		Given using OCS API version "<ocs_api_version>"
-		And group "group0" has been created
-		And user "user1" has been added to group "group0"
-		And user "user0" has shared file "textfile0.txt" with group "group0"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
+		And user "user0" has shared file "textfile0.txt" with group "grp1"
 		When user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiSharing/changingFilesShare.feature
+++ b/tests/acceptance/features/apiSharing/changingFilesShare.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharing
 	Background:
 		Given using OCS API version "1"

--- a/tests/acceptance/features/apiSharing/createShare.feature
+++ b/tests/acceptance/features/apiSharing/createShare.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharing
 	Background:
 		Given using old DAV path

--- a/tests/acceptance/features/apiSharing/deleteShare.feature
+++ b/tests/acceptance/features/apiSharing/deleteShare.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharing
 	Background:
 		Given using old DAV path
@@ -7,9 +7,9 @@ Feature: sharing
 
 	Scenario Outline: Delete all group shares
 		Given using OCS API version "<ocs_api_version>"
-		And group "group1" has been created
-		And user "user1" has been added to group "group1"
-		And user "user0" has shared file "textfile0.txt" with group "group1"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
+		And user "user0" has shared file "textfile0.txt" with group "grp1"
 		And user "user1" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
 		When user "user0" deletes the last share using the sharing API
 		And user "user1" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
@@ -101,17 +101,18 @@ Feature: sharing
 
 	Scenario Outline: unshare from self
 		Given using OCS API version "<ocs_api_version>"
-		And group "sharing-group" has been created
-		And user "user0" has been added to group "sharing-group"
-		And user "user1" has been added to group "sharing-group"
-		And user "user0" has shared file "/PARENT/parent.txt" with group "sharing-group"
-		And user "user0" has stored etag of element "/PARENT"
+		And group "grp1" has been created
+		And user "user2" has been created
+		And user "user2" has been added to group "grp1"
+		And user "user1" has been added to group "grp1"
+		And user "user2" has shared file "/PARENT/parent.txt" with group "grp1"
+		And user "user2" has stored etag of element "/PARENT"
 		And user "user1" has stored etag of element "/"
 		When user "user1" deletes the last share using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the etag of element "/" of user "user1" should have changed
-		And the etag of element "/PARENT" of user "user0" should not have changed
+		And the etag of element "/PARENT" of user "user2" should not have changed
 		Examples:
 			|ocs_api_version|ocs_status_code|
 			|1              |100            |

--- a/tests/acceptance/features/apiSharing/disableSharing.feature
+++ b/tests/acceptance/features/apiSharing/disableSharing.feature
@@ -1,11 +1,11 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharing
 As an admin
 I want to be able to disable sharing functionality 
 So that ownCloud users cannot share file or folder
 
 	Background:
-		And using old DAV path
+		Given using old DAV path
 		And user "user0" has been created
 		And user "user1" has been created
 
@@ -33,10 +33,10 @@ So that ownCloud users cannot share file or folder
 
 	Scenario Outline: user tries to share a file with group when the sharing api has been disabled
 		Given using OCS API version "<ocs_api_version>"
-		And group "sharinggroup" has been created
-		And user "user1" has been added to group "sharinggroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to share file "welcome.txt" with group "sharinggroup" using the sharing API
+		Then user "user0" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -46,10 +46,10 @@ So that ownCloud users cannot share file or folder
 
 	Scenario Outline: user tries to share a folder with group when the sharing api has been disabled
 		Given using OCS API version "<ocs_api_version>"
-		And group "sharinggroup" has been created
-		And user "user1" has been added to group "sharinggroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to share folder "/FOLDER" with group "sharinggroup" using the sharing API
+		Then user "user0" should not be able to share folder "/FOLDER" with group "grp1" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -81,10 +81,10 @@ So that ownCloud users cannot share file or folder
 
 	Scenario Outline: user tries to share a file with user who is not in his group when sharing outside the group has been restricted
 		Given using OCS API version "<ocs_api_version>"
-		And group "sharinggroup" has been created
-		And user "user0" has been added to group "sharinggroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		Then user "user0" should not be able to share file "welcome.txt" with user "user1" using the sharing API
+		Then user "user1" should not be able to share file "welcome.txt" with user "user0" using the sharing API
 		And the OCS status code should be "403"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -94,11 +94,12 @@ So that ownCloud users cannot share file or folder
 
 	Scenario Outline: user shares a file with user who is in his group when sharing outside the group has been restricted
 		Given using OCS API version "<ocs_api_version>"
-		And group "sharinggroup" has been created
-		And user "user0" has been added to group "sharinggroup"
-		And user "user1" has been added to group "sharinggroup"
+		And group "grp1" has been created
+		And user "user2" has been created
+		And user "user2" has been added to group "grp1"
+		And user "user1" has been added to group "grp1"
 		When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		Then user "user0" should be able to share file "welcome.txt" with user "user1" using the sharing API
+		Then user "user2" should be able to share file "welcome.txt" with user "user1" using the sharing API
 		And the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		Examples:
@@ -108,12 +109,13 @@ So that ownCloud users cannot share file or folder
 
 	Scenario Outline: user shares a file with the group he is not member of when sharing outside the group has been restricted
 		Given using OCS API version "<ocs_api_version>"
-		And group "sharinggroup" has been created
-		And group "anothersharinggroup" has been created
-		And user "user0" has been added to group "sharinggroup"
-		And user "user1" has been added to group "anothersharinggroup"
+		And group "grp2" has been created
+		And group "grp1" has been created
+		And user "user3" has been created
+		And user "user3" has been added to group "grp2"
+		And user "user1" has been added to group "grp1"
 		When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		Then user "user0" should be able to share file "welcome.txt" with group "anothersharinggroup" using the sharing API
+		Then user "user3" should be able to share file "welcome.txt" with group "grp1" using the sharing API
 		And the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		Examples:
@@ -123,10 +125,10 @@ So that ownCloud users cannot share file or folder
 
 	Scenario Outline: user who is not a member of a group tries to share a file in the group when group sharing has been disabled
 		Given using OCS API version "<ocs_api_version>"
-		And group "sharinggroup" has been created
-		And user "user1" has been added to group "sharinggroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		Then user "user0" should not be able to share file "welcome.txt" with group "sharinggroup" using the sharing API
+		Then user "user0" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -136,11 +138,12 @@ So that ownCloud users cannot share file or folder
 
 	Scenario Outline: user who is a member of a group tries to share a file in the group when group sharing has been disabled
 		Given using OCS API version "<ocs_api_version>"
-		And group "sharinggroup" has been created
-		And user "user0" has been added to group "sharinggroup"
-		And user "user1" has been added to group "sharinggroup"
+		And group "grp1" has been created
+		And user "user2" has been created
+		And user "user2" has been added to group "grp1"
+		And user "user1" has been added to group "grp1"
 		When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		Then user "user0" should not be able to share file "welcome.txt" with group "sharinggroup" using the sharing API
+		Then user "user2" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:

--- a/tests/acceptance/features/apiSharing/downloadFromShare.feature
+++ b/tests/acceptance/features/apiSharing/downloadFromShare.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharing
 	Background:
 		Given using OCS API version "1"
@@ -17,12 +17,12 @@ Feature: sharing
 	Scenario: Share a file by multiple channels and download from sub-folder and direct file share
 		Given user "user1" has been created
 		And user "user2" has been created
-		And group "group0" has been created
-		And user "user1" has been added to group "group0"
-		And user "user2" has been added to group "group0"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
+		And user "user2" has been added to group "grp1"
 		And user "user0" has created a folder "/common"
 		And user "user0" has created a folder "/common/sub"
-		And user "user0" has shared folder "common" with group "group0"
+		And user "user0" has shared folder "common" with group "grp1"
 		And user "user1" has shared file "textfile0.txt" with user "user2"
 		And user "user1" has moved file "/textfile0.txt" to "/common/textfile0.txt"
 		And user "user1" has moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
@@ -44,9 +44,9 @@ Feature: sharing
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with default permissions
 		Given user "user1" has been created
-		And group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
-		When user "user0" has shared folder "PARENT" with group "sharegroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
+		When user "user0" has shared folder "PARENT" with group "grp1"
 		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with public with default permissions
@@ -67,12 +67,12 @@ Feature: sharing
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read/Write permission 
 		Given user "user1" has been created
-		And group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		When user "user0" creates a share using the sharing API with settings
 			| path        | PARENT      |
 			| shareType   | 1           |
-			| shareWith   | sharegroup  |
+			| shareWith   | grp1        |
 			| permissions | 15          |
 		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
@@ -81,7 +81,7 @@ Feature: sharing
 			| path         | PARENT   |
 			| shareType    | 3        |
 			| password     | publicpw |
-			| permissions | 15        |
+			| permissions  | 15       |
 		Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "publicpw" and the content should be "wnCloud"
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read only permission 
@@ -95,12 +95,12 @@ Feature: sharing
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with a group with Read only permission 
 		Given user "user1" has been created
-		And group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		When user "user0" creates a share using the sharing API with settings
 			| path        | PARENT      |
 			| shareType   | 1           |
-			| shareWith   | sharegroup  |
+			| shareWith   | grp1        |
 			| permissions | 1           |
 		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 

--- a/tests/acceptance/features/apiSharing/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiSharing/getWebDAVSharePermissions.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharing
 	Background:
 		Given using OCS API version "1"
@@ -20,14 +20,14 @@ Feature: sharing
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
 
 	Scenario: Correct webdav share-permissions for received group shared file with edit and reshare permissions
-		Given group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
+		Given group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has uploaded file with content "foo" to "/tmp.txt"
 		And user "user0" has created a share with settings
 			| path        | /tmp.txt   |
 			| shareType   | 1          |
 			| permissions | 19         |
-			| shareWith   | sharegroup |
+			| shareWith   | grp1       |
 		When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "19"
@@ -42,14 +42,14 @@ Feature: sharing
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
 
 	Scenario: Correct webdav share-permissions for received group shared file with edit permissions but no reshare permissions
-		Given group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
+		Given group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has uploaded file with content "foo" to "/tmp.txt"
 		And user "user0" has created a share with settings
 			| path        | /tmp.txt   |
 			| shareType   | 1          |
 			| permissions | 3          |
-			| shareWith   | sharegroup |
+			| shareWith   | grp1       |
 		When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "3"
@@ -64,14 +64,14 @@ Feature: sharing
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
 
 	Scenario: Correct webdav share-permissions for received group shared file with reshare permissions but no edit permissions
-		Given group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
+		Given group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has uploaded file with content "foo" to "/tmp.txt"
 		And user "user0" has created a share with settings
 			| path        | /tmp.txt   |
 			| shareType   | 1          |
 			| permissions | 17         |
-			| shareWith   | sharegroup |
+			| shareWith   | grp1       |
 		When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "17"
@@ -90,13 +90,13 @@ Feature: sharing
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
 
 	Scenario: Correct webdav share-permissions for received group shared folder with all permissions
-		Given group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
+		Given group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has created a folder "/tmp"
 		And user "user0" has created a share with settings
 			| path        | tmp        |
 			| shareType   | 1          |
-			| shareWith   | sharegroup |
+			| shareWith   | grp1       |
 		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
@@ -111,13 +111,13 @@ Feature: sharing
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "29"
 
 	Scenario: Correct webdav share-permissions for received group shared folder with all permissions but edit
-		Given group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
+		Given group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has created a folder "/tmp"
 		And user "user0" has created a share with settings
 			| path        | tmp        |
 			| shareType   | 1          |
-			| shareWith   | sharegroup |
+			| shareWith   | grp1       |
 			| permissions | 29         |
 		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
@@ -133,13 +133,13 @@ Feature: sharing
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "27"
 
 	Scenario: Correct webdav share-permissions for received group shared folder with all permissions but create
-		Given group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
+		Given group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has created a folder "/tmp"
 		And user "user0" has created a share with settings
 			| path        | tmp        |
 			| shareType   | 1          |
-			| shareWith   | sharegroup |
+			| shareWith   | grp1       |
 			| permissions | 27         |
 		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
@@ -155,13 +155,13 @@ Feature: sharing
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "23"
 
 	Scenario: Correct webdav share-permissions for received group shared folder with all permissions but delete
-		Given group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
+		Given group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has created a folder "/tmp"
 		And user "user0" has created a share with settings
 			| path        | tmp        |
 			| shareType   | 1          |
-			| shareWith   | sharegroup |
+			| shareWith   | grp1       |
 			| permissions | 23         |
 		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |
@@ -177,13 +177,13 @@ Feature: sharing
 		Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "15"
 
 	Scenario: Correct webdav share-permissions for received group shared folder with all permissions but share
-		Given group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
+		Given group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has created a folder "/tmp"
 		And user "user0" has created a share with settings
 			| path        | tmp        |
 			| shareType   | 1          |
-			| shareWith   | sharegroup |
+			| shareWith   | grp1       |
 			| permissions | 15         |
 		When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
 			|{http://open-collaboration-services.org/ns}share-permissions |

--- a/tests/acceptance/features/apiSharing/gettingShares.feature
+++ b/tests/acceptance/features/apiSharing/gettingShares.feature
@@ -1,9 +1,11 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharing
 	Background:
 		Given using old DAV path
-		And user "user0" has been created
-		And user "user1" has been created
+		And these users have been created:
+			|username|displayname|
+			|user0   |User Zero  |
+			|user1   |User One   |
 
 	Scenario Outline: getting all shares of a user using that user
 		Given using OCS API version "<ocs_api_version>"
@@ -66,13 +68,14 @@ Feature: sharing
 
 	Scenario Outline: User's own shares reshared to him don't appear when getting "shared with me" shares
 		Given using OCS API version "<ocs_api_version>"
-		And group "group0" has been created
-		And user "user0" has been added to group "group0"
-		And user "user0" has created a folder "/shared"
-		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-		And user "user0" has shared folder "/shared" with user "user1"
-		And user "user1" has shared folder "/shared" with group "group0"
-		When user "user0" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
+		And group "grp1" has been created
+		And user "user2" has been created
+		And user "user2" has been added to group "grp1"
+		And user "user2" has created a folder "/shared"
+		And user "user2" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+		And user "user2" has shared folder "/shared" with user "user1"
+		And user "user1" has shared folder "/shared" with group "grp1"
+		When user "user2" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?shared_with_me=true"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the last share_id should not be included in the response
@@ -103,8 +106,8 @@ Feature: sharing
 			| mail_send              | 0                  |
 			| uid_owner              | user0              |
 			| file_parent            | A_NUMBER           |
-			| share_with_displayname | user1              |
-			| displayname_owner      | user0              |
+			| share_with_displayname | User One           |
+			| displayname_owner      | User Zero          |
 			| mimetype               | text/plain         |
 		Examples:
 			|ocs_api_version|ocs_status_code|
@@ -123,6 +126,7 @@ Feature: sharing
 			|1              |200             |
 			|2              |404             |
 
+	@skipOnLDAP
 	Scenario: Share of folder to a group, remove user from that group
 		Given using OCS API version "1"
 		And user "user2" has been created

--- a/tests/acceptance/features/apiSharing/mergeShare.feature
+++ b/tests/acceptance/features/apiSharing/mergeShare.feature
@@ -1,23 +1,23 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharing
 	Background:
 		Given using OCS API version "1"
 		And using old DAV path
 		And user "user0" has been created
 		And user "user1" has been created
-		And group "group1" has been created
-		And user "user1" has been added to group "group1"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 
 	Scenario: Merging shares for recipient when shared from outside with group and member
 		Given user "user0" has created a folder "/merge-test-outside"
-		When user "user0" shares folder "/merge-test-outside" with group "group1" using the sharing API
+		When user "user0" shares folder "/merge-test-outside" with group "grp1" using the sharing API
 		And user "user0" shares folder "/merge-test-outside" with user "user1" using the sharing API
 		Then as "user1" the folder "/merge-test-outside" should exist
 		And as "user1" the folder "/merge-test-outside (2)" should not exist
 
 	Scenario: Merging shares for recipient when shared from outside with group and member with different permissions
 		Given user "user0" has created a folder "/merge-test-outside-perms"
-		When user "user0" shares folder "/merge-test-outside-perms" with group "group1" with permissions 1 using the sharing API
+		When user "user0" shares folder "/merge-test-outside-perms" with group "grp1" with permissions 1 using the sharing API
 		And user "user0" shares folder "/merge-test-outside-perms" with user "user1" with permissions 31 using the sharing API
 		And user "user1" gets the following properties of folder "/merge-test-outside-perms" using the WebDAV API
 			|{http://owncloud.org/ns}permissions|
@@ -25,31 +25,31 @@ Feature: sharing
 		And as "user1" the folder "/merge-test-outside-perms (2)" should not exist
 
 	Scenario: Merging shares for recipient when shared from outside with two groups
-		Given group "group2" has been created
-		And user "user1" has been added to group "group2"
+		Given group "grp4" has been created
+		And user "user1" has been added to group "grp4"
 		And user "user0" has created a folder "/merge-test-outside-twogroups"
-		When user "user0" shares folder "/merge-test-outside-twogroups" with group "group1" using the sharing API
-		And user "user0" shares folder "/merge-test-outside-twogroups" with group "group2" using the sharing API
+		When user "user0" shares folder "/merge-test-outside-twogroups" with group "grp1" using the sharing API
+		And user "user0" shares folder "/merge-test-outside-twogroups" with group "grp4" using the sharing API
 		Then as "user1" the folder "/merge-test-outside-twogroups" should exist
 		And as "user1" the folder "/merge-test-outside-twogroups (2)" should not exist
 
 	Scenario: Merging shares for recipient when shared from outside with two groups with different permissions
-		Given group "group2" has been created
-		And user "user1" has been added to group "group2"
+		Given group "grp4" has been created
+		And user "user1" has been added to group "grp4"
 		And user "user0" has created a folder "/merge-test-outside-twogroups-perms"
-		When user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "group1" with permissions 1 using the sharing API
-		And user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "group2" with permissions 31 using the sharing API
+		When user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp1" with permissions 1 using the sharing API
+		And user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp4" with permissions 31 using the sharing API
 		And user "user1" gets the following properties of folder "/merge-test-outside-twogroups-perms" using the WebDAV API
 			|{http://owncloud.org/ns}permissions|
 		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"
 		And as "user1" the folder "/merge-test-outside-twogroups-perms (2)" should not exist
 
 	Scenario: Merging shares for recipient when shared from outside with two groups and member
-		Given group "group2" has been created
-		And user "user1" has been added to group "group2"
+		Given group "grp4" has been created
+		And user "user1" has been added to group "grp4"
 		And user "user0" has created a folder "/merge-test-outside-twogroups-member-perms"
-		When user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "group1" with permissions 1 using the sharing API
-		And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "group2" with permissions 31 using the sharing API
+		When user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp1" with permissions 1 using the sharing API
+		And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp4" with permissions 31 using the sharing API
 		And user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with user "user1" with permissions 1 using the sharing API
 		And user "user1" gets the following properties of folder "/merge-test-outside-twogroups-member-perms" using the WebDAV API
 			|{http://owncloud.org/ns}permissions|
@@ -58,36 +58,36 @@ Feature: sharing
 
 	Scenario: Merging shares for recipient when shared from inside with group
 		Given user "user1" has created a folder "/merge-test-inside-group"
-		When user "user1" shares folder "/merge-test-inside-group" with group "group1" using the sharing API
+		When user "user1" shares folder "/merge-test-inside-group" with group "grp1" using the sharing API
 		Then as "user1" the folder "/merge-test-inside-group" should exist
 		And as "user1" the folder "/merge-test-inside-group (2)" should not exist
 
 	Scenario: Merging shares for recipient when shared from inside with two groups
-		Given group "group2" has been created
-		And user "user1" has been added to group "group2"
+		Given group "grp4" has been created
+		And user "user1" has been added to group "grp4"
 		And user "user1" has created a folder "/merge-test-inside-twogroups"
-		When user "user1" shares folder "/merge-test-inside-twogroups" with group "group1" using the sharing API
-		And user "user1" shares folder "/merge-test-inside-twogroups" with group "group2" using the sharing API
+		When user "user1" shares folder "/merge-test-inside-twogroups" with group "grp1" using the sharing API
+		And user "user1" shares folder "/merge-test-inside-twogroups" with group "grp4" using the sharing API
 		Then as "user1" the folder "/merge-test-inside-twogroups" should exist
 		And as "user1" the folder "/merge-test-inside-twogroups (2)" should not exist
 		And as "user1" the folder "/merge-test-inside-twogroups (3)" should not exist
 
 	Scenario: Merging shares for recipient when shared from inside with group with less permissions
-		Given group "group2" has been created
-		And user "user1" has been added to group "group2"
+		Given group "grp4" has been created
+		And user "user1" has been added to group "grp4"
 		And user "user1" has created a folder "/merge-test-inside-twogroups-perms"
-		When user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "group1" using the sharing API
-		And user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "group2" using the sharing API
+		When user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp1" using the sharing API
+		And user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp4" using the sharing API
 		And user "user1" gets the following properties of folder "/merge-test-inside-twogroups-perms" using the WebDAV API
 			|{http://owncloud.org/ns}permissions|
 		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "RDNVCK" or with value "RMDNVCK"
 		And as "user1" the folder "/merge-test-inside-twogroups-perms (2)" should not exist
 		And as "user1" the folder "/merge-test-inside-twogroups-perms (3)" should not exist
 
-	@skip @issue-29016
+	@skip @issue-29016 @skipOnLDAP
 	Scenario: Merging shares for recipient when shared from outside with group then user and recipient renames in between
 		Given user "user0" has created a folder "/merge-test-outside-groups-renamebeforesecondshare"
-		When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "group1" using the sharing API
+		When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API
 		And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
 		And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
 		And user "user1" gets the following properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
@@ -99,7 +99,7 @@ Feature: sharing
 		Given user "user0" has created a folder "/merge-test-outside-groups-renamebeforesecondshare"
 		When user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with user "user1" using the sharing API
 		And user "user1" moves folder "/merge-test-outside-groups-renamebeforesecondshare" to "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
-		And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "group1" using the sharing API
+		And user "user0" shares folder "/merge-test-outside-groups-renamebeforesecondshare" with group "grp1" using the sharing API
 		And user "user1" gets the following properties of folder "/merge-test-outside-groups-renamebeforesecondshare-renamed" using the WebDAV API
 			|{http://owncloud.org/ns}permissions|
 		Then the single response should contain a property "{http://owncloud.org/ns}permissions" with value "SRDNVCK"

--- a/tests/acceptance/features/apiSharing/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiSharing/moveReceivedShare.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharing
 	Background:
 		Given using OCS API version "1"
@@ -8,11 +8,11 @@ Feature: sharing
 		And user "user2" has been created
 
 	Scenario: Keep usergroup shares (#22143)
-		Given group "group" has been created
-		And user "user1" has been added to group "group"
-		And user "user2" has been added to group "group"
+		Given group "grp1" has been created
+		And user "user1" has been added to group "grp1"
+		And user "user2" has been added to group "grp1"
 		And user "user0" has created a folder "/TMP"
-		When user "user0" shares folder "TMP" with group "group" using the sharing API
+		When user "user0" shares folder "TMP" with group "grp1" using the sharing API
 		And user "user1" creates a folder "/myFOLDER" using the WebDAV API
 		And user "user1" moves folder "/TMP" to "/myFOLDER/myTMP" using the WebDAV API
 		And the administrator deletes user "user2" using the provisioning API

--- a/tests/acceptance/features/apiSharing/multilinksharing.feature
+++ b/tests/acceptance/features/apiSharing/multilinksharing.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: multilinksharing
 
 	Background:

--- a/tests/acceptance/features/apiSharing/reShare.feature
+++ b/tests/acceptance/features/apiSharing/reShare.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharing
 	Background:
 		Given using old DAV path

--- a/tests/acceptance/features/apiSharing/updateShare.feature
+++ b/tests/acceptance/features/apiSharing/updateShare.feature
@@ -1,9 +1,11 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharing
 	Background:
 		Given using OCS API version "1"
 		And using old DAV path
-		And user "user0" has been created
+		And these users have been created: 
+			|username|displayname|
+			|user0   |User Zero  |
 
 	Scenario Outline: Allow modification of reshare
 		Given using OCS API version "<ocs_api_version>"
@@ -46,7 +48,7 @@ Feature: sharing
 			| mail_send         | 0                    |
 			| uid_owner         | user0                |
 			| file_parent       | A_NUMBER             |
-			| displayname_owner | user0                |
+			| displayname_owner | User Zero            |
 			| url               | AN_URL               |
 			| mimetype          | httpd/unix-directory |
 		Examples:
@@ -97,7 +99,7 @@ Feature: sharing
 			| mail_send         | 0                    |
 			| uid_owner         | user0                |
 			| file_parent       | A_NUMBER             |
-			| displayname_owner | user0                |
+			| displayname_owner | User Zero            |
 			| url               | AN_URL               |
 			| mimetype          | httpd/unix-directory |
 		Examples:
@@ -130,7 +132,7 @@ Feature: sharing
 			| mail_send         | 0                    |
 			| uid_owner         | user0                |
 			| file_parent       | A_NUMBER             |
-			| displayname_owner | user0                |
+			| displayname_owner | User Zero            |
 			| url               | AN_URL               |
 			| mimetype          | httpd/unix-directory |
 		Examples:
@@ -163,7 +165,7 @@ Feature: sharing
 			| mail_send         | 0                    |
 			| uid_owner         | user0                |
 			| file_parent       | A_NUMBER             |
-			| displayname_owner | user0                |
+			| displayname_owner | User Zero            |
 			| url               | AN_URL               |
 			| mimetype          | httpd/unix-directory |
 		Examples:
@@ -196,7 +198,7 @@ Feature: sharing
 			| mail_send         | 0                    |
 			| uid_owner         | user0                |
 			| file_parent       | A_NUMBER             |
-			| displayname_owner | user0                |
+			| displayname_owner | User Zero            |
 			| url               | AN_URL               |
 			| mimetype          | httpd/unix-directory |
 		Examples:
@@ -207,9 +209,9 @@ Feature: sharing
 	Scenario Outline: keep group permissions in sync
 		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
-		And group "group1" has been created
-		And user "user1" has been added to group "group1"
-		And user "user0" has shared file "textfile0.txt" with group "group1"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
+		And user "user0" has shared file "textfile0.txt" with group "grp1"
 		And user "user1" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
 		And as user "user0"
 		When the user updates the last share using the sharing API with
@@ -230,7 +232,7 @@ Feature: sharing
 			| mail_send         | 0              |
 			| uid_owner         | user0          |
 			| file_parent       | A_NUMBER       |
-			| displayname_owner | user0          |
+			| displayname_owner | User Zero      |
 			| mimetype          | text/plain     |
 		Examples:
 			|ocs_api_version|ocs_status_code|
@@ -274,8 +276,10 @@ Feature: sharing
 			|2              |400             |
 
 	Scenario: Share ownership change after moving a shared file outside of an outer share
-		Given user "user1" has been created
-		And user "user2" has been created
+		Given these users have been created: 
+			|username|displayname|
+			|user1   |User One   |
+			|user2   |User Two   |
 		And user "user0" has created a folder "/folder1"
 		And user "user0" has created a folder "/folder1/folder2"
 		And user "user1" has created a folder "/moved-out"
@@ -296,14 +300,16 @@ Feature: sharing
 			| mail_send         | 0                    |
 			| uid_owner         | user1                |
 			| file_parent       | A_NUMBER             |
-			| displayname_owner | user1                |
+			| displayname_owner | User One             |
 			| mimetype          | httpd/unix-directory |
 		And as "user0" the folder "/folder1/folder2" should not exist
 		And as "user2" the folder "/folder2" should exist
 
 	Scenario: Share ownership change after moving a shared file to another share
-		Given user "user1" has been created
-		And user "user2" has been created
+		Given these users have been created: 
+			|username|displayname|
+			|user1   |User One   |
+			|user2   |User Two   |
 		And user "user0" has created a folder "/user0-folder"
 		And user "user0" has created a folder "/user0-folder/folder2"
 		And user "user2" has created a folder "/user2-folder"
@@ -324,7 +330,7 @@ Feature: sharing
 			| mail_send         | 0                    |
 			| uid_owner         | user2                |
 			| file_parent       | A_NUMBER             |
-			| displayname_owner | user2                |
+			| displayname_owner | User Two             |
 			| mimetype          | httpd/unix-directory |
 		And as "user0" the folder "/user0-folder/folder2" should not exist
 		And as "user2" the folder "/user2-folder/folder2" should exist
@@ -389,12 +395,13 @@ Feature: sharing
 	Scenario Outline: Increasing permissions is allowed for owner
 		Given using OCS API version "<ocs_api_version>"
 		And user "user1" has been created
-		And group "new-group" has been created
-		And user "user0" has been added to group "new-group"
-		And user "user1" has been added to group "new-group"
-		And user "user0" has been made a subadmin of group "new-group"
-		And as user "user0"
-		And the user has shared folder "/FOLDER" with group "new-group"
+		And user "user2" has been created
+		And group "grp1" has been created
+		And user "user2" has been added to group "grp1"
+		And user "user1" has been added to group "grp1"
+		And user "user2" has been made a subadmin of group "grp1"
+		And as user "user2"
+		And the user has shared folder "/FOLDER" with group "grp1"
 		And the user has updated the last share with
 			| permissions | 1 |
 		When the user updates the last share using the sharing API with

--- a/tests/acceptance/features/apiSharing/uploadToShare.feature
+++ b/tests/acceptance/features/apiSharing/uploadToShare.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: sharing
 	Background:
 		Given using OCS API version "1"
@@ -45,13 +45,13 @@ Feature: sharing
 
 	Scenario: Uploading file to a group read-only share folder does not work
 		Given user "user1" has been created
-		And group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has created a share with settings
 			| path        | FOLDER     |
 			| shareType   | 1          |
 			| permissions | 1          |
-			| shareWith   | sharegroup |
+			| shareWith   | grp1       |
 		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
 		Then the HTTP status code should be "403"
 
@@ -86,13 +86,13 @@ Feature: sharing
 
 	Scenario: Uploading file to a group upload-only share folder works
 		Given user "user1" has been created
-		And group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has created a share with settings
 			| path        | FOLDER     |
 			| shareType   | 1          |
 			| permissions | 4          |
-			| shareWith   | sharegroup |
+			| shareWith   | grp1       |
 		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 
@@ -118,13 +118,13 @@ Feature: sharing
 
 	Scenario: Uploading file to a group read/write share folder works
 		Given user "user1" has been created
-		And group "sharegroup" has been created
-		And user "user1" has been added to group "sharegroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has created a share with settings
 			| path        | FOLDER     |
 			| shareType   | 1          |
 			| permissions | 15         |
-			| shareWith   | sharegroup |
+			| shareWith   | grp1       |
 		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
 		Then the HTTP status code should be "201"
 
@@ -159,13 +159,13 @@ Feature: sharing
 
 	Scenario: Uploading to a group shared folder with read/write permission when the sharer has unsufficient quota does not work
 		Given user "user1" has been created
-		And group "sharinggroup" has been created
-		And user "user1" has been added to group "sharinggroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has created a share with settings
 			| path        | FOLDER       |
 			| shareType   | 1            |
 			| permissions | 15           |
-			| shareWith   | sharinggroup |
+			| shareWith   | grp1         |
 		And the quota of user "user0" has been set to "0"
 		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
 		Then the HTTP status code should be "507"
@@ -174,7 +174,7 @@ Feature: sharing
 		When user "user0" creates a share using the sharing API with settings
 			| path        | FOLDER |
 			| shareType   | 3      |
-			| permissions | 15      |
+			| permissions | 15     |
 		When the quota of user "user0" has been set to "0"
 		Then publicly uploading a file should not work
 		And the HTTP status code should be "507"
@@ -184,7 +184,7 @@ Feature: sharing
 		And user "user0" has created a share with settings
 			| path        | FOLDER     |
 			| shareType   | 0          |
-			| permissions | 4         |
+			| permissions | 4          |
 			| shareWith   | user1      |
 		And the quota of user "user0" has been set to "0"
 		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
@@ -192,13 +192,13 @@ Feature: sharing
 
 	Scenario: Uploading to a group shared folder with upload-only permission when the sharer has unsufficient quota does not work
 		Given user "user1" has been created
-		And group "sharinggroup" has been created
-		And user "user1" has been added to group "sharinggroup"
+		And group "grp1" has been created
+		And user "user1" has been added to group "grp1"
 		And user "user0" has created a share with settings
-			| path        | FOLDER       |
-			| shareType   | 1            |
+			| path        | FOLDER      |
+			| shareType   | 1           |
 			| permissions | 4           |
-			| shareWith   | sharinggroup |
+			| shareWith   | grp1        |
 		And the quota of user "user0" has been set to "0"
 		When user "user1" uploads file "data/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
 		Then the HTTP status code should be "507"
@@ -226,7 +226,7 @@ Feature: sharing
 		And user "user0" has created a share with settings
 			| path        | FOLDER |
 			| shareType   | 3      |
-			| permissions | 31      |
+			| permissions | 31     |
 		When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "yes"
 		Then publicly uploading a file should not work
 		And the HTTP status code should be "403"

--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -1,4 +1,4 @@
-@api @app-required @notifications-app-required
+@api @app-required @notifications-app-required @TestAlsoOnExternalUserBackend
 Feature: Display notifications when receiving a share
 	As a user
 	I want to see notifications about shares that have been offered to me
@@ -8,9 +8,11 @@ Feature: Display notifications when receiving a share
 		Given the app "notifications" has been enabled
 		And using OCS API version "1"
 		And using new DAV path
-		And user "user0" has been created
-		And user "user1" has been created
-		And user "user2" has been created
+		And these users have been created: 
+			|username|displayname|
+			|user0   |User Zero  |
+			|user1   |User One   |
+			|user2   |User Two   |
 		And these groups have been created:
 			|groupname|
 			|grp1     |
@@ -23,11 +25,11 @@ Feature: Display notifications when receiving a share
 		And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
 		Then user "user1" should have 2 notifications
 		And the last notification of user "user1" should match these regular expressions
-			| app         | /^files_sharing$/                       |
-			| subject     | /^"user0" shared "PARENT" with you$/    |
-			| message     | /^"user0" invited you to view "PARENT"$/ |
-			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
-			| object_type | /^local_share$/                         |
+			| app         | /^files_sharing$/                            |
+			| subject     | /^"User Zero" shared "PARENT" with you$/     |
+			| message     | /^"User Zero" invited you to view "PARENT"$/ |
+			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
+			| object_type | /^local_share$/                              |
 
 	Scenario: share to group sends notification to every member
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
@@ -35,18 +37,18 @@ Feature: Display notifications when receiving a share
 		And user "user0" shares file "/textfile0.txt" with group "grp1" using the sharing API
 		Then user "user1" should have 2 notifications
 		And the last notification of user "user1" should match these regular expressions
-			| app         | /^files_sharing$/                       |
-			| subject     | /^"user0" shared "PARENT" with you$/    |
-			| message     | /^"user0" invited you to view "PARENT"$/ |
-			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
-			| object_type | /^local_share$/                         |
+			| app         | /^files_sharing$/                            |
+			| subject     | /^"User Zero" shared "PARENT" with you$/     |
+			| message     | /^"User Zero" invited you to view "PARENT"$/ |
+			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
+			| object_type | /^local_share$/                              |
 		And user "user2" should have 2 notifications
 		And the last notification of user "user2" should match these regular expressions
-			| app         | /^files_sharing$/                       |
-			| subject     | /^"user0" shared "PARENT" with you$/    |
-			| message     | /^"user0" invited you to view "PARENT"$/ |
-			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/ |
-			| object_type | /^local_share$/                         |
+			| app         | /^files_sharing$/                            |
+			| subject     | /^"User Zero" shared "PARENT" with you$/     |
+			| message     | /^"User Zero" invited you to view "PARENT"$/ |
+			| link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/      |
+			| object_type | /^local_share$/                              |
 
 	Scenario: when auto-accepting is enabled no notifications are sent
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
@@ -54,6 +56,7 @@ Feature: Display notifications when receiving a share
 		And user "user0" shares file "/textfile0.txt" with user "user1" using the sharing API
 		Then user "user1" should have 0 notifications
 
+	@skipOnLDAP
 	Scenario: discard notification if target user is not member of the group anymore
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
 		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
@@ -61,6 +64,7 @@ Feature: Display notifications when receiving a share
 		Then user "user1" should have 0 notifications
 		Then user "user2" should have 1 notification
 
+	@skipOnLDAP
 	Scenario: discard notification if group is deleted
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
 		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API

--- a/tests/acceptance/features/apiTrashbin/trashbin-new-endpoint.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbin-new-endpoint.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: trashbin-new-endpoint
 	Background:
 		Given using OCS API version "1"

--- a/tests/acceptance/features/apiTrashbin/trashbin-old-endpoint.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbin-old-endpoint.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: trashbin-new-endpoint
 	Background:
 		Given using OCS API version "1"

--- a/tests/acceptance/features/apiWebdav/webdav-related-new-endpoint.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related-new-endpoint.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: webdav-related-new-endpoint
 	Background:
 		Given using OCS API version "1"

--- a/tests/acceptance/features/apiWebdav/webdav-related-old-endpoint.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related-old-endpoint.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: webdav-related-old-endpoint
 	Background:
 		Given using OCS API version "1"

--- a/tests/acceptance/features/apiWebdav/webdav-related.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related.feature
@@ -1,4 +1,4 @@
-@api
+@api @TestAlsoOnExternalUserBackend
 Feature: webdav-related
 	Background:
 		Given using OCS API version "1"
@@ -440,13 +440,13 @@ Feature: webdav-related
 	Scenario Outline: A file that is shared to a group has a share-types property
 		Given using <dav_version> DAV path
 		And user "user0" has been created
-		And group "group1" has been created
+		And group "grp1" has been created
 		And user "user0" has created a folder "/test"
 		And user "user0" has created a share with settings
 			| path        | test   |
 			| shareType   | 1      |
 			| permissions | 31     |
-			| shareWith   | group1 |
+			| shareWith   | grp1   |
 		When user "user0" gets the following properties of folder "/test" using the WebDAV API
 			|{http://owncloud.org/ns}share-types|
 		Then the response should contain a share-types property with
@@ -477,7 +477,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		And user "user1" has been created
-		And group "group2" has been created
+		And group "grp2" has been created
 		And user "user0" has created a folder "/test"
 		And user "user0" has created a share with settings
 			| path        | test  |
@@ -488,7 +488,7 @@ Feature: webdav-related
 			| path        | test   |
 			| shareType   | 1      |
 			| permissions | 31     |
-			| shareWith   | group2 |
+			| shareWith   | grp2   |
 		And user "user0" has created a share with settings
 			| path        | test  |
 			| shareType   | 3     |
@@ -506,9 +506,9 @@ Feature: webdav-related
 
 	Scenario Outline: A disabled user cannot use webdav
 		Given using <dav_version> DAV path
-		And user "userToBeDisabled" has been created
-		And user "userToBeDisabled" has been disabled
-		When user "userToBeDisabled" downloads the file "/welcome.txt" using the WebDAV API
+		And user "user1" has been created
+		And user "user1" has been disabled
+		When user "user1" downloads the file "/welcome.txt" using the WebDAV API
 		Then the HTTP status code should be "401"
 		Examples:
 			| dav_version   |


### PR DESCRIPTION
## Description
- mark API tests that also should run on LDAP as such
- fix some steps, so that they fit with the .ldif file that we import into LDAP

## Motivation and Context
having better coverage for LDAP

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
