### PR TITLE
[stable10] Remove unneeded SKELETON_DIR reference from .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -291,7 +291,6 @@ pipeline:
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
       - TEST_SERVER_URL=http://server
-      - SKELETON_DIR=/drone/src/apps/testing/data/webUISkeleton
       - PLATFORM=Linux
       - MAILHOG_HOST=email
     commands:


### PR DESCRIPTION
Backport #32289 

Note: the first commit that removed the duplicate INSTALL_SERVER line is not needed in the backport. The error had not been backported.