### PR TITLE
[stable10] run phan on php7.0 - 7.2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -114,8 +114,26 @@ pipeline:
       matrix:
         TEST_SUITE: lint
 
-  php-phan:
+  php-phan-70:
+    image: owncloudci/php:7.0
+    pull: true
+    commands:
+      - make test-php-phan
+    when:
+      matrix:
+        TEST_SUITE: phan
+
+  php-phan-71:
     image: owncloudci/php:7.1
+    pull: true
+    commands:
+      - make test-php-phan
+    when:
+      matrix:
+        TEST_SUITE: phan
+
+  php-phan-72:
+    image: owncloudci/php:7.2
     pull: true
     commands:
       - make test-php-phan

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ test-php-style: $(composer_dev_deps)
 
 .PHONY: test-php-phan
 test-php-phan: $(PHAN_BIN)
-	php $(PHAN_BIN) --config-file .phan/config.php --require-config-exists -p
+	php $(PHAN_BIN) --config-file .phan/config.php --require-config-exists
 
 .PHONY: test
 test: test-php-lint test-php-style test-php test-js test-acceptance


### PR DESCRIPTION
## Description
Added 2 permutations for phan, to run it with php 7.0, 7.1 and 7.2

## Motivation and Context
phan analyzes the AST - which gets compiled from the underlying php. Running in the different versions, ensures that methods / interface are staying compatible with the different php runtimes


## How Has This Been Tested?
- 🤖 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
