### PR TITLE
rename modifyServerConfig to modifyAppConfig

### DIFF
--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -69,7 +69,7 @@ class AppConfigHelper {
 		// also changes some sub-settings. So the "interim" state as we set
 		// the config values could be unexpectedly different from the original
 		// saved state.
-		self::modifyServerConfig(
+		self::modifyAppConfig(
 			$baseUrl,
 			$user,
 			$password,
@@ -148,7 +148,7 @@ class AppConfigHelper {
 			}
 		}
 
-		self::modifyServerConfigs(
+		self::modifyAppConfigs(
 			$baseUrl,
 			$user,
 			$password,
@@ -251,7 +251,7 @@ class AppConfigHelper {
 	 *
 	 * @return void
 	 */
-	public static function modifyServerConfig(
+	public static function modifyAppConfig(
 		$baseUrl,
 		$user,
 		$password, $app, $parameter, $value, $ocsApiVersion = 2
@@ -283,7 +283,7 @@ class AppConfigHelper {
 	 *
 	 * @return void
 	 */
-	public static function modifyServerConfigs(
+	public static function modifyAppConfigs(
 		$baseUrl,
 		$user,
 		$password, $appParameterValues, $ocsApiVersion = 2

--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -93,7 +93,7 @@ trait AppConfiguration {
 		$user = $this->currentUser;
 		$this->currentUser = $this->getAdminUsername();
 
-		$this->modifyServerConfig($app, $parameter, $value);
+		$this->modifyAppConfig($app, $parameter, $value);
 
 		$this->currentUser = $user;
 	}
@@ -290,8 +290,8 @@ trait AppConfiguration {
 	 *
 	 * @return void
 	 */
-	protected function modifyServerConfig($app, $parameter, $value) {
-		AppConfigHelper::modifyServerConfig(
+	protected function modifyAppConfig($app, $parameter, $value) {
+		AppConfigHelper::modifyAppConfig(
 			$this->getBaseUrl(),
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
@@ -307,8 +307,8 @@ trait AppConfiguration {
 	 *
 	 * @return void
 	 */
-	protected function modifyServerConfigs($appParameterValues) {
-		AppConfigHelper::modifyServerConfigs(
+	protected function modifyAppConfigs($appParameterValues) {
+		AppConfigHelper::modifyAppConfigs(
 			$this->getBaseUrl(),
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
@@ -388,7 +388,7 @@ trait AppConfiguration {
 			if (($server === 'LOCAL') || $this->federatedServerExists()) {
 				$this->usingServer($server);
 				if (\key_exists($this->getBaseUrl(), $this->savedCapabilitiesChanges)) {
-					$this->modifyServerConfigs($this->savedCapabilitiesChanges[$this->getBaseUrl()]);
+					$this->modifyAppConfigs($this->savedCapabilitiesChanges[$this->getBaseUrl()]);
 				}
 			}
 		}

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -589,7 +589,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @throws \Exception
 	 */
 	public function tearDownSuite() {
-		AppConfigHelper::modifyServerConfigs(
+		AppConfigHelper::modifyAppConfigs(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getAdminUsername(),
 			$this->featureContext->getAdminPassword(),


### PR DESCRIPTION
## Description
``modifyServerConfig()`` becomes ``modifyAppConfig()``
``modifyServerConfigs()`` becomes ``modifyAppConfigs()``

## Motivation and Context
Acceptance tests methods named like ``modifyServerConfig()`` actually modify app config settings. The method name can be misleading.

Ref: #32448 where we added ``deleteAppConfig()`` which is a better way to name this group of methods.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
