### PR TITLE
Helper methods for deleting app config settings

### DIFF
--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -306,4 +306,65 @@ class AppConfigHelper {
 		}
 		SetupHelper::resetOpcache($baseUrl, $user, $password);
 	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $app
+	 * @param string $parameter
+	 * @param int $ocsApiVersion (1|2)
+	 *
+	 * @return void
+	 */
+	public static function deleteAppConfig(
+		$baseUrl, $user, $password, $app, $parameter, $ocsApiVersion = 2
+	) {
+		$body = [];
+		$response = OcsApiHelper::sendRequest(
+			$baseUrl,
+			$user,
+			$password,
+			'delete',
+			"/apps/testing/api/v1/app/{$app}/{$parameter}",
+			$body,
+			$ocsApiVersion
+		);
+		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
+		if ($ocsApiVersion === 1) {
+			PHPUnit_Framework_Assert::assertEquals(
+				"100", self::getOCSResponse($response)
+			);
+		}
+	}
+
+	/**
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param array $appParameterValues 'appid' and 'configkey' to delete
+	 * @param int $ocsApiVersion (1|2)
+	 *
+	 * @return void
+	 */
+	public static function deleteAppConfigs(
+		$baseUrl, $user, $password, $appParameterValues, $ocsApiVersion = 2
+	) {
+		$body = ['values' => $appParameterValues];
+		$response = OcsApiHelper::sendRequest(
+			$baseUrl,
+			$user,
+			$password,
+			'delete',
+			"/apps/testing/api/v1/apps",
+			$body,
+			$ocsApiVersion
+		);
+		PHPUnit_Framework_Assert::assertEquals("200", $response->getStatusCode());
+		if ($ocsApiVersion === 1) {
+			PHPUnit_Framework_Assert::assertEquals(
+				"100", self::getOCSResponse($response)
+			);
+		}
+	}
 }


### PR DESCRIPTION
## Description
Add methods to ``AppConfigHelper.php`` to allow deleting a single setting, or deleting a whole array of settings in a single call to the testing app.

## Motivation and Context
Current acceptance test code sets various app config settings using ``modifyServerConfigs()``
For ``password_policy`` (and for other tests in the future) we want to be able to delete app config settings. That lets them fall back to the app-provided default (rather than the test specifying what it thinks the app default is).

Note: the testing app already has an end-point for deleting app config settings. We just need to use it.

## How Has This Been Tested?
Local acceptance test runs of password_policy test code that will use these.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
