### PR TITLE
fix suites-to-run calculation in run.sh acceptance tests script

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -483,10 +483,17 @@ else
 		#divide the suites and round up
 		SUITES_PER_RUN=$(((${COUNT_ALL_SUITES} + ${DIVIDE_INTO_NUM_PARTS} - 1) / ${DIVIDE_INTO_NUM_PARTS}))
 		COUNT_FINISH_AND_TODO_SUITES=$((${RUN_PART} * ${SUITES_PER_RUN}))
+		COUNT_FINISH_SUITES=$(((${RUN_PART} - 1) * ${SUITES_PER_RUN}))
 		if [ ${RUN_PART} -eq ${DIVIDE_INTO_NUM_PARTS} ]
 		then
 			#the last run might have less suites
-			SUITES_PER_RUN=$((${COUNT_ALL_SUITES} - (${RUN_PART} - 1) * ${SUITES_PER_RUN}))
+			SUITES_PER_RUN=$((${COUNT_ALL_SUITES} - ${COUNT_FINISH_SUITES}))
+		fi
+		if [ ${SUITES_PER_RUN} -eq 0 ]
+		then
+			echo "there are ${COUNT_ALL_SUITES} suites ${COUNT_FINISH_SUITES} done, nothing to do"
+			teardown
+			exit 0
 		fi
 		BEHAT_SUITES+=(`echo "${ALL_SUITES}" | head -n ${COUNT_FINISH_AND_TODO_SUITES} | tail -n ${SUITES_PER_RUN}`)
 	fi


### PR DESCRIPTION
## Description
in special cases the `$SUITES_PER_RUN` variable might end up being `0` and then the script tries to run all suites, what is not the  goal.
This happens e.g. if we have 16 suites, divide by 5 and run the last part. For run 1-4 `$SUITES_PER_RUN` would be `4 = ceiling(16/5)` but after 4 runs all the work is done, so there is no need to run the last division.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
