### PR TITLE
Make Given steps for various webUI actions

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -201,6 +201,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user browses directly to display the :tabName details of file :fileName in folder :folderName
+	 * @Given the user has browsed directly to display the :tabName details of file :fileName in folder :folderName
 	 *
 	 * @param string $tabName
 	 * @param string $fileName
@@ -333,6 +334,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When /^the user creates a folder with the (invalid|)\s?name ((?:'[^']*')|(?:"[^"]*")) using the webUI$/
+	 * @Given /^the user has created a folder with the (invalid|)\s?name ((?:'[^']*')|(?:"[^"]*")) using the webUI$/
 	 *
 	 * @param string $invalid contains "invalid"
 	 *                        if the folder creation is expected to fail
@@ -376,6 +378,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user creates a folder with the following name using the webUI
+	 * @Given the user has created a folder with the following name using the webUI
 	 *
 	 * @param TableNode $namePartsTable table of parts of the file name
 	 *                                  table headings: must be: |name-parts |
@@ -839,6 +842,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	/**
 	 * @When the user chooses :label in the upload dialog
 	 * @When I click the :label button
+	 * @Given the user has chosen :label in the upload dialog
+	 * @Given I have clicked the :label button
 	 *
 	 * @param string $label
 	 *
@@ -1597,6 +1602,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user enables the setting to view hidden files/folders on the webUI
+	 * @Given the user has enabled the setting to view hidden files/folders on the webUI
 	 * @return void
 	 */
 	public function theUserEnablesTheSettingToViewHiddenFoldersOnTheWebUI() {

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -72,6 +72,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user re-logs in with username :username and password :password using the webUI
+	 * @Given the user has re-logged in with username :username and password :password using the webUI
 	 *
 	 * @param string $username
 	 * @param string $password
@@ -106,6 +107,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user re-logs in with username :username and password :password to :server using the webUI
+	 * @Given the user has re-logged in with username :username and password :password to :server using the webUI
 	 *
 	 * @param string $username
 	 * @param string $password
@@ -168,6 +170,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user logs in with username :username and password :password using the webUI after a redirect from the :page page
+	 * @Given the user has logged in with username :username and password :password using the webUI after a redirect from the :page page
 	 *
 	 * @param string $username
 	 * @param string $password
@@ -229,6 +232,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user requests the password reset link using the webUI
+	 * @Given the user has requested the password reset link using the webUI
 	 *
 	 * @return void
 	 */
@@ -253,6 +257,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user follows the password reset link from email address :emailAddress
+	 * @Given the user has followed the password reset link from email address :emailAddress
 	 *
 	 * @param string $emailAddress
 	 *
@@ -276,6 +281,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user resets the password to :newPassword using the webUI
+	 * @Given the user has reset the password to :newPassword using the webUI
 	 *
 	 * @param string $newPassword
 	 *

--- a/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
@@ -96,6 +96,7 @@ class WebUINotificationsContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When /^the user follows the link of the (first|last) notification on the webUI$/
+	 * @Given /^the user has followed the link of the (first|last) notification on the webUI$/
 	 *
 	 * @param string $firstOrLast first|last
 	 *
@@ -126,6 +127,7 @@ class WebUINotificationsContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When /^the user reacts with "(Accept|Decline)" to all notifications on the webUI$/
+	 * @Given /^the user has reacted with "(Accept|Decline)" to all notifications on the webUI$/
 	 *
 	 * @param string $reaction
 	 *
@@ -143,6 +145,7 @@ class WebUINotificationsContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user accepts all shares displayed in the notifications on the webUI
+	 * @Given the user has accepted all shares displayed in the notifications on the webUI
 	 *
 	 * @return void
 	 */
@@ -152,6 +155,7 @@ class WebUINotificationsContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user declines all shares displayed in the notifications on the webUI
+	 * @Given the user has declined all shares displayed in the notifications on the webUI
 	 *
 	 * @return void
 	 */

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -78,6 +78,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	 * if the expected page is not actually reached.
 	 *
 	 * @When /^the user attempts to browse to the personal general settings page$/
+	 * @Given /^the user has attempted to browse to the personal general settings page$/
 	 *
 	 * @return void
 	 */
@@ -91,6 +92,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 
 	/**
 	 * @When the user changes the language to :language using the webUI
+	 * @Given the user has changed the language to :language using the webUI
 	 *
 	 * @param string $language
 	 *
@@ -105,6 +107,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 
 	/**
 	 * @When the user changes the password to :newPassword using the webUI
+	 * @Given the user has changed the password to :newPassword using the webUI
 	 *
 	 * @param string $newPassword
 	 *
@@ -121,6 +124,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	
 	/**
 	 * @When the user changes the password to :newPassword entering the wrong current password using the webUI
+	 * @Given the user has changed the password to :newPassword entering the wrong current password using the webUI
 	 *
 	 * @param string $newPassword
 	 *
@@ -137,6 +141,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 
 	/**
 	 * @When the user changes the full name to :newFullname using the webUI
+	 * @Given the user has changed the full name to :newFullname using the webUI
 	 *
 	 * @param string $newFullname
 	 *
@@ -150,6 +155,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 
 	/**
 	 * @When the user changes the email address to :emailAddress using the webUI
+	 * @Given the user has changed the email address to :emailAddress using the webUI
 	 *
 	 * @param string $emailAddress
 	 *
@@ -163,6 +169,7 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 
 	/**
 	 * @When the user follows the email change confirmation link received by :emailAddress using the webUI
+	 * @Given the user has followed the email change confirmation link received by :emailAddress using the webUI
 	 *
 	 * @param string $emailAddress
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
@@ -118,6 +118,7 @@ class WebUIPersonalSecuritySettingsContext extends RawMinkContext implements Con
 
 	/**
 	 * @When the user re-logs in with username :username and generated app password using the webUI
+	 * @Given the user has re-logged in with username :username and generated app password using the webUI
 	 *
 	 * @param string $username
 	 *
@@ -131,6 +132,7 @@ class WebUIPersonalSecuritySettingsContext extends RawMinkContext implements Con
 
 	/**
 	 * @When the user deletes the app password
+	 * @Given the user has deleted the app password
 	 *
 	 * @return void
 	 * @throws \Exception
@@ -148,6 +150,7 @@ class WebUIPersonalSecuritySettingsContext extends RawMinkContext implements Con
 
 	/**
 	 * @When the user re-logs in with username :username and deleted app password using the webUI
+	 * @Given the user has re-logged in with username :username and deleted app password using the webUI
 	 *
 	 * @param string $username
 	 *

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -286,6 +286,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user types :input in the share-with-field
+	 * @Given the user has typed :input in the share-with-field
 	 *
 	 * @param string $input
 	 *
@@ -401,6 +402,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the public accesses the last created public link using the webUI
+	 * @Given the public has accessed the last created public link using the webUI
 	 *
 	 * @return void
 	 * @throws \Exception
@@ -420,6 +422,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the public adds the public link to :server as user :username with the password :password using the webUI
+	 * @Given the public has added the public link to :server as user :username with the password :password using the webUI
 	 *
 	 * @param string $server
 	 * @param string $username
@@ -443,6 +446,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When /^the user (declines|accepts) the share "([^"]*)" offered by user "([^"]*)" using the webUI$/
+	 * @Given /^the user has (declined|accepted) the share "([^"]*)" offered by user "([^"]*)" using the webUI$/
 	 *
 	 * @param string $action
 	 * @param string $share
@@ -461,7 +465,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$found = false;
 		foreach ($fileRows as $fileRow) {
 			if ($offeredBy === $fileRow->getSharer()) {
-				if ($action === "accepts") {
+				if (\substr($action, 0, 6) === "accept") {
 					$fileRow->acceptShare($this->getSession());
 				} else {
 					$fileRow->declineShare($this->getSession());


### PR DESCRIPTION
## Description
Add ``Given`` forms of various ``webUI`` ``When`` steps that might be useful some time when setting up a scenario in an app.

## Motivation and Context
From ``password_policy`` I want to write scenarios like:
```
  Scenario: user resets their password to a just long-enough string
    Given the administrator has enabled the minimum characters password policy
    And the administrator has set the minimum characters to "10"
    And the user requests the password reset link using the webUI
    And the user follows the password reset link from email address "u1@oc.com.np"
    When the user resets the password to "10ten10ten" using the webUI
    And the user logs in with username "user1" and password "10ten10ten" using the webUI
    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
```

Those first few steps are "setup" in the case of this scenario. It is resetting the password that is the active thing to be tested. So I want to be able to use the ``Given`` step forms:
```
    And the user has requested the password reset link using the webUI
    And the user has followed the password reset link from email address "u1@oc.com.np"
```

And as I add ``password_policy`` scenarios I am going to find more of this stuff. So I have looked through the ``webUI`` for steps that could be useful to have a ``Given`` form.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
