### PR TITLE
Prevent passwords being set with empty strings

### DIFF
--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -11,6 +11,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  * @author Lukas Reschke <lukas@statuscode.ch>
+ * @author Matthew Setter <matthew@matthewsetter.com>
  * @author Michael Gapczynski <GapczynskiM@gmail.com>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author nishiki <nishiki@yaegashi.fr>
@@ -116,14 +117,20 @@ class Database extends Backend implements IUserBackend, IProvidesHomeBackend, IP
 	}
 
 	/**
-	 * Set password
-	 * @param string $uid The username
+	 * Change a user's password
+	 *
+	 * @param string $uid The user's username
 	 * @param string $password The new password
 	 * @return bool
 	 *
-	 * Change the password of a user
+	 * @throws \OC\DatabaseException
+	 * @throws \InvalidArgumentException
 	 */
 	public function setPassword($uid, $password) {
+		if (Util::isEmptyString($password)) {
+			throw new \InvalidArgumentException('Password cannot be empty');
+		}
+
 		if ($this->userExists($uid)) {
 			$query = \OC_DB::prepare('UPDATE `*PREFIX*users` SET `password` = ? WHERE `uid` = ?');
 			$result = $query->execute([\OC::$server->getHasher()->hash($password), $uid]);

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -48,6 +48,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 
 class User implements IUser {
 	use EventEmitterTrait;
+
 	/** @var Account */
 	private $account;
 
@@ -251,13 +252,18 @@ class User implements IUser {
 	}
 
 	/**
-	 * Set the password of the user
+	 * Set the user's password
 	 *
 	 * @param string $password
 	 * @param string $recoveryPassword for the encryption app to reset encryption keys
 	 * @return bool
+	 * @throws \InvalidArgumentException
 	 */
 	public function setPassword($password, $recoveryPassword = null) {
+		if (\OCP\Util::isEmptyString($password)) {
+			throw new \InvalidArgumentException('Password cannot be empty');
+		}
+
 		return $this->emittingCall(function () use (&$password, &$recoveryPassword) {
 			if ($this->emitter) {
 				$this->emitter->emit('\OC\User', 'preSetPassword', [$this, $password, $recoveryPassword]);

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -655,6 +655,18 @@ class Util {
 	}
 
 	/**
+	 * Determine if the string is, strictly-speaking, empty or not
+	 *
+	 * @param $value
+	 * @return bool
+	 * @since 10.0.1
+	 */
+	public static function isEmptyString($value) {
+		$value = \trim(\strval($value));
+		return ($value === '' || $value === '0');
+	}
+
+	/**
 	 * Generates a cryptographic secure pseudo-random string
 	 * @param int $length of the random string
 	 * @return string

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -526,6 +526,18 @@ abstract class TestCase extends BaseTestCase {
 	}
 
 	/**
+	 * @return array A list of items equivalent to an empty values
+	 */
+	public function getEmptyValues() {
+		return [
+			[''],
+			[0],
+			[null],
+			[false],
+		];
+	}
+
+	/**
 	 * @param string $string
 	 * @return bool|resource
 	 */

--- a/tests/lib/User/DatabaseTest.php
+++ b/tests/lib/User/DatabaseTest.php
@@ -3,6 +3,7 @@
 * ownCloud
 *
 * @author Robin Appelman
+* @author Matthew Setter <matthew@matthewsetter.com>
 * @copyright Copyright (c) 2012 Robin Appelman icewind@owncloud.com
 *
 * This library is free software; you can redistribute it and/or
@@ -21,6 +22,7 @@
 */
 
 namespace Test\User;
+use Test\Traits\PasswordTrait;
 
 /**
  * Class DatabaseTest
@@ -39,7 +41,7 @@ class DatabaseTest extends BackendTestCase {
 
 	protected function setUp() {
 		parent::setUp();
-		$this->backend=new \OC\User\Database();
+		$this->backend = new \OC\User\Database();
 	}
 
 	protected function tearDown() {
@@ -50,6 +52,20 @@ class DatabaseTest extends BackendTestCase {
 			$this->backend->deleteUser($user);
 		}
 		parent::tearDown();
+	}
+
+	/**
+	 * Tests that a \OC\User\ArgumentNotSetException is thrown when the supplied password is empty.
+	 *
+	 * @param string $password
+	 * @dataProvider getEmptyValues
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage Password cannot be empty
+	 */
+	public function testCannotSetEmptyPassword($password) {
+		$user1 = $this->getUser();
+		$this->backend->createUser($this->getUser(), 'pw');
+		$this->backend->setPassword($user1, $password);
 	}
 
 	public function testCreateUserInvalidatesCache() {

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -24,6 +24,7 @@ use OCP\User\IChangePasswordBackend;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Test\TestCase;
+use Test\Traits\PasswordTrait;
 
 /**
  * Class UserTest
@@ -33,7 +34,6 @@ use Test\TestCase;
  * @package Test\User
  */
 class UserTest extends TestCase {
-
 	/** @var AccountMapper | \PHPUnit_Framework_MockObject_MockObject */
 	private $accountMapper;
 	/** @var Account */
@@ -134,6 +134,21 @@ class UserTest extends TestCase {
 		$this->assertEquals('bar', $calledEvents['user.aftersetpassword']->getArgument('password'));
 		$this->assertEquals('', $calledEvents['user.aftersetpassword']->getArgument('recoveryPassword'));
 	}
+
+	/**
+	 * @param string $password
+	 * @dataProvider getEmptyValues
+	 * @expectedException \InvalidArgumentException
+	 * @expectedExceptionMessage Password cannot be empty
+	 * @throws \InvalidArgumentException
+	 */
+	public function testSetEmptyPasswordNotPermitted($password) {
+		(new User(
+			$this->createMock(Account::class),
+			$this->accountMapper
+		))->setPassword($password, 'bar');
+	}
+
 	public function testSetPasswordNotSupported() {
 		$this->config->expects($this->never())
 			->method('deleteUserValue')


### PR DESCRIPTION
## Description

Currently, if an attempt is made to set a password with an, effectively, empty string it will be accepted
without question. This PR seeks to prevent that from happening, by ensuring that passwords must be set to a meaningful/valid value.

## Related Issue

- Fixes https://github.com/owncloud/security-tracker/issues/282.

## Motivation and Context

It prevents a user's password from being set to an empty string. 

## How Has This Been Tested?

- Unit tests have been added to cover the changes. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Technical debt
- [X] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
