### PR TITLE
allow to set password when sending direct requests in accenptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -637,6 +637,19 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to URL "([^"]*)" with password "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $verb
+	 * @param string $url
+	 *
+	 * @return void
+	 */
+	public function userSendsHTTPMethodToUrlWithPassword($user, $verb, $url, $password) {
+		$this->sendingToWithDirectUrl($user, $verb, $url, null, $password);
+	}
+
+	/**
 	 * @param string $user
 	 * @param string $verb
 	 * @param string $url
@@ -644,12 +657,16 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	public function sendingToWithDirectUrl($user, $verb, $url, $body) {
+	public function sendingToWithDirectUrl($user, $verb, $url, $body, $password = null) {
 		$fullUrl = $this->getBaseUrl() . $url;
 		$client = new Client();
 		$options = [];
-		$options['auth'] = $this->getAuthOptionForUser($user);
-
+		if ($password === null) {
+			$options['auth'] = $this->getAuthOptionForUser($user);
+		} else {
+			$options['auth'] = [$user, $password];
+		}
+		
 		if (!empty($this->cookieJar->toArray())) {
 			$options['cookies'] = $this->cookieJar;
 		}


### PR DESCRIPTION
## Description
extra steps that allow to specify a password when sending requests

## Related Issue
https://github.com/owncloud/brute_force_protection/issues/12

## Motivation and Context
in bruteforce protection we want to specify invalid passwords for requests to see if users are blocked correctly

## How Has This Been Tested?
made tests in bruteforce protection app that use this steps

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
