### PR TITLE
[objectstore] Fix checksums not being updated on modifying shared file

### DIFF
--- a/apps/files_sharing/lib/Scanner.php
+++ b/apps/files_sharing/lib/Scanner.php
@@ -65,10 +65,31 @@ class Scanner extends \OC\Files\Cache\Scanner {
 		}
 	}
 
+	/**
+	 * scan a folder and all it's children,  use source scanner if needed
+	 *
+	 * @inheritdoc
+	 */
+	public function scan($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $lock = true) {
+		$sourceScanner = $this->getSourceScanner();
+		if ($sourceScanner instanceof NoopScanner) {
+			list(, $internalPath) = $this->storage->resolvePath($path);
+			return $sourceScanner->scan($internalPath, $recursive, $reuse, $lock);
+		} else {
+			return parent::scan($path, $recursive, $reuse, $lock);
+		}
+	}
+
+	/**
+	 * scan a single file and use source scanner if needed
+	 *
+	 * @inheritdoc
+	 */
 	public function scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = null, $lock = true) {
 		$sourceScanner = $this->getSourceScanner();
 		if ($sourceScanner instanceof NoopScanner) {
-			return [];
+			list(, $internalPath) = $this->storage->resolvePath($file);
+			return parent::scan($internalPath, $reuseExisting, $parentId, $cacheData, $lock);
 		} else {
 			return parent::scanFile($file, $reuseExisting, $parentId, $cacheData, $lock);
 		}

--- a/lib/private/Files/ObjectStore/NoopScanner.php
+++ b/lib/private/Files/ObjectStore/NoopScanner.php
@@ -43,6 +43,7 @@ class NoopScanner extends Scanner {
 	 * @return array an array of metadata of the scanned file
 	 */
 	public function scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = null, $lock = true) {
+		$this->updateChecksums($file);
 		return [];
 	}
 
@@ -56,15 +57,15 @@ class NoopScanner extends Scanner {
 	 */
 	public function scan($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $lock = true) {
 		// we only update the checksums - still returning no data
-		$meta = $this->storage->getMetaData($path);
-		if (!empty($meta['checksum'])) {
-			$this->storage->getCache()->put(
-				$path,
-				['checksum' => $meta['checksum']]
-			);
-		}
-
+		$this->updateChecksums($path);
 		return [];
+	}
+
+	/**
+	 * walk over any folders that are not fully scanned yet and scan them
+	 */
+	public function backgroundScan() {
+		//noop
 	}
 
 	/**
@@ -81,9 +82,17 @@ class NoopScanner extends Scanner {
 	}
 
 	/**
-	 * walk over any folders that are not fully scanned yet and scan them
+	 * Update file checksums
+	 *
+	 * @param string $path
 	 */
-	public function backgroundScan() {
-		//noop
+	private function updateChecksums($path) {
+		$meta = $this->storage->getMetaData($path);
+		if (!empty($meta['checksum'])) {
+			$this->storage->getCache()->put(
+				$path,
+				['checksum' => $meta['checksum']]
+			);
+		}
 	}
 }


### PR DESCRIPTION
### Issue
Failing smashbox tests with sharing on objectstore.

### Solution

SharingScanner did not update checksums in file cache for object store, since logic for obcjectstorage has not been implemented (SharingScanner assumes by default Local Filesystem). This PR adds logic for objectstorage.
@DeepDiver1975 @patrickjahns 