### PR TITLE
Expand occ user reset password email validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
         "deepdiver/zipstreamer": "^1.1",
         "zendframework/zend-inputfilter": "^2.8",
         "zendframework/zend-servicemanager": "^3.3",
-        "symfony/translation": "^3.4"
+        "symfony/translation": "^3.4",
+        "zendframework/zend-validator": "^2.10"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -64,9 +64,9 @@
         "lukasreschke/id3parser": "^0.0.3",
         "sabre/dav": "^3.2",
         "deepdiver/zipstreamer": "^1.1",
+        "symfony/translation": "^3.4",
         "zendframework/zend-inputfilter": "^2.8",
         "zendframework/zend-servicemanager": "^3.3",
-        "symfony/translation": "^3.4",
         "zendframework/zend-validator": "^2.10"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff18e9c01a4dc2372c06e5c666e39972",
+    "content-hash": "4c0cc6f770dea29f27e2624271b80ec4",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",

--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -44,6 +44,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
+use Zend\Validator\EmailAddress;
 
 class ResetPassword extends Command {
 
@@ -123,7 +124,7 @@ class ResetPassword extends Command {
 			$userId = $user->getUID();
 			list($link, $token) = $this->lostController->generateTokenAndLink($userId);
 
-			if ($emailLink && $this->hasValidEmailAddress($user)) {
+			if ($emailLink && $this->hasValidEmailAddress($user->getEMailAddress())) {
 				try {
 					$this->config->deleteUserValue($userId, 'owncloud', 'lostpassword');
 					$this->lostController->sendEmail($userId, $token, $link);
@@ -184,14 +185,12 @@ class ResetPassword extends Command {
 	}
 
 	/**
-	 * Performs a simplistic test of whether the user's email address is valid.
+	 * Determines if the user's email address is valid.
 	 *
-	 * @param $user \OCP\IUser
+	 * @param string $emailAddress
 	 * @return bool
 	 */
-	protected function hasValidEmailAddress($user) {
-		$emailAddress = $user->getEMailAddress();
-
-		return ($emailAddress !== null && $emailAddress !== '');
+	protected function hasValidEmailAddress($emailAddress) {
+		return (new EmailAddress())->isValid($emailAddress);
 	}
 }

--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -123,7 +123,7 @@ class ResetPassword extends Command {
 			$userId = $user->getUID();
 			list($link, $token) = $this->lostController->generateTokenAndLink($userId);
 
-			if ($emailLink && $user->getEMailAddress() !== null) {
+			if ($emailLink && $this->hasValidEmailAddress($user)) {
 				try {
 					$this->config->deleteUserValue($userId, 'owncloud', 'lostpassword');
 					$this->lostController->sendEmail($userId, $token, $link);
@@ -181,5 +181,17 @@ class ResetPassword extends Command {
 			$output->writeln("<error>Error while resetting password!</error>");
 			return 1;
 		}
+	}
+
+	/**
+	 * Performs a simplistic test of whether the user's email address is valid.
+	 *
+	 * @param $user \OCP\IUser
+	 * @return bool
+	 */
+	protected function hasValidEmailAddress($user) {
+		$emailAddress = $user->getEMailAddress();
+
+		return ($emailAddress !== null && $emailAddress !== '');
 	}
 }

--- a/tests/Core/Command/User/ResetPasswordTest.php
+++ b/tests/Core/Command/User/ResetPasswordTest.php
@@ -179,6 +179,25 @@ class ResetPasswordTest extends TestCase {
 		return [
 			[null],
 			[''],
+			[0],
+			['plainaddress'],
+			['#@%^%#$@#$@#.com'],
+			['@example.com'],
+			['Joe Smith <email@example.com>'],
+			['email.example.com'],
+			['email@example@example.com'],
+			['.email@example.com'],
+			['email.@example.com'],
+			['email..email@example.com'],
+			['email@example.com (Joe Smith)'],
+			['email@example'],
+			['email@-example.com'],
+			['email@example.web'],
+			['email@111.222.333.44444'],
+			['email@example..com'],
+			['Abc..123@example.com'],
+			['”(),:;<>[\]@example.com'],
+			['this\ is"really"not\allowed@example.com'],
 		];
 	}
 

--- a/tests/Core/Command/User/ResetPasswordTest.php
+++ b/tests/Core/Command/User/ResetPasswordTest.php
@@ -175,7 +175,17 @@ class ResetPasswordTest extends TestCase {
 		$this->assertEquals(0, $this->invokePrivate($this->resetPassword, 'execute', [$input, $output]));
 	}
 
-	public function testEmailLinkFailure() {
+	public function emailLinkFailureDataProvider() {
+		return [
+			[null],
+			[''],
+		];
+	}
+
+	/**
+	 * @dataProvider emailLinkFailureDataProvider
+	 */
+	public function testEmailLinkFailure($emailAddress) {
 		$input = $this->createMock(InputInterface::class);
 		$output = $this->createMock(OutputInterface::class);
 
@@ -195,7 +205,7 @@ class ResetPasswordTest extends TestCase {
 
 		$user->expects($this->once())
 			->method('getEMailAddress')
-			->willReturn(null);
+			->willReturn($emailAddress);
 		$user->method('getUID')
 			->willReturn('foo');
 


### PR DESCRIPTION
## Description

Improves the email address validation performed when running `occ user:resetpassword --email-link`.

## Related Issue

- Extends https://github.com/owncloud/core/pull/32345
- Relates to https://github.com/owncloud/core/issues/29542

## Motivation and Context

When I was documenting the changes that https://github.com/owncloud/core/pull/32345 made, I found that when running `occ user:resetpassword --email-link`, an error message is displayed only if a user's password is `null`. However, if it was an empty string, then the error would not be thrown and the code would attempt to send an email using the invalid email address. 

I created these changes to ensure that only valid email addresses are able to be used.

:information_desk_person: fwiw, I'm not totally sure that using a [Zend\Validator\EmailAddress](https://docs.zendframework.com/zend-validator/validators/email-address/) object directly is the best approach.

## How Has This Been Tested?

- Updated the covering tests and ensured that they all passed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [X] Backport (if applicable set "backport-request" label and remove when the backport was done)
