### PR TITLE
Provide convenience methods for CSRF disable, enable, delete in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -26,6 +26,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\ResponseInterface;
 use TestHelpers\OcsApiHelper;
+use TestHelpers\SetupHelper;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
@@ -333,6 +334,60 @@ trait BasicStructure {
 			$this->currentServer = 'REMOTE';
 		}
 		return $previousServer;
+	}
+
+	/**
+	 * disable CSRF
+	 *
+	 * @throws Exception
+	 * @return string the previous setting of csrf.disabled
+	 */
+	public function disableCSRF() {
+		return $this->setCSRFDotDisabled('true');
+	}
+
+	/**
+	 * enable CSRF
+	 *
+	 * @throws Exception
+	 * @return string the previous setting of csrf.disabled
+	 */
+	public function enableCSRF() {
+		return $this->setCSRFDotDisabled('false');
+	}
+
+	/**
+	 * set csrf.disabled
+	 *
+	 * @param string $setting "true", "false" or "" to delete the setting
+	 *
+	 * @throws Exception
+	 * @return string the previous setting of csrf.disabled
+	 */
+	public function setCSRFDotDisabled($setting) {
+		$oldCSRFSetting = SetupHelper::runOcc(
+			['config:system:get', 'csrf.disabled']
+		)['stdOut'];
+
+		if ($setting === "") {
+			SetupHelper::runOcc(['config:system:delete', 'csrf.disabled']);
+		} elseif (($setting === 'true') || ($setting === 'false')) {
+			SetupHelper::runOcc(
+				[
+					'config:system:set',
+					'csrf.disabled',
+					'--type',
+					'boolean',
+					'--value',
+					$setting
+				]
+			);
+		} else {
+			throw new \http\Exception\InvalidArgumentException(
+				'setting must be "true", "false" or ""'
+			);
+		}
+		return \trim($oldCSRFSetting);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Provide ``disableCSRF`` ``enableCSRF`` and ``setCSRFDotDisabled`` as convenience methods that acceptance tests can use as needed.

## Motivation and Context
The core API acceptance tests run OK  with CSRF enabled. So it is "a good thing" (tm) to try and keep it like that.

But some app API  acceptance tests need CSRF disabled for a few things (e.g. guest registration).

Instead of duplicating the code to disable and enable CSRF in various app acceptance tests, provide convenience methods in core that can be used as needed.

## How Has This Been Tested?
CI knows.
Check that it can be used from guests acceptance tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
