### PR TITLE
Create local_storage dir via testing app

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -211,16 +211,6 @@ pipeline:
       matrix:
         CALDAV_CARDDAV_JOB: true
 
-  setup-api-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      # pre-create local_storage so fix-permissions will set its owner appropriately
-      - mkdir -p /drone/src/tests/acceptance/work/local_storage
-    when:
-      matrix:
-        TEST_SUITE: api
-
   install-notifications-app:
     image: owncloudci/php:${PHP_VERSION}
     pull: true


### PR DESCRIPTION
## Description
Use the testing app to create the ``work/local_storage`` folder.

This is the first step, which at least:
- gets rid of the need for the special ``setup-api-acceptance-tests`` pipeline step in core drone, and which has been pasted into a couple of app ``.drone.yml`` that had to have it.
- when running locally, and your server install is, e.g., on Apache owned by ``www-data``, you will not have the trouble that the test runner has no priv to create ``work/local_storage``

See the issue comments for other future things to be considered/done - https://github.com/owncloud/core/issues/32606#issuecomment-419787114

## Related Issue
#32606 

## Motivation and Context
The "temporary" folder for ``local_storage`` in API acceptance tests is being created directly by the test runner code in ``tests/acceptance/run.sh``. The file system local to the test runner may not be writable, and may not even be the file system on the system under test.


## How Has This Been Tested?
Local runs of some acceptance test scenarios

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
