### PR TITLE
[stable10] Be consistent in acceptance test steps 'when the administrator'

### DIFF
--- a/tests/acceptance/features/apiMain/status.feature
+++ b/tests/acceptance/features/apiMain/status.feature
@@ -2,7 +2,7 @@
 Feature: Status
 
   Scenario: Status.php is correct
-      When the admin requests status.php
+      When the administrator requests status.php
       Then the status.php response should match with
       """
       {"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"$CURRENT_VERSION","versionstring":"$CURRENT_VERSION_STRING","edition":"Community","productname":"ownCloud"}

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1022,7 +1022,7 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @When the admin requests status.php
+	 * @When the administrator requests status.php
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/WebUIAdminAppsSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminAppsSettingsContext.php
@@ -50,8 +50,8 @@ class WebUIAdminAppsSettingsContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the admin browses to the admin apps settings page
-	 * @Given the admin has browsed to the admin apps settings page
+	 * @When the administrator browses to the admin apps settings page
+	 * @Given the administrator has browsed to the admin apps settings page
 	 *
 	 * @return void
 	 */
@@ -64,7 +64,7 @@ class WebUIAdminAppsSettingsContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given the admin has browsed to disabled apps page
+	 * @Given the administrator has browsed to the disabled apps page
 	 *
 	 * @return void
 	 */
@@ -76,7 +76,7 @@ class WebUIAdminAppsSettingsContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the admin disables the app :app using the webUI
+	 * @When the administrator disables the app :app using the webUI
 	 *
 	 * @param string $appName
 	 *
@@ -90,7 +90,7 @@ class WebUIAdminAppsSettingsContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the admin enables the app :app using the webUI
+	 * @When the administrator enables the app :app using the webUI
 	 *
 	 * @param string $appName
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -52,8 +52,8 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When the admin browses to the admin sharing settings page
-	 * @Given the admin has browsed to the admin sharing settings page
+	 * @When the administrator browses to the admin sharing settings page
+	 * @Given the administrator has browsed to the admin sharing settings page
 	 *
 	 * @return void
 	 */
@@ -63,7 +63,7 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When /^the admin (enables|disables) the share API using the webUI$/
+	 * @When /^the administrator (enables|disables) the share API using the webUI$/
 	 * @param string $action
 	 *
 	 * @return void
@@ -76,7 +76,7 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When /^the admin (enables|disables) share via link using the webUI$/
+	 * @When /^the administrator (enables|disables) share via link using the webUI$/
 	 * @param string $action
 	 *
 	 * @return void
@@ -89,7 +89,7 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When /^the admin (enables|disables) public uploads using the webUI$/
+	 * @When /^the administrator (enables|disables) public uploads using the webUI$/
 	 * @param string $action
 	 *
 	 * @return void
@@ -102,7 +102,7 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When /^the admin (enables|disables) mail notification on public share using the webUI$/
+	 * @When /^the administrator (enables|disables) mail notification on public share using the webUI$/
 	 * @param string $action
 	 *
 	 * @return void
@@ -115,7 +115,7 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When /^the admin (enables|disables) social media share on public share using the webUI$/
+	 * @When /^the administrator (enables|disables) social media share on public share using the webUI$/
 	 * @param string $action
 	 *
 	 * @return void
@@ -128,7 +128,7 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When /^the admin (enables|disables) enforce password protection for read-only links using the webUI$/
+	 * @When /^the administrator (enables|disables) enforce password protection for read-only links using the webUI$/
 	 * @param string $action
 	 *
 	 * @return void
@@ -141,7 +141,7 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When /^the admin (enables|disables) enforce password protection for read and write links using the webUI$/
+	 * @When /^the administrator (enables|disables) enforce password protection for read and write links using the webUI$/
 	 * @param string $action
 	 *
 	 * @return void
@@ -154,7 +154,7 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When /^the admin (enables|disables) enforce password protection for upload only links using the webUI$/
+	 * @When /^the administrator (enables|disables) enforce password protection for upload only links using the webUI$/
 	 * @param string $action
 	 *
 	 * @return void
@@ -167,7 +167,7 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When /^the admin (enables|disables) resharing using the webUI$/
+	 * @When /^the administrator (enables|disables) resharing using the webUI$/
 	 * @param string $action
 	 *
 	 * @return void
@@ -180,7 +180,7 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When /^the admin (enables|disables) sharing with groups using the webUI$/
+	 * @When /^the administrator (enables|disables) sharing with groups using the webUI$/
 	 * @param string $action
 	 *
 	 * @return void
@@ -193,7 +193,7 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When /^the admin (enables|disables) restrict users to only share with their group members using the webUI$/
+	 * @When /^the administrator (enables|disables) restrict users to only share with their group members using the webUI$/
 	 * @param string $action
 	 *
 	 * @return void

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -215,7 +215,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the admin disables the user :username using the webUI
+	 * @When the administrator disables the user :username using the webUI
 	 *
 	 * @param string $username
 	 *

--- a/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
@@ -5,15 +5,15 @@ Feature: admin apps settings
 	So that I can enable or disable apps on the ownCloud server
 
 	Background:
-		Given the admin has browsed to the admin apps settings page
+		Given the administrator has browsed to the admin apps settings page
 
 	Scenario: admin disables an app
 		Given the app "comments" has been enabled
-		When the admin disables the app "comments" using the webUI
+		When the administrator disables the app "comments" using the webUI
 		Then app "comments" should be disabled
 
 	Scenario: admin enables an app
 		Given the app "comments" has been disabled
-		And the admin has browsed to disabled apps page
-		When the admin enables the app "comments" using the webUI
+		And the administrator has browsed to the disabled apps page
+		When the administrator enables the app "comments" using the webUI
 		Then app "comments" should be enabled

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -5,88 +5,88 @@ Feature: admin sharing settings
 	So that I can enable, disable, allow or restrict different sharing behaviour
 
 	Scenario: disable share API
-		Given the admin has browsed to the admin sharing settings page
-		When the admin disables the share API using the webUI
+		Given the administrator has browsed to the admin sharing settings page
+		When the administrator disables the share API using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value |
 			| files_sharing | api_enabled     | EMPTY |
 
 	Scenario: disable public sharing
-		Given the admin has browsed to the admin sharing settings page
-		When the admin disables share via link using the webUI
+		Given the administrator has browsed to the admin sharing settings page
+		When the administrator disables share via link using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element  | value |
 			| files_sharing | public@@@enabled | EMPTY |
 
 	Scenario: disable public upload
-		Given the admin has browsed to the admin sharing settings page
-		When the admin disables public uploads using the webUI
+		Given the administrator has browsed to the admin sharing settings page
+		When the administrator disables public uploads using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value |
 			| files_sharing | public@@@upload | EMPTY |
 
 	Scenario: enable mail notification on public share
-		Given the admin has browsed to the admin sharing settings page
-		When the admin enables mail notification on public share using the webUI
+		Given the administrator has browsed to the admin sharing settings page
+		When the administrator enables mail notification on public share using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element    | value |
 			| files_sharing | public@@@send_mail | 1     |
 
 	Scenario: disable social media share on public share
-		Given the admin has browsed to the admin sharing settings page
-		When the admin disables social media share on public share using the webUI
+		Given the administrator has browsed to the admin sharing settings page
+		When the administrator disables social media share on public share using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element       | value |
 			| files_sharing | public@@@social_share | EMPTY |
 
 	Scenario: enable enforce password protection for read-only links
-		Given the admin has browsed to the admin sharing settings page
-		When the admin enables enforce password protection for read-only links using the webUI
+		Given the administrator has browsed to the admin sharing settings page
+		When the administrator enables enforce password protection for read-only links using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                              | value |
 			| files_sharing | public@@@password@@@enforced_for@@@read_only | 1     |
 
 	Scenario: enable enforce password protection for read and write links
-		Given the admin has browsed to the admin sharing settings page
-		When the admin enables enforce password protection for read and write links using the webUI
+		Given the administrator has browsed to the admin sharing settings page
+		When the administrator enables enforce password protection for read and write links using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                               | value |
 			| files_sharing | public@@@password@@@enforced_for@@@read_write | 1     |
 
 	Scenario: enable enforce password protection for upload-only links
-		Given the admin has browsed to the admin sharing settings page
-		When the admin enables enforce password protection for upload only links using the webUI
+		Given the administrator has browsed to the admin sharing settings page
+		When the administrator enables enforce password protection for upload only links using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                                | value |
 			| files_sharing | public@@@password@@@enforced_for@@@upload_only | 1     |
 
 	Scenario: disable resharing
-		Given the admin has browsed to the admin sharing settings page
-		When the admin disables resharing using the webUI
+		Given the administrator has browsed to the admin sharing settings page
+		When the administrator disables resharing using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value     |
 			| files_sharing | resharing       | EMPTY     |
 
 	Scenario: disable sharing with groups
-		Given the admin has browsed to the admin sharing settings page
-		When the admin disables sharing with groups using the webUI
+		Given the administrator has browsed to the admin sharing settings page
+		When the administrator disables sharing with groups using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value     |
 			| files_sharing | group_sharing   | EMPTY     |
 
 	Scenario: enable restrict users to only share with users in their groups
-		Given the admin has browsed to the admin sharing settings page
-		When the admin enables restrict users to only share with their group members using the webUI
+		Given the administrator has browsed to the admin sharing settings page
+		When the administrator enables restrict users to only share with their group members using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element               | value |
@@ -94,8 +94,8 @@ Feature: admin sharing settings
 
 	Scenario: enable share API
 		Given parameter "shareapi_enabled" of app "core" has been set to "no"
-		And the admin has browsed to the admin sharing settings page
-		When the admin enables the share API using the webUI
+		And the administrator has browsed to the admin sharing settings page
+		When the administrator enables the share API using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value |
@@ -103,8 +103,8 @@ Feature: admin sharing settings
 
 	Scenario: enable public sharing
 		Given parameter "shareapi_allow_links" of app "core" has been set to "no"
-		And the admin has browsed to the admin sharing settings page
-		When the admin enables share via link using the webUI
+		And the administrator has browsed to the admin sharing settings page
+		When the administrator enables share via link using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element  | value |
@@ -112,8 +112,8 @@ Feature: admin sharing settings
 
 	Scenario: enable public upload
 		Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-		And the admin has browsed to the admin sharing settings page
-		When the admin enables public uploads using the webUI
+		And the administrator has browsed to the admin sharing settings page
+		When the administrator enables public uploads using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value |
@@ -121,8 +121,8 @@ Feature: admin sharing settings
 
 	Scenario: disable mail notification on public share
 		Given parameter "shareapi_allow_public_send_mail" of app "core" has been set to "no"
-		And the admin has browsed to the admin sharing settings page
-		When the admin disables mail notification on public share using the webUI
+		And the administrator has browsed to the admin sharing settings page
+		When the administrator disables mail notification on public share using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element    | value |
@@ -130,8 +130,8 @@ Feature: admin sharing settings
 
 	Scenario: enable social media share on public share
 		Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
-		And the admin has browsed to the admin sharing settings page
-		When the admin enables social media share on public share using the webUI
+		And the administrator has browsed to the admin sharing settings page
+		When the administrator enables social media share on public share using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element       | value |
@@ -139,8 +139,8 @@ Feature: admin sharing settings
 
 	Scenario: disable enforce password protection for read-only links
 		Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
-		And the admin has browsed to the admin sharing settings page
-		When the admin disables enforce password protection for read-only links using the webUI
+		And the administrator has browsed to the admin sharing settings page
+		When the administrator disables enforce password protection for read-only links using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                              | value |
@@ -148,8 +148,8 @@ Feature: admin sharing settings
 
 	Scenario: disable enforce password protection for read and write links
 		Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "no"
-		And the admin has browsed to the admin sharing settings page
-		When the admin disables enforce password protection for read and write links using the webUI
+		And the administrator has browsed to the admin sharing settings page
+		When the administrator disables enforce password protection for read and write links using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                               | value |
@@ -157,8 +157,8 @@ Feature: admin sharing settings
 
 	Scenario: disable enforce password protection for upload-only links
 		Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "no"
-		And the admin has browsed to the admin sharing settings page
-		When the admin disables enforce password protection for upload only links using the webUI
+		And the administrator has browsed to the admin sharing settings page
+		When the administrator disables enforce password protection for upload only links using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element                                | value |
@@ -166,8 +166,8 @@ Feature: admin sharing settings
 
 	Scenario: enable resharing
 		Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
-		And the admin has browsed to the admin sharing settings page
-		When the admin enables resharing using the webUI
+		And the administrator has browsed to the admin sharing settings page
+		When the administrator enables resharing using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value |
@@ -175,8 +175,8 @@ Feature: admin sharing settings
 
 	Scenario: enable sharing with groups
 		Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-		And the admin has browsed to the admin sharing settings page
-		When the admin enables sharing with groups using the webUI
+		And the administrator has browsed to the admin sharing settings page
+		When the administrator enables sharing with groups using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element | value |
@@ -184,8 +184,8 @@ Feature: admin sharing settings
 
 	Scenario: disable restrict users to only share with users in their groups
 		Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-		And the admin has browsed to the admin sharing settings page
-		When the admin disables restrict users to only share with their group members using the webUI
+		And the administrator has browsed to the admin sharing settings page
+		When the administrator disables restrict users to only share with their group members using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element               | value |

--- a/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
@@ -13,7 +13,7 @@ Feature: disable users
 		And the administrator has browsed to the users page
 
 	Scenario: disable a user
-		When the admin disables the user "user1" using the webUI
+		When the administrator disables the user "user1" using the webUI
 		And the disabled user "user1" tries to login using the password "1234" from the webUI
 		Then the user should be redirected to a webUI page with the title "ownCloud"
 		When the user has browsed to the login page


### PR DESCRIPTION
Backport #32443 

Note:  the 2nd commit is for acceptance tests that are in core ``stable10`` but not in ``master``. They are also adjusted in the user_management app in PR https://github.com/owncloud/user_management/pull/53