### PR TITLE
Add method to clear notification when user is deletd

### DIFF
--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -22,6 +22,7 @@
 
 namespace OC\Notification;
 
+use OCP\IUser;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use OCP\Notification\IApp;
 use OCP\Notification\IManager;
@@ -32,6 +33,7 @@ use OCP\Notification\Events\RegisterConsumerEvent;
 use OCP\Notification\Events\RegisterNotifierEvent;
 use OC\Notification\Events\RegisterConsumerEventImpl;
 use OC\Notification\Events\RegisterNotifierEventImpl;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 class Manager implements IManager {
 	/** @var EventDispatcherInterface */
@@ -72,6 +74,10 @@ class Manager implements IManager {
 		$this->notifiersInfoClosures = [];
 
 		$this->builtAppsHolder = [];
+
+		$this->dispatcher->addListener('user.afterdelete', function (GenericEvent $event) {
+			$this->removeUserNotifications($event->getArgument('uid'));
+		});
 	}
 
 	/**
@@ -298,5 +304,13 @@ class Manager implements IManager {
 		}
 
 		return $count;
+	}
+
+	public function removeUserNotifications($uid) {
+		$apps = $this->getApps();
+
+		foreach ($apps as $app) {
+			$app->removeUserNotifications($uid);
+		}
 	}
 }

--- a/lib/public/Notification/IApp.php
+++ b/lib/public/Notification/IApp.php
@@ -49,4 +49,11 @@ interface IApp {
 	 * @since 9.0.0
 	 */
 	public function getCount(INotification $notification);
+
+	/**
+	 * @param string $uid uid of the user
+	 * @return null
+	 * @since 10.0.10
+	 */
+	public function removeUserNotifications($uid);
 }

--- a/tests/lib/Notification/ManagerTest.php
+++ b/tests/lib/Notification/ManagerTest.php
@@ -645,4 +645,17 @@ class ManagerTest extends TestCase {
 
 		$this->assertSame(63, $this->manager->getCount($notification));
 	}
+
+	public function testRemoveUserNotifications() {
+		$app = $this->createMock(IApp::class);
+		$app->expects($this->once())
+			->method('removeUserNotifications')
+			->with('foo');
+
+		$this->manager->registerApp(function () use ($app) {
+			return $app;
+		});
+
+		$this->manager->removeUserNotifications('foo');
+	}
 }


### PR DESCRIPTION
Added a method to clear notification entry of user
when the user is deleted from oC.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
User entries from notification table should be deleted, once the user is deleted from oC.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
User entries from notification table should be deleted, once the user is deleted from oC.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Requires https://github.com/owncloud/notifications/pull/221

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
