### PR TITLE
[stable10] Backport of Make email field as default to create user

### DIFF
--- a/lib/public/InvalidUserTokenException.php
+++ b/lib/public/InvalidUserTokenException.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP;
+
+/**
+ * Class InvalidUserTokenException
+ *
+ * @package OCP
+ * @since 10.0.10
+ */
+class InvalidUserTokenException extends UserTokenException {
+	/**
+	 * InvalidUserTokenException constructor.
+	 *
+	 * @param string $message
+	 * @param int $code
+	 * @since 10.0.10
+	 */
+	public function __construct($message = "", $code = 0) {
+		parent::__construct($message, $code, $this);
+	}
+}

--- a/lib/public/UserTokenException.php
+++ b/lib/public/UserTokenException.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP;
+
+/**
+ * Class UserTokenException
+ *
+ * @package OCP
+ * @since 10.0.10
+ */
+class UserTokenException extends \Exception {
+	/**
+	 * UserTokenException constructor.
+	 *
+	 * @param string $message
+	 * @param $code
+	 * @param \Exception|null $previous
+	 * @since 10.0.10
+	 */
+	public function __construct($message = "", $code, \Exception $previous = null) {
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/lib/public/UserTokenExpiredException.php
+++ b/lib/public/UserTokenExpiredException.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP;
+
+/**
+ * Class UserTokenExpiredException
+ *
+ * @package OCP
+ * @since 10.0.10
+ */
+class UserTokenExpiredException extends UserTokenException {
+	/**
+	 * UserTokenExpiredException constructor.
+	 *
+	 * @param string $message
+	 * @param int $code
+	 * @since 10.0.10
+	 */
+	public function __construct($message = "", $code = 0) {
+		parent::__construct($message, $code, $this);
+	}
+}

--- a/lib/public/UserTokenMismatchException.php
+++ b/lib/public/UserTokenMismatchException.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP;
+
+/**
+ * Class UserTokenMismatchException
+ *
+ * @package OCP
+ * @since 10.0.10
+ */
+class UserTokenMismatchException extends UserTokenException {
+	/**
+	 * UserTokenMismatchException constructor.
+	 *
+	 * @param string $message
+	 * @param int $code
+	 * @since 10.0.10
+	 */
+	public function __construct($message = "", $code = 0) {
+		parent::__construct($message, $code, $this);
+	}
+}

--- a/settings/Application.php
+++ b/settings/Application.php
@@ -158,7 +158,8 @@ class Application extends App {
 				$c->query('DefaultMailAddress'),
 				$c->query('URLGenerator'),
 				$c->query('OCP\\App\\IAppManager'),
-				$c->query('OCP\\IAvatarManager')
+				$c->query('OCP\\IAvatarManager'),
+				$c->query('ServerContainer')->getEventDispatcher()
 			);
 		});
 		$container->registerService('LogSettingsController', function (IContainer $c) {

--- a/settings/css/setpassword.css
+++ b/settings/css/setpassword.css
@@ -1,0 +1,15 @@
+#reset-password p {
+	position: relative;
+}
+
+.text-center {
+	text-align: center;
+}
+
+#submit {
+	width: 100%;
+}
+
+#password {
+	width: 100%;
+}

