### PR TITLE
Remove unneeded resetOpcache()

### DIFF
--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -304,7 +304,6 @@ class AppConfigHelper {
 				"100", self::getOCSResponse($response)
 			);
 		}
-		SetupHelper::resetOpcache($baseUrl, $user, $password);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Delete ``resetOpcache()`` from ``modifyAppConfigs()``

## Motivation and Context
``modifyAppConfigs()`` only sets app config keys in the database. It does not modify ``config.php``
So there should be no need to ``resetOpcache()`` (which is for when some PHP code changes and we want the server to immediately notice the change).

## How Has This Been Tested?
Let's see if CI has a problem.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
