### PR TITLE
Remove core references to apps/testing that are no longer relevant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,6 @@ $(dist_dir)/owncloud: $(composer_deps) $(nodejs_deps) $(core_all_src)
 	rm -Rf $@; mkdir -p $@/config
 	cp -RL $(core_all_src) $@
 	cp -R config/config.sample.php $@/config
-	rm -Rf $(dist_dir)/owncloud/apps/testing
 	find $@ -name .gitkeep -delete
 	find $@ -name .gitignore -delete
 	find $@ -name no-php -delete

--- a/build/license.php
+++ b/build/license.php
@@ -271,7 +271,6 @@ if (isset($argv[1])) {
 		__DIR__ . '/../apps/files_versions',
 		__DIR__ . '/../apps/provisioning_api',
 		__DIR__ . '/../apps/systemtags',
-		__DIR__ . '/../apps/testing',
 		__DIR__ . '/../apps/updatenotification',
 		__DIR__ . '/../core',
 		__DIR__ . '/../lib',

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -31,7 +31,6 @@
 				<directory suffix=".php">../apps/files_trashbin/tests</directory>
 				<directory suffix=".php">../apps/files_versions/tests</directory>
 				<directory suffix=".php">../apps/provisioning_api/tests</directory>
-				<directory suffix=".php">../apps/testing</directory>
 				<directory suffix=".php">../apps/updatenotification/tests</directory>
 				<directory suffix=".php">../tests</directory>
 				<directory suffix=".php">../build</directory>


### PR DESCRIPTION
## Description
Remove core reference to ``apps/testing`` that are no longer relevant.
 
## Motivation and Context
Some scripts and settings in core still refer to ``apps/acceptance`` as if it still lives in core.

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
