### PR TITLE
Escapre urlencoding of strings to allow them read properly

### DIFF
--- a/core/js/sharedialoglinklistview.js
+++ b/core/js/sharedialoglinklistview.js
@@ -133,7 +133,7 @@
 			var index = 1;
 			var baseName = t('core', '{fileName} link', {
 				fileName: this.fileInfoModel.get('name')
-			});
+			}, null, {escape: false});
 			var name = baseName;
 
 			while (this.collection.findWhere({name: name})) {

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -313,7 +313,7 @@
 			if (item.value.shareType === OC.Share.SHARE_TYPE_GROUP) {
 				text = t('core', '{sharee} (group)', {
 					sharee: text
-				});
+				}, null, {escape: false});
 			} else if (item.value.shareType === OC.Share.SHARE_TYPE_REMOTE) {
 				if (item.value.server) {
 					text = t('core', '{sharee} (at {server})', {


### PR DESCRIPTION
Escape urlencoding of strings to make them read properly.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Show the strings like share link file name and custom groups with special characters display without urlencoding.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Show the strings like share link file name and custom groups with special characters display without urlencoding.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create a folder with `a'b`
- Launch the public link dialog window the `Link name` text box should display `a'b link` instead of encoded text
- Create a custom group with `a'b`
- Try to share a file or folder with the group, the suggestion should show the group name properly.

## Screenshots (if appropriate):
- public link 
![publink](https://user-images.githubusercontent.com/3600427/45204424-ca17cd80-b29c-11e8-9f05-cd098ba19e51.png)
- group name 
![group](https://user-images.githubusercontent.com/3600427/45204433-d3a13580-b29c-11e8-8cd3-e07a73d523dc.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
