### PR TITLE
IServerContainer interface should extend IContainer

### DIFF
--- a/lib/public/IServerContainer.php
+++ b/lib/public/IServerContainer.php
@@ -53,7 +53,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * This container holds all ownCloud services
  * @since 6.0.0
  */
-interface IServerContainer {
+interface IServerContainer extends IContainer {
 
 	/**
 	 * The contacts manager will act as a broker between consumers for contacts information and


### PR DESCRIPTION
## Description
While bumping phan to the 1.0.x branch - several issues have been caught. 
Amongst is the fact, that our Applications have access to the ServerContainer via a `IAppContainer` 
 https://github.com/owncloud/core/blob/2de709ee929ff8ffd480019c82e09929134ad41d/lib/public/AppFramework/IAppContainer.php#L54

This method returns a `IServerContainer` - which has specific services defined - but not general `query` method.

Some applications, then proceed to use `query` on the object they have received - which during RunTime is https://github.com/owncloud/core/blob/bc84acd48053b314100f101c975100bc220adc9a/lib/private/Server.php

But this is not correct - the interface doesn't provide the method and we are relying on the implementation here.

I propose to state, that `IServerContainer` infact extends `IContainer` so we are conform with allowing `query` methods.

**Alternative** - be strict about and rewrite the apps that rely on this implementation detail to use only allowed methods from the interface

## Related Issue
Fixes the issues found by phan:

```
[php-phan:L55:86s] apps/files_external/lib/AppInfo/Application.php:47 PhanUndeclaredMethod Call to undeclared method \OCP\IServerContainer::query
[php-phan:L56:86s] apps/files_external/lib/AppInfo/Application.php:50 PhanUndeclaredMethod Call to undeclared method \OCP\IServerContainer::query
[php-phan:L57:86s] apps/files_external/lib/AppInfo/Application.php:53 PhanUndeclaredMethod Call to undeclared method \OCP\IServerContainer::query
[php-phan:L58:86s] apps/files_external/lib/AppInfo/Application.php:56 PhanUndeclaredMethod Call to undeclared method \OCP\IServerContainer::query
[php-phan:L59:86s] apps/files_external/lib/AppInfo/Application.php:59 PhanUndeclaredMethod Call to undeclared method \OCP\IServerContainer::query
[php-phan:L60:86s] apps/files_external/lib/AppInfo/Application.php:62 PhanUndeclaredMethod Call to undeclared method \OCP\IServerContainer::query
```

## Motivation and Context
Solve technical debt, prevent future bugs

## How Has This Been Tested?
- 🤖 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
