### PR TITLE
[stable10] Add missing ILogger declaration in MigrationService

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -46,6 +46,8 @@ class MigrationService {
 	private $connection;
 	/** @var string */
 	private $appName;
+	/** @var ILogger */
+	private $logger;
 
 	/**
 	 * MigrationService constructor.


### PR DESCRIPTION
Add missing bit to stable10 as it was reported by phan on https://github.com/owncloud/core/pull/32463