### PR TITLE
Add make test-php-style-fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ help:
 	@echo -e "Testing:\n"
 	@echo -e "make test\t\t\trun all tests"
 	@echo -e "make test-php\t\t\trun all PHP tests"
+	@echo -e "make test-php-style\t\trun PHP code style checks"
 	@echo -e "make test-js\t\t\trun Javascript tests"
 	@echo -e "make test-js-debug\t\trun Javascript tests in debug mode (continuous)"
 	@echo -e "make test-acceptance\t\trun acceptance tests"
@@ -100,8 +101,9 @@ help:
 	@echo -e "make test-php TEST_DATABASE=mysql TEST_PHP_SUITE=path/to/testfile.php"
 	@echo
 	@echo -e "Tools:\n"
+	@echo -e "make test-php-style-fix\t\trun PHP code style checks and fix any issues found"
 	@echo -e "make update-php-license-header\tUpdate license headers"
-	
+
 
 #
 # Basic required tools
@@ -193,6 +195,10 @@ test-php-lint: $(composer_dev_deps)
 test-php-style: $(composer_dev_deps)
 	$(composer_deps)/bin/php-cs-fixer fix -v --diff --diff-format udiff --dry-run --allow-risky yes
 	php build/OCPSinceChecker.php
+
+.PHONY: test-php-style-fix
+test-php-style-fix: $(composer_dev_deps)
+	$(composer_deps)/bin/php-cs-fixer fix -v --diff --diff-format udiff --allow-risky yes
 
 .PHONY: test-php-phan
 test-php-phan: $(PHAN_BIN)


### PR DESCRIPTION
## Description
Add ``make test-php-style-fix`` that, as well as checking the style, fixes it.

After running this, any fixed code style will be waiting in your current branch for you to review/add/commit.

## Related Issue

## Motivation and Context
Some app repos have this now. I have got used to it, and it takes time to find the full ``php-cs-fixer`` command line to run. We can have it in core easily.

## How Has This Been Tested?
Use the new ``make test-php-style-fix``  command to fix some code style and confirm it worked.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
- [ ] Development environnment

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
