### PR TITLE
Remove automagic timezone changing

### DIFF
--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -1,8 +1,6 @@
 <?php /** @var $l \OCP\IL10N */ ?>
 <?php
-vendor_script('jsTimezoneDetect/jstz');
 script('core', [
-	'visitortimezone',
 	'lostpassword',
 	'login',
 	'browser-update'
@@ -58,7 +56,7 @@ script('core', [
 				<?php p($_['user_autofocus'] ? '' : 'autofocus'); ?>
 				autocomplete="on" autocapitalize="off" autocorrect="off" required>
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
-			<input type="submit" id="submit" class="login primary icon-confirm" title="<?php p($l->t('Log in')); ?>" value="" disabled="disabled"/>
+			<input type="submit" id="submit" class="login primary icon-confirm" title="<?php p($l->t('Log in')); ?>" value=""/>
 		</p>
 
 		<?php if (!empty($_['csrf_error'])) {
@@ -102,8 +100,6 @@ script('core', [
 			<label for="remember_login"><?php p($l->t('Stay logged in')); ?></label>
 		</div>
 		<?php endif; ?>
-		<input type="hidden" name="timezone-offset" id="timezone-offset"/>
-		<input type="hidden" name="timezone" id="timezone"/>
 		<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>">
 	</fieldset>
 </form>

--- a/settings/Application.php
+++ b/settings/Application.php
@@ -34,6 +34,7 @@ namespace OC\Settings;
 use OC\Server;
 use OC\AppFramework\Utility\TimeFactory;
 use OC\Settings\Controller\CorsController;
+use OC\Settings\Controller\TimezoneController;
 use OC\Settings\Controller\SettingsPageController;
 use OC\Settings\Controller\AppSettingsController;
 use OC\Settings\Controller\AuthSettingsController;
@@ -150,6 +151,15 @@ class Application extends App {
 				$c->query('Logger'),
 				$c->query('URLGenerator'),
 				$c->query('Config')
+			);
+		});
+		$container->registerService('TimezoneController', function (IContainer $c) {
+			return new TimezoneController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$c->query('Config'),
+				$c->query('L10N'),
+				$c->query('UserSession')
 			);
 		});
 

--- a/settings/Controller/TimezoneController.php
+++ b/settings/Controller/TimezoneController.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Settings\Controller;
+
+use OC\AppFramework\Http;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUserSession;
+use OCP\PreConditionNotMetException;
+
+/**
+ * @package OC\Settings\Controller
+ */
+class TimezoneController extends Controller {
+
+	/** @var IRequest */
+	protected $request;
+	/** @var IConfig  */
+	protected $config;
+	/** @var IL10N  */
+	protected $l;
+	/** @var IUserSession  */
+	protected $session;
+
+	public function __construct(
+		$appName,
+		IRequest $request,
+		IConfig $config,
+		IL10N $l,
+		IUserSession $session
+	) {
+		parent::__construct($appName, $request);
+		$this->request = $request;
+		$this->config = $config;
+		$this->l = $l;
+		$this->session = $session;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 */
+	public function set() {
+
+		$available = \DateTimeZone::listIdentifiers();
+		if (!in_array($this->request->getParam('timezoneInput'), $available, true)) {
+			return new JSONResponse(
+				['message' => $this->l->t('Timezone not recognised')],
+				Http::STATUS_BAD_REQUEST);
+		}
+		try {
+			$this->config->setUserValue(
+				$this->session->getUser()->getUID(),
+				'core',
+				'timezone',
+				$this->request->getParam('timezoneInput'));
+			return new JSONResponse(
+				['message' => $this->l->t('Done')],
+				Http::STATUS_ACCEPTED);
+		} catch (PreConditionNotMetException $e) {
+			return new JSONResponse(
+				['message' => $this->l->t('Could not save configuration')],
+				Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+
+}

--- a/settings/Panels/Personal/Profile.php
+++ b/settings/Panels/Personal/Profile.php
@@ -94,6 +94,17 @@ class Profile implements ISettings {
 		$selector->assign('commonlanguages', $commonLanguages);
 		$selector->assign('languages', $languages);
 
+		$timezoneSelector = new Template('settings', 'timezone');
+		$timezoneSelector->assign(
+			'activeTimezone',
+			$this->config->getUserValue(
+				$this->userSession->getUser()->getUID(),
+				'core',
+				'timezone',
+				null));
+		$timezoneSelector->assign('timezones', \DateTimeZone::listIdentifiers());
+
+
 		$tmpl = new Template('settings', 'panels/personal/profile');
 		$tmpl->assign('email', $this->userSession->getUser()->getEMailAddress());
 		$tmpl->assign('displayName', $this->userSession->getUser()->getDisplayName());
@@ -101,6 +112,7 @@ class Profile implements ISettings {
 		$tmpl->assign('avatarChangeSupported', $this->userSession->getUser()->canChangeAvatar());
 		$tmpl->assign('displayNameChangeSupported', $this->userSession->getUser()->canChangeDisplayName());
 		$tmpl->assign('passwordChangeSupported', $this->userSession->getUser()->canChangePassword());
+		$tmpl->assign('timezoneSelector', $timezoneSelector->fetchPage());
 		$groups = $this->groupManager->getUserGroupIds($this->userSession->getUser());
 		\sort($groups);
 		$tmpl->assign('groups', $groups);

--- a/settings/js/panels/profile.js
+++ b/settings/js/panels/profile.js
@@ -230,8 +230,21 @@ $(document).ready(function () {
 				location.reload();
 			}
 			else {
-				$('#passworderror').text(data.data.message);
+				OC.Notification.showTemporary(t('settings', 'Error saving language: {message}', { message: data.data.message }));
 			}
+		});
+		return false;
+	});
+
+	$("#timezoneInput").change(function () {
+		// Serialize the data
+		var post = $("#timezoneInput").serialize();
+		// Ajax foo
+		$.post(OC.generateUrl('/settings/personal/timezone'), post, function (data) {
+			OC.Notification.showTemporary(t('settings', 'Timezone saved'));
+
+		}).fail(function(data) {
+			OC.Notification.showTemporary(t('settings', 'Error saving timezone: {message}', { message: data.responseJSON.message }));
 		});
 		return false;
 	});

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -60,6 +60,8 @@ $application->registerRoutes($this, [
 		['name' => 'Cors#removeDomain', 'url' => '/settings/domains/{id}', 'verb' => 'DELETE'],
 		['name' => 'LegalSettings#setImprintUrl', 'url' => '/settings/admin/legal/imprint', 'verb' => 'POST'],
 		['name' => 'LegalSettings#setPrivacyPolicyUrl', 'url' => '/settings/admin/legal/privacypolicy', 'verb' => 'POST'],
+		// Timezone set support from personal profile settings
+		['name' => 'Timezone#set', 'url' => '/settings/personal/timezone', 'verb' => 'POST']
 	]
 ]);
 

--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -133,7 +133,7 @@ if ($_['passwordChangeSupported']) {
 ?>
 <form class="section">
 	<h2>
-		<label><?php p($l->t('Language'));?></label>
+		<label><?php p($l->t('Language & Timezone'));?></label>
 	</h2>
 	<?php print_unescaped($_['languageSelector']); ?>
 	<?php if (OC_Util::getEditionString() === OC_Util::EDITION_COMMUNITY): ?>
@@ -142,4 +142,5 @@ if ($_['passwordChangeSupported']) {
 			<em><?php p($l->t('Help translate'));?></em>
 		</a>
 	<?php endif; ?>
+	<?php print_unescaped($_['timezoneSelector']); ?>
 </form>

--- a/settings/templates/timezone.php
+++ b/settings/templates/timezone.php
@@ -1,0 +1,16 @@
+<select id="timezoneInput" name="timezoneInput" data-placeholder="<?php p($l->t('Timezone'));?>">
+	<?php if($_['activeTimezone'] === null) { ?>
+		<option value="<?php p($_['activeTimezone']);?>">
+			<?php p($l->t('Server default'));?>
+		</option>
+	<?php } else { ?>
+		<option value="<?php p($_['activeTimezone']);?>">
+			<?php p($_['activeTimezone']);?>
+		</option>
+	<?php } ?>
+	<?php foreach ($_['timezones'] as $timezone):?>
+		<option value="<?php p($timezone);?>">
+			<?php p($timezone);?>
+		</option>
+	<?php endforeach;?>
+</select>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
No automagic timezone set on login, which doesnt work when using SSO, in favour of selector in personal settings. Later, we could add the auto detection to flag up that you are in a different timezone, and maybe you want to change your settings to your current timezone.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/32165

## Motivation and Context
Automagic timezone changing when you travel affects everything you see in ownCloud, including activity emails. If you don't 'login' then this wont happen, so it is unreliable. AND this only happens when using the login form, SSO does not use this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):
Nothing set, default when you login:
<img width="556" alt="screen shot 2018-08-17 at 13 16 15" src="https://user-images.githubusercontent.com/660805/44265772-ebe2df00-a21f-11e8-87ef-abd1b18a17af.png">

When you have a timezone set, or preset by your admin (oc_preferences table, app=core, configkey=timezone)
<img width="611" alt="screen shot 2018-08-17 at 13 15 48" src="https://user-images.githubusercontent.com/660805/44265805-0ae17100-a220-11e8-89f9-8ee4f311f5b9.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
- [ ] Not sure if timezone lib is used elsewhere, remove from `package.json` ? 
- [ ] Unit tests on `SetTimezoneController`