### PR TITLE
Password reset text formatted and token reset for users not logged in

### DIFF
--- a/core/templates/lostpassword/resetpassword.php
+++ b/core/templates/lostpassword/resetpassword.php
@@ -32,7 +32,16 @@ script('core', 'lostpassword');
 			<label for="password" class="infield"><?php p($l->t('New password')); ?></label>
 			<input type="password" name="password" id="password" value="" placeholder="<?php p($l->t('New Password')); ?>" required autofocus />
 		</p>
-		<input type="submit" id="submit" value="<?php p($l->t('Reset password')); ?>" />
+		<input type="submit" id="submit" value="<?php
+			$link =  \explode('/', $_['link']);
+			$uid = \array_pop($link);
+			$user = \OC::$server->getUserManager()->get($uid);
+			if (($user !== null) && ($user->getLastLogin() > 0)) {
+				p($l->t('Reset password for'));
+			} else {
+				p($l->t('Please set your password'));
+			}
+		?>" />
 		<p class="text-center">
 			<img class="hidden" id="float-spinner" src="<?php p(image_path('core', 'loading-dark.gif'));?>"/>
 		</p>


### PR DESCRIPTION
Password reset text is formatted accordingly for
users who had not logged in once. Also token reset
is required if the password is reset using password
reset link, when the token is expired.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Password reset template should have text accordingly for users who have not logged in once. The token should be reset, if user sets password for first time using password reset link, and the token is expired. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Password reset template should have text accordingly for users who have not logged in once. The token should be reset, if user sets password for first time using password reset link, and the token is expired. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Required https://github.com/owncloud/user_management/pull/48

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
