### PR TITLE
[stable10] skip can_share capabilities test on 10.0.9

### DIFF
--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -39,7 +39,6 @@ Feature: capabilities
 			| core          | pollinterval                          | 60                |
 			| core          | webdav-root                           | remote.php/webdav |
 			| files_sharing | api_enabled                           | 1                 |
-			| files_sharing | can_share                             | 1                 |
 			| files_sharing | public@@@enabled                      | 1                 |
 			| files_sharing | public@@@upload                       | 1                 |
 			| files_sharing | public@@@send_mail                    | EMPTY             |
@@ -54,6 +53,14 @@ Feature: capabilities
 			| files         | bigfilechunking                       | 1                 |
 			| files         | undelete                              | 1                 |
 			| files         | versioning                            | 1                 |
+
+	#feature added in #31824 will be released in 10.0.10
+	@smokeTest @skipOnOcV10.0.9
+	Scenario: getting capabilities with admin user
+		When the user retrieves the capabilities using the capabilities API
+		Then the capabilities should contain
+			| capability    | path_to_element                       | value             |
+			| files_sharing | can_share                             | 1                 |
 
 	Scenario: Changing public upload
 		Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"


### PR DESCRIPTION
## Description
skip test on 10.0.9 for a function that was introduced in #31824
this also means the test will not run on PRs as long there version in stable10 branch is not bumped

## Related Issue
- https://github.com/owncloud-docker/server/pull/75

## Motivation and Context
running tests on 10.0.9 docker containers

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
