### PR TITLE
skip app management tool tests on remote systems

### DIFF
--- a/tests/acceptance/features/apiMain/appmanagement.feature
+++ b/tests/acceptance/features/apiMain/appmanagement.feature
@@ -1,4 +1,4 @@
-@api
+@api @skipWhenTestingRemoteSystems
 Feature: AppManagement
 
   Background:

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -35,7 +35,7 @@ class AppManagementContext implements Context {
 	private $cmdOutput;
 	
 	/**
-	 * @BeforeScenario
+	 * @BeforeScenario @skipWhenTestingRemoteSystems
 	 *
 	 * Remember the config values before each scenario
 	 *
@@ -49,7 +49,7 @@ class AppManagementContext implements Context {
 	}
 	
 	/**
-	 * @AfterScenario
+	 * @AfterScenario @skipWhenTestingRemoteSystems
 	 *
 	 * Reset the config values after each scenario
 	 *


### PR DESCRIPTION
## Description
`AppManagementContext` calls oc php code, that does not work if we tests a remote system
real fix is on the ToDo list #32040

## Related Issue
https://github.com/owncloud-docker/server/issues/75

## Motivation and Context
see https://github.com/owncloud-docker/server/issues/75

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
