### PR TITLE
[stable10] tests to create users by supplying and email address an no password

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -937,6 +937,7 @@ matrix:
       INSTALL_SERVER: true
       CHOWN_SERVER: true
       USE_EMAIL: true
+      OWNCLOUD_LOG: true
 
     - PHP_VERSION: 7.1
       TEST_SUITE: selenium

--- a/tests/TestHelpers/EmailHelper.php
+++ b/tests/TestHelpers/EmailHelper.php
@@ -59,9 +59,29 @@ class EmailHelper {
 	 * @return mixed
 	 */
 	public static function getBodyOfLastEmail($mailhogUrl, $address) {
+		return self::getBodyOfEmail($mailhogUrl, $address, 0);
+	}
+
+	/**
+	 *
+	 * @param string $mailhogUrl
+	 * @param string $address
+	 * @param int $numEmails which number of multiple emails to read (first email is 1)
+	 *
+	 * @throws \Exception
+	 *
+	 * @return mixed
+	 */
+	public static function getBodyOfEmail($mailhogUrl, $address, $numEmails = 1) {
+		$skip = 1;
 		foreach (self::getEmails($mailhogUrl)->items as $item) {
 			$expectedEmail = $item->To[0]->Mailbox . "@" . $item->To[0]->Domain;
 			if ($expectedEmail === $address) {
+				if ($skip < $numEmails) {
+					$skip++;
+					continue;
+				}
+
 				$body = \str_replace(
 					"\r\n", "\n",
 					\quoted_printable_decode($item->Content->Body)

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -284,6 +284,33 @@ trait Provisioning {
 	}
 
 	/**
+	 * @When the administrator changes the password of user :user to :password using the provisioning API
+	 *
+	 * @param string $user
+	 * @param string $password
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function adminResetsUserPasswordUsingTheProvisioningApi(
+		$user, $password
+	) {
+		$result = UserHelper::editUser(
+			$this->getBaseUrl(),
+			$user,
+			'password',
+			$password,
+			$this->getAdminUsername(),
+			$this->getAdminPassword()
+		);
+		if ($result->getStatusCode() !== 200) {
+			throw new \Exception(
+				"could not change password of user. "
+				. $result->getStatusCode() . " " . $result->getBody()
+			);
+		}
+	}
+	/**
 	 * @When /^user "([^"]*)" (enables|disables) the app "([^"]*)"$/
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -29,9 +29,11 @@ use Page\LoginPage;
 use Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use TestHelpers\AppConfigHelper;
+use TestHelpers\EmailHelper;
 use TestHelpers\OcsApiHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\UploadHelper;
+use Page\GeneralErrorPage;
 
 require_once 'bootstrap.php';
 
@@ -40,6 +42,11 @@ require_once 'bootstrap.php';
  */
 class WebUIGeneralContext extends RawMinkContext implements Context {
 	private $owncloudPage;
+	/**
+	 *
+	 * @var GeneralErrorPage
+	 */
+	private $generalErrorPage;
 	private $loginPage;
 	private $oldCSRFSetting = null;
 	private $oldPreviewSetting = null;
@@ -128,9 +135,14 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @param OwncloudPage $owncloudPage
 	 * @param LoginPage $loginPage
 	 */
-	public function __construct(OwncloudPage $owncloudPage, LoginPage $loginPage) {
+	public function __construct(
+		OwncloudPage $owncloudPage,
+		LoginPage $loginPage,
+		GeneralErrorPage $generalErrorPage
+	) {
 		$this->owncloudPage = $owncloudPage;
 		$this->loginPage = $loginPage;
+		$this->generalErrorPage = $generalErrorPage;
 	}
 
 	/**
@@ -217,6 +229,23 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		if ($this->webUIFilesContext !== null) {
 			$this->webUIFilesContext->resetFilesContext();
 		}
+	}
+
+	/**
+	 *
+	 * @param string $emailAddress
+	 * @param string $regexSearch
+	 * @param string $errorMessage
+	 * @param int $numEmails which number of multiple emails to read (first email is 1)
+	 */
+	public function followLinkFromEmail($emailAddress, $regexSearch, $errorMessage, $numEmails = 1) {
+		$content = EmailHelper::getBodyOfEmail(
+			EmailHelper::getMailhogUrl(), $emailAddress, $numEmails
+		);
+		$matches = [];
+		\preg_match($regexSearch, $content, $matches);
+		PHPUnit_Framework_Assert::assertArrayHasKey(1, $matches, $errorMessage);
+		$this->visitPath($matches[1]);
 	}
 
 	/**
@@ -365,6 +394,33 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	public function theUserShouldBeRedirectedToAWebUIPageWithTheTitle($title) {
 		$this->owncloudPage->waitForOutstandingAjaxCalls($this->getSession());
 		PHPUnit_Framework_Assert::assertEquals($title, $this->owncloudPage->getPageTitle());
+	}
+
+	/**
+	 * @Then the user should be redirected to the general error webUI page with the title :title
+	 *
+	 * @param string $title
+	 *
+	 * @return void
+	 */
+	public function theUserShouldBeRedirectedToGeneralErrorPage($title) {
+		$this->generalErrorPage->waitTillPageIsLoaded($this->getSession());
+		PHPUnit_Framework_Assert::assertEquals(
+			$title, $this->generalErrorPage->getPageTitle()
+		);
+	}
+	
+	/**
+	 * @Then an error should be displayed on the general error webUI page saying :error
+	 *
+	 * @param string $error
+	 *
+	 * @return void
+	 */
+	public function anErrorShouldBeDisplayedOnTheGeneralErrorPage($error) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$error, $this->generalErrorPage->getErrorMessage()
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -268,23 +268,16 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 * @throws \Exception
 	 */
 	public function theUserFollowsThePasswordResetLinkFromTheirEmail($emailAddress) {
-		$content = EmailHelper::getBodyOfLastEmail(
-			EmailHelper::getMailhogUrl(), $emailAddress
-		);
-		\preg_match(
-			'/Use the following link to reset your password: (http.*)/',
-			$content, $matches
-		);
-		PHPUnit_Framework_Assert::assertArrayHasKey(
-			1, $matches,
+		$this->webUIGeneralContext->followLinkFromEmail(
+			$emailAddress,
+			"/Use the following link to reset your password: (http.*)/",
 			"Couldn't find password reset link in the email"
 		);
-		$this->visitPath($matches[1]);
 	}
 
 	/**
-	 * @When the user resets the password to :newPassword using the webUI
-	 * @Given the user has reset the password to :newPassword using the webUI
+	 * @When the user resets/sets the password to :newPassword using the webUI
+	 * @Given the user has reset/set the password to :newPassword using the webUI
 	 *
 	 * @param string $newPassword
 	 *
@@ -292,6 +285,24 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 */
 	public function theUserResetsThePasswordToUsingTheWebui($newPassword) {
 		$this->loginPage->resetThePassword($newPassword, $this->getSession());
+	}
+
+	/**
+	 * @When /^the user follows the password set link received by "([^"]*)"(?: in Email number (\d+))? using the webUI$/
+	 *
+	 * @param string $emailAddress
+	 * @param int $numEmails which number of multiple emails to read (first email is 1)
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theUserFollowsThePasswordSetLinkReceivedByEmail($emailAddress, $numEmails = 1) {
+		$this->webUIGeneralContext->followLinkFromEmail(
+			$emailAddress,
+			"/Access it: (http.*)/",
+			"Couldn't find password set link in the email",
+			$numEmails
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -126,6 +126,25 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When /^the administrator (attempts to create|creates) a user with the name "([^"]*)" and the email "([^"]*)" without a password(?: that is a member of these groups)? using the webUI$/
+	 *
+	 * @param string $attemptTo
+	 * @param string $username
+	 * @param string $password
+	 * @param string $email
+	 * @param TableNode $groupsTable table of groups with a heading | group |
+	 *
+	 * @return void
+	 */
+	public function theAdminCreatesAUserUsingWithoutAPasswordTheWebUI(
+		$attemptTo, $username, $email, TableNode $groupsTable=null
+	) {
+		$this->theAdminCreatesAUserUsingTheWebUI(
+			$attemptTo, $username, null, $email, $groupsTable
+		);
+	}
+
+	/**
 	 *
 	 * @When the administrator deletes the group named :name using the webUI
 	 *

--- a/tests/acceptance/features/lib/DisabledUserPage.php
+++ b/tests/acceptance/features/lib/DisabledUserPage.php
@@ -22,47 +22,13 @@
 
 namespace Page;
 
-use Behat\Mink\Session;
-
 /**
  * Disabled page.
  */
-class DisabledUserPage extends OwncloudPage {
+class DisabledUserPage extends GeneralErrorPage {
 
 	/**
 	 * @var string $path
 	 */
 	protected $path = '/index.php/login';
-	protected $userDisabledXpath = ".//li[@class='error']";
-
-	/**
-	 *
-	 * @param Session $session
-	 * @param int $timeout_msec
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function waitTillPageIsLoaded(
-		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
-	) {
-		$currentTime = \microtime(true);
-		$end = $currentTime + ($timeout_msec / 1000);
-		while ($currentTime <= $end) {
-			if ($this->findAll("xpath", $this->userDisabledXpath)) {
-				break;
-			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
-			$currentTime = \microtime(true);
-		}
-
-		if ($currentTime > $end) {
-			throw new \Exception(
-				__METHOD__ . " timeout waiting for page to load"
-			);
-		}
-
-		$this->waitForOutstandingAjaxCalls($session);
-	}
 }

--- a/tests/acceptance/features/lib/GeneralErrorPage.php
+++ b/tests/acceptance/features/lib/GeneralErrorPage.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2018 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page;
+
+use Behat\Mink\Session;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+
+/**
+ * GeneralErrorPage page.
+ */
+class GeneralErrorPage extends OwncloudPage {
+	protected $errorMessageXpath = ".//li[@class='error']";
+
+	/**
+	 *
+	 * @throws ElementNotFoundException
+	 * @return string
+	 */
+	public function getErrorMessage() {
+		$errorMessageElement = $this->find("xpath", $this->errorMessageXpath);
+		if ($errorMessageElement === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" could not find error element xpath: '$this->errorMessageXpath'"
+			);
+		}
+		return $errorMessageElement->getText();
+	}
+
+	/**
+	 *
+	 * @param Session $session
+	 * @param int $timeout_msec
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function waitTillPageIsLoaded(
+		Session $session,
+		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+	) {
+		$currentTime = \microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
+			if ($this->findAll("xpath", $this->errorMessageXpath)) {
+				break;
+			}
+			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			$currentTime = \microtime(true);
+		}
+
+		if ($currentTime > $end) {
+			throw new \Exception(
+				__METHOD__ . " timeout waiting for page to load"
+			);
+		}
+
+		$this->waitForOutstandingAjaxCalls($session);
+	}
+}

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -213,7 +213,9 @@ class UsersPage extends OwncloudPage {
 	) {
 		$this->setSetting("Set password for new users", $password !== null);
 		$this->fillField($this->newUserUsernameFieldId, $username);
-		$this->fillField($this->newUserPasswordFieldId, $password);
+		if ($password !== null) {
+			$this->fillField($this->newUserPasswordFieldId, $password);
+		}
 		if ($email !== null) {
 			$this->fillField($this->newUserEmailFieldId, $email);
 		}

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @mailhog
 Feature: add users
   As an admin
   I want to add users
@@ -47,3 +47,94 @@ Feature: add users
       |user|  pwd |
       |"a" | "abc"|
       |"a1"|"abcd"|
+
+  Scenario: use the webUI to create a simple user with an Email address but without a password
+    When the administrator creates a user with the name "guiusr1" and the email "guiusr1@owncloud" without a password using the webUI
+    Then the email address "guiusr1@owncloud" should have received an email with the body containing
+      """
+      just letting you know that you now have an ownCloud account.
+      
+      Your username: guiusr1
+      Access it:
+      """
+
+  Scenario Outline: user sets his own password after being created with an Email address only
+    When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
+    And the administrator logs out of the webUI
+    And the user follows the password set link received by "guiusr1@owncloud" using the webUI
+    And the user sets the password to "newpassword" using the webUI
+    Then the email address "guiusr1@owncloud" should have received an email with the body containing
+      """
+      Password changed successfully
+      """
+    When the user logs in with username "<username>" and password "newpassword" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+    Examples:
+     | username | comment              |
+     | guiusr1  | simple user-name     |
+     | a@-_.'b  | complicated user-name|
+
+  Scenario Outline: webUI refuses to create users with invalid Email addresses
+    When the administrator creates a user with the name "guiusr1" and the email "<email>" without a password using the webUI
+    Then notifications should be displayed on the webUI with the text
+      |Error creating user: Invalid mail address|
+    Examples:
+      |email   | comment       |
+      | string | no @ sign     |
+      | a@     | no domain name|
+      #there would be much more to test here, but its complicated and would be slow
+      #see http://codefool.tumblr.com/post/15288874550/list-of-valid-and-invalid-email-addresses
+      #email address validation would better go into an unit test
+
+  Scenario: webUI refuses to create a user with an empty Email address
+    When the administrator creates a user with the name "guiusr1" and the email "" without a password using the webUI
+    Then notifications should be displayed on the webUI with the text
+      |Error creating user: A valid email must be provided|
+
+  Scenario: changing the user password as an admin invalidates the user sets-password-token
+    When the administrator creates a user with the name "guiusr1" and the email "guiusr1@owncloud" without a password using the webUI
+    And the administrator changes the password of user "guiusr1" to "123" using the provisioning API
+    And the administrator logs out of the webUI
+    And the user follows the password set link received by "guiusr1@owncloud" using the webUI
+    Then the user should be redirected to the general error webUI page with the title "ownCloud"
+    And an error should be displayed on the general error webUI page saying "The token provided is invalid."
+
+  Scenario: sets-password-token cannot be used twice
+    When the administrator creates a user with the name "guiusr1" and the email "guiusr1@owncloud" without a password using the webUI
+    And the administrator logs out of the webUI
+    And the user follows the password set link received by "guiusr1@owncloud" using the webUI
+    And the user sets the password to "newpassword" using the webUI
+    And the user follows the password set link received by "guiusr1@owncloud" in Email number 2 using the webUI
+    Then the user should be redirected to the general error webUI page with the title "ownCloud"
+    And an error should be displayed on the general error webUI page saying "The token provided is invalid."
+
+  Scenario: recreating a user with same name after deletion sends a new token to new address
+    When the administrator creates a user with the name "guiusr1" and the email "mistake@owncloud" without a password using the webUI
+    And the administrator deletes the user "guiusr1" using the webUI
+    And the administrator creates a user with the name "guiusr1" and the email "correct@owncloud" without a password using the webUI
+    And the administrator logs out of the webUI
+    And the user follows the password set link received by "correct@owncloud" using the webUI
+    And the user sets the password to "newpassword" using the webUI
+    And the user logs in with username "guiusr1" and password "newpassword" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+
+  Scenario: recreating a user with same name after deletion makes the first token invalid
+    When the administrator creates a user with the name "guiusr1" and the email "mistake@owncloud" without a password using the webUI
+    And the administrator deletes the user "guiusr1" using the webUI
+    And the administrator creates a user with the name "guiusr1" and the email "correct@owncloud" without a password using the webUI
+    And the administrator logs out of the webUI
+    And the user follows the password set link received by "mistake@owncloud" using the webUI
+    Then the user should be redirected to the general error webUI page with the title "ownCloud"
+    And an error should be displayed on the general error webUI page saying "The token provided is invalid."
+
+  @skip @issue-32651
+  Scenario: when recreating a user with same second token can be used even if someone tried to use the first one
+    When the administrator creates a user with the name "guiusr1" and the email "mistake@owncloud" without a password using the webUI
+    And the administrator deletes the user "guiusr1" using the webUI
+    And the administrator creates a user with the name "guiusr1" and the email "correct@owncloud" without a password using the webUI
+    And the administrator logs out of the webUI
+    And the user follows the password set link received by "mistake@owncloud" using the webUI
+    And the user follows the password set link received by "correct@owncloud" using the webUI
+    And the user sets the password to "newpassword" using the webUI
+    And the user logs in with username "guiusr1" and password "newpassword" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"


### PR DESCRIPTION
## Description
UI tests for "New User Registration Page" and the workflow where the administrator can create a user without providing a password. The user will be notified by Email and can set the password himself

## Related Issue
-  #32560

## How Has This Been Tested?
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] make a similar PR to user_management app
