### PR TITLE
Encapsulate extracting the XML from a response with getResponseXml()

### DIFF
--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -205,7 +205,7 @@ class AppConfigHelper {
 	 * @return string
 	 */
 	public static function getOCSResponse($response) {
-		return $response->xml()->meta[0]->statuscode;
+		return HttpRequestHelper::getResponseXml($response)->meta[0]->statuscode;
 	}
 
 	/**
@@ -236,7 +236,7 @@ class AppConfigHelper {
 	 * @return string retrieved capabilities in XML format
 	 */
 	public static function getCapabilitiesXml($response) {
-		return $response->xml()->data->capabilities;
+		return HttpRequestHelper::getResponseXml($response)->data->capabilities;
 	}
 
 	/**

--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -26,6 +26,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Message\ResponseInterface;
+use SimpleXMLElement;
 
 /**
  * Helper for HTTP requests
@@ -224,5 +225,16 @@ class HttpRequestHelper {
 		return self::sendRequest(
 			$url, 'DELETE', $user, $password, $headers, $body, $config, $cookies, $stream
 		);
+	}
+
+	/**
+	 * Parses the response as XML
+	 *
+	 * @param ResponseInterface $response
+	 *
+	 * @return SimpleXMLElement
+	 */
+	public static function getResponseXml($response) {
+		return $response->xml();
 	}
 }

--- a/tests/TestHelpers/LoggingHelper.php
+++ b/tests/TestHelpers/LoggingHelper.php
@@ -21,6 +21,8 @@
  */
 namespace TestHelpers;
 
+use SimpleXMLElement;
+
 /**
  * Helper to read and analyze the owncloud log file
  *
@@ -63,7 +65,7 @@ class LoggingHelper {
 	 * @param int $noOfLinesToRead
 	 *
 	 * @throws \Exception
-	 * @return \SimpleXMLElement[]
+	 * @return SimpleXMLElement
 	 */
 	public static function getLogFileContent(
 		$baseUrl, $adminUsername, $adminPassword, $noOfLinesToRead = 0
@@ -77,7 +79,7 @@ class LoggingHelper {
 				"could not get logfile content " . $result->getReasonPhrase()
 			);
 		}
