### PR TITLE
[stable10] Backport of Do not delete token if token mismatch happens

### DIFF
--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -572,7 +572,6 @@ class UsersController extends Controller {
 		}
 
 		if (!\hash_equals($splittedToken[1], $token)) {
-			$this->config->deleteUserValue($userId, 'owncloud', 'lostpassword');
 			throw new UserTokenMismatchException($this->l10n->t('The token provided is invalid.'));
 		}
 	}


### PR DESCRIPTION
Do not delete token if token mismatch happens

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Do not delete token if the token mismatch happens when the user is yet to set the password.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/32651

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Do not delete token if the token mismatch happens when the user is yet to set the password.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create `admin` user
- Create `user1` with `foo@gmail.com`
- Received the email to set the password for `user1`. Now delete `user1`
- Create `user1` again with a different email address, lets say `bar@gmail.com`
- Received the email for setting up the password.
- Now try to access the link from `foo@gmail.com`, user sees that token is invalid. Correct behaviour.
- Try to access link from `bar@gmail.com`, user sees password setting page, where new password can be set. Correct behaviour.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
