### PR TITLE
skipOnLDAP test scenarios that add a user to a group

### DIFF
--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -52,6 +52,7 @@ Feature: Display notifications when receiving a share
 
 	# This scenario documents behavior discussed in core issue 31870
 	# An old share keeps its old auto-accept behavior, even after auto-accept has been disabled.
+	@skipOnLDAP
 	Scenario: share to group does not send notifications to either existing or new members for an old share created before auto-accept is disabled
 		Given user "user0" has shared folder "/PARENT" with group "grp1"
 		When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "no"
@@ -63,6 +64,7 @@ Feature: Display notifications when receiving a share
 
 	# This scenario documents behavior discussed in core issue 31870
 	# As users are added to an existing group, they are not sent notifications about group shares.
+	@skipOnLDAP
 	Scenario: share to group sends notifications to existing members, but not to new members, for a share created after auto-accept is disabled
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
 		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API
@@ -87,6 +89,7 @@ Feature: Display notifications when receiving a share
 	# This scenario documents behavior discussed in core issue 31870
 	# Similar to the previous scenario, a new user added to the group does not get a notification,
 	# even though the group, when originally created, had notifications on.
+	@skipOnLDAP
 	Scenario: share to group sends notifications to existing members, but not to new members, for an old share created before auto-accept is enabled
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
 		And user "user0" has shared folder "/PARENT" with group "grp1"
@@ -109,6 +112,7 @@ Feature: Display notifications when receiving a share
 			| object_type | /^local_share$/                         |
 		And user "user3" should have 0 notifications
 
+	@skipOnLDAP
 	Scenario: share to group does not send notifications to existing and new members for a share created after auto-accept is enabled
 		Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
 		When user "user0" shares folder "/PARENT" with group "grp1" using the sharing API


### PR DESCRIPTION
## Description
``skipOnLDAP`` the new acceptance test scenarios added by PR #31913 

## Related Issue
#31870 

## Motivation and Context
These acceptance test scenarios are failing on ``user_ldap`` CI because they need to change group membership during the test - they try to add ``user3`` t o``grp1``. In the LDAP environment, that cannot be done within ownCloud. So we need to skip such scenarios.

Some time in the future we might add the capability for the acceptance tests to "externally" manage the test LDAP server and sync changes etc, but not now.

## How Has This Been Tested?
We will know when ``user_ldap`` CI runs overnight.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
