### PR TITLE
Only restore capabilities in acceptance tests if the previous settings were saved

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -384,7 +384,9 @@ trait AppConfiguration {
 		$previousServer = $this->currentServer;
 		foreach (['LOCAL','REMOTE'] as $server) {
 			$this->usingServer($server);
-			$this->modifyServerConfigs($this->savedCapabilitiesChanges[$this->getBaseUrl()]);
+			if (\key_exists($this->getBaseUrl(), $this->savedCapabilitiesChanges)) {
+				$this->modifyServerConfigs($this->savedCapabilitiesChanges[$this->getBaseUrl()]);
+			}
 		}
 		$this->usingServer($previousServer);
 		$this->currentUser = $user;


### PR DESCRIPTION
## Description
Only call ``modifyServerConfigs`` when doing ``restoreParametersAfterScenario`` if there actually were some saved parameters.

## Motivation and Context
Some app acceptance tests do not currently set any capabilities.
The code that restores the capabilities explodes with an undefined index when no capabilities were set.
It is good not to explode.

## How Has This Been Tested?
CI knows.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
