### PR TITLE
Prevent LDAP Password to appear in log file

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -101,7 +101,14 @@ class Log implements ILogger {
 		'decrypt',
 
 		//LoginController
-		'tryLogin'
+		'tryLogin',
+
+		//bind
+		'bind',
+
+		//invokeLDAPMethod
+		'invokeLDAPMethod'
+
 	];
 
 	/**


### PR DESCRIPTION
If connection to LDAP server is lost, the LDAP password is shown in the stack trace.

This should prevent this from happening.