### PR TITLE
[stable10] Backport of Share notification recipients should be added …

### DIFF
--- a/core/js/sharedialogmailview.js
+++ b/core/js/sharedialogmailview.js
@@ -21,8 +21,8 @@
 		'  <input class="emailPrivateLinkForm--emailField full-width" id="emailPrivateLinkField-{{cid}}" />' +
 		'  <div class="emailPrivateLinkForm--elements hidden">' +
 		'    {{#if userHasEmail}}' +
-		'    <label class="public-link-modal--bccSelf">' +
-		'      <input class="emailPrivateLinkForm--emailBccSelf" type="checkbox"> {{bccSelf}}' +
+		'    <label class="public-link-modal--toSelf">' +
+		'      <input class="emailPrivateLinkForm--emailToSelf" type="checkbox"> {{toSelf}}' +
 		'    </label>' +
 		'    {{/if}}' +
 		'    <label class="public-link-modal--label" for="emailBodyPrivateLinkField-{{cid}}">{{mailMessageLabel}}</label>' +
@@ -104,7 +104,7 @@
 				action      : 'email',
 				toAddress   : this._addresses.join(','),
 				emailBody   : mail.body,
-				bccSelf     : mail.bccSelf,
+				toSelf     : mail.toSelf,
 				link        : this.model.getLink(),
 				itemType    : itemType,
 				itemSource  : itemSource,
@@ -145,7 +145,7 @@
 			var $formSendIndicator = this.$el.find('.emailPrivateLinkForm--sending-indicator');
 			var  mail = {
 				 to      : this._addresses.join(','),
-				 bccSelf : this.$el.find('.emailPrivateLinkForm--emailBccSelf').is(':checked'),
+				 toSelf : this.$el.find('.emailPrivateLinkForm--emailToSelf').is(':checked'),
 				 body    : this.$el.find('.emailPrivateLinkForm--emailBodyField').val()
 			};
 
@@ -179,7 +179,7 @@
 				cid                 : this.cid,
 				userHasEmail        : !!OC.getCurrentUser().email,
 				mailPlaceholder     : t('core', 'Email link to person'),
-				bccSelf             : t('core', 'Send copy to self'),
+				toSelf             : t('core', 'Send copy to self'),
 				mailLabel           : t('core', 'Send link via email'),
 				mailBodyPlaceholder : t('core', 'Add personal message'),
 				sending             : t('core', 'Sending') + ' ...',

