### PR TITLE
Fix version previews when no provider available

### DIFF
--- a/apps/files_versions/css/versions.css
+++ b/apps/files_versions/css/versions.css
@@ -44,6 +44,9 @@
 
 .versionsTabView img.preview {
 	cursor: default;
+	background-size: 32px;
+	width: 32px;
+	height: 32px;
 }
 
 .versionsTabView .version-container {

--- a/apps/files_versions/js/versioncollection.js
+++ b/apps/files_versions/js/versioncollection.js
@@ -8,6 +8,8 @@
  *
  */
 
+/* global moment */
+
 (function() {
 	/**
 	 * @memberof OCA.Versions
@@ -46,6 +48,7 @@
 					fullPath: fullPath,
 					timestamp: moment(new Date(version['{DAV:}getlastmodified'])).format('X'),
 					size: version['{DAV:}getcontentlength'],
+					mimetype: version['{DAV:}getcontenttype'],
 					fileId: fileId
 				};
 			});

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -9,6 +9,21 @@
  */
 
 (function() {
+
+	function getPreviewUrl(model) {
+		var mime = model.get('mimetype');
+
+		var enabledPreviewProviders = OC.appConfig.core.enabledPreviewProviders || [];
+		if (enabledPreviewProviders.length > 0) {
+			var allMimesPattern = new RegExp(enabledPreviewProviders.join('|'));
+			if (OC.appConfig.core.previewsEnabled && allMimesPattern.test(mime)) {
+				return model.getPreviewUrl();
+			}
+		}
+
+		return OC.MimeType.getIconUrl(mime);
+	}
+
 	var TEMPLATE_ITEM =
 		'<li data-revision="{{versionId}}">' +
 		'<div>' +
@@ -185,6 +200,7 @@
 		_formatItem: function(version) {
 			var timestamp = version.get('timestamp') * 1000;
 			var size = version.has('size') ? version.get('size') : 0;
+
 			return _.extend({
 				versionId: version.get('id'),
 				formattedTimestamp: OC.Util.formatDate(timestamp),
@@ -195,7 +211,7 @@
 				downloadUrl: version.getDownloadUrl(),
 				downloadIconUrl: OC.imagePath('core', 'actions/download'),
 				revertIconUrl: OC.imagePath('core', 'actions/history'),
-				previewUrl: version.getPreviewUrl(),
+				previewUrl: getPreviewUrl(version),
 				revertLabel: t('files_versions', 'Restore'),
 				canRevert: (this.collection.getFileInfo().get('permissions') & OC.PERMISSION_UPDATE) !== 0
 			}, version.attributes);


### PR DESCRIPTION


<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Fixes issue where ODT file or others that have no preview provider
registered would show a broken icon. It will now show the default icon
for such file types.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/2812

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- test with text file, create versions through overwriting, open versions tab: text previews are shown
- test with ODT file, create versions through overwriting, open versions tab: default ODT mime type icon is shown
- unit tests cover more cases where previews are disabled completely

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
