### PR TITLE
jQuery UI migration

### DIFF
--- a/apps/files_external/js/oauth1.js
+++ b/apps/files_external/js/oauth1.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
 
 	function displayGranted($tr) {
-		$tr.find('.configuration input.auth-param').attr('disabled', 'disabled').addClass('disabled-success');
+		$tr.find('.configuration input.auth-param').prop('disabled', true).addClass('disabled-success');
 	}
 
 	OCA.External.Settings.mountConfig.whenSelectAuthMechanism(function($tr, authMechanism, scheme, onCompletion) {

--- a/apps/files_external/js/oauth2.js
+++ b/apps/files_external/js/oauth2.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
 
 	function displayGranted($tr) {
-		$tr.find('.configuration input.auth-param').attr('disabled', 'disabled').addClass('disabled-success');
+		$tr.find('.configuration input.auth-param').prop('disabled', true).addClass('disabled-success');
 	}
 
 	OCA.External.Settings.mountConfig.whenSelectAuthMechanism(function($tr, authMechanism, scheme, onCompletion) {

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -1007,7 +1007,7 @@ MountConfigListView.prototype = _.extend({
 
 						// disable any other inputs
 						$tr.find('.mountOptionsToggle, .remove').empty();
-						$tr.find('input:not(.user_provided), select:not(.user_provided)').attr('disabled', 'disabled');
+						$tr.find('input:not(.user_provided), select:not(.user_provided)').prop('disabled', true);
 
 						if (isUserGlobal) {
 							$tr.find('.configuration').find(':not(.user_provided)').remove();
@@ -1588,7 +1588,7 @@ OCA.External.Settings.OAuth2.verifyCode = function (backendUrl, data) {
 				OCA.External.Settings.mountConfig.saveStorageConfig($tr, function(status) {
 					if (status) {
 						$tr.find('.configuration input.auth-param')
-							.attr('disabled', 'disabled')
+							.prop('disabled', true)
 							.addClass('disabled-success')
 					}
 					deferredObject.resolve(status);

--- a/build/package.json
+++ b/build/package.json
@@ -23,9 +23,8 @@
     "@bower_components/es6-promise": "components/es6-promise#4.1.1",
     "@bower_components/handlebars": "components/handlebars.js#4.0.11",
     "@bower_components/jcrop": "tapmodo/Jcrop#0.9.12",
-    "@bower_components/jquery": "jquery/jquery-dist#2.1.4",
-    "@bower_components/jquery-migrate": "appleboy/jquery-migrate#1.4.0",
-    "@bower_components/jquery-ui": "components/jqueryui#1.10.0",
+    "@bower_components/jquery": "jquery/jquery-dist#2.2.4",
+    "@bower_components/jquery-ui": "components/jqueryui#1.12.1",
     "@bower_components/jsTimezoneDetect": "HenningM/jstimezonedetect#1.0.5",
     "@bower_components/jstzdetect": "HenningM/jstimezonedetect#1.0.6",
     "@bower_components/moment": "moment/moment#2.19.4",
@@ -40,7 +39,6 @@
     "handlebars": "^4.0.11",
     "jasmine-core": "^2.99.1",
     "jasmine-sinon": "^0.4.0",
-    "sinon": "^2.0.0",
     "jsdoc": "~3.5.5",
     "karma": "^2.0.5",
     "karma-coverage": "*",
@@ -48,7 +46,8 @@
     "karma-jasmine-sinon": "^1.0.4",
     "karma-junit-reporter": "*",
     "karma-phantomjs-launcher": "*",
-    "phantomjs-prebuilt": "*"
+    "phantomjs-prebuilt": "*",
+    "sinon": "^2.0.0"
   },
   "engines": {
     "node": ">= 6.9",

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -60,17 +60,13 @@
   version "0.0.0"
   resolved "https://codeload.github.com/tapmodo/Jcrop/tar.gz/1902fbc6afa14481dc019a17e0dcb7d62b808a98"
 
-"@bower_components/jquery-migrate@appleboy/jquery-migrate#1.4.0":
-  version "0.0.0"
-  resolved "https://codeload.github.com/appleboy/jquery-migrate/tar.gz/29077d39689bddad05036a537d49c4cf96488569"
+"@bower_components/jquery-ui@components/jqueryui#1.12.1":
+  version "1.12.1"
+  resolved "https://codeload.github.com/components/jqueryui/tar.gz/44ecf3794cc56b65954cc19737234a3119d036cc"
 
-"@bower_components/jquery-ui@components/jqueryui#1.10.0":
-  version "1.10.0"
-  resolved "https://codeload.github.com/components/jqueryui/tar.gz/4c0bac635cc97c8cd5087bb244d497100429fea2"
-
-"@bower_components/jquery@jquery/jquery-dist#2.1.4":
-  version "2.1.4"
-  resolved "https://codeload.github.com/jquery/jquery-dist/tar.gz/7751e69b615c6eca6f783a81e292a55725af6b85"
+"@bower_components/jquery@jquery/jquery-dist#2.2.4":
+  version "2.2.4"
+  resolved "https://codeload.github.com/jquery/jquery-dist/tar.gz/c0185ab7c75aab88762c5aae780b9d83b80eda72"
 
 "@bower_components/jsTimezoneDetect@HenningM/jstimezonedetect#1.0.5":
   version "1.0.5"

--- a/core/css/jquery-ui-fixes.css
+++ b/core/css/jquery-ui-fixes.css
@@ -3,6 +3,7 @@
 .ui-widget {
 	font-family: "Lucida Grande", Arial, Verdana, sans-serif;
 	font-size: 1em;
+	z-index: 501;
 }
 .ui-widget button {
 	font-family: "Lucida Grande", Arial, Verdana, sans-serif;
@@ -120,6 +121,22 @@
 .ui-state-error .ui-icon,
 .ui-state-error-text .ui-icon {
 	background-image: url('images/ui-icons_ffd27a_256x240.png');
+}
+
+.ui-menu-item-wrapper {
+	display: block;
+	margin: 3px;
+	border-radius: 4px;
+}
+
+.ui-menu .ui-state-active {
+	margin: 2px;
+}
+
+/* make it look like ui-state-focus from the old version */
+.ui-menu-item-wrapper.ui-state-active {
+	border: 1px solid #ddd;
+	font-weight: normal;
 }
 
 /* Misc visuals

--- a/core/js/core.json
+++ b/core/js/core.json
@@ -1,8 +1,7 @@
 {
 	"vendor": [
 		"jquery/dist/jquery.min.js",
-		"jquery-migrate/jquery-migrate.min.js",
-		"jquery-ui/ui/jquery-ui.custom.js",
+		"jquery-ui/jquery-ui.js",
 		"underscore/underscore.js",
 		"moment/min/moment-with-locales.js",
 		"handlebars/handlebars.js",

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -760,7 +760,7 @@ var OC = {
 	 * @return {String} locale string
 	 */
 	getLocale: function () {
-		return $('html').prop('lang');
+		return $('html').attr('lang');
 	},
 
 	/**

--- a/core/js/setup.js
+++ b/core/js/setup.js
@@ -57,8 +57,8 @@ $(document).ready(function() {
 		$('.float-spinner').show(250);
 
 		// Disable inputs
-		$(':submit', this).attr('disabled','disabled').val($(':submit', this).data('finishing'));
-		$('input', this).addClass('ui-state-disabled').attr('disabled','disabled');
+		$(':submit', this).prop('disabled', true).val($(':submit', this).data('finishing'));
+		$('input', this).addClass('ui-state-disabled').prop('disabled', true);
 		// only disable buttons if they are present
 		if($('#selectDbType').find('.ui-button').length > 0) {
 			$('#selectDbType').buttonset('disable');

--- a/core/js/setup.js
+++ b/core/js/setup.js
@@ -61,7 +61,7 @@ $(document).ready(function() {
 		$('input', this).addClass('ui-state-disabled').prop('disabled', true);
 		// only disable buttons if they are present
 		if($('#selectDbType').find('.ui-button').length > 0) {
-			$('#selectDbType').buttonset('disable');
+			$('#selectDbType').controlgroup('disable');
 		}
 		$('.strengthify-wrapper, .tipsy')
 			.css('-ms-filter', '"progid:DXImageTransform.Microsoft.Alpha(Opacity=30)"')

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -193,6 +193,7 @@
 
 			$.ajax({
 				type: 'GET',
+				dataType: 'text',
 				url: OC.generateUrl('heartbeat'),
 				allowAuthErrors: true
 			}).then(afterCall, afterCall);

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -134,7 +134,7 @@
 			$el.find('.error-message').addClass('hidden');
 
 			// prevent tinkering with form while loading
-			$formElements.attr('disabled', true);
+			$formElements.prop('disabled', true);
 			$select2Elements.addClass('hidden');
 
 			// remove errors (if present)

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -349,7 +349,7 @@
 
 		_onSelectRecipient: function(e, s) {
 			e.preventDefault();
-			$(e.target).attr('disabled', true)
+			$(e.target).prop('disabled', true)
 				.val(s.item.label);
 			var $loading = this.$el.find('.shareWithLoading');
 			$loading.removeClass('hidden')
@@ -357,12 +357,12 @@
 
 			this.model.addShare(s.item.value, {success: function() {
 				$(e.target).val('')
-					.attr('disabled', false);
+					.prop('disabled', false);
 				$loading.addClass('hidden')
 					.removeClass('inlineblock');
 			}, error: function(obj, msg) {
 				OC.Notification.showTemporary(msg);
-				$(e.target).attr('disabled', false)
+				$(e.target).prop('disabled', false)
 					.autocomplete('search', $(e.target).val());
 				$loading.addClass('hidden')
 					.removeClass('inlineblock');

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -26,7 +26,7 @@ describe('OC.SetupChecks tests', function() {
 		it('should fail with another response status code than 201 or 207', function(done) {
 			var async = OC.SetupChecks.checkWebDAV();
 
-			suite.server.requests[0].respond(200);
+			suite.server.requests[0].respond(200, {}, '');
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([{
@@ -40,7 +40,7 @@ describe('OC.SetupChecks tests', function() {
 		it('should return no error with a response status code of 207', function(done) {
 			var async = OC.SetupChecks.checkWebDAV();
 
-			suite.server.requests[0].respond(207);
+			suite.server.requests[0].respond(207, {}, '');
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([]);
@@ -51,7 +51,7 @@ describe('OC.SetupChecks tests', function() {
 		it('should return no error with a response status code of 401', function(done) {
 			var async = OC.SetupChecks.checkWebDAV();
 
-			suite.server.requests[0].respond(401);
+			suite.server.requests[0].respond(401, {}, '');
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([]);
@@ -64,7 +64,7 @@ describe('OC.SetupChecks tests', function() {
 		it('should fail with another response status code than 207', function(done) {
 			var async = OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav/', 'http://example.org/PLACEHOLDER', true);
 
-			suite.server.requests[0].respond(200);
+			suite.server.requests[0].respond(200, {}, '');
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([{
@@ -78,7 +78,7 @@ describe('OC.SetupChecks tests', function() {
 		it('should return no error with a response status code of 207', function(done) {
 			var async = OC.SetupChecks.checkWellKnownUrl('/.well-known/caldav/', 'http://example.org/PLACEHOLDER', true);
 
-			suite.server.requests[0].respond(207);
+			suite.server.requests[0].respond(207, {}, '');
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([]);
@@ -118,7 +118,7 @@ describe('OC.SetupChecks tests', function() {
 		it('should not return an error if data directory is protected', function(done) {
 			var async = OC.SetupChecks.checkDataProtected();
 
-			suite.server.requests[0].respond(403);
+			suite.server.requests[0].respond(403, {}, '');
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([]);
@@ -385,8 +385,9 @@ describe('OC.SetupChecks tests', function() {
 			suite.server.requests[0].respond(
 				500,
 				{
-					'Content-Type': 'application/json'
-				}
+					'Content-Type': 'text/plain'
+				},
+				''
 			);
 
 			async.done(function( data, s, x ){
@@ -410,7 +411,8 @@ describe('OC.SetupChecks tests', function() {
 				{
 					'Content-Type': 'application/json',
 					'Strict-Transport-Security': 'max-age=15768000'
-				}
+				},
+				''
 			);
 
 			async.done(function( data, s, x ){
@@ -452,7 +454,9 @@ describe('OC.SetupChecks tests', function() {
 					'Strict-Transport-Security': 'max-age=15768000;preload',
 					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
-				}
+					'Content-Type': 'text/plain'
+				},
+				''
 			);
 
 			async.done(function( data, s, x ){
@@ -481,7 +485,9 @@ describe('OC.SetupChecks tests', function() {
 					'Strict-Transport-Security': 'max-age=15768000',
 					'X-Download-Options': 'noopen',
 					'X-Permitted-Cross-Domain-Policies': 'none',
-				}
+					'Content-Type': 'text/plain'
+				},
+				''
 			);
 
 			async.done(function( data, s, x ){
@@ -503,7 +509,9 @@ describe('OC.SetupChecks tests', function() {
 				'X-Frame-Options': 'SAMEORIGIN',
 				'X-Download-Options': 'noopen',
 				'X-Permitted-Cross-Domain-Policies': 'none',
-			}
+				'Content-Type': 'text/plain'
+			},
+			''
 		);
 
 		async.done(function( data, s, x ){
@@ -549,7 +557,9 @@ describe('OC.SetupChecks tests', function() {
 				'X-Frame-Options': 'SAMEORIGIN',
 				'X-Download-Options': 'noopen',
 				'X-Permitted-Cross-Domain-Policies': 'none',
-			}
+				'Content-Type': 'text/plain'
+			},
+			''
 		);
 
 		async.done(function( data, s, x ){
@@ -574,7 +584,9 @@ describe('OC.SetupChecks tests', function() {
 				'X-Frame-Options': 'SAMEORIGIN',
 				'X-Download-Options': 'noopen',
 				'X-Permitted-Cross-Domain-Policies': 'none',
-			}
+				'Content-Type': 'text/plain'
+			},
+			''
 		);
 
 		async.done(function( data, s, x ){
@@ -599,7 +611,9 @@ describe('OC.SetupChecks tests', function() {
 				'X-Frame-Options': 'SAMEORIGIN',
 				'X-Download-Options': 'noopen',
 				'X-Permitted-Cross-Domain-Policies': 'none',
-			}
+				'Content-Type': 'text/plain'
+			},
+			''
 		);
 
 		async.done(function( data, s, x ){
@@ -615,15 +629,19 @@ describe('OC.SetupChecks tests', function() {
 		protocolStub.returns('https');
 		var async = OC.SetupChecks.checkGeneric();
 
-		suite.server.requests[0].respond(200, {
-			'Strict-Transport-Security': 'max-age=15768000',
-			'X-XSS-Protection': '1; mode=block',
-			'X-Content-Type-Options': 'nosniff',
-			'X-Robots-Tag': 'none',
-			'X-Frame-Options': 'SAMEORIGIN',
-			'X-Download-Options': 'noopen',
-			'X-Permitted-Cross-Domain-Policies': 'none',
-		});
+		suite.server.requests[0].respond(
+			200, {
+				'Strict-Transport-Security': 'max-age=15768000',
+				'X-XSS-Protection': '1; mode=block',
+				'X-Content-Type-Options': 'nosniff',
+				'X-Robots-Tag': 'none',
+				'X-Frame-Options': 'SAMEORIGIN',
+				'X-Download-Options': 'noopen',
+				'X-Permitted-Cross-Domain-Policies': 'none',
+				'Content-Type': 'text/plain'
+			},
+			''
+		);
 
 		async.done(function( data, s, x ){
 			expect(data).toEqual([]);
@@ -635,15 +653,19 @@ describe('OC.SetupChecks tests', function() {
 		protocolStub.returns('https');
 		var async = OC.SetupChecks.checkGeneric();
 
-		suite.server.requests[0].respond(200, {
-			'Strict-Transport-Security': 'max-age=99999999',
-			'X-XSS-Protection': '1; mode=block',
-			'X-Content-Type-Options': 'nosniff',
-			'X-Robots-Tag': 'none',
-			'X-Frame-Options': 'SAMEORIGIN',
-			'X-Download-Options': 'noopen',
-			'X-Permitted-Cross-Domain-Policies': 'none',
-		});
+		suite.server.requests[0].respond(
+			200, {
+				'Strict-Transport-Security': 'max-age=99999999',
+				'X-XSS-Protection': '1; mode=block',
+				'X-Content-Type-Options': 'nosniff',
+				'X-Robots-Tag': 'none',
+				'X-Frame-Options': 'SAMEORIGIN',
+				'X-Download-Options': 'noopen',
+				'X-Permitted-Cross-Domain-Policies': 'none',
+				'Content-Type': 'text/plain'
+			},
+			''
+		);
 
 		async.done(function( data, s, x ){
 			expect(data).toEqual([]);
@@ -655,15 +677,19 @@ describe('OC.SetupChecks tests', function() {
 		protocolStub.returns('https');
 		var async = OC.SetupChecks.checkGeneric();
 
-		suite.server.requests[0].respond(200, {
-			'Strict-Transport-Security': 'max-age=99999999; includeSubDomains',
-			'X-XSS-Protection': '1; mode=block',
-			'X-Content-Type-Options': 'nosniff',
-			'X-Robots-Tag': 'none',
-			'X-Frame-Options': 'SAMEORIGIN',
-			'X-Download-Options': 'noopen',
-			'X-Permitted-Cross-Domain-Policies': 'none',
-		});
+		suite.server.requests[0].respond(
+			200, {
+				'Strict-Transport-Security': 'max-age=99999999; includeSubDomains',
+				'X-XSS-Protection': '1; mode=block',
+				'X-Content-Type-Options': 'nosniff',
+				'X-Robots-Tag': 'none',
+				'X-Frame-Options': 'SAMEORIGIN',
+				'X-Download-Options': 'noopen',
+				'X-Permitted-Cross-Domain-Policies': 'none',
+				'Content-Type': 'text/plain'
+			},
+			''
+		);
 
 		async.done(function( data, s, x ){
 			expect(data).toEqual([]);
@@ -675,15 +701,18 @@ describe('OC.SetupChecks tests', function() {
 		protocolStub.returns('https');
 		var async = OC.SetupChecks.checkGeneric();
 
-		suite.server.requests[0].respond(200, {
-			'Strict-Transport-Security': 'max-age=99999999; preload; includeSubDomains',
-			'X-XSS-Protection': '1; mode=block',
-			'X-Content-Type-Options': 'nosniff',
-			'X-Robots-Tag': 'none',
-			'X-Frame-Options': 'SAMEORIGIN',
-			'X-Download-Options': 'noopen',
-			'X-Permitted-Cross-Domain-Policies': 'none',
-		});
+		suite.server.requests[0].respond(
+			200, {
+				'Strict-Transport-Security': 'max-age=99999999; preload; includeSubDomains',
+				'X-XSS-Protection': '1; mode=block',
+				'X-Content-Type-Options': 'nosniff',
+				'X-Robots-Tag': 'none',
+				'X-Frame-Options': 'SAMEORIGIN',
+				'X-Download-Options': 'noopen',
+				'X-Permitted-Cross-Domain-Policies': 'none',
+				'Content-Type': 'text/plain'
+			}, ''
+		);
 
 		async.done(function( data, s, x ){
 			expect(data).toEqual([]);


### PR DESCRIPTION
- Replace deprecated `buttonset()` with `controlgroup()` 

**Note**: _This PR is based on the [jquery-2-migration](https://github.com/owncloud/core/tree/jquery-2-migration) branch!_

Fixes: https://github.com/owncloud/core/issues/32484