### PR TITLE
Splitting config.sample.php into two files for core and app

### DIFF
--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This configuration file is only provided to document the different
+ * configuration options and their usage for apps maintained by ownCloud.
+ *
+ * DO NOT COMPLETELY BASE YOUR CONFIGURATION FILE ON THESE SAMPLES. THIS MAY BREAK
+ * YOUR INSTANCE. Instead, manually copy configuration switches that you
+ * consider important for your instance to your working ``config.php``, and
+ * apply configuration options that are pertinent for your instance.
+ *
+ * All keys are only valid if the corresponding app is installed and enabled.
+ * You MUST copy the keys needed to the active config.php file.
+ * 
+ * This file is used to generate the configuration documentation.
+ * Please consider following requirements of the current parser:
+ *  * all comments need to start with `/**` and end with ` *\/` - each on their
+ *    own line
+ *  * add a `@see CONFIG_INDEX` to copy a previously described config option
+ *    also to this line
+ *  * everything between the ` *\/` and the next `/**` will be treated as the
+ *    config option
+ *  * use RST syntax
+ */
+
+$CONFIG = array(
+
+/**
+ * App: Activity
+ * 
+ * Possible values: ``activity_expire_days`` days
+ */
+ 
+/**
+ * Retention for activities of the activity app
+ */
+
+'activity_expire_days' => 365,
+
+/**
+ * App: LDAP
+ * 
+ * Possible values: ``ldapIgnoreNamingRules`` 'doSet' or false
+ * 
+ * Possible values: ``user_ldap.enable_medial_search`` true or false
+ */
+ 
+/** 
+ */
+
+'ldapIgnoreNamingRules' => false,
+'user_ldap.enable_medial_search' => false,
+
+/**
+ * App: Market
+ * 
+ * Possible values: ``appstoreurl`` URL
+ */
+
+/**
+ * Configuring the download URL for apps
+ */
+
+'appstoreurl' => 'https://marketplace.owncloud.com',
+
+/**
+ * App: Firstrunwizard
+ * 
+ * Possible values: ``customclient_desktop`` URL
+ * 
+ * Possible values: ``customclient_android`` URL
+ * 
+ * Possible values: ``customclient_ios`` URL
+ */
+
+/** Configuring the download links for ownCloud clients, 
+ * as seen in the first-run wizard and on Personal pages
+ */
+ 
+'customclient_desktop' =>
+	'https://owncloud.org/install/#install-clients',
+'customclient_android' =>
+	'https://play.google.com/store/apps/details?id=com.owncloud.android',
+'customclient_ios' =>
+	'https://itunes.apple.com/us/app/owncloud/id543672169?mt=8',
+
+/**
+ * App: Richdocuments
+ * 
+ * Possible values: ``collabora_group`` string
+ */
+
+/** Configuring the group name for users allowed to use collabora
+ */
+
+'collabora_group' => '',
+
+
+);

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2,7 +2,7 @@
 
 /**
  * This configuration file is only provided to document the different
- * configuration options and their usage.
+ * configuration options and their usage for the core system.
  *
  * DO NOT COMPLETELY BASE YOUR CONFIGURATION FILE ON THIS SAMPLE. THIS MAY BREAK
  * YOUR INSTANCE. Instead, manually copy configuration switches that you
@@ -716,16 +716,6 @@ $CONFIG = array(
  * Some of the ownCloud code may be stored in alternate locations.
  */
 
-/**
- * This section is for configuring the download links for ownCloud clients, as
- * seen in the first-run wizard and on Personal pages.
- */
-'customclient_desktop' =>
-	'https://owncloud.org/install/#install-clients',
-'customclient_android' =>
-	'https://play.google.com/store/apps/details?id=com.owncloud.android',
-'customclient_ios' =>
-	'https://itunes.apple.com/us/app/owncloud/id543672169?mt=8',
 
 /**
  * If you want to store apps in a custom directory instead of ownCloud’s default 
@@ -980,7 +970,7 @@ $CONFIG = array(
 	'port' => 6379,
 	'timeout' => 0.0,
 	'password' => '', // Optional, if not defined no password will be used.
-	'dbindex' => 0, // Optional, if undefined SELECT will not run and will use Redis Server's default DB Index.
+	'dbindex' => 0,   // Optional, if undefined SELECT will not run and will use Redis Server's default DB Index.
 ],
 
 /**
@@ -992,8 +982,8 @@ $CONFIG = array(
  * Redis Cluster support requires the php module phpredis in version 3.0.0 or higher.
  *
  * Available failover modes:
- *  - \RedisCluster::FAILOVER_NONE - only send commands to master nodes (default)
- *  - \RedisCluster::FAILOVER_ERROR - failover to slaves for read commands if master is unavailable
+ *  - \RedisCluster::FAILOVER_NONE       - only send commands to master nodes (default)
+ *  - \RedisCluster::FAILOVER_ERROR      - failover to slaves for read commands if master is unavailable
  *  - \RedisCluster::FAILOVER_DISTRIBUTE - randomly distribute read commands across master and slaves
  */
 'redis.cluster' => [


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR splits the current ``config.sample.php`` into two files:

``config.sample.php`` core related
  and
``config.apps.sample.php`` apps related

``config.sample.php`` contains all keys for the core system.
It stays more or less the same, only one set of keys has been moved.
(The moved keys are not used when installing the system from scratch so no issue.)

``config.apps.sample.php`` contains now all keys for apps provided by ownCloud.
I went thru all repros and added all keys I have identified and described on best effort.


## Related Issue
- Fixes https://github.com/owncloud/core/issues/32268 (config.sample.php does not mention activity_expire_days)
- Fixing an old discussion 

## Motivation and Context
It clearly seperates keys used by core and those by apps.
It helps app developers to add keys to the right location

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
no test needed 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)

@settermjd as discussed on talk, you need to update your script generating the documentation version to add the new file.

Note: we are planning the same split for occ commands in documentation.
