### PR TITLE
[stable10] clean up deprecated encryption functions in test script

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -132,6 +132,18 @@ pipeline:
       matrix:
         INSTALL_SERVER: true
 
+  configure-encryption:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      - php occ a:e encryption
+      - php occ encryption:enable
+      - php occ encryption:select-encryption-type ${ENCRYPTION_TYPE} --yes
+      - php occ config:list
+    when:
+      matrix:
+        CONFIGURE_ENCRYPTION: true
+
   prepare-objectstore:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -942,3 +954,26 @@ matrix:
       CHOWN_SERVER: true
       OWNCLOUD_LOG: true
       CALDAV_CARDDAV_JOB: true
+
+    # encryption tests
+    - PHP_VERSION: 5.6
+      TEST_SUITE: api
+      BEHAT_SUITE: apiEncryption
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      CONFIGURE_ENCRYPTION: true
+      ENCRYPTION_TYPE: masterkey
+
+    - PHP_VERSION: 7.1
+      TEST_SUITE: api
+      BEHAT_SUITE: apiEncryption
+      DB_TYPE: mariadb
+      USE_SERVER: true
+      INSTALL_SERVER: true
+      CHOWN_SERVER: true
+      OWNCLOUD_LOG: true
+      CONFIGURE_ENCRYPTION: true
+      ENCRYPTION_TYPE: masterkey

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -16,6 +16,12 @@ default:
         - CalDavContext:
         - AppManagementContext:
 
+    apiEncryption:
+      paths:
+        - %paths.base%/../features/apiEncryption
+      contexts:
+        - FeatureContext: *common_feature_context_params
+
     apiCapabilities:
       paths:
         - %paths.base%/../features/apiCapabilities

--- a/tests/acceptance/features/apiEncryption/recreatemasterkey.feature
+++ b/tests/acceptance/features/apiEncryption/recreatemasterkey.feature
@@ -1,14 +1,11 @@
 @api
 Feature: recreate-master-key
 
-	@masterkey_encryption
 	Scenario: recreate masterkey
-		Given user "admin" has been created
-		And user "admin" has uploaded file "data/textfile.txt" to "/somefile.txt"
+		Given user "admin" has uploaded file "data/textfile.txt" to "/somefile.txt"
 		When the administrator successfully recreates the encryption masterkey using the occ command
 		Then the downloaded content when downloading file "/somefile.txt" for user "admin" with range "bytes=0-6" should be "This is"
 
-	@masterkey_encryption
 	Scenario: recreate masterkey and upload data
 		Given user "user0" has been created
 		And user "user0" has uploaded file "data/textfile.txt" to "/somefile.txt"

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -4,9 +4,7 @@ Feature: external-storage
     Given using OCS API version "1"
     And using old DAV path
 
-  # TODO: change to @no_default_encryption once all this works with master key
   @local_storage
-  @no_encryption
   Scenario: Share by link a file inside a local external storage
     Given user "user0" has been created
     And user "user1" has been created
@@ -25,7 +23,6 @@ Feature: external-storage
       | mimetype | httpd/unix-directory |
 
   @local_storage
-  @no_encryption
   Scenario: Move a file into storage
     Given user "user0" has been created
     And user "user1" has been created
@@ -35,7 +32,6 @@ Feature: external-storage
     And as "user0" the file "/local_storage/foo1/textfile0.txt" should exist
 
   @local_storage
-  @no_encryption
   Scenario: Move a file out of storage
     Given user "user0" has been created
     And user "user1" has been created

--- a/tests/acceptance/features/apiMain/transfer-ownership.feature
+++ b/tests/acceptance/features/apiMain/transfer-ownership.feature
@@ -143,7 +143,6 @@ Feature: transfer-ownership
 		And using received transfer folder of "user1" as dav path
 		And the downloaded content when downloading file "/test/somefile.txt" for user "user1" with range "bytes=0-6" should be "This is"
 
-	@no_default_encryption
 	Scenario: transferring ownership of only a single folder containing an empty folder
 		Given user "user0" has been created
 		And user "user1" has been created
@@ -155,7 +154,6 @@ Feature: transfer-ownership
 		And as "user1" the folder "/test" should exist
 		And as "user1" the folder "/test/subfolder" should exist
 
-	@no_default_encryption
 	Scenario: transferring ownership of an account containing only an empty folder
 		Given user "user0" has been created
 		And user "user1" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -7,7 +7,6 @@ So that I can manage apps
 	Background:
 		Given using OCS API version "1"
 
-	@no_encryption
 	Scenario: admin gets enabled apps
 		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
 		Then the OCS status code should be "100"

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -7,7 +7,6 @@ So that I can manage apps
 	Background:
 		Given using OCS API version "2"
 
