### PR TITLE
[stable10] remove testing caldav/carddav/litmus from travis pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -255,16 +255,6 @@ matrix:
         hosts: *common_hosts
         sauce_connect: true
     - php: 5.6
-      env: DB=pgsql TC=litmus-v1
-    - php: 5.6
-      env: DB=sqlite TC=carddav
-    - php: 5.6
-      env: DB=sqlite TC=caldav
-    - php: 5.6
-      env: DB=sqlite TC=caldav-old-endpoint
-    - php: 5.6
-      env: DB=sqlite TC=carddav-old-endpoint
-    - php: 5.6
       if: type = cron
       env: DB=pgsql TC=selenium BROWSER="chrome" BROWSER_VERSION="latest-1" BEHAT_SUITE="webUIFavorites" PLATFORM="Windows 10" TEST_DAV=0
       addons:


### PR DESCRIPTION
Backport #31879 

These litmus/carddav/caldav jobs are all happening in drone already on stable10.

I don't think there is a big rush to remove these.