### PR TITLE
Concat all email addresses that had sending problems

### DIFF
--- a/core/ajax/share.php
+++ b/core/ajax/share.php
@@ -267,7 +267,7 @@ if (isset($_POST['action'], $_POST['itemType'], $_POST['itemSource'])) {
 				OCP\JSON::error([
 					'data' => [
 						'message' => $l->t("Couldn't send mail to following recipient(s): %s ",
-								\implode(', ', $result)
+								\implode(', ', $results)
 							)
 					]
 				]);


### PR DESCRIPTION
## Description
Implode all the failed email address results, not just the last one.

## Related Issue
#31845 

## Motivation and Context
#32506 changes the email sending when creating public links so that it sends an individual email to each recipient, instead of a bulk email with the recipients as Bcc.

After that change, issue #31845 is back, in that it only reports the last recipient email that could not be sent. It should report all the email addresses that could be not sent. That issue was fixed earlier by PR #31847

## How Has This Been Tested?
Manually in the UI, following steps like in PR #31847

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
