### PR TITLE
Add getters for private vars of acceptance test traits

### DIFF
--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -54,6 +54,26 @@ trait Auth {
 	private $tokenAuthHasBeenSetTo = '';
 
 	/**
+	 * get the client token that was last generated
+	 * app acceptance tests that have their own step code may need to use this
+	 *
+	 * @return string client token
+	 */
+	public function getClientToken() {
+		return $this->clientToken;
+	}
+
+	/**
+	 * get the app token that was last generated
+	 * app acceptance tests that have their own step code may need to use this
+	 *
+	 * @return string app token
+	 */
+	public function getAppToken() {
+		return $this->appToken;
+	}
+
+	/**
 	 * @BeforeScenario
 	 *
 	 * @return void

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -23,6 +23,7 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\ResponseInterface;
 use TestHelpers\OcsApiHelper;
@@ -120,7 +121,7 @@ trait BasicStructure {
 	private $response = null;
 
 	/**
-	 * @var \GuzzleHttp\Cookie\CookieJar
+	 * @var CookieJar
 	 */
 	private $cookieJar;
 
@@ -150,7 +151,7 @@ trait BasicStructure {
 		$this->regularUserPassword = $regularUserPassword;
 		$this->localBaseUrl = $this->baseUrl;
 		$this->currentServer = 'LOCAL';
-		$this->cookieJar = new \GuzzleHttp\Cookie\CookieJar();
+		$this->cookieJar = new CookieJar();
 		$this->ocPath = $ocPath;
 
 		// in case of CI deployment we take the server url from the environment
@@ -223,6 +224,20 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @return CookieJar
+	 */
+	public function getCookieJar() {
+		return $this->cookieJar;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getRequestToken() {
+		return $this->requestToken;
+	}
+
+	/**
 	 * returns the base URL (which is without a slash at the end)
 	 *
 	 * @return string
@@ -288,6 +303,13 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getOcsApiVersion() {
+		return $this->ocsApiVersion;
+	}
+
+	/**
 	 * @Given /^using OCS API version "([^"]*)"$/
 	 *
 	 * @param string $version
@@ -324,6 +346,13 @@ trait BasicStructure {
 	 */
 	public function getResponse() {
 		return $this->response;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getCurrentServer() {
+		return $this->currentServer;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -349,6 +349,18 @@ trait BasicStructure {
 	}
 
 	/**
+	 * let this class remember a response that was received elsewhere
+	 * so that steps in this class can be used to examine the response
+	 *
+	 * @param ResponseInterface $response
+	 *
+	 * @return void
+	 */
+	public function setResponse($response) {
+		$this->response = $response;
+	}
+
+	/**
 	 * @return string
 	 */
 	public function getCurrentServer() {

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -41,6 +41,36 @@ trait CommandLine {
 	private $lastStdErr;
 
 	/**
+	 * get the exit status of the last occ command
+	 * app acceptance tests that have their own step code may need to process this
+	 *
+	 * @return int exit status code of the last occ command
+	 */
+	public function getExitStatusCodeOfOccCommand() {
+		return $this->lastCode;
+	}
+
+	/**
+	 * get the normal output of the last occ command
+	 * app acceptance tests that have their own step code may need to process this
+	 *
+	 * @return string normal output of the last occ command
+	 */
+	public function getStdOutOfOccCommand() {
+		return $this->lastStdOut;
+	}
+
+	/**
+	 * get the error output of the last occ command
+	 * app acceptance tests that have their own step code may need to process this
+	 *
+	 * @return string error output of the last occ command
+	 */
+	public function getStdErrOfOccCommand() {
+		return $this->lastStdErr;
+	}
+
+	/**
 	 * Invokes an OCC command
 	 *
 	 * @param array $args of the occ command


### PR DESCRIPTION
## Description
Provide getters for all the "useful/interesting" private variables in the ``FeatureContext`` traits, so that apps that care can find out the results of ``FeatureContext`` actions without being forced to ``use BasicStructure`` trait.

## Motivation and Context
App acceptance tests want to add their own new step definitions/methods. Those want to use some of the methods available in core. For example, ``runOcc()``, which remembers internally the ``occ`` command exit status, ``StdOut`` and ``StdErr`` text. There are some core methods that process those looking for strings etc. But if the app needs to parse the output in some special way unique to the app, then it needs to be able to get the "raw" ``StdOut``.

Currently to do this, the app does ``use BasicStructure`` in its own ``AppContext.php`` - giving it a "private" view of all the methods and variables that would normally appear in core ``FeatureContext``. But that runs into trouble if the app needs to also refer to other core contexts like ``FederationContext``. ``FederationContext`` itself makes use of ``FeatureContext``, which forces the app to also include ``FeatureContext`` in its list of contexts. But ``FeatureContext`` also does ``use BasicStructure`` - this results in duplicate step definitions.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