-	@no_encryption
 	Scenario: admin gets enabled apps
 		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
 		Then the OCS status code should be "200"

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -169,36 +169,6 @@ function env_alt_home_clear {
 	remote_occ ${ADMIN_AUTH} ${OCC_URL} "app:disable testing" || { echo "Unable to disable testing app" >&2; exit 1; }
 }
 
-function env_encryption_enable {
-	remote_occ ${ADMIN_AUTH} ${OCC_URL} "app:enable encryption"
-	remote_occ ${ADMIN_AUTH} ${OCC_URL} "encryption:enable"
-}
-
-function env_encryption_enable_master_key {
-	env_encryption_enable || { echo "Unable to enable masterkey encryption" >&2; exit 1; }
-	remote_occ ${ADMIN_AUTH} ${OCC_URL} "encryption:select-encryption-type masterkey --yes"
-}
-
-function env_encryption_enable_user_keys {
-	env_encryption_enable || { echo "Unable to enable user-keys encryption" >&2; exit 1; }
-	remote_occ ${ADMIN_AUTH} ${OCC_URL} "encryption:select-encryption-type user-keys --yes"
-}
-
-function env_encryption_disable {
-	remote_occ ${ADMIN_AUTH} ${OCC_URL} "encryption:disable"
-	remote_occ ${ADMIN_AUTH} ${OCC_URL} "app:disable encryption"
-}
-
-function env_encryption_disable_master_key {
-	env_encryption_disable || { echo "Unable to disable masterkey encryption" >&2; exit 1; }
-	remote_occ ${ADMIN_AUTH} ${OCC_URL} "config:app:delete encryption useMasterKey"
-}
-
-function env_encryption_disable_user_keys {
-	env_encryption_disable || { echo "Unable to disable user-keys encryption" >&2; exit 1; }
-	remote_occ ${ADMIN_AUTH} ${OCC_URL} "config:app:delete encryption userSpecificKey"
-}
-
 # expected variables
 # --------------------
 # $SUITE_FEATURE_TEXT - human readable which test to run
@@ -368,23 +338,7 @@ function teardown() {
 	then
 		env_alt_home_clear
 	fi
-	
-	# Disable encryption if requested
-	if [ "${OC_TEST_ENCRYPTION_ENABLED}" = "1" ]
-	then
-		env_encryption_disable
-	fi
-	
-	if [ "${OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED}" = "1" ]
-	then
-		env_encryption_disable_master_key
-	fi
-	
-	if [ "${OC_TEST_ENCRYPTION_USER_KEYS_ENABLED}" = "1" ]
-	then
-		env_encryption_disable_user_keys
-	fi
-	
+
 	if [ "${TEST_WITH_PHPDEVSERVER}" == "true" ]
 	then
 		kill ${PHPPID}
@@ -739,29 +693,10 @@ then
 	BEHAT_FILTER_TAGS='~@skipWhenTestingRemoteSystems&&'${BEHAT_FILTER_TAGS}
 fi
 
-# Enable encryption if requested
-if [ "${OC_TEST_ENCRYPTION_ENABLED}" = "1" ]
-then
-	env_encryption_enable
-	BEHAT_EXTRA_TAGS="~@no_encryption&&~@no_default_encryption"
-elif [ "${OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED}" = "1" ]
-then
-	env_encryption_enable_master_key
-	BEHAT_EXTRA_TAGS="~@no_encryption&&~@no_masterkey_encryption"
-elif [ "${OC_TEST_ENCRYPTION_USER_KEYS_ENABLED}" = "1" ]
-then
-	env_encryption_enable_user_keys
-	BEHAT_EXTRA_TAGS="~@no_encryption&&~@no_userkeys_encryption"
-else
-	BEHAT_EXTRA_TAGS="~@masterkey_encryption"
-fi
-
 if [ "${OC_TEST_ON_OBJECTSTORE}" = "1" ]
 then
-   	BEHAT_FILTER_TAGS="${BEHAT_FILTER_TAGS}&&~@skip_on_objectstore"
+	BEHAT_FILTER_TAGS="${BEHAT_FILTER_TAGS}&&~@skip_on_objectstore"
 fi
-
-BEHAT_FILTER_TAGS="${BEHAT_FILTER_TAGS}&&${BEHAT_EXTRA_TAGS}"
 
 # If the caller did not mention specific tags, skip the skipped tests by default
 if [ "${BEHAT_TAGS_OPTION_FOUND}" = false ]


### PR DESCRIPTION
partly backport of #32354
note that `recreatemasterkey.feature` was not deleted and the tests run in core as the encryption app is bundled in core for stable10