### PR TITLE
Fix sinon js tests

### DIFF
--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -76,7 +76,7 @@ describe('OC.Upload tests', function() {
 				originalFiles: files,
 				files: [file],
 				jqXHR: jqXHR,
-				response: sinon.stub.returns(jqXHR),
+				response: sinon.stub().returns(jqXHR),
 				submit: sinon.stub(),
 				abort: sinon.stub()
 			};

--- a/apps/files_sharing/tests/js/shareSpec.js
+++ b/apps/files_sharing/tests/js/shareSpec.js
@@ -471,13 +471,13 @@ describe('OCA.Sharing.Util tests', function() {
 	});
 
 	describe('ShareTabView interaction', function() {
-		var shareTabSpy;
+		var onSpy;
 		var fileInfoModel;
 		var configModel;
 		var shareModel;
 
 		beforeEach(function() {
-			shareTabSpy = sinon.spy(OCA.Sharing, 'ShareTabView');
+			onSpy = sinon.spy(OCA.Sharing.ShareTabView.prototype, 'on');
 
 			var attributes = {
 				itemType: 'file',
@@ -530,14 +530,14 @@ describe('OCA.Sharing.Util tests', function() {
 			fileList.setFiles(testFiles);
 		});
 		afterEach(function() { 
-			shareTabSpy.restore(); 
+			onSpy.restore();
 		});
 
 		it('updates fileInfoModel when shares changed', function() {
 			var changeHandler = sinon.stub();
 			fileInfoModel.on('change', changeHandler);
 
-			shareTabSpy.getCall(0).thisValue.trigger('sharesChanged', shareModel);
+			onSpy.thisValues[0].trigger('sharesChanged', shareModel);
 
 			expect(changeHandler.calledOnce).toEqual(true);
 			expect(changeHandler.getCall(0).args[0].changed).toEqual({

--- a/core/js/tests/specHelper.js
+++ b/core/js/tests/specHelper.js
@@ -100,6 +100,7 @@ window.oc_appconfig = {
 	core: {}
 };
 window.oc_defaults = {};
+window.oc_requesttoken = 'testrequesttoken';
 
 /* jshint camelcase: true */
 
@@ -155,6 +156,9 @@ window.isPhantom = /phantom/i.test(navigator.userAgent);
 		// custom responses
 		window.fakeServer = fakeServer;
 
+		window.oc_requesttoken = 'testrequesttoken';
+		OC.requestToken = window.oc_requesttoken;
+
 		if (!OC.TestUtil) {
 			OC.TestUtil = TestUtil;
 		}
@@ -163,6 +167,9 @@ window.isPhantom = /phantom/i.test(navigator.userAgent);
 
 		// reset plugins
 		OC.Plugins._plugins = [];
+
+		// reset default Files.Client instance
+		delete OC.Files._defaultClient;
 
 		// dummy select2 (which isn't loaded during the tests)
 		$.fn.select2 = function() { return this; };


### PR DESCRIPTION
Fixes JS unit tests to be able to work with future Sinon JS releases.

This is related to https://github.com/owncloud/core/pull/32316 but is missing the davclient.js update.

As the tests work with the current version let's just update them here to avoid future conflicts.