### PR TITLE
[stable10] Add log entry for each migration that is run

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -57,14 +57,19 @@ class MigrationService {
 	 * @throws \Exception
 	 */
 	public function __construct($appName,
-						 IDBConnection $connection,
-						 IOutput $output = null,
-						 AppLocator $appLocator = null) {
+						IDBConnection $connection,
+						IOutput $output = null,
+						AppLocator $appLocator = null,
+						ILogger $logger = null) {
 		$this->appName = $appName;
 		$this->connection = $connection;
 		$this->output = $output;
 		if ($this->output === null) {
 			$this->output = new SimpleOutput(\OC::$server->getLogger(), $appName);
+		}
+		$this->logger = $logger;
+		if ($this->logger === null) {
+			$this->logger = \OC::$server->getLogger();
 		}
 
 		if ($appName === 'core') {
@@ -385,6 +390,7 @@ class MigrationService {
 	 * @param string $version
 	 */
 	public function executeStep($version) {
+		$this->logger->debug("Migrations: starting $version from app {$this->appName}", ['app' => 'core']);
 		$instance = $this->createInstance($version);
 		if ($instance instanceof ISimpleMigration) {
 			$instance->run($this->output);
@@ -403,6 +409,7 @@ class MigrationService {
 			$this->connection->migrateToSchema($toSchema);
 		}
 		$this->markAsExecuted($version);
+		$this->logger->debug("Migrations: completed $version from app {$this->appName}", ['app' => 'core']);
 	}
 
 	private function ensureMigrationsAreLoaded() {


### PR DESCRIPTION
## Description
Add log entries when running DB migrations.
Should hopefully help more update related issues where migrations did not run...

## Related Issue
- For https://github.com/owncloud/enterprise/issues/2811

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

1. delete some core and app migrations in oc_migrations
2. increase version.php
3. increase app version
4. run `occ upgrade`
5. check owncloud.log and see the migrations mentioned after they ran

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)

@cdamken 