### PR TITLE
Pass an additional parameter on the core update

### DIFF
--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -73,7 +73,13 @@ class Upgrade extends Command {
 				null,
 				InputOption::VALUE_NONE,
 				'Skip disabling of third party apps.'
-			);
+			)
+			->addOption(
+				'--major',
+				null,
+				InputOption::VALUE_NONE,
+				'Automatically update apps to new major versions during minor updates of ownCloud Server'
+				);
 	}
 
 	/**
@@ -96,12 +102,15 @@ class Upgrade extends Command {
 				$output->setFormatter($timestampFormatter);
 			}
 
-			$self = $this;
 			$updater = new Updater(
 					$this->config,
 					\OC::$server->getIntegrityCodeChecker(),
 					$this->logger
 			);
+
+			if ($input->getOption('major')) {
+				$updater->setForceMajorUpgrade(true);
+			}
 
 			$dispatcher = \OC::$server->getEventDispatcher();
 			$progress = new ProgressBar($output);

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -195,7 +195,6 @@ class Repair implements IOutput {
 			new SqliteAutoincrement($connection),
 			new RepairOrphanedSubshare($connection),
 			new SearchLuceneTables(),
-			new Apps(\OC::$server->getAppManager(), \OC::$server->getEventDispatcher(), \OC::$server->getConfig(), new \OC_Defaults()),
 		];
 
 		//There is no need to delete all previews on every single update

--- a/tests/lib/Repair/AppsTest.php
+++ b/tests/lib/Repair/AppsTest.php
@@ -19,10 +19,12 @@
  *
  */
 namespace Test\Repair;
+
 use OC\Repair\Apps;
 use OCP\App\IAppManager;
 use OCP\IConfig;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
 /**
@@ -32,11 +34,11 @@ use Test\TestCase;
  */
 class AppsTest extends TestCase {
 
-	/** @var Apps */
+	/** @var Apps | \PHPUnit_Framework_MockObject_MockObject */
 	protected $repair;
 	/** @var IAppManager | \PHPUnit_Framework_MockObject_MockObject */
 	protected $appManager;
-	/** @var  EventDispatcher | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var  EventDispatcherInterface | \PHPUnit_Framework_MockObject_MockObject */
 	protected $eventDispatcher;
 	/** @var  IConfig | \PHPUnit_Framework_MockObject_MockObject*/
 	protected $config;
@@ -45,12 +47,16 @@ class AppsTest extends TestCase {
 
 	protected function setUp() {
 		parent::setUp();
-
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->defaults = $this->createMock(\OC_Defaults::class);
-		$this->eventDispatcher = $this->createMock(EventDispatcher::class);
+		$this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 		$this->config = $this->createMock(IConfig::class);
-		$this->repair = new Apps($this->appManager, $this->eventDispatcher, $this->config, $this->defaults);
+		$this->repair = new Apps(
+			$this->appManager,
+			$this->eventDispatcher,
+			$this->config,
+			$this->defaults
+		);
 	}
 
 	public function testMarketEnableVersionCompare10() {
@@ -71,5 +77,65 @@ class AppsTest extends TestCase {
 	public function testMarketEnableVersionCompareCurrent() {
 		$this->config->expects($this->once())->method('getSystemValue')->with('version', '0.0.0')->willReturn('10.0.1');
 		$this->assertFalse($this->invokePrivate($this->repair, 'requiresMarketEnable'));
+	}
+
+	public function dataTestUpdateEvent() {
+		return [
+			['10.1.0.0', [10, 1, 3, 7], false, false], // same major version
+			['10.1.0.0', [10, 1, 3, 7], true, true],   // same major version, but major forced
+			['10.1.0.0', [11, 0, 2, 0], false, true],  // different major version
+			['10.1.0.0', [10, 0, 2, 0], true, true],  // different major version, major forced
+		];
+	}
+
+	/**
+	 * @dataProvider dataTestUpdateEvent
+	 * @param string $installedVersion
+	 * @param int[] $sourcesVersion
+	 * @param bool $forceMajorUpdate
+	 * @param bool $expectedIsMajorUpdate
+	 */
+	public function testUpdateAppEvent($installedVersion, $sourcesVersion, $forceMajorUpdate, $expectedIsMajorUpdate) {
+		$appName = 'fakeapp';
+
+		$this->config->method('getSystemValue')
+			->with('version', '0.0.0')
+			->willReturn($installedVersion);
+		$this->configureRepair(['getSourcesVersion'], $forceMajorUpdate);
+
+		$this->repair->method('getSourcesVersion')
+			->willReturn($sourcesVersion);
+
+		$this->eventDispatcher->expects($this->once())->method('dispatch')
+			->willReturnCallback(
+				function ($eventName, $event) use ($appName) {
+					$this->assertEquals($appName, $event->getSubject());
+					$this->assertEquals(true, $event->getArgument('isMajorUpdate'));
+				}
+			);
+		$this->invokePrivate(
+			$this->repair,
+			'getAppsFromMarket',
+			[
+				new \OC\Migration\ConsoleOutput(new NullOutput()),
+				[ $appName ],
+				'john'
+			]
+		);
+	}
+
+	private function configureRepair($mockedMethods, $forceMajorUpgrade = false) {
+		$this->repair = $this->getMockBuilder(Apps::class)
+			->setConstructorArgs(
+				[
+					$this->appManager,
+					$this->eventDispatcher,
+					$this->config,
+					$this->defaults,
+					$forceMajorUpgrade
+				]
+			)
+			->setMethods($mockedMethods)
+			->getMock();
 	}
 }


### PR DESCRIPTION
## Description
pass the additional argument that shows whether major core update in progress

## Related Issue
- Fixes https://github.com/owncloud/market/issues/387

## Motivation and Context
Minor ownCloud upgrades should not trigger minor app updates

## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x]  Pass `--major` CLI option into the repair step
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
