### PR TITLE
check if user/group were created in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -238,6 +238,9 @@ trait Provisioning {
 		$this->createUser(
 			$user, $this->getPasswordForUser($user), null, null, true
 		);
+		if (\getenv("TEST_EXTERNAL_USER_BACKENDS") !== "true") {
+			$this->userShouldExist($user);
+		}
 	}
 
 	/**
@@ -928,7 +931,9 @@ trait Provisioning {
 	 */
 	public function groupHasBeenCreated($group) {
 		$this->createTheGroup($group);
-		$this->groupShouldExist($group);
+		if (\getenv("TEST_EXTERNAL_USER_BACKENDS") !== "true") {
+			$this->groupShouldExist($group);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
check if the user/group was created in the `@Given` step, but only if we are not using LDAP

## Motivation and Context
its good to check the outcome of the `@Given` step, but when using LDAP, the ldif file is not imported yes, that happens in `@BeforeScenario`

## How Has This Been Tested?
run LDAP tests with the change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
