### PR TITLE
Register areCredentialsValid as a sensitive logging method

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -103,11 +103,14 @@ class Log implements ILogger {
 		//LoginController
 		'tryLogin',
 
-		//bind
+		//User_LDAP\Connection
 		'bind',
 
-		//invokeLDAPMethod
-		'invokeLDAPMethod'
+		//User_LDAP\LDAP
+		'invokeLDAPMethod',
+
+		//User_LDAP\Access
+		'areCredentialsValid'
 
 	];
 


### PR DESCRIPTION
## Description

Prevent LDAP password from being written to the ownCloud log file.

## Related Issue

- n/a

## Motivation and Context

As the method stores a username and password in clear text, if an exception is thrown during its execution the password may be written to the log file. This change prevents that from happening.

## How Has This Been Tested?

-

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:

- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 