### PR TITLE
Use --remote for acceptance tests run on drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -276,7 +276,7 @@ pipeline:
     commands:
       - touch /drone/saved-settings.sh
       - . /drone/saved-settings.sh
-      - ./tests/drone/test-acceptance.sh
+      - ./tests/drone/test-acceptance.sh --remote
     when:
       matrix:
         TEST_SUITE: api

--- a/tests/drone/test-acceptance.sh
+++ b/tests/drone/test-acceptance.sh
@@ -10,5 +10,5 @@ declare -x OC_TEST_ALT_HOME
 [[ -z "${OC_TEST_ALT_HOME}" ]] && OC_TEST_ALT_HOME=1
 
 pushd tests/acceptance
-    su-exec www-data ./run.sh
+    su-exec www-data ./run.sh "$@"
 popd


### PR DESCRIPTION
## Description
1) Pass through any input arguments from ``tests/drone/test-acceptance.sh`` to the acceptance test ``run.sh``
2) Add the ``--remote`` argument to the place it is missing in ``.drone.yml``

## Motivation and Context
``tests/drone/test-acceptance.sh`` is used with arguments in some places, but actually it ignores its arguments. So those places are totally misleading at the moment. It should pass its arguments through to ``run.sh`` when it calls it.

The ``--remote`` argument is to indicate that the system-under-test is "black-box" or "remote" - i.e. we cannot or should not rely on being able to "manipulate it under the hood" by doing local commands from the test script. At the moment, what that means in practice, is that we assume that the SUT already has the testing app enabled, so we do not need to bother trying to enable it, and can do all our setup using the testing app. We should be consistent and always use ``--remote`` when running on drone, because the testing app is indeed pre-enabled and ready.

## How Has This Been Tested?
CI will show.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
