### PR TITLE
[WIP] User actioned transfer of folders to other users

### DIFF
--- a/apps/files/appinfo/Migrations/Version20180901190932.php
+++ b/apps/files/appinfo/Migrations/Version20180901190932.php
@@ -7,7 +7,7 @@ use OCA\Files\Service\TransferOwnership\TransferRequestMapper;
 use OCP\Migration\ISchemaMigration;
 
 /**
- * Auto-generated migration step: Please modify to your needs!
+ * Create table to track user initiated transfer requests
  */
 class Version20180901190932 implements ISchemaMigration {
 

--- a/apps/files/appinfo/Migrations/Version20180901190932.php
+++ b/apps/files/appinfo/Migrations/Version20180901190932.php
@@ -1,0 +1,73 @@
+<?php
+namespace OCA\files\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use OCA\Files\Service\TransferOwnership\TransferRequestMapper;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version20180901190932 implements ISchemaMigration {
+
+	public function changeSchema(Schema $schema, array $options) {
+		// Add a new table to track user file transfer request
+		$table = $options['tablePrefix'] . TransferRequestMapper::TABLENAME;
+		$table = $schema->createTable($table);
+		$table->addColumn(
+			'id',
+			Type::INTEGER,
+			[
+				'comment' => 'Unique identifier for the transfer request',
+				'autoincrement' => true
+			]);
+		$table->addColumn(
+			'source_user_id',
+			Type::STRING,
+			[
+				'comment' => 'The user who initiated the request'
+			]);
+		$table->addColumn(
+			'destination_user_id',
+			Type::STRING,
+			[
+				'comment' => 'The user who should receive the files'
+			]);
+		$table->addColumn(
+			'file_id',
+			Type::BIGINT,
+			[
+				'comment' => 'The file id for the folder to be transferred'
+			]);
+		$table->addColumn(
+			'requested_time',
+			Type::INTEGER,
+			[
+				'comment' => 'Time when the request was created by the source user'
+			]);
+		$table->addColumn(
+			'accepted_time',
+			Type::INTEGER,
+			[
+				'comment' => 'Time when the request was accepted by the destination user',
+				'notnull' => false
+			]);
+		$table->addColumn(
+			'rejected_time',
+			Type::INTEGER,
+			[
+				'comment' => 'Time when the request was rejected by the destination user',
+				'notnull' => false
+			]);
+		$table->addColumn(
+			'actioned_time',
+			Type::INTEGER,
+			[
+				'comment' => 'Time when the transfer actually completed on storage',
+				'notnull' => false
+			]);
+		$table->setPrimaryKey(['id']);
+	}
+
+}

--- a/apps/files/appinfo/app.php
+++ b/apps/files/appinfo/app.php
@@ -62,4 +62,6 @@ $templateManager->registerTemplate('application/vnd.oasis.opendocument.spreadshe
 	);
 });
 
+$app->registerNotifier();
+
 \OCP\Util::connectHook('\OCP\Config', 'js', '\OCA\Files\App', 'extendJsConfig');

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<licence>AGPL</licence>
 	<author>Robin Appelman, Vincent Petry</author>
 	<default_enable/>
-	<version>1.5.2</version>
+	<version>1.5.3</version>
 	<types>
 		<filesystem/>
 	</types>
@@ -35,4 +35,6 @@
 		<route>files.view.index</route>
 		<order>0</order>
 	</navigation>
+
+	<use-migrations>true</use-migrations>
 </info>

--- a/apps/files/appinfo/routes.php
+++ b/apps/files/appinfo/routes.php
@@ -59,6 +59,21 @@ $application->registerRoutes(
 				'url' => '/',
 				'verb' => 'GET',
 			],
+			[
+				'name' => 'Transfer#transfer',
+				'url' => '/api/v1/transfer/',
+				'verb' => 'POST',
+			],
+			[
+				'name' => 'Transfer#accept',
+				'url' => '/api/v1/transfer/{requestId}',
+				'verb' => 'POST',
+			],
+			[
+				'name' => 'Transfer#reject',
+				'url' => '/api/v1/transfer/{requestId}',
+				'verb' => 'DELETE',
+			],
 
 		]
 	]

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -661,19 +661,17 @@
 				}
 			});
 
-			// TODO only for folders, not files
 			this.registerAction({
 				name: 'Transfer',
 				displayName: function(context) {
 					return t('files', 'Transfer');
 				},
-				mime: 'httpd/unix-directory',
+				mime: 'all',
 				order: 1000,
 				permissions: OC.PERMISSION_READ,
 				iconClass: 'icon-give',
 				actionHandler: function(fileName, context) {
 					context.fileList.do_transfer(fileName, context.dir);
-					$('.tipsy').remove();
 				}
 			});
 

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -661,6 +661,22 @@
 				}
 			});
 
+			// TODO only for folders, not files
+			this.registerAction({
+				name: 'Transfer',
+				displayName: function(context) {
+					return t('files', 'Transfer');
+				},
+				mime: 'httpd/unix-directory',
+				order: 1000,
+				permissions: OC.PERMISSION_READ,
+				iconClass: 'icon-give',
+				actionHandler: function(fileName, context) {
+					context.fileList.do_transfer(fileName, context.dir);
+					$('.tipsy').remove();
+				}
+			});
+
 			this.setDefault('dir', 'Open');
 		},
 

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2411,6 +2411,54 @@
 		},
 
 		/**
+		 * Give the current files to a certain user
+		 * @param files file names list (without path)
+		 * @param dir directory in which to delete the files, defaults to the current
+		 * directory
+		 */
+		do_transfer:function(files, dir) {
+			// TODO only do this if they own the file
+			var self = this;
+			if (files && files.substr) {
+				files=[files];
+			}
+			if (!files) {
+				// delete all files in directory
+				files = _.pluck(this.files, 'name');
+			}
+			if (files) {
+				this.showFileBusyState(files, true);
+			}
+			// Finish any existing actions
+			if (this.lastAction) {
+				this.lastAction();
+			}
+
+			dir = dir || this.getCurrentDirectory();
+
+
+			OC.dialogs.prompt(
+				'Please enter the username of the user who should receive the folder and corresponding shares.',
+				'Transfer folder to another user',
+				function(result, userid) {
+					$.post(OC.generateUrl('/apps/files/api/v1/transfer'), {
+						file: files[0],
+						uid: userid,
+						dir: dir
+					}).done(function(){
+						OC.Notification.showTemporary('Transfer request created. Wait for the user to accept.');
+					}).fail(function(){
+						OC.Notification.showTemporary('There was an error creating the transfer request');
+					});
+
+					self.showFileBusyState(files, false);
+				},
+				true,
+				'Username',
+				false);
+			},
+
+		/**
 		 * Delete the given files from the given dir
 		 * @param files file names list (without path)
 		 * @param dir directory in which to delete the files, defaults to the current

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2445,13 +2445,13 @@
 						file: files[0],
 						uid: userid,
 						dir: dir
-					}).done(function(){
+					}, function() {
 						OC.Notification.showTemporary('Transfer request created. Wait for the user to accept.');
+					}).done(function(){
+						self.showFileBusyState(files, false);
 					}).fail(function(){
 						OC.Notification.showTemporary('There was an error creating the transfer request');
 					});
-
-					self.showFileBusyState(files, false);
 				},
 				true,
 				'Username',

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2413,22 +2413,13 @@
 		/**
 		 * Give the current files to a certain user
 		 * @param files file names list (without path)
-		 * @param dir directory in which to delete the files, defaults to the current
+		 * @param dir directory in which to transfer the files from, defaults to the current
 		 * directory
 		 */
