### PR TITLE
don't crash on filescan where folder has symlink

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -430,7 +430,7 @@ class Scanner extends BasicEmitter implements IScanner {
 					} elseif ($data['mimetype'] === 'httpd/unix-directory' and $recursive === self::SCAN_RECURSIVE_INCOMPLETE and $data['size'] === -1) {
 						// only recurse into folders which aren't fully scanned
 						$childQueue[$child] = $data['fileid'];
-					} elseif ($data['size'] === -1) {
+					} elseif (!isSet($data['size']) || $data['size'] === -1) {
 						$size = -1;
 					} elseif ($size !== -1) {
 						$size += $data['size'];

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -430,7 +430,7 @@ class Scanner extends BasicEmitter implements IScanner {
 					} elseif ($data['mimetype'] === 'httpd/unix-directory' and $recursive === self::SCAN_RECURSIVE_INCOMPLETE and $data['size'] === -1) {
 						// only recurse into folders which aren't fully scanned
 						$childQueue[$child] = $data['fileid'];
-					} elseif (!isSet($data['size']) || $data['size'] === -1) {
+					} elseif (!isset($data['size']) || $data['size'] === -1) {
 						$size = -1;
 					} elseif ($size !== -1) {
 						$size += $data['size'];


### PR DESCRIPTION
$data['size'] does not exist for symlink files

