### PR TITLE
delete encryption related steps

### DIFF
--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -312,18 +312,6 @@ trait CommandLine {
 	}
 
 	/**
-	 * @When /^the administrator successfully recreates the encryption masterkey using the occ command$/
-	 * @Given /^the administrator has successfully recreated the encryption masterkey$/
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function recreateMasterKeyUsingOccCommand() {
-		$this->runOcc(['encryption:recreate-master-key', '-y']);
-		$this->theCommandShouldHaveBeenSuccessful();
-	}
-
-	/**
 	 * @When /^the administrator transfers ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)" using the occ command$/
 	 * @Given /^the administrator has transferred ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)"$/
 	 *


### PR DESCRIPTION
## Description
this steps have to move  over to the encryption app, tests already moved in https://github.com/owncloud/core/pull/32354

## Motivation and Context
encryption in not bundled in core any-more, so need to run the tests there

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 