### PR TITLE
Remove inputField operations after setValue in webUI tests

### DIFF
--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -212,7 +212,6 @@ class FileRow extends OwncloudPage {
 		$this->waitTillElementIsNotNull($this->fileRenameInputXpath);
 		$inputField = $this->findRenameInputField();
 		$this->cleanInputAndSetValue($inputField, $toName);
-		$inputField->blur();
 		$this->waitTillElementIsNull($this->fileBusyIndicatorXpath);
 	}
 

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -211,7 +211,7 @@ class FileRow extends OwncloudPage {
 		$actionMenu->rename();
 		$this->waitTillElementIsNotNull($this->fileRenameInputXpath);
 		$inputField = $this->findRenameInputField();
-		$this->cleanInputAndSetValue($inputField, $toName);
+		$inputField->setValue($toName);
 		$this->waitTillElementIsNull($this->fileBusyIndicatorXpath);
 	}
 

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -658,27 +658,6 @@ class OwncloudPage extends Page {
 	}
 
 	/**
-	 * sends an END key and then BACKSPACEs to delete the current value
-	 * then sends the new value
-	 * checks the set value and sends the Escape key + throws an exception
-	 * if the value is not set correctly
-	 *
-	 * @param NodeElement $inputField
-	 * @param string $value
-	 *
-	 * @throws \Exception
-	 * @return void
-	 */
-	protected function cleanInputAndSetValue(NodeElement $inputField, $value) {
-		$resultValue = $inputField->getValue();
-		$existingValueLength = \strlen($resultValue);
-		$deleteSequence
-			= Key::END . \str_repeat(Key::BACKSPACE, $existingValueLength);
-		$inputField->setValue($deleteSequence);
-		$inputField->setValue($value);
-	}
-
-	/**
 	 * Fill an element with a text value and keep focus on the element.
 	 *
 	 * The existing fillField and setValue methods have a problem. They blur out

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -676,11 +676,6 @@ class OwncloudPage extends Page {
 			= Key::END . \str_repeat(Key::BACKSPACE, $existingValueLength);
 		$inputField->setValue($deleteSequence);
 		$inputField->setValue($value);
-		$resultValue = $inputField->getValue();
-		if ($resultValue !== $value) {
-			$inputField->keyUp(27); //send escape
-			throw new \Exception("value of input field is not what we expect");
-		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
The ``setValue`` method "these days" does a blur out of the field at the end. That means that when ``cleanInputAndSetValue()`` enters the new file/folder name into the text field, the text is entered and also the field is exited ("blurred away"). So the rename operation actually happens. Because the file/folder name has now already changed, the ``inputField`` object no longer refers to a valid DOM component. So double-checking the entered value by trying to read it back will throw an exception. Similarly manually calling ``blur()`` will throw an exception.

Remove these bits of not-needed code.

## Related Issue
- Fixes #32249 

## Motivation and Context
File and folder renames in webUI tests are taking a long time. They are retrying the rename 5 times, when actually the first rename succeeded.

## How Has This Been Tested?
Local run of a sample webUI rename scenario, e.g.
```
./run.sh --norerun features/webUIRenameFiles/renameFiles.feature:23
```

CI will do the full set.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [x] Acceptance tests added

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
