### PR TITLE
Add test for PROPPATCH with complex values

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties/setFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/setFileProperties.feature
@@ -20,6 +20,18 @@ Feature: set file properties
       | old         |
       | new         |
 
+  @skip @issue-32670
+  Scenario Outline: Setting custom complex DAV property and reading it
+    Given using <dav_version> DAV path
+    And user "user0" has uploaded file "data/textfile.txt" to "/testcustomprop.txt"
+    And user "user0" has set property "{http://whatever.org/ns}very-custom-prop" of file "/testcustomprop.txt" to complex "<foo xmlns='http://bar'/>"
+    When user "user0" gets a custom property "{http://whatever.org/ns}very-custom-prop" of file "/testcustomprop.txt"
+    Then the response should contain a custom "{http://whatever.org/ns}very-custom-prop" property with "<foo xmlns='http://bar'/>"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
   Scenario Outline: Setting custom DAV property and reading it after the file is renamed
     Given using <dav_version> DAV path
     And user "user0" has uploaded file "data/textfile.txt" to "/testcustompropwithmove.txt"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -27,6 +27,7 @@ use Sabre\DAV\Xml\Property\ResourceType;
 use Sabre\Xml\LibXMLException;
 use TestHelpers\WebDavHelper;
 use TestHelpers\HttpRequestHelper;
+use Sabre\DAV\Xml\Property\Complex;
 
 require __DIR__ . '/../../../../lib/composer/autoload.php';
 
@@ -704,20 +705,24 @@ trait WebDav {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" sets property "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)" using the WebDAV API$/
-	 * @Given /^user "([^"]*)" has set property "([^"]*)" of (?:file|folder|entry) "([^"]*)" to "([^"]*)"$/
+	 * @When /^user "([^"]*)" sets property "([^"]*)" of (?:file|folder|entry) "([^"]*)" to\s?(complex|) "([^"]*)" using the WebDAV API$/
+	 * @Given /^user "([^"]*)" has set property "([^"]*)" of (?:file|folder|entry) "([^"]*)" to\s?(complex|) "([^"]*)"$/
 	 *
-	 * @param string $user
-	 * @param string $propertyName
-	 * @param string $path
-	 * @param string $propertyValue
+	 * @param string $user user id who sets the property
+	 * @param string $propertyName name of property in Clark notation
+	 * @param string $path path on which to set properties to
+	 * @param string $complex if set to "complex", will parse the property value with the Complex type
+	 * @param string $propertyValue property value
 	 *
 	 * @return void
 	 */
 	public function userHasSetPropertyOfEntryTo(
-		$user, $propertyName, $path, $propertyValue
+		$user, $propertyName, $path, $complex = '', $propertyValue
 	) {
 		$client = $this->getSabreClient($user);
+		if ($complex === 'complex') {
+			$propertyValue = new Complex($propertyValue);
+		}
 		$properties = [
 				$propertyName => $propertyValue
 		];


### PR DESCRIPTION
## Description
Adds acceptance tests on for Webdav PROPPATCH with values containing
sub-tags.

## Related Issue
- For https://github.com/owncloud/core/issues/32670

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
It's a test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
