### PR TITLE
Refactor another getResponseXml

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -239,7 +239,7 @@ class SetupHelper {
 				"could not get sysinfo " . $result->getReasonPhrase()
 			);
 		}
-		return $result->xml()->data;
+		return HttpRequestHelper::getResponseXml($result)->data;
 	}
 
 	/**


### PR DESCRIPTION
## Description
Refactor the remaining ``xml()`` call to use ``getResponseXml()``

## Motivation and Context
PR #32601 encapsulated acceptance test ``xml()`` calls into ``HttpRequestHelper::getResponseXml()``
At the time there was another PR that added ``SetupHelper::getSysInfo()`` and it added another of these ``xml()`` calls.


## How Has This Been Tested?
:robot: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
