### PR TITLE
[stable10] Only restore capabilities in acceptance tests if the previous settings were saved

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -384,7 +384,9 @@ trait AppConfiguration {
 		$previousServer = $this->currentServer;
 		foreach (['LOCAL','REMOTE'] as $server) {
 			$this->usingServer($server);
-			$this->modifyServerConfigs($this->savedCapabilitiesChanges[$this->getBaseUrl()]);
+			if (\key_exists($this->getBaseUrl(), $this->savedCapabilitiesChanges)) {
+				$this->modifyServerConfigs($this->savedCapabilitiesChanges[$this->getBaseUrl()]);
+			}
 		}
 		$this->usingServer($previousServer);
 		$this->currentUser = $user;


### PR DESCRIPTION
Backport #32274 