### PR TITLE
gitignore the testing app - it is no longer in core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@
 !/apps/files_versions
 !/apps/provisioning_api
 !/apps/systemtags
-!/apps/testing
 !/apps/theme-example
 !/apps/updatenotification
 /apps/files_external/3rdparty/irodsphp/PHPUnitTest


### PR DESCRIPTION
## Description
Do not exclude the testing app from being ignored by git.

## Motivation and Context
When cloning the testing app into inside a clone of core, git thinks the testing app files are new files for core.

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
