### PR TITLE
Allow 'No scenarios' behat test runs to pass

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -230,7 +230,22 @@ function run_behat_tests() {
 	then
 		PASSED=true
 	else
-		PASSED=false
+		# If there were no scenarios in the requested suite or feature that match
+		# the requested combination of tags, then Behat exits with an error status
+		# and reports "No scenarios" in its output.
+		# This can happen, for example, when running core suites from an app and
+		# requesting some tag combination that does not happen frequently. Then
+		# sometimes there may not be any matching scenarios in one of the suites.
+		# In this case, consider the test has passed.
+		MATCHING_COUNT=`grep -c '^No scenarios$' ${TEST_LOG_FILE}`
+		if [ ${MATCHING_COUNT} -eq 1 ]
+		then
+			echo "Information: no matching scenarios were found."
+			BEHAT_EXIT_STATUS=0
+			PASSED=true
+		else
+			PASSED=false
+		fi
 	fi
 	
 	# With webUI tests, we try running failed tests again.


### PR DESCRIPTION
## Description
If a ``behat`` run exits with an error status, then check the command output. If it contains a line "No scenarios" then consider that the run has passed.

## Motivation and Context
When an acceptance test suite is run and a set of tags are requested, sometimes there might be no scenarios in that test suite that match the combination of tags requested.

When that happens, Behat reports "No scenarios" in the output and/but Behat exits with an error status. This causes the test run to fail.

But actually this is expected. e.g. when running core test suites from the ``files_primary_s3`` app, only a subset of tagged scenarios are run. In this case (and other cases) some core test suites have no scenarios that match the requested tags.

## How Has This Been Tested?
Local test runs specifying Behat tags that do not occur.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
