### PR TITLE
delete unused try/catch

### DIFF
--- a/tests/acceptance/features/bootstrap/Comments.php
+++ b/tests/acceptance/features/bootstrap/Comments.php
@@ -92,17 +92,9 @@ trait Comments {
 		$fileId = $this->getFileIdForPath($user, $path);
 		$commentsPath = "/comments/files/$fileId/";
 		$properties = '<oc:limit>200</oc:limit><oc:offset>0</oc:offset>';
-		try {
-			$elementList = $this->reportElementComments(
-				$user, $commentsPath, $properties
-			);
-		} catch (BadResponseException $e) {
-			$this->response = $e->getResponse();
-			$statusCode = $this->response->getStatusCode();
-			PHPUnit_Framework_Assert::fail(
-				"checkComments failed to get comments for user $user path $path status $statusCode"
-			);
-		}
+		$elementList = $this->reportElementComments(
+			$user, $commentsPath, $properties
+		);
 
 		if ($expectedElements instanceof TableNode) {
 			$elementRows = $expectedElements->getRows();
@@ -136,20 +128,12 @@ trait Comments {
 		$fileId = $this->getFileIdForPath($user, $path);
 		$commentsPath = "/comments/files/$fileId/";
 		$properties = '<oc:limit>200</oc:limit><oc:offset>0</oc:offset>';
-		try {
-			$elementList = $this->reportElementComments(
-				$user, $commentsPath, $properties
-			);
-			PHPUnit_Framework_Assert::assertCount(
-				(int) $numberOfComments, $elementList
-			);
-		} catch (BadResponseException $e) {
-			$this->response = $e->getResponse();
-			$statusCode = $this->response->getStatusCode();
-			PHPUnit_Framework_Assert::fail(
-				"checkNumberOfComments failed to get comments for user $user path $path status $statusCode"
-			);
-		}
+		$elementList = $this->reportElementComments(
+			$user, $commentsPath, $properties
+		);
+		PHPUnit_Framework_Assert::assertCount(
+			(int) $numberOfComments, $elementList
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1127,6 +1127,8 @@ trait WebDav {
 	 * @param string $properties properties which needs to be included in the report
 	 *
 	 * @return array
+	 *
+	 * @throws Sabre\HTTP\ClientException, - in case a curl error occurred.
 	 */
 	public function reportElementComments($user, $path, $properties) {
 		$client = $this->getSabreClient($user);


### PR DESCRIPTION
## Description
`reportElementComments()` does not throw a `BadResponseException` because its using sabre not guzzle, so no need to catch it.
also the exception `reportElementComments()` might throw does not have any `getResponse()` property

## Motivation and Context
deleted code is debugged code

## How Has This Been Tested?
ran comments API tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
