### PR TITLE
API acceptance tests for slash in group name

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -33,6 +33,31 @@ So that I can more easily manage access to resources by groups rather than indiv
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
+	# Note: these groups do get created OK, but the "should exist" step fails
+	# because the API to check their existence does not work.
+	@skip @issue-31015
+	Scenario Outline: admin creates a group with a forward-slash in the group name
+		When the administrator sends a group creation request for group "<group_id>" using the provisioning API
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And group "<group_id>" should exist
+		Examples:
+			| group_id            | comment                                 |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| var/../etc          | using slash-dot-dot                     |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+
+	# A group name must not end in "/subadmins" because that would create ambiguity
+	# with the endpoint for getting the subadmins of a group
+	@skip @issue-31015
+	Scenario: admin tries to create a group with name ending in "/subadmins"
+		Given group "new-group" has been created
+		When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
+		Then the OCS status code should be "101"
+		And the HTTP status code should be "200"
+		And group "priv/subadmins" should not exist
+
 	Scenario: admin tries to create a group that already exists
 		Given group "new-group" has been created
 		When the administrator sends a group creation request for group "new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -35,6 +35,21 @@ So that I can give a user access to the resources of the group
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
+	@skip @issue-31015
+	Scenario Outline: adding a user to a group that has a forward-slash in the group name
+		Given user "brand-new-user" has been created
+		And group "<group_id>" has been created
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+			| groupid | <group_id> |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		Examples:
+			| group_id            | comment                                 |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| var/../etc          | using slash-dot-dot                     |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+
 	Scenario: normal user tries to add himself to a group
 		Given user "brand-new-user" has been created
 		When user "brand-new-user" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -34,6 +34,20 @@ So that I can remove unnecessary groups
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
+	@skip @issue-31015
+	Scenario Outline: admin deletes a group that has a forward-slash in the group name
+		Given group "<group_id>" has been created
+		When the administrator deletes group "<group_id>" using the provisioning API
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And group "<group_id>" should not exist
+		Examples:
+			| group_id            | comment                                 |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| var/../etc          | using slash-dot-dot                     |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+
 	Scenario: normal user tries to delete the group
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
@@ -30,6 +30,40 @@ So that I can manage group membership
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
 
+	# Note: when the issue is fixed, use this scenario and delete the scenario above.
+	@skip @issue-31015
+	Scenario: admin gets groups of an user, including groups containing a slash
+		Given user "brand-new-user" has been created
+		And group "unused-group" has been created
+		And group "new-group" has been created
+		And group "0" has been created
+		And group "Admin & Finance (NP)" has been created
+		And group "admin:Pokhara@Nepal" has been created
+		And group "नेपाली" has been created
+		And group "Mgmt/Sydney" has been created
+		And group "var/../etc" has been created
+		And group "priv/subadmins/1" has been created
+		And user "brand-new-user" has been added to group "new-group"
+		And user "brand-new-user" has been added to group "0"
+		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
+		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
+		And user "brand-new-user" has been added to group "नेपाली"
+		And user "brand-new-user" has been added to group "Mgmt/Sydney"
+		And user "brand-new-user" has been added to group "var/../etc"
+		And user "brand-new-user" has been added to group "priv/subadmins/1"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+		Then the groups returned by the API should be
+			| new-group            |
+			| 0                    |
+			| Admin & Finance (NP) |
+			| admin:Pokhara@Nepal  |
+			| नेपाली               |
+			| Mgmt/Sydney          |
+			| var/../etc           |
+			| priv/subadmins/1     |
+		And the OCS status code should be "100"
+		And the HTTP status code should be "200"
+
 	Scenario: subadmin tries to get other groups of the user in his group
 		Given user "newuser" has been created
 		And user "subadmin" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -37,6 +37,23 @@ So that I can manage user access to group resources
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
+	@skip @issue-31015
+	Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
+		Given user "brand-new-user" has been created
+		And group "<group_id>" has been created
+		And user "brand-new-user" has been added to group "<group_id>"
+		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+			| groupid | <group_id> |
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And user "brand-new-user" should not belong to group "<group_id>"
+		Examples:
+			| group_id            | comment                                 |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| var/../etc          | using slash-dot-dot                     |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+
 	Scenario: admin tries to remove a user from a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -33,6 +33,31 @@ So that I can more easily manage access to resources by groups rather than indiv
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
+	# Note: these groups do get created OK, but the "should exist" step fails
+	# because the API to check their existence does not work.
+	@skip @issue-31015
+	Scenario Outline: admin creates a group with a forward-slash in the group name
+		When the administrator sends a group creation request for group "<group_id>" using the provisioning API
+		Then the OCS status code should be "200"
+		And the HTTP status code should be "200"
+		And group "<group_id>" should exist
+		Examples:
+			| group_id            | comment                                 |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| var/../etc          | using slash-dot-dot                     |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+
+	# A group name must not end in "/subadmins" because that would create ambiguity
+	# with the endpoint for getting the subadmins of a group
+	@skip @issue-31015
+	Scenario: admin tries to create a group with name ending in "/subadmins"
+		Given group "new-group" has been created
+		When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
+		Then the OCS status code should be "400"
+		And the HTTP status code should be "400"
+		And group "priv/subadmins" should not exist
+
 	Scenario: admin tries to create a group that already exists
 		Given group "new-group" has been created
 		When the administrator sends a group creation request for group "new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -35,6 +35,21 @@ So that I can give a user access to the resources of the group
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
+	@skip @issue-31015
+	Scenario Outline: adding a user to a group that has a forward-slash in the group name
+		Given user "brand-new-user" has been created
+		And group "<group_id>" has been created
+		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+			| groupid | <group_id> |
+		Then the OCS status code should be "200"
+		And the HTTP status code should be "200"
+		Examples:
+			| group_id            | comment                                 |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| var/../etc          | using slash-dot-dot                     |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+
 	@skip @issue-31276
 	Scenario: normal user tries to add himself to a group
 		Given user "brand-new-user" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -34,6 +34,20 @@ So that I can remove unnecessary groups
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
+	@skip @issue-31015
+	Scenario Outline: admin deletes a group that has a forward-slash in the group name
+		Given group "<group_id>" has been created
+		When the administrator deletes group "<group_id>" using the provisioning API
+		Then the OCS status code should be "200"
+		And the HTTP status code should be "200"
+		And group "<group_id>" should not exist
+		Examples:
+			| group_id            | comment                                 |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| var/../etc          | using slash-dot-dot                     |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+
 	@skip @issue-31276
 	Scenario: normal user tries to delete the group
 		Given user "brand-new-user" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
