### PR TITLE
reset opcache every time the config was changed in a acceptance tests

### DIFF
--- a/apps/testing/appinfo/routes.php
+++ b/apps/testing/appinfo/routes.php
@@ -27,6 +27,7 @@ use OCA\Testing\Locking\Provisioning;
 use OCA\Testing\Occ;
 use OCA\Testing\Notifications;
 use OCP\API;
+use OCA\Testing\Opcache;
 
 $config = new Config(
 	\OC::$server->getConfig(),
@@ -113,6 +114,16 @@ API::register(
 	'post',
 	'/apps/testing/api/v1/occ',
 	[$occ, 'execute'],
+	'testing',
+	API::ADMIN_AUTH
+);
+
+$opcache = new Opcache();
+
+API::register(
+	'delete',
+	'/apps/testing/api/v1/opcache',
+	[$opcache, 'execute'],
 	'testing',
 	API::ADMIN_AUTH
 );

--- a/apps/testing/lib/Opcache.php
+++ b/apps/testing/lib/Opcache.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Testing;
+
+use OC\OCS\Result;
+
+class Opcache {
+
+	/**
+	 *
+	 * @return Result
+	 */
+	public function execute() {
+		\opcache_reset();
+		return new Result();
+	}
+}

--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -22,6 +22,7 @@
 namespace TestHelpers;
 
 use GuzzleHttp\Message\ResponseInterface;
+use GuzzleHttp\Exception\ServerException;
 use PHPUnit_Framework_Assert;
 
 /**
@@ -303,5 +304,6 @@ class AppConfigHelper {
 				"100", self::getOCSResponse($response)
 			);
 		}
+		SetupHelper::resetOpcache($baseUrl, $user, $password);
 	}
 }

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -23,6 +23,7 @@ namespace TestHelpers;
 use Behat\Testwork\Hook\Scope\HookScope;
 use GuzzleHttp\Exception\ServerException;
 use Exception;
+use GuzzleHttp\Message\ResponseInterface;
 
 /**
  * Helper to setup UI / Integration tests
@@ -353,6 +354,30 @@ class SetupHelper {
 		$return['code'] = $return['code'][0]->__toString();
 		$return['stdOut'] = $return['stdOut'][0]->__toString();
 		$return['stdErr'] = $return['stdErr'][0]->__toString();
+		self::resetOpcache($baseUrl, $adminUsername, $adminPassword);
 		return $return;
+	}
+	
+	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 *
+	 * @return ResponseInterface
+	 */
+	public static function resetOpcache(
+		$baseUrl,
+		$user,
+		$password
+	) {
+		try {
+			return OcsApiHelper::sendRequest(
+				$baseUrl, $user,
+				$password, "DELETE", "/apps/testing/api/v1/opcache"
+			);
+		} catch (ServerException $e) {
+			echo "could not reset opcache, if tests fail try to set " .
+				 "'opcache.revalidate_freq=0' in the php.ini file\n";
+		}
 	}
 }


### PR DESCRIPTION
## Description
the config of oC is cached by opcache. When a test implements a change and checks it right away it can happen that the old setting is still in the cache.
So we can reset the cache after every change of the configuration

## Motivation and Context
Same effect can be achieved by setting `opcache.revalidate_freq=0` in the php.ini file, but I'm keep on forgetting it, so lets eliminate one extra thing to remember and to document and let the computer care for it self.

## How Has This Been Tested?
ran auth token tests with enabled opcache

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
