### PR TITLE
Do not check testing app with php-cs-fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -15,7 +15,6 @@ $bundledApps = [
 	'files_versions',
 	'provisioning_api',
 	'systemtags',
-	'testing',
 	'updatenotification'
 ];
 


### PR DESCRIPTION
## Description
Do not check the testing app files when running ``php-cs-fixer`` from core.

## Motivation and Context
The testing app has been moved to a separate repo.
But if the testing app has a code style problem, then ``make test-php-style`` in core is reporting it locally. That will be annoying for developers, who will wonder what they should do in core to fix "their PR".

## How Has This Been Tested?
``make test-php-style``
and confirm it does not fix code in ``apps/testing``

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
