### PR TITLE
Reset stalled state in upload data after retrying

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1124,6 +1124,7 @@ OC.Uploader.prototype = _.extend({
 									});
 
 									// clear the previous data:
+									upload.data.stalled = false;
 									data.data = null;
 									// overwrite chunk
 									delete data.headers['If-None-Match'];

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -854,7 +854,8 @@ OC.Uploader.prototype = _.extend({
 			if (progress >= total) {
 				// change message if we stalled at 100%
 				this.$uploadprogressbar.find('.label .desktop').text(t('core', 'Processing files...'));
-			} else if (new Date().getTime() - this._lastProgressTime >= this._uploadStallTimeout * 1000 ) {
+			}
+			if (new Date().getTime() - this._lastProgressTime >= this._uploadStallTimeout * 1000 ) {
 				// TODO: move to "fileuploadprogress" event instead and use data.uploadedBytes
 				// stalling needs to be checked here because the file upload no longer triggers events
 				// restart upload

--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -364,6 +364,7 @@ describe('OC.Upload tests', function() {
 			// uploaded bytes was set to the sum of all chunk sizes
 			expect(result[0].uploadedBytes).toEqual(300);
 			expect(result[0].data).toBeFalsy();
+			expect(upload.data.stalled).toEqual(false);
 
 			// header was cleared for overwriting
 			expect(result[0].headers['If-None-Match']).not.toBeDefined();


### PR DESCRIPTION
## Description
After retrying a chunk, we need to reset the upload object's "stalled" state, else the next stalled chunk is not retried.

## Related Issue
Fixes https://github.com/owncloud/core/issues/32282

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
See steps in original ticket as it needs patching

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
- [x] add unit tests