### PR TITLE
User logs in steps

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -154,6 +154,9 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 * @When the user logs in with username :username and invalid password :password using the webUI
 	 * @When the user logs in with invalid username :username and password :password using the webUI
 	 * @When the user logs in with invalid username :username and invalid password :password using the webUI
+	 * @Given the user has logged in with username :username and invalid password :password using the webUI
+	 * @Given the user has logged in with invalid username :username and password :password using the webUI
+	 * @Given the user has logged in with invalid username :username and invalid password :password using the webUI
 	 *
 	 * @param string $username
 	 * @param string $password

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -152,8 +152,8 @@ class WebUILoginContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user logs in with username :username and invalid password :password using the webUI
-	 * @When the user logs with invalid username :username and password :password using the webUI
-	 * @When the user logs with invalid username :username and invalid password :password using the webUI
+	 * @When the user logs in with invalid username :username and password :password using the webUI
+	 * @When the user logs in with invalid username :username and invalid password :password using the webUI
 	 *
 	 * @param string $username
 	 * @param string $password


### PR DESCRIPTION
## Description
Add some more ways to say "the user logs in".
The existing step text lines that I corrected are not used anywhere yet, so no backward-compatibility problem.

## Motivation and Context
It will read more nicely in some password policy acceptance test steps.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
