### PR TITLE
Only prepareParametersBeforeScenario and restore on remote if federatedServerExists

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -365,8 +365,10 @@ trait AppConfiguration {
 		$this->currentUser = $this->getAdminUsername();
 		$previousServer = $this->currentServer;
 		foreach (['LOCAL','REMOTE'] as $server) {
-			$this->usingServer($server);
-			$this->resetAppConfigs();
+			if (($server === 'LOCAL') || $this->federatedServerExists()) {
+				$this->usingServer($server);
+				$this->resetAppConfigs();
+			}
 		}
 		$this->usingServer($previousServer);
 		$this->currentUser = $user;
@@ -383,9 +385,11 @@ trait AppConfiguration {
 		$this->currentUser = $this->getAdminUsername();
 		$previousServer = $this->currentServer;
 		foreach (['LOCAL','REMOTE'] as $server) {
-			$this->usingServer($server);
-			if (\key_exists($this->getBaseUrl(), $this->savedCapabilitiesChanges)) {
-				$this->modifyServerConfigs($this->savedCapabilitiesChanges[$this->getBaseUrl()]);
+			if (($server === 'LOCAL') || $this->federatedServerExists()) {
+				$this->usingServer($server);
+				if (\key_exists($this->getBaseUrl(), $this->savedCapabilitiesChanges)) {
+					$this->modifyServerConfigs($this->savedCapabilitiesChanges[$this->getBaseUrl()]);
+				}
 			}
 		}
 		$this->usingServer($previousServer);

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -103,6 +103,13 @@ trait BasicStructure {
 	private $remoteBaseUrl = '';
 
 	/**
+	 *
+	 *
+	 * @var boolean true if TEST_SERVER_FED_URL is defined
+	 */
+	private $federatedServerExists = false;
+
+	/**
 	 * @var int
 	 */
 	private $ocsApiVersion = 1;
@@ -157,8 +164,10 @@ trait BasicStructure {
 		$testRemoteServerUrl = \getenv('TEST_SERVER_FED_URL');
 		if ($testRemoteServerUrl !== false) {
 			$this->remoteBaseUrl = \rtrim($testRemoteServerUrl, '/');
+			$this->federatedServerExists = true;
 		} else {
 			$this->remoteBaseUrl = $this->localBaseUrl;
+			$this->federatedServerExists = false;
 		}
 
 		// get the admin username from the environment (if defined)
@@ -334,6 +343,14 @@ trait BasicStructure {
 			$this->currentServer = 'REMOTE';
 		}
 		return $previousServer;
+	}
+
+	/**
+	 *
+	 * @return boolean
+	 */
+	public function federatedServerExists() {
+		return $this->federatedServerExists;
 	}
 
 	/**


### PR DESCRIPTION
## Description
1) Provide "memory" of if the federated server exists
2) Only prepare and restore parameters on the federated server if it exists

## Motivation and Context
If app acceptance tests do not need/do not have a federated server in the test environment, then code in ``prepareParametersBeforeScenario`` should not try to setup stuff on the federated server. Similarly ``restoreParametersAfterScenario`` should not try to restore on the federated server.

This is a hassle at the moment if an app wants to set/restore some capabilities across scenarios, but does not need a federated server set up.

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
