### PR TITLE
check correct upload reply code

### DIFF
--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -35,7 +35,7 @@ Feature: quota
 		And the quota of user "user0" has been set to "10 MB"
 		And user "user0" has uploaded file with content "test" to "/testquota.txt"
 		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be "204"
+		Then the HTTP status code of all upload responses should be between "201" and "204"
 		Examples:
 			| dav_version   |
 			| old           |
@@ -97,7 +97,7 @@ Feature: quota
 		And user "user1" has uploaded file with content "test" to "/testquota/testquota.txt"
 		And user "user1" has shared folder "/testquota" with user "user0" with permissions 31
 		When user "user0" overwrites file "data/textfile.txt" to "/testquota/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be "204"
+		Then the HTTP status code of all upload responses should be between "201" and "204"
 		Examples:
 			| dav_version   |
 			| old           |
@@ -131,7 +131,7 @@ Feature: quota
 		And user "user1" has uploaded file with content "test" to "/testquota.txt"
 		And user "user1" has shared file "/testquota.txt" with user "user0" with permissions 19
 		When user "user0" overwrites file "data/textfile.txt" to "/testquota.txt" with all mechanisms using the WebDAV API
-		Then the HTTP status code of all upload responses should be "204"
+		Then the HTTP status code of all upload responses should be between "201" and "204"
 		Examples:
 			| dav_version   |
 			| old           |

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1448,6 +1448,31 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then /^the HTTP status code of all upload responses should be between "(\d+)" and "(\d+)"$/
+	 *
+	 * @param int $minStatusCode
+	 * @param int $maxStatusCode
+	 *
+	 * @return void
+	 */
+	public function theHTTPStatusCodeOfAllUploadResponsesShouldBeBetween(
+		$minStatusCode, $maxStatusCode
+	) {
+		foreach ($this->uploadResponses as $response) {
+			PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
+				$minStatusCode,
+				$response->getStatusCode(),
+				'Response for ' . $response->getEffectiveUrl() . ' did not return expected status code'
+			);
+			PHPUnit_Framework_Assert::assertLessThanOrEqual(
+				$maxStatusCode,
+				$response->getStatusCode(),
+				'Response for ' . $response->getEffectiveUrl() . ' did not return expected status code'
+			);
+		}
+	}
+
+	/**
 	 * Check that all the files uploaded with old/new dav and chunked/non-chunked exist.
 	 *
 	 * @Then as :user the files uploaded to :destination with all mechanisms should exist
@@ -1715,7 +1740,7 @@ trait WebDav {
 			$num -= 1;
 			$data = \GuzzleHttp\Stream\Stream::factory($data);
 			$file = "$destination-chunking-42-$total-$num";
-			$this->makeDavRequest(
+			$this->response = $this->makeDavRequest(
 				$user, 'PUT', $file, ['OC-Chunked' => '1'], $data, "uploads"
 			);
 		} catch (\GuzzleHttp\Exception\RequestException $ex) {


### PR DESCRIPTION
## Description
while working on https://github.com/owncloud/core/pull/32505 I discovered that the response of the old chunking upload was not recorded correctly
The tests would pass but not checking the correct response. The old chunking does not return "204" in that case but "201"

## Motivation and Context
eliminate :snake: :oil_drum: tests

## How Has This Been Tested?
run quota tests locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
