### PR TITLE
[stable10] Backport of Add default option 'no' to --continue for comm…

### DIFF
--- a/core/Command/Encryption/DecryptAll.php
+++ b/core/Command/Encryption/DecryptAll.php
@@ -128,7 +128,8 @@ class DecryptAll extends Command {
 			'continue',
 			'c',
 			InputOption::VALUE_OPTIONAL,
-			'Provide yes or no. Whether to ask for permission to continue.'
+			'Provide yes or no. Whether to ask for permission to continue.',
+			'no'
 		);
 	}
 


### PR DESCRIPTION
…and decryptall

Add default option 'no' to --continue
option for the command decryptall.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add option no to `--continue` for command decryptall.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/encryption/issues/51

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add option no to `--continue` for command decryptall.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create 2 users `admin` and `user1`.
- Enable user-keys encryption
- Below is the logs captured from the console
```
➜  owncloud2 git:(add-default-option-decrypt-all-stable10) ✗ ./occ encryption:decrypt-all       
Cannot load Xdebug - it was already loaded
Disable server side encryption... done.


You are about to start to decrypt all files stored in your ownCloud.
It will depend on the encryption module and your setup if this is possible.
Depending on the number and size of your files this can take some time
Please make sure that no user access his files during this process!

Do you really want to continue? (y/n) y
prepare encryption modules...
 done.


 starting to decrypt files... 
 [->--------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
 decrypt files for user admin (1 of 2): /admin/files/welcome.txt 
 [-->-------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
 decrypt files for user user1 (2 of 2): /user1/files/welcome.txt 
 [--->------------------------]

 starting to decrypt files... finished 
 [============================]


all files could be decrypted successfully!
➜  owncloud2 git:(add-default-option-decrypt-all-stable10) ✗  ./occ encryption:enable 
Cannot load Xdebug - it was already loaded
Encryption enabled

Default module: OC_DEFAULT_MODULE
➜  owncloud2 git:(add-default-option-decrypt-all-stable10) ✗ ./occ encryption:decrypt-all  -c yes      
Cannot load Xdebug - it was already loaded
Disable server side encryption... done.


You are about to start to decrypt all files stored in your ownCloud.
It will depend on the encryption module and your setup if this is possible.
Depending on the number and size of your files this can take some time
Please make sure that no user access his files during this process!

prepare encryption modules...
 done.


 starting to decrypt files... 
 [->--------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
 decrypt files for user admin (1 of 2): /admin/files/welcome.txt 
 [-->-------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
 decrypt files for user user1 (2 of 2): /user1/files/welcome.txt 
 [--->------------------------]

 starting to decrypt files... finished 
 [============================]


all files could be decrypted successfully!
➜  owncloud2 git:(add-default-option-decrypt-all-stable10) ✗ ./occ encryption:enable             
Cannot load Xdebug - it was already loaded
Encryption enabled

Default module: OC_DEFAULT_MODULE
➜  owncloud2 git:(add-default-option-decrypt-all-stable10) ✗ ./occ encryption:decrypt-all  user1  
Cannot load Xdebug - it was already loaded
Disable server side encryption... done.


You are about to start to decrypt all files stored in user1's account.
It will depend on the encryption module and your setup if this is possible.
Depending on the number and size of your files this can take some time
Please make sure that no user access his files during this process!

Do you really want to continue? (y/n) y
prepare encryption modules...
 done.


 starting to decrypt files... 
 [->--------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
 decrypt files for user user1 (1 of 1): /user1/files/welcome.txt 
 [-->-------------------------]

 starting to decrypt files... finished 
 [============================]


all files could be decrypted successfully!
Server side encryption remains enabled
➜  owncloud2 git:(add-default-option-decrypt-all-stable10) ✗ ./occ encryption:decrypt-all  -c yes user1
Cannot load Xdebug - it was already loaded
Disable server side encryption... done.


You are about to start to decrypt all files stored in user1's account.
It will depend on the encryption module and your setup if this is possible.
Depending on the number and size of your files this can take some time
Please make sure that no user access his files during this process!

prepare encryption modules...
 done.


 starting to decrypt files... 
 [->--------------------------]
Prepare "Default encryption module"

Configuring encryption module for decryption with user based keys
 decrypt files for user user1 (1 of 1): /user1/files/welcome.txt 
 [-->-------------------------]

 starting to decrypt files... finished 
 [============================]


all files could be decrypted successfully!
Server side encryption remains enabled
➜  owncloud2 git:(add-default-option-decrypt-all-stable10) ✗
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
