### PR TITLE
Avatar performance

### DIFF
--- a/lib/private/Avatar.php
+++ b/lib/private/Avatar.php
@@ -1,5 +1,6 @@
 <?php
 /**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
  * @author Christopher Schäpers <kondou@ts.unde.re>
  * @author Lukas Reschke <lukas@statuscode.ch>
@@ -28,11 +29,11 @@
 
 namespace OC;
 
+use OC\Files\Storage\File;
 use OC\User\User;
-use OCP\Files\Folder;
-use OCP\Files\File;
 use OCP\Files\NotFoundException;
-use OCP\Files\NotPermittedException;
+use OCP\Files\Storage\IStorage;
+use OCP\Files\StorageNotAvailableException;
 use OCP\IAvatar;
 use OCP\IImage;
 use OCP\IL10N;
@@ -44,28 +45,35 @@ use OCP\ILogger;
  */
 
 class Avatar implements IAvatar {
-	/** @var Folder */
-	private $folder;
+	/** @var IStorage */
+	private $storage;
 	/** @var IL10N */
 	private $l;
 	/** @var User */
 	private $user;
 	/** @var ILogger  */
 	private $logger;
+	/** @var string */
+	private $path;
 
 	/**
 	 * constructor
 	 *
-	 * @param Folder $folder The folder where the avatars are
+	 * @param IStorage $storage The storage where the avatars are
 	 * @param IL10N $l
 	 * @param User $user
 	 * @param ILogger $logger
 	 */
-	public function __construct(Folder $folder, IL10N $l, $user, ILogger $logger) {
-		$this->folder = $folder;
+	public function __construct(IStorage $storage, IL10N $l, User $user, ILogger $logger) {
+		$this->storage = $storage;
 		$this->l = $l;
 		$this->user = $user;
 		$this->logger = $logger;
+		$this->path = $this->buildAvatarPath();
+	}
+
+	private function buildAvatarPath() {
+		return \substr_replace(\substr_replace(\md5($this->user->getUID()), '/', 4, 0), '/', 2, 0);
 	}
 
 	/**
@@ -89,7 +97,12 @@ class Avatar implements IAvatar {
 	 * @return bool
 	 */
 	public function exists() {
-		return $this->folder->nodeExists('avatar.jpg') || $this->folder->nodeExists('avatar.png');
+		try {
+			return $this->storage->file_exists("{$this->path}/avatar.jpg")
+				|| $this->storage->file_exists("{$this->path}/avatar.png");
+		} catch (StorageNotAvailableException $e) {
+			return false;
+		}
 	}
 
 	/**
@@ -112,35 +125,33 @@ class Avatar implements IAvatar {
 			$type = 'jpg';
 		}
 		if ($type !== 'jpg' && $type !== 'png') {
-			throw new \Exception($this->l->t("Unknown filetype"));
+			throw new \Exception($this->l->t('Unknown filetype'));
 		}
 
 		if (!$img->valid()) {
-			throw new \Exception($this->l->t("Invalid image"));
+			throw new \Exception($this->l->t('Invalid image'));
 		}
 
 		if (!($img->height() === $img->width())) {
-			throw new NotSquareException($this->l->t("Avatar image is not square"));
+			throw new NotSquareException($this->l->t('Avatar image is not square'));
 		}
 
 		$this->remove();
-		$this->folder->newFile('avatar.'.$type)->putContent($data);
+		if (!$this->storage->mkdir($this->path)) {
+			$this->logger->error("Could not create {$this->path} for {$this->user->getUID()}");
+		}
+		$path = "$this->path/avatar.$type";
+		if ($this->storage->file_put_contents($path, $data) === false) {
+			$this->logger->error("Failed to save resized avatar for {$this->user->getUID()} to $path");
+		}
 		$this->user->triggerChange('avatar');
 	}
 
 	/**
-	 * remove the users avatar
-	 * @return void
+	 * remove the users avatars
 	*/
 	public function remove() {
-		$regex = '/^avatar\.([0-9]+\.)?(jpg|png)$/';
-		$avatars = $this->folder->getDirectoryListing();
-
-		foreach ($avatars as $avatar) {
-			if (\preg_match($regex, $avatar->getName())) {
-				$avatar->delete();
-			}
-		}
+		$this->storage->rmdir($this->path);
 		$this->user->triggerChange('avatar');
 	}
 
@@ -150,35 +161,36 @@ class Avatar implements IAvatar {
 	public function getFile($size) {
 		$ext = $this->getExtension();
 
+		$basePath = "{$this->path}/avatar.$ext";
+
 		if ($size === -1) {
-			$path = 'avatar.' . $ext;
+			$resizedPath = $basePath;
 		} else {
-			$path = 'avatar.' . $size . '.' . $ext;
+			$resizedPath = "{$this->path}/avatar.$size.$ext";
 		}
-
-		try {
-			$file = $this->folder->get($path);
-		} catch (NotFoundException $e) {
+		// do we have the requested size?
+		if (!$this->storage->file_exists($resizedPath)) {
 			if ($size <= 0) {
-				throw new NotFoundException;
+				throw new NotFoundException($resizedPath);
 			}
-
+			// do we have a base image?
+			if (!$this->storage->file_exists($basePath)) {
+				throw new NotFoundException($basePath);
+			}
+			// resize!
 			$avatar = new OC_Image();
-			/** @var File $file */
-			$file = $this->folder->get('avatar.' . $ext);
-			$avatar->loadFromData($file->getContent());
+			$data = $this->storage->file_get_contents($basePath);
+			$avatar->loadFromData($data);
 			if ($size !== -1) {
 				$avatar->resize($size);
 			}
-			try {
-				$file = $this->folder->newFile($path);
-				$file->putContent($avatar->data());
-			} catch (NotPermittedException $e) {
-				$this->logger->error('Failed to save avatar for ' . $this->user->getUID());
+			$result = $this->storage->file_put_contents($resizedPath, $avatar->data());
+			if ($result === false) {
+				$this->logger->error("Failed to save resized avatar for {$this->user->getUID()} to $resizedPath");
 			}
 		}
 
-		return $file;
+		return new File($this->storage, $resizedPath);
 	}
 
 	/**
@@ -186,13 +198,15 @@ class Avatar implements IAvatar {
 	 *
 	 * @return string
 	 * @throws NotFoundException
+	 * @throws StorageNotAvailableException
 	 */
 	private function getExtension() {
-		if ($this->folder->nodeExists('avatar.jpg')) {
+		if ($this->storage->file_exists("{$this->path}/avatar.jpg")) {
 			return 'jpg';
-		} elseif ($this->folder->nodeExists('avatar.png')) {
+		}
+		if ($this->storage->file_exists("{$this->path}/avatar.png")) {
 			return 'png';
 		}
-		throw new NotFoundException;
+		throw new NotFoundException("{$this->path}/avatar.jpg|png");
 	}
 }

--- a/lib/private/Files/Storage/File.php
+++ b/lib/private/Files/Storage/File.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Storage;
+
+use OCP\Files\File as FilesFile;
+
+class File extends Node implements FilesFile {
+
+	/**
+	 * Get the content of the file as string
+	 *
+	 * @return string
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function getContent() {
+		return $this->storage->file_get_contents($this->path);
+	}
+
+	/**
+	 * Write to the file from string data
+	 *
+	 * @param string $data
+	 * @return void
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function putContent($data) {
+		$this->storage->file_put_contents($this->path, $data);
+	}
+
+	/**
+	 * Open the file as stream, resulting resource can be operated as stream like the result from php's own fopen
+	 *
+	 * @param string $mode
+	 * @return resource
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function fopen($mode) {
+		return $this->storage->fopen($this->path, $mode);
+	}
+
+	/**
+	 * Delete the folder
+	 *
+	 * @return void
+	 * @throws \Exception
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function delete() {
+		$this->storage->unlink($this->path);
+	}
+
+	/**
+	 * Compute the hash of the file
+	 * Type of hash is set with $type and can be anything supported by php's hash_file
+	 *
+	 * @param string $type
+	 * @param bool $raw
+	 * @return string
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function hash($type, $raw = false) {
+		return $this->storage->hash($type, $this->path, $raw);
+	}
+}

--- a/lib/private/Files/Storage/Folder.php
+++ b/lib/private/Files/Storage/Folder.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Storage;
+
+use OCP\Files\Folder as FilesFolder;
+use OCP\Files\NotPermittedException;
+
+class Folder extends Node implements FilesFolder {
+	/**
+	 * Get the full path of an item in the folder within owncloud's filesystem
+	 *
+	 * @param string $path relative path of an item in the folder
+	 * @throws NotPermittedException
+	 */
+	public function getFullPath($path) {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * Get the path of an item in the folder relative to the folder
+	 *
+	 * @param string $path absolute path of an item in the folder
+	 * @throws NotPermittedException
+	 */
+	public function getRelativePath($path) {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * check if a node is a (grand-)child of the folder
+	 *
+	 * @param \OCP\Files\Node $node
+	 * @throws NotPermittedException
+	 */
+	public function isSubNode($node) {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * get the content of this directory
+	 *
+	 * @return \OCP\Files\Node[]
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function getDirectoryListing() {
+		$dh = $this->storage->opendir($this->path);
+
+		$entries = [];
+
+		while ($entry = \readdir($dh)) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+
+			$entry = $this->get($entry);
+			if ($entry instanceof Node) {
+				$entries[] = $entry;
+			}
+		}
+
+		\closedir($dh);
+
+		return $entries;
+	}
+
+	/**
+	 * Get the node at $path
+	 *
+	 * @param string $path relative path of the file or folder
+	 * @return \OCP\Files\Node
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function get($path) {
+		$newPath = "$this->path/$path";
+		$type = $this->storage->filetype($newPath);
+		switch ($type) {
+			case 'file': return new File($this->storage, $newPath);
+			case 'dir': return new Folder($this->storage, $newPath);
+		}
+		// TODO log error?
+		return null;
+	}
+
+	/**
+	 * Check if a file or folder exists in the folder
+	 *
+	 * @param string $path relative path of the file or folder
+	 * @return bool
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function nodeExists($path) {
+		return $this->storage->file_exists(\rtrim("$this->path/$path", '/'));
+	}
+
+	/**
+	 * Create a new folder
+	 *
+	 * @param string $path relative path of the new folder
+	 * @return \OCP\Files\Folder
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function newFolder($path) {
+		$newPath = "$this->path/$path";
+		$this->storage->mkdir($newPath);
+		return new Folder($this->storage, $newPath);
+	}
+
+	/**
+	 * Create a new file
+	 *
+	 * @param string $path relative path of the new file
+	 * @return \OCP\Files\File
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function newFile($path) {
+		$newPath = "$this->path/$path";
+		$this->storage->touch($newPath);
+		return new File($this->storage, $newPath);
+	}
+
+	/**
+	 * Delete the folder
+	 *
+	 * @return void
+	 * @throws \Exception
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function delete() {
+		$this->storage->rmdir($this->path);
+	}
+
+	/**
+	 * search for files with the name matching $query
+	 *
+	 * @param string $query
+	 * @throws NotPermittedException
+	 */
+	public function search($query) {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * search for files by mimetype
+	 * $mimetype can either be a full mimetype (image/png) or a wildcard mimetype (image)
+	 *
+	 * @param string $mimetype
+	 * @throws NotPermittedException
+	 */
+	public function searchByMime($mimetype) {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * search for files by tag
+	 *
+	 * @param string|int $tag tag name or tag id
+	 * @param string $userId owner of the tags
+	 * @throws NotPermittedException
+	 */
+	public function searchByTag($tag, $userId) {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * get a file or folder inside the folder by it's internal id
+	 *
+	 * @param int $id
+	 * @param bool $first
+	 * @throws NotPermittedException
+	 */
+	public function getById($id, $first = false) {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * Get the amount of free space inside the folder
+	 *
+	 * @return int
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function getFreeSpace() {
+		return $this->storage->free_space($this->path);
+	}
+
+	/**
+	 * Add a suffix to the name in case the file exists
+	 *
+	 * @param string $name
+	 * @throws NotPermittedException
+	 */
+	public function getNonExistingName($name) {
+		throw new NotPermittedException();
+	}
+}

--- a/lib/private/Files/Storage/Node.php
+++ b/lib/private/Files/Storage/Node.php
@@ -1,0 +1,390 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Files\Storage;
+
+use OCP\Files\Folder;
+use OCP\Files\Node as FilesNode;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\Files\Storage\IStorage;
+use OC\Files\Storage\Folder as StorageFolder;
+
+/**
+ * Class Node
+ *
+ * The Storage/Node classes are intended to work directly on the storage,
+ * bypassing any updates to the metadata in the filecache, which is expensive
+ * and not needed for avatars, thumbnails and maybe other things.
+ *
+ * @package OC\Files\Storage
+ */
+abstract class Node implements FilesNode {
+
+	/** @var IStorage */
+	protected $storage;
+
+	/** @var string $path relativ to the storage root */
+	protected $path;
+
+	/**
+	 * @param IStorage $storage
+	 * @param $path
+	 */
+	public function __construct(IStorage $storage, $path) {
+		$this->storage = $storage;
+		$this->path = $path;
+	}
+
+	/**
+	 * Get the full mimetype of the file or folder i.e. 'image/png'
+	 *
+	 * @return string
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function getMimetype() {
+		return $this->storage->getMimeType($this->path);
+	}
+
+	/**
+	 * Get the first part of the mimetype of the file or folder i.e. 'image'
+	 *
+	 * @return string
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function getMimePart() {
+		return \explode('/', $this->getMimetype(), 2)[0];
+	}
+
+	/** {@inheritdoc} */
+	public function isEncrypted() {
+		return false;
+	}
+
+	/**
+	 * Check whether this is a file or a folder
+	 *
+	 * @return string \OCP\Files\FileInfo::TYPE_FILE|\OCP\Files\FileInfo::TYPE_FOLDER
+	 * @throws \Exception
+	 * @throws \UnexpectedValueException
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function getType() {
+		$type = $this->storage->filetype($this->path);
+		switch ($type) {
+			case 'file': return \OCP\Files\FileInfo::TYPE_FILE;
+			case 'dir': return \OCP\Files\FileInfo::TYPE_FOLDER;
+			case 'link': //TODO readlink and check it if path is in same storage
+			default:
+				throw new \UnexpectedValueException("filetype $type not supported ");
+		}
+	}
+
+	/**
+	 * Check whether new files or folders can be created inside this folder
+	 *
+	 * @return bool
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function isCreatable() {
+		return $this->storage->isCreatable($this->path);
+	}
+
+	/** {@inheritdoc} */
+	public function isShared() {
+		return false;
+	}
+
+	/**
+	 * Check if a file or folder is mounted
+	 *
+	 * @throws NotPermittedException
+	 */
+	public function isMounted() {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * Get the mountpoint the file belongs to
+	 *
+	 * @throws NotPermittedException
+	 */
+	public function getMountPoint() {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * Get the owner of the file
+	 *
+	 * @throws NotPermittedException
+	 */
+	public function getOwner() {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * Get the stored checksum for this file
+	 *
+	 * @throws NotPermittedException
+	 */
+	public function getChecksum() {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * Move the file or folder to a new location
+	 *
+	 * @param string $targetPath the absolute target path
+	 * @throws NotPermittedException
+	 */
+	public function move($targetPath) {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * Delete the file or folder
+	 *
+	 * @return void
+	 * @throws \Exception
+	 * @throws \UnexpectedValueException
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	abstract public function delete();
+
+	/**
+	 * Cope the file or folder to a new location
+	 *
+	 * @param string $targetPath the absolute target path
+	 * @throws NotPermittedException
+	 */
+	public function copy($targetPath) {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * Change the modified date of the file or folder
+	 * If $mtime is omitted the current time will be used
+	 *
+	 * @param int $mtime (optional) modified date as unix timestamp
+	 * @return void
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function touch($mtime = null) {
+		$this->storage->touch($this->path, $mtime);
+	}
+
+	/** {@inheritdoc} */
+	public function getStorage() {
+		return $this->storage;
+	}
+
+	/**
+	 * Get the full path of the file or folder
+	 *
+	 * @return string
+	 * @throws NotPermittedException
+	 */
+	public function getPath() {
+		throw new NotPermittedException();
+	}
+
+	/** {@inheritdoc} */
+	public function getInternalPath() {
+		return $this->path;
+	}
+
+	/**
+	 * Get the internal file id for the file or folder
+	 *
+	 * @throws NotPermittedException
+	 */
+	public function getId() {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * Get metadata of the file or folder
+	 * The returned array contains the following values:
+	 *  - mtime
+	 *  - size
+	 *
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 * @return array
+	 */
+	public function stat() {
+		return $this->storage->stat($this->path);
+	}
+
+	/**
+	 * Get the modified date of the file or folder as unix timestamp
+	 *
+	 * @return int
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function getMTime() {
+		return $this->storage->filemtime($this->path);
+	}
+
+	/**
+	 * Get the size of the file or folder in bytes
+	 *
+	 * @return int
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function getSize() {
+		return $this->storage->filesize($this->path);
+	}
+
+	/**
+	 * Get the Etag of the file or folder
+	 * The Etag is an string id used to detect changes to a file or folder,
+	 * every time the file or folder is changed the Etag will change to
+	 *
+	 * @return string
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function getEtag() {
+		return $this->storage->getETag($this->path);
+	}
+
+	/**
+	 * Get the permissions of the file or folder as a combination of one or more of the following constants:
+	 *  - \OCP\Constants::PERMISSION_READ
+	 *  - \OCP\Constants::PERMISSION_UPDATE
+	 *  - \OCP\Constants::PERMISSION_CREATE
+	 *  - \OCP\Constants::PERMISSION_DELETE
+	 *  - \OCP\Constants::PERMISSION_SHARE
+	 *
+	 * @return int
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function getPermissions() {
+		return $this->storage->getPermissions($this->path);
+	}
+
+	/**
+	 * Check if the file or folder is readable
+	 *
+	 * @return bool
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function isReadable() {
+		return $this->storage->isReadable($this->path);
+	}
+
+	/**
+	 * Check if the file or folder is writable
+	 *
+	 * @return bool
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function isUpdateable() {
+		return $this->storage->isUpdatable($this->path);
+	}
+
+	/**
+	 * Check if the file or folder is deletable
+	 *
+	 * @return bool
+	 * @throws \OCP\Files\StorageNotAvailableException
+	 */
+	public function isDeletable() {
+		return $this->storage->isDeletable($this->path);
+	}
+
+	/** {@inheritdoc} */
+	public function isShareable() {
+		return false;
+	}
+
+	/**
+	 * Get the parent folder of the file or folder
+	 *
+	 * @return Folder
+	 * @throws \OCP\Files\NotFoundException
+	 */
+	public function getParent() {
+		$parent = \dirname($this->path);
+		if ($parent === '' || $parent === '.') {
+			throw new NotFoundException($parent);
+		}
+		return new StorageFolder($this->storage, $parent);
+	}
+
+	/** {@inheritdoc} */
+	public function getName() {
+		return \basename($this->path);
+	}
+
+	/**
+	 * Acquire a lock on this file or folder.
+	 *
+	 * A shared (read) lock will prevent any exclusive (write) locks from being created but any number of shared locks
+	 * can be active at the same time.
+	 * An exclusive lock will prevent any other lock from being created (both shared and exclusive).
+	 *
+	 * A locked exception will be thrown if any conflicting lock already exists
+	 *
+	 * Note that this uses mandatory locking, if you acquire an exclusive lock on a file it will block *all*
+	 * other operations for that file, even within the same php process.
+	 *
+	 * Acquiring any lock on a file will also create a shared lock on all parent folders of that file.
+	 *
+	 * Note that in most cases you won't need to manually manage the locks for any files you're working with,
+	 * any filesystem operation will automatically acquire the relevant locks for that operation.
+	 *
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @throws NotPermittedException
+	 */
+	public function lock($type) {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * Check the type of an existing lock.
+	 *
+	 * A shared lock can be changed to an exclusive lock is there is exactly one shared lock on the file,
+	 * an exclusive lock can always be changed to a shared lock since there can only be one exclusive lock int he first place.
+	 *
+	 * A locked exception will be thrown when these preconditions are not met.
+	 * Note that this is also the case if no existing lock exists for the file.
+	 *
+	 * @param int $targetType \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @throws NotPermittedException
+	 */
+	public function changeLock($targetType) {
+		throw new NotPermittedException();
+	}
+
+	/**
+	 * Release an existing lock.
+	 *
+	 * This will also free up the shared locks on any parent folder that were automatically acquired when locking the file.
+	 *
+	 * Note that this method will not give any sort of error when trying to free a lock that doesn't exist.
+	 *
+	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+	 * @throws NotPermittedException
+	 */
+	public function unlock($type) {
+		throw new NotPermittedException();
+	}
+}

--- a/lib/private/Repair/MoveAvatarOutsideHome.php
+++ b/lib/private/Repair/MoveAvatarOutsideHome.php
@@ -146,7 +146,9 @@ class MoveAvatarOutsideHome implements IRepairStep {
 	 */
 	public function run(IOutput $output) {
 		$ocVersionFromBeforeUpdate = $this->config->getSystemValue('version', '0.0.0');
-		if (\version_compare($ocVersionFromBeforeUpdate, '9.2.0.2', '<')) {
+		$avatarMigrationStatus = $this->config->getAppValue('core', 'avatar_migration_completed', 'false');
+		if (($avatarMigrationStatus === 'false') &&
+			\version_compare($ocVersionFromBeforeUpdate, '9.2.0.2', '<')) {
 			$function = function (IUser $user) use ($output) {
 				$this->moveAvatars($output, $user);
 				$output->advance();
@@ -155,6 +157,9 @@ class MoveAvatarOutsideHome implements IRepairStep {
 			$output->startProgress($this->userManager->countSeenUsers());
 
 			$this->userManager->callForSeenUsers($function);
+
+			//Set this if repair step is executed
+			$this->config->setAppValue('core', 'avatar_migration_completed', 'true');
 
 			$output->finishProgress();
 		} else {

--- a/lib/private/Repair/MoveAvatarOutsideHome.php
+++ b/lib/private/Repair/MoveAvatarOutsideHome.php
@@ -21,7 +21,12 @@
  */
 namespace OC\Repair;
 
+use OC\Files\Node\File;
+use OC\NotSquareException;
+use OC\User\NoUserException;
+use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\Storage\IStorage;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\ILogger;
@@ -104,22 +109,33 @@ class MoveAvatarOutsideHome implements IRepairStep {
 	private function moveAvatars(IOutput $out, IUser $user) {
 		$userId = $user->getUID();
 
-		\OC\Files\Filesystem::initMountPoints($userId);
-
-		// call get instead of getUserFolder to avoid needless skeleton copy
 		try {
-			$oldAvatarUserFolder = $this->rootFolder->get('/' . $userId);
-			$oldAvatar = new Avatar($oldAvatarUserFolder, $this->l, $user, $this->logger);
-			if ($oldAvatar->exists()) {
-				$newAvatarsUserFolder = $this->avatarManager->getAvatarFolder($user);
+			\OC\Files\Filesystem::initMountPoints($userId);
 
-				// get original file
-				$oldAvatarFile = $oldAvatar->getFile(-1);
-				$oldAvatarFile->move($newAvatarsUserFolder->getPath() . '/' . $oldAvatarFile->getName());
-				$oldAvatar->remove();
+			/** @var File $oldAvatarFile */
+			$oldAvatarFile = null;
+
+			// call get instead of getUserFolder to avoid needless skeleton copy
+			/** @var Folder $oldAvatarFolder */
+			$oldAvatarFolder = $this->rootFolder->get('/' . $userId . '/avatars/');
+			try {
+				$oldAvatarFile = $oldAvatarFolder->get('/avatar.jpg');
+			} catch (NotFoundException $e) {
+				$oldAvatarFile = $oldAvatarFolder->get('/avatar.png');
 			}
+			$newAvatarStorage = $this->rootFolder->get('/avatars/')->getStorage();
+			$avatar = new Avatar($newAvatarStorage, $this->l, $user, $this->logger);
+			$avatar->set($oldAvatarFile->getContent());
+			$oldAvatarFile->delete();
+		} catch (NoUserException $e) {
+			$this->logger->warning("Skipping avatar move for $userId: User does not exist.", ['app' => __METHOD__]);
 		} catch (NotFoundException $e) {
 			// not all users have a home, ignore
+			$this->logger->debug("Skipping avatar move for $userId: User has no home or avatar folder.", ['app' => __METHOD__]);
+		} catch (NotSquareException $e) {
+			$this->logger->warning("Skipping avatar move for $userId: avatar image {$oldAvatarFile->getPath()} for user $userId is not square.", ['app' => __METHOD__]);
+		} catch (\Exception $e) {
+			$this->logger->logException($e, ['app' => __METHOD__, 'message' => "Skipping avatar move for $userId"]);
 		}
 
 		\OC_Util::tearDownFS();

--- a/lib/public/Files/Storage/IStorage.php
+++ b/lib/public/Files/Storage/IStorage.php
@@ -232,11 +232,11 @@ interface IStorage {
 	public function file_get_contents($path);
 
 	/**
-	 * see http://php.net/manual/en/function.file_put_contents.php
+	 * see http://php.net/manual/en/function.file-put-contents.php
 	 *
 	 * @param string $path
 	 * @param string $data
-	 * @return bool
+	 * @return int|false the number of bytes that were written to the file, or FALSE on failure
 	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */

--- a/tests/lib/Files/Storage/FileTest.php
+++ b/tests/lib/Files/Storage/FileTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Files\Storage;
+use OC\Files\Storage\File;
+use OCP\Files\Storage\IStorage;
+
+/**
+ * Class FileTest
+ *
+ * @package Test\Files\Storage
+ */
+class FileTest extends NodeTest {
+	/**
+	 * @param $path
+	 * @param IStorage|\PHPUnit_Framework_MockObject_MockObject|null $storage
+	 * @return File
+	 */
+	protected function createTestNode($path, IStorage $storage = null) {
+		if ($storage === null) {
+			$storage = $this->storage;
+		}
+		return new File($storage, $path);
+	}
+
+	public function testGetContent() {
+		$this->storage->expects($this->once())
+			->method('file_get_contents')
+			->with('/f1.txt')
+			->willReturn('content');
+
+		$file = $this->createTestNode('/f1.txt');
+		self::assertSame('content', $file->getContent());
+	}
+
+	public function testPutContent() {
+		$this->storage->expects($this->once())
+			->method('file_put_contents')
+			->with('/f1.txt', 'content');
+
+		$file = $this->createTestNode('/f1.txt');
+		$file->putContent('content');
+	}
+
+	public function testDelete() {
+		$this->storage->expects($this->once())
+			->method('unlink')
+			->with('/f1.txt');
+
+		$node = $this->createTestNode('/f1.txt');
+		$node->delete();
+	}
+
+	public function testHash() {
+		$this->storage->expects($this->once())
+			->method('hash')
+			->with('type', '/f1.txt', false)
+			->willReturn('hashed');
+
+		$file = $this->createTestNode('/f1.txt');
+		self::assertSame('hashed', $file->hash('type', false));
+	}
+
+	public function testFopen() {
+		$stream = \fopen('php://memory', 'wb+');
+		$this->storage->expects($this->once())
+			->method('fopen')
+			->with('/f1.txt', 'wb+')
+			->willReturn($stream);
+
+		$file = $this->createTestNode('/f1.txt');
+		self::assertSame($stream, $file->fopen('wb+'));
+	}
+}

--- a/tests/lib/Files/Storage/FolderTest.php
+++ b/tests/lib/Files/Storage/FolderTest.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Files\Storage;
+
+use OC\Files\Storage\File;
+use OC\Files\Storage\Folder;
+use OCP\Files\Storage\IStorage;
+
+/**
+ * Class FolderTest
+ *
+ * @package Test\Files\Storage
+ */
+class FolderTest extends NodeTest {
+
+	/**
+	 * @param $path
+	 * @param IStorage|\PHPUnit_Framework_MockObject_MockObject|null $storage
+	 * @return Folder
+	 */
+	protected function createTestNode($path, IStorage $storage = null) {
+		if ($storage === null) {
+			$storage = $this->storage;
+		}
+		return new Folder($storage, $path);
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testGetFullPath() {
+		$this->createTestNode('/')
+			->getFullPath('/');
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testGetRelativePath() {
+		$this->createTestNode('/')
+			->getRelativePath('/');
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testIsSubNode() {
+		$this->createTestNode('/')
+			->isSubNode(new Folder($this->storage, '/foo'));
+	}
+
+	public function testGetDirectoryContent() {
+		$tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
+		$storage = new \OC\Files\Storage\Local(['datadir' => $tmpDir]);
+		$storage->mkdir('sub');
+		$storage->touch('sub/f1.txt');
+		$storage->mkdir('sub/folder1');
+
+		$node = $this->createTestNode('sub', $storage);
+		$children = $node->getDirectoryListing();
+		$this->assertCount(2, $children);
+		$this->assertInstanceOf(File::class, $children[0]);
+		$this->assertInstanceOf(Folder::class, $children[1]);
+		$this->assertEquals('f1.txt', $children[0]->getName());
+		$this->assertEquals('folder1', $children[1]->getName());
+	}
+
+	public function testGet() {
+		$this->storage->expects($this->exactly(3))
+			->method('filetype')
+			->willReturnOnConsecutiveCalls('file', 'dir', 'link');
+
+		$node = $this->createTestNode('sub');
+		$file = $node->get('file.txt');
+		self::assertInstanceOf(File::class, $file);
+		self::assertSame('sub/file.txt', $file->getInternalPath());
+
+		$folder = $node->get('folder');
+		self::assertInstanceOf(Folder::class, $folder);
+		self::assertSame('sub/folder', $folder->getInternalPath());
+
+		self::assertNull($node->get('symbolic link'));
+	}
+
+	public function testNodeExists() {
+		$this->storage->expects($this->exactly(3))
+			->method('file_exists')
+			->withConsecutive(['sub/file.txt'], ['sub/folder'], ['sub/folder'])
+			->willReturnOnConsecutiveCalls(true, false, false);
+
+		$node = $this->createTestNode('sub');
+		self::assertTrue($node->nodeExists('file.txt'));
+		self::assertFalse($node->nodeExists('folder'));
+		self::assertFalse($node->nodeExists('folder/'));
+	}
+
+	public function testNewFolder() {
+		$this->storage->expects($this->once())
+			->method('mkdir')
+			->with('sub/folder');
+
+		$node = $this->createTestNode('sub');
+		$folder = $node->newFolder('folder');
+		self::assertInstanceOf(Folder::class, $folder);
+		self::assertSame('sub/folder', $folder->getInternalPath());
+	}
+
+	public function testNewFile() {
+		$this->storage->expects($this->once())
+			->method('touch')
+			->with('sub/file.txt');
+
+		$node = $this->createTestNode('sub');
+		$file = $node->newFile('file.txt');
+		self::assertInstanceOf(File::class, $file);
+		self::assertSame('sub/file.txt', $file->getInternalPath());
+	}
+
+	public function testDelete() {
+		$this->storage->expects($this->once())
+			->method('rmdir')
+			->with('/folder');
+
+		$node = $this->createTestNode('/folder');
+		$node->delete();
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testSearch() {
+		$this->createTestNode('/')
+			->search('/foo');
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testSearchByMime() {
+		$this->createTestNode('/')
+			->searchByMime('text/plain');
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testSearchByTag() {
+		$this->createTestNode('/')
+			->searchByMime('text/plain');
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testGetById() {
+		$this->createTestNode('/')
+			->getById(1);
+	}
+
+	public function testGetFreeSpace() {
+		$this->storage->expects($this->once())
+			->method('free_space')
+			->with('/')
+			->willReturn(100);
+
+		$folder = $this->createTestNode('/');
+		self::assertSame(100, $folder->getFreeSpace());
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testGetNonExistingName() {
+		$this->createTestNode('/')
+			->getNonExistingName('name');
+	}
+}

--- a/tests/lib/Files/Storage/FolderTest.php
+++ b/tests/lib/Files/Storage/FolderTest.php
@@ -78,10 +78,13 @@ class FolderTest extends NodeTest {
 		$node = $this->createTestNode('sub', $storage);
 		$children = $node->getDirectoryListing();
 		$this->assertCount(2, $children);
-		$this->assertInstanceOf(File::class, $children[0]);
-		$this->assertInstanceOf(Folder::class, $children[1]);
-		$this->assertEquals('f1.txt', $children[0]->getName());
-		$this->assertEquals('folder1', $children[1]->getName());
+		foreach ($children as $child) {
+			if ($child instanceof File) {
+				$this->assertEquals('f1.txt', $child->getName());
+			} elseif ($child instanceof Folder) {
+				$this->assertEquals('folder1', $child->getName());
+			}
+		}
 	}
 
 	public function testGet() {

--- a/tests/lib/Files/Storage/NodeTest.php
+++ b/tests/lib/Files/Storage/NodeTest.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Files\Storage;
+
+use OC\Files\Storage\Folder;
+use OC\Files\Storage\Node;
+use OCP\Files\Storage\IStorage;
+use Test\TestCase;
+
+/**
+ * Class NodeTest
+ *
+ * @package Test\Files\Storage
+ */
+abstract class NodeTest extends TestCase {
+	protected $viewDeleteMethod = 'unlink';
+	protected $user;
+	/**
+	 * @var IStorage|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected $storage;
+
+	protected function setUp() {
+		parent::setUp();
+		$this->storage = $this->createMock(IStorage::class);
+		$this->storage->expects($this->any())
+			->method('getId')
+			->will($this->returnValue('test::storage'));
+	}
+
+	/**
+	 * @param $path
+	 * @param IStorage $storage
+	 * @return Node
+	 */
+	abstract protected function createTestNode($path, IStorage $storage = null);
+
+	public function testGetMimetype() {
+		$this->storage->expects($this->once())
+			->method('getMimeType')
+			->with('/path')
+			->willReturn('node/type');
+
+		$node = $this->createTestNode('/path');
+		self::assertSame('node/type', $node->getMimetype());
+	}
+
+	public function testGetMimePart() {
+		$this->storage->expects($this->once())
+			->method('getMimeType')
+			->with('/path')
+			->willReturn('node/type');
+
+		$node = $this->createTestNode('/path');
+		self::assertSame('node', $node->getMimePart());
+	}
+
+	public function testIsEncrypted() {
+		$node = $this->createTestNode('/path');
+		self::assertFalse($node->isEncrypted());
+	}
+
+	public function testGetType() {
+		$this->storage->expects($this->exactly(2))
+			->method('filetype')
+			->willReturnOnConsecutiveCalls('file', 'dir');
+
+		self::assertSame(\OCP\Files\FileInfo::TYPE_FILE, $this->createTestNode('/f1.txt')->getType());
+		self::assertSame(\OCP\Files\FileInfo::TYPE_FOLDER, $this->createTestNode('/folder')->getType());
+	}
+
+	/**
+	 * @expectedException \UnexpectedValueException
+	 */
+	public function testGetTypeUnexpected() {
+		$this->storage->expects($this->once())
+			->method('filetype')
+			->willReturn('link');
+
+		$this->createTestNode('/f1.txt')->getType();
+	}
+
+	public function testIsCreatable() {
+		$this->storage->expects($this->once())
+			->method('isCreatable')
+			->with('/path')
+			->willReturn(true);
+
+		$node = $this->createTestNode('/path');
+		self::assertTrue($node->isCreatable());
+	}
+
+	public function testIsShared() {
+		$node = $this->createTestNode('/path');
+		self::assertFalse($node->isShared());
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testIsMounted() {
+		$this->createTestNode('/path')
+			->isMounted();
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testGetMountPoint() {
+		$this->createTestNode('/path')
+			->getMountPoint();
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testGetOwner() {
+		$this->createTestNode('/path')
+			->getOwner();
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testGetChecksum() {
+		$this->createTestNode('/path')
+			->getChecksum();
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testMove() {
+		$this->createTestNode('/path')
+			->move('/target');
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testCopy() {
+		$this->createTestNode('/path')
+			->copy('/target');
+	}
+
+	public function testTouch() {
+		$this->storage->expects($this->once())
+			->method('touch')
+			->with('/path', 123);
+
+		$node = $this->createTestNode('/path');
+		$node->touch(123);
+	}
+
+	public function testGetStorage() {
+		$node = $this->createTestNode('/path');
+		self::assertSame($this->storage, $node->getStorage());
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testGetPath() {
+		$this->createTestNode('/path')
+			->getPath();
+	}
+
+	public function testGetInternalPath() {
+		$node = $this->createTestNode('/path');
+		self::assertSame('/path', $node->getInternalPath());
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testGetId() {
+		$this->createTestNode('/path')
+			->getId();
+	}
+
+	public function testStat() {
+		$stat = ['inode' => 1];
+
+		$this->storage->expects($this->once())
+			->method('stat')
+			->with('/path')
+			->willReturn($stat);
+
+		$node = $this->createTestNode('/path');
+		self::assertSame($stat, $node->stat());
+	}
+
+	public function testGetMTime() {
+		$this->storage->expects($this->once())
+			->method('filemtime')
+			->with('/path')
+			->willReturn(123);
+
+		$node = $this->createTestNode('/path');
+		self::assertSame(123, $node->getMTime());
+	}
+
+	public function testGetSize() {
+		$this->storage->expects($this->once())
+			->method('filesize')
+			->with('/path')
+			->willReturn(123);
+
+		$node = $this->createTestNode('/path');
+		self::assertSame(123, $node->getSize());
+	}
+
+	public function testGetEtag() {
+		$this->storage->expects($this->once())
+			->method('getETag')
+			->with('/path')
+			->willReturn('"foo"');
+
+		$node = $this->createTestNode('/path');
+		self::assertSame('"foo"', $node->getEtag());
+	}
+
+	public function testGetPermissions() {
+		$this->storage->expects($this->once())
+			->method('getPermissions')
+			->with('/path')
+			->willReturn(32);
+
+		$node = $this->createTestNode('/path');
+		self::assertSame(32, $node->getPermissions());
+	}
+
+	public function testIsReadable() {
+		$this->storage->expects($this->once())
+			->method('isReadable')
+			->with('/path')
+			->willReturn(true);
+
+		$node = $this->createTestNode('/path');
+		self::assertTrue($node->isReadable());
+	}
+
+	public function testIsUpdateable() {
+		$this->storage->expects($this->once())
+			->method('isUpdatable')
+			->with('/path')
+			->willReturn(true);
+
+		$node = $this->createTestNode('/path');
+		self::assertTrue($node->isUpdateable());
+	}
+
+	public function testIsDeletable() {
+		$this->storage->expects($this->once())
+			->method('isDeletable')
+			->with('/path')
+			->willReturn(true);
+
+		$node = $this->createTestNode('/path');
+		self::assertTrue($node->isDeletable());
+	}
+
+	public function testIsShareable() {
+		$node = $this->createTestNode('/path');
+		self::assertFalse($node->isShareable());
+	}
+
+	public function testGetParent() {
+		$node = $this->createTestNode('/path');
+		$root = $node->getParent();
+		self::assertInstanceOf(Folder::class, $root);
+		self::assertSame('/', $root->getInternalPath());
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotFoundException
+	 */
+	public function testGetParentNotExisting() {
+		$root = $this->createTestNode('');
+		$root->getParent();
+	}
+
+	public function testGetName() {
+		$node = $this->createTestNode('/path');
+		self::assertSame('path', $node->getName());
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testLock() {
+		$this->createTestNode('/path')
+			->lock(\OCP\Lock\ILockingProvider::LOCK_SHARED);
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testChangeLock() {
+		$this->createTestNode('/path')
+			->changeLock(\OCP\Lock\ILockingProvider::LOCK_SHARED);
+	}
+
+	/**
+	 * @expectedException \OCP\Files\NotPermittedException
+	 */
+	public function testUnlock() {
+		$this->createTestNode('/path')
+			->unlock(\OCP\Lock\ILockingProvider::LOCK_SHARED);
+	}
+}


### PR DESCRIPTION
revive of https://github.com/owncloud/core/pull/31105 this time with adjusted avatar migration, see https://github.com/owncloud/core/pull/32175 and https://github.com/owncloud/core/issues/28902 why it is needed for migrating user from 8.2 to 10, directly.

@tomneedham maybe you want to migrate the avatars completely differently?

cc @DeepDiver1975 