-		return $result->xml()->data->element;
+		return HttpRequestHelper::getResponseXml($result)->data->element;
 	}
 
 	/**

--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -49,7 +49,7 @@ class OcsApiHelper {
 			$fullUrl .= '/';
 		}
 		$fullUrl .= "ocs/v{$ocsApiVersion}.php" . $path;
-		
+
 		return HttpRequestHelper::sendRequest($fullUrl, $method, $user, $password, [], $body);
 	}
 }

--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -232,7 +232,7 @@ class UserHelper {
 		$baseUrl, $adminUser, $adminPassword, $search =""
 	) {
 		$result = self::getGroups($baseUrl, $adminUser, $adminPassword, $search);
-		$groups = $result->xml()->xpath(".//groups")[0];
+		$groups = HttpRequestHelper::getResponseXml($result)->xpath(".//groups")[0];
 		$return = [];
 		foreach ($groups as $group) {
 			$return[] = $group->__toString();

--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -167,7 +167,7 @@ trait AppConfiguration {
 	 * @return string latest retrieved capabilities in XML format
 	 */
 	public function getCapabilitiesXml() {
-		return $this->response->xml()->data->capabilities;
+		return $this->getResponseXml()->data->capabilities;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -541,7 +541,22 @@ trait BasicStructure {
 	 * @return string
 	 */
 	public function getOCSResponseStatusCode($response) {
-		return (string) $response->xml()->meta[0]->statuscode;
+		return (string) $this->getResponseXml($response)->meta[0]->statuscode;
+	}
+
+	/**
+	 * Parses the response as XML
+	 *
+	 * @param ResponseInterface $response
+	 *
+	 * @return SimpleXMLElement
+	 */
+	public function getResponseXml($response = null) {
+		if ($response === null) {
+			$response = $this->response;
+		}
+
+		return HttpRequestHelper::getResponseXml($response);
 	}
 
 	/**
@@ -553,7 +568,7 @@ trait BasicStructure {
 	 * @return string
 	 */
 	public function getOCSResponseStatusMessage($response) {
-		return (string) $response->xml()->meta[0]->message;
+		return (string) $this->getResponseXml($response)->meta[0]->message;
 	}
 
 	/**
@@ -566,7 +581,7 @@ trait BasicStructure {
 	 * @return string
 	 */
 	public function getXMLKey1Key2Value($response, $key1, $key2) {
-		return $response->xml()->$key1->$key2;
+		return $this->getResponseXml($response)->$key1->$key2;
 	}
 
 	/**
@@ -580,7 +595,7 @@ trait BasicStructure {
 	 * @return string
 	 */
 	public function getXMLKey1Key2Key3Value($response, $key1, $key2, $key3) {
-		return $response->xml()->$key1->$key2->$key3;
+		return $this->getResponseXml($response)->$key1->$key2->$key3;
 	}
 
 	/**
@@ -597,7 +612,7 @@ trait BasicStructure {
 	public function getXMLKey1Key2Key3AttributeValue(
 		$response, $key1, $key2, $key3, $attribute
 	) {
-		return (string) $response->xml()->$key1->$key2->$key3->attributes()->$attribute;
+		return (string) $this->getResponseXml($response)->$key1->$key2->$key3->attributes()->$attribute;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -93,12 +93,7 @@ class FederationContext implements Context {
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBe('200');
 		$this->featureContext->theOCSStatusCodeShouldBe('100');
-		/**
-		 *
-		 * @var ResponseInterface $response
-		 */
-		$response = $this->featureContext->getResponse();
-		$share_id = $response->xml()->data[0]->element[0]->id;
+		$share_id = $this->featureContext->getResponseXml()->data[0]->element[0]->id;
 		$this->featureContext->theUserSendsToOcsApiEndpointWithBody(
 			'POST',
 			"/apps/files_sharing/api/v1/remote_shares/pending/{$share_id}",

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1397,7 +1397,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theDisplayNameReturnedByTheApiShouldBe($displayname) {
-		$responseName = $this->response->xml()->data[0]->displayname;
+		$responseName = $this->getResponseXml()->data[0]->displayname;
 		PHPUnit_Framework_Assert::assertEquals($displayname, $responseName);
 	}
 
@@ -1409,7 +1409,8 @@ trait Provisioning {
 	 * @return array
 	 */
 	public function getArrayOfUsersResponded($resp) {
-		$listCheckedElements = $resp->xml()->data[0]->users[0]->element;
+		$listCheckedElements
+			= $this->getResponseXml($resp)->data[0]->users[0]->element;
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -1423,7 +1424,8 @@ trait Provisioning {
 	 * @return array
 	 */
 	public function getArrayOfGroupsResponded($resp) {
-		$listCheckedElements = $resp->xml()->data[0]->groups[0]->element;
+		$listCheckedElements
+			= $this->getResponseXml($resp)->data[0]->groups[0]->element;
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -1437,7 +1439,8 @@ trait Provisioning {
 	 * @return array
 	 */
 	public function getArrayOfAppsResponded($resp) {
-		$listCheckedElements = $resp->xml()->data[0]->apps[0]->element;
+		$listCheckedElements
+			= $this->getResponseXml($resp)->data[0]->apps[0]->element;
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -1451,7 +1454,8 @@ trait Provisioning {
 	 * @return array
 	 */
 	public function getArrayOfSubadminsResponded($resp) {
-		$listCheckedElements = $resp->xml()->data[0]->element;
+		$listCheckedElements
+			= $this->getResponseXml($resp)->data[0]->element;
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -1465,7 +1469,8 @@ trait Provisioning {
 	 * @return array
 	 */
 	public function getArrayOfAppInfoResponded($resp) {
-		$listCheckedElements = $resp->xml()->data[0];
+		$listCheckedElements
+			= $this->getResponseXml($resp)->data[0];
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -1551,7 +1556,7 @@ trait Provisioning {
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
 		PHPUnit_Framework_Assert::assertEquals(
-			"false", $this->response->xml()->data[0]->enabled
+			"false", $this->getResponseXml()->data[0]->enabled
 		);
 	}
 
@@ -1569,7 +1574,7 @@ trait Provisioning {
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
 		PHPUnit_Framework_Assert::assertEquals(
-			"true", $this->response->xml()->data[0]->enabled
+			"true", $this->getResponseXml()->data[0]->enabled
 		);
 	}
 
@@ -1629,7 +1634,7 @@ trait Provisioning {
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
-		return $this->response->xml()->data[0]->home;
+		return $this->getResponseXml()->data[0]->home;
 	}
 
 	/**
@@ -1642,7 +1647,7 @@ trait Provisioning {
 	public function checkUserAttributes($body) {
 		$fd = $body->getRowsHash();
 		foreach ($fd as $field => $value) {
-			$data = $this->response->xml()->data[0];
+			$data = $this->getResponseXml()->data[0];
 			$field_array = \explode(' ', $field);
 			foreach ($field_array as $field_name) {
 				$data = $data->$field_name;
@@ -1677,7 +1682,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theApiShouldNotReturnAnyData() {
-		$responseData = $this->response->xml()->data[0];
+		$responseData = $this->getResponseXml()->data[0];
 		PHPUnit_Framework_Assert::assertEmpty(
 			$responseData,
 			"Response data is not empty but it should be empty"
@@ -1690,7 +1695,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theListOfUsersReturnedByTheApiShouldBeEmpty() {
-		$usersList = $this->response->xml()->data[0]->users[0];
+		$usersList = $this->getResponseXml()->data[0]->users[0];
 		PHPUnit_Framework_Assert::assertEmpty(
 			$usersList,
 			"Users list is not empty but it should be empty"
@@ -1703,7 +1708,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theListOfGroupsReturnedByTheApiShouldBeEmpty() {
-		$groupsList = $this->response->xml()->data[0]->groups[0];
+		$groupsList = $this->getResponseXml()->data[0]->groups[0];
 		PHPUnit_Framework_Assert::assertEmpty(
 			$groupsList,
 			"Groups list is not empty but it should be empty"

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -117,7 +117,7 @@ class ShareesContext implements Context {
 	public function getArrayOfShareesResponded(
 		ResponseInterface $response, $shareeType
 	) {
-		$elements = $response->xml()->data;
+		$elements = $this->featureContext->getResponseXml($response)->data;
 		$elements = \json_decode(\json_encode($elements), 1);
 		if (\strpos($shareeType, 'exact ') === 0) {
 			$elements = $elements['exact'];

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -97,7 +97,7 @@ trait Sharing {
 		$this->response = HttpRequestHelper::post(
 			$fullUrl, $user, $this->getPasswordForUser($user), null, $fd
 		);
-		$this->lastShareData = $this->response->xml();
+		$this->lastShareData = $this->getResponseXml();
 	}
 
 	/**
@@ -155,7 +155,7 @@ trait Sharing {
 			$this->ocsApiVersion,
 			$this->sharingApiVersion
 		);
-		$this->lastShareData = $this->response->xml();
+		$this->lastShareData = $this->getResponseXml();
 	}
 
 	/**
@@ -572,7 +572,7 @@ trait Sharing {
 			$this->ocsApiVersion,
 			$this->sharingApiVersion
 		);
-		$this->lastShareData = $this->response->xml();
+		$this->lastShareData = $this->getResponseXml();
 	}
 
 	/**
@@ -582,7 +582,7 @@ trait Sharing {
 	 * @return bool
 	 */
 	public function isFieldInResponse($field, $contentExpected) {
-		$data = $this->response->xml()->data[0];
+		$data = $this->getResponseXml()->data[0];
 		if ((string)$field == 'expiration') {
 			$contentExpected
 				= \date('Y-m-d', \strtotime($contentExpected)) . " 00:00:00";
@@ -712,7 +712,7 @@ trait Sharing {
 	 * @return bool
 	 */
 	public function isUserOrGroupInSharedData($userOrGroup, $permissions = null) {
-		$data = $this->response->xml()->data[0];
+		$data = $this->getResponseXml()->data[0];
 		foreach ($data as $element) {
 			if ($element->share_with == $userOrGroup
 				&& ($permissions === null || $permissions == $element->permissions)
@@ -969,7 +969,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function checkingTheResponseEntriesCount($count) {
-		$actualCount = \count($this->response->xml()->data[0]);
+		$actualCount = \count($this->getResponseXml()->data[0]);
 		PHPUnit_Framework_Assert::assertEquals($count, $actualCount);
 	}
 
@@ -1093,7 +1093,7 @@ trait Sharing {
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $user, $this->getPasswordForUser($user)
 		);
-		return $this->response->xml()->data->element;
+		return $this->getResponseXml()->data->element;
 	}
 
 	/**


### PR DESCRIPTION
## Description
Encapsulate the ``response->xml()`` repeated code to be inside new ``getResponseXml()`` methods.

## Motivation and Context
GuzzleV6 has a different way to do this. The code waiting there has encapsulated the code in new ``getResponseXml()`` methods. We can do the encapsulation now, and it will greatly reduce the diffs and future "random" merge conflicts experienced in the GuzzleV6 PR.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
