### PR TITLE
allow omitting leading slash before file name for makeSabrePath

### DIFF
--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -516,7 +516,6 @@ trait Tags {
 	 *
 	 * @param string $fileName
 	 * @param string $sharingUser
-	 * @param TableNode $table
 	 *
 	 * @return bool
 	 * @throws \Exception
@@ -535,7 +534,6 @@ trait Tags {
 	 *
 	 * @param string $fileName
 	 * @param string $user
-	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws \Exception

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -731,7 +731,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function userHasSetPropertyOfEntryTo(
-		$user, $propertyName, $path, $complex = '', $propertyValue
+		$user, $propertyName, $path, $complex, $propertyValue
 	) {
 		$client = $this->getSabreClient($user);
 		if ($complex === 'complex') {

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -764,9 +764,7 @@ trait WebDav {
 	public function asTheFileOrFolderShouldNotExist($user, $entry, $path) {
 		$client = $this->getSabreClient($user);
 		$response = $client->request(
-			'HEAD', $this->makeSabrePath(
-				$user, '/' . \ltrim($path, '/')
-			)
+			'HEAD', $this->makeSabrePath($user, $path)
 		);
 		if ($response['statusCode'] !== 404) {
 			throw new \Exception(
@@ -1170,7 +1168,9 @@ trait WebDav {
 	 * @return string
 	 */
 	public function makeSabrePath($user, $path) {
-		return $this->encodePath($this->getDavFilesPath($user) . $path);
+		return $this->encodePath(
+			$this->getDavFilesPath($user) . '/' . \ltrim($path, '/')
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -277,6 +277,17 @@ trait WebDav {
 	}
 
 	/**
+	 * @param string $user
+	 * @param string $fileDestination
+	 *
+	 * @return string
+	 */
+	private function destinationHeaderValue($user, $fileDestination) {
+		$fullUrl = $this->getBaseUrl() . '/' . $this->getDavFilesPath($user);
+		return $fullUrl . '/' . \ltrim($fileDestination, '/');
+	}
+
+	/**
 	 * @Given /^user "([^"]*)" has moved (?:file|folder|entry) "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -288,8 +299,9 @@ trait WebDav {
 	public function userHasMovedFile(
 		$user, $fileSource, $fileDestination
 	) {
-		$fullUrl = $this->getBaseUrl() . '/' . $this->getDavFilesPath($user);
-		$headers['Destination'] = $fullUrl . $fileDestination;
+		$headers['Destination'] = $this->destinationHeaderValue(
+			$user, $fileDestination
+		);
 		$this->response = $this->makeDavRequest(
 			$user, "MOVE", $fileSource, $headers
 		);
@@ -310,8 +322,9 @@ trait WebDav {
 	public function userMovesFileUsingTheAPI(
 		$user, $fileSource, $fileDestination
 	) {
-		$fullUrl = $this->getBaseUrl() . '/' . $this->getDavFilesPath($user);
-		$headers['Destination'] = $fullUrl . $fileDestination;
+		$headers['Destination'] = $this->destinationHeaderValue(
+			$user, $fileDestination
+		);
 		$this->response = $this->makeDavRequest(
 			$user, "MOVE", $fileSource, $headers
 		);
@@ -349,8 +362,9 @@ trait WebDav {
 	public function userCopiesFileUsingTheAPI(
 		$user, $fileSource, $fileDestination
 	) {
-		$fullUrl = $this->getBaseUrl() . '/' . $this->getDavFilesPath($user);
-		$headers['Destination'] = $fullUrl . $fileDestination;
+		$headers['Destination'] = $this->destinationHeaderValue(
+			$user, $fileDestination
+		);
 		$this->response = $this->makeDavRequest(
 			$user, "COPY", $fileSource, $headers
 		);
@@ -1880,16 +1894,16 @@ trait WebDav {
 	 *
 	 * @param string $user user
 	 * @param string $id upload id
-	 * @param string $dest destination path
+	 * @param string $destination destination path
 	 * @param array $headers extra headers
 	 *
 	 * @return void
 	 */
-	private function moveNewDavChunkToFinalFile($user, $id, $dest, $headers) {
+	private function moveNewDavChunkToFinalFile($user, $id, $destination, $headers) {
 		$source = "/uploads/$user/$id/.file";
-		$destination = $this->getBaseUrl() . '/' . $this->getDavFilesPath($user) . $dest;
-
-		$headers['Destination'] = $destination;
+		$headers['Destination'] = $this->destinationHeaderValue(
+			$user, $destination
+		);
 
 		$this->response = $this->makeDavRequest(
 			$user, 'MOVE', $source, $headers, null, "uploads"

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -134,6 +134,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 *
 	 * @param OwncloudPage $owncloudPage
 	 * @param LoginPage $loginPage
+	 * @param GeneralErrorPage $generalErrorPage
 	 */
 	public function __construct(
 		OwncloudPage $owncloudPage,
@@ -237,6 +238,8 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @param string $regexSearch
 	 * @param string $errorMessage
 	 * @param int $numEmails which number of multiple emails to read (first email is 1)
+	 *
+	 * @return void
 	 */
 	public function followLinkFromEmail($emailAddress, $regexSearch, $errorMessage, $numEmails = 1) {
 		$content = EmailHelper::getBodyOfEmail(


### PR DESCRIPTION
## Description
1) Let callers pass a file name and/or path to ``makeSabrePath`` with or without a leading slash.
2) When moving a file, construct the 'Destination' header value putting the slash in if needed.
3) Fix some code style.

## Motivation and Context
Test steps can say:
```
Then as "user0" the file "abc.txt" should not exist
```

But if the file should exist, the file name has to be preceded by a slash:
```
Then as "user0" the file "/abc.txt" should exist
```

Code in the first case puts in the root ``/`` if it is not specified. In the 2nd case it does not.

I annoyed myself again 1 last time with this while writing a test scenario today, so take 5 minutes to make it consistent.

## How Has This Been Tested?
Try it in a test scenario that I am developing.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
