### PR TITLE
su-exec www-data is not needed for acceptance tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -211,6 +211,16 @@ pipeline:
       matrix:
         CALDAV_CARDDAV_JOB: true
 
+  setup-api-acceptance-tests:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    commands:
+      # pre-create local_storage so fix-permissions will set its owner appropriately
+      - mkdir -p /drone/src/tests/acceptance/work/local_storage
+    when:
+      matrix:
+        TEST_SUITE: api
+
   install-notifications-app:
     image: owncloudci/php:${PHP_VERSION}
     pull: true

--- a/tests/acceptance/features/apiMain/appmanagement.feature
+++ b/tests/acceptance/features/apiMain/appmanagement.feature
@@ -1,4 +1,4 @@
-@api @skipWhenTestingRemoteSystems
+@api
 Feature: AppManagement
 
   Background:

--- a/tests/acceptance/features/apiMain/appmanagement.feature
+++ b/tests/acceptance/features/apiMain/appmanagement.feature
@@ -7,11 +7,11 @@ Feature: AppManagement
   Scenario: Two app instances exist the first is more recent
     Given app "multidirtest" with version "1.0.1" has been put in dir "apps"
     And app "multidirtest" with version "1.0.0" has been put in dir "apps2"
-    When the administrator loads app "multidirtest" using the console
+    When the administrator gets the path for app "multidirtest" using the console
     Then the path to "multidirtest" should be "apps"
 
   Scenario: Two app instances exist the second is more recent
     Given app "multidirtest" with version "1.0.0" has been put in dir "apps"
     And app "multidirtest" with version "1.0.5" has been put in dir "apps2"
-    When the administrator loads app "multidirtest" using the console
+    When the administrator gets the path for app "multidirtest" using the console
     Then the path to "multidirtest" should be "apps2"

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -20,6 +20,7 @@
  */
 
 use Behat\Behat\Context\Context;
