### PR TITLE
move getPageTitle() to pageObject

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -364,10 +364,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 */
 	public function theUserShouldBeRedirectedToAWebUIPageWithTheTitle($title) {
 		$this->owncloudPage->waitForOutstandingAjaxCalls($this->getSession());
-		$actualTitle = $this->getSession()->getPage()->find(
-			'xpath', './/title'
-		)->getHtml();
-		PHPUnit_Framework_Assert::assertEquals($title, \trim($actualTitle));
+		PHPUnit_Framework_Assert::assertEquals($title, $this->owncloudPage->getPageTitle());
 	}
 
 	/**

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -39,6 +39,7 @@ class OwncloudPage extends Page {
 	protected $notificationId = "notification";
 	protected $ocDialogXpath = ".//*[@class='oc-dialog']";
 	protected $avatarImgXpath = ".//div[@id='settings']//div[contains(@class, 'avatardiv')]/img";
+	protected $titleXpath = ".//title";
 
 	/**
 	 * used to store the unchanged path string when $path gets changed
@@ -179,6 +180,21 @@ class OwncloudPage extends Page {
 			\array_push($notificationsText, $this->getTrimmedText($notification));
 		}
 		return $notificationsText;
+	}
+
+	/**
+	 *
+	 * @throws ElementNotFoundException
+	 * @return string
+	 */
+	public function getPageTitle() {
+		$title = $this->find('xpath', $this->titleXpath);
+		if ($title === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ . " could not find title element"
+			);
+		}
+		return \trim($title->getHtml());
 	}
 
 	/**


### PR DESCRIPTION
## Description
I was about to copy paste this lines for an other function and decided to be a good guy and to move it where it belogs

## Motivation and Context
DRY

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
