### PR TITLE
use sabreclient factory in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1926,13 +1926,7 @@ trait WebDav {
 	public function changeFavStateOfAnElement(
 		$user, $path, $favOrUnfav
 	) {
-		$settings = [
-			'baseUri' => $this->getBaseUrl() . '/',
-			'userName' => $user,
-			'password' => $this->getPasswordForUser($user),
-			'authType' => SClient::AUTH_BASIC
-		];
-		$client = new SClient($settings);
+		$client = $this->getSabreClient($user);
 		$properties = [
 			'{http://owncloud.org/ns}favorite' => $favOrUnfav
 		];


### PR DESCRIPTION
## Description
found a place where the sabre client is not used through the factory

## Related Issue
working towards owncloud/QA#581

## Motivation and Context
centralized sabre client settings

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