-		do_transfer:function(files, dir) {
+		do_transfer:function(file, dir) {
 			// TODO only do this if they own the file
 			var self = this;
-			if (files && files.substr) {
-				files=[files];
-			}
-			if (!files) {
-				// delete all files in directory
-				files = _.pluck(this.files, 'name');
-			}
-			if (files) {
-				this.showFileBusyState(files, true);
-			}
+
 			// Finish any existing actions
 			if (this.lastAction) {
 				this.lastAction();
@@ -2442,7 +2433,7 @@
 				'Transfer folder to another user',
 				function(result, userid) {
 					$.post(OC.generateUrl('/apps/files/api/v1/transfer'), {
-						file: files[0],
+						file: file,
 						uid: userid,
 						dir: dir
 					}, function() {

--- a/apps/files/lib/AppInfo/Application.php
+++ b/apps/files/lib/AppInfo/Application.php
@@ -27,8 +27,10 @@ namespace OCA\Files\AppInfo;
 use OCA\Files\Controller\ApiController;
 use OCA\Files\Controller\ViewController;
 use OCA\Files\Service\TagService;
+use OCA\Files\Service\TransferOwnership\TransferRequestManager;
 use OCP\AppFramework\App;
 use OCP\IContainer;
+use OCP\Notification\Events\RegisterNotifierEvent;
 
 class Application extends App {
 	public function __construct(array $urlParams= []) {
@@ -94,5 +96,25 @@ class Application extends App {
 		 * Register capabilities
 		 */
 		$container->registerCapability('OCA\Files\Capabilities');
+
+	}
+
+	/**
+	 * Registers the notifier
+	 */
+	public function registerNotifier() {
+		$container = $this->getContainer();
+		$dispatcher = $container->getServer()->getEventDispatcher();
+
+		$dispatcher->addListener(
+			RegisterNotifierEvent::NAME,
+			function (RegisterNotifierEvent $event) use ($container) {
+			$l10n = $container->getServer()->getL10N('files');
+			$event->registerNotifier(
+				$container->query(TransferRequestManager::class),
+				'files',
+				$l10n->t('Files'));
+		});
+
 	}
 }

--- a/apps/files/lib/BackgroundJob/CleanupTransferRequests.php
+++ b/apps/files/lib/BackgroundJob/CleanupTransferRequests.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\BackgroundJob;
+
+use OC\BackgroundJob\TimedJob;
+use OC\Lock\Persistent\LockMapper;
+use OCA\Files\Service\TransferOwnership\TransferRequestMapper;
+
+/**
+ * Clean up transfer requests that are long since unaccepted
+ */
+class CleanupTransferRequests extends TimedJob {
+
+	/**
+	 * Default interval in minutes
+	 *
+	 * @var int $defaultIntervalMin
+	 **/
+	protected $defaultIntervalMin = 60;
+	/** @var TransferRequestMapper */
+	private $mapper;
+
+	/**
+	 * CleanupTransferRequests constructor.
+	 *
+	 * @param LockMapper $lockMapper
+	 */
+	public function __construct(TransferRequestMapper $mapper) {
+		$this->interval = $this->defaultIntervalMin * 60;
+		$this->mapper = $mapper;
+	}
+
+	/**
+	 * @param $argument
+	 */
+	public function run($argument) {
+		$this->mapper->cleanup();
+	}
+}

--- a/apps/files/lib/BackgroundJob/TransferOwnership.php
+++ b/apps/files/lib/BackgroundJob/TransferOwnership.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace OCA\Files\BackgroundJob;
+
+use OC\BackgroundJob\QueuedJob;
+use OCA\Files\Service\TransferOwnership\TransferOwnershipService;
+use OCP\ILogger;
+use OCP\IUserManager;
+
+class TransferOwnership extends QueuedJob {
+
+	/** @var ILogger */
+	protected $logger;
+	/** @var TransferOwnershipService  */
+	protected $service;
+	/** @var IUserManager  */
+	protected $userManager;
+
+	public function __construct(TransferOwnershipService $service, IUserManager $userManager) {
+		$this->service = $service;
+		$this->userManager = $userManager;
+	}
+
+	public function execute($jobList, ILogger $logger = null) {
+		$this->logger = $logger;
+		parent::execute($jobList, $logger);
+	}
+
+	public function run($argument) {
+		// Get the arguments;
+		$arguments = json_decode($argument);
+		if (!isset($arguments['sourceUser'], $arguments['destinationUser'], $arguments['sourcePath'])) {
+			$this->logger->error(self::class . ' called with invalid argument: '.$argument, ['app' => 'files']);
+			return;
+		}
+		// Call the transfer service
+		$sourceUser = $this->userManager->get($arguments['sourceUser']);
+		$destinationUser = $this->userManager->get($arguments['destinationuser']);
+
+		if ($sourceUser === null || $destinationUser === null) {
+			$this->logger->error("Trasnfer job called with missing users", ['app' => 'files']);
+			return;
+		}
+
+		$sourcePath = $arguments['sourcePath'];
+		try {
+			$this->service->transfer($sourceUser, $destinationUser, $sourcePath);
+		} catch (\Exception $e) {
+			$this->logger->logException($e, ['app' =>  'files']);
+			return;
+		}
+
+		$this->logger->info("Finished transfer of $sourcePath from {$sourceUser->getUID()} to {$destinationUser->getUID()}");
+	}
+
+}

--- a/apps/files/lib/BackgroundJob/TransferOwnership.php
+++ b/apps/files/lib/BackgroundJob/TransferOwnership.php
@@ -1,4 +1,23 @@
 <?php
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 namespace OCA\Files\BackgroundJob;
 

--- a/apps/files/lib/BackgroundJob/TransferOwnership.php
+++ b/apps/files/lib/BackgroundJob/TransferOwnership.php
@@ -4,6 +4,10 @@ namespace OCA\Files\BackgroundJob;
 
 use OC\BackgroundJob\QueuedJob;
 use OCA\Files\Service\TransferOwnership\TransferOwnershipService;
+use OCA\Files\Service\TransferOwnership\TransferRequestManager;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
 use OCP\ILogger;
 use OCP\IUserManager;
 
@@ -15,10 +19,20 @@ class TransferOwnership extends QueuedJob {
 	protected $service;
 	/** @var IUserManager  */
 	protected $userManager;
+	/** @var TransferRequestManager  */
+	protected $requestManager;
+	/** @var IRootFolder  */
+	protected $rootFolder;
 
-	public function __construct(TransferOwnershipService $service, IUserManager $userManager) {
+	public function __construct(
+		TransferOwnershipService $service,
+		IUserManager $userManager,
+		TransferRequestManager $requestManager,
+		IRootFolder $rootFolder) {
 		$this->service = $service;
 		$this->userManager = $userManager;
+		$this->requestManager = $requestManager;
+		$this->rootFolder = $rootFolder;
 	}
 
 	public function execute($jobList, ILogger $logger = null) {
@@ -29,20 +43,34 @@ class TransferOwnership extends QueuedJob {
 	public function run($argument) {
 		// Get the arguments;
 		$arguments = json_decode($argument);
-		if (!isset($arguments['sourceUser'], $arguments['destinationUser'], $arguments['sourcePath'])) {
-			$this->logger->error(self::class . ' called with invalid argument: '.$argument, ['app' => 'files']);
+		try {
+			$request = $this->requestManager->getRequestById($arguments->requestId);
+		} catch (DoesNotExistException $e) {
+			// Can happen if this gets deleted before the cron runs
+			$this->logger->info("Transfer job called but request is missing");
 			return;
 		}
+
 		// Call the transfer service
-		$sourceUser = $this->userManager->get($arguments['sourceUser']);
-		$destinationUser = $this->userManager->get($arguments['destinationuser']);
+		$sourceUser = $this->userManager->get($request->getSourceUserId());
+		$destinationUser = $this->userManager->get($request->getDestinationUserId());
 
 		if ($sourceUser === null || $destinationUser === null) {
-			$this->logger->error("Trasnfer job called with missing users", ['app' => 'files']);
+			$this->logger->error("Trasnfer job called but at least one of the users in the request are missing: source:{$request->getSourceUserId()} destination:{$request->getDestinationUserId()}", ['app' => 'files']);
 			return;
 		}
 
-		$sourcePath = $arguments['sourcePath'];
+		try {
+			$sourcePath = $this->rootFolder->getUserFolder($request->getSourceUserId())
+				->getById($request->getFileId())[0]
+				->getInternalPath();
+		} catch (NotFoundException $e) {
+			$this->logger->error("Transfer job called but node no longer exists");
+			$this->requestManager->deleteRequest($request);
+			return;
+		}
+
+
 		try {
 			$this->service->transfer($sourceUser, $destinationUser, $sourcePath);
 		} catch (\Exception $e) {
@@ -51,6 +79,8 @@ class TransferOwnership extends QueuedJob {
 		}
 
 		$this->logger->info("Finished transfer of $sourcePath from {$sourceUser->getUID()} to {$destinationUser->getUID()}");
+		$this->requestManager->actionRequest($request);
+
 	}
 
 }

--- a/apps/files/lib/BackgroundJob/TransferOwnership.php
+++ b/apps/files/lib/BackgroundJob/TransferOwnership.php
@@ -75,6 +75,7 @@ class TransferOwnership extends QueuedJob {
 			$this->service->transfer($sourceUser, $destinationUser, $sourcePath);
 		} catch (\Exception $e) {
 			$this->logger->logException($e, ['app' =>  'files']);
+			$this->requestManager->actionRequestFailure($request);
 			return;
 		}
 

--- a/apps/files/lib/BackgroundJob/TransferOwnership.php
+++ b/apps/files/lib/BackgroundJob/TransferOwnership.php
@@ -75,14 +75,13 @@ class TransferOwnership extends QueuedJob {
 		$destinationUser = $this->userManager->get($request->getDestinationUserId());
 
 		if ($sourceUser === null || $destinationUser === null) {
-			$this->logger->error("Trasnfer job called but at least one of the users in the request are missing: source:{$request->getSourceUserId()} destination:{$request->getDestinationUserId()}", ['app' => 'files']);
+			$this->logger->error("Transfer job called but at least one of the users in the request are missing: source:{$request->getSourceUserId()} destination:{$request->getDestinationUserId()}", ['app' => 'files']);
 			return;
 		}
 
 		try {
-			$sourcePath = $this->rootFolder->getUserFolder($request->getSourceUserId())
-				->getById($request->getFileId())[0]
-				->getInternalPath();
+			$userFolder = $this->rootFolder->getUserFolder($request->getSourceUserId());
+			$sourcePath = $userFolder->getRelativePath($userFolder->getById($request->getFileId())[0]->getPath());
 		} catch (NotFoundException $e) {
 			$this->logger->error("Transfer job called but node no longer exists");
 			$this->requestManager->deleteRequest($request);

--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -4,6 +4,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Tom Needham <tom@owncloud.com>
  *
  * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0

--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -24,19 +24,9 @@
 
 namespace OCA\Files\Command;
 
-use OC\Encryption\Manager;
-use OC\Files\Filesystem;
-use OC\Files\View;
-use OC\Share20\ProviderFactory;
 use OCA\Files\Service\TransferOwnership\TransferOwnershipService;
-use OCP\Files\FileInfo;
-use OCP\Files\Mount\IMountManager;
-use OCP\ILogger;
 use OCP\IUserManager;
-use OCP\Share\IManager;
-use OCP\Share\IShare;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -28,6 +28,7 @@ use OC\Encryption\Manager;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OC\Share20\ProviderFactory;
+use OCA\Files\Service\TransferOwnership\TransferOwnershipService;
 use OCP\Files\FileInfo;
 use OCP\Files\Mount\IMountManager;
 use OCP\ILogger;
@@ -43,55 +44,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class TransferOwnership extends Command {
 
-	/** @var IUserManager $userManager */
-	private $userManager;
+	/** @var TransferOwnershipService */
+	protected $service;
+	/** @var IUserManager  */
+	protected $userManager;
 
-	/** @var IManager */
-	private $shareManager;
-
-	/** @var IMountManager */
-	private $mountManager;
-
-	/** @var Manager  */
-	private $encryptionManager;
-
-	/** @var ILogger  */
-	private $logger;
-
-	/** @var ProviderFactory  */
-	private $shareProviderFactory;
-
-	/** @var bool */
-	private $filesExist = false;
-
-	/** @var bool */
-	private $foldersExist = false;
-
-	/** @var FileInfo[] */
-	private $encryptedFiles = [];
-
-	/** @var IShare[] */
-	private $shares = [];
-
-	/** @var string */
-	private $sourceUser;
-
-	/** @var string */
-	private $destinationUser;
-
-	/** @var string */
-	private $inputPath;
-
-	/** @var string */
-	private $finalTarget;
-
-	public function __construct(IUserManager $userManager, IManager $shareManager, IMountManager $mountManager, Manager $encryptionManager, ILogger $logger, ProviderFactory $shareProviderFactory) {
+	public function __construct(TransferOwnershipService $service, IUserManager $userManager) {
+		$this->service = $service;
 		$this->userManager = $userManager;
-		$this->shareManager = $shareManager;
-		$this->mountManager = $mountManager;
-		$this->encryptionManager = $encryptionManager;
-		$this->logger = $logger;
-		$this->shareProviderFactory = $shareProviderFactory;
 		parent::__construct();
 	}
 
@@ -121,227 +81,26 @@ class TransferOwnership extends Command {
 		$sourceUserObject = $this->userManager->get($input->getArgument('source-user'));
 		$destinationUserObject = $this->userManager->get($input->getArgument('destination-user'));
 		if ($sourceUserObject === null) {
-			$output->writeln("<error>Unknown source user $this->sourceUser</error>");
+			$output->writeln("<error>Unknown source user {$input->getArgument('source-user')}</error>");
 			return 1;
 		}
 		if ($destinationUserObject === null) {
-			$output->writeln("<error>Unknown destination user $this->destinationUser</error>");
+			$output->writeln("<error>Unknown destination user {$input->getArgument('destination-user')}</error>");
 			return 1;
 		}
 
-		$this->sourceUser = $sourceUserObject->getUID();
-		$this->destinationUser = $destinationUserObject->getUID();
-		$this->inputPath = $input->getOption('path');
-		$this->inputPath = \ltrim($this->inputPath, '/');
+		$inputPath = $input->getOption('path');
+		$inputPath = \ltrim($inputPath, '/');
 
-		// target user has to be ready
-		if (!\OC::$server->getEncryptionManager()->isReadyForUser($this->destinationUser)) {
-			$output->writeln("<error>The target user is not ready to accept files. The user has at least to be logged in once.</error>");
-			return 2;
-		}
-
-		// use a date format compatible across client OS
-		$date = \date('Ymd_his');
-		$this->finalTarget = "$this->destinationUser/files/transferred from $this->sourceUser on $date";
-
-		// setup filesystem
-		Filesystem::initMountPoints($this->sourceUser);
-		Filesystem::initMountPoints($this->destinationUser);
-
-		if (\strlen($this->inputPath) >= 1) {
-			$view = new View();
-			$unknownDir = $this->inputPath;
-			$this->inputPath = $this->sourceUser . "/files/" . $this->inputPath;
-			if (!$view->is_dir($this->inputPath)) {
-				$output->writeln("<error>Unknown path provided: $unknownDir</error>");
-				return 1;
-			}
-		}
-
-		// analyse source folder
-		$this->analyse($output);
-
-		if (!$this->filesExist and !$this->foldersExist) {
-			$output->writeln("<comment>No files/folders to transfer</comment>");
+		try {
+			$this->service->transfer($sourceUserObject, $destinationUserObject, $inputPath);
+		} catch (\Exception $e) {
+			$output->writeln('<error>And error occurred during the transfer: '.$e->getMessage().'</error>');
 			return 1;
 		}
+		$output->writeln('<info>Done!</info>');
+		return 0;
+}
 
-		// collect all the shares
-		$this->collectUsersShares($output);
 
-		// transfer the files
-		$this->transfer($output);
-
-		// restore the shares
-		return $this->restoreShares($output);
-	}
-
-	private function walkFiles(View $view, $path, \Closure $callBack) {
-		foreach ($view->getDirectoryContent($path) as $fileInfo) {
-			if (!$callBack($fileInfo)) {
-				return;
-			}
-			if ($fileInfo->getType() === FileInfo::TYPE_FOLDER) {
-				$this->walkFiles($view, $fileInfo->getPath(), $callBack);
-			}
-		}
-	}
-
-	/**
-	 * @param OutputInterface $output
-	 * @throws \Exception
-	 */
-	protected function analyse(OutputInterface $output) {
-		$view = new View();
-		$output->writeln("Analysing files of $this->sourceUser ...");
-		$progress = new ProgressBar($output);
-		$progress->start();
-		$self = $this;
-		$walkPath = "$this->sourceUser/files";
-		if (\strlen($this->inputPath) > 0) {
-			if ($this->inputPath !== "$this->sourceUser/files") {
-				$walkPath = $this->inputPath;
-				$this->foldersExist = true;
-			}
-		}
-
-		$this->walkFiles($view, $walkPath,
-				function (FileInfo $fileInfo) use ($progress, $self) {
-					if ($fileInfo->getType() === FileInfo::TYPE_FOLDER) {
-						// only analyze into folders from main storage,
-						// sub-storages have an empty internal path
-						if ($fileInfo->getInternalPath() === '' && $fileInfo->getPath() !== '') {
-							return false;
-						}
-
-						$this->foldersExist = true;
-						return true;
-					}
-					$progress->advance();
-					$this->filesExist = true;
-					if ($fileInfo->isEncrypted()) {
-						if (\OC::$server->getAppConfig()->getValue('encryption', 'useMasterKey', 0) !== 0) {
-							/**
-							 * We are not going to add this to encryptedFiles array.
-							 * Because its encrypted with masterKey and hence it doesn't
-							 * require user's specific password.
-							 */
-							return true;
-						}
-						$this->encryptedFiles[] = $fileInfo;
-					}
-					return true;
-				});
-		$progress->finish();
-		$output->writeln('');
-
-		// no file is allowed to be encrypted
-		if (!empty($this->encryptedFiles)) {
-			$output->writeln("<error>Some files are encrypted - please decrypt them first</error>");
-			foreach ($this->encryptedFiles as $encryptedFile) {
-				/** @var FileInfo $encryptedFile */
-				$output->writeln("  " . $encryptedFile->getPath());
-			}
-			throw new \Exception('Execution terminated.');
-		}
-	}
-
-	/**
-	 * @param OutputInterface $output
-	 */
-	private function collectUsersShares(OutputInterface $output) {
-		$output->writeln("Collecting all share information for files and folder of $this->sourceUser ...");
-
-		$progress = new ProgressBar($output, \count($this->shares));
-		foreach ([\OCP\Share::SHARE_TYPE_GROUP, \OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_LINK, \OCP\Share::SHARE_TYPE_REMOTE] as $shareType) {
-			$offset = 0;
-			while (true) {
-				$sharePage = $this->shareManager->getSharesBy($this->sourceUser, $shareType, null, true, 50, $offset);
-				$progress->advance(\count($sharePage));
-				if (empty($sharePage)) {
-					break;
-				}
-
-				$this->shares = \array_merge($this->shares, $sharePage);
-				$offset += 50;
-			}
-		}
-
-		$progress->finish();
-		$output->writeln('');
-	}
-
-	/**
-	 * @param OutputInterface $output
-	 */
-	protected function transfer(OutputInterface $output) {
-		$view = new View();
-		$output->writeln("Transferring files to $this->finalTarget ...");
-		$sourcePath = (\strlen($this->inputPath) > 0) ? $this->inputPath : "$this->sourceUser/files";
-		// This change will help user to transfer the folder specified using --path option.
-		// Else only the content inside folder is transferred which is not correct.
-		if (\strlen($this->inputPath) > 0) {
-			if ($this->inputPath !== \ltrim("$this->sourceUser/files", '/')) {
-				$view->mkdir($this->finalTarget);
-				$this->finalTarget = $this->finalTarget . '/' . \basename($sourcePath);
-			}
-		}
-
-		$view->rename($sourcePath, $this->finalTarget);
-
-		if (!\is_dir("$this->sourceUser/files")) {
-			// because the files folder is moved away we need to recreate it
-			$view->mkdir("$this->sourceUser/files");
-		}
-	}
-
-	/**
-	 * @param OutputInterface $output
-	 */
-	private function restoreShares(OutputInterface $output) {
-		$output->writeln("Restoring shares ...");
-		$progress = new ProgressBar($output, \count($this->shares));
-		$status = 0;
-
-		$childShares = [];
-		foreach ($this->shares as $share) {
-			try {
-				/**
-				 * Do not process children which are already processed.
-				 * This piece of code populates the childShare array
-				 * with the child shares which will be processed. And
-				 * hence will avoid further processing of same share
-				 * again.
-				 */
-				if ($share->getSharedWith() === $this->destinationUser) {
-					$provider = $this->shareProviderFactory->getProviderForType($share->getShareType());
-					foreach ($provider->getChildren($share) as $child) {
-						$childShares[] = $child->getId();
-					}
-				} else {
-					/**
-					 * Before doing handover to transferShare, check if the share
-					 * id is present in the childShares. If so then just ignore
-					 * this share and continue. If not ignored, the child shares
-					 * would be processed again, if their parent share was shared
-					 * with destination user. And hence we can safely avoid the
-					 * duplicate processing of shares here.
-					 */
-					if (\in_array($share->getId(), $childShares, true)) {
-						continue;
-					}
-				}
-				$this->shareManager->transferShare($share, $this->sourceUser, $this->destinationUser, $this->finalTarget);
-			} catch (\OCP\Files\NotFoundException $e) {
-				$output->writeln('<error>Share with id ' . $share->getId() . ' points at deleted file, skipping</error>');
-			} catch (\Exception $e) {
-				$output->writeln('<error>Could not restore share with id ' . $share->getId() . ':' . $e->getTraceAsString() . '</error>');
-				$status = 1;
-			}
-			$progress->advance();
-		}
-		$progress->finish();
-		$output->writeln('');
-		return $status;
-	}
 }

--- a/apps/files/lib/Controller/TransferController.php
+++ b/apps/files/lib/Controller/TransferController.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\Controller;
+
+use OCA\Files\Service\TransferOwnership\TransferRequestManager;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\ILogger;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * Class TransferController
+ *
+ * @package OCA\Files\Controller
+ */
+class TransferController extends Controller {
+	/** @var string */
+	protected $appName;
+	/** @var IRequest */
+	protected $request;
+	/** @var TransferRequestManager  */
+	protected $transferManager;
+	/** @var IUserSession  */
+	protected $userSession;
+	/** @var ILogger  */
+	protected $logger;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param TransferRequestManager $transferManager
+	 */
+	public function __construct($appName,
+								IRequest $request,
+								TransferRequestManager $transferManager,
+								IUserSession $userSession,
+								ILogger $logger
+	) {
+		parent::__construct($appName, $request);
+		$this->appName = $appName;
+		$this->request = $request;
+		$this->transferManager = $transferManager;
+		$this->userSession = $userSession;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 */
+	public function transfer() {
+		$file = $this->request->getParam('file');
+		$dir = $this->request->getParam('dir');
+		$destinationUser = $this->request->getParam('uid');
+		$destinationUser = \OC::$server->getUserManager()->get($destinationUser);
+		$sessionUser = \OC::$server->getUserSession()->getUser();
+		$fileId = \OC::$server->getUserFolder($sessionUser->getUID())->get($dir.'/'.$file)->getId();
+		try {
+			$this->transferManager->newTransferRequest($sessionUser, $destinationUser, $fileId);
+			return new JSONResponse();
+		} catch (\Exception $e) {
+			return new JSONResponse(['message' => $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * @NoAdminRequired
+	 */
+	public function accept($requestId) {
+		// Check this user is the recipient of this request
+		try {
+			// Not found, bad request
+			$request = $this->transferManager->getRequestById($requestId);
+		} catch (DoesNotExistException $e) {
+			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
+		}
+		$sessionUser = $this->userSession->getUser();
+		if ($request->getDestinationUserId() !== $sessionUser->getUID()) {
+			// This isn't their request to respond to, bad request
+			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
+		try {
+			$this->transferManager->acceptRequest($request);
+			return new JSONResponse([]);
+		} catch (\Exception $e) {
+			$this->logger->logException($e, ['app' => 'files']);
+			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * @NoAdminRequired
+	 */
+	public function reject($requestId) {
+		// Check this user is the recipient of this request
+		try {
+			// Not found, bad request
+			$request = $this->transferManager->getRequestById($requestId);
+		} catch (DoesNotExistException $e) {
+			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
+		}
+		$sessionUser = $this->userSession->getUser();
+		if ($request->getDestinationUserId() !== $sessionUser->getUID()) {
+			// This isn't their request to respond to, bad request
+			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
+		}
+
+		try {
+			$this->transferManager->rejectRequest($request);
+			return new JSONResponse([]);
+		} catch (\Exception $e) {
+			$this->logger->logException($e, ['app' => 'files']);
+			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+	}
+
+
+
+
+}

--- a/apps/files/lib/Service/TransferOwnership/TransferOwnershipService.php
+++ b/apps/files/lib/Service/TransferOwnership/TransferOwnershipService.php
@@ -1,4 +1,23 @@
 <?php
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 namespace OCA\Files\Service\TransferOwnership;
 

--- a/apps/files/lib/Service/TransferOwnership/TransferOwnershipService.php
+++ b/apps/files/lib/Service/TransferOwnership/TransferOwnershipService.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace OCA\Files\Service\TransferOwnership;
+
+use OC\Encryption\Manager;
+use OC\Files\Filesystem;
+use OC\Files\View;
+use OC\Share20\ProviderFactory;
+use OCP\Files\FileInfo;
+use OCP\Files\NotFoundException;
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+
+class TransferOwnershipService {
+
+	/** @var bool */
+	private $filesExist = false;
+	/** @var bool */
+	private $foldersExist = false;
+	/** @var FileInfo[] */
+	private $encryptedFiles = [];
+	/** @var IShare[] */
+	private $shares = [];
+	/** @var string */
+	private $sourceUser;
+	/** @var string */
+	private $destinationUser;
+	/** @var string */
+	private $inputPath;
+	/** @var string */
+	private $finalTarget;
+
+	/** @var Manager  */
+	protected $encryptionManager;
+	/** @var IUserManager  */
+	protected $userManager;
+	/** @var ILogger */
+	protected $logger;
+	/** @var IConfig  */
+	protected $config;
+	/** @var ProviderFactory  */
+	private $shareProviderFactory;
+	/** @var IManager */
+	protected $shareManager;
+
+	public function __construct(
+		Manager $encryptionManager,
+		IUserManager $userManager,
+		ILogger $logger,
+		IConfig $config,
+		ProviderFactory $shareProviderFactory,
+		IManager $shareManager
+	) {
+		$this->encryptionManager = $encryptionManager;
+		$this->userManager = $userManager;
+		$this->loggger = $logger;
+		$this->config = $config;
+		$this->shareProviderFactory = $shareProviderFactory;
+		$this->shareManager = $shareManager;
+	}
+
+	public function transfer(IUser $sourceUser, IUser $destinationUser, $sourcePath = '/') {
+
+		$this->inputPath = $sourcePath;
+		$this->destinationUser = $destinationUser->getUID();
+		$this->sourceUser = $sourceUser->getUID();
+
+		// target user has to be ready
+		if (!$this->encryptionManager->isReadyForUser($this->destinationUser)) {
+			throw new \Exception('The target user is not ready to accept files. The user has at least to be logged in once.');
+		}
+
+		// use a date format compatible across client OS
+		$date = \date('Ymd_his');
+		$this->finalTarget = "$this->destinationUser/files/transferred from $this->sourceUser on $date";
+
+		// setup filesystem
+		Filesystem::initMountPoints($this->sourceUser);
+		Filesystem::initMountPoints($this->destinationUser);
+
+		if (\strlen($this->inputPath) >= 1) {
+			$view = new View();
+			$unknownDir = $this->inputPath;
+			$this->inputPath = $this->sourceUser . "/files/" . $this->inputPath;
+			if (!$view->is_dir($this->inputPath)) {
+				throw new NotFoundException("$unknownDir not found");
+			}
+		}
+
+		// analyse source folder
+		$this->analyse();
+
+		if (!$this->filesExist and !$this->foldersExist) {
+			throw new NotFoundException("No files/folders found for transfer");
+		}
+
+		// collect all the shares
+		$this->collectUsersShares();
+
+		// transfer the files
+		$this->doTransfer();
+
+		// restore the shares
+		$status = $this->restoreShares();
+
+		if ($status !== 0) {
+			throw new \Exception('Failed to complete transfer');
+		}
+
+		return true;
+	}
+
+	private function walkFiles(View $view, $path, \Closure $callBack) {
+		foreach ($view->getDirectoryContent($path) as $fileInfo) {
+			if (!$callBack($fileInfo)) {
+				return;
+			}
+			if ($fileInfo->getType() === FileInfo::TYPE_FOLDER) {
+				$this->walkFiles($view, $fileInfo->getPath(), $callBack);
+			}
+		}
+	}
+
+	/**
+	 * @throws \Exception
+	 */
+	protected function analyse() {
+		$view = new View();
+		$walkPath = "$this->sourceUser/files";
+		if (\strlen($this->inputPath) > 0) {
+			if ($this->inputPath !== "$this->sourceUser/files") {
+				$walkPath = $this->inputPath;
+				$this->foldersExist = true;
+			}
+		}
+
+		$this->walkFiles($view, $walkPath,
+			function (FileInfo $fileInfo) {
+				if ($fileInfo->getType() === FileInfo::TYPE_FOLDER) {
+					// only analyze into folders from main storage,
+					// sub-storages have an empty internal path
+					if ($fileInfo->getInternalPath() === '' && $fileInfo->getPath() !== '') {
+						return false;
+					}
+
+					$this->foldersExist = true;
+					return true;
+				}
+				$this->filesExist = true;
+				if ($fileInfo->isEncrypted()) {
+					if ($this->config->getAppValue('encryption', 'useMasterKey', 0) !== 0) {
+						/**
+						 * We are not going to add this to encryptedFiles array.
+						 * Because its encrypted with masterKey and hence it doesn't
+						 * require user's specific password.
+						 */
+						return true;
+					}
+					$this->encryptedFiles[] = $fileInfo;
+				}
+				return true;
+			});
+
+		// no file is allowed to be encrypted
+		if (!empty($this->encryptedFiles)) {
+			throw new \Exception('Encrypted files found - decrypt them first');
+		}
+	}
+
+	/**
+	 */
+	private function collectUsersShares() {
+		foreach ([\OCP\Share::SHARE_TYPE_GROUP, \OCP\Share::SHARE_TYPE_USER, \OCP\Share::SHARE_TYPE_LINK, \OCP\Share::SHARE_TYPE_REMOTE] as $shareType) {
+			$offset = 0;
+			while (true) {
+				$sharePage = $this->shareManager->getSharesBy($this->sourceUser, $shareType, null, true, 50, $offset);
+				if (empty($sharePage)) {
+					break;
+				}
+
+				$this->shares = \array_merge($this->shares, $sharePage);
+				$offset += 50;
+			}
+		}
+
+	}
+
+	/**
+	 */
+	protected function doTransfer() {
+		$view = new View();
+		$sourcePath = (\strlen($this->inputPath) > 0) ? $this->inputPath : "$this->sourceUser/files";
+		// This change will help user to transfer the folder specified using --path option.
+		// Else only the content inside folder is transferred which is not correct.
+		if (\strlen($this->inputPath) > 0) {
+			if ($this->inputPath !== \ltrim("$this->sourceUser/files", '/')) {
+				$view->mkdir($this->finalTarget);
+				$this->finalTarget = $this->finalTarget . '/' . \basename($sourcePath);
+			}
+		}
+
+		$view->rename($sourcePath, $this->finalTarget);
+
+		if (!\is_dir("$this->sourceUser/files")) {
+			// because the files folder is moved away we need to recreate it
+			$view->mkdir("$this->sourceUser/files");
+		}
+	}
+
+	/**
+	 */
+	private function restoreShares() {
+		$status = 0;
+
+		$childShares = [];
+		foreach ($this->shares as $share) {
+			try {
+				/**
+				 * Do not process children which are already processed.
+				 * This piece of code populates the childShare array
+				 * with the child shares which will be processed. And
+				 * hence will avoid further processing of same share
+				 * again.
+				 */
+				if ($share->getSharedWith() === $this->destinationUser) {
+					$provider = $this->shareProviderFactory->getProviderForType($share->getShareType());
+					foreach ($provider->getChildren($share) as $child) {
+						$childShares[] = $child->getId();
+					}
+				} else {
+					/**
+					 * Before doing handover to transferShare, check if the share
+					 * id is present in the childShares. If so then just ignore
+					 * this share and continue. If not ignored, the child shares
+					 * would be processed again, if their parent share was shared
+					 * with destination user. And hence we can safely avoid the
+					 * duplicate processing of shares here.
+					 */
+					if (\in_array($share->getId(), $childShares, true)) {
+						continue;
+					}
+				}
+				$this->shareManager->transferShare($share, $this->sourceUser, $this->destinationUser, $this->finalTarget);
+			} catch (\OCP\Files\NotFoundException $e) {
+				$this->logger->error('Share with id ' . $share->getId() . ' points at deleted file, skipping');
+			} catch (\Exception $e) {
+				$this->logger->error('Could not restore share with id ' . $share->getId() . ':' . $e->getTraceAsString() . '</error>');
+				$status = 1;
+			}
+		}
+		return $status;
+	}
+
+}

--- a/apps/files/lib/Service/TransferOwnership/TransferRequest.php
+++ b/apps/files/lib/Service/TransferOwnership/TransferRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace OCA\Files\Service\TransferOwnership;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * Class TransferRequest
+ *
+ * @method integer getId()
+ * @method string getSourceUserId()
+ * @method string getDestinationUserId()
+ * @method integer getFileId()
+ * @method integer getAcceptedTime()
+ * @method integer getRejectedTime()
+ * @method integer getRequestedTime()
+ * @method integer getActionedTime()
+ * @method setSourceUserId(string)
+ * @method setDestinationUserId(string)
+ * @method setFileId(integer)
+ * @method setAcceptedTime(integer)
+ * @method setRejectedTime(integer)
+ * @method setRequestedTime(integer)
+ * @method setActionedTime(integer)
+ *
+ * @package OCA\Files\Service\TransferOwnership
+ */
+class TransferRequest extends Entity {
+
+	protected $sourceUserId;
+	protected $destinationUserId;
+	protected $fileId;
+	protected $requestedTime;
+	protected $acceptedTime;
+	protected $rejectedTime;
+	protected $actionedTime;
+
+}

--- a/apps/files/lib/Service/TransferOwnership/TransferRequest.php
+++ b/apps/files/lib/Service/TransferOwnership/TransferRequest.php
@@ -1,4 +1,23 @@
 <?php
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 namespace OCA\Files\Service\TransferOwnership;
 

--- a/apps/files/lib/Service/TransferOwnership/TransferRequestManager.php
+++ b/apps/files/lib/Service/TransferOwnership/TransferRequestManager.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace OCA\Files\Service\TransferOwnership;
+
+use OC\Command\CommandJob;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\Files\Storage\IPersistentLockingStorage;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use OCP\Lock\Persistent\ILock;
+use OCP\Notification\IManager;
+use OCP\Notification\INotification;
+use OCP\Notification\INotifier;
+use OCP\Util;
+
+class TransferRequestManager implements INotifier {
+
+	/** @var IRootFolder */
+	protected $rootFolder;
+	/** @var IManager */
+	protected $notificationManager;
+	/** @var IUserManager  */
+	protected $userManager;
+	/** @var ITimeFactory */
+	protected $timeFactory;
+	/** @var TransferRequestMapper  */
+	protected $requestMapper;
+	/** @var IURLGenerator  */
+	protected $urlGenerator;
+	/** @var IFactory */
+	protected $factory;
+	/** @var IJobList */
+	protected $jobList;
+
+	public function __construct(
+		IRootFolder $rootFolder,
+		IManager $notificationManager,
+		IUserManager $userManager,
+		ITimeFactory $timeFactory,
+		TransferRequestMapper $requestMapper,
+		IURLGenerator $urlGenerator,
+		IFactory $factory,
+		IJobList $jobList) {
+		$this->rootFolder = $rootFolder;
+		$this->notificationManager = $notificationManager;
+		$this->userManager = $userManager;
+		$this->timeFactory = $timeFactory;
+		$this->requestMapper = $requestMapper;
+		$this->urlGenerator = $urlGenerator;
+		$this->factory = $factory;
+		$this->jobList = $jobList;
+	}
+
+	/**
+	 * @param IUser $sourceUser
+	 * @param IUser $destinationUser
+	 * @param $fileId
+	 * @throws NotFoundException
+	 * @throws \Exception
+	 */
+	public function newTransferRequest(IUser $sourceUser, IUser $destinationUser, $fileId) {
+		// Cannot give to self
+		if ($sourceUser->getUID() === $destinationUser->getUID()) {
+			throw new \Exception('Cannot transfer to self');
+		}
+		// Check folder exists
+		$sourceFolder = $this->rootFolder->getById($fileId)[0];
+		// Check we are a folder
+		if (!$sourceFolder instanceof Folder) {
+			throw new \Exception('Must be a folder');
+		}
+		// Check source user owns the file
+		if ($sourceFolder->getOwner()->getUID() !== $sourceUser->getUID()) {
+			throw new NotPermittedException('Cannot move a file you dont own');
+		}
+		// Check the folder is on persistent lockable storage otherwise we can't do this in the background
+		if (!$sourceFolder->getStorage() instanceof IPersistentLockingStorage) {
+			throw new \Exception('Source folder storage not lockable');
+		}
+		// Check therer is no request with the same signature
+		if (count($this->requestMapper->findRequestWithSameSignature($sourceUser->getUID(), $destinationUser->getUID(), $fileId)) > 0) {
+			// There is
+			throw new \Exception('There is already a request to transer this file');
+		}
+		// Check we are not trying to request a transfer for a folder that is inside a current request
+		$folder = $sourceFolder;
+		$fileids = [$folder->getId()];
+		while($folder->getPath() !== '/') {
+			$folder = $folder->getParent();
+			$fileids[] = $folder->getId();
+		}
+		if (count($this->requestMapper->findOpenRequestForGivenFiles($fileids)) > 0) {
+			throw new \Exception('This folder is already pending an existing transfer');
+		}
+
+		// Create the transfer request object
+		$request = new TransferRequest();
+		$request->setRequestedTime($this->timeFactory->getTime());
+		$request->setSourceUserId($sourceUser->getUID());
+		$request->setDestinationUserId($destinationUser->getUID());
+		$request->setFileId($fileId);
+		$request = $this->requestMapper->insert($request);
+
+		/** @var IPersistentLockingStorage $storage */
+		$storage = $sourceFolder->getStorage();
+		try {
+			$storage->lockNodePersistent($sourceFolder->getInternalPath(), [
+				'depth' => ILock::LOCK_DEPTH_INFINITE,
+				'token' => $this->getLockTokenFromRequest($request),
+				'timeout' => 60*60*2 // 2 hours to allow a cron run
+			]);
+		} catch (\Exception $e) {
+			// Cleanup transfer request and fail
+			$this->requestMapper->delete($request);
+			throw $e;
+		}
+
+		$this->sendRequestNotification($request);
+	}
+
+	public function acceptRequest(TransferRequest $request) {
+		if ($request->getAcceptedTime() !== null || $request->getActionedTime() !== null || $request->getRejectedTime() !== null) {
+			throw new \Exception('Already actioned, accepted or rejected');
+		}
+		// Create a background job, update accepted time
+		$request->setAcceptedTime($this->timeFactory->getTime());
+		$this->requestMapper->update($request);
+		$sourcePath = $this->rootFolder->getUserFolder(
+			$request->getSourceUserId())->getById($request->getFileId())[0]->getInternalPath();
+		$this->jobList->add(CommandJob::class, [
+			'sourcePath' => $sourcePath,
+			'sourceUser' => $request->getSourceUserId(),
+			'destinationUser' => $request->getDestinationUserId()
+		]);
+		$notification = $this->notificationManager->createNotification();
+		$notification->setApp('files')
+			->setUser($request->getDestinationUserId())
+			->setObject('transfer_request', $request->getId());
+		$this->notificationManager->markProcessed($notification);
+	}
+
+	public function rejectRequest(TransferRequest $request) {
+		// Cleanup the lock, save reject timestamp
+		if ($request->getAcceptedTime() !== null || $request->getActionedTime() !== null || $request->getRejectedTime() !== null) {
+			throw new \Exception('Already actioned, accepted or rejected');
+		}
+		// Create a background job, update accepted time
+		$request->setRejectedTime($this->timeFactory->getTime());
+		$this->requestMapper->update($request);
+		$notification = $this->notificationManager->createNotification();
+		$notification->setApp('files')
+			->setUser($request->getDestinationUserId())
+			->setObject('transfer_request', $request->getId());
+		$this->notificationManager->markProcessed($notification);
+		$file = $this->rootFolder->getById($request->getFileId())[0];
+		/** @var IPersistentLockingStorage $storage */
+		$storage = $file->getStorage();
+		$storage->unlockNodePersistent($file->getInternalPath(), ['token' => $this->getLockTokenFromRequest($request)]);
+	}
+
+	public function deleteRequest(TransferRequest $request) {
+		// Cleanup the lock and the notification
+		$this->requestMapper->delete($request);
+		$notification = $this->notificationManager->createNotification();
+		$notification->setApp('files')
+			->setUser($request->getDestinationUserId())
+			->setObject('transfer_request', $request->getId());
+		$this->notificationManager->markProcessed($notification);
+		$file = $this->rootFolder->getById($request->getFileId())[0];
+		/** @var IPersistentLockingStorage $storage */
+		$storage = $file->getStorage();
+		$storage->unlockNodePersistent($file->getInternalPath(), ['token' => $this->getLockTokenFromRequest($request)]);
+	}
+
+
+	/**
+	 * @param TransferRequest $request the request object
+	 */
+	protected function sendRequestNotification(TransferRequest $request) {
+		$time = new \DateTime();
+		$time->setTimestamp($this->timeFactory->getTime());
+		$notification = $this->notificationManager->createNotification();
+		$notification->setApp('files')
+			->setUser($request->getDestinationUserId())
+			->setDateTime($time)
+			->setObject('transfer_request', $request->getId());
+
+		$notification->setIcon(
+			$this->urlGenerator->imagePath('core', 'actions/give.svg')
+		);
+		$notification->setLink('test.com');
+
+		$sourceUser = $this->userManager->get($request->getSourceUserId());
+		$folder = $this->rootFolder->getById($request->getFileId())[0];
+		$notification->setSubject("new_transfer_request");
+		$notification->setMessage("new_transfer_request", [$sourceUser->getDisplayName(), $folder->getName(), Util::humanFileSize($folder->getSize())]);
+
+		$endpoint = $this->urlGenerator->linkToRouteAbsolute(
+			'files.Transfer.accept',
+			['requestId' => $request->getId()]
+		);
+		$declineAction = $notification->createAction();
+		$declineAction->setLabel('reject');
+		$declineAction->setLink($endpoint, 'DELETE');
+		$notification->addAction($declineAction);
+
+		$acceptAction = $notification->createAction();
+		$acceptAction->setLabel('accept');
+		$acceptAction->setLink($endpoint, 'POST');
+		$acceptAction->setPrimary(true);
+		$notification->addAction($acceptAction);
+
+		$this->notificationManager->notify($notification);
+	}
+
+	public function prepare(INotification $notification, $languageCode) {
+		if ($notification->getApp() !== 'files') {
+			throw new \InvalidArgumentException();
+		}
+
+		// Read the language from the notification
+		$l = $this->factory->get('files', $languageCode);
+
+		switch ($notification->getObjectType()) {
+			case 'transfer_request':
+				$requestId = $notification->getObjectId();
+				try {
+					$this->requestMapper->findById($requestId);
+				} catch (DoesNotExistException $ex) {
+					$this->notificationManager->markProcessed($notification);
+					throw new \InvalidArgumentException();
+				}
+				return $this->formatNotification($notification, $l);
+
+			default:
+				throw new \InvalidArgumentException();
+		}
+	}
+
+	protected function formatNotification(INotification $notification, IL10N $l) {
+		$notification->setParsedSubject((string) $l->t('A user would like to transfer a folder to you'));
+
+		$notification->setParsedMessage(
+			(string) $l->t(
+				'"%1$s" requested to transfer "%2$s" to you (%3$s)"',
+				$notification->getMessageParameters())
+		);
+
+		foreach ($notification->getActions() as $action) {
+			switch ($action->getLabel()) {
+				case 'accept':
+					$action->setParsedLabel(
+						(string) $l->t('Accept')
+					);
+					break;
+				case 'reject':
+					$action->setParsedLabel(
+						(string) $l->t('Decline')
+					);
+					break;
+			}
+			$notification->addParsedAction($action);
+		}
+
+		return $notification;
+	}
+
+	public function cleanup() {
+		// Delete request that are older than 24 hours
+		$oldRequests = $this->requestMapper->findOpenRequestsOlderThan(1);
+		/** @var TransferRequest $request */
+		foreach ($oldRequests as $request) {
+			// Remove the lock
+			try {
+				$file = $this->rootFolder->getById($request->getFileId())[0];
+				/** @var IPersistentLockingStorage $storage */
+				$storage = $file->getStorage();
+				$storage->unlockNodePersistent($file->getInternalPath(), $this->getLockTokenFromRequest($request));
+			} catch (\Exception $e) {
+				\OC::$server->getLogger()->logException($e, ['app' => 'files']);
+			}
+			// Now remove the request
+			$this->requestMapper->delete($request);
+			// And lets remove the notification to save confusion
+			$notification = $this->notificationManager->createNotification();
+			$notification->setApp('files')
+				->setUser($request->getDestinationUserId())
+				->setObject('transfer_request', $request->getId());
+			$this->notificationManager->markProcessed($notification);
+		}
+	}
+
+	protected function getLockTokenFromRequest(TransferRequest $request) {
+		return 'transfer-request-'.$request->getId();
+	}
+
+	public function getRequestById($requestId) {
+		return $this->requestMapper->findById($requestId);
+	}
+
+
+}

--- a/apps/files/lib/Service/TransferOwnership/TransferRequestManager.php
+++ b/apps/files/lib/Service/TransferOwnership/TransferRequestManager.php
@@ -1,13 +1,30 @@
 <?php
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 namespace OCA\Files\Service\TransferOwnership;
 
-use OC\Command\CommandJob;
 use OCA\Files\BackgroundJob\TransferOwnership;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
-use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;

--- a/apps/files/lib/Service/TransferOwnership/TransferRequestManager.php
+++ b/apps/files/lib/Service/TransferOwnership/TransferRequestManager.php
@@ -72,13 +72,9 @@ class TransferRequestManager implements INotifier {
 		if ($sourceUser->getUID() === $destinationUser->getUID()) {
 			throw new \Exception('Cannot transfer to self');
 		}
-		// Check folder exists
+		// Check node exists
 		$sourceFolder = $this->rootFolder->getById($fileId)[0];
-		// Check we are a folder
-		if (!$sourceFolder instanceof Folder) {
-			throw new \Exception('Must be a folder');
-		}
-		// Check source user owns the file
+		// Check source user owns the node
 		if ($sourceFolder->getOwner()->getUID() !== $sourceUser->getUID()) {
 			throw new NotPermittedException('Cannot move a file you dont own');
 		}
@@ -89,7 +85,7 @@ class TransferRequestManager implements INotifier {
 		// Check therer is no request with the same signature
 		if (count($this->requestMapper->findRequestWithSameSignature($sourceUser->getUID(), $destinationUser->getUID(), $fileId)) > 0) {
 			// There is
-			throw new \Exception('There is already a request to transer this file');
+			throw new \Exception('There is already a request to transfer this file/folder');
 		}
 		// Check we are not trying to request a transfer for a folder that is inside a current request
 		$folder = $sourceFolder;
@@ -99,7 +95,7 @@ class TransferRequestManager implements INotifier {
 			$fileids[] = $folder->getId();
 		}
 		if (count($this->requestMapper->findOpenRequestForGivenFiles($fileids)) > 0) {
-			throw new \Exception('This folder is already pending an existing transfer');
+			throw new \Exception('This file/folder is already pending an existing transfer');
 		}
 
 		// Create the transfer request object

--- a/apps/files/lib/Service/TransferOwnership/TransferRequestMapper.php
+++ b/apps/files/lib/Service/TransferOwnership/TransferRequestMapper.php
@@ -1,4 +1,23 @@
 <?php
+/**
+ * @author Tom Needham <tom@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
 
 namespace OCA\Files\Service\TransferOwnership;
 

--- a/apps/files/lib/Service/TransferOwnership/TransferRequestMapper.php
+++ b/apps/files/lib/Service/TransferOwnership/TransferRequestMapper.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace OCA\Files\Service\TransferOwnership;
+
+use OCP\AppFramework\Db\Mapper;
+use OCP\IDBConnection;
+
+class TransferRequestMapper extends Mapper {
+
+	const TABLENAME = 'transfer_requests';
+
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, self::TABLENAME, TransferRequest::class);
+	}
+
+	/**
+	 * @param $requestId
+	 * @return \OCP\AppFramework\Db\Entity|TransferRequest
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 */
+	public function findById($requestId) {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq('id', $query->expr()->literal($requestId)));
+		return $this->findEntity($query->getSQL(), $query->getParameters());
+	}
+
+	/**
+	 * Finds a pending transfer for the same file between two users
+	 * @param $sourceUser
+	 * @param $destinationUser
+	 * @param $fileId
+	 * @return array
+	 */
+	public function findRequestWithSameSignature($sourceUser, $destinationUser, $fileId) {
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->eq('source_user_id', $query->expr()->literal($sourceUser)))
+			->andWhere($query->expr()->eq('destination_user_id', $query->expr()->literal($destinationUser)))
+			->andWhere($query->expr()->eq('file_id', $query->expr()->literal($fileId)))
+			->andWhere($query->expr()->isNull('rejected_time'))
+			->andWhere($query->expr()->isNull('accepted_time'))
+			->andWhere($query->expr()->isNull('actioned_time'));
+		return $this->findEntities($query->getSQL(), $query->getParameters());
+	}
+
+	/**
+	 * Tries to see if there is an open request for a range of file ids
+	 * This is used to check if we are trying to make a new request on a file that is already pending transfer
+	 * @param array $files
+	 * @return array
+	 */
+	public function findOpenRequestForGivenFiles($files) {
+		$query = $this->db->getQueryBuilder();
+		$files = array_map(function($fileid) use ($query) {
+			return $query->expr()->literal($fileid);
+		}, $files);
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->in('file_id', $files))
+			->andWhere($query->expr()->isNull('rejected_time'))
+			->andWhere($query->expr()->isNull('accepted_time'))
+			->andWhere($query->expr()->isNull('actioned_time'));
+		return $this->findEntities($query->getSQL(), $query->getParameters());
+	}
+
+	public function findOpenRequestsOlderThan($days) {
+		$threshold = \OC::$server->getTimeFactory()->getTime() - 60*60*$days;
+		$query = $this->db->getQueryBuilder();
+		$query->select('*')
+			->from($this->getTableName())
+			->where($query->expr()->isNull('rejected_time'))
+			->andWhere($query->expr()->isNull('accepted_time'))
+			->andWhere($query->expr()->isNull('actioned_time'))
+			->andWhere($query->expr()->lt('requested_time', $query->expr()->literal($threshold)));
+		return $this->findEntities($query->getSQL(), $query->getParameters());
+	}
+
+}

--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -169,6 +169,10 @@ img.icon-loading-small-dark, object.icon-loading-small-dark, video.icon-loading-
 	background-image: url('../img/actions/download.svg');
 }
 
+.icon-give {
+	background-image: url('../img/actions/give.svg');
+}
+
 .icon-download-white {
 	background-image: url('../img/actions/download-white.svg');
 }

--- a/core/img/actions/give.svg
+++ b/core/img/actions/give.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
+	<g transform="translate(0 -1036.4)">
+		<path d="m6 1037.4h4v7h5l-7 7-7-7h5z"/>
+	</g>
+</svg>

--- a/core/js/oc-dialogs.js
+++ b/core/js/oc-dialogs.js
@@ -98,6 +98,7 @@ var OCdialogs = {
 			});
 			var input = $('<input/>');
 			input.attr('type', password ? 'password' : 'text').attr('id', dialogName + '-input');
+			input.attr('autofocus', true);
 			var label = $('<label/>').attr('for', dialogName + '-input').text(name + ': ');
 			$dlg.append(label);
 			$dlg.append(input);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
I felt like implementing something for fun - and learning some more. 

So, I heard this requested a few times and decided to crack on and see if I can implement it.

## Motivation and Context
Often when working with groups, or with projects, there are a series of project folders which are shared with the group members. However, if the team/project leader leaves the company or project, these shares and folders need to be handed over to a new user. Typically this can be done by just providing the data using a share, or more ancient ways like emailing the files over to the new user. Or even by the admin copying the files in the filesystem.

This FR allows users to initiate transfers of folders, including their shares, to new users. It is done with the same request/reject flow as new pending shares. 

This allows the project to continue working, with all members accessing the same shares, including public shares, but the files change ownership to the new user. 

This also brings a lot of power to existing instances who want to reconfigure their share setups, for example maybe to move away, or towards utilising data users.

In writing this PR I learnt how to use the notification framework, with actions as well. I also touched the persistent locking for the first time. And got to use file actions.

## How Has This Been Tested?
 - Manual prodding around the UI. It doesn't work yet anyway....

## Screenshots (if appropriate):
Step 1, user click on a folder:
<img width="350" alt="screen shot 2018-09-02 at 00 20 48" src="https://user-images.githubusercontent.com/660805/44950708-ec49bf80-ae46-11e8-8b2f-d9e9b1353e13.png">

Step 2: Selects the user to receive the files (needs better ui, more explanations here)
<img width="934" alt="screen shot 2018-09-02 at 00 21 13" src="https://user-images.githubusercontent.com/660805/44950714-f9ff4500-ae46-11e8-9de3-5d67ab7c31ba.png">

Step 3:
Request is created, and now it must be accepted
<img width="418" alt="screen shot 2018-09-02 at 00 21 43" src="https://user-images.githubusercontent.com/660805/44950715-008dbc80-ae47-11e8-8807-4c7b6431597d.png">

Step 4:
Recipient receives a notifiaction, with accept/reject options.
<img width="458" alt="screen shot 2018-09-02 at 00 21 50" src="https://user-images.githubusercontent.com/660805/44950718-0c797e80-ae47-11e8-9284-399fb7103662.png">

After the request is created, a persistent lock is put on the folder for 1 day, so that the contents cannot change. After 1 day the lock and requests are cleaned up, as this is obstructive to normal workflow and it should be resolved quickly after the request is created.

This should probably come with a UI that allows users to see the requests they have created. Also in the UI it would be nice to show on the folder that this is locked, and pending a transfer (to help them understand why it is locked. However, I would expect this function to be used with the users having prior knowledge of it happening.

Once the request is accepted, it is queued as a background job and will wait for the next cron run. On completion (or failure) a notification is given to both the sending and receiving user letting them know it has completed - including (for the receiving user) a private link directly to the file so they know where it ended up. 

Destiantion user:
<img width="454" alt="screen shot 2018-09-02 at 22 31 16" src="https://user-images.githubusercontent.com/660805/44960916-17dcb080-af00-11e8-91f6-d6d89cc2728c.png">

Source user:
<img width="434" alt="screen shot 2018-09-02 at 22 33 18" src="https://user-images.githubusercontent.com/660805/44960929-35aa1580-af00-11e8-8689-df23925bdbc5.png">


Open questions:
 - [ ] How / when to check that the recipient actually has enough space to receive the folder
 - [ ] How to indicate to the user what the share structure looks like, would be nice to visualise what they are accepting??

TODO tasks:
 - [x] Schedule the background job on acceptance
 - [x] Move transfer logic to service and wire up from command and scheduled job
 - [ ] Integration tests
 - [ ] Unit tests
 - [ ] Activity integration?
 - [ ] UI for viewing pending transfers? Not sure if this is necessary with the 1 day limitation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
