### PR TITLE
acceptance tests - stop uploading when receiving an error

### DIFF
--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -88,7 +88,7 @@ class UploadHelper {
 		if ($chunkingVersion === 1) {
 			$headers['OC-Chunked'] = '1';
 		} elseif ($chunkingVersion === 2) {
-			WebDavHelper::makeDavRequest(
+			$result = WebDavHelper::makeDavRequest(
 				$baseUrl,
 				$user,
 				$password,
@@ -98,6 +98,9 @@ class UploadHelper {
 				$davPathVersionToUse,
 				"uploads"
 			);
+			if ($result->getStatusCode() >= 400) {
+				return $result;
+			}
 		}
 
 		//upload chunks
@@ -123,6 +126,9 @@ class UploadHelper {
 				$davPathVersionToUse,
 				$davRequestType
 			);
+			if ($result->getStatusCode() >= 400) {
+				return $result;
+			}
 		}
 		//finish upload for new chunking
 		if ($chunkingVersion === 2) {
@@ -141,6 +147,9 @@ class UploadHelper {
 				$davPathVersionToUse,
 				"uploads"
 			);
+			if ($result->getStatusCode() >= 400) {
+				return $result;
+			}
 		}
 		return $result;
 	}


### PR DESCRIPTION
## Description
stop uploading with there is an error
when uploading chunks and receiving an error on one chunk, the upload helper would still doing the other steps of the upload

## Related Issue
- Fixes https://github.com/owncloud/firewall/issues/516

## Motivation and Context
Before  https://github.com/owncloud/core/pull/32505 there was an exception thrown on errors. We don't do that any-more, because the higher layers might just expect the error code. But now we need to return the error code when it happens and not doing other requests afterwards.

## How Has This Been Tested?
run failing tests of firewall

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
