### PR TITLE
[stable10] does not have zsync

### DIFF
--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -41,7 +41,6 @@ class Capabilities implements ICapability {
 		$cap =  [
 			'dav' => [
 				'chunking' => '1.0',
-				'zsync' => '1.0',
 				'reports' => [
 					'search-files',
 				]


### PR DESCRIPTION
## Description
zsync is master only

## Related Issue
...
## Motivation and Context
do not 💥 on stable10

## How Has This Been Tested?
no tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
