### PR TITLE
Continue with upgrade even if the market app cannot be…

### DIFF
--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -325,7 +325,12 @@ class Apps implements IRepairStep {
 
 		// Then we need to enable the market app to support app updates / downloads during upgrade
 		$output->info('Enabling market app to assist with update');
-		$this->appManager->enableApp('market');
-		return true;
+		try {
+			$this->appManager->enableApp('market');
+			return true;
+		} catch (\Exception $ex) {
+			$output->warning($ex->getMessage());
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
… enabled/installed

## Description
In some cases the market app cannot be enabled - we should continue with the upgrade never the less.

## Related Issue
Fixes #32270

## How Has This Been Tested?
Upgrade testing drone job will follow ....
https://drone.owncloud.com/owncloud/update-testing/116

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
