### PR TITLE
Remove personal mounts when user is deleted

### DIFF
--- a/lib/private/Files/External/PersonalMount.php
+++ b/lib/private/Files/External/PersonalMount.php
@@ -97,4 +97,13 @@ class PersonalMount extends MountPoint implements MoveableMount {
 		// note: home storage check already done in View
 		return true;
 	}
+
+	/**
+	 * Get the numeric storage id
+	 *
+	 * @return int
+	 */
+	public function getNumbericStorage() {
+		return $this->numericStorageId;
+	}
 }

--- a/lib/private/Files/External/Service/UserStoragesService.php
+++ b/lib/private/Files/External/Service/UserStoragesService.php
@@ -24,8 +24,10 @@
 
 namespace OC\Files\External\Service;
 
+use OC\Files\External\PersonalMount;
 use OC\Files\Filesystem;
 
+use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\Config\IUserMountCache;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -146,10 +148,21 @@ class UserStoragesService extends StoragesService implements IUserStoragesServic
 	/**
 	 * Deletes the storages mounted to a user
 	 * @param IUser $user
+	 * @param IMountProviderCollection $mountProviderCollection
 	 * @return bool
 	 */
-	public function deleteAllMountsForUser(IUser $user) {
+	public function deleteAllMountsForUser(IUser $user, IMountProviderCollection $mountProviderCollection) {
 		$getUserMounts = $this->userMountCache->getMountsForUser($user);
+		$getMountCollection = $mountProviderCollection->getMountsForUser($user);
+		if (\count($getMountCollection) > 0) {
+			foreach ($getMountCollection as $userMount) {
+				if ($userMount instanceof PersonalMount) {
+					$storageId = $userMount->getNumbericStorage();
+					$this->removeStorage($storageId);
+				}
+			}
+		}
+
 		$result = false;
 		if (\count($getUserMounts) > 0) {
 			foreach ($getUserMounts as $userMount) {

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -257,7 +257,7 @@ class User implements IUser {
 		\OC::$server->getConfig()->deleteAllUserValues($this->getUID());
 
 		// Delete all mount points for user
-		\OC::$server->getUserStoragesService()->deleteAllMountsForUser($this);
+		\OC::$server->getUserStoragesService()->deleteAllMountsForUser($this, \OC::$server->getMountProviderCollection());
 		//Delete external storage or remove user from applicableUsers list
 		\OC::$server->getGlobalStoragesService()->deleteAllForUser($this);
 

--- a/lib/public/Files/External/Service/IUserStoragesService.php
+++ b/lib/public/Files/External/Service/IUserStoragesService.php
@@ -21,6 +21,8 @@
 
 namespace OCP\Files\External\Service;
 
+use OCP\Files\Config\IMountProviderCollection;
+
 /**
  * Service class to manage user external storages
  * (aka personal storages)
@@ -31,8 +33,9 @@ interface IUserStoragesService extends IStoragesService {
 	/**
 	 * Deletes the storages mounted to a user
 	 * @param \OCP\IUser $user
+	 * @param IMountProviderCollection $mountProviderCollection
 	 * @return bool
 	 * @since 10.0.10
 	 */
-	public function deleteAllMountsForUser(\OCP\IUser $user);
+	public function deleteAllMountsForUser(\OCP\IUser $user, IMountProviderCollection $mountProviderCollection);
 }


### PR DESCRIPTION
Remove personal mounts when user is deleted.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When user is deleted, they should be removed from the external storages. For example the personal mounts created by the user were not removed. This change addresses the issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/32637

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When user is deleted, they should be removed from the external storages. For example the personal mounts created by the user were not removed. This change addresses the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Followed the steps from https://github.com/owncloud/core/issues/32637#issue-358009322.
- Before the user is deleted below is the snapshot of the db tables queried:
```
sqlite> select * from oc_mounts;
id          storage_id  root_id     user_id     mount_point
----------  ----------  ----------  ----------  -----------
1           1           1           admin       /admin/    
2           4           23          user4       /user4/    
3           3           29          user4       /user4/file
sqlite> select * from oc_external_mounts;
mount_id    mount_point  storage_backend  auth_backend        priority    type      
----------  -----------  ---------------  ------------------  ----------  ----------
1           /sftp        sftp             password::password  100         1         
2           /sftpuser4   sftp             password::password  100         1         
3           /sftpdirect  sftp             password::password  100         2         
sqlite> select * from oc_external_applicable;
applicable_id  mount_id    type        value     
-------------  ----------  ----------  ----------
1              1           1                     
3              2           3           user1     
4              2           3           user2     
5              2           3           user4     
6              2           3           user3     
7              3           3           user4     
sqlite> select * from oc_external_config;
config_id   mount_id    key         value     
----------  ----------  ----------  ----------
1           1           host        localhost 
2           1           root        /tmp/a    
3           1           user        sujith    
4           1           password    dda85e672b
5           2           host        localhost 
6           2           root        /tmp/a    
7           2           user        sujith    
8           2           password    4ff85bd2db
9           3           host        localhost 
10          3           root        /tmp/a    
11          3           user        sujith    
12          3           password    342fa23d1b
sqlite>
```
- After the user is deleted below is the snapshot of the db tables queried:
```
sqlite> select * from oc_mounts;
id          storage_id  root_id     user_id     mount_point
----------  ----------  ----------  ----------  -----------
1           1           1           admin       /admin/    
4           3           29          admin       /admin/file
sqlite> select * from oc_external_mounts;
mount_id    mount_point  storage_backend  auth_backend        priority    type      
----------  -----------  ---------------  ------------------  ----------  ----------
1           /sftp        sftp             password::password  100         1         
2           /sftpuser4   sftp             password::password  100         1         
sqlite> select * from oc_external_applicable;
applicable_id  mount_id    type        value     
-------------  ----------  ----------  ----------
1              1           1                     
3              2           3           user1     
4              2           3           user2     
6              2           3           user3     
sqlite> select * from oc_external_config;
config_id   mount_id    key         value     
----------  ----------  ----------  ----------
1           1           host        localhost 
2           1           root        /tmp/a    
3           1           user        sujith    
4           1           password    dda85e672b
5           2           host        localhost 
6           2           root        /tmp/a    
7           2           user        sujith    
8           2           password    4ff85bd2db
sqlite>
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
