### PR TITLE
use guzzle globally through a helper

### DIFF
--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace TestHelpers;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+use GuzzleHttp\Exception\BadResponseException;
+
+/**
+ * Helper for HTTP requests
+ */
+class HttpRequestHelper {
+	/**
+	 *
+	 * @param string $url
+	 * @param string $method
+	 * @param string $user
+	 * @param string $password
+	 * @param array $headers ['X-MyHeader' => 'value']
+	 * @param mixed $body
+	 * @param array $config
+	 * @param CookieJar $cookies
+	 * @param boolean $stream
+	 *
+	 * @throws BadResponseException
+	 * @return \GuzzleHttp\Message\ResponseInterface|NULL|\GuzzleHttp\Message\FutureResponse
+	 */
+	public static function sendRequest(
+		$url,
+		$method = 'GET',
+		$user = null,
+		$password = null,
+		$headers = null,
+		$body = null,
+		$config = null,
+		$cookies = null,
+		$stream = false
+	) {
+		$client = new Client();
+		$options = [];
+		if ($user !== null) {
+			$options['auth'] = [$user, $password];
+		}
+		if ($body !== null) {
+			$options['body'] = $body;
+		}
+		if ($config !== null) {
+			$options['config'] = $config;
+		}
+		if ($cookies !== null) {
+			$options['cookies'] = $cookies;
+		}
+		$options['stream'] = $stream;
+		$options['verify'] = false;
+		
+		$request = $client->createRequest($method, $url, $options);
+		if ($headers !== null) {
+			foreach ($headers as $key => $value) {
+				if ($request->hasHeader($key) === true) {
+					$request->setHeader($key, $value);
+				} else {
+					$request->addHeader($key, $value);
+				}
+			}
+		}
+
+		try {
+			$response = $client->send($request);
+		} catch (BadResponseException $ex) {
+			$response = $ex->getResponse();
+			
+			//if the response was null for some reason do not return it but re-throw
+			if ($response === null) {
+				throw $ex;
+			}
+		}
+		return $response;
+	}
+
+	/**
+	 * same as HttpRequestHelper::sendRequest() but with "GET" as method
+	 *
+	 * @see HttpRequestHelper::sendRequest()
+	 *
+	 * @param string $url
+	 * @param string $user
+	 * @param string $password
+	 * @param array $headers ['X-MyHeader' => 'value']
+	 * @param mixed $body
+	 * @param array $config
+	 * @param CookieJar $cookies
+	 * @param boolean $stream
+	 *
+	 * @throws BadResponseException
+	 * @return \GuzzleHttp\Message\ResponseInterface|NULL|\GuzzleHttp\Message\FutureResponse
+	 */
+	public static function get(
+		$url,
+		$user = null,
+		$password = null,
+		$headers = null,
+		$body = null,
+		$config = null,
+		$cookies = null,
+		$stream = false
+	) {
+		return self::sendRequest(
+			$url, 'GET', $user, $password, $headers, $body, $config, $cookies, $stream
+		);
+	}
+
+	/**
+	 * same as HttpRequestHelper::sendRequest() but with "POST" as method
+	 *
+	 * @see HttpRequestHelper::sendRequest()
+	 *
+	 * @param string $url
+	 * @param string $user
+	 * @param string $password
+	 * @param array $headers ['X-MyHeader' => 'value']
+	 * @param mixed $body
+	 * @param array $config
+	 * @param CookieJar $cookies
+	 * @param boolean $stream
+	 *
+	 * @throws BadResponseException
+	 * @return \GuzzleHttp\Message\ResponseInterface|NULL|\GuzzleHttp\Message\FutureResponse
+	 */
+	public static function post(
+		$url,
+		$user = null,
+		$password = null,
+		$headers = null,
+		$body = null,
+		$config = null,
+		$cookies = null,
+		$stream = false
+	) {
+		return self::sendRequest(
+			$url, 'POST', $user, $password, $headers, $body, $config, $cookies, $stream
+		);
+	}
+
+	/**
+	 * same as HttpRequestHelper::sendRequest() but with "PUT" as method
+	 *
+	 * @see HttpRequestHelper::sendRequest()
+	 *
+	 * @param string $url
+	 * @param string $user
+	 * @param string $password
+	 * @param array $headers ['X-MyHeader' => 'value']
+	 * @param mixed $body
+	 * @param array $config
+	 * @param CookieJar $cookies
+	 * @param boolean $stream
+	 *
+	 * @throws BadResponseException
+	 * @return \GuzzleHttp\Message\ResponseInterface|NULL|\GuzzleHttp\Message\FutureResponse
+	 */
+	public static function put(
+		$url,
+		$user = null,
+		$password = null,
+		$headers = null,
+		$body = null,
+		$config = null,
+		$cookies = null,
+		$stream = false
+	) {
+		return self::sendRequest(
+			$url, 'PUT', $user, $password, $headers, $body, $config, $cookies, $stream
+		);
+	}
+
+	/**
+	 * same as HttpRequestHelper::sendRequest() but with "DELETE" as method
+	 *
+	 * @see HttpRequestHelper::sendRequest()
+	 *
+	 * @param string $url
+	 * @param string $user
+	 * @param string $password
+	 * @param array $headers ['X-MyHeader' => 'value']
+	 * @param mixed $body
+	 * @param array $config
+	 * @param CookieJar $cookies
+	 * @param boolean $stream
+	 *
+	 * @throws BadResponseException
+	 * @return \GuzzleHttp\Message\ResponseInterface|NULL|\GuzzleHttp\Message\FutureResponse
+	 */
+	public static function delete(
+		$url,
+		$user = null,
+		$password = null,
+		$headers = null,
+		$body = null,
+		$config = null,
+		$cookies = null,
+		$stream = false
+	) {
+		return self::sendRequest(
+			$url, 'DELETE', $user, $password, $headers, $body, $config, $cookies, $stream
+		);
+	}
+}

--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -21,9 +21,7 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Client;
 use GuzzleHttp\Message\ResponseInterface;
-use GuzzleHttp\Exception\ClientException;
 
 /**
  * Helper to make requests to the OCS API
@@ -42,7 +40,6 @@ class OcsApiHelper {
 	 * @param int $ocsApiVersion (1|2) default 2
 	 *
 	 * @return ResponseInterface
-	 * @throws ClientException
 	 */
 	public static function sendRequest(
 		$baseUrl, $user, $password, $method, $path, $body = [], $ocsApiVersion = 2
@@ -52,25 +49,7 @@ class OcsApiHelper {
 			$fullUrl .= '/';
 		}
 		$fullUrl .= "ocs/v{$ocsApiVersion}.php" . $path;
-		$client = new Client();
-		$options = [];
-		if ($user !== null) {
-			$options['auth'] = [$user, $password];
-		}
-		$options['body'] = $body;
 		
-		try {
-			$response = $client->send(
-				$client->createRequest($method, $fullUrl, $options)
-			);
-		} catch (ClientException $ex) {
-			$response = $ex->getResponse();
-			
-			//if the response was null for some reason do not return it but re-throw
-			if ($response === null) {
-				throw $ex;
-			}
-		}
-		return $response;
+		return HttpRequestHelper::sendRequest($fullUrl, $method, $user, $password, [], $body);
 	}
 }

