### PR TITLE
API acceptance tests for case-sensitive file move-rename

### DIFF
--- a/apps/testing/data/apiSkeleton/PARENT/CHILD/child.txt
+++ b/apps/testing/data/apiSkeleton/PARENT/CHILD/child.txt
@@ -1,1 +1,1 @@
-ownCloud test text file
+ownCloud test text file child

--- a/apps/testing/data/apiSkeleton/PARENT/parent.txt
+++ b/apps/testing/data/apiSkeleton/PARENT/parent.txt
@@ -1,1 +1,1 @@
-ownCloud test text file
+ownCloud test text file parent

--- a/apps/testing/data/apiSkeleton/textfile0.txt
+++ b/apps/testing/data/apiSkeleton/textfile0.txt
@@ -1,1 +1,1 @@
-ownCloud test text file
+ownCloud test text file 0

--- a/apps/testing/data/apiSkeleton/textfile1.txt
+++ b/apps/testing/data/apiSkeleton/textfile1.txt
@@ -1,1 +1,1 @@
-ownCloud test text file
+ownCloud test text file 1

--- a/apps/testing/data/apiSkeleton/textfile2.txt
+++ b/apps/testing/data/apiSkeleton/textfile2.txt
@@ -1,1 +1,1 @@
-ownCloud test text file
+ownCloud test text file 2

--- a/apps/testing/data/apiSkeleton/textfile3.txt
+++ b/apps/testing/data/apiSkeleton/textfile3.txt
@@ -1,1 +1,1 @@
-ownCloud test text file
+ownCloud test text file 3

--- a/apps/testing/data/apiSkeleton/textfile4.txt
+++ b/apps/testing/data/apiSkeleton/textfile4.txt
@@ -1,1 +1,1 @@
-ownCloud test text file
+ownCloud test text file 4

--- a/tests/acceptance/features/apiWebdav/webdav-related.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related.feature
@@ -343,7 +343,7 @@ Feature: webdav-related
 		When the administrator sets the quota of user "user0" to "10 MB" using the provisioning API
 		And user "user0" gets the following properties of folder "/" using the WebDAV API
 		  |{DAV:}quota-available-bytes|
-		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "10485429"
+		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "10485406"
 		Examples:
 			| dav_version   |
 			| old           |
@@ -363,7 +363,7 @@ Feature: webdav-related
 			| shareWith   | user0     |
 		When user "user0" gets the following properties of folder "/testquota" using the WebDAV API
 		  |{DAV:}quota-available-bytes|
-		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "10485429"
+		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "10485406"
 		Examples:
 			| dav_version   |
 			| old           |
@@ -376,7 +376,7 @@ Feature: webdav-related
 		And user "user0" has added file "/prueba.txt" of 93 bytes
 		When user "user0" gets the following properties of folder "/" using the WebDAV API
 		  |{DAV:}quota-available-bytes|
-		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "600"
+		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "577"
 		Examples:
 			| dav_version   |
 			| old           |
@@ -391,7 +391,7 @@ Feature: webdav-related
 		And user "user0" has shared file "user0.txt" with user "user1"
 		When user "user1" gets the following properties of folder "/" using the WebDAV API
 		  |{DAV:}quota-available-bytes|
-		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "693"
+		Then the single response should contain a property "{DAV:}quota-available-bytes" with value "670"
 		Examples:
 			| dav_version   |
 			| old           |

--- a/tests/acceptance/features/apiWebdav/webdav-related.feature
+++ b/tests/acceptance/features/apiWebdav/webdav-related.feature
@@ -37,6 +37,42 @@ Feature: webdav-related
 			| old           |
 			| new           |
 
+	Scenario Outline: Moving (renaming) a file to be only different case
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/textfile0.txt" to "/TextFile0.txt" using the WebDAV API
+		Then the HTTP status code should be "201"
+		And as "user0" the file "/textfile0.txt" should not exist
+		And the content of file "/TextFile0.txt" for user "user0" should be "ownCloud test text file 0" plus end-of-line
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
+	Scenario Outline: Moving (renaming) a file to a file with only different case to an existing file
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/textfile1.txt" to "/TextFile0.txt" using the WebDAV API
+		Then the HTTP status code should be "201"
+		And the content of file "/textfile0.txt" for user "user0" should be "ownCloud test text file 0" plus end-of-line
+		And the content of file "/TextFile0.txt" for user "user0" should be "ownCloud test text file 1" plus end-of-line
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
+	Scenario Outline: Moving (renaming) a file to a file in a folder with only different case to an existing file
+		Given using <dav_version> DAV path
+		And user "user0" has been created
+		When user "user0" moves file "/textfile1.txt" to "/PARENT/Parent.txt" using the WebDAV API
+		Then the HTTP status code should be "201"
+		And the content of file "/PARENT/parent.txt" for user "user0" should be "ownCloud test text file parent" plus end-of-line
+		And the content of file "/PARENT/Parent.txt" for user "user0" should be "ownCloud test text file 1" plus end-of-line
+		Examples:
+			| dav_version   |
+			| old           |
+			| new           |
+
 	Scenario Outline: Moving a file to a folder with no permissions
 		Given using <dav_version> DAV path
 		And user "user0" has been created
@@ -169,7 +205,7 @@ Feature: webdav-related
 		Given using <dav_version> DAV path
 		And user "user0" has been created
 		When user "user0" downloads the file "/textfile0.txt" using the WebDAV API
-		Then the downloaded content should be "ownCloud test text file" plus end-of-line
+		Then the downloaded content should be "ownCloud test text file 0" plus end-of-line
 		Examples:
 			| dav_version   |
 			| old           |

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -485,6 +485,19 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then /^the content of file "([^"]*)" should be "([^"]*)" plus end-of-line$/
+	 *
+	 * @param string $fileName
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function contentOfFileShouldBePlusEndOfLine($fileName, $content) {
+		$this->theUserDownloadsTheFileUsingTheAPI($fileName);
+		$this->downloadedContentShouldBePlusEndOfLine($content);
+	}
+
+	/**
 	 * @Then /^the content of file "([^"]*)" for user "([^"]*)" should be "([^"]*)"$/
 	 *
 	 * @param string $fileName


### PR DESCRIPTION
## Description
1) Make the content of the ``apiSkeleton`` text files all a bit different, so we can easily test which file is "really" which.
2) Add test scenarios for moving files with case differences.

## Related Issue
#32357 part

## Motivation and Context
Test.allTheThings

## How Has This Been Tested?
Local test runs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
