### PR TITLE
run api acceptance tests with SSL

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,7 +31,9 @@ pipeline:
       - php occ config:system:set trusted_domains 2 --value=federated
       - php occ log:manage --level 0
       - php occ config:list
-      - echo "export TEST_SERVER_FED_URL=http://federated" > /drone/saved-settings.sh
+      - echo "export TEST_SERVER_FED_URL=https://federated" > /drone/saved-settings.sh
+      - php occ security:certificates:import /drone/server.crt
+      - php occ security:certificates
     when:
       matrix:
         USE_FEDERATED_SERVER: true
@@ -137,6 +139,8 @@ pipeline:
       - php occ config:system:set trusted_domains 2 --value=federated
       - php occ log:manage --level 0
       - php occ config:list
+      - php occ security:certificates:import /drone/federated.crt
+      - php occ security:certificates
     when:
       matrix:
         INSTALL_SERVER: true
@@ -239,8 +243,8 @@ pipeline:
       - echo 'Sharing a folder ..'
       - OC_PASS=123456 php occ user:add --password-from-env user1
       - chown www-data /drone/src -R
-      - curl -s -u user1:123456 -X MKCOL 'http://server/remote.php/webdav/new_folder'
-      - curl -s -u user1:123456 "http://server/ocs/v2.php/apps/files_sharing/api/v1/shares" --data 'path=/new_folder&shareType=0&permissions=15&name=new_folder&shareWith=admin'
+      - curl -k -s -u user1:123456 -X MKCOL 'https://server/remote.php/webdav/new_folder'
+      - curl -k -s -u user1:123456 "https://server/ocs/v2.php/apps/files_sharing/api/v1/shares" --data 'path=/new_folder&shareType=0&permissions=15&name=new_folder&shareWith=admin'
     when:
       matrix:
         TEST_SUITE: litmus
@@ -249,7 +253,7 @@ pipeline:
     image: owncloud/litmus
     pull: true
     environment:
-      - LITMUS_URL=http://server/remote.php/webdav
+      - LITMUS_URL=https://server/remote.php/webdav
       - LITMUS_USERNAME=admin
       - LITMUS_PASSWORD=admin
     when:
@@ -260,7 +264,7 @@ pipeline:
     image: owncloud/litmus
     pull: true
     environment:
-    - LITMUS_URL=http://server/remote.php/dav/files/admin
+    - LITMUS_URL=https://server/remote.php/dav/files/admin
     - LITMUS_USERNAME=admin
     - LITMUS_PASSWORD=admin
     when:
@@ -271,7 +275,7 @@ pipeline:
     image: owncloud/litmus
     pull: true
     environment:
-    - LITMUS_URL=http://server/remote.php/dav/files/admin/local_storage/
+    - LITMUS_URL=https://server/remote.php/dav/files/admin/local_storage/
     - LITMUS_USERNAME=admin
     - LITMUS_PASSWORD=admin
     when:
@@ -282,7 +286,7 @@ pipeline:
     image: owncloud/litmus
     pull: true
     environment:
-    - LITMUS_URL=http://server/remote.php/webdav/local_storage/
+    - LITMUS_URL=https://server/remote.php/webdav/local_storage/
     - LITMUS_USERNAME=admin
     - LITMUS_PASSWORD=admin
     when:
@@ -293,7 +297,7 @@ pipeline:
     image: owncloud/litmus
     pull: true
     environment:
-    - LITMUS_URL=http://server/remote.php/dav/files/admin/new_folder/
+    - LITMUS_URL=https://server/remote.php/dav/files/admin/new_folder/
     - LITMUS_USERNAME=admin
     - LITMUS_PASSWORD=admin
     when:
@@ -304,7 +308,7 @@ pipeline:
     image: owncloud/litmus
     pull: true
     environment:
-    - LITMUS_URL=http://server/remote.php/webdav/new_folder/
+    - LITMUS_URL=https://server/remote.php/webdav/new_folder/
     - LITMUS_USERNAME=admin
     - LITMUS_PASSWORD=admin
     when:
@@ -337,7 +341,7 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
-      - TEST_SERVER_URL=http://server
+      - TEST_SERVER_URL=https://server
     commands:
       - touch /drone/saved-settings.sh
       - . /drone/saved-settings.sh
@@ -353,7 +357,7 @@ pipeline:
       - BROWSER=chrome
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
-      - TEST_SERVER_URL=http://server
+      - TEST_SERVER_URL=https://server
       - PLATFORM=Linux
       - MAILHOG_HOST=email
     commands:
@@ -458,6 +462,10 @@ services:
     pull: true
     environment:
       - APACHE_WEBROOT=/drone/src/
+      - APACHE_CONFIG_TEMPLATE=ssl
+      - APACHE_SSL_CERT_CN=server
+      - APACHE_SSL_CERT=/drone/server.crt
+      - APACHE_SSL_KEY=/drone/server.key
     command: [ "/usr/local/bin/apachectl", "-e", "debug" , "-D", "FOREGROUND" ]
     when:
       matrix:
@@ -468,6 +476,10 @@ services:
     pull: true
     environment:
       - APACHE_WEBROOT=/drone/fed-server/
+      - APACHE_CONFIG_TEMPLATE=ssl
+      - APACHE_SSL_CERT_CN=federated
+      - APACHE_SSL_CERT=/drone/federated.crt
+      - APACHE_SSL_KEY=/drone/federated.key
     command: [ "/usr/local/bin/apachectl", "-e", "debug" , "-D", "FOREGROUND" ]
     when:
       matrix:

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -186,8 +186,9 @@ class WebDavHelper {
 				'password' => $password,
 				'authType' => SClient::AUTH_BASIC
 		];
-		
-		return new SClient($settings);
+		$client = new SClient($settings);
+		$client->addCurlSetting(CURLOPT_SSL_VERIFYPEER, false);
+		return $client;
 	}
 
 	/**

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -151,7 +151,7 @@ export LANG=C
 # @return occ return code given in the xml data
 function remote_occ() {
 	COMMAND=`echo $3 | xargs`
-	CURL_OCC_RESULT=`curl -s -u $1 $2 -d "command=${COMMAND}"`
+	CURL_OCC_RESULT=`curl -k -s -u $1 $2 -d "command=${COMMAND}"`
 	# xargs is (miss)used to trim the output
 	RETURN=`echo ${CURL_OCC_RESULT} | xmllint --xpath "string(ocs/data/code)" - | xargs`
 	# We could not find a proper return of the testing app, so something went wrong


### PR DESCRIPTION
## Description
make acceptance tests run on a server that is using HTTPS only

## Related Issue
- Fixes https://github.com/owncloud/QA/issues/581

## Motivation and Context
ownCloud should be installed using SSL, so we want to run the tests also with SSL

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
