### PR TITLE
Pass environment vars to testing app

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -272,6 +272,7 @@ class SetupHelper {
 	 * @param string|null $adminPassword
 	 * @param string|null $baseUrl
 	 * @param string|null $ocPath
+	 * @param array|null $envVariables
 	 *
 	 * @return string[] associated array with "code", "stdOut", "stdErr"
 	 * @throws Exception if parameters have not been provided yet or the testing app is not enabled
@@ -281,7 +282,8 @@ class SetupHelper {
 		$adminUsername = null,
 		$adminPassword = null,
 		$baseUrl = null,
-		$ocPath = null
+		$ocPath = null,
+		$envVariables = null
 	) {
 		if (self::$adminUsername === null
 			&& $adminUsername === null
@@ -323,11 +325,18 @@ class SetupHelper {
 		if ($ocPath === null) {
 			$ocPath = self::$ocPath;
 		}
+
+		$body = [];
+		$body['command'] = \implode(' ', $args);
+
+		if ($envVariables !== null) {
+			$body['env_variables'] = $envVariables;
+		}
+
 		try {
 			$result = OcsApiHelper::sendRequest(
-				$baseUrl, $adminUsername,
-				$adminPassword, "POST", $ocPath,
-				['command' => \implode(' ', $args)]
+				$baseUrl, $adminUsername, $adminPassword,
+				"POST", $ocPath, $body
 			);
 		} catch (ServerException $e) {
 			throw new Exception(

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Phil Davis <phil@jankaritech.com>
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\TableNode;
+
+require_once 'bootstrap.php';
+
+/**
+ * Occ context for test steps that test occ commands
+ */
+class OccContext implements Context {
+
+	/**
+	 *
+	 * @var FeatureContext
+	 */
+	private $featureContext;
+
+	/**
+	 * @When /^the administrator creates (?:these users|this user) using the occ command:$/
+	 * @Given /^(?:these users have|this user has) been created using the occ command:$/
+	 * expects a table of users with the heading
+	 * "|username|password|displayname|email|"
+	 * displayname & email are optional
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theseUsersHaveBeenCreatedUsingTheOccCommand(TableNode $table) {
+		foreach ($table as $row) {
+			$username = $row['username'];
+			$cmd = "user:add $username  --password-from-env";
+
+			if (isset($row['displayname'])) {
+				$displayName = $row['displayname'];
+				$cmd = "$cmd --display-name='$displayName'";
+			} else {
+				$displayName = null;
+			}
+			if (isset($row['email'])) {
+				$email = $row['email'];
+				$cmd = "$cmd --email='$email'";
+			} else {
+				$email = null;
+			}
+
+			if (isset($row['password'])) {
+				$password = $row['password'];
+			} else {
+				$password = $this->featureContext->getPasswordForUser($row ['username']);
+			}
+
+			$this->featureContext->invokingTheCommandWithEnvVariable(
+				$cmd,
+				'OC_PASS',
+				$password
+			);
+
+			$this->featureContext->addUserToCreatedUsersList(
+				$username,
+				$password,
+				$displayName,
+				$email
+			);
+		}
+	}
+
+	/**
+	 * This will run before EVERY scenario.
+	 * It will set the properties for this object.
+	 *
+	 * @BeforeScenario
+	 *
+	 * @param BeforeScenarioScope $scope
+	 *
+	 * @return void
+	 */
+	public function before(BeforeScenarioScope $scope) {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->featureContext = $environment->getContext('FeatureContext');
+	}
+}


### PR DESCRIPTION
## Description
Pass an array of environment variables to the testing app, along with an ``occ`` command to execute.
Provide test steps for running an ``occ`` command with an environment variable.
Provide a test step for creating a user using the occ command (this is a first of future test steps for testing various ``occ`` commands).

## Related Issue
Password policy https://github.com/owncloud/password_policy/issues/58
Core #31403 

## Motivation and Context
The ``occ user:add`` command is provided with the password for the user by setting an environment variable ``OC_PASS`` before running the command. It is easy enough to do that from inside the testing app. We just need to pass the desired env variable(s) across to the testing app along with the ``occ`` command to be executed.

## How Has This Been Tested?
Local acceptance test runs with the associated testing app changes and password policy test scenarios using these new test steps.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
