### PR TITLE
Fix update cases from 9.0.9 and below

### DIFF
--- a/core/Migrations/Version20170213215145.php
+++ b/core/Migrations/Version20170213215145.php
@@ -13,12 +13,13 @@ class Version20170213215145 implements ISchemaMigration {
 		$prefix = $options['tablePrefix'];
 		if ($schema->hasTable("${prefix}jobs")) {
 			$table = $schema->getTable("${prefix}jobs");
-
-			$table->addColumn('execution_duration', 'integer', [
-				'notnull' => true,
-				'length' => 5,
-				'default' => -1,
-			]);
+			if (!$table->hasColumn('execution_duration')) {
+				$table->addColumn('execution_duration', 'integer', [
+					'notnull' => true,
+					'length' => 5,
+					'default' => -1,
+				]);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Description
Prepare oc_jobs for a market app by adding new columns.
Forward port of https://github.com/owncloud/core/pull/32573

## Related Issue
- Fixes https://github.com/owncloud/update-testing/issues/5

## Motivation and Context
Not possible to migrate from 9.0.9 and below smoothely

## How Has This Been Tested?
1. Checkout v9.0.9 (don't forget the good old git submodule update)
2. Check out templateeditor into the "apps" folder (stable9.1 branch)
3. Set it up
4. occ app:enable templateeditor (needs patching min-version)
5. Delete "apps/templateeditor"
6. Checkout stable10, make clean, make
7. Check out market app into the "apps" folder
8. Run occ upgrade 
### Expected
```
...
2018-09-04T19:31:25+00:00 Repair step: Upgrade app code from the marketplace
2018-09-04T19:31:25+00:00 Repair info: Enabling market app to assist with update
2018-09-04T19:31:25+00:00 Repair info: Using market to update existing apps
2018-09-04T19:31:25+00:00 Repair info: Attempting to update the following missing apps from market: templateeditor
2018-09-04T19:31:25+00:00 Repair info: Fetching app from market: templateeditor
...
```

### Actual
```
2018-09-04T19:11:19+00:00 Set log level to debug
2018-09-04T19:11:19+00:00 Turned on maintenance mode
2018-09-04T19:11:19+00:00 Repair step: Repair MySQL database engine
2018-09-04T19:11:19+00:00 Repair info: Not a mysql database -> nothing to do
2018-09-04T19:11:19+00:00 Repair step: Repair MySQL collation
2018-09-04T19:11:19+00:00 Repair info: Not a mysql database -> nothing to do
2018-09-04T19:11:19+00:00 Repair step: Repair SQLite autoincrement
2018-09-04T19:11:19+00:00 Repair step: Repair orphaned reshare
2018-09-04T19:11:19+00:00 Repair step: Repair duplicate entries in oc_lucene_status
2018-09-04T19:11:19+00:00 Repair info: lucene_status table does not exist -> nothing to do
2018-09-04T19:11:19+00:00 Repair step: Upgrade app code from the marketplace
2018-09-04T19:11:19+00:00 Repair info: Enabling market app to assist with update
2018-09-04T19:11:19+00:00 Doctrine\DBAL\Exception\InvalidFieldNameException: An exception occurred while executing 'INSERT INTO "oc_jobs" ("class", "argument", "last_run", "last_checked") VALUES(?, ?, ?, ?)' with params ["OCA\\Market\\CheckUpdateBackgroundJob", "null", 0, 1536088279]:

SQLSTATE[HY000]: General error: 1 table oc_jobs has no column named last_checked
2018-09-04T19:11:19+00:00 Update failed
2018-09-04T19:11:19+00:00 Maintenance mode is kept active
2018-09-04T19:11:19+00:00 Reset log level
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added https://github.com/owncloud/update-testing/pull/6

## Open tasks:
