### PR TITLE
fix segmentation faults when testing with php7.2

### DIFF
--- a/tests/drone/test-phpunit.sh
+++ b/tests/drone/test-phpunit.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -xeo pipefail
 
+# Note this is a fix for issues with php7.2 where having php-memcached present
+# leads to encountering segmentation faults
+#
+# Ref: https://github.com/owncloud-ci/php/issues/33
+
+export ZEND_DONT_UNLOAD_MODULES=1
+
 if [[ "$(pwd)" == "$(cd "$(dirname "$0")"; pwd -P)" ]]; then
   echo "Can only be executed from project root!"
   exit 1


### PR DESCRIPTION
## Description
Change that should fix the issue with unloading memcached extension leading to segfaults

## Related Issue
https://github.com/owncloud-ci/php/issues/33

## Motivation and Context
Get CI green

## How Has This Been Tested?
🤖 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)

Backport here: #32507 