### PR TITLE
Fix sharedByHasTheFollowingTags

### DIFF
--- a/tests/acceptance/features/apiMetadataApps/tags.feature
+++ b/tests/acceptance/features/apiMetadataApps/tags.feature
@@ -88,6 +88,16 @@ Feature: tags
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for "admin"
 
+  Scenario: Deleting a normal tag that has already been assigned to a file should work
+    Given user "user0" has been created
+    And user "user0" has created a "normal" tag with name "JustARegularTagName"
+    And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
+    And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
+    When user "user0" deletes the tag with name "JustARegularTagName" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And tag "JustARegularTagName" should not exist for "admin"
+    And file "/myFileToTag.txt" should have no tags for user "user0"
+
   Scenario: Deleting a not user-assignable tag as regular user should fail
     Given user "user0" has been created
     And user "admin" has created a "not user-assignable" tag with name "JustARegularTagName"
@@ -378,8 +388,7 @@ Feature: tags
     When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then file "/myFileToTag.txt" should have the following tags for user "user0"
       | MyFirstTag | normal |
-    And file "/myFileToTag.txt" should have the following tags for user "user1"
-      ||
+    And the HTTP status when user "user1" requests tags for file "/myFileToTag.txt" owned by "user0" should be "404"
 
   Scenario: User can assign tags when in the tag's groups
     Given user "user0" has been created

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -459,6 +459,7 @@ trait Tags {
 		\array_shift($tagList);
 		$found = false;
 		foreach ($table->getRowsHash() as $rowDisplayName => $rowType) {
+			$found = false;
 			foreach ($tagList as $path => $tagData) {
 				if (!empty($tagData)
 					&& $tagData['{http://owncloud.org/ns}display-name'] === $rowDisplayName

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -439,6 +439,24 @@ trait Tags {
 	}
 
 	/**
+	 * @Then /^the HTTP status when user "([^"]*)" requests tags for (?:file|folder|entry) "([^"]*)" (?:shared|owned) by "([^"]*)" should be "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $fileName
+	 * @param string $sharingUser
+	 * @param string $status
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theHttpStatusWhenuserRequestsTagsForEntryOwnedByShouldBe(
+		$user, $fileName, $sharingUser, $status
+	) {
+		$response = $this->requestTagsForFile($user, $fileName, $sharingUser);
+		PHPUnit_Framework_Assert::assertEquals($status, $response->getStatus());
+	}
+
+	/**
 	 * @Then /^(?:file|folder|entry) "([^"]*)" (?:shared|owned) by "([^"]*)" should have the following tags$/
 	 *
 	 * @param string $fileName
@@ -452,10 +470,9 @@ trait Tags {
 		$fileName, $sharingUser, TableNode $table
 	) {
 		$tagList = $this->requestTagsForFile($sharingUser, $fileName);
-		//Check if we are looking for no tags
-		if ((!\is_array($tagList)) && ($table->getRowAsString(0) === '|  |')) {
-			return true;
-		}
+		PHPUnit_Framework_Assert::assertInternalType('array', $tagList);
+		// The array of tags has a single "empty" item at the start.
+		// Remove this entry.
 		\array_shift($tagList);
 		$found = false;
 		foreach ($table->getRowsHash() as $rowDisplayName => $rowType) {
@@ -492,6 +509,39 @@ trait Tags {
 		$fileName, $user, TableNode $table
 	) {
 		$this->sharedByHasTheFollowingTags($fileName, $user, $table);
+	}
+
+	/**
+	 * @Then /^(?:file|folder|entry) "([^"]*)" (?:shared|owned) by "([^"]*)" should have no tags$/
+	 *
+	 * @param string $fileName
+	 * @param string $sharingUser
+	 * @param TableNode $table
+	 *
+	 * @return bool
+	 * @throws \Exception
+	 */
+	public function sharedByHasNoTags($fileName, $sharingUser) {
+		$tagList = $this->requestTagsForFile($sharingUser, $fileName);
+		PHPUnit_Framework_Assert::assertInternalType('array', $tagList);
+		// The array of tags has a single "empty" item at the start.
+		// If there are no tags, then the array should have just this
+		// one entry.
+		PHPUnit_Framework_Assert::assertCount(1, $tagList);
+	}
+
+	/**
+	 * @Then file :fileName should have no tags for user :user
+	 *
+	 * @param string $fileName
+	 * @param string $user
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function fileHasNoTagsForUser($fileName, $user) {
+		$this->sharedByHasNoTags($fileName, $user);
 	}
 
 	/**


### PR DESCRIPTION
## Description
1) In ``sharedByHasTheFollowingTags()``, reset ``found`` to ``false`` each time before looping to check for a matching tag. (1st commit)
2) 
a) Provide an explicit step to check for the case when a user requests the tags of a file that is owned by someone else - that should give a 404.
b) Provide explicit steps for the "should have no tags" conditions, rather than trying to include them as an empty table in the steps for having tags.
c) Make a new scenario for the case when a tag has already been assigned to a file, then the tag itself is deleted. The file should no longer have that tag. This common scenario was not anywhere to be seen.

## Related Issue

## Motivation and Context
1) For steps that use ``sharedByHasTheFollowingTags()`` to check for more than 1 tag, you can put any tag name you like after the first tag name. Only the first tag name really gets checked, all the others always pass, if they are there or not.

2) The existing code to check for a file having no tags does not work. It happens to work in the 1 place that it is currently used, because that place has a scenario where the user concerned actually does not have a view of the file anyway, so the request for tags gets a 4** response.

## How Has This Been Tested?
Running some Tags acceptance tests locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