--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -21,8 +21,6 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Client as GClient;
-
 /**
  * manage Shares via OCS API
  *
@@ -81,7 +79,6 @@ class SharingHelper {
 		$sharingApiVersion = 1
 	) {
 		$fd = [];
-		$options = [];
 		foreach ([$path, $baseUrl, $user, $password] as $variableToCheck) {
 			if (!\is_string($variableToCheck)) {
 				throw new \InvalidArgumentException(
@@ -155,8 +152,6 @@ class SharingHelper {
 			$fullUrl .= '/';
 		}
 		$fullUrl .= "ocs/v{$ocsApiVersion}.php/apps/files_sharing/api/v{$sharingApiVersion}/shares";
-		$client = new GClient();
-		$options['auth'] = [$user, $password];
 		$fd['path'] = $path;
 		$fd['shareType'] = $shareType;
 
@@ -173,8 +168,6 @@ class SharingHelper {
 			$fd['name'] = $linkName;
 		}
 
-		$options['body'] = $fd;
-
-		return $client->send($client->createRequest("POST", $fullUrl, $options));
+		return HttpRequestHelper::post($fullUrl, $user, $password, null, $fd);
 	}
 }

--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -141,8 +141,7 @@ class TagsHelper {
 	 * @param string $groups separated by "|"
 	 * @param int $davPathVersionToUse (1|2)
 	 *
-	 * @return array ['lastTagId', 'HTTPResponse']
-	 * @throws \GuzzleHttp\Exception\ClientException
+	 * @return \GuzzleHttp\Message\ResponseInterface|NULL|\GuzzleHttp\Message\FutureResponse
 	 * @link self::makeDavRequest()
 	 */
 	public static function createTag(
@@ -166,7 +165,7 @@ class TagsHelper {
 			$body['groups'] = $groups;
 		}
 
-		$response = WebDavHelper::makeDavRequest(
+		return WebDavHelper::makeDavRequest(
 			$baseUrl,
 			$user,
 			$password,
@@ -178,10 +177,6 @@ class TagsHelper {
 			$davPathVersionToUse,
 			"systemtags"
 		);
-		$responseHeaders = $response->getHeaders();
-		$tagUrl = $responseHeaders['Content-Location'][0];
-		$lastTagId = \substr($tagUrl, \strrpos($tagUrl, '/') + 1);
-		return ['lastTagId' => $lastTagId, 'HTTPResponse' => $response];
 	}
 
 	/**
@@ -193,7 +188,6 @@ class TagsHelper {
 	 * @param int $davPathVersionToUse (1|2)
 	 *
 	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
-	 * @throws \GuzzleHttp\Exception\ClientException
 	 */
 	public static function deleteTag(
 		$baseUrl,

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -22,12 +22,11 @@
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
-use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
-use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\ResponseInterface;
 use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
+use TestHelpers\HttpRequestHelper;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
@@ -707,44 +706,39 @@ trait BasicStructure {
 	 */
 	public function sendingToWithDirectUrl($user, $verb, $url, $body, $password = null) {
 		$fullUrl = $this->getBaseUrl() . $url;
-		$client = new Client();
-		$options = [];
+
 		if ($password === null) {
-			$options['auth'] = $this->getAuthOptionForUser($user);
-		} else {
-			$options['auth'] = [$user, $password];
+			$password = $this->getPasswordForUser($user);
 		}
 		
-		if (!empty($this->guzzleClientHeaders)) {
-			$options ['headers'] = $this->guzzleClientHeaders;
-		}
-		
+		$headers = $this->guzzleClientHeaders;
+
+		$config = null;
 		if ($this->sourceIpAddress !== null) {
-			$options ['config'] = [
+			$config = [
 				'curl' => [
 					CURLOPT_INTERFACE => $this->sourceIpAddress
 				]
 			];
 		}
 		
+		$cookies = null;
 		if (!empty($this->cookieJar->toArray())) {
-			$options['cookies'] = $this->cookieJar;
+			$cookies = $this->cookieJar;
 		}
 
+		$fd = null;
 		if ($body instanceof TableNode) {
 			$fd = $body->getRowsHash();
-			$options['body'] = $fd;
 		}
 
-		try {
-			$request = $client->createRequest($verb, $fullUrl, $options);
-			if (isset($this->requestToken)) {
-				$request->addHeader('requesttoken', $this->requestToken);
-			}
-			$this->response = $client->send($request);
-		} catch (BadResponseException $ex) {
-			$this->response = $ex->getResponse();
+		if (isset($this->requestToken)) {
+			$headers['requesttoken'] = $this->requestToken;
 		}
+
+		$this->response = HttpRequestHelper::sendRequest(
+			$fullUrl, $verb, $user, $password, $headers, $fd, $config, $cookies
+		);
 	}
 
 	/**
@@ -883,32 +877,31 @@ trait BasicStructure {
 	public function userHasLoggedInToAWebStyleSessionUsingTheAPI($user) {
 		$loginUrl = $this->getBaseUrl() . '/login';
 		// Request a new session and extract CSRF token
-		$client = new Client();
-		$options = [];
-		if (!empty($this->guzzleClientHeaders)) {
-			$options ['headers'] = $this->guzzleClientHeaders;
-		}
 		
+		$config = null;
 		if ($this->sourceIpAddress !== null) {
-			$options ['config'] = [
+			$config = [
 				'curl' => [
 					CURLOPT_INTERFACE => $this->sourceIpAddress
 				]
 			];
 		}
-		$options ['cookies'] = $this->cookieJar;
-		$response = $client->get($loginUrl, $options);
+
+		$response = HttpRequestHelper::get(
+			$loginUrl, null, null, $this->guzzleClientHeaders, null, $config, $this->cookieJar
+		);
 		$this->extractRequestTokenFromResponse($response);
 
 		// Login and extract new token
 		$password = $this->getPasswordForUser($user);
-		$client = new Client();
-		$options ['body'] = [
+		$body = [
 			'user' => $user,
 			'password' => $password,
 			'requesttoken' => $this->requestToken
 		];
-		$response = $client->post($loginUrl, $options);
+		$response = HttpRequestHelper::post(
+			$loginUrl, null, null, $this->guzzleClientHeaders, $body, $config, $this->cookieJar
+		);
 		$this->extractRequestTokenFromResponse($response);
 	}
 
@@ -922,29 +915,23 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function sendingAToWithRequesttoken($method, $url) {
-		$client = new Client();
-		$options = [];
-		if (!empty($this->guzzleClientHeaders)) {
-			$options ['headers'] = $this->guzzleClientHeaders;
-		}
+		$headers = $this->guzzleClientHeaders;
 		
+		$config = null;
 		if ($this->sourceIpAddress !== null) {
-			$options ['config'] = [
+			$config = [
 				'curl' => [
 					CURLOPT_INTERFACE => $this->sourceIpAddress
 				]
 			];
 		}
-		$options ['cookies'] = $this->cookieJar;
-		$request = $client->createRequest(
-			$method, $this->getBaseUrl() . $url, $options
+
+		$headers['requesttoken'] = $this->requestToken;
+
+		$url = $this->getBaseUrl() . $url;
+		$this->response = HttpRequestHelper::sendRequest(
+			$url, $method, null, null, $headers, null, $config, $this->cookieJar
 		);
-		$request->addHeader('requesttoken', $this->requestToken);
-		try {
-			$this->response = $client->send($request);
-		} catch (BadResponseException $e) {
-			$this->response = $e->getResponse();
-		}
 	}
 
 	/**
@@ -957,28 +944,20 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function sendingAToWithoutRequesttoken($method, $url) {
-		$client = new Client();
-		$options = [];
-		if (!empty($this->guzzleClientHeaders)) {
-			$options ['headers'] = $this->guzzleClientHeaders;
-		}
-		
+		$config = null;
 		if ($this->sourceIpAddress !== null) {
-			$options ['config'] = [
+			$config = [
 				'curl' => [
 					CURLOPT_INTERFACE => $this->sourceIpAddress
 				]
 			];
 		}
-		$options ['cookies'] = $this->cookieJar;
-		$request = $client->createRequest(
-			$method, $this->getBaseUrl() . $url, $options
+
+		$url = $this->getBaseUrl() . $url;
+		$this->response = HttpRequestHelper::sendRequest(
+			$url, $method, null, null, $this->guzzleClientHeaders,
+			null, $config, $this->cookieJar
 		);
-		try {
-			$this->response = $client->send($request);
-		} catch (BadResponseException $e) {
-			$this->response = $e->getResponse();
-		}
 	}
 
 	/**
@@ -1109,28 +1088,20 @@ trait BasicStructure {
 	 */
 	public function getStatusPhp() {
 		$fullUrl = $this->getBaseUrl() . "/status.php";
-		$client = new Client();
-		$options = [];
-		if (!empty($this->guzzleClientHeaders)) {
-			$options ['headers'] = $this->guzzleClientHeaders;
-		}
 		
+		$config = null;
 		if ($this->sourceIpAddress !== null) {
-			$options ['config'] = [
+			$config = [
 				'curl' => [
 					CURLOPT_INTERFACE => $this->sourceIpAddress
 				]
 			];
 		}
-		$options ['cookies'] = $this->cookieJar;
-		$options['auth'] = $this->getAuthOptionForUser('admin');
-		try {
-			$this->response = $client->send(
-				$client->createRequest('GET', $fullUrl, $options)
-			);
-		} catch (BadResponseException $ex) {
-			$this->response = $ex->getResponse();
-		}
+
+		$this->response = HttpRequestHelper::get(
+			$fullUrl, $this->getAdminUsername(),
+			$this->getAdminPassword(), $this->guzzleClientHeaders, null, $config
+		);
 	}
 
 	/**
@@ -1321,8 +1292,6 @@ trait BasicStructure {
 			$fullUrl .= '/';
 		}
 		$fullUrl .= "ocs/v1.php/apps/testing/api/v1/increasefileid";
-		$client = new Client();
-		$options = [];
 		$suiteSettingsContexts = $scope->getSuite()->getSettings()['contexts'];
 		$adminUsername = null;
 		$adminPassword = null;
@@ -1352,7 +1321,6 @@ trait BasicStructure {
 			);
 		}
 
-		$options['auth'] = [$adminUsername, $adminPassword];
-		$client->send($client->createRequest('POST', $fullUrl, $options));
+		HttpRequestHelper::post($fullUrl, $adminUsername, $adminPassword);
 	}
 }

--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -22,18 +22,13 @@
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\ResponseInterface;
+use TestHelpers\HttpRequestHelper;
 
 /**
  * CalDav functions
  */
 class CalDavContext implements \Behat\Behat\Context\Context {
-	/**
-	 * @var Client
-	 */
-	private $client;
 	/**
 	 * @var ResponseInterface
 	 */
@@ -60,7 +55,6 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
-		$this->client = new Client();
 		$this->responseXml = '';
 	}
 
@@ -72,15 +66,11 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	public function afterScenario() {
 		$davUrl = $this->featureContext->getBaseUrl()
 			. '/remote.php/dav/calendars/admin/MyCalendar';
-		try {
-			$this->client->delete(
-				$davUrl,
-				[
-					'auth' => $this->featureContext->getAuthOptionForAdmin()
-				]
-			);
-		} catch (BadResponseException $e) {
-		}
+		HttpRequestHelper::delete(
+			$davUrl,
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword()
+		);
 	}
 
 	/**
@@ -95,16 +85,9 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 		$davUrl = $this->featureContext->getBaseUrl()
 			. "/remote.php/dav/calendars/$calendar";
 
-		try {
-			$this->response = $this->client->get(
-				$davUrl,
-				[
-					'auth' => $this->featureContext->getAuthOptionForUser($user)
-				]
-			);
-		} catch (BadResponseException $e) {
-			$this->response = $e->getResponse();
-		}
+		$this->response = HttpRequestHelper::get(
+			$davUrl, $user, $this->featureContext->getPasswordForUser($user)
+		);
 	}
 
 	/**
@@ -191,16 +174,20 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 		$davUrl = $this->featureContext->getBaseUrl()
 			. "/remote.php/dav/calendars/$user/$name";
 
-		$request = $this->client->createRequest(
-			'MKCALENDAR',
-			$davUrl,
-			[
-				'body' => '<c:mkcalendar xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:d="DAV:" xmlns:a="http://apple.com/ns/ical/" xmlns:o="http://owncloud.org/ns"><d:set><d:prop><d:displayname>test</d:displayname><o:calendar-enabled>1</o:calendar-enabled><a:calendar-color>#21213D</a:calendar-color><c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set></d:prop></d:set></c:mkcalendar>',
-				'auth' => $this->featureContext->getAuthOptionForUser($user)
-			]
-		);
+		$body
+			= '<c:mkcalendar xmlns:c="urn:ietf:params:xml:ns:caldav" ' .
+			'xmlns:d="DAV:" xmlns:a="http://apple.com/ns/ical/" ' .
+			'xmlns:o="http://owncloud.org/ns"><d:set><d:prop><d:displayname>' .
+			'test</d:displayname><o:calendar-enabled>1</o:calendar-enabled>' .
+			'<a:calendar-color>#21213D</a:calendar-color>' .
+			'<c:supported-calendar-component-set><c:comp name="VEVENT"/>' .
+			'</c:supported-calendar-component-set></d:prop></d:set>' .
+			'</c:mkcalendar>';
 
-		$this->response = $this->client->send($request);
+		$this->response = HttpRequestHelper::sendRequest(
+			$davUrl, "MKCALENDAR", $user,
+			$this->featureContext->getPasswordForUser($user), null, $body
+		);
 		$this->theCalDavHttpStatusCodeShouldBe(201);
 	}
 }

--- a/tests/acceptance/features/bootstrap/CardDavContext.php
+++ b/tests/acceptance/features/bootstrap/CardDavContext.php
@@ -22,18 +22,13 @@
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\ResponseInterface;
+use TestHelpers\HttpRequestHelper;
 
 /**
  * CardDav functions
  */
 class CardDavContext implements \Behat\Behat\Context\Context {
-	/**
-	 * @var Client
-	 */
-	private $client;
 	/**
 	 * @var ResponseInterface
 	 */
@@ -60,7 +55,6 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
-		$this->client = new Client();
 		$this->responseXml = '';
 	}
 
@@ -72,15 +66,10 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	public function afterScenario() {
 		$davUrl = $this->featureContext->getBaseUrl()
 			. '/remote.php/dav/addressbooks/users/admin/MyAddressbook';
-		try {
-			$this->client->delete(
-				$davUrl,
-				[
-					'auth' => $this->featureContext->getAuthOptionForAdmin()
-				]
-			);
-		} catch (BadResponseException $e) {
-		}
+		HttpRequestHelper::delete(
+			$davUrl, $this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword()
+		);
 	}
 
 	/**
@@ -96,16 +85,9 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 		$davUrl = $this->featureContext->getBaseUrl()
 			. "/remote.php/dav/addressbooks/users/$addressBook";
 
-		try {
-			$this->response = $this->client->get(
-				$davUrl,
-				[
-					'auth' => $this->featureContext->getAuthOptionForUser($user)
-				]
-			);
-		} catch (BadResponseException $e) {
-			$this->response = $e->getResponse();
-		}
+		$this->response = HttpRequestHelper::get(
+			$davUrl, $user, $this->featureContext->getPasswordForUser($user)
+		);
 	}
 
 	/**
@@ -121,11 +103,8 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 		$davUrl = $this->featureContext->getBaseUrl()
 			. "/remote.php/dav/addressbooks/users/$user/$addressBook";
 
-		$request = $this->client->createRequest(
-			'MKCOL',
-			$davUrl,
-			[
-				'body' => '<d:mkcol xmlns:card="urn:ietf:params:xml:ns:carddav"
+		$headers = ['Content-Type' => 'application/xml;charset=UTF-8'];
+		$body = '<d:mkcol xmlns:card="urn:ietf:params:xml:ns:carddav"
               xmlns:d="DAV:">
     <d:set>
       <d:prop>
@@ -134,15 +113,11 @@ class CardDavContext implements \Behat\Behat\Context\Context {
           </d:resourcetype>,<d:displayname>' . $addressBook . '</d:displayname>
       </d:prop>
     </d:set>
-  </d:mkcol>',
-				'auth' => $this->featureContext->getAuthOptionForUser($user),
-				'headers' => [
-					'Content-Type' => 'application/xml;charset=UTF-8',
-				],
-			]
+  </d:mkcol>';
+		$this->response = HttpRequestHelper::sendRequest(
+			$davUrl, 'MKCOL', $user, $this->featureContext->getPasswordForUser($user),
+			$headers, $body
 		);
-
-		$this->response = $this->client->send($request);
 		$this->theCardDavHttpStatusCodeShouldBe(201);
 	}
 

--- a/tests/acceptance/features/bootstrap/Checksums.php
+++ b/tests/acceptance/features/bootstrap/Checksums.php
@@ -21,7 +21,7 @@
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
-use GuzzleHttp\Client;
+use TestHelpers\HttpRequestHelper;
 
 /**
  * Checksum functions
@@ -78,21 +78,16 @@ trait Checksums {
 	 * @return void
 	 */
 	public function userRequestsTheChecksumOfViaPropfind($user, $path) {
-		$client = new Client();
-		$request = $client->createRequest(
-			'PROPFIND',
-			$this->getBaseUrl() . '/' . $this->getDavFilesPath($user) . $path,
-			[
-				'body' => '<?xml version="1.0"?>
+		$body = '<?xml version="1.0"?>
 <d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
   <d:prop>
     <oc:checksums />
   </d:prop>
-</d:propfind>',
-				'auth' => $this->getAuthOptionForUser($user)
-			]
+</d:propfind>';
+		$url = $this->getBaseUrl() . '/' . $this->getDavFilesPath($user) . $path;
+		$this->response = HttpRequestHelper::sendRequest(
+			$url, 'PROPFIND', $user, $this->getPasswordForUser($user), null, $body
 		);
-		$this->response = $client->send($request);
 	}
 
 	/**
@@ -191,20 +186,16 @@ trait Checksums {
 	public function userUploadsChunkFileOfWithToWithChecksum(
 		$user, $num, $total, $data, $destination, $checksum
 	) {
-		try {
-			$num -= 1;
-			$data = \GuzzleHttp\Stream\Stream::factory($data);
-			$file = "$destination-chunking-42-$total-$num";
-			$this->response = $this->makeDavRequest(
-				$user,
-				'PUT',
-				$file,
-				['OC-Checksum' => $checksum, 'OC-Chunked' => '1'],
-				$data,
-				"files"
-			);
-		} catch (\GuzzleHttp\Exception\RequestException $ex) {
-			$this->response = $ex->getResponse();
-		}
+		$num -= 1;
+		$data = \GuzzleHttp\Stream\Stream::factory($data);
+		$file = "$destination-chunking-42-$total-$num";
+		$this->response = $this->makeDavRequest(
+			$user,
+			'PUT',
+			$file,
+			['OC-Checksum' => $checksum, 'OC-Chunked' => '1'],
+			$data,
+			"files"
+		);
 	}
 }

--- a/tests/acceptance/features/bootstrap/Comments.php
+++ b/tests/acceptance/features/bootstrap/Comments.php
@@ -21,7 +21,6 @@
  */
 
 use Behat\Gherkin\Node\TableNode;
-use GuzzleHttp\Exception\BadResponseException;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
@@ -53,29 +52,27 @@ trait Comments {
 		$fileId = $this->getFileIdForPath($user, $path);
 		$this->lastFileId = $fileId;
 		$commentsPath = "/comments/files/$fileId/";
-		try {
-			$this->response = $this->makeDavRequest(
-				$user,
-				"POST",
-				$commentsPath,
-				['Content-Type' => 'application/json'],
-				null,
-				"uploads",
-				'{"actorId":"user0",
-					"actorDisplayName":"user0",
-					"actorType":"users",
-					"verb":"comment",
-					"message":"' . $content . '",
-					"creationDateTime":"Thu, 18 Feb 2016 17:04:18 GMT",
-					"objectType":"files"}'
-			);
-			$responseHeaders =  $this->response->getHeaders();
+		$this->response = $this->makeDavRequest(
+			$user,
+			"POST",
+			$commentsPath,
+			['Content-Type' => 'application/json'],
+			null,
+			"uploads",
+			'{"actorId":"user0",
+			"actorDisplayName":"user0",
+			"actorType":"users",
+			"verb":"comment",
+			"message":"' . $content . '",
+			"creationDateTime":"Thu, 18 Feb 2016 17:04:18 GMT",
+			"objectType":"files"}'
+		);
+		$responseHeaders =  $this->response->getHeaders();
+		if (isset($responseHeaders['Content-Location'][0])) {
 			$commentUrl = $responseHeaders['Content-Location'][0];
 			$this->lastCommentId = \substr(
 				$commentUrl, \strrpos($commentUrl, '/') + 1
 			);
-		} catch (BadResponseException $ex) {
-			$this->response = $ex->getResponse();
 		}
 	}
 
@@ -145,19 +142,15 @@ trait Comments {
 	 */
 	public function deleteComment($user, $fileId, $commentId) {
 		$commentsPath = "/comments/files/$fileId/$commentId";
-		try {
-			$this->response = $this->makeDavRequest(
-				$user,
-				"DELETE",
-				$commentsPath,
-				[],
-				null,
-				"uploads",
-				null
-			);
-		} catch (BadResponseException $ex) {
-			$this->response = $ex->getResponse();
-		}
+		$this->response = $this->makeDavRequest(
+			$user,
+			"DELETE",
+			$commentsPath,
+			[],
+			null,
+			"uploads",
+			null
+		);
 	}
 
 	/**
@@ -223,26 +216,22 @@ trait Comments {
 	 */
 	public function editAComment($user, $content, $fileId, $commentId) {
 		$commentsPath = "/comments/files/$fileId/$commentId";
-		try {
-			$this->response = $this->makeDavRequest(
-				$user,
-				"PROPPATCH",
-				$commentsPath,
-				[],
-				null,
-				"uploads",
-				'<?xml version="1.0"?>
-					<d:propertyupdate  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
-						<d:set>
-							<d:prop>
-								<oc:message>' . \htmlspecialchars($content, ENT_XML1, 'UTF-8') . '</oc:message>
-							</d:prop>
-						</d:set>
-					</d:propertyupdate>'
-			);
-		} catch (BadResponseException $ex) {
-			$this->response = $ex->getResponse();
-		}
+		$this->response = $this->makeDavRequest(
+			$user,
+			"PROPPATCH",
+			$commentsPath,
+			[],
+			null,
+			"uploads",
+			'<?xml version="1.0"?>
+				<d:propertyupdate  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+					<d:set>
+						<d:prop>
+							<oc:message>' . \htmlspecialchars($content, ENT_XML1, 'UTF-8') . '</oc:message>
+						</d:prop>
+					</d:set>
+				</d:propertyupdate>'
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -24,7 +24,6 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use GuzzleHttp\Message\ResponseInterface;
 
 require_once 'bootstrap.php';
 


### PR DESCRIPTION
## Description
1. use Guzzle through a Helper class
2. don't catch Guzzle exceptions all over the place, as there are not thrown any-more, but only check responses

## Related Issue
https://github.com/owncloud/QA/issues/586

## Motivation and Context
have only one place where guzzle can be configured globally

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
