### PR TITLE
 Acceptance test step for occ user:resetpassword 

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -89,6 +89,23 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @When the administrator resets the password of user :username to :password using the occ command
+	 *
+	 * @param string $username
+	 * @param string $password
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function resetUserPasswordUsingTheOccCommand($username, $password) {
+		$this->featureContext->invokingTheCommandWithEnvVariable(
+			"user:resetpassword $username  --password-from-env",
+			'OC_PASS',
+			$password
+		);
+	}
+
+	/**
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -71,6 +71,7 @@ trait WebDav {
 
 	/**
 	 * response content parsed from XML to an array
+	 *
 	 * @var array
 	 */
 	private $responseXml = [];
@@ -210,7 +211,10 @@ trait WebDav {
 
 	/**
 	 * parses the body content of $response and sets $this->responseXml
+	 *
 	 * @param ResponseInterface|null $response if null $this->response will be used
+	 *
+	 * @return void
 	 */
 	public function parseResponseIntoXml($response = null) {
 		if ($response === null) {
@@ -2170,6 +2174,7 @@ trait WebDav {
 	 * @Then the DAV exception should be :message
 	 *
 	 * @param string $message
+	 * @param array|null $responseXml
 	 *
 	 * @return void
 	 * @throws \Exception
@@ -2182,6 +2187,7 @@ trait WebDav {
 	 * @Then the DAV message should be :message
 	 *
 	 * @param string $message
+	 * @param array|null $responseXml
 	 *
 	 * @return void
 	 * @throws \Exception
@@ -2194,9 +2200,10 @@ trait WebDav {
 	 * @Then the DAV reason should be :message
 	 *
 	 * @param string $message
+	 * @param array|null $responseXml
 	 *
 	 * @return void
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function theDavReasonShouldBe($message, $responseXml = null) {
 		$this->theDavResponseElementShouldBe("reason", $message, $responseXml);
@@ -2206,7 +2213,9 @@ trait WebDav {
 	 *
 	 * @param string $element exception|message|reason
 	 * @param string $expectedValue
-	 * @param array $responseXml
+	 * @param array|null $responseXml
+	 *
+	 * @return void
 	 * @throws \Exception
 	 */
 	public function theDavResponseElementShouldBe($element, $expectedValue, $responseXml = null) {


### PR DESCRIPTION
## Description
1) Add an acceptance test step that can do ``occ user:resetpassword``
2) Some code style changes to ``WebDav.php``

## Motivation and Context
We need to be able to test various ``occ`` commands. 
``occ user:resetpassword`` is needed for password policy acceptance testing.

## How Has This Been Tested?
Use it locally in password policy app acceptance tests that are coming.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
