### PR TITLE
[stable10] compare UIDs instead of objects when changing displayname

### DIFF
--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -710,7 +710,7 @@ class UsersController extends Controller {
 			(
 				!$this->groupManager->isAdmin($currentUser->getUID()) &&
 				!$this->groupManager->getSubAdmin()->isUserAccessible($currentUser, $user) &&
-				$currentUser !== $user)
+				$currentUser->getUID() !== $user->getUID())
 			) {
 			return new DataResponse([
 				'status' => 'error',


### PR DESCRIPTION
same problem as in https://github.com/owncloud/core/pull/32391