### PR TITLE
[stable10] compare UIDs instead of objects when changing email address

### DIFF
--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -823,7 +823,7 @@ class UsersController extends Controller {
 		$user = $this->userManager->get($userId);
 		$sessionUser = $this->userSession->getUser();
 
-		if ($user !== $sessionUser) {
+		if ($user->getUID() !== $sessionUser->getUID()) {
 			$this->log->error("The logged in user is different than expected.", ['app' => 'settings']);
 			return new RedirectResponse($this->urlGenerator->linkToRoute('settings.SettingsPage.getPersonal', ['changestatus' => 'error']));
 		}

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -2306,14 +2306,25 @@ class UsersControllerTest extends \Test\TestCase {
 	public function testDifferentLoggedUserAndRequestUser() {
 		$token = 'AVerySecretToken';
 		$userId = 'ExistingUser';
+		$differentUserId = 'ExistingUser2';
 		$mailAddress = 'sample@email.com';
-		$userObject = $this->getMockBuilder('OCP\IUser')
+		$userObject = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()->getMock();
-		$diffUserObject = $this->getMockBuilder('OCP\IUser')
+		$userObject
+			->expects($this->atLeastOnce())
+			->method('getUID')
+			->willReturn($userId);
+
+		$diffUserObject = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()->getMock();
 
+		$diffUserObject
+			->expects($this->atLeastOnce())
+			->method('getUID')
+			->willReturn($differentUserId);
+			
 		$this->container['UserManager']
-			->expects($this->once())
+			->expects($this->atLeastOnce())
 			->method('get')
 			->with($userId)
 			->will($this->returnValue($userObject));


### PR DESCRIPTION
## Description
when strictly comparing objects two instances of the same class are not the same see https://secure.php.net/manual/en/language.oop5.object-comparison.php

## Motivation and Context
acceptance tests that try to change email addresses would fail with: `{"reqId":"1SFByAuzpbf68kTErEUV","level":3,"time":"2018-08-21T05:18:04+00:00","remoteAddr":"172.23.0.4","user":"user1","app":"settings","method":"GET","url":"\/settings\/mailaddress\/change\/MPoCQms4jPeoUAndqGG8f\/user1","message":"The logged in user is different than expected."}`

## How Has This Been Tested?
- change email while being logged in with the correct user
- change email while being logged in with an other user

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
