### PR TITLE
[stable10] skip log-check test on upload on 10.0.9

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavOperations/uploadFileUsingNewChunking.feature
@@ -102,7 +102,9 @@ Feature: upload file using new chunking
       | app |
       | dav |
 
-  @smokeTest
+  #logfile problem was fixed in #32166 and will be released in 10.0.10
+  #only skipping this test because this in the only smokeTest checking the logs
+  @smokeTest @skipOnOcV10.0.9
   Scenario Outline: Upload files with difficult names using new chunking
     When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
     And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
@@ -114,6 +116,22 @@ Feature: upload file using new chunking
     And the log file should not contain any log-entries containing these attributes:
       | app |
       | dav |
+    Examples:
+      | file-name |
+      | &#?       |
+      | TIÄFÜ     |
+
+  #ToDo: delete this test after 10.0.10 is released and we stop testing 10.0.9
+  #it is identical to the one above but missing the log file check because of issue #31631
+  @smokeTest
+  Scenario Outline: Upload files with difficult names using new chunking
+    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "user0" moves new chunk file with id "chunking-42" to "/<file-name>" using the WebDAV API
+    Then as "user0" the file "/<file-name>" should exist
+    And the content of file "/<file-name>" for user "user0" should be "AAAAABBBBBCCCCC"
     Examples:
       | file-name |
       | &#?       |


### PR DESCRIPTION
## Description
skip test on 10.0.9 for a bug fix that was fixed by #32166and will be released in 10.0.10
this also means the test will not run on PRs as long there version in stable10 branch is not bumped

## Related Issue
owncloud-docker/server#75

## Motivation and Context
running tests on 10.0.9 docker containers

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
