### PR TITLE
Simplify body of Scanner::getData

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -116,9 +116,13 @@ class Scanner extends BasicEmitter implements IScanner {
 		if ($data === null) {
 			\OCP\Util::writeLog(Scanner::class, "!!! Path '$path' is not accessible or present !!!", \OCP\Util::DEBUG);
 			// Last Line of Defence against potential Metadata-loss
-			if ($this->storage->instanceOfStorage(IHomeStorage::class) && !$this->storage->instanceOfStorage(ISharedStorage::class) && ($path === '' || $path === 'files')) {
-				\OCP\Util::writeLog(Scanner::class, 'Missing important folder "' . $path . '" in home storage!!! - ' . $this->storageId, \OCP\Util::ERROR);
-				throw new \OCP\Files\StorageNotAvailableException('Missing important folder "' . $path . '" in home storage - ' . $this->storageId);
+			if ($this->storage->instanceOfStorage(IHomeStorage::class)
+				&& !$this->storage->instanceOfStorage(ISharedStorage::class)
+				&& ($path === '' || $path === 'files')
+			) {
+				$errorMsg = \sprintf('Missing important folder "%s" in home storage - %s', $path, $this->storageId);
+				\OCP\Util::writeLog(Scanner::class, $errorMsg, \OCP\Util::ERROR);
+				throw new \OCP\Files\StorageNotAvailableException($errorMsg);
 			}
 		}
 		return $data;


### PR DESCRIPTION
## Description

Improves readability and maintainability of `\OC\Files\Cache\Scanner::getData`.

## Related Issue

- none

## Motivation and Context

When I was reviewing this section of code, as part of a larger code investigation, the final if block in `\OC\Files\Cache\Scanner::getData` was harder to read than I felt that it should have been. Secondly, a string was created twice, when it would be less error-prone to create it once and reuse it. Given these two points, I've created this commit, to simplify the code and improve readability.

## How Has This Been Tested?

- I ran the existing test suite.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 