### PR TITLE
skip encryption tests on object store

### DIFF
--- a/tests/acceptance/features/apiEncryption/recreatemasterkey.feature
+++ b/tests/acceptance/features/apiEncryption/recreatemasterkey.feature
@@ -1,4 +1,4 @@
-@api
+@api @skip_on_objectstore
 Feature: recreate-master-key
 
 	Scenario: recreate masterkey


### PR DESCRIPTION
this test fails on objectstore because drone does not include encryption in that run.