--- a/settings/js/setpassword.js
+++ b/settings/js/setpassword.js
@@ -1,0 +1,52 @@
+(function () {
+	var SetPassword = {
+		init : function() {
+			$('#set-password #submit').click(this.onClickSetPassword);
+		},
+
+		onClickSetPassword : function(event){
+			event.preventDefault();
+			var passwordObj = $('#password');
+			if (passwordObj.val()){
+				$.post(
+					passwordObj.parents('form').attr('action'),
+					{password : passwordObj.val()}
+				).done(function (result) {
+					OCA.UserManagement.SetPassword._resetDone(result);
+				}).fail(function (result) {
+					OCA.UserManagement.SetPassword._onSetPasswordFail(result);
+				});
+			}
+		},
+
+		_onSetPasswordFail: function(result) {
+			var responseObj = JSON.parse(result.responseText);
+			var errorObject = $('#error-message');
+			var showErrorMessage = false;
+
+			var errorMessage;
+			errorMessage = responseObj.message;
+
+			if (errorMessage) {
+				errorObject.text(errorMessage);
+				errorObject.show();
+				$('#submit').prop('disabled', true);
+			}
+		},
+
+		_resetDone : function(result){
+			if (result && result.status === 'success') {
+				OC.redirect(OC.getRootPath());
+			}
+		}
+	};
+
+	if (!OCA.UserManagement) {
+		OCA.UserManagement = {};
+	}
+	OCA.UserManagement.SetPassword = SetPassword;
+})();
+
+$(document).ready(function () {
+	OCA.UserManagement.SetPassword.init();
+});

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -711,6 +711,19 @@ $(document).ready(function () {
 	// TODO: move other init calls inside of initialize
 	UserList.initialize($('#userlist'));
 
+	OC.AppConfig.getValue('core', 'umgmt_set_password', 'false', function (data) {
+		var showPassword = $.parseJSON(data);
+		if (showPassword === true) {
+			$("#newuserpassword").show();
+			$("#newemail").hide();
+			$('#CheckBoxPasswordOnUserCreate').attr('checked', true);
+		} else {
+			$("#newemail").show();
+			$("#newuserpassword").hide();
+			$('#CheckBoxPasswordOnUserCreate').attr('checked', false);
+		}
+	});
+
 	$userListBody.on('click', '.password', function (event) {
 		event.stopPropagation();
 
@@ -883,20 +896,20 @@ $(document).ready(function () {
 			}));
 			return false;
 		}
-		if ($.trim(password) === '') {
-			OC.Notification.showTemporary(t('settings', 'Error creating user: {message}', {
-				message: t('settings', 'A valid password must be provided')
-			}));
-			return false;
-		}
-		if(!$('#CheckboxMailOnUserCreate').is(':checked')) {
-			email = '';
-		}
-		if ($('#CheckboxMailOnUserCreate').is(':checked') && $.trim(email) === '') {
-			OC.Notification.showTemporary( t('settings', 'Error creating user: {message}', {
-				message: t('settings', 'A valid email must be provided')
-			}));
-			return false;
+		if ($('#CheckBoxPasswordOnUserCreate').is(':checked')) {
+			if ($.trim(password) === '') {
+				OC.Notification.showTemporary(t('settings', 'Error creating user: {message}', {
+					message: t('settings', 'A valid password must be provided')
+				}));
+				return false;
+			}
+		} else {
+			if ($.trim(email) === '') {
+				OC.Notification.showTemporary( t('settings', 'Error creating user: {message}', {
+					message: t('settings', 'A valid email must be provided')
+				}));
+				return false;
+			}
 		}
 
 		var promise;
@@ -1014,17 +1027,19 @@ $(document).ready(function () {
 		}
 	});
 
-	if ($('#CheckboxMailOnUserCreate').is(':checked')) {
-		$("#newemail").show();
+	if ($('#CheckBoxPasswordOnUserCreate').is(':checked')) {
+		$("#newuserpassword").show();
 	}
 	// Option to display/hide the "E-Mail" input field
-	$('#CheckboxMailOnUserCreate').click(function() {
-		if ($('#CheckboxMailOnUserCreate').is(':checked')) {
-			$("#newemail").show();
-			OC.AppConfig.setValue('core', 'umgmt_send_email', 'true');
+	$('#CheckBoxPasswordOnUserCreate').click(function () {
+		if ($('#CheckBoxPasswordOnUserCreate').is(':checked')) {
+			OC.AppConfig.setValue('core', 'umgmt_set_password', 'true');
+			$('#newemail').hide();
+			$('#newuserpassword').show();
 		} else {
-			$("#newemail").hide();
-			OC.AppConfig.setValue('core', 'umgmt_send_email', 'false');
+			OC.AppConfig.setValue('core', 'umgmt_set_password', 'false');
+			$('#newemail').show();
+			$("#newuserpassword").hide();
 		}
 	});
 

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -67,6 +67,10 @@ $application->registerRoutes($this, [
 		['name' => 'Cors#removeDomain', 'url' => '/settings/domains/{id}', 'verb' => 'DELETE'],
 		['name' => 'LegalSettings#setImprintUrl', 'url' => '/settings/admin/legal/imprint', 'verb' => 'POST'],
 		['name' => 'LegalSettings#setPrivacyPolicyUrl', 'url' => '/settings/admin/legal/privacypolicy', 'verb' => 'POST'],
+		['name' => 'ChangePassword#changePassword', 'url' => '/users/changepassword', 'verb' => 'POST'],
+		['name' => 'Users#setPasswordForm', 'url' => '/settings/users/setpassword/form/{token}/{userId}', 'verb' => 'GET'],
+		['name' => 'Users#resendToken', 'url' => '/resend/token/{userId}', 'verb' => 'POST'],
+		['name' => 'Users#setPassword', 'url' => '/setpassword/{token}/{userId}', 'verb' => 'POST'],
 	]
 ]);
 

--- a/settings/templates/email.new_user.php
+++ b/settings/templates/email.new_user.php
@@ -12,7 +12,7 @@
 					<td width="20px">&nbsp;</td>
 					<td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">
 						<?php
-						print_unescaped($l->t('Hey there,<br><br>just letting you know that you now have an %s account.<br><br>Your username: %s<br>Access it: <a href="%s">%s</a><br><br>', [$theme->getName(), $_['username'], $_['url'], $_['url']]));
+						print_unescaped($l->t('Hey there,<br><br>just letting you know that you now have an %s account.<br><br>Your username: %s<br>Please set the password by accessing it: <a href="%s">Here</a><br><br>', [$theme->getName(), $_['username'], $_['url']]));
 
 						// TRANSLATORS term at the end of a mail
 						p($l->t('Cheers!'));

--- a/settings/templates/resendtokenbymail.php
+++ b/settings/templates/resendtokenbymail.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+?>
+
+<form action="<?php print_unescaped($_['link']) ?>" id="resendtoken" method="post">
+	<fieldset>
+		<p>
+			<label><?php p($l->t('The activation link has expired. Click the button below to request a new one and complete the registration.')); ?></label>
+		</p>
+		<input type="submit" id="submit" value="<?php
+			p($l->t('Resend activation link'));
+		?>" />
+	</fieldset>
+</form>

--- a/settings/templates/setpassword.php
+++ b/settings/templates/setpassword.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+style('settings', 'setpassword');
+script('settings', 'setpassword');
+?>
+
+<label id="error-message" class="warning" style="display:none"></label>
+<form action="<?php print_unescaped($_['link']) ?>" id="set-password" method="post">
+	<fieldset>
+		<p>
+			<label for="password" class="infield"><?php p($l->t('New password')); ?></label>
+			<input type="password" name="password" id="password" value=""
+				   placeholder="<?php p($l->t('New Password')); ?>"
+				   autocomplete="off" autocapitalize="off" autocorrect="off"
+				   required autofocus />
+		</p>
+		<input type="submit" id="submit" value="<?php
+			p($l->t('Please set your password'));
+		?>" />
+	</fieldset>
+</form>

--- a/settings/templates/tokensendnotify.php
+++ b/settings/templates/tokensendnotify.php
@@ -1,0 +1,2 @@
+<?php
+p($l->t('Activation link was sent to an email address, if one was configured.'));

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -81,12 +81,12 @@ translation('settings');
 					</label>
 				</p>
 				<p>
-					<input type="checkbox" name="MailOnUserCreate" value="MailOnUserCreate" id="CheckboxMailOnUserCreate"
-						class="checkbox" <?php if ($_['send_email'] === 'true') {
+					<input type="checkbox" name="AddPasswordOnUserCreate" value="AddPasswordOnUserCreate" id="CheckBoxPasswordOnUserCreate"
+						class="checkbox" <?php if ($_['add_password'] === 'true') {
 	print_unescaped('checked="checked"');
 } ?> />
-					<label for="CheckboxMailOnUserCreate">
-						<?php p($l->t('Send email to new user')) ?>
+					<label for="CheckBoxPasswordOnUserCreate">
+						<?php p($l->t('Set password for new users')) ?>
 					</label>
 				</p>
 				<p>

--- a/settings/templates/users/part.createuser.php
+++ b/settings/templates/users/part.createuser.php
@@ -4,10 +4,10 @@
 			placeholder="<?php p($l->t('Username'))?>"
 			autocomplete="off" autocapitalize="off" autocorrect="off" />
 		<input
-			type="password" id="newuserpassword"
+			type="password" id="newuserpassword" style="display:none"
 			placeholder="<?php p($l->t('Password'))?>"
 			autocomplete="off" autocapitalize="off" autocorrect="off" />
-		<input id="newemail" type="text" style="display:none"
+		<input id="newemail" type="text"
 			   placeholder="<?php p($l->t('E-Mail'))?>"
 			   autocomplete="off" autocapitalize="off" autocorrect="off" />
 		<div class="groups"><div class="groupsListContainer multiselect button" data-placeholder="<?php p($l->t('Groups'))?>"><span class="title groupsList"></span><span class="icon-triangle-s"></span></div></div>

--- a/settings/users.php
+++ b/settings/users.php
@@ -124,6 +124,6 @@ $tmpl->assign('show_storage_location', $config->getAppValue('core', 'umgmt_show_
 $tmpl->assign('show_last_login', $config->getAppValue('core', 'umgmt_show_last_login', 'false'));
 $tmpl->assign('show_email', $config->getAppValue('core', 'umgmt_show_email', 'false'));
 $tmpl->assign('show_backend', $config->getAppValue('core', 'umgmt_show_backend', 'false'));
-$tmpl->assign('send_email', $config->getAppValue('core', 'umgmt_send_email', 'false'));
+$tmpl->assign('set_password', $config->getAppValue('core', 'umgmt_set_password', 'false'));
 
 $tmpl->printPage();

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -211,9 +211,9 @@ class UsersPage extends OwncloudPage {
 	public function createUser(
 		Session $session, $username, $password, $email = null, $groups = null
 	) {
+		$this->setSetting("Set password for new users", $password !== null);
 		$this->fillField($this->newUserUsernameFieldId, $username);
 		$this->fillField($this->newUserPasswordFieldId, $password);
-		$this->setSetting("Send email to new user", $email !== null);
 		if ($email !== null) {
 			$this->fillField($this->newUserEmailFieldId, $email);
 		}


### PR DESCRIPTION
Make email field as default to create user.
Previously we had username, password. With
this change it becomes username, email. This
would help admins to create users with email
address.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Make email field as default to create a user. The old option of creating user with username and password is still available in the settings.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make email field as default to create a user. The old option of creating user with username and password is still available in the settings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create `admin` user and navigate to users page.
- [x] By default user should see following text box `Username`, `E-Mail` ( Previously it was `Username`, `Password`)
- The password option is still available. The user has to click the settings button available in the left bottom of the page and enable `Set password for new users`
- Once the email is configured in the config.php, create a new user with Username and E-Mail.
- An email should arrive to the user saying account is created.
- Click on the link provided in the email to set the password. The user should  be able to set the password using the link provided.
- The message that arrives during token expiry is verified.
- The message that arrives when token is invalid or token mismatch happens is also verified.
- When the token is expired a page showing resend activation link button appears. Which when clicked another email is sent to the user. The user needs to click the link from the email to set the password.
- Adjusted the unit tests for the backport.
- Verified with the previous setup of `Username` + `Password`. It worked.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
