### PR TITLE
separate When from the Given step in acceptance tests

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
@@ -10,7 +10,6 @@ So that I can see all the groups in my ownCloud
 	Scenario: admin gets all the groups
 		Given group "0" has been created
 		And group "new-group" has been created
-		And group "admin" has been created
 		And group "España" has been created
 		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
 		Then the groups returned by the API should be

--- a/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
@@ -10,7 +10,6 @@ So that I can see all the groups in my ownCloud
 	Scenario: admin gets all the groups
 		Given group "0" has been created
 		And group "new-group" has been created
-		And group "admin" has been created
 		And group "España" has been created
 		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
 		Then the groups returned by the API should be

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -906,7 +906,6 @@ trait Provisioning {
 
 	/**
 	 * @When /^the administrator creates group "([^"]*)" using the provisioning API$/
-	 * @Given /^group "([^"]*)" has been created$/
 	 *
 	 * @param string $group
 	 *
@@ -917,6 +916,18 @@ trait Provisioning {
 		if (!$this->groupExists($group)) {
 			$this->createTheGroup($group, 'api');
 		}
+		$this->groupShouldExist($group);
+	}
+
+	/** @Given /^group "([^"]*)" has been created$/
+	 *
+	 * @param string $group
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function groupHasBeenCreated($group) {
+		$this->createTheGroup($group);
 		$this->groupShouldExist($group);
 	}
 


### PR DESCRIPTION
## Description
Given steps should not been forced to use a specific way (API/OCC/webUI) to achieve a specific state

## Related Issue
when using this step for LDAP tests it fails because in LDAP we do not create groups, but skips it and believe they exist. Still the given step should work and not throw an exception.
We can check for the existence of the group afterwards, because even with LDAP the groups get synced directly at the request

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
