### PR TITLE
Support json for system:config:set

### DIFF
--- a/core/Command/Config/System/SetConfig.php
+++ b/core/Command/Config/System/SetConfig.php
@@ -56,7 +56,7 @@ class SetConfig extends Base {
 				'type',
 				null,
 				InputOption::VALUE_REQUIRED,
-				'Value type [string, integer, double, boolean].',
+				'Value type [string, integer, double, boolean, json].',
 				'string'
 			)
 			->addOption(
@@ -160,6 +160,16 @@ class SetConfig extends Base {
 				return [
 					'value' => $value,
 					'readable-value' => ($value === '') ? 'empty string' : 'string ' . $value,
+				];
+
+			case 'json':
+				$decodedJson = \json_decode($value, true);
+				if ($decodedJson === null) {
+					throw new \InvalidArgumentException('Unable to parse value as json');
+				}
+				return [
+					'value' => $decodedJson,
+					'readable-value' => 'json ' . $value,
 				];
 
 			default:

--- a/tests/Core/Command/Config/System/SetConfigTest.php
+++ b/tests/Core/Command/Config/System/SetConfigTest.php
@@ -122,6 +122,44 @@ class SetConfigTest extends TestCase {
 		$this->invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
 	}
 
+	public function setJsonData() {
+		return [
+			[['name'], '{"sub-key":"value"}', null, ['sub-key' => 'value']],
+			[['name'], '{"sub-key":"value"}', 'something', ['sub-key' => 'value']],
+			[['name'], '{"sub-key":"value"}', ['sub-key' => 'old-value', 'other-key' => 'will disappear'], ['sub-key' => 'value']],
+			[['name'], '[{"key1":"value1","key2":"value2"}]', null, [['key1' => 'value1', 'key2' => 'value2']]],
+		];
+	}
+
+	/**
+	 * @dataProvider setJsonData
+	 *
+	 * @param array $configNames
+	 * @param string $newValue
+	 * @param mixed $existingData
+	 * @param mixed $expectedValue
+	 */
+	public function testSetJson($configNames, $newValue, $existingData, $expectedValue) {
+		$this->systemConfig->expects($this->once())
+			->method('setValue')
+			->with($configNames[0], $expectedValue);
+		$this->systemConfig->method('getValue')
+			->with($configNames[0])
+			->willReturn($existingData);
+
+		$this->consoleInput->expects($this->once())
+			->method('getArgument')
+			->with('name')
+			->willReturn($configNames);
+		$this->consoleInput->method('getOption')
+			->will($this->returnValueMap([
+				['value', $newValue],
+				['type', 'json'],
+			]));
+
+		$this->invokePrivate($this->command, 'execute', [$this->consoleInput, $this->consoleOutput]);
+	}
+
 	public function castValueProvider() {
 		return [
 			[null, 'string', ['value' => '', 'readable-value' => 'empty string']],
@@ -138,6 +176,9 @@ class SetConfigTest extends TestCase {
 
 			['true', 'boolean', ['value' => true, 'readable-value' => 'boolean true']],
 			['false', 'bool', ['value' => false, 'readable-value' => 'boolean false']],
+
+			['{"config_key":"the-value"}', 'json', ['value' => ['config_key' => 'the-value'], 'readable-value' => 'json {"config_key":"the-value"}']],
+			['[{"key1":"value1","key2":"value2"}]', 'json', ['value' => [['key1' => 'value1', 'key2' => 'value2']], 'readable-value' => 'json [{"key1":"value1","key2":"value2"}]']],
 		];
 	}
 
@@ -159,6 +200,8 @@ class SetConfigTest extends TestCase {
 			['76ggg', 'double'],
 			['true', 'float'],
 			['foobar', 'boolean'],
+			['invalid-json', 'json'],
+			['', 'json'],
 		];
 	}
 


### PR DESCRIPTION
## Description
Add support for ``--type json`` to the ``occ config:system:set`` command.

See commands below for examples of the type of things that can be done.

This allows configuring multi-key system config options in a single command, avoiding catch-22's.

## Related Issue
- Fixes #32511 

## Motivation and Context
In acceptance tests I want to be able to clear any ``apps_paths`` settings and then set up ``apps_paths`` in different ways for the tests. To do that I can get the testing app to run ``occ config:system:set`` but I need to be able to do it in a single ``occ`` command, to avoid the catch-22 in the referenced issue.

I noticed this challenge today when looking at how to get the ``appmanagement.feature`` acceptance tests to setup their environment via the testing app. (At present they "cheat" and directly call ``setSystemValue()`` in the backend - which will not work for proper blackbox testing).

## How Has This Been Tested?
Manual ``occ`` commands like:
```
php occ config:system:set apps_paths --type=json --value='[{"path":"/home/phil/git/owncloud/core/apps","url":"apps","writable":1},{"path":"/home/phil/git/owncloud/core/apps2","url":"apps2","writable":1}]'
```
or
```
php occ config:system:set apps_paths 1 --type=json --value='{"path":"/home/phil/git/owncloud/core/apps2","url":"apps2","writable":1}'
```
and inspecting the result in ``config.php``

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/documentation/issues/4404
(documentation needed)

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
