### PR TITLE
[stable10] minimum desktop client version is 2.3.3

### DIFF
--- a/apps/dav/lib/Connector/Sabre/BlockLegacyClientPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/BlockLegacyClientPlugin.php
@@ -66,7 +66,7 @@ class BlockLegacyClientPlugin extends ServerPlugin {
 			return;
 		}
 
-		$minimumSupportedDesktopVersion = $this->config->getSystemValue('minimum.supported.desktop.version', '2.2.4');
+		$minimumSupportedDesktopVersion = $this->config->getSystemValue('minimum.supported.desktop.version', '2.3.3');
 
 		// Match on the mirall version which is in scheme "Mozilla/5.0 (%1) mirall/%2" or
 		// "mirall/%1" for older releases

--- a/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
@@ -77,7 +77,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
-			->with('minimum.supported.desktop.version', '2.2.4')
+			->with('minimum.supported.desktop.version', $this->anything())
 			->will($this->returnValue('2.2.4'));
 
 		$this->blockLegacyClientVersionPlugin->beforeHandler($request);
@@ -112,7 +112,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
-			->with('minimum.supported.desktop.version', '2.2.4')
+			->with('minimum.supported.desktop.version', $this->anything())
 			->will($this->returnValue('2.2.4'));
 
 		$this->blockLegacyClientVersionPlugin->beforeHandler($request);

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1296,7 +1296,7 @@ $CONFIG = array(
  * client may not function as expected, and could lead to permanent data loss for
  * clients or other unexpected results.
  */
-'minimum.supported.desktop.version' => '2.2.4',
+'minimum.supported.desktop.version' => '2.3.3',
 
 /**
  * EXPERIMENTAL: option whether to include external storage in quota


### PR DESCRIPTION
## Description
We recommend Desktop Client 2.3.3 for ownCloud 10 - with 10.0.10 we intend to bump the min version

## How Has This Been Tested?
🤖 + automated tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
