### PR TITLE
Federated sharing new spec

### DIFF
--- a/apps/federatedfilesharing/appinfo/app.php
+++ b/apps/federatedfilesharing/appinfo/app.php
@@ -21,12 +21,9 @@
  *
  */
 
-$app = new \OCA\FederatedFileSharing\AppInfo\Application();
-
 use OCA\FederatedFileSharing\Notifier;
-use OCP\Share\Events\AcceptShare;
-use OCP\Share\Events\DeclineShare;
-use OCP\Defaults;
+
+$app = new \OCA\FederatedFileSharing\AppInfo\Application();
 
 $manager = \OC::$server->getNotificationManager();
 $manager->registerNotifier(function () {
@@ -46,30 +43,4 @@ $manager->registerNotifier(function () {
 // FIXME versions, comments, tags and sharing ui still uses it https://github.com/owncloud/core/search?utf8=%E2%9C%93&q=loadAdditionalScripts&type=
 OCP\Util::connectHook('OCP\Share', 'share_link_access', 'OCA\FederatedFileSharing\HookHandler', 'loadPublicJS');
 
-// react to accept and decline share events
-$eventDispatcher = \OC::$server->getEventDispatcher();
-$eventDispatcher->addListener(
-	AcceptShare::class,
-	function (AcceptShare $event) use ($app) {
-		/** @var \OCA\FederatedFileSharing\Notifications $notifications */
-		$notifications = $app->getContainer()->query('OCA\FederatedFileSharing\Notifications');
-		$notifications->sendAcceptShare(
-			$event->getRemote(),
-			$event->getRemoteId(),
-			$event->getShareToken()
-		);
-	}
-);
-
-$eventDispatcher->addListener(
-	DeclineShare::class,
-	function (DeclineShare $event) use ($app) {
-		/** @var \OCA\FederatedFileSharing\Notifications $notifications */
-		$notifications = $app->getContainer()->query('OCA\FederatedFileSharing\Notifications');
-		$notifications->sendDeclineShare(
-			$event->getRemote(),
-			$event->getRemoteId(),
-			$event->getShareToken()
-		);
-	}
-);
+$app->registerListeners();

--- a/apps/federatedfilesharing/appinfo/routes.php
+++ b/apps/federatedfilesharing/appinfo/routes.php
@@ -1,7 +1,27 @@
 <?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 return [
 	'ocs' => [
+		// ocm 0.3
 		['root' => '/cloud', 'name' => 'RequestHandler#createShare', 'url' => '/shares', 'verb' => 'POST'],
 		['root' => '/cloud', 'name' => 'RequestHandler#reShare', 'url' => '/shares/{id}/reshare', 'verb' => 'POST'],
 		['root' => '/cloud', 'name' => 'RequestHandler#updatePermissions', 'url' => '/shares/{id}/permissions', 'verb' => 'POST'],
@@ -10,5 +30,15 @@ return [
 		['root' => '/cloud', 'name' => 'RequestHandler#declineShare', 'url' => '/shares/{id}/decline', 'verb' => 'POST'],
 		['root' => '/cloud', 'name' => 'RequestHandler#unshare', 'url' => '/shares/{id}/unshare', 'verb' => 'POST'],
 		['root' => '/cloud', 'name' => 'RequestHandler#revoke', 'url' => '/shares/{id}/revoke', 'verb' => 'POST'],
+
+		// ocm 1.0-proposal1
+		['root' => '/', 'name' => 'OcmController#discovery', 'url' => '/ocm-provider', 'verb' => 'GET'],
+	],
+
+	'routes' => [
+		// ocm 1.0-proposal1
+		['name' => 'ocm#index', 'url' => '/', 'verb' => 'GET'],
+		['name' => 'ocm#createShare', 'url' => '/shares', 'verb' => 'POST'],
+		['name' => 'ocm#processNotification', 'url' => '/notifications', 'verb' => 'POST'],
 	]
 ];

--- a/apps/federatedfilesharing/lib/Address.php
+++ b/apps/federatedfilesharing/lib/Address.php
@@ -63,8 +63,10 @@ class Address {
 	 * @return string
 	 */
 	public function getUserId() {
+		// userId is everything except the last part
 		$parts = \explode('@', $this->cloudId);
-		return $parts[0];
+		\array_pop($parts);
+		return \implode('@', $parts);
 	}
 
 	/**
@@ -73,8 +75,9 @@ class Address {
 	 * @return string
 	 */
 	public function getHostName() {
+		// hostname is the last part
 		$parts = \explode('@', $this->cloudId);
-		return $parts[1];
+		return \array_pop($parts);
 	}
 
 	/**

--- a/apps/federatedfilesharing/lib/Address.php
+++ b/apps/federatedfilesharing/lib/Address.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing;
+
+/**
+ * Class Address
+ *
+ * @package OCA\FederatedFileSharing
+ */
+class Address {
+	/**
+	 * @var string
+	 */
+	protected $cloudId;
+
+	/**
+	 * @var string
+	 */
+	protected $displayName;
+
+	/**
+	 * Address constructor.
+	 *
+	 * @param string $cloudId
+	 * @param string $displayName
+	 */
+	public function __construct($cloudId, $displayName = '') {
+		$this->cloudId = $cloudId;
+		$this->displayName = $displayName;
+	}
+
+	/**
+	 * Get user federated id
+	 *
+	 * @return string
+	 */
+	public function getCloudId() {
+		return $this->cloudId;
+	}
+
+	/**
+	 * Get user id
+	 *
+	 * @return string
+	 */
+	public function getUserId() {
+		$parts = \explode('@', $this->cloudId);
+		return $parts[0];
+	}
+
+	/**
+	 * Get user host
+	 *
+	 * @return string
+	 */
+	public function getHostName() {
+		$parts = \explode('@', $this->cloudId);
+		return $parts[1];
+	}
+
+	/**
+	 * Get user display name, fallback to userId if it is empty
+	 *
+	 * @return string
+	 */
+	public function getDisplayName() {
+		return ($this->displayName !== '') ? $this->displayName : $this->getUserId();
+	}
+}

--- a/apps/federatedfilesharing/lib/Address.php
+++ b/apps/federatedfilesharing/lib/Address.php
@@ -81,6 +81,17 @@ class Address {
 	}
 
 	/**
+	 * Get user host without protocol and trailing slash
+	 *
+	 * @return string
+	 */
+	public function getCleanHostName() {
+		$hostName = \rtrim($this->getHostName(), '/');
+		// replace all characters before :// and :// itself
+		return \preg_replace('|^(.*?://)|', '', $hostName);
+	}
+
+	/**
 	 * Get user display name, fallback to userId if it is empty
 	 *
 	 * @return string

--- a/apps/federatedfilesharing/lib/AddressHandler.php
+++ b/apps/federatedfilesharing/lib/AddressHandler.php
@@ -101,6 +101,16 @@ class AddressHandler {
 	}
 
 	/**
+	 * @param string $uid
+	 *
+	 * @return Address
+	 */
+	public function getLocalUserFederatedAddress($uid) {
+		$host = $this->generateRemoteURL();
+		return new Address("{$uid}@{$host}");
+	}
+
+	/**
 	 * generate remote URL part of federated ID
 	 *
 	 * @return string url of the current server
@@ -108,40 +118,6 @@ class AddressHandler {
 	public function generateRemoteURL() {
 		$url = $this->urlGenerator->getAbsoluteURL('/');
 		return $url;
-	}
-
-	/**
-	 * check if two federated cloud IDs refer to the same user
-	 *
-	 * @param string $user1
-	 * @param string $server1
-	 * @param string $user2
-	 * @param string $server2
-	 * @return bool true if both users and servers are the same
-	 */
-	public function compareAddresses($user1, $server1, $user2, $server2) {
-		$normalizedServer1 = \strtolower($this->removeProtocolFromUrl($server1));
-		$normalizedServer2 = \strtolower($this->removeProtocolFromUrl($server2));
-
-		if (\rtrim($normalizedServer1, '/') === \rtrim($normalizedServer2, '/')) {
-			// FIXME this should be a method in the user management instead
-			\OCP\Util::emitHook(
-				'\OCA\Files_Sharing\API\Server2Server',
-				'preLoginNameUsedAsUserName',
-				['uid' => &$user1]
-			);
-			\OCP\Util::emitHook(
-				'\OCA\Files_Sharing\API\Server2Server',
-				'preLoginNameUsedAsUserName',
-				['uid' => &$user2]
-			);
-
-			if ($user1 === $user2) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	/**
@@ -153,19 +129,6 @@ class AddressHandler {
 	public function removeProtocolFromUrl($url) {
 		// replace all characters before :// and :// itself
 		return \preg_replace('|^(.*?://)|', '', $url);
-	}
-
-	/**
-	 * Get a remote name without a protocol, potential file names
-	 * and a trailing slash
-	 *
-	 * @param string $remote
-	 *
-	 * @return string
-	 */
-	public function normalizeRemote($remote) {
-		$fixedRemote = $this->fixRemoteURL($remote);
-		return $this->removeProtocolFromUrl($fixedRemote);
 	}
 
 	/**

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -113,7 +113,11 @@ class Application extends App {
 				return new OcmController(
 					$c->query('AppName'),
 					$c->query('Request'),
-					$server->getURLGenerator()
+					$server->getURLGenerator(),
+					$server->getUserManager(),
+					$c->query('FederatedShareManager'),
+					$c->query('AddressHandler'),
+					$server->getLogger()
 				);
 			}
 		);

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -117,9 +117,10 @@ class Application extends App {
 					$c->query('Request'),
 					$this->getFederatedShareProvider(),
 					$server->getURLGenerator(),
+					$server->getAppManager(),
 					$server->getUserManager(),
-					$c->query('FederatedShareManager'),
 					$c->query('AddressHandler'),
+					$c->query('FederatedShareManager'),
 					$server->getLogger()
 				);
 			}

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -26,6 +26,7 @@ use OCA\FederatedFileSharing\Controller\OcmController;
 use OCA\FederatedFileSharing\DiscoveryManager;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\FedShareManager;
+use OCA\FederatedFileSharing\Middleware\OcmMiddleware;
 use OCA\FederatedFileSharing\Notifications;
 use OCA\FederatedFileSharing\Controller\RequestHandlerController;
 use OCA\FederatedFileSharing\TokenHandler;
@@ -95,13 +96,25 @@ class Application extends App {
 		);
 
 		$container->registerService(
+			'OcmMiddleware',
+			function ($c) use ($server) {
+				return new OcmMiddleware(
+					$this->getFederatedShareProvider(),
+					$server->getAppManager(),
+					$server->getUserManager(),
+					$c->query('AddressHandler'),
+					$server->getLogger()
+				);
+			}
+		);
+
+		$container->registerService(
 			'RequestHandlerController',
 			function ($c) use ($server) {
 				return new RequestHandlerController(
 					$c->query('AppName'),
 					$c->query('Request'),
-					$this->getFederatedShareProvider(),
-					$server->getAppManager(),
+					$c->query('OcmMiddleware'),
 					$server->getUserManager(),
 					$c->query('AddressHandler'),
 					$c->query('FederatedShareManager')
@@ -115,9 +128,8 @@ class Application extends App {
 				return new OcmController(
 					$c->query('AppName'),
 					$c->query('Request'),
-					$this->getFederatedShareProvider(),
+					$c->query('OcmMiddleware'),
 					$server->getURLGenerator(),
-					$server->getAppManager(),
 					$server->getUserManager(),
 					$c->query('AddressHandler'),
 					$c->query('FederatedShareManager'),

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -22,6 +22,7 @@
 namespace OCA\FederatedFileSharing\AppInfo;
 
 use OCA\FederatedFileSharing\AddressHandler;
+use OCA\FederatedFileSharing\Controller\OcmController;
 use OCA\FederatedFileSharing\DiscoveryManager;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\FedShareManager;
@@ -102,6 +103,17 @@ class Application extends App {
 					$server->getUserManager(),
 					$c->query('AddressHandler'),
 					$c->query('FederatedShareManager')
+				);
+			}
+		);
+
+		$container->registerService(
+			'OcmController',
+			function ($c) use ($server) {
+				return new OcmController(
+					$c->query('AppName'),
+					$c->query('Request'),
+					$server->getURLGenerator()
 				);
 			}
 		);

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -113,6 +113,7 @@ class Application extends App {
 				return new OcmController(
 					$c->query('AppName'),
 					$c->query('Request'),
+					$this->getFederatedShareProvider(),
 					$server->getURLGenerator(),
 					$server->getUserManager(),
 					$c->query('FederatedShareManager'),

--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -29,6 +29,8 @@ use OCA\FederatedFileSharing\FedShareManager;
 use OCA\FederatedFileSharing\Middleware\OcmMiddleware;
 use OCA\FederatedFileSharing\Notifications;
 use OCA\FederatedFileSharing\Controller\RequestHandlerController;
+use OCA\FederatedFileSharing\Ocm\NotificationManager;
+use OCA\FederatedFileSharing\Ocm\Permissions;
 use OCA\FederatedFileSharing\TokenHandler;
 use OCP\AppFramework\App;
 use OCP\Share\Events\AcceptShare;
@@ -74,6 +76,7 @@ class Application extends App {
 					$c->query('AddressHandler'),
 					$server->getHTTPClientService(),
 					$c->query('DiscoveryManager'),
+					$c->query('NotificationManager'),
 					$server->getJobList(),
 					$server->getConfig()
 				);
@@ -90,6 +93,7 @@ class Application extends App {
 					$server->getActivityManager(),
 					$server->getNotificationManager(),
 					$c->query('AddressHandler'),
+					$c->query('Permissions'),
 					$server->getEventDispatcher()
 				);
 			}
@@ -137,6 +141,22 @@ class Application extends App {
 				);
 			}
 		);
+
+		$container->registerService(
+			'NotificationManager',
+			function ($c) {
+				return new NotificationManager(
+					$c->query('Permissions')
+				);
+			}
+		);
+
+		$container->registerService(
+			'Permissions',
+			function ($c) {
+				return new Permissions();
+			}
+		);
 	}
 
 	/**
@@ -163,10 +183,14 @@ class Application extends App {
 			\OC::$server->getMemCacheFactory(),
 			\OC::$server->getHTTPClientService()
 		);
+		$notificationManager = new NotificationManager(
+			new Permissions()
+		);
 		$notifications = new Notifications(
 			$addressHandler,
 			\OC::$server->getHTTPClientService(),
 			$discoveryManager,
+			$notificationManager,
 			\OC::$server->getJobList(),
 			\OC::$server->getConfig()
 		);

--- a/apps/federatedfilesharing/lib/BackgroundJob/RetryJob.php
+++ b/apps/federatedfilesharing/lib/BackgroundJob/RetryJob.php
@@ -24,6 +24,7 @@ namespace OCA\FederatedFileSharing\BackgroundJob;
 use OC\BackgroundJob\Job;
 use OC\BackgroundJob\JobList;
 use OCA\FederatedFileSharing\AddressHandler;
+use OCA\FederatedFileSharing\AppInfo\Application;
 use OCA\FederatedFileSharing\DiscoveryManager;
 use OCA\FederatedFileSharing\Notifications;
 use OCP\BackgroundJob\IJobList;
@@ -60,21 +61,8 @@ class RetryJob extends Job {
 		if ($notifications) {
 			$this->notifications = $notifications;
 		} else {
-			$addressHandler = new AddressHandler(
-				\OC::$server->getURLGenerator(),
-				\OC::$server->getL10N('federatedfilesharing')
-			);
-			$discoveryManager = new DiscoveryManager(
-				\OC::$server->getMemCacheFactory(),
-				\OC::$server->getHTTPClientService()
-			);
-			$this->notifications = new Notifications(
-				$addressHandler,
-				\OC::$server->getHTTPClientService(),
-				$discoveryManager,
-				\OC::$server->getJobList(),
-				\OC::$server->getConfig()
-			);
+			$federatedFileSharingApp = new Application();
+			$this->notifications = $federatedFileSharingApp->getContainer()->query('Notifications');
 		}
 	}
 

--- a/apps/federatedfilesharing/lib/Controller/OcmController.php
+++ b/apps/federatedfilesharing/lib/Controller/OcmController.php
@@ -21,9 +21,18 @@
 
 namespace OCA\FederatedFileSharing\Controller;
 
+use OCA\FederatedFileSharing\Address;
+use OCA\FederatedFileSharing\AddressHandler;
+use OCP\AppFramework\Http\JSONResponse;
+use OCA\FederatedFileSharing\Exception\InvalidShareException;
+use OCA\FederatedFileSharing\Exception\NotSupportedException;
+use OCA\FederatedFileSharing\FedShareManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use OCP\IUserManager;
 
 /**
  * Class OcmController
@@ -33,14 +42,57 @@ use OCP\IURLGenerator;
 class OcmController extends Controller {
 	const API_VERSION = '1.0-proposal1';
 
+	/**
+	 * @var IURLGenerator
+	 */
 	protected $urlGenerator;
 
+	/**
+	 * @var IUserManager
+	 */
+	protected $userManager;
+
+	/**
+	 * @var AddressHandler
+	 */
+	protected $addressHandler;
+
+	/**
+	 * @var FedShareManager
+	 */
+	protected $fedShareManager;
+
+	/**
+	 * @var ILogger
+	 */
+	protected $logger;
+
+	/**
+	 * OcmController constructor.
+	 *
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IURLGenerator $urlGenerator
+	 * @param IUserManager $userManager
+	 * @param AddressHandler $addressHandler
+	 * @param FedShareManager $fedShareManager
+	 * @param ILogger $logger
+	 */
 	public function __construct($appName,
-								IRequest $request,
-								IURLGenerator $urlGenerator) {
+									IRequest $request,
+									IURLGenerator $urlGenerator,
+									IUserManager $userManager,
+									AddressHandler $addressHandler,
+									FedShareManager $fedShareManager,
+									ILogger $logger
+	) {
 		parent::__construct($appName, $request);
 
 		$this->urlGenerator = $urlGenerator;
+		$this->userManager = $userManager;
+		$this->addressHandler = $addressHandler;
+		$this->fedShareManager = $fedShareManager;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -72,14 +124,17 @@ class OcmController extends Controller {
 	 *
 	 *
 	 *
-	 * @param string $shareWith identifier of the user or group to share the resource with
+	 * @param string $shareWith identifier of the user or group
+	 * 							to share the resource with
 	 * @param string $name name of the shared resource
 	 * @param string $description share description (optional)
 	 * @param string $providerId Identifier of the resource at the provider side
 	 * @param string $owner identifier of the user that owns the resource
 	 * @param string $ownerDisplayName display name of the owner
-	 * @param string $sender Provider specific identifier of the user that wants to share the resource
-	 * @param string $senderDisplayName Display name of the user that wants to share the resource
+	 * @param string $sender Provider specific identifier of the user that wants
+	 * 							to share the resource
+	 * @param string $senderDisplayName Display name of the user that wants
+	 * 									to share the resource
 	 * @param string $shareType Share type (user or group share)
 	 * @param string $resourceType only 'file' is supported atm
 	 * @param array $protocol
@@ -108,7 +163,80 @@ class OcmController extends Controller {
 								$protocol
 
 	) {
-		// TODO: implement
+		try {
+			$hasMissingParams = $this->hasNull(
+				[$shareWith, $name, $providerId, $owner, $shareType, $resourceType]
+			);
+			if ($hasMissingParams
+				|| !\is_array($protocol)
+				|| !isset($protocol['name'])
+				|| !isset($protocol['options'])
+				|| !\is_array($protocol['options'])
+				|| !isset($protocol['options']['sharedSecret'])
+			) {
+				throw new InvalidShareException(
+					'server can not add remote share, missing parameter'
+				);
+			}
+			if (!\OCP\Util::isValidFileName($name)) {
+				throw new InvalidShareException(
+					'The mountpoint name contains invalid characters.'
+				);
+			}
+			// FIXME this should be a method in the user management instead
+			$this->logger->debug(
+				"shareWith before, $shareWith",
+				['app' => $this->appName]
+			);
+			\OCP\Util::emitHook(
+				'\OCA\Files_Sharing\API\Server2Server',
+				'preLoginNameUsedAsUserName',
+				['uid' => &$shareWith]
+			);
+			$this->logger->debug(
+				"shareWith after, $shareWith",
+				['app' => $this->appName]
+			);
+
+			if (!$this->userManager->userExists($shareWith)) {
+				throw new InvalidShareException("User $shareWith does not exist");
+			}
+
+			$ownerAddress = new Address($owner, $ownerDisplayName);
+			$sharedByAddress = new Address($sender, $senderDisplayName);
+
+			$this->fedShareManager->createShare(
+				$ownerAddress,
+				$sharedByAddress,
+				$shareWith,
+				$providerId,
+				$name,
+				$protocol['options']['sharedSecret']
+			);
+		} catch (InvalidShareException $e) {
+			return new JSONResponse(
+				['message' => $e->getMessage()],
+				Http::STATUS_BAD_REQUEST
+			);
+		} catch (NotSupportedException $e) {
+			return new JSONResponse(
+				['message' => 'Server does not support federated cloud sharing'],
+				Http::STATUS_SERVICE_UNAVAILABLE
+			);
+		} catch (\Exception $e) {
+			$this->logger->error(
+				"server can not add remote share, {$e->getMessage()}",
+				['app' => 'federatefilesharing']
+			);
+			return new JSONResponse(
+				['message' => "internal server error, was not able to add share from {$ownerAddress->getHostName()}"],
+				Http::STATUS_INTERNAL_SERVER_ERROR
+			);
+		}
+		return new JSONResponse(
+			[],
+			Http::STATUS_CREATED
+		);
 	}
 
 	/**
@@ -117,8 +245,8 @@ class OcmController extends Controller {
 	 * @param string $providerId Identifier of the resource at the provider side
 	 * @param array $notification
 	 * 		[
-	 * 			optional additional parameters, depending on the notification and the resource type
-	 *
+	 * 			optional additional parameters, depending on the notification
+	 * 				and the resource type
 	 * 		]
 	 */
 	public function processNotification($notificationType,
@@ -135,4 +263,18 @@ class OcmController extends Controller {
 		];
 	}
 
+	/**
+	 * Check if value is null or an array has any null item
+	 *
+	 * @param mixed $param
+	 *
+	 * @return bool
+	 */
+	protected function hasNull($param) {
+		if (\is_array($param)) {
+			return \in_array(null, $param, true);
+		} else {
+			return $param === null;
+		}
+	}
 }

--- a/apps/federatedfilesharing/lib/Controller/OcmController.php
+++ b/apps/federatedfilesharing/lib/Controller/OcmController.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+
+/**
+ * Class OcmController
+ *
+ * @package OCA\FederatedFileSharing\Controller
+ */
+class OcmController extends Controller {
+	const API_VERSION = '1.0-proposal1';
+
+	protected $urlGenerator;
+
+	public function __construct($appName,
+								IRequest $request,
+								IURLGenerator $urlGenerator) {
+		parent::__construct($appName, $request);
+
+		$this->urlGenerator = $urlGenerator;
+	}
+
+	/**
+	 * @NoCSRFRequired
+	 * @PublicPage
+	 *
+	 * EndPoint discovery
+	 * Responds to /ocm-provider/ requests
+	 *
+	 * @return array
+	 */
+	public function discovery() {
+		return [
+			'enabled' => true,
+			'apiVersion' => self::API_VERSION,
+			'endPoint' => $this->urlGenerator->linkToRouteAbsolute(
+				"{$this->appName}.ocm.index"
+			),
+			'shareTypes' => [
+				'name' => 'file',
+				'protocols' => $this->getProtocols()
+			]
+		];
+	}
+
+	/**
+	 * @NoCSRFRequired
+	 * @PublicPage
+	 *
+	 *
+	 *
+	 * @param string $shareWith identifier of the user or group to share the resource with
+	 * @param string $name name of the shared resource
+	 * @param string $description share description (optional)
+	 * @param string $providerId Identifier of the resource at the provider side
+	 * @param string $owner identifier of the user that owns the resource
+	 * @param string $ownerDisplayName display name of the owner
+	 * @param string $sender Provider specific identifier of the user that wants to share the resource
+	 * @param string $senderDisplayName Display name of the user that wants to share the resource
+	 * @param string $shareType Share type (user or group share)
+	 * @param string $resourceType only 'file' is supported atm
+	 * @param array $protocol
+	 * 		[
+	 * 			'name' => (string) protocol name. Only 'webdav' is supported atm,
+	 * 			'options' => [
+	 * 				protocol specific options
+	 * 				only `webdav` options are supported atm
+	 * 				e.g. `uri`,	`access_token`, `password`, `permissions` etc.
+	 *
+	 * 				For backward compatibility the webdav protocol will use
+	 * 				the 'sharedSecret" as username and password
+	 * 			]
+	 *
+	 */
+	public function createShare($shareWith,
+								$name,
+								$description,
+								$providerId,
+								$owner,
+								$ownerDisplayName,
+								$sender,
+								$senderDisplayName,
+								$shareType,
+								$resourceType,
+								$protocol
+
+	) {
+		// TODO: implement
+	}
+
+	/**
+	 * @param string $notificationType notification type (SHARE_REMOVED, etc)
+	 * @param string $resourceType only 'file' is supported atm
+	 * @param string $providerId Identifier of the resource at the provider side
+	 * @param array $notification
+	 * 		[
+	 * 			optional additional parameters, depending on the notification and the resource type
+	 *
+	 * 		]
+	 */
+	public function processNotification($notificationType,
+										$resourceType,
+										$providerId,
+										$notification
+	) {
+		// TODO: implement
+	}
+
+	protected function getProtocols() {
+		return [
+			'webdav' => '/public.php/webdav/'
+		];
+	}
+
+}

--- a/apps/federatedfilesharing/lib/Controller/OcmController.php
+++ b/apps/federatedfilesharing/lib/Controller/OcmController.php
@@ -375,6 +375,12 @@ class OcmController extends Controller {
 					);
 					break;
 				case FileNotification::NOTIFICATION_TYPE_RESHARE_UNDO:
+					// Stub. Let it fallback to the prev endpoint for now
+					return new JSONResponse(
+						['message' => "Notification of type {$notificationType} is not supported"],
+						Http::STATUS_NOT_IMPLEMENTED
+					);
+
 					// owner or sender unshared a resource
 					$share = $this->ocmMiddleware->getValidShare(
 						$providerId, $notification['sharedSecret']

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -27,6 +27,7 @@
 namespace OCA\FederatedFileSharing\Controller;
 
 use OC\OCS\Result;
+use OCA\FederatedFileSharing\Address;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\Exception\NotSupportedException;
 use OCA\FederatedFileSharing\Exception\InvalidShareException;
@@ -140,15 +141,25 @@ class RequestHandlerController extends OCSController {
 			if (!$this->userManager->userExists($shareWith)) {
 				throw new InvalidShareException('User does not exist');
 			}
+
+			if ($ownerFederatedId === null) {
+				$ownerFederatedId = $owner . '@' . $this->addressHandler->normalizeRemote($remote);
+			}
+			// if the owner of the share and the initiator are the same user
+			// we also complete the federated share ID for the initiator
+			if ($sharedByFederatedId === null && $owner === $sharedBy) {
+				$sharedByFederatedId = $ownerFederatedId;
+			}
+
+			$ownerAddress = new Address($ownerFederatedId);
+			$sharedByAddress = new Address($sharedByFederatedId);
+
 			$this->fedShareManager->createShare(
+				$ownerAddress,
+				$sharedByAddress,
 				$shareWith,
-				$remote,
 				$remoteId,
-				$owner,
 				$name,
-				$ownerFederatedId,
-				$sharedByFederatedId,
-				$sharedBy,
 				$token
 			);
 		} catch (InvalidShareException $e) {

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -29,18 +29,16 @@ namespace OCA\FederatedFileSharing\Controller;
 use OC\OCS\Result;
 use OCA\FederatedFileSharing\Address;
 use OCA\FederatedFileSharing\AddressHandler;
-use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\FedShareManager;
+use OCA\FederatedFileSharing\Middleware\OcmMiddleware;
 use OCA\FederatedFileSharing\Ocm\Exception\BadRequestException;
 use OCA\FederatedFileSharing\Ocm\Exception\NotImplementedException;
 use OCA\FederatedFileSharing\Ocm\Exception\OcmException;
-use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\OCSController;
 use OCP\Constants;
 use OCP\IRequest;
 use OCP\IUserManager;
-use OCP\Share;
 use OCP\Share\IShare;
 
 /**
@@ -52,11 +50,8 @@ use OCP\Share\IShare;
  */
 class RequestHandlerController extends OCSController {
 
-	/** @var FederatedShareProvider */
-	private $federatedShareProvider;
-
-	/** @var IAppManager */
-	private $appManager;
+	/** @var OcmMiddleware */
+	private $ocmMiddleware;
 
 	/** @var IUserManager */
 	private $userManager;
@@ -72,24 +67,21 @@ class RequestHandlerController extends OCSController {
 	 *
 	 * @param string $appName
 	 * @param IRequest $request
-	 * @param FederatedShareProvider $federatedShareProvider
-	 * @param IAppManager $appManager
+	 * @param OcmMiddleware $ocmMiddleware
 	 * @param IUserManager $userManager
 	 * @param AddressHandler $addressHandler
 	 * @param FedShareManager $fedShareManager
 	 */
 	public function __construct($appName,
 								IRequest $request,
-								FederatedShareProvider $federatedShareProvider,
-								IAppManager $appManager,
+								OcmMiddleware $ocmMiddleware,
 								IUserManager $userManager,
 								AddressHandler $addressHandler,
 								FedShareManager $fedShareManager
 	) {
 		parent::__construct($appName, $request);
 
-		$this->federatedShareProvider = $federatedShareProvider;
-		$this->appManager = $appManager;
+		$this->ocmMiddleware = $ocmMiddleware;
 		$this->userManager = $userManager;
 		$this->addressHandler = $addressHandler;
 		$this->fedShareManager = $fedShareManager;
@@ -105,7 +97,7 @@ class RequestHandlerController extends OCSController {
 	 */
 	public function createShare() {
 		try {
-			$this->assertIncomingSharingEnabled();
+			$this->ocmMiddleware->assertIncomingSharingEnabled();
 			$remote = $this->request->getParam('remote', null);
 			$token = $this->request->getParam('token', null);
 			$name = $this->request->getParam('name', null);
@@ -118,14 +110,17 @@ class RequestHandlerController extends OCSController {
 				null
 			);
 			$ownerFederatedId = $this->request->getParam('ownerFederatedId', null);
-			$hasMissingParams = $this->hasNull(
-				[$remote, $token, $name, $owner, $remoteId, $shareWith]
+			$this->ocmMiddleware->assertNotNull(
+				[
+					'remote' => $remote,
+					'token' => $token,
+					'name' => $name,
+					'owner' => $owner,
+					'remoteId' => $remoteId,
+					'shareWith' => $shareWith
+				]
 			);
-			if ($hasMissingParams) {
-				throw new BadRequestException(
-					'server can not add remote share, missing parameter'
-				);
-			}
+
 			if (!\OCP\Util::isValidFileName($name)) {
 				throw new BadRequestException(
 					'The mountpoint name contains invalid characters.'
@@ -200,14 +195,19 @@ class RequestHandlerController extends OCSController {
 		$permission = $this->request->getParam('permission', null);
 		$remoteId = $this->request->getParam('remoteId', null);
 
-		if ($this->hasNull([$id, $token, $shareWith, $permission, $remoteId])) {
-			return new Result(null, Http::STATUS_BAD_REQUEST);
-		}
-
 		try {
+			$this->ocmMiddleware->assertNotNull(
+				[
+					'id' => $id,
+					'token' => $token,
+					'shareWith' => $shareWith,
+					'permission'  => $permission,
+					'remoteId' => $remoteId
+				]
+			);
 			$permission = (int) $permission;
 			$remoteId = (int) $remoteId;
-			$share = $this->getValidShare($id);
+			$share = $this->ocmMiddleware->getValidShare($id, $token);
 
 			// don't allow to share a file back to the owner
 			list($user, $remote) = $this->addressHandler->splitUserRemote($shareWith);
@@ -227,10 +227,12 @@ class RequestHandlerController extends OCSController {
 				$shareWith,
 				$permission
 			);
-		} catch (Share\Exceptions\ShareNotFound $e) {
-			return new Result(null, Http::STATUS_NOT_FOUND);
-		} catch (BadRequestException $e) {
-			return new Result(null, Http::STATUS_FORBIDDEN);
+		} catch (OcmException $e) {
+			return new Result(
+				null,
+				$e->getHttpStatusCode(),
+				$e->getMessage()
+			);
 		} catch (\Exception $e) {
 			return new Result(null, Http::STATUS_BAD_REQUEST);
 		}
@@ -255,8 +257,9 @@ class RequestHandlerController extends OCSController {
 	 */
 	public function acceptShare($id) {
 		try {
-			$this->assertOutgoingSharingEnabled();
-			$share = $this->getValidShare($id);
+			$this->ocmMiddleware->assertOutgoingSharingEnabled();
+			$token = $this->request->getParam('token', null);
+			$share = $this->ocmMiddleware->getValidShare($id, $token);
 			$this->fedShareManager->acceptShare($share);
 		} catch (NotImplementedException $e) {
 			return new Result(
@@ -264,8 +267,6 @@ class RequestHandlerController extends OCSController {
 				Http::STATUS_SERVICE_UNAVAILABLE,
 				'Server does not support federated cloud sharing'
 			);
-		} catch (Share\Exceptions\ShareNotFound $e) {
-			// pass
 		}
 		return new Result();
 	}
@@ -282,8 +283,9 @@ class RequestHandlerController extends OCSController {
 	 */
 	public function declineShare($id) {
 		try {
-			$this->assertOutgoingSharingEnabled();
-			$share = $this->getValidShare($id);
+			$token = $this->request->getParam('token', null);
+			$this->ocmMiddleware->assertOutgoingSharingEnabled();
+			$share = $this->ocmMiddleware->getValidShare($id, $token);
 			$this->fedShareManager->declineShare($share);
 		} catch (NotImplementedException $e) {
 			return new Result(
@@ -291,8 +293,6 @@ class RequestHandlerController extends OCSController {
 				Http::STATUS_SERVICE_UNAVAILABLE,
 				'Server does not support federated cloud sharing'
 			);
-		} catch (Share\Exceptions\ShareNotFound $e) {
-			// pass
 		}
 
 		return new Result();
@@ -310,7 +310,7 @@ class RequestHandlerController extends OCSController {
 	 */
 	public function unshare($id) {
 		try {
-			$this->assertOutgoingSharingEnabled();
+			$this->ocmMiddleware->assertOutgoingSharingEnabled();
 			$token = $this->request->getParam('token', null);
 			if ($token && $id) {
 				$this->fedShareManager->unshare($id, $token);
@@ -339,7 +339,8 @@ class RequestHandlerController extends OCSController {
 	 */
 	public function revoke($id) {
 		try {
-			$share = $this->getValidShare($id);
+			$token = $this->request->getParam('token', null);
+			$share = $this->getValidShare($id, $token);
 			$this->fedShareManager->revoke($share);
 		} catch (\Exception $e) {
 			return new Result(null, Http::STATUS_BAD_REQUEST);
@@ -361,8 +362,8 @@ class RequestHandlerController extends OCSController {
 	public function updatePermissions($id) {
 		try {
 			$permissions = $this->request->getParam('permissions', null);
-
-			$share = $this->getValidShare($id);
+			$token = $this->request->getParam('token', null);
+			$share = $this->ocmMiddleware->getValidShare($id, $token);
 			$validPermission = \ctype_digit((string)$permissions);
 			if (!$validPermission) {
 				throw new \Exception();
@@ -373,71 +374,5 @@ class RequestHandlerController extends OCSController {
 		}
 
 		return new Result();
-	}
-
-	/**
-	 * Get share by id, validate it's type and token
-	 *
-	 * @param int $id
-	 *
-	 * @return IShare
-	 *
-	 * @throws Share\Exceptions\ShareNotFound
-	 * @throws BadRequestException
-	 */
-	protected function getValidShare($id) {
-		$share = $this->federatedShareProvider->getShareById($id);
-		$token = $this->request->getParam('token', null);
-		if ($share->getShareType() !== FederatedShareProvider::SHARE_TYPE_REMOTE
-			|| $share->getToken() !== $token
-		) {
-			throw new BadRequestException();
-		}
-		return $share;
-	}
-
-	/**
-	 * Make sure that incoming shares are enabled
-	 *
-	 * @return void
-	 *
-	 * @throws NotImplementedException
-	 */
-	protected function assertIncomingSharingEnabled() {
-		if (!$this->appManager->isEnabledForUser('files_sharing')
-			|| !$this->federatedShareProvider->isIncomingServer2serverShareEnabled()
-		) {
-			throw new NotImplementedException();
-		}
-	}
-	
-	/**
-	 * Make sure that outgoing shares are enabled
-	 *
-	 * @return void
-	 *
-	 * @throws NotImplementedException
-	 */
-	protected function assertOutgoingSharingEnabled() {
-		if (!$this->appManager->isEnabledForUser('files_sharing')
-			|| !$this->federatedShareProvider->isOutgoingServer2serverShareEnabled()
-		) {
-			throw new NotImplementedException();
-		}
-	}
-
-	/**
-	 * Check if value is null or an array has any null item
-	 *
-	 * @param mixed $param
-	 *
-	 * @return bool
-	 */
-	protected function hasNull($param) {
-		if (\is_array($param)) {
-			return \in_array(null, $param, true);
-		} else {
-			return $param === null;
-		}
 	}
 }

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -202,7 +202,9 @@ class RequestHandlerController extends OCSController {
 					'remoteId' => $remoteId
 				]
 			);
-			$permission = (int) $permission;
+			$permission = $this->ocmMiddleware->normalizePermissions(
+				(int) $permission
+			);
 			$remoteId = (int) $remoteId;
 			$share = $this->ocmMiddleware->getValidShare($id, $token);
 
@@ -332,8 +334,8 @@ class RequestHandlerController extends OCSController {
 	public function revoke($id) {
 		try {
 			$token = $this->request->getParam('token', null);
-			$share = $this->getValidShare($id, $token);
-			$this->fedShareManager->revoke($share);
+			$share = $this->ocmMiddleware->getValidShare($id, $token);
+			$this->fedShareManager->undoReshare($share);
 		} catch (\Exception $e) {
 			return new Result(null, Http::STATUS_BAD_REQUEST);
 		}
@@ -360,7 +362,10 @@ class RequestHandlerController extends OCSController {
 			if (!$validPermission) {
 				throw new \Exception();
 			}
-			$this->fedShareManager->updatePermissions($share, (int)$permissions);
+			$permissions = $this->ocmMiddleware->normalizePermissions(
+				(int) $permissions
+			);
+			$this->fedShareManager->updatePermissions($share, $permissions);
 		} catch (\Exception $e) {
 			return new Result(null, Http::STATUS_BAD_REQUEST);
 		}

--- a/apps/federatedfilesharing/lib/DiscoveryManager.php
+++ b/apps/federatedfilesharing/lib/DiscoveryManager.php
@@ -90,39 +90,100 @@ class DiscoveryManager {
 		if (\defined('PHPUNIT_RUN') && !$this->underTest) {
 			return $discoveredServices;
 		}
-		// Read the data from the response body
-		try {
-			$response = $this->client->get($remote . '/ocs-provider/', [
-				'timeout' => 10,
-				'connect_timeout' => 10,
-			]);
-			if ($response->getStatusCode() === 200) {
-				$decodedService = \json_decode($response->getBody(), true);
-				if (\is_array($decodedService)) {
-					$endpoints = [
-						'webdav',
-						'share',
-					];
 
-					foreach ($endpoints as $endpoint) {
-						if (isset($decodedService['services']['FEDERATED_SHARING']['endpoints'][$endpoint])) {
-							$endpointUrl = (string)$decodedService['services']['FEDERATED_SHARING']['endpoints'][$endpoint];
-							if ($this->isSafeUrl($endpointUrl)) {
-								$discoveredServices[$endpoint] = $endpointUrl;
-							}
-						}
+		$decodedService = $this->makeRequest($remote . '/ocs-provider/');
+		if (!empty($decodedService)) {
+			$endpoints = [
+				'webdav',
+				'share',
+			];
+
+			foreach ($endpoints as $endpoint) {
+				if (isset($decodedService['services']['FEDERATED_SHARING']['endpoints'][$endpoint])) {
+					$endpointUrl = (string)$decodedService['services']['FEDERATED_SHARING']['endpoints'][$endpoint];
+					if ($this->isSafeUrl($endpointUrl)) {
+						$discoveredServices[$endpoint] = $endpointUrl;
 					}
 				}
+			}
+		}
+
+		// Write into cache
+		$this->cache->set($remote, \json_encode($discoveredServices));
+		return $discoveredServices;
+	}
+
+	/**
+	 * Discover the actual data and do some naive caching to ensure that the data
+	 * is not requested multiple times.
+	 *
+	 * If no valid discovery data is found the ownCloud defaults are returned.
+	 *
+	 * @param string $remote
+	 * @return array
+	 */
+	private function ocmDiscover($remote) {
+		// Check if something is in the cache
+		if ($cacheData = $this->cache->get('OCM' . $remote)) {
+			return \json_decode($cacheData, true);
+		}
+
+		// Default response body
+		$discoveredServices = [
+			'webdav' => '/public.php/webdav',
+			'ocm' => '/index.php/apps/federatedfilesharing',
+		];
+
+		if (\defined('PHPUNIT_RUN') && !$this->underTest) {
+			return $discoveredServices;
+		}
+
+		$decodedService = $this->makeRequest($remote . '/ocm-provider/');
+		if (!empty($decodedService)) {
+			$discoveredServices['ocm'] = $decodedService['endPoint'];
+			$shareTypes = $discoveredServices['shareTypes'];
+			foreach ($shareTypes as $type) {
+				if ($type['name'] == 'file') {
+					$discoveredServices['webdav'] = $type['protocols']['webdav'];
+				}
+			}
+		}
+
+		// Write into cache
+		$this->cache->set('OCM' . $remote, \json_encode($discoveredServices));
+		return $discoveredServices;
+	}
+
+	/**
+	 * Send GET request and return decoded body of response on success
+	 *
+	 * @param $url
+	 *
+	 * @return array
+	 */
+	private function makeRequest($url) {
+		$decodedService = [];
+		try {
+			// make timeout configurable?
+			$response = $this->client->get(
+				$url,
+				[
+					'timeout' => 10,
+					'connect_timeout' => 10,
+				]
+			);
+			if ($response->getStatusCode() === 200) {
+				$decodedService = \json_decode($response->getBody(), true);
+			}
+			if (\is_array($decodedService) === false) {
+				$decodedService = [];
 			}
 		} catch (ClientException $e) {
 			// Don't throw any exception since exceptions are handled before
 		} catch (ConnectException $e) {
 			// Don't throw any exception since exceptions are handled before
 		}
-
-		// Write into cache
-		$this->cache->set($remote, \json_encode($discoveredServices));
-		return $discoveredServices;
+		return $decodedService;
 	}
 
 	/**
@@ -143,5 +204,13 @@ class DiscoveryManager {
 	 */
 	public function getShareEndpoint($host) {
 		return $this->discover($host)['share'];
+	}
+
+	public function getOcmWebDavEndPoint($host) {
+		return $this->ocmDiscover($host)['webdav'];
+	}
+
+	public function getOcmShareEndPoint($host) {
+		return $this->ocmDiscover($host)['ocm'];
 	}
 }

--- a/apps/federatedfilesharing/lib/DiscoveryManager.php
+++ b/apps/federatedfilesharing/lib/DiscoveryManager.php
@@ -141,7 +141,7 @@ class DiscoveryManager {
 		$decodedService = $this->makeRequest($remote . '/ocm-provider/');
 		if (!empty($decodedService)) {
 			$discoveredServices['ocm'] = $decodedService['endPoint'];
-			$shareTypes = $discoveredServices['shareTypes'];
+			$shareTypes = $decodedService['shareTypes'];
 			foreach ($shareTypes as $type) {
 				if ($type['name'] == 'file') {
 					$discoveredServices['webdav'] = $type['protocols']['webdav'];

--- a/apps/federatedfilesharing/lib/DiscoveryManager.php
+++ b/apps/federatedfilesharing/lib/DiscoveryManager.php
@@ -139,7 +139,7 @@ class DiscoveryManager {
 		}
 
 		$decodedService = $this->makeRequest($remote . '/ocm-provider/');
-		if (!empty($decodedService)) {
+		if (!empty($decodedService) && $decodedService['enabled'] === true) {
 			$discoveredServices['ocm'] = $decodedService['endPoint'];
 			$shareTypes = $decodedService['shareTypes'];
 			foreach ($shareTypes as $type) {
@@ -147,6 +147,11 @@ class DiscoveryManager {
 					$discoveredServices['webdav'] = $type['protocols']['webdav'];
 				}
 			}
+		} else {
+			return [
+				'webdav' => false,
+				'ocm' => false,
+			];
 		}
 
 		// Write into cache
@@ -193,7 +198,10 @@ class DiscoveryManager {
 	 * @return string
 	 */
 	public function getWebDavEndpoint($host) {
-		return $this->discover($host)['webdav'];
+		$ocmWebDavEndpoint = $this->ocmDiscover($host)['webdav'];
+		return ($ocmWebDavEndpoint !== false)
+			? $ocmWebDavEndpoint
+			: $this->discover($host)['webdav'];
 	}
 
 	/**
@@ -204,10 +212,6 @@ class DiscoveryManager {
 	 */
 	public function getShareEndpoint($host) {
 		return $this->discover($host)['share'];
-	}
-
-	public function getOcmWebDavEndPoint($host) {
-		return $this->ocmDiscover($host)['webdav'];
 	}
 
 	public function getOcmShareEndPoint($host) {

--- a/apps/federatedfilesharing/lib/FedShareManager.php
+++ b/apps/federatedfilesharing/lib/FedShareManager.php
@@ -334,11 +334,15 @@ class FedShareManager {
 	 */
 	protected function notifyRemote($share, $callback) {
 		if ($share->getShareOwner() !== $share->getSharedBy()) {
-			list(, $remote) = $this->addressHandler->splitUserRemote(
-				$share->getSharedBy()
-			);
-			$remoteId = $this->federatedShareProvider->getRemoteId($share);
-			$callback($remote, $remoteId, $share->getToken());
+			try {
+				list(, $remote) = $this->addressHandler->splitUserRemote(
+					$share->getSharedBy()
+				);
+				$remoteId = $this->federatedShareProvider->getRemoteId($share);
+				$callback($remote, $remoteId, $share->getToken());
+			} catch (\Exception $e) {
+				// expected fail if sender is a local user
+			}
 		}
 	}
 

--- a/apps/federatedfilesharing/lib/FedShareManager.php
+++ b/apps/federatedfilesharing/lib/FedShareManager.php
@@ -122,7 +122,7 @@ class FedShareManager {
 	) {
 		$owner = $ownerAddress->getUserId();
 		$shareId = $this->federatedShareProvider->addShare(
-			$ownerAddress->getHostName(), $token, $name, $owner, $shareWith, $remoteId
+			$ownerAddress->getOrigin(), $token, $name, $owner, $shareWith, $remoteId
 		);
 
 		$this->eventDispatcher->dispatch(
@@ -255,8 +255,7 @@ class FedShareManager {
 		if ($shareRow === false) {
 			return;
 		}
-		$remote = $this->addressHandler->normalizeRemote($shareRow['remote']);
-		$owner = $shareRow['owner'] . '@' . $remote;
+		$ownerAddress = new Address($shareRow['owner'] . '@' . $shareRow['remote']);
 		$mountpoint = $shareRow['mountpoint'];
 		$user = $shareRow['user'];
 		if ($shareRow['accepted']) {
@@ -270,7 +269,7 @@ class FedShareManager {
 		$this->publishActivity(
 			$user,
 			Activity::SUBJECT_REMOTE_SHARE_UNSHARED,
-			[$owner, $path],
+			[$ownerAddress->getCloudId(), $path],
 			'files',
 			'',
 			'',

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -220,19 +220,24 @@ class FederatedShareProvider implements IShareProvider {
 		);
 
 		try {
-			$sharedByFederatedId = $share->getSharedBy();
-			if ($this->userManager->userExists($sharedByFederatedId)) {
-				$sharedByFederatedId = $sharedByFederatedId . '@' . $this->addressHandler->generateRemoteURL();
+			$instanceCloudId = $this->addressHandler->generateRemoteURL();
+			$sharedBy = $share->getSharedBy();
+			$sharedByCloudId = '';
+			if ($this->userManager->userExists($sharedBy)) {
+				$sharedByCloudId = $instanceCloudId;
 			}
+			$sharedByAddress = new Address("{$sharedBy}@{$sharedByCloudId}");
+			$owner = $share->getShareOwner();
+			$ownerAddress = new Address("{$owner}@{$instanceCloudId}");
+			$sharedWith = $share->getSharedWith();
+			$shareWithAddress = new Address($sharedWith);
 			$send = $this->notifications->sendRemoteShare(
+				$shareWithAddress,
+				$ownerAddress,
+				$sharedByAddress,
 				$token,
-				$share->getSharedWith(),
 				$share->getNode()->getName(),
-				$shareId,
-				$share->getShareOwner(),
-				$share->getShareOwner() . '@' . $this->addressHandler->generateRemoteURL(),
-				$share->getSharedBy(),
-				$sharedByFederatedId
+				$shareId
 			);
 
 			if ($send === false) {

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -481,8 +481,6 @@ class FederatedShareProvider implements IShareProvider {
 
 		$isOwner = false;
 
-		$this->removeShareFromTable($share);
-
 		// if the local user is the owner we can send the unShare request directly...
 		if ($this->userManager->userExists($share->getShareOwner())) {
 			$this->notifications->sendRemoteUnShare($remote, $share->getId(), $share->getToken());
@@ -504,6 +502,7 @@ class FederatedShareProvider implements IShareProvider {
 			}
 			$this->notifications->sendRevokeShare($remote, $remoteId, $share->getToken());
 		}
+		$this->removeShareFromTable($share);
 	}
 
 	/**

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -226,7 +226,12 @@ class FederatedShareProvider implements IShareProvider {
 			if ($this->userManager->userExists($sharedBy)) {
 				$sharedByCloudId = $instanceCloudId;
 			}
-			$sharedByAddress = new Address("{$sharedBy}@{$sharedByCloudId}");
+
+			$sharedByFullAddress =  ($sharedByCloudId !== '')
+				? "{$sharedBy}@{$sharedByCloudId}"
+				: $sharedBy;
+
+			$sharedByAddress = new Address($sharedByFullAddress);
 			$owner = $share->getShareOwner();
 			$ownerAddress = new Address("{$owner}@{$instanceCloudId}");
 			$sharedWith = $share->getSharedWith();

--- a/apps/federatedfilesharing/lib/Middleware/OcmMiddleware.php
+++ b/apps/federatedfilesharing/lib/Middleware/OcmMiddleware.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Middleware;
+
+use OCA\FederatedFileSharing\AddressHandler;
+use OCA\FederatedFileSharing\FederatedShareProvider;
+use OCA\FederatedFileSharing\Ocm\Exception\BadRequestException;
+use OCA\FederatedFileSharing\Ocm\Exception\ForbiddenException;
+use OCA\FederatedFileSharing\Ocm\Exception\NotImplementedException;
+use OCP\App\IAppManager;
+use OCP\ILogger;
+use OCP\IUserManager;
+use OCP\Share;
+use OCP\Share\IShare;
+
+/**
+ * Class OcmMiddleware
+ *
+ * @package OCA\FederatedFileSharing\Controller\Middleware
+ */
+class OcmMiddleware {
+	/**
+	 * @var FederatedShareProvider
+	 */
+	protected $federatedShareProvider;
+
+	/**
+	 * @var IAppManager
+	 */
+	protected $appManager;
+
+	/**
+	 * @var IUserManager
+	 */
+	protected $userManager;
+
+	/**
+	 * @var AddressHandler
+	 */
+	protected $addressHandler;
+
+	/**
+	 * @var ILogger
+	 */
+	protected $logger;
+
+	/**
+	 * constructor.
+	 *
+	 * @param FederatedShareProvider $federatedShareProvider
+	 * @param IAppManager $appManager
+	 * @param IUserManager $userManager
+	 * @param AddressHandler $addressHandler
+	 * @param ILogger $logger
+	 */
+	public function __construct(
+								FederatedShareProvider $federatedShareProvider,
+								IAppManager $appManager,
+								IUserManager $userManager,
+								AddressHandler $addressHandler,
+								ILogger $logger
+	) {
+		$this->federatedShareProvider = $federatedShareProvider;
+		$this->appManager = $appManager;
+		$this->userManager = $userManager;
+		$this->addressHandler = $addressHandler;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Check if value an array has any null item
+	 *
+	 * @param string[] $params
+	 *
+	 * @return bool
+	 *
+	 * @throws BadRequestException
+	 */
+	public function assertNotNull($params) {
+		if (\is_array($params)) {
+			$nullKeys = \array_keys(
+				\array_filter(
+					$params,
+					function ($b) {
+						return $b === null;
+					}
+				)
+			);
+			if (\count($nullKeys) > 0) {
+				$nullKeysAsString = \implode(',', $nullKeys);
+				throw new BadRequestException(
+					"Required parameters are missing: $nullKeysAsString"
+				);
+			}
+		}
+	}
+
+	/**
+	 * Get share by id, validate its type and token
+	 *
+	 * @param int $id
+	 * @param string $sharedSecret
+	 *
+	 * @return IShare
+	 *
+	 * @throws BadRequestException
+	 * @throws ForbiddenException
+	 */
+	public function getValidShare($id, $sharedSecret) {
+		try {
+			$share = $this->federatedShareProvider->getShareById($id);
+		} catch (Share\Exceptions\ShareNotFound $e) {
+			throw new BadRequestException("Share with id {$id} does not exist");
+		}
+		if ($share->getShareType() !== FederatedShareProvider::SHARE_TYPE_REMOTE) {
+			throw new BadRequestException("Share with id {$id} does not exist");
+		}
+
+		if ($share->getToken() !== $sharedSecret) {
+			throw new ForbiddenException("The secret does not match");
+		}
+		return $share;
+	}
+
+	/**
+	 * Make sure that incoming shares are enabled
+	 *
+	 * @return void
+	 *
+	 * @throws NotImplementedException
+	 */
+	public function assertIncomingSharingEnabled() {
+		if (!$this->appManager->isEnabledForUser('files_sharing')
+			|| !$this->federatedShareProvider->isIncomingServer2serverShareEnabled()
+		) {
+			throw new NotImplementedException();
+		}
+	}
+
+	/**
+	 * Make sure that outgoing shares are enabled
+	 *
+	 * @return void
+	 *
+	 * @throws NotImplementedException
+	 */
+	public function assertOutgoingSharingEnabled() {
+		if (!$this->appManager->isEnabledForUser('files_sharing')
+			|| !$this->federatedShareProvider->isOutgoingServer2serverShareEnabled()
+		) {
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/apps/federatedfilesharing/lib/Middleware/OcmMiddleware.php
+++ b/apps/federatedfilesharing/lib/Middleware/OcmMiddleware.php
@@ -200,4 +200,19 @@ class OcmMiddleware {
 			throw new NotImplementedException();
 		}
 	}
+
+	/**
+	 * Drop unused bits for permissions
+	 *
+	 * @param int $permissions
+	 *
+	 * @return int
+	 */
+	public function normalizePermissions($permissions) {
+		$mask = Constants::PERMISSION_READ
+			| Constants::PERMISSION_CREATE
+			| Constants::PERMISSION_UPDATE
+			| Constants::PERMISSION_SHARE;
+		return $mask & $permissions;
+	}
 }

--- a/apps/federatedfilesharing/lib/Middleware/OcmMiddleware.php
+++ b/apps/federatedfilesharing/lib/Middleware/OcmMiddleware.php
@@ -21,11 +21,13 @@
 
 namespace OCA\FederatedFileSharing\Middleware;
 
+use OCA\FederatedFileSharing\Address;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\Ocm\Exception\BadRequestException;
 use OCA\FederatedFileSharing\Ocm\Exception\ForbiddenException;
 use OCA\FederatedFileSharing\Ocm\Exception\NotImplementedException;
+use OCP\Constants;
 use OCP\App\IAppManager;
 use OCP\ILogger;
 use OCP\IUserManager;
@@ -139,6 +141,34 @@ class OcmMiddleware {
 			throw new ForbiddenException("The secret does not match");
 		}
 		return $share;
+	}
+
+	/**
+	 * @param IShare $share
+	 *
+	 * @return void
+	 *
+	 * @throws BadRequestException
+	 */
+	public function assertSharingPermissionSet(IShare $share) {
+		$reSharingAllowed = $share->getPermissions() & Constants::PERMISSION_SHARE;
+		if (!$reSharingAllowed) {
+			throw new BadRequestException("Owner restricted sharing for this resource");
+		}
+	}
+
+	/**
+	 * @param Address $user1
+	 * @param Address $user2
+	 *
+	 * @return void
+	 *
+	 * @throws ForbiddenException
+	 */
+	public function assertNotSameUser(Address $user1, Address $user2) {
+		if ($user1->equalTo($user2)) {
+			throw new ForbiddenException('Sharing back to the owner is not allowed');
+		}
 	}
 
 	/**

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -25,6 +25,7 @@
 
 namespace OCA\FederatedFileSharing;
 
+use OCA\FederatedFileSharing\Ocm\NotificationManager;
 use OCP\AppFramework\Http;
 use OCP\BackgroundJob\IJobList;
 use OCP\Http\Client\IClientService;
@@ -72,48 +73,45 @@ class Notifications {
 	/**
 	 * send server-to-server share to remote server
 	 *
+	 * @param Address $shareWithAddress
+	 * @param Address $ownerAddress
+	 * @param Address $sharedByAddress
 	 * @param string $token
 	 * @param string $shareWith
 	 * @param string $name
 	 * @param int $remote_id
-	 * @param string $owner
-	 * @param string $ownerFederatedId
-	 * @param string $sharedBy
-	 * @param string $sharedByFederatedId
+	 *
 	 * @return bool
+	 *
 	 * @throws \OC\HintException
 	 * @throws \OC\ServerNotAvailableException
 	 */
-	public function sendRemoteShare($token, $shareWith, $name, $remote_id, $owner, $ownerFederatedId, $sharedBy, $sharedByFederatedId) {
-		list($user, $remote) = $this->addressHandler->splitUserRemote($shareWith);
-
-		if ($user && $remote) {
-			$url = $remote;
-			$local = $this->addressHandler->generateRemoteURL();
-
-			$fields = [
-				'shareWith' => $user,
-				'token' => $token,
-				'name' => $name,
-				'remoteId' => $remote_id,
-				'owner' => $owner,
-				'ownerFederatedId' => $ownerFederatedId,
-				'sharedBy' => $sharedBy,
-				'sharedByFederatedId' => $sharedByFederatedId,
-				'remote' => $local,
-			];
-
-			$url = $this->addressHandler->removeProtocolFromUrl($url);
-			$result = $this->tryHttpPostToShareEndpoint($url, '', $fields);
-			$status = \json_decode($result['result'], true);
-
-			if ($result['success'] && ($status['ocs']['meta']['statuscode'] === 100 || $status['ocs']['meta']['statuscode'] === 200)) {
-				\OC_Hook::emit('OCP\Share', 'federated_share_added', ['server' => $remote]);
-				return true;
+	public function sendRemoteShare(Address $shareWithAddress,
+		Address $ownerAddress,
+		Address $sharedByAddress,
+		$token,
+		$name,
+		$remote_id
+	) {
+		$remoteShareSuccess = false;
+		if ($shareWithAddress->getUserId() && $shareWithAddress->getCloudId()) {
+			$remoteShareSuccess = $this->sendOcmRemoteShare(
+				$shareWithAddress, $ownerAddress, $sharedByAddress, $token, $name, $remote_id
+			);
+			if (!$remoteShareSuccess) {
+				$remoteShareSuccess = $this->sendPreOcmRemoteShare(
+					$shareWithAddress, $ownerAddress, $sharedByAddress, $token, $name, $remote_id
+				);
 			}
 		}
-
-		return false;
+		if ($remoteShareSuccess) {
+			\OC_Hook::emit(
+				'OCP\Share',
+				'federated_share_added',
+				['server' => $shareWithAddress->getHostName()]
+			);
+		}
+		return $remoteShareSuccess;
 	}
 
 	/**
@@ -129,6 +127,30 @@ class Notifications {
 	 * @throws \Exception
 	 */
 	public function requestReShare($token, $id, $shareId, $remote, $shareWith, $permission) {
+		$ocmNotificationManager = new NotificationManager();
+		$data = [
+			'shareWith' => $shareWith,
+			'senderId' => $id
+		];
+		$ocmNotification = $ocmNotificationManager->convertToOcmFileNotification($shareId, $token, 'reshare', $data);
+		$ocmFields = $ocmNotification->toArray();
+
+		$url = \rtrim(
+			$this->addressHandler->removeProtocolFromUrl($remote),
+			'/'
+		);
+		$result = $this->tryHttpPostToShareEndpoint($url, '/notifications', $ocmFields, true);
+		if (isset($result['statusCode']) && $result['statusCode'] === Http::STATUS_CREATED) {
+			$response = \json_decode($result['result'], true);
+			if (\is_array($response) && isset($response['token'], $response['providerId'])) {
+				return [
+					$response['token'],
+					(int) $response['providerId']
+				];
+			}
+			return true;
+		}
+
 		$fields = [
 			'shareWith' => $shareWith,
 			'token' => $token,
@@ -141,11 +163,10 @@ class Notifications {
 		$status = \json_decode($result['result'], true);
 
 		$httpRequestSuccessful = $result['success'];
-		$ocsCallSuccessful = $status['ocs']['meta']['statuscode'] === 100 || $status['ocs']['meta']['statuscode'] === 200;
 		$validToken = isset($status['ocs']['data']['token']) && \is_string($status['ocs']['data']['token']);
 		$validRemoteId = isset($status['ocs']['data']['remoteId']);
 
-		if ($httpRequestSuccessful && $ocsCallSuccessful && $validToken && $validRemoteId) {
+		if ($httpRequestSuccessful && $this->isOcsStatusOk($status) && $validToken && $validRemoteId) {
 			return [
 				$status['ocs']['data']['token'],
 				(int)$status['ocs']['data']['remoteId']
@@ -218,29 +239,43 @@ class Notifications {
 	 * inform remote server whether server-to-server share was accepted/declined
 	 *
 	 * @param string $remote
-	 * @param string $token
 	 * @param int $remoteId Share id on the remote host
-	 * @param string $action possible actions: accept, decline, unshare, revoke, permissions
+	 * @param string $token
+	 * @param string $action possible actions:
+	 * 	                     accept, decline, unshare, revoke, permissions
 	 * @param array $data
 	 * @param int $try
+	 *
 	 * @return boolean
+	 *
 	 * @throws \Exception
 	 */
 	public function sendUpdateToRemote($remote, $remoteId, $token, $action, $data = [], $try = 0) {
+		$ocmNotificationManager = new NotificationManager();
+		$ocmNotification = $ocmNotificationManager->convertToOcmFileNotification($remoteId, $token, $action, $data);
+		$ocmFields = $ocmNotification->toArray();
+		$url = \rtrim(
+			$this->addressHandler->removeProtocolFromUrl($remote),
+			'/'
+		);
+		$result = $this->tryHttpPostToShareEndpoint($url, '/notifications', $ocmFields, true);
+		if (isset($result['statusCode']) && $result['statusCode'] === Http::STATUS_CREATED) {
+			return true;
+		}
+
 		$fields = ['token' => $token];
 		foreach ($data as $key => $value) {
 			$fields[$key] = $value;
 		}
 
-		$url = $this->addressHandler->removeProtocolFromUrl($remote);
-		$result = $this->tryHttpPostToShareEndpoint(\rtrim($url, '/'), '/' . $remoteId . '/' . $action, $fields);
+		$url = \rtrim(
+			$this->addressHandler->removeProtocolFromUrl($remote),
+			'/'
+		);
+		$result = $this->tryHttpPostToShareEndpoint($url, '/' . $remoteId . '/' . $action, $fields);
 		$status = \json_decode($result['result'], true);
 
-		if ($result['success'] &&
-			($status['ocs']['meta']['statuscode'] === 100 ||
-				$status['ocs']['meta']['statuscode'] === 200
-			)
-		) {
+		if ($result['success'] && $this->isOcsStatusOk($status)) {
 			return true;
 		} elseif ($try === 0) {
 			// only add new job on first try
@@ -275,10 +310,13 @@ class Notifications {
 	 * @param string $remoteDomain
 	 * @param string $urlSuffix
 	 * @param array $fields post parameters
+	 * @param bool $useOcm send request to OCM endpoint instead of OCS
+	 *
 	 * @return array
+	 *
 	 * @throws \Exception
 	 */
-	protected function tryHttpPostToShareEndpoint($remoteDomain, $urlSuffix, array $fields) {
+	protected function tryHttpPostToShareEndpoint($remoteDomain, $urlSuffix, array $fields, $useOcm = false) {
 		$client = $this->httpClientService->newClient();
 		$protocol = 'https://';
 		$result = [
@@ -288,14 +326,22 @@ class Notifications {
 		$try = 0;
 
 		while ($result['success'] === false && $try < 2) {
-			$endpoint = $this->discoveryManager->getShareEndpoint($protocol . $remoteDomain);
+			if ($useOcm) {
+				$endpoint = $this->discoveryManager->getOcmShareEndpoint($protocol . $remoteDomain);
+				$endpoint .= $urlSuffix;
+			} else {
+				$relativePath = $this->discoveryManager->getShareEndpoint($protocol . $remoteDomain);
+				$endpoint = $protocol . $remoteDomain . $relativePath . $urlSuffix . '?format=' . self::RESPONSE_FORMAT;
+			}
+
 			try {
-				$response = $client->post($protocol . $remoteDomain . $endpoint . $urlSuffix . '?format=' . self::RESPONSE_FORMAT, [
+				$response = $client->post($endpoint, [
 					'body' => $fields,
 					'timeout' => 10,
 					'connect_timeout' => 10,
 				]);
 				$result['result'] = $response->getBody();
+				$result['statusCode'] = $response->getStatusCode();
 				$result['success'] = true;
 				break;
 			} catch (\Exception $e) {
@@ -315,5 +361,66 @@ class Notifications {
 		}
 
 		return $result;
+	}
+
+	protected function sendOcmRemoteShare(Address $shareWithAddress, Address $ownerAddress, Address $sharedByAddress, $token, $name, $remote_id) {
+		$fields = [
+			'shareWith' => $shareWithAddress->getCloudId(),
+			'name' => $name,
+			'providerId' => $remote_id,
+			'owner' => $ownerAddress->getCloudId(),
+			'ownerDisplayName' => $ownerAddress->getDisplayName(),
+			'sender' => $sharedByAddress->getCloudId(),
+			'senderDisplayName' => $sharedByAddress->getDisplayName(),
+			'shareType' => 'user',
+			'resourceType' => 'file',
+			'protocol' => [
+				'name' => 'webdav',
+				'options' => [
+					'sharedSecret' => $token
+				]
+			]
+		];
+
+		$url = $shareWithAddress->getCleanHostName();
+		$result = $this->tryHttpPostToShareEndpoint($url, '/shares', $fields, true);
+
+		if (isset($result['statusCode']) && $result['statusCode'] === Http::STATUS_CREATED) {
+			return true;
+		}
+		return false;
+	}
+
+	protected function sendPreOcmRemoteShare(Address $shareWithAddress, Address $ownerAddress, Address $sharedByAddress, $token, $name, $remote_id) {
+		$fields = [
+			'shareWith' => $shareWithAddress->getUserId(),
+			'token' => $token,
+			'name' => $name,
+			'remoteId' => $remote_id,
+			'owner' => $ownerAddress->getUserId(),
+			'ownerFederatedId' => $ownerAddress->getCloudId(),
+			'sharedBy' => $sharedByAddress->getUserId(),
+			'sharedByFederatedId' => $sharedByAddress->getUserId(),
+			'remote' => $this->addressHandler->generateRemoteURL(),
+		];
+		$url = $shareWithAddress->getCleanHostName();
+		$result = $this->tryHttpPostToShareEndpoint($url, '', $fields);
+		$status = \json_decode($result['result'], true);
+
+		if ($result['success'] && $this->isOcsStatusOk($status)) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Validate ocs response - 100 or 200 means success
+	 *
+	 * @param array $status
+	 *
+	 * @return bool
+	 */
+	private function isOcsStatusOk($status) {
+		return \in_array($status['ocs']['meta']['statuscode'], [100, 200]);
 	}
 }

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -130,9 +130,9 @@ class Notifications {
 		$ocmNotificationManager = new NotificationManager();
 		$data = [
 			'shareWith' => $shareWith,
-			'senderId' => $id
+			'senderId' => $shareId
 		];
-		$ocmNotification = $ocmNotificationManager->convertToOcmFileNotification($shareId, $token, 'reshare', $data);
+		$ocmNotification = $ocmNotificationManager->convertToOcmFileNotification($id, $token, 'reshare', $data);
 		$ocmFields = $ocmNotification->toArray();
 
 		$url = \rtrim(
@@ -142,9 +142,9 @@ class Notifications {
 		$result = $this->tryHttpPostToShareEndpoint($url, '/notifications', $ocmFields, true);
 		if (isset($result['statusCode']) && $result['statusCode'] === Http::STATUS_CREATED) {
 			$response = \json_decode($result['result'], true);
-			if (\is_array($response) && isset($response['token'], $response['providerId'])) {
+			if (\is_array($response) && isset($response['sharedSecret'], $response['providerId'])) {
 				return [
-					$response['token'],
+					$response['sharedSecret'],
 					(int) $response['providerId']
 				];
 			}

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -77,7 +77,6 @@ class Notifications {
 	 * @param Address $ownerAddress
 	 * @param Address $sharedByAddress
 	 * @param string $token
-	 * @param string $shareWith
 	 * @param string $name
 	 * @param int $remote_id
 	 *
@@ -382,7 +381,7 @@ class Notifications {
 			]
 		];
 
-		$url = $shareWithAddress->getCleanHostName();
+		$url = $shareWithAddress->getHostName();
 		$result = $this->tryHttpPostToShareEndpoint($url, '/shares', $fields, true);
 
 		if (isset($result['statusCode']) && $result['statusCode'] === Http::STATUS_CREATED) {
@@ -403,7 +402,7 @@ class Notifications {
 			'sharedByFederatedId' => $sharedByAddress->getUserId(),
 			'remote' => $this->addressHandler->generateRemoteURL(),
 		];
-		$url = $shareWithAddress->getCleanHostName();
+		$url = $shareWithAddress->getHostName();
 		$result = $this->tryHttpPostToShareEndpoint($url, '', $fields);
 		$status = \json_decode($result['result'], true);
 

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -43,6 +43,9 @@ class Notifications {
 	/** @var DiscoveryManager */
 	private $discoveryManager;
 
+	/** @var NotificationManager */
+	private $notificationManager;
+
 	/** @var IJobList  */
 	private $jobList;
 
@@ -60,12 +63,14 @@ class Notifications {
 		AddressHandler $addressHandler,
 		IClientService $httpClientService,
 		DiscoveryManager $discoveryManager,
+		NotificationManager $notificationManager,
 		IJobList $jobList,
 		IConfig $config
 	) {
 		$this->addressHandler = $addressHandler;
 		$this->httpClientService = $httpClientService;
 		$this->discoveryManager = $discoveryManager;
+		$this->notificationManager = $notificationManager;
 		$this->jobList = $jobList;
 		$this->config = $config;
 	}
@@ -126,12 +131,11 @@ class Notifications {
 	 * @throws \Exception
 	 */
 	public function requestReShare($token, $id, $shareId, $remote, $shareWith, $permission) {
-		$ocmNotificationManager = new NotificationManager();
 		$data = [
 			'shareWith' => $shareWith,
 			'senderId' => $shareId
 		];
-		$ocmNotification = $ocmNotificationManager->convertToOcmFileNotification($id, $token, 'reshare', $data);
+		$ocmNotification = $this->notificationManager->convertToOcmFileNotification($id, $token, 'reshare', $data);
 		$ocmFields = $ocmNotification->toArray();
 
 		$url = \rtrim(
@@ -250,8 +254,7 @@ class Notifications {
 	 * @throws \Exception
 	 */
 	public function sendUpdateToRemote($remote, $remoteId, $token, $action, $data = [], $try = 0) {
-		$ocmNotificationManager = new NotificationManager();
-		$ocmNotification = $ocmNotificationManager->convertToOcmFileNotification($remoteId, $token, $action, $data);
+		$ocmNotification = $this->notificationManager->convertToOcmFileNotification($remoteId, $token, $action, $data);
 		$ocmFields = $ocmNotification->toArray();
 		$url = \rtrim(
 			$this->addressHandler->removeProtocolFromUrl($remote),

--- a/apps/federatedfilesharing/lib/Ocm/Exception/BadRequestException.php
+++ b/apps/federatedfilesharing/lib/Ocm/Exception/BadRequestException.php
@@ -19,12 +19,18 @@
  *
  */
 
-namespace OCA\FederatedFileSharing\Exception;
+namespace OCA\FederatedFileSharing\Ocm\Exception;
+
+use OCP\AppFramework\Http;
 
 /**
- * Exception that used when federated sharing is disabled
- *
- * @package OCA\FederatedFileSharing\Exception
+ * Used when a request has missing or invalid parameters
  */
-class NotSupportedException extends \Exception {
+class BadRequestException extends OcmException {
+	/**
+	 * @return int
+	 */
+	public function getHttpStatusCode() {
+		return Http::STATUS_BAD_REQUEST;
+	}
 }

--- a/apps/federatedfilesharing/lib/Ocm/Exception/ForbiddenException.php
+++ b/apps/federatedfilesharing/lib/Ocm/Exception/ForbiddenException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Ocm\Exception;
+
+use OCP\AppFramework\Http;
+
+/**
+ * Used when a trusted service is not authorized to create shares or notifications
+ */
+class ForbiddenException extends OcmException {
+	/**
+	 * @return int
+	 */
+	public function getHttpStatusCode() {
+		return Http::STATUS_FORBIDDEN;
+	}
+}

--- a/apps/federatedfilesharing/lib/Ocm/Exception/NotImplementedException.php
+++ b/apps/federatedfilesharing/lib/Ocm/Exception/NotImplementedException.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Ocm\Exception;
+
+use OCP\AppFramework\Http;
+
+/**
+ * Exception that used when
+ * 1. Federated file sharing is disabled
+ * 2. Protocol is not supported
+ * 3. Resource Type is not supported
+ * 4. Share Type is not supported
+ *
+ * @package OCA\FederatedFileSharing\Exception
+ */
+class NotImplementedException extends OcmException {
+	/**
+	 * @return int
+	 */
+	public function getHttpStatusCode() {
+		return Http::STATUS_NOT_IMPLEMENTED;
+	}
+}

--- a/apps/federatedfilesharing/lib/Ocm/Exception/OcmException.php
+++ b/apps/federatedfilesharing/lib/Ocm/Exception/OcmException.php
@@ -19,12 +19,14 @@
  *
  */
 
-namespace OCA\FederatedFileSharing\Exception;
+namespace OCA\FederatedFileSharing\Ocm\Exception;
 
 /**
- * Exception that used when request token doesn't match share token
- *
- * @package OCA\FederatedFileSharing\Exception
+ * Base Ocm Exception class
  */
-class InvalidShareException extends \Exception {
+abstract class OcmException extends \Exception {
+	/**
+	 * @return int
+	 */
+	abstract public function getHttpStatusCode();
 }

--- a/apps/federatedfilesharing/lib/Ocm/Notification/FileNotification.php
+++ b/apps/federatedfilesharing/lib/Ocm/Notification/FileNotification.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Ocm\Notification;
+
+/**
+ * Class Notification
+ *
+ * @package OCA\FederatedFileSharing\Ocm
+ */
+class FileNotification extends Notification {
+	const NOTIFICATION_TYPE_SHARE_ACCEPTED = 'SHARE_ACCEPTED';
+	const NOTIFICATION_TYPE_SHARE_DECLINED = 'SHARE_DECLINED';
+	const NOTIFICATION_TYPE_SHARE_UNSHARED = 'SHARE_UNSHARED';
+	const NOTIFICATION_TYPE_REQUEST_RESHARE = 'REQUEST_RESHARE';
+	const NOTIFICATION_TYPE_RESHARE_UNDO = 'RESHARE_UNDO';
+	const NOTIFICATION_TYPE_RESHARE_CHANGE_PERMISSION = 'RESHARE_CHANGE_PERMISSION';
+
+	const RESOURCE_TYPE_FILE = 'file';
+
+	/**
+	 * @return string
+	 */
+	public function getResourceType() {
+		return self::RESOURCE_TYPE_FILE;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getNotificationType() {
+		return $this->notificationType;
+	}
+
+	/**
+	 * @param string $notificationType
+	 *
+	 * @return void
+	 */
+	public function setNotificationType($notificationType) {
+		$this->notificationType = $notificationType;
+	}
+
+	/**
+	 * Get all available notification types
+	 *
+	 * @return string[]
+	 */
+	public function getNotificationTypes() {
+		return [
+			self::NOTIFICATION_TYPE_SHARE_ACCEPTED,
+			self::NOTIFICATION_TYPE_SHARE_DECLINED,
+			self::NOTIFICATION_TYPE_SHARE_UNSHARED,
+			self::NOTIFICATION_TYPE_REQUEST_RESHARE,
+			self::NOTIFICATION_TYPE_RESHARE_UNDO,
+			self::NOTIFICATION_TYPE_RESHARE_CHANGE_PERMISSION
+		];
+	}
+}

--- a/apps/federatedfilesharing/lib/Ocm/Notification/Notification.php
+++ b/apps/federatedfilesharing/lib/Ocm/Notification/Notification.php
@@ -84,7 +84,7 @@ abstract class Notification {
 
 	/**
 	 * @param string $field
-	 * @param string $value
+	 * @param mixed $value
 	 *
 	 * @return void
 	 */

--- a/apps/federatedfilesharing/lib/Ocm/Notification/Notification.php
+++ b/apps/federatedfilesharing/lib/Ocm/Notification/Notification.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Ocm\Notification;
+
+/**
+ * Class AbstractNotification
+ *
+ * @package OCA\FederatedFileSharing\Ocm\Notification
+ */
+abstract class Notification {
+
+	/**
+	 * @var string Specifies to which shared resource the notification belong to
+	 */
+	protected $providerId;
+
+	/**
+	 * @var string Resource-specific type of the notification.
+	 */
+	protected $notificationType;
+
+	/**
+	 * @var string[] Payload of the notification
+	 */
+	protected $notificationData = [];
+
+	/**
+	 * Get all available notification types for this resource type
+	 *
+	 * @return string[]
+	 */
+	abstract public function getNotificationTypes();
+
+	/**
+	 * @return string
+	 */
+	abstract public function getResourceType();
+
+	/**
+	 * @return string
+	 */
+	public function getProviderId() {
+		return $this->providerId;
+	}
+
+	/**
+	 * @param string $providerId
+	 *
+	 * @return void
+	 */
+	public function setProviderId($providerId) {
+		$this->providerId = $providerId;
+	}
+
+	/**
+	 * Check if notification is supported
+	 *
+	 * @param string $type
+	 *
+	 * @return bool
+	 */
+	public function isValidNotificationType($type) {
+		return \in_array($type, $this->getNotificationTypes());
+	}
+
+	/**
+	 * @param string $field
+	 * @param string $value
+	 *
+	 * @return void
+	 */
+	public function addNotificationData($field, $value) {
+		$this->notificationData[$field] = $value;
+	}
+
+	/**
+	 * Prepare notification
+	 *
+	 * @return array
+	 */
+	public function toArray() {
+		return [
+			'notificationType' => $this->notificationType,
+			'resourceType' => $this->getResourceType(),
+			'providerId' => $this->providerId,
+			'notification' => $this->notificationData
+		];
+	}
+}

--- a/apps/federatedfilesharing/lib/Ocm/NotificationManager.php
+++ b/apps/federatedfilesharing/lib/Ocm/NotificationManager.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Ocm;
+
+use OCA\FederatedFileSharing\Ocm\Notification\FileNotification;
+use OCP\Constants;
+
+/**
+ * Class NotificationManager
+ *
+ * @package OCA\FederatedFileSharing\Ocm
+ */
+class NotificationManager {
+	/**
+	 * @param string $type
+	 *
+	 * @return FileNotification
+	 */
+	public function getFileNotification($type) {
+		$notification = new FileNotification();
+		$notification->setNotificationType($type);
+		return $notification;
+	}
+
+	/**
+	 * @param string $remoteId
+	 * @param string $token
+	 * @param string $action
+	 * @param array $data
+	 *
+	 * @return FileNotification
+	 */
+	public function convertToOcmFileNotification($remoteId, $token, $action, $data = []) {
+		$notification = new FileNotification();
+		$map = [
+			'accept' => FileNotification::NOTIFICATION_TYPE_SHARE_ACCEPTED,
+			'decline' => FileNotification::NOTIFICATION_TYPE_SHARE_DECLINED,
+			'unshare' => FileNotification::NOTIFICATION_TYPE_SHARE_UNSHARED,
+			'revoke' => FileNotification::NOTIFICATION_TYPE_RESHARE_UNDO,
+			'permissions' => FileNotification::NOTIFICATION_TYPE_RESHARE_CHANGE_PERMISSION,
+			'reshare' => FileNotification::NOTIFICATION_TYPE_REQUEST_RESHARE
+		];
+		$notification->setNotificationType($map[$action]);
+		$notification->setProviderId($remoteId);
+		$notification->addNotificationData('sharedSecret', $token);
+
+		if ($action === 'permissions') {
+			$ocmPermissions = $this->toOcmPermissions($data['permissions']);
+			$notification->addNotificationData('permission', $ocmPermissions);
+		}
+
+		if ($action === 'reshare') {
+			$ocmPermissions = $this->toOcmPermissions($data['permissions']);
+			$notification->addNotificationData('permission', $ocmPermissions);
+			$notification->addNotificationData('senderId', $data['senderId']);
+			$notification->addNotificationData('shareWith', $data['shareWith']);
+		}
+
+		return $notification;
+	}
+
+	/**
+	 * Maps numeric permissions to an array of string permissions
+	 *
+	 * @param int $permissions
+	 * @return array
+	 */
+	protected function toOcmPermissions($permissions) {
+		$permissions = (int) $permissions;
+		$ocmPermissions = [];
+		if ($permissions & Constants::PERMISSION_READ) {
+			$ocmPermissions[] = 'read';
+		}
+		if (($permissions & Constants::PERMISSION_CREATE)
+			|| ($permissions & Constants::PERMISSION_UPDATE)
+		) {
+			$ocmPermissions[] = 'write';
+		}
+		if ($permissions & Constants::PERMISSION_SHARE) {
+			$ocmPermissions[] = 'share';
+		}
+		return $ocmPermissions;
+	}
+}

--- a/apps/federatedfilesharing/lib/Ocm/NotificationManager.php
+++ b/apps/federatedfilesharing/lib/Ocm/NotificationManager.php
@@ -22,7 +22,6 @@
 namespace OCA\FederatedFileSharing\Ocm;
 
 use OCA\FederatedFileSharing\Ocm\Notification\FileNotification;
-use OCP\Constants;
 
 /**
  * Class NotificationManager
@@ -30,6 +29,20 @@ use OCP\Constants;
  * @package OCA\FederatedFileSharing\Ocm
  */
 class NotificationManager {
+	/**
+	 * @var Permissions
+	 */
+	protected $permissions;
+
+	/**
+	 * NotificationManager constructor.
+	 *
+	 * @param Permissions $permissions
+	 */
+	public function __construct(Permissions $permissions) {
+		$this->permissions = $permissions;
+	}
+
 	/**
 	 * @param string $type
 	 *
@@ -74,41 +87,15 @@ class NotificationManager {
 		$notification->addNotificationData('message', $messages[$action]);
 
 		if ($action === 'permissions') {
-			$ocmPermissions = $this->toOcmPermissions($data['permissions']);
+			$ocmPermissions = $this->permissions->toOcmPermissions($data['permissions']);
 			$notification->addNotificationData('permission', $ocmPermissions);
 		}
 
 		if ($action === 'reshare') {
-			$ocmPermissions = $this->toOcmPermissions($data['permissions']);
-			$notification->addNotificationData('permission', $ocmPermissions);
 			$notification->addNotificationData('senderId', $data['senderId']);
 			$notification->addNotificationData('shareWith', $data['shareWith']);
 		}
 
 		return $notification;
-	}
-
-	/**
-	 * Maps numeric permissions to an array of string permissions
-	 *
-	 * @param int $permissions
-	 *
-	 * @return array
-	 */
-	protected function toOcmPermissions($permissions) {
-		$permissions = (int) $permissions;
-		$ocmPermissions = [];
-		if ($permissions & Constants::PERMISSION_READ) {
-			$ocmPermissions[] = 'read';
-		}
-		if (($permissions & Constants::PERMISSION_CREATE)
-			|| ($permissions & Constants::PERMISSION_UPDATE)
-		) {
-			$ocmPermissions[] = 'write';
-		}
-		if ($permissions & Constants::PERMISSION_SHARE) {
-			$ocmPermissions[] = 'share';
-		}
-		return $ocmPermissions;
 	}
 }

--- a/apps/federatedfilesharing/lib/Ocm/NotificationManager.php
+++ b/apps/federatedfilesharing/lib/Ocm/NotificationManager.php
@@ -59,9 +59,19 @@ class NotificationManager {
 			'permissions' => FileNotification::NOTIFICATION_TYPE_RESHARE_CHANGE_PERMISSION,
 			'reshare' => FileNotification::NOTIFICATION_TYPE_REQUEST_RESHARE
 		];
+		$messages = [
+			'accept' => "Recipient accepted the share",
+			'decline' => "Recipient declined the share or unshared it from themself",
+			'unshare' => "File was unshared",
+			'revoke' => "Tell the owner (or the sender of a reshare) that the reshare was unshared",
+			'permissions' => "Tell the owner (or the sender of the reshare) that the permissions changed",
+			'reshare' => "Recipient of a share ask the owner to reshare the file with another user"
+		];
+
 		$notification->setNotificationType($map[$action]);
 		$notification->setProviderId($remoteId);
 		$notification->addNotificationData('sharedSecret', $token);
+		$notification->addNotificationData('message', $messages[$action]);
 
 		if ($action === 'permissions') {
 			$ocmPermissions = $this->toOcmPermissions($data['permissions']);
@@ -82,6 +92,7 @@ class NotificationManager {
 	 * Maps numeric permissions to an array of string permissions
 	 *
 	 * @param int $permissions
+	 *
 	 * @return array
 	 */
 	protected function toOcmPermissions($permissions) {

--- a/apps/federatedfilesharing/lib/Ocm/Permissions.php
+++ b/apps/federatedfilesharing/lib/Ocm/Permissions.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Ocm;
+
+use OCP\Constants;
+
+/**
+ * Class Permissions
+ *
+ * @package OCA\FederatedFileSharing\Ocm
+ */
+class Permissions {
+	const OCM_PERMISSION_READ = 'read';
+	const OCM_PERMISSION_WRITE = 'write';
+	const OCM_PERMISSION_SHARE = 'share';
+
+	/**
+	 * Maps numeric permissions to an array of string permissions
+	 *
+	 * @param int $ocPermissions
+	 *
+	 * @return array
+	 */
+	public function toOcmPermissions($ocPermissions) {
+		$ocPermissions = (int) $ocPermissions;
+		$ocmPermissions = [];
+		if ($ocPermissions & Constants::PERMISSION_READ) {
+			$ocmPermissions[] = self::OCM_PERMISSION_READ . '';
+		}
+		if (($ocPermissions & Constants::PERMISSION_CREATE)
+			|| ($ocPermissions & Constants::PERMISSION_UPDATE)
+		) {
+			$ocmPermissions[] = self::OCM_PERMISSION_WRITE;
+		}
+		if ($ocPermissions & Constants::PERMISSION_SHARE) {
+			$ocmPermissions[] = self::OCM_PERMISSION_SHARE;
+		}
+		return $ocmPermissions;
+	}
+
+	/**
+	 * @param string[] $ocmPermissions
+	 *
+	 * @return int
+	 */
+	public function toOcPermissions($ocmPermissions) {
+		$permissionMap = [
+			self::OCM_PERMISSION_READ => Constants::PERMISSION_READ,
+			self::OCM_PERMISSION_WRITE => Constants::PERMISSION_CREATE + Constants::PERMISSION_UPDATE,
+			self::OCM_PERMISSION_SHARE => Constants::PERMISSION_SHARE
+		];
+		$ocPermissions = 0;
+		foreach ($ocmPermissions as $ocmPermission) {
+			if (isset($permissionMap[$ocmPermission])) {
+				$ocPermissions += $permissionMap[$ocmPermission];
+			}
+		}
+
+		return $ocPermissions;
+	}
+}

--- a/apps/federatedfilesharing/tests/AddressHandlerTest.php
+++ b/apps/federatedfilesharing/tests/AddressHandlerTest.php
@@ -120,41 +120,6 @@ class AddressHandlerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestCompareAddresses
-	 *
-	 * @param string $user1
-	 * @param string $server1
-	 * @param string $user2
-	 * @param string $server2
-	 * @param bool $expected
-	 */
-	public function testCompareAddresses($user1, $server1, $user2, $server2, $expected) {
-		$this->assertSame($expected,
-			$this->addressHandler->compareAddresses($user1, $server1, $user2, $server2)
-		);
-	}
-
-	public function dataTestCompareAddresses() {
-		return [
-			['user1', 'http://server1', 'user1', 'http://server1', true],
-			['user1', 'https://server1', 'user1', 'http://server1', true],
-			['user1', 'http://serVer1', 'user1', 'http://server1', true],
-			['user1', 'http://server1/',  'user1', 'http://server1', true],
-			['user1', 'server1', 'user1', 'http://server1', true],
-			['user1', 'http://server1', 'user1', 'http://server2', false],
-			['user1', 'https://server1', 'user1', 'http://server2', false],
-			['user1', 'http://serVer1', 'user1', 'http://serer2', false],
-			['user1', 'http://server1/', 'user1', 'http://server2', false],
-			['user1', 'server1', 'user1', 'http://server2', false],
-			['user1', 'http://server1', 'user2', 'http://server1', false],
-			['user1', 'https://server1', 'user2', 'http://server1', false],
-			['user1', 'http://serVer1', 'user2', 'http://server1', false],
-			['user1', 'http://server1/',  'user2', 'http://server1', false],
-			['user1', 'server1', 'user2', 'http://server1', false],
-		];
-	}
-
-	/**
 	 * @dataProvider dataTestRemoveProtocolFromUrl
 	 *
 	 * @param string $url
@@ -191,27 +156,6 @@ class AddressHandlerTest extends \Test\TestCase {
 			['http://localhost/', 'http://localhost'],
 			['http://localhost/index.php', 'http://localhost'],
 			['http://localhost/index.php/s/AShareToken', 'http://localhost'],
-		];
-	}
-
-	/**
-	 * @dataProvider dataTestNormalizeRemote
-	 *
-	 * @param string $url
-	 * @param string $expected
-	 */
-	public function testNormalizeRemote($url, $expected) {
-		$result = $this->addressHandler->normalizeRemote($url);
-		$this->assertSame($expected, $result);
-	}
-
-	public function dataTestNormalizeRemote() {
-		return [
-			['http://localhost', 'localhost'],
-			['http://localhost/', 'localhost'],
-			['http://localhost/index.php', 'localhost'],
-			['http://localhost/index.php/s/AShareToken', 'localhost'],
-			['http://localhost/index.php/s/AShareToken/', 'localhost'],
 		];
 	}
 }

--- a/apps/federatedfilesharing/tests/AddressTest.php
+++ b/apps/federatedfilesharing/tests/AddressTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Tests;
+
+use OCA\FederatedFileSharing\Address;
+
+/**
+ * Class AddressTest
+ *
+ * @package OCA\FederatedFileSharing\Tests
+ */
+class AddressTest extends \Test\TestCase {
+	/**
+	 * @dataProvider dataTestGetUserId
+	 *
+	 * @param string $address
+	 * @param string $expectedUserId
+	 */
+	public function testGetUserId($address, $expectedUserId) {
+		$cloudAddress = new Address($address);
+		$userId = $cloudAddress->getUserId();
+		$this->assertEquals($userId, $expectedUserId);
+	}
+
+	public function dataTestGetUserId() {
+		return [
+			['john@domain.com', 'john'],
+			['john@domain.com@some.host', 'john@domain.com'],
+			['john@domain.com@http://some.host', 'john@domain.com']
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestGetHostName
+	 *
+	 * @param string $address
+	 * @param string $expectedHostName
+	 */
+	public function testGetHostName($address, $expectedHostName) {
+		$cloudAddress = new Address($address);
+		$hostName = $cloudAddress->getHostName();
+		$this->assertEquals($hostName, $expectedHostName);
+	}
+
+	public function dataTestGetHostName() {
+		return [
+			['john@domain.com', 'domain.com'],
+			['john@domain.com@some.host', 'some.host'],
+			['john@domain.com@https://some.host', 'some.host'],
+			['john@domain.com@http://some.host', 'some.host'],
+			['john@domain.com@http://some.host/index.php/', 'some.host'],
+			['john@domain.com@http://localhost/index.php/s/token', 'localhost']
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestGetCloudId
+	 *
+	 * @param string $address
+	 * @param string $expectedCloudId
+	 */
+	public function testGetCloudId($address, $expectedCloudId) {
+		$cloudAddress = new Address($address);
+		$cleanHostName = $cloudAddress->getCloudId();
+		$this->assertEquals($cleanHostName, $expectedCloudId);
+	}
+
+	public function dataTestGetCloudId() {
+		return [
+			['john@domain.com', 'john@domain.com'],
+			['john@domain.com@some.host', 'john@domain.com@some.host'],
+			['john@domain.com@http://some.host', 'john@domain.com@http://some.host'],
+			['john@domain.com@https://some.host', 'john@domain.com@https://some.host'],
+			['john@domain.com@https://some.host/', 'john@domain.com@https://some.host']
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestEqualTo
+	 *
+	 * @param Address $cloudAddress1
+	 * @param Address $cloudAddress2
+	 * @param bool $expectedIsEqual
+	 */
+	public function testEqualTo(Address $cloudAddress1, Address $cloudAddress2, $expectedIsEqual) {
+		$isEqual = $cloudAddress1->equalTo($cloudAddress2);
+		$this->assertEquals($isEqual, $expectedIsEqual);
+	}
+
+	public function dataTestEqualTo() {
+		return [
+			[ new Address('alice@host1'), new Address('bob@host1'), false],
+			[ new Address('alice@host1'), new Address('alice@host2'), false],
+			[ new Address('alice@host1'), new Address('alice@host1'), true],
+			[ new Address('alice@http://host1'), new Address('alice@https://host1'), true],
+			[ new Address('alice@host1'), new Address('alice@https://host1'), true],
+			[ new Address('alice@http://host1'), new Address('alice@https://host1/'), true],
+			[ new Address('alice@http://host1'), new Address('alice@https://HOst1/'), true],
+		];
+	}
+}

--- a/apps/federatedfilesharing/tests/Controller/OcmControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/OcmControllerTest.php
@@ -1,0 +1,360 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Tests\Controller;
+
+use OCA\FederatedFileSharing\AddressHandler;
+use OCA\FederatedFileSharing\FederatedShareProvider;
+use OCA\FederatedFileSharing\FedShareManager;
+use OCA\FederatedFileSharing\Controller\OcmController;
+use OCA\FederatedFileSharing\Ocm\Notification\FileNotification;
+use OCA\FederatedFileSharing\Tests\TestCase;
+use OCP\AppFramework\Http;
+use OCP\ILogger;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\Share\IShare;
+
+/**
+ * Class OcmControllerTest
+ *
+ * @package OCA\FederatedFileSharing\Tests
+ * @group DB
+ */
+class OcmControllerTest extends TestCase {
+	/**
+	 * @var IRequest | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $request;
+
+	/**
+	 * @var FederatedShareProvider | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $federatedShareProvider;
+
+	/**
+	 * @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $urlGenerator;
+
+	/**
+	 * @var IUserManager | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $userManager;
+
+	/**
+	 * @var AddressHandler | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $addressHandler;
+
+	/**
+	 * @var FedShareManager | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $fedShareManager;
+
+	/**
+	 * @var ILogger | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $logger;
+
+	/**
+	 * @var OcmController
+	 */
+	private $ocmController;
+
+	/**
+	 * @var string
+	 */
+	private $shareToken = 'abc';
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->request = $this->getMockBuilder(IRequest::class)
+			->disableOriginalConstructor()->getMock();
+		$this->federatedShareProvider = $this->getMockBuilder(
+			FederatedShareProvider::class
+		)
+			->disableOriginalConstructor()->getMock();
+		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)
+			->disableOriginalConstructor()->getMock();
+		$this->userManager = $this->getMockBuilder(IUserManager::class)
+			->disableOriginalConstructor()->getMock();
+		$this->addressHandler = $this->getMockBuilder(AddressHandler::class)
+			->disableOriginalConstructor()->getMock();
+		$this->fedShareManager = $this->getMockBuilder(FedShareManager::class)
+			->disableOriginalConstructor()->getMock();
+		$this->logger = $this->getMockBuilder(ILogger::class)
+			->disableOriginalConstructor()->getMock();
+
+		$this->ocmController = new OcmController(
+			'federatedfilesharing',
+			$this->request,
+			$this->federatedShareProvider,
+			$this->urlGenerator,
+			$this->userManager,
+			$this->addressHandler,
+			$this->fedShareManager,
+			$this->logger
+		);
+	}
+
+	public function testDiscovery() {
+		$response = $this->ocmController->discovery();
+		$this->assertArrayHasKey('apiVersion', $response);
+		$this->assertEquals(OcmController::API_VERSION, $response['apiVersion']);
+	}
+
+	public function testCreateShareWithMissingParam() {
+		$response = $this->ocmController->createShare(
+			'bob@localhost',
+			'example.txt',
+			'just a file',
+			'70',
+			null,
+			'incognito',
+			'sender@remote',
+			'some sender',
+			'user',
+			FileNotification::RESOURCE_TYPE_FILE,
+			[
+				'options' => [
+					'sharedSecret' => ''
+				]
+			]
+		);
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function testCreateShareForNotExistingUser() {
+		$this->userManager->expects($this->once())
+			->method('userExists')
+			->with('bob')
+			->willReturn(false);
+		$response = $this->ocmController->createShare(
+			'bob@localhost',
+			'example.txt',
+			'just a file',
+			'70',
+			'steve@another',
+			'incognito',
+			'sender@remote',
+			'some sender',
+			'user',
+			FileNotification::RESOURCE_TYPE_FILE,
+			[
+				'name' => 'webdav',
+				'options' => [
+					'sharedSecret' => ''
+				]
+			]
+		);
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function testCreateShareException() {
+		$this->userManager->expects($this->once())
+			->method('userExists')
+			->with('bob')
+			->willReturn(true);
+
+		$this->fedShareManager->expects($this->once())
+			->method('createShare')
+			->willThrowException(new \Exception('blocked by test'));
+
+		$response = $this->ocmController->createShare(
+			'bob@localhost',
+			'example.txt',
+			'just a file',
+			'70',
+			'steve@another',
+			'incognito',
+			'sender@remote',
+			'some sender',
+			'user',
+			FileNotification::RESOURCE_TYPE_FILE,
+			[
+				'name' => 'webdav',
+				'options' => [
+					'sharedSecret' => ''
+				]
+			]
+		);
+		$this->assertEquals(
+			Http::STATUS_INTERNAL_SERVER_ERROR,
+			$response->getStatus()
+		);
+	}
+
+	public function testCreateShareSuccess() {
+		$this->userManager->expects($this->once())
+			->method('userExists')
+			->with('bob')
+			->willReturn(true);
+
+		$this->fedShareManager->expects($this->once())
+			->method('createShare')
+			->willReturn(null);
+
+		$response = $this->ocmController->createShare(
+			'bob@localhost',
+			'example.txt',
+			'just a file',
+			'70',
+			'steve@another',
+			'incognito',
+			'sender@remote',
+			'some sender',
+			'user',
+			FileNotification::RESOURCE_TYPE_FILE,
+			[
+				'name' => 'webdav',
+				'options' => [
+					'sharedSecret' => ''
+				]
+			]
+		);
+		$this->assertEquals(
+			Http::STATUS_CREATED,
+			$response->getStatus()
+		);
+	}
+
+	public function testProcessNotificationWithMissingParam() {
+		$response = $this->ocmController->processNotification(
+			FileNotification::NOTIFICATION_TYPE_SHARE_ACCEPTED,
+			FileNotification::RESOURCE_TYPE_FILE,
+			null,
+			[]
+		);
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function testProcessUnknownFileNotificationType() {
+		$response = $this->ocmController->processNotification(
+			'something strange',
+			FileNotification::RESOURCE_TYPE_FILE,
+			'90',
+			[
+				'sharedSecret' => $this->shareToken
+			]
+		);
+		$this->assertEquals(Http::STATUS_NOT_IMPLEMENTED, $response->getStatus());
+	}
+
+	public function testProcessAcceptShareNotificationForInvalidShare() {
+		$shareMock = $this->getValidShareMock($this->shareToken);
+		$this->federatedShareProvider->expects($this->once())
+			->method('getShareById')
+			->willReturn($shareMock);
+
+		$response = $this->ocmController->processNotification(
+			FileNotification::NOTIFICATION_TYPE_SHARE_ACCEPTED,
+			FileNotification::RESOURCE_TYPE_FILE,
+			'90',
+			[
+				'sharedSecret' => "broken{$this->shareToken}"
+			]
+		);
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function testProcessAcceptShareSuccess() {
+		$shareMock = $this->getValidShareMock($this->shareToken);
+		$this->federatedShareProvider->expects($this->once())
+			->method('getShareById')
+			->willReturn($shareMock);
+
+		$response = $this->ocmController->processNotification(
+			FileNotification::NOTIFICATION_TYPE_SHARE_ACCEPTED,
+			FileNotification::RESOURCE_TYPE_FILE,
+			'90',
+			[
+				'sharedSecret' => $this->shareToken
+			]
+		);
+		$this->assertEquals(Http::STATUS_CREATED, $response->getStatus());
+	}
+
+	public function testProcessDeclineShareNotificationForInvalidShare() {
+		$shareMock = $this->getValidShareMock($this->shareToken);
+		$this->federatedShareProvider->expects($this->once())
+			->method('getShareById')
+			->willReturn($shareMock);
+
+		$response = $this->ocmController->processNotification(
+			FileNotification::NOTIFICATION_TYPE_SHARE_DECLINED,
+			FileNotification::RESOURCE_TYPE_FILE,
+			'90',
+			[
+				'sharedSecret' => "broken{$this->shareToken}"
+			]
+		);
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function testProcessDeclineShareSuccess() {
+		$shareMock = $this->getValidShareMock($this->shareToken);
+		$this->federatedShareProvider->expects($this->once())
+			->method('getShareById')
+			->willReturn($shareMock);
+
+		$response = $this->ocmController->processNotification(
+			FileNotification::NOTIFICATION_TYPE_SHARE_DECLINED,
+			FileNotification::RESOURCE_TYPE_FILE,
+			'90',
+			[
+				'sharedSecret' => $this->shareToken
+			]
+		);
+		$this->assertEquals(Http::STATUS_CREATED, $response->getStatus());
+	}
+
+	public function testReShareUndoSuccess() {
+		$shareMock = $this->getValidShareMock($this->shareToken);
+		$this->federatedShareProvider->expects($this->once())
+			->method('getShareById')
+			->willReturn($shareMock);
+
+		$response = $this->ocmController->processNotification(
+			FileNotification::NOTIFICATION_TYPE_RESHARE_UNDO,
+			FileNotification::RESOURCE_TYPE_FILE,
+			'90',
+			[
+				'sharedSecret' => $this->shareToken
+			]
+		);
+		$this->assertEquals(Http::STATUS_CREATED, $response->getStatus());
+	}
+
+	protected function getValidShareMock($token) {
+		$share = $this->getMockBuilder(IShare::class)
+			->disableOriginalConstructor()->getMock();
+		$share->expects($this->any())
+			->method('getToken')
+			->willReturn($token);
+		$share->expects($this->any())
+			->method('getShareType')
+			->willReturn(FederatedShareProvider::SHARE_TYPE_REMOTE);
+		return $share;
+	}
+}

--- a/apps/federatedfilesharing/tests/Controller/OcmControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/OcmControllerTest.php
@@ -275,7 +275,7 @@ class OcmControllerTest extends TestCase {
 				'sharedSecret' => "broken{$this->shareToken}"
 			]
 		);
-		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertEquals(Http::STATUS_FORBIDDEN, $response->getStatus());
 	}
 
 	public function testProcessAcceptShareSuccess() {
@@ -309,7 +309,7 @@ class OcmControllerTest extends TestCase {
 				'sharedSecret' => "broken{$this->shareToken}"
 			]
 		);
-		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertEquals(Http::STATUS_FORBIDDEN, $response->getStatus());
 	}
 
 	public function testProcessDeclineShareSuccess() {

--- a/apps/federatedfilesharing/tests/Controller/OcmControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/OcmControllerTest.php
@@ -27,6 +27,7 @@ use OCA\FederatedFileSharing\FedShareManager;
 use OCA\FederatedFileSharing\Controller\OcmController;
 use OCA\FederatedFileSharing\Ocm\Notification\FileNotification;
 use OCA\FederatedFileSharing\Tests\TestCase;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\ILogger;
 use OCP\IRequest;
@@ -55,6 +56,11 @@ class OcmControllerTest extends TestCase {
 	 * @var IURLGenerator | \PHPUnit_Framework_MockObject_MockObject
 	 */
 	private $urlGenerator;
+
+	/**
+	 * @var IAppManager | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $appManager;
 
 	/**
 	 * @var IUserManager | \PHPUnit_Framework_MockObject_MockObject
@@ -89,28 +95,23 @@ class OcmControllerTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->request = $this->getMockBuilder(IRequest::class)
-			->disableOriginalConstructor()->getMock();
-		$this->federatedShareProvider = $this->getMockBuilder(
+		$this->request = $this->createMock(IRequest::class);
+		$this->federatedShareProvider = $this->createMock(
 			FederatedShareProvider::class
-		)
-			->disableOriginalConstructor()->getMock();
-		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)
-			->disableOriginalConstructor()->getMock();
-		$this->userManager = $this->getMockBuilder(IUserManager::class)
-			->disableOriginalConstructor()->getMock();
-		$this->addressHandler = $this->getMockBuilder(AddressHandler::class)
-			->disableOriginalConstructor()->getMock();
-		$this->fedShareManager = $this->getMockBuilder(FedShareManager::class)
-			->disableOriginalConstructor()->getMock();
-		$this->logger = $this->getMockBuilder(ILogger::class)
-			->disableOriginalConstructor()->getMock();
+		);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->addressHandler = $this->createMock(AddressHandler::class);
+		$this->fedShareManager = $this->createMock(FedShareManager::class);
+		$this->logger = $this->createMock(ILogger::class);
 
 		$this->ocmController = new OcmController(
 			'federatedfilesharing',
 			$this->request,
 			$this->federatedShareProvider,
 			$this->urlGenerator,
+			$this->appManager,
 			$this->userManager,
 			$this->addressHandler,
 			$this->fedShareManager,
@@ -124,7 +125,31 @@ class OcmControllerTest extends TestCase {
 		$this->assertEquals(OcmController::API_VERSION, $response['apiVersion']);
 	}
 
+	public function testShareIsNotCreatedWhenSharingIsDisabled() {
+		$this->expectFileSharingApp('disabled');
+		$response = $this->ocmController->createShare(
+			'bob@localhost',
+			'example.txt',
+			'just a file',
+			'70',
+			null,
+			'incognito',
+			'sender@remote',
+			'some sender',
+			'user',
+			FileNotification::RESOURCE_TYPE_FILE,
+			[
+				'options' => [
+					'sharedSecret' => ''
+				]
+			]
+		);
+		$this->assertEquals(Http::STATUS_NOT_IMPLEMENTED, $response->getStatus());
+	}
+
 	public function testCreateShareWithMissingParam() {
+		$this->expectFileSharingApp('enabled');
+		$this->expectIncomingSharing('enabled');
 		$response = $this->ocmController->createShare(
 			'bob@localhost',
 			'example.txt',
@@ -146,6 +171,8 @@ class OcmControllerTest extends TestCase {
 	}
 
 	public function testCreateShareForNotExistingUser() {
+		$this->expectFileSharingApp('enabled');
+		$this->expectIncomingSharing('enabled');
 		$this->userManager->expects($this->once())
 			->method('userExists')
 			->with('bob')
@@ -172,6 +199,8 @@ class OcmControllerTest extends TestCase {
 	}
 
 	public function testCreateShareException() {
+		$this->expectFileSharingApp('enabled');
+		$this->expectIncomingSharing('enabled');
 		$this->userManager->expects($this->once())
 			->method('userExists')
 			->with('bob')
@@ -206,6 +235,8 @@ class OcmControllerTest extends TestCase {
 	}
 
 	public function testCreateShareSuccess() {
+		$this->expectFileSharingApp('enabled');
+		$this->expectIncomingSharing('enabled');
 		$this->userManager->expects($this->once())
 			->method('userExists')
 			->with('bob')
@@ -347,8 +378,7 @@ class OcmControllerTest extends TestCase {
 	}
 
 	protected function getValidShareMock($token) {
-		$share = $this->getMockBuilder(IShare::class)
-			->disableOriginalConstructor()->getMock();
+		$share = $this->createMock(IShare::class);
 		$share->expects($this->any())
 			->method('getToken')
 			->willReturn($token);
@@ -356,5 +386,24 @@ class OcmControllerTest extends TestCase {
 			->method('getShareType')
 			->willReturn(FederatedShareProvider::SHARE_TYPE_REMOTE);
 		return $share;
+	}
+
+	protected function expectIncomingSharing($state) {
+		$this->federatedShareProvider->expects($this->once())
+			->method('isIncomingServer2serverShareEnabled')
+			->willReturn($state === 'enabled');
+	}
+
+	protected function expectOutgoingSharing($state) {
+		$this->federatedShareProvider->expects($this->once())
+			->method('isOutgoingServer2serverShareEnabled')
+			->willReturn($state === 'enabled');
+	}
+
+	protected function expectFileSharingApp($state) {
+		$this->appManager->expects($this->once())
+			->method('isEnabledForUser')
+			->with('files_sharing')
+			->willReturn($state === 'enabled');
 	}
 }

--- a/apps/federatedfilesharing/tests/Controller/OcmControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/OcmControllerTest.php
@@ -355,23 +355,6 @@ class OcmControllerTest extends TestCase {
 		$this->assertEquals(Http::STATUS_CREATED, $response->getStatus());
 	}
 
-	public function testReShareUndoSuccess() {
-		$shareMock = $this->getValidShareMock($this->shareToken);
-		$this->ocmMiddleware->expects($this->once())
-			->method('getValidShare')
-			->willReturn($shareMock);
-
-		$response = $this->ocmController->processNotification(
-			FileNotification::NOTIFICATION_TYPE_RESHARE_UNDO,
-			FileNotification::RESOURCE_TYPE_FILE,
-			'90',
-			[
-				'sharedSecret' => $this->shareToken
-			]
-		);
-		$this->assertEquals(Http::STATUS_CREATED, $response->getStatus());
-	}
-
 	protected function getValidShareMock($token) {
 		$share = $this->createMock(IShare::class);
 		$share->expects($this->any())

--- a/apps/federatedfilesharing/tests/Controller/RequestHandlerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/RequestHandlerTest.php
@@ -116,7 +116,7 @@ class RequestHandlerTest extends TestCase {
 			->method('createShare');
 		$response = $this->requestHandlerController->createShare();
 		$this->assertEquals(
-			Http::STATUS_SERVICE_UNAVAILABLE,
+			Http::STATUS_NOT_IMPLEMENTED,
 			$response->getStatusCode()
 		);
 	}
@@ -126,7 +126,7 @@ class RequestHandlerTest extends TestCase {
 		$this->expectIncomingSharing('disabled');
 		$response = $this->requestHandlerController->createShare();
 		$this->assertEquals(
-			Http::STATUS_SERVICE_UNAVAILABLE,
+			Http::STATUS_NOT_IMPLEMENTED,
 			$response->getStatusCode()
 		);
 	}

--- a/apps/federatedfilesharing/tests/DiscoveryManagerTest.php
+++ b/apps/federatedfilesharing/tests/DiscoveryManagerTest.php
@@ -78,7 +78,17 @@ class DiscoveryManagerTest extends \Test\TestCase {
 			->method('getBody')
 			->willReturn('CertainlyNotJson');
 		$this->client
-			->expects($this->once())
+			->expects($this->at(0))
+			->method('get')
+			->with('https://myhost.com/ocm-provider/', [
+				'timeout' => 10,
+				'connect_timeout' => 10,
+			])
+			->willReturn(
+				$this->createMock('\OCP\Http\Client\IResponse')
+			);
+		$this->client
+			->expects($this->at(1))
 			->method('get')
 			->with('https://myhost.com/ocs-provider/', [
 				'timeout' => 10,
@@ -86,16 +96,16 @@ class DiscoveryManagerTest extends \Test\TestCase {
 			])
 			->willReturn($response);
 		$this->cache
-			->expects($this->at(0))
+			->expects($this->at(1))
 			->method('get')
 			->with('https://myhost.com')
 			->willReturn(null);
 		$this->cache
-			->expects($this->at(1))
+			->expects($this->at(2))
 			->method('set')
 			->with('https://myhost.com', '{"webdav":"\/public.php\/webdav","share":"\/ocs\/v1.php\/cloud\/shares"}');
 		$this->cache
-			->expects($this->at(2))
+			->expects($this->at(3))
 			->method('get')
 			->with('https://myhost.com')
 			->willReturn('{"webdav":"\/public.php\/webdav","share":"\/ocs\/v1.php\/cloud\/shares"}');
@@ -115,7 +125,17 @@ class DiscoveryManagerTest extends \Test\TestCase {
 			->method('getBody')
 			->willReturn('{"version":2,"services":{"PRIVATE_DATA":{"version":1,"endpoints":{"store":"\/ocs\/v2.php\/privatedata\/setattribute","read":"\/ocs\/v2.php\/privatedata\/getattribute","delete":"\/ocs\/v2.php\/privatedata\/deleteattribute"}},"SHARING":{"version":1,"endpoints":{"share":"\/ocs\/v2.php\/apps\/files_sharing\/api\/v1\/shares"}},"FEDERATED_SHARING":{"version":1,"endpoints":{"share":"\/ocs\/v2.php\/cloud\/shares","webdav":"\/public.php\/MyCustomEndpoint\/"}},"ACTIVITY":{"version":1,"endpoints":{"list":"\/ocs\/v2.php\/cloud\/activity"}},"PROVISIONING":{"version":1,"endpoints":{"user":"\/ocs\/v2.php\/cloud\/users","groups":"\/ocs\/v2.php\/cloud\/groups","apps":"\/ocs\/v2.php\/cloud\/apps"}}}}');
 		$this->client
-			->expects($this->once())
+			->expects($this->at(0))
+			->method('get')
+			->with('https://myhost.com/ocm-provider/', [
+				'timeout' => 10,
+				'connect_timeout' => 10,
+			])
+			->willReturn(
+				$this->createMock('\OCP\Http\Client\IResponse')
+			);
+		$this->client
+			->expects($this->at(1))
 			->method('get')
 			->with('https://myhost.com/ocs-provider/', [
 				'timeout' => 10,
@@ -133,12 +153,22 @@ class DiscoveryManagerTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('getStatusCode')
 			->willReturn(200);
+		$this->client
+			->expects($this->at(0))
+			->method('get')
+			->with('https://myhost.com/ocm-provider/', [
+				'timeout' => 10,
+				'connect_timeout' => 10,
+			])
+			->willReturn(
+				$this->createMock('\OCP\Http\Client\IResponse')
+			);
 		$response
 			->expects($this->once())
 			->method('getBody')
 			->willReturn('{"version":2,"PRIVATE_DATA":{"version":1,"endpoints":{"store":"\/ocs\/v2.php\/privatedata\/setattribute","read":"\/ocs\/v2.php\/privatedata\/getattribute","delete":"\/ocs\/v2.php\/privatedata\/deleteattribute"}},"SHARING":{"version":1,"endpoints":{"share":"\/ocs\/v2.php\/apps\/files_sharing\/api\/v1\/shares"}},"FEDERATED_SHARING":{"version":1,"endpoints":{"share":"\/ocs\/v2.php\/cloud\/shares","webdav":"\/public.php\/MyCustomEndpoint\/"}},"ACTIVITY":{"version":1,"endpoints":{"list":"\/ocs\/v2.php\/cloud\/activity"}},"PROVISIONING":{"version":1,"endpoints":{"user":"\/ocs\/v2.php\/cloud\/users","groups":"\/ocs\/v2.php\/cloud\/groups","apps":"\/ocs\/v2.php\/cloud\/apps"}}}');
 		$this->client
-			->expects($this->once())
+			->expects($this->at(1))
 			->method('get')
 			->with('https://myhost.com/ocs-provider/', [
 				'timeout' => 10,
@@ -184,7 +214,17 @@ class DiscoveryManagerTest extends \Test\TestCase {
 			->method('getBody')
 			->willReturn('{"version":2,"services":{"PRIVATE_DATA":{"version":1,"endpoints":{"store":"\/ocs\/v2.php\/privatedata\/setattribute","read":"\/ocs\/v2.php\/privatedata\/getattribute","delete":"\/ocs\/v2.php\/privatedata\/deleteattribute"}},"SHARING":{"version":1,"endpoints":{"share":"\/ocs\/v2.php\/apps\/files_sharing\/api\/v1\/shares"}},"FEDERATED_SHARING":{"version":1,"endpoints":{"share":"\/ocs\/v2.php\/cl@oud\/MyCustomShareEndpoint","webdav":"\/public.php\/MyC:ustomEndpoint\/"}},"ACTIVITY":{"version":1,"endpoints":{"list":"\/ocs\/v2.php\/cloud\/activity"}},"PROVISIONING":{"version":1,"endpoints":{"user":"\/ocs\/v2.php\/cloud\/users","groups":"\/ocs\/v2.php\/cloud\/groups","apps":"\/ocs\/v2.php\/cloud\/apps"}}}}');
 		$this->client
-			->expects($this->once())
+			->expects($this->at(0))
+			->method('get')
+			->with('https://myhost.com/ocm-provider/', [
+				'timeout' => 10,
+				'connect_timeout' => 10,
+			])
+			->willReturn(
+				$this->createMock('\OCP\Http\Client\IResponse')
+			);
+		$this->client
+			->expects($this->at(1))
 			->method('get')
 			->with('https://myhost.com/ocs-provider/', [
 				'timeout' => 10,
@@ -192,16 +232,16 @@ class DiscoveryManagerTest extends \Test\TestCase {
 			])
 			->willReturn($response);
 		$this->cache
-			->expects($this->at(0))
+			->expects($this->at(1))
 			->method('get')
 			->with('https://myhost.com')
 			->willReturn(null);
 		$this->cache
-			->expects($this->at(1))
+			->expects($this->at(2))
 			->method('set')
 			->with('https://myhost.com', '{"webdav":"\/public.php\/webdav","share":"\/ocs\/v1.php\/cloud\/shares"}');
 		$this->cache
-			->expects($this->at(2))
+			->expects($this->at(3))
 			->method('get')
 			->with('https://myhost.com')
 			->willReturn('{"webdav":"\/public.php\/webdav","share":"\/ocs\/v1.php\/cloud\/shares"}');

--- a/apps/federatedfilesharing/tests/FedShareManagerTest.php
+++ b/apps/federatedfilesharing/tests/FedShareManagerTest.php
@@ -21,6 +21,7 @@
 
 namespace OCA\FederatedFileSharing\Tests;
 
+use OCA\FederatedFileSharing\Address;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\FedShareManager;
@@ -104,13 +105,14 @@ class FedShareManagerTest extends TestCase {
 
 	public function testCreateShare() {
 		$shareWith = 'Bob';
-		$remote = 'server2';
-		$remoteId = 42;
 		$owner = 'Alice';
-		$name = 'McGee';
-		$ownerFederatedId = '17';
-		$sharedByFederatedId = '18';
+		$ownerFederatedId = 'server2';
+		$sharedByFederatedId = 'server3';
 		$sharedBy = 'Steve';
+		$ownerAddress = new Address("$owner@$ownerFederatedId");
+		$sharedByAddress = new Address("$sharedBy@$sharedByFederatedId");
+		$remoteId = 42;
+		$name = 'file.ext';
 		$token = 'idk';
 
 		$event = $this->getMockBuilder(IEvent::class)->getMock();
@@ -137,14 +139,11 @@ class FedShareManagerTest extends TestCase {
 			->willReturn($notification);
 
 		$this->fedShareManager->createShare(
+			$ownerAddress,
+			$sharedByAddress,
 			$shareWith,
-			$remote,
 			$remoteId,
-			$owner,
 			$name,
-			$ownerFederatedId,
-			$sharedByFederatedId,
-			$sharedBy,
 			$token
 		);
 	}

--- a/apps/federatedfilesharing/tests/FedShareManagerTest.php
+++ b/apps/federatedfilesharing/tests/FedShareManagerTest.php
@@ -26,6 +26,7 @@ use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\FedShareManager;
 use OCA\FederatedFileSharing\Notifications;
+use OCA\FederatedFileSharing\Ocm\Permissions;
 use OCA\Files_Sharing\Activity;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager as ActivityManager;
@@ -64,6 +65,9 @@ class FedShareManagerTest extends TestCase {
 	/** @var AddressHandler | \PHPUnit_Framework_MockObject_MockObject */
 	private $addressHandler;
 
+	/** @var Permissions | \PHPUnit_Framework_MockObject_MockObject */
+	private $permissions;
+
 	/** @var EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject */
 	private $eventDispatcher;
 
@@ -84,6 +88,8 @@ class FedShareManagerTest extends TestCase {
 		$this->addressHandler = $this->getMockBuilder(AddressHandler::class)
 			->disableOriginalConstructor()->getMock();
 
+		$this->permissions = $this->createMock(Permissions::class);
+
 		$this->eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)
 			->getMock();
 
@@ -96,6 +102,7 @@ class FedShareManagerTest extends TestCase {
 					$this->activityManager,
 					$this->notificationManager,
 					$this->addressHandler,
+					$this->permissions,
 					$this->eventDispatcher
 				]
 			)
@@ -257,12 +264,12 @@ class FedShareManagerTest extends TestCase {
 		$this->fedShareManager->unshare($shareRow['id'], $shareRow['share_token']);
 	}
 
-	public function testRevoke() {
+	public function testReshareUndo() {
 		$share = $this->getMockBuilder(IShare::class)
 			->disableOriginalConstructor()->getMock();
 		$this->federatedShareProvider->expects($this->once())
 			->method('removeShareFromTable')
 			->with($share);
-		$this->fedShareManager->revoke($share);
+		$this->fedShareManager->undoReshare($share);
 	}
 }

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -24,6 +24,7 @@
  */
 namespace OCA\FederatedFileSharing\Tests;
 
+use OCA\FederatedFileSharing\Address;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\Notifications;
@@ -134,17 +135,19 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->addressHandler->expects($this->any())->method('splitUserRemote')
 			->willReturn(['user', 'server.com']);
 
+		$shareWithAddress = new Address('user@server.com');
+		$ownerAddress = new Address('shareOwner@http://localhost/');
+		$sharedByAddress = new Address('sharedBy@http://localhost/');
+
 		$this->notifications->expects($this->once())
 			->method('sendRemoteShare')
 			->with(
+				$this->equalTo($shareWithAddress),
+				$this->equalTo($ownerAddress),
+				$this->equalTo($sharedByAddress),
 				$this->equalTo('token'),
-				$this->equalTo('user@server.com'),
 				$this->equalTo('myFile'),
-				$this->anything(),
-				'shareOwner',
-				'shareOwner@http://localhost/',
-				'sharedBy',
-				'sharedBy@http://localhost/'
+				$this->anything()
 			)->willReturn(true);
 
 		$this->rootFolder->expects($this->never())->method($this->anything());
@@ -205,17 +208,19 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->addressHandler->expects($this->any())->method('splitUserRemote')
 			->willReturn(['user', 'server.com']);
 
+		$shareWithAddress = new Address('user@server.com');
+		$ownerAddress = new Address('shareOwner@http://localhost/');
+		$sharedByAddress = new Address('sharedBy@http://localhost/');
+
 		$this->notifications->expects($this->once())
 			->method('sendRemoteShare')
 			->with(
+				$this->equalTo($shareWithAddress),
+				$this->equalTo($ownerAddress),
+				$this->equalTo($sharedByAddress),
 				$this->equalTo('token'),
-				$this->equalTo('user@server.com'),
 				$this->equalTo('myFile'),
-				$this->anything(),
-				'shareOwner',
-				'shareOwner@http://localhost/',
-				'sharedBy',
-				'sharedBy@http://localhost/'
+				$this->anything()
 			)->willReturn(false);
 
 		$this->rootFolder->method('getById')
@@ -254,25 +259,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setPermissions(19)
 			->setNode($node);
 
-		$this->tokenHandler->method('generateToken')->willReturn('token');
-
 		$this->addressHandler->expects($this->any())->method('generateRemoteURL')
 			->willReturn('http://localhost/');
-		$this->addressHandler->expects($this->any())->method('splitUserRemote')
-			->willReturn(['user', 'server.com']);
+
+		$this->tokenHandler->method('generateToken')->willReturn('token');
 
 		$this->notifications->expects($this->once())
 			->method('sendRemoteShare')
-			->with(
-				$this->equalTo('token'),
-				$this->equalTo('user@server.com'),
-				$this->equalTo('myFile'),
-				$this->anything(),
-				'shareOwner',
-				'shareOwner@http://localhost/',
-				'sharedBy',
-				'sharedBy@http://localhost/'
-			)->willThrowException(new \Exception('dummy'));
+			->willThrowException(new \Exception('dummy'));
 
 		$this->rootFolder->method('getById')
 			->with('42')
@@ -357,17 +351,19 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->addressHandler->expects($this->any())->method('generateRemoteURL')
 			->willReturn('http://localhost/');
 
+		$shareWithAddress = new Address('user@server.com');
+		$ownerAddress = new Address('shareOwner@http://localhost/');
+		$sharedByAddress = new Address('sharedBy@http://localhost/');
+
 		$this->notifications->expects($this->once())
 			->method('sendRemoteShare')
 			->with(
+				$this->equalTo($shareWithAddress),
+				$this->equalTo($ownerAddress),
+				$this->equalTo($sharedByAddress),
 				$this->equalTo('token'),
-				$this->equalTo('user@server.com'),
 				$this->equalTo('myFile'),
-				$this->anything(),
-				'shareOwner',
-				'shareOwner@http://localhost/',
-				'sharedBy',
-				'sharedBy@http://localhost/'
+				$this->anything()
 			)->willReturn(true);
 
 		$this->rootFolder->expects($this->never())->method($this->anything());
@@ -420,17 +416,19 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->addressHandler->expects($this->any())->method('generateRemoteURL')
 			->willReturn('http://localhost/');
 
+		$shareWithAddress = new Address('user@server.com');
+		$ownerAddress = new Address("{$owner}@http://localhost/");
+		$sharedByAddress = new Address("{$sharedBy}@http://localhost/");
+
 		$this->notifications->expects($this->once())
 			->method('sendRemoteShare')
 			->with(
+				$this->equalTo($shareWithAddress),
+				$this->equalTo($ownerAddress),
+				$this->equalTo($sharedByAddress),
 				$this->equalTo('token'),
-				$this->equalTo('user@server.com'),
 				$this->equalTo('myFile'),
-				$this->anything(),
-				$owner,
-				$owner . '@http://localhost/',
-				$sharedBy,
-				$sharedBy . '@http://localhost/'
+				$this->anything()
 			)->willReturn(true);
 
 		if ($owner === $sharedBy) {

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -130,14 +130,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 
 		$this->tokenHandler->method('generateToken')->willReturn('token');
 
-		$this->addressHandler->expects($this->any())->method('generateRemoteURL')
-			->willReturn('http://localhost/');
-		$this->addressHandler->expects($this->any())->method('splitUserRemote')
-			->willReturn(['user', 'server.com']);
-
 		$shareWithAddress = new Address('user@server.com');
 		$ownerAddress = new Address('shareOwner@http://localhost/');
 		$sharedByAddress = new Address('sharedBy@http://localhost/');
+		$this->addressHandler->expects($this->any())->method('getLocalUserFederatedAddress')
+			->will($this->onConsecutiveCalls($ownerAddress, $sharedByAddress, $ownerAddress));
+
+		$this->addressHandler->expects($this->any())->method('splitUserRemote')
+			->willReturn(['user', 'server.com']);
 
 		$this->notifications->expects($this->once())
 			->method('sendRemoteShare')
@@ -203,14 +203,14 @@ class FederatedShareProviderTest extends \Test\TestCase {
 
 		$this->tokenHandler->method('generateToken')->willReturn('token');
 
-		$this->addressHandler->expects($this->any())->method('generateRemoteURL')
-			->willReturn('http://localhost/');
 		$this->addressHandler->expects($this->any())->method('splitUserRemote')
 			->willReturn(['user', 'server.com']);
 
 		$shareWithAddress = new Address('user@server.com');
 		$ownerAddress = new Address('shareOwner@http://localhost/');
 		$sharedByAddress = new Address('sharedBy@http://localhost/');
+		$this->addressHandler->expects($this->any())->method('getLocalUserFederatedAddress')
+			->will($this->onConsecutiveCalls($ownerAddress, $sharedByAddress, $ownerAddress));
 
 		$this->notifications->expects($this->once())
 			->method('sendRemoteShare')
@@ -259,10 +259,9 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setPermissions(19)
 			->setNode($node);
 
-		$this->addressHandler->expects($this->any())->method('generateRemoteURL')
-			->willReturn('http://localhost/');
-
 		$this->tokenHandler->method('generateToken')->willReturn('token');
+		$this->addressHandler->expects($this->any())->method('getLocalUserFederatedAddress')
+			->willReturn(new Address('user@host'));
 
 		$this->notifications->expects($this->once())
 			->method('sendRemoteShare')
@@ -298,10 +297,9 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$node->method('getId')->willReturn(42);
 		$node->method('getName')->willReturn('myFile');
 
-		$this->addressHandler->expects($this->any())->method('compareAddresses')
-			->willReturn(true);
-
 		$shareWith = 'sharedBy@localhost';
+		$this->addressHandler->expects($this->any())->method('getLocalUserFederatedAddress')
+			->willReturn(new Address($shareWith));
 
 		$share->setSharedWith($shareWith)
 			->setSharedBy('sharedBy')
@@ -347,13 +345,11 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setNode($node);
 
 		$this->tokenHandler->method('generateToken')->willReturn('token');
-
-		$this->addressHandler->expects($this->any())->method('generateRemoteURL')
-			->willReturn('http://localhost/');
-
 		$shareWithAddress = new Address('user@server.com');
 		$ownerAddress = new Address('shareOwner@http://localhost/');
 		$sharedByAddress = new Address('sharedBy@http://localhost/');
+		$this->addressHandler->expects($this->any())->method('getLocalUserFederatedAddress')
+			->will($this->onConsecutiveCalls($ownerAddress, $sharedByAddress, $ownerAddress));
 
 		$this->notifications->expects($this->once())
 			->method('sendRemoteShare')
@@ -413,12 +409,12 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setNode($node);
 
 		$this->tokenHandler->method('generateToken')->willReturn('token');
-		$this->addressHandler->expects($this->any())->method('generateRemoteURL')
-			->willReturn('http://localhost/');
-
 		$shareWithAddress = new Address('user@server.com');
 		$ownerAddress = new Address("{$owner}@http://localhost/");
 		$sharedByAddress = new Address("{$sharedBy}@http://localhost/");
+
+		$this->addressHandler->expects($this->any())->method('getLocalUserFederatedAddress')
+			->will($this->onConsecutiveCalls($ownerAddress, $sharedByAddress, $ownerAddress));
 
 		$this->notifications->expects($this->once())
 			->method('sendRemoteShare')
@@ -479,6 +475,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
 			->setNode($node);
+		$this->addressHandler->expects($this->any())->method('getLocalUserFederatedAddress')
+			->willReturn(new Address('user@host'));
 		$this->provider->create($share);
 
 		$node2 = $this->createMock('\OCP\Files\File');
@@ -517,6 +515,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
 			->setNode($node);
+		$this->addressHandler->expects($this->any())->method('getLocalUserFederatedAddress')
+			->willReturn(new Address('user@host'));
 		$this->provider->create($share);
 
 		$share2 = $this->shareManager->newShare();
@@ -567,6 +567,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
 			->setNode($node);
+		$this->addressHandler->expects($this->any())->method('getLocalUserFederatedAddress')
+			->willReturn(new Address('user@host'));
 		$this->provider->create($share);
 
 		$share2 = $this->shareManager->newShare();
@@ -602,6 +604,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
 			->setNode($node);
+		$this->addressHandler->expects($this->any())->method('getLocalUserFederatedAddress')
+			->willReturn(new Address('user@host'));
 		$this->provider->create($share);
 
 		$node2 = $this->createMock('\OCP\Files\File');
@@ -640,6 +644,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			->setShareOwner('shareOwner')
 			->setPermissions(19)
 			->setNode($node);
+		$this->addressHandler->expects($this->any())->method('getLocalUserFederatedAddress')
+			->willReturn(new Address('user@host'));
 		$this->provider->create($share);
 
 		$share2 = $this->shareManager->newShare();
@@ -675,6 +681,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 
 		$this->rootFolder->expects($this->never())->method($this->anything());
 
+		$this->addressHandler->expects($this->any())->method('getLocalUserFederatedAddress')
+			->willReturn(new Address('user@host'));
 		$share = $this->shareManager->newShare();
 		$share->setSharedWith('user@server.com')
 			->setSharedBy('sharedBy')

--- a/apps/federatedfilesharing/tests/Middleware/OcmMiddlewareTest.php
+++ b/apps/federatedfilesharing/tests/Middleware/OcmMiddlewareTest.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Tests\Middleware;
+
+use OCA\FederatedFileSharing\AddressHandler;
+use OCA\FederatedFileSharing\FederatedShareProvider;
+use OCA\FederatedFileSharing\Middleware\OcmMiddleware;
+use OCA\FederatedFileSharing\Ocm\Exception\BadRequestException;
+use OCA\FederatedFileSharing\Ocm\Exception\ForbiddenException;
+use OCA\FederatedFileSharing\Ocm\Exception\NotImplementedException;
+use OCA\FederatedFileSharing\Tests\TestCase;
+use OCP\App\IAppManager;
+use OCP\ILogger;
+use OCP\IUserManager;
+use OCP\Share;
+use OCP\Share\IShare;
+
+/**
+ * Class OcmMiddlewareTest
+ *
+ * @package OCA\FederatedFileSharing\Tests\Middleware
+ * @group DB
+ */
+class OcmMiddlewareTest extends TestCase {
+	/**
+	 * @var OcmMiddleware
+	 */
+	private $ocmMiddleware;
+
+	/**
+	 * @var FederatedShareProvider | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $federatedShareProvider;
+
+	/**
+	 * @var IAppManager | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $appManager;
+
+	/**
+	 * @var IUserManager | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $userManager;
+
+	/**
+	 * @var AddressHandler | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $addressHandler;
+
+	/**
+	 * @var ILogger | \PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $logger;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->federatedShareProvider = $this->createMock(
+			FederatedShareProvider::class
+		);
+
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->addressHandler = $this->createMock(AddressHandler::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->ocmMiddleware = new OcmMiddleware(
+			$this->federatedShareProvider,
+			$this->appManager,
+			$this->userManager,
+			$this->addressHandler,
+			$this->logger
+		);
+	}
+
+	/**
+	 * @dataProvider dataTestAssertNotNull
+	 *
+	 * @param $input
+	 * @param $expectedResult
+	 * @throws BadRequestException
+	 */
+	public function testAssertNotNull($input, $expectedResult) {
+		if (\is_string($expectedResult)) {
+			$this->expectException($expectedResult);
+		}
+		$this->ocmMiddleware->assertNotNull($input);
+	}
+
+	public function dataTestAssertNotNull() {
+		return [
+			[
+				[
+					'do' => '1',
+					'it' => 'df',
+					'now' => -1
+				],
+				false,
+			],
+			[
+				[
+					'do' => '1',
+					'not' => null,
+					'do' => false,
+					'it' => null,
+					'now' => -1
+				],
+				BadRequestException::class
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestGetValidShare
+	 */
+	public function testGetValidShare($providerResult, $sharedSecret, $expectedResult) {
+		if (\is_string($providerResult)) {
+			$this->federatedShareProvider->method('getShareById')
+				->willThrowException(new $providerResult);
+		} else {
+			$this->federatedShareProvider->method('getShareById')
+				->willReturn($providerResult);
+		}
+
+		if (\is_string($expectedResult)) {
+			$this->expectException($expectedResult);
+		}
+
+		$result = $this->ocmMiddleware->getValidShare(5, $sharedSecret);
+
+		if (!\is_string($expectedResult)) {
+			$this->assertSame($expectedResult, $result);
+		}
+	}
+
+	public function dataTestGetValidShare() {
+		$token = 'token';
+		$wrongTypedShare = $this->createMock(IShare::class);
+		$wrongTypedShare->method('getShareType')
+			->willReturn(FederatedShareProvider::SHARE_TYPE_REMOTE - 1);
+		$wrongTypedShare->method('getToken')
+			->willReturn($token);
+
+		$wrongTokenShare = $this->createMock(IShare::class);
+		$wrongTokenShare->method('getShareType')
+			->willReturn(FederatedShareProvider::SHARE_TYPE_REMOTE);
+		$wrongTypedShare->method('getToken')
+			->willReturn("wrong $token");
+
+		$goodShare = $this->createMock(IShare::class);
+		$goodShare->method('getShareType')
+			->willReturn(FederatedShareProvider::SHARE_TYPE_REMOTE);
+		$goodShare->method('getToken')
+			->willReturn($token);
+
+		return [
+			[
+				Share\Exceptions\ShareNotFound::class,
+				'token',
+				BadRequestException::class
+			],
+			[
+				$wrongTypedShare,
+				'token',
+				BadRequestException::class
+			],
+			[
+				$wrongTokenShare,
+				'token',
+				ForbiddenException::class
+			],
+			[
+				$goodShare,
+				'token',
+				$goodShare
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestAssertIncomingSharingEnabled
+	 */
+	public function testAssertIncomingSharingEnabled($isSharingAppEnabled, $isIncomingSharingEnabled, $isExceptionExpected) {
+		$this->expectFileSharingApp($isSharingAppEnabled);
+		$this->expectIncomingSharing($isIncomingSharingEnabled);
+		if ($isExceptionExpected) {
+			$this->expectException(NotImplementedException::class);
+		}
+		$this->ocmMiddleware->assertIncomingSharingEnabled();
+	}
+
+	public function dataTestAssertIncomingSharingEnabled() {
+		return [
+			[true, true, false],
+			[true, false, true],
+			[false, true, true],
+			[false, true, true],
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestAssertOutgoingSharingEnabled
+	 */
+	public function testAssertOutgoingSharingEnabled($isSharingAppEnabled, $isOutgoingSharingEnabled, $isExceptionExpected) {
+		$this->expectFileSharingApp($isSharingAppEnabled);
+		$this->expectOutgoingSharing($isOutgoingSharingEnabled);
+		if ($isExceptionExpected) {
+			$this->expectException(NotImplementedException::class);
+		}
+		$this->ocmMiddleware->assertOutgoingSharingEnabled();
+	}
+
+	public function dataTestAssertOutgoingSharingEnabled() {
+		return [
+			[true, true, false],
+			[true, false, true],
+			[false, true, true],
+			[false, true, true],
+		];
+	}
+
+	protected function expectIncomingSharing($state) {
+		$this->federatedShareProvider
+			->method('isIncomingServer2serverShareEnabled')
+			->willReturn($state);
+	}
+
+	protected function expectOutgoingSharing($state) {
+		$this->federatedShareProvider
+			->method('isOutgoingServer2serverShareEnabled')
+			->willReturn($state);
+	}
+
+	protected function expectFileSharingApp($state) {
+		$this->appManager
+			->method('isEnabledForUser')
+			->with('files_sharing')
+			->willReturn($state);
+	}
+}

--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -22,6 +22,7 @@
 
 namespace OCA\FederatedFileSharing\Tests;
 
+use OC\AppFramework\Http;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\DiscoveryManager;
 use OCA\FederatedFileSharing\Notifications;
@@ -94,10 +95,11 @@ class NotificationsTest extends \Test\TestCase {
 	 * @dataProvider dataTestSendUpdateToRemote
 	 *
 	 * @param int $try
+	 * @param array $ocmHttpRequestResult
 	 * @param array $httpRequestResult
 	 * @param bool $expected
 	 */
-	public function testSendUpdateToRemote($try, $httpRequestResult, $expected) {
+	public function testSendUpdateToRemote($try, $ocmHttpRequestResult, $httpRequestResult, $expected) {
 		$remote = 'remote';
 		$id = 42;
 		$timestamp = 63576;
@@ -106,11 +108,15 @@ class NotificationsTest extends \Test\TestCase {
 
 		$instance->expects($this->any())->method('getTimestamp')->willReturn($timestamp);
 
-		$instance->expects($this->once())->method('tryHttpPostToShareEndpoint')
+		$instance->expects($this->at(0))->method('tryHttpPostToShareEndpoint')
+			->with($remote, '/notifications', $this->anything(), true)
+			->willReturn($ocmHttpRequestResult);
+
+		$instance->expects($this->at(1))->method('tryHttpPostToShareEndpoint')
 			->with($remote, '/'.$id.'/unshare', ['token' => $token, 'data1Key' => 'data1Value'])
 			->willReturn($httpRequestResult);
 
-		$this->addressHandler->expects($this->once())->method('removeProtocolFromUrl')
+		$this->addressHandler->method('removeProtocolFromUrl')
 			->with($remote)->willReturn($remote);
 
 		// only add background job on first try
@@ -140,17 +146,17 @@ class NotificationsTest extends \Test\TestCase {
 	public function dataTestSendUpdateToRemote() {
 		return [
 			// test if background job is added correctly
-			[0, ['success' => true, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 200]]])], true],
-			[1, ['success' => true, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 200]]])], true],
-			[0, ['success' => false, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 200]]])], false],
-			[1, ['success' => false, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 200]]])], false],
+			[0, ['statusCode' => Http::STATUS_NOT_IMPLEMENTED], ['success' => true, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 200]]])], true],
+			[1, ['statusCode' => Http::STATUS_NOT_IMPLEMENTED], ['success' => true, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 200]]])], true],
+			[0, ['statusCode' => Http::STATUS_NOT_IMPLEMENTED], ['success' => false, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 200]]])], false],
+			[1, ['statusCode' => Http::STATUS_NOT_IMPLEMENTED], ['success' => false, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 200]]])], false],
 			// test all combinations of 'statuscode' and 'success'
-			[0, ['success' => true, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 200]]])], true],
-			[0, ['success' => true, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 100]]])], true],
-			[0, ['success' => true, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 400]]])], false],
-			[0, ['success' => false, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 200]]])], false],
-			[0, ['success' => false, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 100]]])], false],
-			[0, ['success' => false, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 400]]])], false],
+			[0, ['statusCode' => Http::STATUS_NOT_IMPLEMENTED], ['success' => true, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 200]]])], true],
+			[0, ['statusCode' => Http::STATUS_NOT_IMPLEMENTED], ['success' => true, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 100]]])], true],
+			[0, ['statusCode' => Http::STATUS_NOT_IMPLEMENTED], ['success' => true, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 400]]])], false],
+			[0, ['statusCode' => Http::STATUS_NOT_IMPLEMENTED], ['success' => false, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 200]]])], false],
+			[0, ['statusCode' => Http::STATUS_NOT_IMPLEMENTED], ['success' => false, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 100]]])], false],
+			[0, ['statusCode' => Http::STATUS_NOT_IMPLEMENTED], ['success' => false, 'result' => \json_encode(['ocs' => ['meta' => ['statuscode' => 400]]])], false],
 		];
 	}
 }

--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -26,6 +26,8 @@ use OC\AppFramework\Http;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\DiscoveryManager;
 use OCA\FederatedFileSharing\Notifications;
+use OCA\FederatedFileSharing\Ocm\NotificationManager;
+use OCA\FederatedFileSharing\Ocm\Permissions;
 use OCP\BackgroundJob\IJobList;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
@@ -42,6 +44,9 @@ class NotificationsTest extends \Test\TestCase {
 	/** @var  DiscoveryManager | \PHPUnit_Framework_MockObject_MockObject */
 	private $discoveryManager;
 
+	/** @var NotificationManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $notificationManager;
+
 	/** @var  IJobList | \PHPUnit_Framework_MockObject_MockObject */
 	private $jobList;
 
@@ -55,6 +60,9 @@ class NotificationsTest extends \Test\TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->discoveryManager = $this->getMockBuilder(DiscoveryManager::class)
 			->disableOriginalConstructor()->getMock();
+		$this->notificationManager = new NotificationManager(
+			$this->createMock(Permissions::class)
+		);
 		$this->httpClientService = $this->createMock(IClientService::class);
 		$this->addressHandler = $this->getMockBuilder(AddressHandler::class)
 			->disableOriginalConstructor()->getMock();
@@ -72,6 +80,7 @@ class NotificationsTest extends \Test\TestCase {
 				$this->addressHandler,
 				$this->httpClientService,
 				$this->discoveryManager,
+				$this->notificationManager,
 				$this->jobList,
 				$this->config
 			);
@@ -82,6 +91,7 @@ class NotificationsTest extends \Test\TestCase {
 						$this->addressHandler,
 						$this->httpClientService,
 						$this->discoveryManager,
+						$this->notificationManager,
 						$this->jobList,
 						$this->config
 					]

--- a/apps/federatedfilesharing/tests/Ocm/PermissionsTest.php
+++ b/apps/federatedfilesharing/tests/Ocm/PermissionsTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\FederatedFileSharing\Tests\Ocm;
+
+use OCA\FederatedFileSharing\Ocm\Permissions;
+use OCA\FederatedFileSharing\Tests\TestCase;
+use OCP\Constants;
+
+/**
+ * Class PermissionsTest
+ *
+ * @package OCA\FederatedFileSharing\Tests\Ocm
+ * @group DB
+ */
+class PermissionsTest extends TestCase {
+	/**
+	 * @var Permissions
+	 */
+	private $permissions;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->permissions = new Permissions();
+	}
+
+	/**
+	 * @dataProvider dataTestToOcPermissions
+	 *
+	 * @param string[] $ocmPermissions
+	 * @param int $expectedOcPermissions
+	 */
+	public function testToOcPermissions($ocmPermissions, $expectedOcPermissions) {
+		$ocPermissions = $this->permissions->toOcPermissions($ocmPermissions);
+		$this->assertEquals($expectedOcPermissions, $ocPermissions);
+	}
+
+	public function dataTestToOcPermissions() {
+		return [
+			[
+				[
+					Permissions::OCM_PERMISSION_READ,
+					Permissions::OCM_PERMISSION_WRITE,
+					Permissions::OCM_PERMISSION_SHARE
+				],
+				Constants::PERMISSION_READ | Constants::PERMISSION_CREATE
+				| Constants::PERMISSION_UPDATE | Constants::PERMISSION_SHARE
+			],
+			[
+				[
+					Permissions::OCM_PERMISSION_READ,
+				],
+				Constants::PERMISSION_READ
+			],
+			[
+				[
+					Permissions::OCM_PERMISSION_WRITE,
+				],
+				Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE
+			],
+			[
+				[
+					Permissions::OCM_PERMISSION_SHARE,
+				],
+				Constants::PERMISSION_SHARE
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestToOcmPermissions
+	 *
+	 * @param int $ocPermissions
+	 * @param string[] $expectedOcmPermissions
+	 */
+	public function testToOcmPermissions($ocPermissions, $expectedOcmPermissions) {
+		$ocmPermissions = $this->permissions->toOcmPermissions($ocPermissions);
+		$this->assertEquals($expectedOcmPermissions, $ocmPermissions);
+	}
+
+	public function dataTestToOcmPermissions() {
+		return [
+			[
+				Constants::PERMISSION_ALL,
+				[
+					Permissions::OCM_PERMISSION_READ,
+					Permissions::OCM_PERMISSION_WRITE,
+					Permissions::OCM_PERMISSION_SHARE
+				]
+			],
+			[
+				Constants::PERMISSION_READ,
+				[
+					Permissions::OCM_PERMISSION_READ,
+				]
+			],
+			[
+				Constants::PERMISSION_UPDATE,
+				[
+					Permissions::OCM_PERMISSION_WRITE,
+				]
+			],
+			[
+				Constants::PERMISSION_CREATE,
+				[
+					Permissions::OCM_PERMISSION_WRITE,
+				]
+			],
+			[
+				Constants::PERMISSION_SHARE,
+				[
+					Permissions::OCM_PERMISSION_SHARE,
+				]
+			],
+		];
+	}
+}

--- a/apps/files_sharing/ajax/external.php
+++ b/apps/files_sharing/ajax/external.php
@@ -61,10 +61,6 @@ if (\OC\Share\Helper::isSameUserOnSameServer($owner, $remote, $currentUser, $cur
 	exit();
 }
 
-$discoveryManager = new \OCA\FederatedFileSharing\DiscoveryManager(
-	\OC::$server->getMemCacheFactory(),
-	\OC::$server->getHTTPClientService()
-);
 $externalManager = new \OCA\Files_Sharing\External\Manager(
 		\OC::$server->getDatabaseConnection(),
 		\OC\Files\Filesystem::getMountManager(),

--- a/apps/files_sharing/lib/Hooks.php
+++ b/apps/files_sharing/lib/Hooks.php
@@ -26,7 +26,6 @@
 namespace OCA\Files_Sharing;
 
 use OC\Files\Filesystem;
-use OCA\FederatedFileSharing\DiscoveryManager;
 use OCP\IURLGenerator;
 use OCP\Files\IRootFolder;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -76,10 +75,6 @@ class Hooks {
 	}
 
 	public static function deleteUser($params) {
-		$discoveryManager = new DiscoveryManager(
-			\OC::$server->getMemCacheFactory(),
-			\OC::$server->getHTTPClientService()
-		);
 		$manager = new External\Manager(
 			\OC::$server->getDatabaseConnection(),
 			\OC\Files\Filesystem::getMountManager(),

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -22,11 +22,8 @@
  */
 namespace OC\Share20;
 
-use OCA\FederatedFileSharing\AddressHandler;
-use OCA\FederatedFileSharing\DiscoveryManager;
+use OCA\FederatedFileSharing\AppInfo\Application;
 use OCA\FederatedFileSharing\FederatedShareProvider;
-use OCA\FederatedFileSharing\Notifications;
-use OCA\FederatedFileSharing\TokenHandler;
 use OCP\Share\IProviderFactory;
 use OC\Share20\Exception\ProviderException;
 use OCP\IServerContainer;
@@ -89,37 +86,8 @@ class ProviderFactory implements IProviderFactory {
 			/*
 			 * TODO: add factory to federated sharing app
 			 */
-			$l = $this->serverContainer->getL10N('federatedfilessharing');
-			$addressHandler = new AddressHandler(
-				$this->serverContainer->getURLGenerator(),
-				$l
-			);
-			$discoveryManager = new DiscoveryManager(
-				$this->serverContainer->getMemCacheFactory(),
-				$this->serverContainer->getHTTPClientService()
-			);
-			$notifications = new Notifications(
-				$addressHandler,
-				$this->serverContainer->getHTTPClientService(),
-				$discoveryManager,
-				$this->serverContainer->getJobList(),
-				$this->serverContainer->getConfig()
-			);
-			$tokenHandler = new TokenHandler(
-				$this->serverContainer->getSecureRandom()
-			);
-
-			$this->federatedProvider = new FederatedShareProvider(
-				$this->serverContainer->getDatabaseConnection(),
-				$addressHandler,
-				$notifications,
-				$tokenHandler,
-				$l,
-				$this->serverContainer->getLogger(),
-				$this->serverContainer->getLazyRootFolder(),
-				$this->serverContainer->getConfig(),
-				$this->serverContainer->getUserManager()
-			);
+			$federatedFileSharingApp = new Application();
+			$this->federatedProvider = $federatedFileSharingApp->getFederatedShareProvider();
 		}
 
 		return $this->federatedProvider;

--- a/ocm-provider/index.php
+++ b/ocm-provider/index.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+require_once __DIR__ . '/../lib/base.php';
+
+$server = \OC::$server;
+
+$isFederationEnabled = $server->getAppManager()
+	->isEnabledForUser('federatedfilesharing');
+if ($isFederationEnabled) {
+	\OC_App::loadApp('federatedfilesharing');
+	$federatedSharingApp = new \OCA\FederatedFileSharing\AppInfo\Application();
+	$federatedSharingApp->dispatch('OcmController', 'discovery');
+} else {
+	$output = new \OC\AppFramework\Http\Output('');
+	$output->setHttpResponseCode(
+		\OCP\AppFramework\Http::STATUS_NOT_IMPLEMENTED
+	);
+	$output->setOutput('501 Not Implemented');
+}

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1142,7 +1142,7 @@ trait Sharing {
 				if (\substr($field, 0, 6) === "remote") {
 					$value = \str_replace(
 						"REMOTE",
-						$this->getRemoteBaseUrl() . '/',
+						$this->getRemoteBaseUrl(),
 						$value
 					);
 					$value = \str_replace(

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -33,9 +33,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user has reloaded the current page of the webUI
     Then dialogs should be displayed on the webUI
       | title        | content                                                                                              |
-      | Remote share | Do you want to add the remote share /simple-folder from user1@%remote_server_without_scheme%/?       |
-      | Remote share | Do you want to add the remote share /simple-empty-folder from user2@%remote_server_without_scheme%/? |
-      | Remote share | Do you want to add the remote share /lorem.txt from user3@%remote_server_without_scheme%/?           |
+      | Remote share | Do you want to add the remote share /simple-folder from user1@%remote_server_without_scheme%?        |
+      | Remote share | Do you want to add the remote share /simple-empty-folder from user2@%remote_server_without_scheme%?  |
+      | Remote share | Do you want to add the remote share /lorem.txt from user3@%remote_server_without_scheme%?            |
     When the user accepts the offered remote shares using the webUI
     Then the file "lorem (2).txt" should be listed on the webUI
     And the content of "lorem (2).txt" on the local server should be the same as the original "lorem.txt"


### PR DESCRIPTION
## Description
- [x] `/ocm-provider` endpoint
- [x] discovery of `/ocm-provider` endpoint
- [x] fallback to the old endpoint when `/ocm-provider` is not accessible
- [x] `/index.php/apps/federatedfilesharing/shares` to process new incoming shares
- [x] `/index.php/apps/federatedfilesharing/notifications` to process new incoming notifications
- [ ] sending/recieving the of the following notifications
  - [x] `SHARE_ACCEPTED`
  - [x] `SHARE_DECLINED`
  - [x] `SHARE_UNSHARED`
  - [x] `REQUEST_RESHARE` 
  - [ ] `RESHARE_UNDO` (not tested yet)
  - [x] `RESHARE_CHANGE_PERMISSION`
## Related Issue
- Fixes <issue_link>

## Motivation and Context
Implements OCM API 1.0-proposal1

## How Has This Been Tested?
###  Environment: 10.0.8 (**stable**)  and this branch (**ocm**)
- [x] sharing from **stable** + declining from **ocm**
- [x] sharing from **stable** + accepting from  **ocm** + unsharing from  **ocm**
- [x] sharing from **stable** + accepting from  **ocm** + unsharing from   **stable**

- [x] sharing from **ocm** + declining from **stable**
- [x] sharing from **ocm** + accepting from  **stable** + unsharing from  **stable**
- [x] sharing from **ocm** + accepting from  **stable** + unsharing from   **ocm**

###  Environment:  two instances @  this branch - **ocm1** and **ocm2**
- [x] sharing from **ocm1** + declining from **ocm2**
- [x] sharing from **ocm1** + accepting from  **ocm2** + unsharing from  **ocm2**
- [x] sharing from **ocm1** + accepting from  **ocm2** + unsharing from   **ocm1**


###  Resharing: testing still in progress 


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Add more unit tests
- [ ] Think over how new permissions will be stored (change DAV to expose OCM permissions if needed)
- [ ] expose to the user Display names of sender/owner/etc
- [ ] expose to the user Optional share description
- [ ] exposed to the user `message` field in new notifications 


## Nice to haves (once the spec leaves it's current draft status):
- [ ] Refactor the old code to the new spec completely leaving only RequestHandlerController in place. 
It would just convert old data to match the new requirements
E.g. `OCA\FederatedFileSharing\BackgroundJob\RetryJob` still uses data in old format.


