### PR TITLE
resetpassword command supports send password reset link and display link

### DIFF
--- a/core/register_command.php
+++ b/core/register_command.php
@@ -145,7 +145,12 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\ListUsers(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\ListUserGroups(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Report(\OC::$server->getUserManager()));
-	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\User\ResetPassword(\OC::$server->getUserManager(), \OC::$server->getConfig(), \OC::$server->getTimeFactory(),
+		new \OC\Helper\EnvironmentHelper(), new \OC\Core\Controller\LostController('settings',
+			\OC::$server->getRequest(), \OC::$server->getURLGenerator(), \OC::$server->getUserManager(), new \OC_Defaults(),
+			\OC::$server->getL10N('settings'), \OC::$server->getConfig(), \OC::$server->getSecureRandom(),
+			\OCP\Util::getDefaultEmailAddress('lostpassword-noreply'), \OC::$server->getEncryptionManager()->isEnabled(),
+			\OC::$server->getMailer(), \OC::$server->getTimeFactory(), \OC::$server->getLogger(), \OC::$server->getUserSession())));
 	$application->add(new OC\Core\Command\User\Setting(\OC::$server->getUserManager(), \OC::$server->getConfig(), \OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\User\Modify(\OC::$server->getUserManager(), \OC::$server->getMailer()));
 	$application->add(new OC\Core\Command\User\SyncBackend(\OC::$server->getAccountMapper(), \OC::$server->getConfig(), \OC::$server->getUserManager(), \OC::$server->getLogger()));

--- a/tests/Core/Command/User/ResetPasswordTest.php
+++ b/tests/Core/Command/User/ResetPasswordTest.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\User;
+
+use OC\Core\Command\User\ResetPassword;
+use OC\Core\Controller\LostController;
+use OC\Helper\EnvironmentHelper;
+use OC\Mail\Message;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Mail\IMailer;
+use OCP\Security\ISecureRandom;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Test\TestCase;
+
+/**
+ * Class ResetPasswordTest
+ *
+ * @group DB
+ * @package Tests\Core\Command\User
+ */
+class ResetPasswordTest extends TestCase {
+	/** @var  IUserManager | \PHPUnit_Framework_MockObject_MockObject */
+	private $userManager;
+	/** @var  IConfig | \PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+	/** @var  ITimeFactory | \PHPUnit_Framework_MockObject_MockObject */
+	private $timeFactory;
+	/** @var  EnvironmentHelper | \PHPUnit_Framework_MockObject_MockObject */
+	private $environmentHelper;
+	/** @var LostController | \PHPUnit_Framework_MockObject_MockObject */
+	private $lostController;
+	/** @var  ResetPassword */
+	private $resetPassword;
+	protected function setUp() {
+		parent::setUp();
+
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->environmentHelper = $this->createMock(EnvironmentHelper::class);
+		$this->lostController = $this->createMock(LostController::class);
+		$this->resetPassword = new ResetPassword($this->userManager, $this->config, $this->timeFactory,
+			$this->environmentHelper, $this->lostController);
+	}
+
+	public function testResetPasswordFromEnv() {
+		$input = $this->createMock(InputInterface::class);
+		$output = $this->createMock(OutputInterface::class);
+
+		$input->expects($this->once())
+			->method('getArgument')
+			->willReturn('foo');
+		$input->expects($this->exactly(3))
+			->method('getOption')
+			->willReturnMap([
+				['send-email', false],
+				['output-link', false],
+				['password-from-env', true]
+			]);
+
+		$this->environmentHelper->expects($this->once())
+			->method('getEnvVar')
+			->willReturn('fooPass');
+
+		$user = $this->createMock(IUser::class);
+		$user->expects($this->once())
+			->method('setPassword')
+			->willReturn(true);
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->willReturn($user);
+
+		$this->assertNull($this->invokePrivate($this->resetPassword, 'execute', [$input, $output]));
+	}
+
+	public function testDisplayLink() {
+		$input = $this->createMock(InputInterface::class);
+		$output = $this->createMock(OutputInterface::class);
+
+		$input->expects($this->once())
+			->method('getArgument')
+			->willReturn('foo');
+
+		$input->expects($this->exactly(3))
+			->method('getOption')
+			->willReturnMap([
+				['send-email', false],
+				['output-link', true],
+				['password-from-env', false]
+			]);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')
+			->willReturn('foo');
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->willReturn($user);
+
+		$this->lostController->method('generateTokenAndLink')
+			->with('foo')
+			->willReturn(['http://localhost/foo/bar/123AbcFooBar/foo', '123AbcFooBar']);
+
+		$output->expects($this->once())
+			->method('writeln')
+			->with('The password reset link is: http://localhost/foo/bar/123AbcFooBar/foo');
+
+		$this->invokePrivate($this->resetPassword, 'execute', [$input, $output]);
+	}
+
+	public function testEmailLink() {
+		$input = $this->createMock(InputInterface::class);
+		$output = $this->createMock(OutputInterface::class);
+
+		$input->expects($this->once())
+			->method('getArgument')
+			->willReturn('foo');
+
+		$input->expects($this->exactly(3))
+			->method('getOption')
+			->willReturnMap([
+				['send-email', true],
+				['output-link', false],
+				['password-from-env', false]
+			]);
+
+		$user = $this->createMock(IUser::class);
+
+		$user->method('getEMailAddress')
+			->willReturn('foo@bar.com');
+
+		$user->method('getUID')
+			->willReturn('foo');
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->willReturn($user);
+
+		$this->lostController->method('generateTokenAndLink')
+			->with('foo')
+			->willReturn(['http://localhost/foo/bar/123AbcFooBar/foo', '123AbcFooBar']);
+		$this->lostController->method('sendEmail')
+			->with('foo', '123AbcFooBar', 'http://localhost/foo/bar/123AbcFooBar/foo');
+
+		$output->expects($this->once())
+			->method('writeln')
+			->with('The password reset link is: http://localhost/foo/bar/123AbcFooBar/foo');
+
+		$this->assertEquals(0, $this->invokePrivate($this->resetPassword, 'execute', [$input, $output]));
+	}
+
+	public function testEmailLinkFailure() {
+		$input = $this->createMock(InputInterface::class);
+		$output = $this->createMock(OutputInterface::class);
+
+		$input->expects($this->once())
+			->method('getArgument')
+			->willReturn('foo');
+
+		$input->expects($this->exactly(3))
+			->method('getOption')
+			->willReturnMap([
+				['send-email', true],
+				['output-link', false],
+				['password-from-env', false]
+			]);
+
+		$user = $this->createMock(IUser::class);
+
+		$user->expects($this->once())
+			->method('getEMailAddress')
+			->willReturn(null);
+		$user->method('getUID')
+			->willReturn('foo');
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->willReturn($user);
+
+		$output->expects($this->once())
+			->method('writeln')
+			->with('<error>Email address is not set for the user foo</error>');
+		$this->invokePrivate($this->resetPassword, 'execute', [$input, $output]);
+	}
+}


### PR DESCRIPTION
The resetpassword supports options to
1) display the password reset link in command line.
2) send email to reset the password for user and
   display the link in the command line.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The resetpassword supports options to 
1) display the password reset link in command line.
2) send email to reset the password for user and display the link in the command line.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/29542

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The resetpassword supports options to 
1) display the password reset link in command line.
2) send email to reset the password for user and display the link in the command line.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
