### PR TITLE
Trigger missing migrations in files_sharing

### DIFF
--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -10,7 +10,7 @@ Turning the feature off removes shared files and folders on the server for all s
 	<licence>AGPL</licence>
 	<author>Michael Gapczynski, Bjoern Schiessle</author>
 	<default_enable/>
-	<version>0.10.1</version>
+	<version>0.11.0</version>
 	<types>
 		<filesystem/>
 	</types>


### PR DESCRIPTION
## Description
Some migrations were added but the version number of the app was not
increased, so these migrations would not run when upgrading from any
version that did not change that number.

Side effect: on systems where the migration did not run before due to this bug, the new added index will speed it up significantly!

## Related Issue
- Partial fix for https://github.com/owncloud/enterprise/issues/2820

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- git checkout v10.0.4, setup OC, git checkout master, ugprade, check `occ migration:status files_sharing`:
    - before fix: some migrations still pending
    - on this branch instead of master: all migrations of the app have run

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
