### PR TITLE
Allow to set cache scanner only by config, dont expose via class

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -524,13 +524,4 @@ class Scanner extends BasicEmitter implements IScanner {
 			// skip unavailable storages
 		}
 	}
-
-	/**
-	 * Set whether the cache is affected by scan operations
-	 *
-	 * @param boolean $active The active state of the cache
-	 */
-	public function setCacheActive($active) {
-		$this->cacheActive = $active;
-	}
 }


### PR DESCRIPTION
The function is used nowhere, and generaly it exposed internal implementation. If one wants to use it, there is a config flag - https://github.com/owncloud/core/blob/master/lib/private/Files/Cache/Scanner.php#L92