@@ -30,6 +30,40 @@ So that I can manage group membership
 		And the OCS status code should be "200"
 		And the HTTP status code should be "200"
 
+	# Note: when the issue is fixed, use this scenario and delete the scenario above.
+	@skip @issue-31015
+	Scenario: admin gets groups of an user, including groups containing a slash
+		Given user "brand-new-user" has been created
+		And group "unused-group" has been created
+		And group "new-group" has been created
+		And group "0" has been created
+		And group "Admin & Finance (NP)" has been created
+		And group "admin:Pokhara@Nepal" has been created
+		And group "नेपाली" has been created
+		And group "Mgmt/Sydney" has been created
+		And group "var/../etc" has been created
+		And group "priv/subadmins/1" has been created
+		And user "brand-new-user" has been added to group "new-group"
+		And user "brand-new-user" has been added to group "0"
+		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
+		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
+		And user "brand-new-user" has been added to group "नेपाली"
+		And user "brand-new-user" has been added to group "Mgmt/Sydney"
+		And user "brand-new-user" has been added to group "var/../etc"
+		And user "brand-new-user" has been added to group "priv/subadmins/1"
+		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+		Then the groups returned by the API should be
+			| new-group            |
+			| 0                    |
+			| Admin & Finance (NP) |
+			| admin:Pokhara@Nepal  |
+			| नेपाली               |
+			| Mgmt/Sydney          |
+			| var/../etc           |
+			| priv/subadmins/1     |
+		And the OCS status code should be "200"
+		And the HTTP status code should be "200"
+
 	Scenario: subadmin tries to get other groups of the user in his group
 		Given user "newuser" has been created
 		And user "subadmin" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -37,7 +37,24 @@ So that I can manage user access to group resources
 			| 50%2Fix             | %2F literal looks like an escaped slash |
 			| staff?group         | Question mark                           |
 
-		Scenario: admin tries to remove a user from a group which does not exist
+	@skip @issue-31015
+	Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
+		Given user "brand-new-user" has been created
+		And group "<group_id>" has been created
+		And user "brand-new-user" has been added to group "<group_id>"
+		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+			| groupid | <group_id> |
+		Then the OCS status code should be "200"
+		And the HTTP status code should be "200"
+		And user "brand-new-user" should not belong to group "<group_id>"
+		Examples:
+			| group_id            | comment                                 |
+			| Mgmt/Sydney         | Slash (special escaping happens)        |
+			| Mgmt//NSW/Sydney    | Multiple slash                          |
+			| var/../etc          | using slash-dot-dot                     |
+			| priv/subadmins/1    | Subadmins mentioned not at the end      |
+
+	Scenario: admin tries to remove a user from a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
 		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -969,6 +969,18 @@ trait Provisioning {
 	}
 
 	/**
+	 * @When /^the administrator tries to send a group creation request for group "([^"]*)" using the provisioning API$/
+	 *
+	 * @param string $group
+	 *
+	 * @return void
+	 */
+	public function adminTriesToSendGroupCreationRequestUsingTheAPI($group) {
+		$this->adminSendsGroupCreationRequestUsingTheAPI($group);
+		$this->rememberThatGroupIsNotExpectedToExist($group);
+	}
+
+	/**
 	 * creates a single group
 	 *
 	 * @param string $group


### PR DESCRIPTION
## Description
Add acceptance test scenarios for the provisioning API for managing groups with a slash in the group name.

## Related Issue
#31015 

## Motivation and Context
Group names containing a slash ``/`` do not work in the provisioning API.
Let's document test scenarios that should work, so a future fix can use them.

## How Has This Been Tested?
CI runs without the skip tag, confirming that these scenarios currently fail.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
