### PR TITLE
correct return php-doc in acceptance tests

### DIFF
--- a/tests/TestHelpers/DeleteHelper.php
+++ b/tests/TestHelpers/DeleteHelper.php
@@ -21,7 +21,6 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\FutureResponse;
 use GuzzleHttp\Message\ResponseInterface;
 
 /**
@@ -45,7 +44,7 @@ class DeleteHelper {
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
 	 *
-	 * @return FutureResponse|ResponseInterface|NULL
+	 * @return ResponseInterface
 	 */
 	public static function delete(
 		$baseUrl,

--- a/tests/TestHelpers/DownloadHelper.php
+++ b/tests/TestHelpers/DownloadHelper.php
@@ -21,7 +21,6 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\FutureResponse;
 use GuzzleHttp\Message\ResponseInterface;
 
 /**
@@ -45,7 +44,7 @@ class DownloadHelper {
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
 	 *
-	 * @return FutureResponse|ResponseInterface|NULL
+	 * @return ResponseInterface
 	 */
 	public static function download(
 		$baseUrl,

--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -25,6 +25,7 @@ namespace TestHelpers;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Message\ResponseInterface;
 
 /**
  * Helper for HTTP requests
@@ -43,7 +44,7 @@ class HttpRequestHelper {
 	 * @param boolean $stream
 	 *
 	 * @throws BadResponseException
-	 * @return \GuzzleHttp\Message\ResponseInterface|NULL|\GuzzleHttp\Message\FutureResponse
+	 * @return ResponseInterface
 	 */
 	public static function sendRequest(
 		$url,
@@ -112,7 +113,7 @@ class HttpRequestHelper {
 	 * @param boolean $stream
 	 *
 	 * @throws BadResponseException
-	 * @return \GuzzleHttp\Message\ResponseInterface|NULL|\GuzzleHttp\Message\FutureResponse
+	 * @return ResponseInterface
 	 */
 	public static function get(
 		$url,
@@ -144,7 +145,7 @@ class HttpRequestHelper {
 	 * @param boolean $stream
 	 *
 	 * @throws BadResponseException
-	 * @return \GuzzleHttp\Message\ResponseInterface|NULL|\GuzzleHttp\Message\FutureResponse
+	 * @return ResponseInterface
 	 */
 	public static function post(
 		$url,
@@ -176,7 +177,7 @@ class HttpRequestHelper {
 	 * @param boolean $stream
 	 *
 	 * @throws BadResponseException
-	 * @return \GuzzleHttp\Message\ResponseInterface|NULL|\GuzzleHttp\Message\FutureResponse
+	 * @return ResponseInterface
 	 */
 	public static function put(
 		$url,
@@ -208,7 +209,7 @@ class HttpRequestHelper {
 	 * @param boolean $stream
 	 *
 	 * @throws BadResponseException
-	 * @return \GuzzleHttp\Message\ResponseInterface|NULL|\GuzzleHttp\Message\FutureResponse
+	 * @return ResponseInterface
 	 */
 	public static function delete(
 		$url,

--- a/tests/TestHelpers/MoveCopyHelper.php
+++ b/tests/TestHelpers/MoveCopyHelper.php
@@ -21,6 +21,8 @@
  */
 namespace TestHelpers;
 
+use GuzzleHttp\Message\ResponseInterface;
+
 /**
  * Helper for move and copy files
  *
@@ -44,7 +46,7 @@ class MoveCopyHelper {
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
 	 *
-	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @return ResponseInterface
 	 */
 	public static function copy(
 		$baseUrl,
@@ -77,7 +79,7 @@ class MoveCopyHelper {
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
 	 *
-	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @return ResponseInterface
 	 */
 	public static function move(
 		$baseUrl,
@@ -111,7 +113,7 @@ class MoveCopyHelper {
 	 * @param int    $davPathVersionToUse (1|2)
 	 * @param string $sourceIpAddress
 	 *
-	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @return ResponseInterface
 	 */
 	private static function copyOrMove(
 		$baseUrl,

--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -21,6 +21,8 @@
  */
 namespace TestHelpers;
 
+use GuzzleHttp\Message\ResponseInterface;
+
 /**
  * manage Shares via OCS API
  *
@@ -61,7 +63,8 @@ class SharingHelper {
 	 * @param int $ocsApiVersion
 	 * @param int $sharingApiVersion
 	 *
-	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @throws \InvalidArgumentException
+	 * @return ResponseInterface
 	 */
 	public static function createShare(
 		$baseUrl,

--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -21,6 +21,8 @@
  */
 namespace TestHelpers;
 
+use GuzzleHttp\Message\ResponseInterface;
+
 /**
  * Helper to administer Tags
  *
@@ -39,7 +41,7 @@ class TagsHelper {
 	 * @param string $fileOwner
 	 * @param int $davPathVersionToUse (1|2)
 	 *
-	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @return ResponseInterface
 	 */
 	public static function tag(
 		$baseUrl,
@@ -141,7 +143,7 @@ class TagsHelper {
 	 * @param string $groups separated by "|"
 	 * @param int $davPathVersionToUse (1|2)
 	 *
-	 * @return \GuzzleHttp\Message\ResponseInterface|NULL|\GuzzleHttp\Message\FutureResponse
+	 * @return ResponseInterface
 	 * @link self::makeDavRequest()
 	 */
 	public static function createTag(
@@ -187,7 +189,7 @@ class TagsHelper {
 	 * @param int $tagID
 	 * @param int $davPathVersionToUse (1|2)
 	 *
-	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @return ResponseInterface
 	 */
 	public static function deleteTag(
 		$baseUrl,

--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -21,7 +21,6 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\FutureResponse;
 use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Stream\Stream;
 use PHPUnit_Framework_Assert;
@@ -50,7 +49,7 @@ class UploadHelper {
 	 *                                    if set to null chunking will not be used
 	 * @param int    $noOfChunks          how many chunks do we want to upload
 	 *
-	 * @return FutureResponse|ResponseInterface|NULL
+	 * @return ResponseInterface
 	 */
 	public static function upload(
 		$baseUrl,

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -22,7 +22,7 @@
 namespace TestHelpers;
 
 use Exception;
-use GuzzleHttp\Client as GClient;
+use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Stream\Stream;
 use GuzzleHttp\Stream\StreamInterface;
 use InvalidArgumentException;
@@ -88,7 +88,7 @@ class WebDavHelper {
 	 * @param string $sourceIpAddress to initiate the request from
 	 * @param string $authType basic|bearer
 	 *
-	 * @return \GuzzleHttp\Message\FutureResponse|\GuzzleHttp\Message\ResponseInterface|NULL
+	 * @return ResponseInterface
 	 */
 	public static function makeDavRequest(
 		$baseUrl,

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -20,7 +20,6 @@
  */
 
 use Behat\Gherkin\Node\TableNode;
-use GuzzleHttp\Message\FutureResponse;
 use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Stream\StreamInterface;
 use Sabre\DAV\Client as SClient;
@@ -213,7 +212,7 @@ trait WebDav {
 	 * @param string|null $requestBody
 	 * @param string|null $davPathVersion
 	 *
-	 * @return FutureResponse|ResponseInterface|NULL
+	 * @return ResponseInterface
 	 */
 	public function makeDavRequest(
 		$user,


### PR DESCRIPTION
## Description
this methods do not return `NULL` nor `FutureResponse` so delete that out of the phpdoc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
