### PR TITLE
Add escape character to like query

### DIFF
--- a/lib/private/DB/AdapterOCI8.php
+++ b/lib/private/DB/AdapterOCI8.php
@@ -39,7 +39,6 @@ class AdapterOCI8 extends Adapter {
 	const UNIX_TIMESTAMP_REPLACEMENT = "(cast(sys_extract_utc(systimestamp) as date) - date'1970-01-01') * 86400";
 
 	public function fixupStatement($statement) {
-		$statement = \preg_replace('( LIKE \?)', '$0 ESCAPE \'\\\'', $statement);
 		$statement = \preg_replace('/`(\w+)` ILIKE \?/', "LOWER(`$1`) LIKE LOWER(?) ESCAPE '\\' -- \\'' \n", $statement);  // FIXME workaround for singletick matching with regexes in SQLParserUtils::getUnquotedStatementFragments
 		$statement = \str_replace('`', '"', $statement);
 		$statement = \str_ireplace('NOW()', 'CURRENT_TIMESTAMP', $statement);

--- a/lib/private/DB/AdapterSqlite.php
+++ b/lib/private/DB/AdapterSqlite.php
@@ -39,7 +39,6 @@ class AdapterSqlite extends Adapter {
 	}
 
 	public function fixupStatement($statement) {
-		$statement = \preg_replace('( I?LIKE \?)', '$0 ESCAPE \'\\\'', $statement);
 		$statement = \preg_replace('/`(\w+)` ILIKE \?/', 'LOWER($1) LIKE LOWER(?)', $statement);
 		$statement = \str_replace('`', '"', $statement);
 		$statement = \str_ireplace('NOW()', 'datetime(\'now\')', $statement);

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
@@ -276,7 +276,7 @@ class ExpressionBuilder implements IExpressionBuilder {
 	public function like($x, $y, $type = null) {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->like($x, $y);
+		return $this->expressionBuilder->like($x, $y, "'\'");
 	}
 
 	/**
@@ -309,7 +309,7 @@ class ExpressionBuilder implements IExpressionBuilder {
 	public function notLike($x, $y, $type = null) {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);
-		return $this->expressionBuilder->notLike($x, $y);
+		return $this->expressionBuilder->notLike($x, $y, "'\'");
 	}
 
 	/**

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/MySqlExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/MySqlExpressionBuilder.php
@@ -28,6 +28,15 @@ class MySqlExpressionBuilder extends ExpressionBuilder {
 	/**
 	 * @inheritdoc
 	 */
+	public function like($x, $y, $type = null) {
+		$x = $this->helper->quoteColumnName($x);
+		$y = $this->helper->quoteColumnName($y);
+		return $this->expressionBuilder->like($x, $y);
+	}
+
+	/**
+	 * @inheritdoc
+	 */
 	public function iLike($x, $y, $type = null) {
 		$x = $this->helper->quoteColumnName($x);
 		$y = $this->helper->quoteColumnName($y);


### PR DESCRIPTION
## Description
As soon as the like pattern contains a wildcard _ or % the queries before this change will no match with any data in the database because the missing sql statment ESCAPE is missing which tells the database that \ is used as escape character.

There is a regex which adds ESCAPE to the statements but this one does not match on the queries which are generated with the query builder:

		$statement = \preg_replace('( I?LIKE \?)', '$0 ESCAPE \'\\\'', $statement);
Query builder statments don't use ? but :dcValue

## Related Issue
found during #31651 

## How Has This Been Tested?
- unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] search for a solution for stable10 - this change does not apply because of different dbal versions
- [ ] search for all like/notLike usage and analyse the impact