### PR TITLE
Make more acceptance test methods public

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -785,7 +785,7 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	private function extractRequestTokenFromResponse(ResponseInterface $response) {
+	public function extractRequestTokenFromResponse(ResponseInterface $response) {
 		$this->requestToken = \substr(
 			\preg_replace(
 				'/(.*)data-requesttoken="(.*)">(.*)/sm', '\2',

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -257,7 +257,7 @@ trait CommandLine {
 	 *
 	 * @return string|null
 	 */
-	private function findLastTransferFolderForUser($sourceUser, $targetUser) {
+	public function findLastTransferFolderForUser($sourceUser, $targetUser) {
 		$foundPaths = [];
 		$results = $this->listFolder($targetUser, '', 1);
 		foreach ($results as $path => $data) {

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1390,7 +1390,7 @@ trait Sharing {
 	/**
 	 * @return string authorization token
 	 */
-	private function getLastShareToken() {
+	public function getLastShareToken() {
 		if (\count($this->lastShareData->data->element) > 0) {
 			return $this->lastShareData->data[0]->token;
 		}

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -88,14 +88,14 @@ trait WebDav {
 	/**
 	 * @return string
 	 */
-	private function getOldDavPath() {
+	public function getOldDavPath() {
 		return "remote.php/webdav";
 	}
 
 	/**
 	 * @return string
 	 */
-	private function getNewDavPath() {
+	public function getNewDavPath() {
 		return "remote.php/dav";
 	}
 
@@ -173,7 +173,7 @@ trait WebDav {
 	 *
 	 * @return int DAV path version (1 or 2) selected, or appropriate for the endpoint
 	 */
-	private function getDavPathVersion($for = null) {
+	public function getDavPathVersion($for = null) {
 		if ($for === 'systemtags') {
 			// systemtags only exists since dav v2
 			return 2;
@@ -196,7 +196,7 @@ trait WebDav {
 	 *
 	 * @return string DAV path selected, or appropriate for the endpoint
 	 */
-	private function getDavPath($for = null) {
+	public function getDavPath($for = null) {
 		if ($this->getDavPathVersion($for) === 1) {
 			return $this->getOldDavPath();
 		}
@@ -1934,7 +1934,7 @@ trait WebDav {
 	 *
 	 * @return string encoded path
 	 */
-	private function encodePath($path) {
+	public function encodePath($path) {
 		// slashes need to stay
 		return \str_replace('%2F', '/', \rawurlencode($path));
 	}


### PR DESCRIPTION
## Description
Make various acceptance test methods public, that look useful.

## Motivation and Context
App acceptance tests need to be able to know what is the current value of ``davPath`` for times when they are making their own test steps. Unfortunately the methods in core were marked private. It is fine for them to be public so other acceptance test contexts can get the information.

## How Has This Been Tested?
Running locally against come customgroups refactoring that I cam doing.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
