### PR TITLE
[master] Skip two factor challenge in account module middleware

### DIFF
--- a/core/Middleware/AccountModuleMiddleware.php
+++ b/core/Middleware/AccountModuleMiddleware.php
@@ -32,6 +32,7 @@ use OCP\Authentication\Exceptions\AccountCheckException;
 use OCP\Authentication\IAccountModuleController;
 use OCP\ILogger;
 use OCP\IUserSession;
+use OC\Core\Controller\TwoFactorChallengeController;
 
 /**
  * Class AccountModuleMiddleware
@@ -91,6 +92,11 @@ class AccountModuleMiddleware extends Middleware {
 
 		if ($controller instanceof IAccountModuleController) {
 			// Don't block any IAccountModuleController controllers
+			return;
+		}
+
+		if ($controller instanceof TwoFactorChallengeController) {
+			// Don't block two factor challenge
 			return;
 		}
 

--- a/tests/Core/Middleware/AccountModuleMiddlewareTest.php
+++ b/tests/Core/Middleware/AccountModuleMiddlewareTest.php
@@ -31,6 +31,7 @@ use OCP\ILogger;
 use OCP\IUser;
 use OCP\IUserSession;
 use Test\TestCase;
+use OC\Core\Controller\TwoFactorChallengeController;
 
 class AccountModuleMiddlewareTest extends TestCase {
 
@@ -99,6 +100,18 @@ class AccountModuleMiddlewareTest extends TestCase {
 			->method('isLoggedIn');
 
 		$controller = $this->createMock(IAccountModuleController::class);
+
+		$this->middleware->beforeController($controller, null);
+	}
+	public function testBeforeControllerSkipsTwoFactorChallengeController() {
+		$this->reflector->expects($this->once())
+			->method('hasAnnotation')
+			->with('PublicPage')
+			->will($this->returnValue(false));
+		$this->userSession->expects($this->never())
+			->method('isLoggedIn');
+
+		$controller = $this->createMock(TwoFactorChallengeController::class);
 
 		$this->middleware->beforeController($controller, null);
 	}


### PR DESCRIPTION
Fixes issue with infinite redirect when trying to access the challenge
page.

port of #32058 