### PR TITLE
[stable10] Backport of Change regex to accept subdomains with hyphens.

### DIFF
--- a/core/js/sharedialogmailview.js
+++ b/core/js/sharedialogmailview.js
@@ -137,7 +137,7 @@
 			if (email.length === 0)
 				return true
 
-			return email.match(/([\w\.\-_]+)?\w+@[\w-_]+(\.\w+){1,}$/);
+			return email.match(/^[A-Za-z0-9\._%+-]+@(?:[A-Za-z0-9-]+\.)+[a-z]{2,}$/);
 		},
 
 		sendEmails: function() {

--- a/core/js/tests/specs/sharedialogmailviewSpec.js
+++ b/core/js/tests/specs/sharedialogmailviewSpec.js
@@ -100,6 +100,19 @@ describe('OC.Share.ShareDialogMailView', function() {
 		});
 	});
 
+	describe('validating addresses', function() {
+		it('works as expected', function() {
+			expect(view.validateEmail('Ada.Wong@umbrella.com')[0]).toEqual('Ada.Wong@umbrella.com');
+			expect(view.validateEmail('Albert.Wesker@umbrella.sub-domain.com')[0]).toEqual('Albert.Wesker@umbrella.sub-domain.com');
+			expect(view.validateEmail('Albert_Wesker@umbrella.sub-domain.com')[0]).toEqual('Albert_Wesker@umbrella.sub-domain.com');
+			expect(view.validateEmail('Albert-Wesker@umbrella-new.sub-domain.com')[0]).toEqual('Albert-Wesker@umbrella-new.sub-domain.com');
+
+			expect(view.validateEmail('Jill.Valentine@umbrella..com')).toEqual(null);
+			expect(view.validateEmail('Jill.Valentine@um#rella.com')).toEqual(null);
+			expect(view.validateEmail('Jürgen.Sörensen@umbrella.com')).toEqual(null);
+		});
+	});
+
 	describe('sending emails', function() {
 		var clock;
 


### PR DESCRIPTION
Backporting #32240 

---

## Description
The filter regex which helps to validate the entered e-mail addresses does not accept subdomains with hyphens.

### Steps to reproduce
1. Configure ownCloud to allow Users to send notification emails while sharing
2. Share something via public link
3. Send link as e-mail
4. Enter e-mail address

### Expected behaviour
E-Mail address is being added to the field

### Actual behaviour
Some E-Mail addresses with "-" charakter in the **second** subdomain get rejected / could not be added.

#### Examples - working
- firstname.lastname@td-l.xyz
- firstname.lastname@s-ub.tdl.xyz
- firstname.lastname@sub.tdl.xyz

#### Examples - not working
- firstname.lastname@sub.t-dl.xyz
- firstname.lastname@stud.uni-example.de

## Related Issue

- Fixes owncloud/enterprise#2773

## Motivation and Context
This has been discovered by a customer whose domains all contain a second subdomain with a hyphen

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- this has been tested manually and 
- and within a regex tester.

## New Regex, proposed solution
`^[A-Za-z0-9\._%+-]+@(?:[A-Za-z0-9-]+\.)+[a-z]{2,}$`

- At the beginning of the string: all letters, numbers, dots, and %_+-charakters
- @ charakter
- after the @ charakter allow all numbers and letters and hyphens, but only single occurrances of dots, so ".." is not possible.
- the toplevel domain must be 2 charakters at least.

## Screenshots (if appropriate):
![screenshot_2018-08-06 dateien - owncloud](https://user-images.githubusercontent.com/4378513/43704690-c99d1cd4-9960-11e8-8b90-4496c3e57890.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
