### PR TITLE
EmailHelper refactor

### DIFF
--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -22,7 +22,6 @@
 namespace TestHelpers;
 
 use GuzzleHttp\Message\ResponseInterface;
-use GuzzleHttp\Exception\ServerException;
 use PHPUnit_Framework_Assert;
 
 /**

--- a/tests/TestHelpers/EmailHelper.php
+++ b/tests/TestHelpers/EmailHelper.php
@@ -21,7 +21,6 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Client;
 use GuzzleHttp\Message\ResponseInterface;
 
 /**
@@ -38,16 +37,17 @@ class EmailHelper {
 	 * @return mixed JSON encoded contents
 	 */
 	public static function getEmails($mailhogUrl) {
-		$client = new Client();
-		$options = ['headers' => ['Content-Type' => 'application/json']];
-		$request = $client->createRequest(
-			'GET', $mailhogUrl . "/api/v2/messages", $options
+		$response = HttpRequestHelper::get(
+			$mailhogUrl . "/api/v2/messages",
+			null,
+			null,
+			['Content-Type' => 'application/json']
 		);
-		$response = $client->send($request);
 
 		$json = \json_decode($response->getBody()->getContents());
 		return $json;
 	}
+
 	/**
 	 *
 	 * @param string $mailhogUrl
@@ -79,12 +79,9 @@ class EmailHelper {
 	 * @return ResponseInterface
 	 */
 	public static function deleteAllMessages($mailhogUrl) {
-		$client = new Client();
-		$request = $client->createRequest(
-			'DELETE', $mailhogUrl . "/api/v1/messages"
+		return HttpRequestHelper::delete(
+			$mailhogUrl . "/api/v1/messages"
 		);
-		$response = $client->send($request);
-		return $response;
 	}
 
 	/**

--- a/tests/TestHelpers/LoggingHelper.php
+++ b/tests/TestHelpers/LoggingHelper.php
@@ -60,6 +60,8 @@ class LoggingHelper {
 	 * @param string $baseUrl
 	 * @param string $adminUsername
 	 * @param string $adminPassword
+	 * @param int $noOfLinesToRead
+	 *
 	 * @throws \Exception
 	 * @return \SimpleXMLElement[]
 	 */

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -20,6 +20,7 @@
  *
  */
 namespace TestHelpers;
+
 use Behat\Testwork\Hook\Scope\HookScope;
 use GuzzleHttp\Exception\ServerException;
 use Exception;

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -25,7 +25,6 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\AdminSharingSettingsPage;
-use Page\LoginPage;
 
 /**
  * WebUI AdminSharingSettings context.


### PR DESCRIPTION
## Description
1) Refactor ``EmailHelper`` to call ``HttpRequestHelper``
2) Fixup a PHPdoc in ``LoggingHelper``
3) Remove some unused use statements the the IDE tells me about

## Related Issue

## Motivation and Context
``EmailHelper`` has some Guzzle client calls that could also use ``HttpRequestHelper``.
I noticed them while rebasing the Guzzle V6 PR.

## How Has This Been Tested?
Local run of ``features/webUILogin/resetPassword.feature`` (which uses mailhog email)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
