### PR TITLE
Standardize acceptance test skip tags

### DIFF
--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -41,7 +41,7 @@ So that public sharing is limited according to organization policy
 		And the public accesses the last created public link using the webUI
 		Then it should not be possible to delete the file "lorem.txt" using the webUI
 
-	@skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue_30392
+	@skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
 	Scenario: mount public link
 		Given using server "REMOTE"
 		And these users have been created:
@@ -58,7 +58,7 @@ So that public sharing is limited according to organization policy
 		And the content of "lorem.txt" on the remote server should be the same as the original "simple-folder/lorem.txt"
 		And it should not be possible to delete the file "lorem.txt" using the webUI
 
-	@skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue_30392
+	@skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
 	Scenario: mount public link and overwrite file
 		Given using server "REMOTE"
 		And these users have been created:

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -24,7 +24,7 @@ So that I can efficiently share my files with other users or groups
 			| other         |
 		And the user has browsed to the login page
 
-	@skipOnLDAP @user_ldap#175
+	@skipOnLDAP @user_ldap-issue-175
 	Scenario: autocompletion of regular existing users
 		Given the user has logged in with username "regularuser" and password "1234" using the webUI
 		And the user has browsed to the files page
@@ -103,7 +103,7 @@ So that I can efficiently share my files with other users or groups
 		Then all users and groups that contain the string "use" in their name should be listed in the autocomplete list on the webUI
 		And the users own name should not be listed in the autocomplete list on the webUI
 
-	@skipOnLDAP @user_ldap#175
+	@skipOnLDAP @user_ldap-issue-175
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
 		Given the user has logged in with username "regularuser" and password "1234" using the webUI
 		And the user has browsed to the files page
@@ -113,7 +113,7 @@ So that I can efficiently share my files with other users or groups
 		Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User One"
 		And the users own name should not be listed in the autocomplete list on the webUI
 
-	@skipOnLDAP @user_ldap#175
+	@skipOnLDAP @user_ldap-issue-175
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (file)
 		Given the user has logged in with username "regularuser" and password "1234" using the webUI
 		And the user has browsed to the files page


### PR DESCRIPTION
## Description
Make all ``skip`` tags have the same format for specifying the issue.

## Motivation and Context
Some acceptance test skip tags were in different formats, making them harder to find.
We specify the issue number in format ``issue-12345`` for ``core`` and ``app_name-issue-123`` for an issue that was raised in an app.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
