### PR TITLE
allow to test capabilities with empty path in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfiguration.php
+++ b/tests/acceptance/features/bootstrap/AppConfiguration.php
@@ -182,7 +182,6 @@ trait AppConfiguration {
 	) {
 		$path_to_element = \explode('@@@', $capabilitiesPath);
 		$answeredValue = $xml->{$capabilitiesApp};
-
 		foreach ($path_to_element as $element) {
 			$nameIndexParts = \explode('[', $element);
 			if (isset($nameIndexParts[1])) {
@@ -193,7 +192,9 @@ trait AppConfiguration {
 				// and use those to construct the reference into the next XML level
 				$answeredValue = $answeredValue->{$name}[$index];
 			} else {
-				$answeredValue = $answeredValue->{$element};
+				if ($element !== "") {
+					$answeredValue = $answeredValue->{$element};
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description
allow to have tests that check capabilities that does not have any path
e.g.
```
		Then the capabilities should contain
			| capability | path_to_element | value |
			| async      |                 | 1.0    |
```
## Related Issue
#32580

## Motivation and Context
the new async capability has not sub-path

## How Has This Been Tested?
made tests that use it

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
