### PR TITLE
Remove skeleton ref from drone yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -289,7 +289,6 @@ pipeline:
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
       - TEST_SERVER_URL=http://server
-      - SKELETON_DIR=/drone/src/apps/testing/data/webUISkeleton
       - PLATFORM=Linux
       - MAILHOG_HOST=email
     commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -486,7 +486,6 @@ matrix:
       TEST_SUITE: litmus
       INSTALL_SERVER: true
       CHOWN_SERVER: true
-      INSTALL_SERVER: true
 
   # Unit Tests
     - PHP_VERSION: 7.1


### PR DESCRIPTION
## Description
1) Remove duplicate INSTALL_SERVER line in ``.drone.yml`` (IDE told me about it)
2) Remove unneeded SKELETON_DIR reference from ``.drone.yml``

## Motivation and Context
The acceptance test ``run.sh`` script should already calculate the correct location of the skeleton dir.
So it should not need to be specified in ``.drone.yml``

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