+use TestHelpers\SetupHelper;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
@@ -27,44 +28,70 @@ require __DIR__ . '/../../../../lib/composer/autoload.php';
  * App Management context.
  */
 class AppManagementContext implements Context {
-	private $oldAppPath;
-	
+	private $oldAppsPaths;
+
 	/**
 	 * @var string stdout of last command
 	 */
 	private $cmdOutput;
-	
+
 	/**
 	 * @BeforeScenario @skipWhenTestingRemoteSystems
 	 *
 	 * Remember the config values before each scenario
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function prepareParameters() {
 		include_once __DIR__ . '/../../../../lib/base.php';
-		$this->oldAppPath = \OC::$server->getConfig()->getSystemValue(
-			'apps_paths', null
-		);
+		$value = SetupHelper::runOcc(
+			['config:system:get', 'apps_paths', '--output', 'json']
+		)['stdOut'];
+
+		if ($value === '') {
+			$this->oldAppsPaths = null;
+		} else {
+			$this->oldAppsPaths = \json_decode($value, true);
+		}
 	}
-	
+
 	/**
 	 * @AfterScenario @skipWhenTestingRemoteSystems
 	 *
 	 * Reset the config values after each scenario
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function undoChangingParameters() {
-		if ($this->oldAppPath !== null) {
-			\OC::$server->getConfig()->setSystemValue(
-				'apps_paths', $this->oldAppPath
-			);
+		if ($this->oldAppsPaths === null) {
+			SetupHelper::runOcc(['config:system:delete', 'apps_paths']);
 		} else {
-			\OC::$server->getConfig()->deleteSystemValue('apps_paths');
+			$this->setAppsPaths($this->oldAppsPaths);
 		}
 	}
-	
+
+	/**
+	 *
+	 * @param array $appsPaths of apps_paths entries
+	 *
+	 * @return string[] associated array with "code", "stdOut", "stdErr"
+	 * @throws Exception
+	 */
+	public function setAppsPaths($appsPaths) {
+		return SetupHelper::runOcc(
+			[
+				'config:system:set',
+				'apps_paths',
+				'--type',
+				'json',
+				'--value',
+				\json_encode($appsPaths)
+			]
+		);
+	}
+
 	/**
 	 * @Given apps have been put in two directories :dir1 and :dir2
 	 *
@@ -72,19 +99,20 @@ class AppManagementContext implements Context {
 	 * @param string $dir2
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function setAppDirectories($dir1, $dir2) {
 		$fullpath1 = \OC::$SERVERROOT . "/$dir1";
 		$fullpath2 = \OC::$SERVERROOT . "/$dir2";
-		\OC::$server->getConfig()->setSystemValue(
-			'apps_paths',
+
+		$this->setAppsPaths(
 			[
 				['path' => $fullpath1, 'url' => $dir1, 'writable' => true],
 				['path' => $fullpath2, 'url' => $dir2, 'writable' => true]
 			]
 		);
 	}
-	
+
 	/**
 	 * @Given app :appId with version :version has been put in dir :dir
 	 *
@@ -95,9 +123,9 @@ class AppManagementContext implements Context {
 	 * @return void
 	 */
 	public function appHasBeenPutInDir($appId, $version, $dir) {
-		$ocVersion = \OC::$server->getConfig()->getSystemValue(
-			'version', '0.0.0'
-		);
+		$ocVersion = SetupHelper::runOcc(
+			['config:system:get', 'version']
+		)['stdOut'];
 		$appInfo = \sprintf(
 			'<?xml version="1.0"?>
 			<info>
@@ -129,49 +157,30 @@ class AppManagementContext implements Context {
 		if (!\file_exists("$appsDir/$appId")) {
 			\mkdir("$appsDir/$appId");
 		}
-		
+
 		$fullpath = "$appsDir/$appId";
-		
+
 		if (!\file_exists("$fullpath/appinfo")) {
 			\mkdir("$fullpath/appinfo");
 		}
-		
+
 		\file_put_contents("$fullpath/appinfo/info.xml", $appInfo);
 	}
-	
+
 	/**
-	 * @When the administrator loads app :appId using the console
-	 * @Given the administrator has loaded app :appId using the console
+	 * @When the administrator gets the path for app :appId using the console
+	 * @Given the administrator has got the path for app :appId using the console
 	 *
 	 * @param string $appId app id
 	 *
 	 * @return void
 	 */
-	public function loadApp($appId) {
-		$args = \explode(' ', "app:getpath $appId");
-		$args = \array_map(
-			function ($arg) {
-				return \escapeshellarg($arg);
-			}, $args
-		);
-		$args[] = '--no-ansi';
-		$args = \implode(' ', $args);
-
-		$descriptor = [
-			0 => ['pipe', 'r'],
-			1 => ['pipe', 'w'],
-			2 => ['pipe', 'w'],
-		];
-		$process = \proc_open(
-			"php console.php $args",
-			$descriptor,
-			$pipes,
-			\OC::$SERVERROOT
-		);
-		$this->cmdOutput = \stream_get_contents($pipes[1]);
-		\proc_close($process);
+	public function adminGetsPathForApp($appId) {
+		$this->cmdOutput = SetupHelper::runOcc(
+			['app:getpath', $appId, '--no-ansi']
+		)['stdOut'];
 	}
-	
+
 	/**
 	 * @Then the path to :appId should be :dir
 	 *
@@ -180,7 +189,7 @@ class AppManagementContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function appVersionIs($appId, $dir) {
+	public function appPathIs($appId, $dir) {
 		PHPUnit_Framework_Assert::assertEquals(
 			\OC::$SERVERROOT . "/$dir/$appId",
 			\trim($this->cmdOutput)

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -36,7 +36,7 @@ class AppManagementContext implements Context {
 	private $cmdOutput;
 
 	/**
-	 * @BeforeScenario @skipWhenTestingRemoteSystems
+	 * @BeforeScenario
 	 *
 	 * Remember the config values before each scenario
 	 *
@@ -57,7 +57,7 @@ class AppManagementContext implements Context {
 	}
 
 	/**
-	 * @AfterScenario @skipWhenTestingRemoteSystems
+	 * @AfterScenario
 	 *
 	 * Reset the config values after each scenario
 	 *

--- a/tests/drone/test-acceptance.sh
+++ b/tests/drone/test-acceptance.sh
@@ -10,5 +10,5 @@ declare -x OC_TEST_ALT_HOME
 [[ -z "${OC_TEST_ALT_HOME}" ]] && OC_TEST_ALT_HOME=1
 
 pushd tests/acceptance
-    su-exec www-data ./run.sh "$@"
+    ./run.sh "$@"
 popd


### PR DESCRIPTION
## Description
1) remove the ``su-exec www-data`` from where it is used to run acceptance tests in drone.
2) the acceptance test ``.run.sh`` script tries to be nice and creates a ``local_storage`` folder inside the server. We can't do that successfully when running as another user (not ``www-data``). So do it in another drone step ``setup-api-acceptance-tests`` that happens before the permissions etc get reset to ``www-data`` for the server.

## Issue
#32459 

## Motivation and Context
The acceptance test script should be able to run "outside" and not as the owner of the server files (e.g. not as ``www-data``)

## How Has This Been Tested?
CI knows

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
