### PR TITLE
[stable10] Trigger missing migrations in files_sharing

### DIFF
--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -10,7 +10,7 @@ Turning the feature off removes shared files and folders on the server for all s
 	<licence>AGPL</licence>
 	<author>Michael Gapczynski, Bjoern Schiessle</author>
 	<default_enable/>
-	<version>0.10.1</version>
+	<version>0.11.0</version>
 	<types>
 		<filesystem/>
 	</types>


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/32553 to stable10