### PR TITLE
[stable10] adjust badges on core readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # ownCloud Core
 
-[![Build Status](https://jenkins.owncloud.org/buildStatus/icon?job=owncloud-core/core/master)](https://jenkins.owncloud.org/job/owncloud-core/job/core/job/master/)
+[![Build Status](https://drone.owncloud.com/api/badges/owncloud/core/status.svg?branch=master)](https://drone.owncloud.com/owncloud/core)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/owncloud/core/badges/quality-score.png?s=ce2f5ded03d4ac628e9ee5c767243fa7412e644f)](https://scrutinizer-ci.com/g/owncloud/core/)
 [![codecov.io](https://codecov.io/github/owncloud/core/coverage.svg?branch=master)](https://codecov.io/github/owncloud/core?branch=master)
-[![Dependency Status](https://www.versioneye.com/user/projects/54f4a2384f3108959a000a16/badge.svg?style=flat)](https://www.versioneye.com/user/projects/54f4a2384f3108959a000a16)
-[![Dependency Status](https://www.versioneye.com/user/projects/54d1f76f3ca0840b190000c0/badge.svg?style=flat)](https://www.versioneye.com/user/projects/54d1f76f3ca0840b190000c0)
 [![Build Status](https://saucelabs.com/buildstatus/DeepDiver1975)](https://saucelabs.com/beta/builds/358889d1dc0a45ff927e3d6b844cabf0)
 
 **[ownCloud](http://ownCloud.org) gives you freedom and control over your own data.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ownCloud Core
 
-[![Build Status](https://drone.owncloud.com/api/badges/owncloud/core/status.svg?branch=master)](https://drone.owncloud.com/owncloud/core)
+[![Build Status](https://drone.owncloud.com/api/badges/owncloud/core/status.svg?branch=stable10)](https://drone.owncloud.com/owncloud/core)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/owncloud/core/badges/quality-score.png?s=ce2f5ded03d4ac628e9ee5c767243fa7412e644f)](https://scrutinizer-ci.com/g/owncloud/core/)
 [![codecov.io](https://codecov.io/github/owncloud/core/coverage.svg?branch=master)](https://codecov.io/github/owncloud/core?branch=master)
 [![Build Status](https://saucelabs.com/buildstatus/DeepDiver1975)](https://saucelabs.com/beta/builds/358889d1dc0a45ff927e3d6b844cabf0)


### PR DESCRIPTION
Backport #32399 

The master PR had backport-request on it. I guess we want to keep ``README.md`` reasonably in sync in ``stable10``