### PR TITLE
Fix the regression caused due to usage of part file in decrypt-all

### DIFF
--- a/lib/private/Encryption/DecryptAll.php
+++ b/lib/private/Encryption/DecryptAll.php
@@ -271,7 +271,9 @@ class DecryptAll {
 			\OC\Files\Storage\Wrapper\Encryption::setDisableWriteEncryption(true);
 			$this->rootView->copy($source, $target);
 			\OC\Files\Storage\Wrapper\Encryption::setDisableWriteEncryption(false);
+			View::setIgnorePartFile(true);
 			$this->rootView->rename($target, $source);
+			View::setIgnorePartFile(false);
 			list($storage, $internalPath) = $this->rootView->resolvePath($source);
 			//Update the encrypted column in file cache to zero, as the file is decrypted
 			$storage->getCache()->put($internalPath, ['encrypted' => 0]);

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -104,6 +104,8 @@ class View {
 
 	private $eventDispatcher;
 
+	private static $ignorePartFile = false;
+
 	/**
 	 * @param string $root
 	 * @throws \Exception If $root contains an invalid path
@@ -837,7 +839,7 @@ class View {
 						$result = $storage2->moveFromStorage($storage1, $internalPath1, $internalPath2);
 					}
 
-					if ((Cache\Scanner::isPartialFile($path1) && !Cache\Scanner::isPartialFile($path2)) && $result !== false) {
+					if ((Cache\Scanner::isPartialFile($path1) && !Cache\Scanner::isPartialFile($path2)) && $result !== false && (self::$ignorePartFile === false)) {
 						// if it was a rename from a part file to a regular file it was a write and not a rename operation
 
 						$this->writeUpdate($storage2, $internalPath2);
@@ -2191,5 +2193,17 @@ class View {
 		}
 		$this->mkdir($filePath);
 		return true;
+	}
+
+	/**
+	 * User can create part files example to a call for rename(), in effect
+	 * it might not be a part file. So for better control in such cases this
+	 * method would help to let the method in rename() to know if it is a
+	 * part file.
+	 *
+	 * @param bool $isIgnored
+	 */
+	public static function setIgnorePartFile($isIgnored) {
+		self::$ignorePartFile = $isIgnored;
 	}
 }

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -1297,7 +1297,9 @@ class ViewTest extends TestCase {
 		$scanner->scan('');
 		Filesystem::mount($storage, [], '/test/');
 		$view = new View('');
+		\OC::$server->getConfig()->setAppValue('core', 'ignorepartfile', 'true');
 		$this->assertTrue($view->rename('/test/foo.txt', '/test/foo/bar.txt'));
+		\OC::$server->getConfig()->deleteAppValue('core', 'ignorepartfile');
 	}
 
 	public function testSetMountOptionsInStorage() {


### PR DESCRIPTION
command

Fix the regression cuased due to the usage of part file in
decryptall command. An exception was thrown in the log
file during the rename operation.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This change fixes the exception caused during rename operation in the decrypt-all. This issue was caused due to the introduction of using `.part` extension to the target. The .part file change in the decrypt-all, didn't affected the outcome of rename method. In fact the files were getting decrypted properly. The exception was happening because `.part` file wasn't added to the filecache, and the during the cod flow, fileinfo of the `.part` file was being accessed. Which was not there. Hence caused an exception which was logged. Basically, the exception didn't harmed the rename operation. In this change, we let the rename method know that this part file needs to be ignored.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/encryption/issues/45

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change fixes the exception caused during rename operation in the decrypt-all. This issue was caused due to the introduction of using `.part` extension to the target.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...
With this PR I have tested with the shares as follows:
- Encrypt the filesystem with user-keys. Create 2 users `admin` and `user1`
- Login as `user1` and logout.
- Login as `admin` and create a group `group1`. 
- Add `user1` to `group1`
- create a file `localshare.txt` and share with `user1`
- create a file `groupshare.txt` and share with `group1`
- create a file `publiclink.txt` and create public link share of the file.
- Now try to decrypt the filey system as follows:

```
➜  owncloud3 git:(master) ✗ ./occ maintenance:singleuser --on; ./occ encryption:decrypt-all -m recovery -c yes; ./occ encryption:disable; ./occ app:disable encryption;
Cannot load Xdebug - it was already loaded
Single user mode enabled
Cannot load Xdebug - it was already loaded
Disable server side encryption... done.


You are about to start to decrypt all files stored in your ownCloud.
It will depend on the encryption module and your setup if this is possible.
Depending on the number and size of your files this can take some time
Please make sure that no user access his files during this process!

prepare encryption modules...
 done.


 starting to decrypt files... 
 [->--------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
 decrypt files for user admin (1 of 2): /admin/files/welcome.txt 
 [----->----------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
 decrypt files for user user1 (2 of 2): /user1/files/welcome.txt 
 [------>---------------------]

 starting to decrypt files... finished 
 [============================]


all files could be decrypted successfully!
Cannot load Xdebug - it was already loaded
Encryption is already disabled
Cannot load Xdebug - it was already loaded
encryption disabled
➜  owncloud3 git:(master) ✗

```
- Now update the database as follows:
```
➜  owncloud3 git:(master) ✗ sqlite3 data/owncloud.db                                                                  
SQLite version 3.22.0 2018-01-22 18:45:57
Enter ".help" for usage hints.
sqlite> select * from oc_appconfig where appid='encryption';
encryption|recoveryKeyId|recoveryKey_09771295
encryption|publicShareKeyId|pubShare_09771295
encryption|masterKeyId|master_09771295
encryption|installed_version|1.3.1
encryption|types|filesystem
encryption|enabled|no
encryption|userSpecificKey|1
encryption|recoveryAdminEnabled|1
sqlite> delete from oc_appconfig where appid='encryption';
sqlite> select * from oc_appconfig where appid='encryption';
sqlite> 
➜  owncloud3 git:(master) ✗
```
- delete the folders `files_encryption` in the data folder

```
➜  owncloud3 git:(master) ✗ rm -fr ./data/files_encryption ./data/user1/files_encryption ./data/admin/files_encryption 
➜  owncloud3 git:(master) ✗
```

- re-encrypt the file system with master key as follows:

```
➜  owncloud3 git:(master) ✗ ./occ app:enable encryption; ./occ encryption:enable; ./occ encryption:select-encryption-type masterkey -y; ./occ encryption:encrypt-all -vvv; ./occ maintenance:singleuser --off
Cannot load Xdebug - it was already loaded
encryption enabled
Cannot load Xdebug - it was already loaded
Encryption enabled

Default module: OC_DEFAULT_MODULE
Cannot load Xdebug - it was already loaded
Master key successfully enabled.
Cannot load Xdebug - it was already loaded


You are about to encrypt all files stored in your ownCloud installation.
Depending on the number of available files, and their size, this may take quite some time.
Please ensure that no user accesses their files during this time!
Note: The encryption module you use determines which files get encrypted.

Do you really want to continue? (y/n) y


Encrypt all files with the Default encryption module
====================================================


Use master key to encrypt all files.


Start to encrypt users files
----------------------------



 all files encrypted 
 [============================]

Cannot load Xdebug - it was already loaded
Single user mode disabled
➜  owncloud3 git:(master) ✗
```
All the shares created were accessible for `user1`. The public link was also accessible.

- test recreate master-key command

```
➜  owncloud3 git:(master) ✗ ./occ encryption:recreate-master-key -y                                                                                                       
Cannot load Xdebug - it was already loaded
Decryption started

    1 [->--------------------------]prepare encryption modules...
 done.


 decrypt files for user user1 (2 of 2): /user1/files/welcome.txt 
 [------>---------------------]

 starting to decrypt files... finished 
 [============================]


all files could be decrypted successfully!
    1 [============================]
Decryption completed

Encryption started

Waiting for creating new masterkey

New masterkey created successfully



Encrypt all files with the Default encryption module
====================================================


Use master key to encrypt all files.


Start to encrypt users files
----------------------------



 all files encrypted 
 [============================]


Encryption completed successfully

➜  owncloud3 git:(master) ✗
```
Did not found the data loss. The shares were again available.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
