### PR TITLE
Fix phpcs code style in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1544,7 +1544,8 @@ trait Provisioning {
 		PHPUnit_Framework_Assert::assertArrayHasKey(
 			'version',
 			$respondedArray,
-			"app info returned for $app app does not have a version");
+			"app info returned for $app app does not have a version"
+		);
 		$appVersion = $respondedArray['version'];
 		PHPUnit_Framework_Assert::assertTrue(
 			\substr_count($appVersion, '.') > 1,

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -507,8 +507,8 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword()
 		);
-		$this->savedCapabilitiesXml[$this->featureContext->getBaseUrl()] =
-			AppConfigHelper::getCapabilitiesXml(
+		$this->savedCapabilitiesXml[$this->featureContext->getBaseUrl()]
+			= AppConfigHelper::getCapabilitiesXml(
 				$response
 			);
 		if ($this->oldCSRFSetting === null) {


### PR DESCRIPTION
The ``phpcs.xml`` settings found a couple of little code style things.