### PR TITLE
Revert "preLogin hook should use string UID not IUser"

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -986,7 +986,7 @@ class Session implements IUserSession, Emitter {
 				return false;
 			}
 
-			$this->manager->emit('\OC\User', 'preLogin', [$user->getUID(), $password]);
+			$this->manager->emit('\OC\User', 'preLogin', [$user, $password]);
 
 			if (!$user->isEnabled()) {
 				$message = \OC::$server->getL10N('lib')->t('User disabled');

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -1582,7 +1582,8 @@ class SessionTest extends TestCase {
 		$iUser->expects($this->once())
 			->method('isEnabled')
 			->willReturn(false);
-		$iUser->method('getUID')
+		$iUser->expects($this->exactly(2))
+			->method('getUID')
 			->willReturn('foo');
 
 		$failedEvent = new GenericEvent(null, ['user' => 'foo']);


### PR DESCRIPTION
Reverts owncloud/core#32225