### PR TITLE
Move ini_set calls before a new session is started

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -408,13 +408,6 @@ class OC {
 	}
 
 	public static function initSession() {
-		// prevents javascript from accessing php session cookies
-		\ini_set('session.cookie_httponly', true);
-
-		// set the cookie path to the ownCloud directory
-		$cookie_path = OC::$WEBROOT ? : '/';
-		\ini_set('session.cookie_path', $cookie_path);
-
 		// Let the session name be changed in the initSession Hook
 		$sessionName = OC_Util::getInstanceId();
 
@@ -593,9 +586,6 @@ class OC {
 		self::checkInstalled();
 
 		OC_Response::addSecurityHeaders();
-		if (self::$server->getRequest()->getServerProtocol() === 'https') {
-			\ini_set('session.cookie_secure', true);
-		}
 
 		if (!\defined('OC_CONSOLE')) {
 			$errors = OC_Util::checkServer(\OC::$server->getConfig());


### PR DESCRIPTION
## Description
Alternative approach to https://github.com/owncloud/core/pull/31525

Inspired by https://github.com/joomla/joomla-cms/pull/15742/files

## Related Issue
- Fixes #31524

## How Has This Been Tested?
- manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