--- a/core/js/tests/specs/sharedialogmailviewSpec.js
+++ b/core/js/tests/specs/sharedialogmailviewSpec.js
@@ -80,7 +80,7 @@ describe('OC.Share.ShareDialogMailView', function() {
 	describe('renders', function() {
 		it('bcc checkbox field if usermail is present', function() {
 			// mail set in initial currentUserStub
-			expect(view.$('.emailPrivateLinkForm--emailBccSelf').length).toEqual(1);
+			expect(view.$('.emailPrivateLinkForm--emailToSelf').length).toEqual(1);
 		});
 	});
 
@@ -143,7 +143,7 @@ describe('OC.Share.ShareDialogMailView', function() {
 				file: 'shared_folder',
 				expiration: '2017-10-12',
 				emailBody: '',
-				bccSelf: 'false'
+				toSelf: 'false'
 			});
 
 			fakeServer.requests[0].respond(
@@ -169,7 +169,7 @@ describe('OC.Share.ShareDialogMailView', function() {
 		it('sends mail to self if BCC is checked', function() {
 			var callback = sinon.stub();
 			view._addAddress('GlaDOS@aperture.com');
-			view.$('.emailPrivateLinkForm--emailBccSelf').prop('checked', 'checked');
+			view.$('.emailPrivateLinkForm--emailToSelf').prop('checked', 'checked');
 			view.$('.emailPrivateLinkForm--emailBodyField').val('The Cake Is A Lie!');
 			view.sendEmails().then(callback);
 
@@ -186,7 +186,7 @@ describe('OC.Share.ShareDialogMailView', function() {
 				file: 'shared_folder',
 				expiration: '2017-10-12',
 				emailBody: 'The Cake Is A Lie!',
-				bccSelf: 'true'
+				toSelf: 'true'
 			});
 
 			fakeServer.requests[0].respond(

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -209,9 +209,10 @@ class MailNotifications {
 		 * - cc ( the cc recipient in mail )
 		 * - bcc ( the bcc recipient in mail )
 		 */
+		$toRecipients = isset($options['to']) ? $options['to'] : '';
 		$ccRecipients = isset($options['cc']) ? $options['cc'] : '';
 		$bccRecipients = isset($options['bcc']) ? $options['bcc'] : '';
-		$event = new GenericEvent(null, ['link' => $link, 'to' => $recipient, 'cc' => $ccRecipients, 'bcc' => $bccRecipients]);
+		$event = new GenericEvent(null, ['link' => $link, 'to' => $toRecipients, 'cc' => $ccRecipients, 'bcc' => $bccRecipients]);
 		$this->eventDispatcher->dispatch('share.sendmail', $event);
 		$options['l10n'] = $l10n;
 		return $this->sendLinkShareMailFromBody($recipient, $subject, $htmlBody, $textBody, $options);
@@ -223,7 +224,7 @@ class MailNotifications {
 	 * @param string $recipient recipient email address
 	 * @param string $filename the shared file
 	 * @param string $link the public link
-	 * @param array $options allows ['cc'] and ['bcc'] recipients
+	 * @param array $options allows ['to], ['cc'] and ['bcc'] recipients
 	 * @param int $expiration expiration date (timestamp)
 	 * @return string[] $result of failed recipients
 	 */
@@ -232,6 +233,7 @@ class MailNotifications {
 		if ($recipient !== null) {
 			$recipients    = $this->_mailStringToArray($recipient);
 		}
+		$toRecipients  = (isset($options['to']) && $options['to'] !== '') ? $this->_mailStringToArray($options['to']) : null;
 		$ccRecipients  = (isset($options['cc']) && $options['cc'] !== '') ? $this->_mailStringToArray($options['cc']) : null;
 		$bccRecipients = (isset($options['bcc']) && $options['bcc'] !== '') ? $this->_mailStringToArray($options['bcc']) : null;
 		$l10n = (isset($options['l10n'])) ? $options['l10n'] : $this->l;
@@ -242,6 +244,9 @@ class MailNotifications {
 			$message->setTo($recipients);
 			if ($htmlBody !== null) {
 				$message->setHtmlBody($htmlBody);
+			}
+			if ($toRecipients !== null) {
+				$message->setTo($toRecipients);
 			}
 			if ($bccRecipients !== null) {
 				$message->setBcc($bccRecipients);
@@ -260,6 +265,12 @@ class MailNotifications {
 			$allRecipientsArr = [];
 			if ($recipient !== null && $recipient !== '') {
 				$allRecipientsArr = \explode(',', $recipient);
+			}
+			if (isset($options['to']) && $options['to'] !== '') {
+				$allRecipientsArr = \array_merge(
+					$allRecipientsArr,
+					\explode(',', $options['to'])
+				);
 			}
 			if (isset($options['cc']) && $options['cc'] !== '') {
 				$allRecipientsArr = \array_merge(


### PR DESCRIPTION
…to list

Share notification recipients should be added to list.
Adding them to bcc was causing spam filters to block
the emails. This change would solve the issue and
users get notified.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add recipients to share notification by email to the 'to' field/list. So that spam filters would not block the emails.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/32008

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add recipients to share notification by email to the 'to' field/list. So that spam filters would not block the emails.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Configure ownCloud to enable share notification by email.
- Create a public link and add multiple recipients
- The emails received by recipients are in the to field.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
