### PR TITLE
AfterScenario BeforeScenario does not need to be static

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1270,7 +1270,7 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	public static function removeFilesFromLocalStorageBefore() {
+	public function removeFilesFromLocalStorageBefore() {
 		$dir = "./work/local_storage/";
 		$di = new RecursiveDirectoryIterator(
 			$dir, FilesystemIterator::SKIP_DOTS
@@ -1288,7 +1288,7 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	public static function removeFilesFromLocalStorageAfter() {
+	public function removeFilesFromLocalStorageAfter() {
 		$dir = "./work/local_storage/";
 		$di = new RecursiveDirectoryIterator(
 			$dir, FilesystemIterator::SKIP_DOTS


### PR DESCRIPTION
## Description
Remove ``static`` from before and after scenario.

## Motivation and Context
I noticed that just these ``BeforeScenario`` and ``AfterScenario`` have been declared ``static``
In this case it works, because they do not make any reference to ``$this``, but everywhere else they are not ``static``

Make these consistent.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
