### PR TITLE
allo to use X-Forwarded-For header in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -137,6 +137,8 @@ trait BasicStructure {
 	 * @var string|null
 	 */
 	private $sourceIpAddress = null;
+	
+	private $guzzleClientHeaders = [];
 
 	/**
 	 * BasicStructure constructor.
@@ -329,6 +331,29 @@ trait BasicStructure {
 	 */
 	public function setSourceIpAddress($sourceIpAddress) {
 		$this->sourceIpAddress = $sourceIpAddress;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getGuzzleClientHeaders() {
+		return $this->guzzleClientHeaders;
+	}
+	
+	/**
+	 * @param array $guzzleClientHeaders ['X-Foo' => 'Bar']
+	 */
+	public function setGuzzleClientHeaders($guzzleClientHeaders) {
+		$this->guzzleClientHeaders = $guzzleClientHeaders;
+	}
+
+	/**
+	 * @param array $guzzleClientHeaders ['X-Foo' => 'Bar']
+	 */
+	public function addGuzzleClientHeaders($guzzleClientHeaders) {
+		$this->guzzleClientHeaders = \array_merge(
+			$this->guzzleClientHeaders, $guzzleClientHeaders
+		);
 	}
 
 	/**
@@ -690,6 +715,10 @@ trait BasicStructure {
 			$options['auth'] = [$user, $password];
 		}
 		
+		if (!empty($this->guzzleClientHeaders)) {
+			$options ['headers'] = $this->guzzleClientHeaders;
+		}
+		
 		if ($this->sourceIpAddress !== null) {
 			$options ['config'] = [
 				'curl' => [
@@ -856,6 +885,10 @@ trait BasicStructure {
 		// Request a new session and extract CSRF token
 		$client = new Client();
 		$options = [];
+		if (!empty($this->guzzleClientHeaders)) {
+			$options ['headers'] = $this->guzzleClientHeaders;
+		}
+		
 		if ($this->sourceIpAddress !== null) {
 			$options ['config'] = [
 				'curl' => [
@@ -891,6 +924,10 @@ trait BasicStructure {
 	public function sendingAToWithRequesttoken($method, $url) {
 		$client = new Client();
 		$options = [];
+		if (!empty($this->guzzleClientHeaders)) {
+			$options ['headers'] = $this->guzzleClientHeaders;
+		}
+		
 		if ($this->sourceIpAddress !== null) {
 			$options ['config'] = [
 				'curl' => [
@@ -922,6 +959,10 @@ trait BasicStructure {
 	public function sendingAToWithoutRequesttoken($method, $url) {
 		$client = new Client();
 		$options = [];
+		if (!empty($this->guzzleClientHeaders)) {
+			$options ['headers'] = $this->guzzleClientHeaders;
+		}
+		
 		if ($this->sourceIpAddress !== null) {
 			$options ['config'] = [
 				'curl' => [
@@ -1070,6 +1111,10 @@ trait BasicStructure {
 		$fullUrl = $this->getBaseUrl() . "/status.php";
 		$client = new Client();
 		$options = [];
+		if (!empty($this->guzzleClientHeaders)) {
+			$options ['headers'] = $this->guzzleClientHeaders;
+		}
+		
 		if ($this->sourceIpAddress !== null) {
 			$options ['config'] = [
 				'curl' => [

--- a/tests/acceptance/features/bootstrap/Ip.php
+++ b/tests/acceptance/features/bootstrap/Ip.php
@@ -45,6 +45,8 @@ trait Ip {
 
 	private $ipv4Url;
 	private $ipv6Url;
+	
+	private $guzzleClientHeaders = [];
 
 	/**
 	 * returns the base URL that matches the currently selected source IP
@@ -61,6 +63,28 @@ trait Ip {
 		return $this->baseUrlForSourceIp;
 	}
 
+	/**
+	 * @return array
+	 */
+	public function getGuzzleClientHeaders() {
+		return $this->guzzleClientHeaders;
+	}
+	
+	/**
+	 * @param array $guzzleClientHeaders ['X-Foo' => 'Bar']
+	 */
+	public function setGuzzleClientHeaders($guzzleClientHeaders) {
+		$this->guzzleClientHeaders = $guzzleClientHeaders;
+	}
+
+	/**
+	 * @param array $guzzleClientHeaders ['X-Foo' => 'Bar']
+	 */
+	public function addGuzzleClientHeaders($guzzleClientHeaders) {
+		$this->guzzleClientHeaders = \array_merge(
+			$this->guzzleClientHeaders, $guzzleClientHeaders
+		);
+	}
 	/**
 	 * @When the client accesses the server from a :networkScope :ipAddressFamily address
 	 *
@@ -98,6 +122,20 @@ trait Ip {
 		$this->featureContext->setSourceIpAddress($sourceIpAddress);
 	}
 
+	/**
+	 * @When the client accesses the server from IP address :sourceIpAddress using X-Forwarded-For header
+	 *
+	 * @param string $sourceIpAddress an IPv4 or IPv6 address
+	 *
+	 * @return void
+	 */
+	public function theClientAccessesTheServerFromIpAddressUsingXForwardedForHeader(
+		$sourceIpAddress
+	) {
+		$this->addGuzzleClientHeaders(["X-Forwarded-For" => $sourceIpAddress]);
+		$this->featureContext->addGuzzleClientHeaders(["X-Forwarded-For" => $sourceIpAddress]);
+	}
+	
 	/**
 	 * @BeforeScenario
 	 *


### PR DESCRIPTION
## Description
allow to use `X-Forwarded-For` header to mock source IP address

## Related Issue
https://github.com/owncloud/brute_force_protection/issues/12

## Motivation and Context
need to fake the source IP in some test. so far we used the loopback address and a routable address, that does not work with drone, because the SUT and the test enviroment running in different docker containers

## How Has This Been Tested?
made tests using this step

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
