### PR TITLE
[stable10] Backport of Fix user-keys encryption when user created wit…

### DIFF
--- a/apps/encryption/lib/Hooks/UserHooks.php
+++ b/apps/encryption/lib/Hooks/UserHooks.php
@@ -246,9 +246,14 @@ class UserHooks implements IHook {
 	 */
 	public function setPassphrase($params) {
 
-		// Get existing decrypted private key
-		$privateKey = $this->session->getPrivateKey();
-		$user = $this->user->getUser();
+		$privateKey = null;
+		$user = null;
+		//Check if the session is there or not
+		if ($this->user->getUser() !== null) {
+			// Get existing decrypted private key
+			$privateKey = $this->session->getPrivateKey();
+			$user = $this->user->getUser();
+		}
 
 		// current logged in user changes his own password
 		if ($user && $params['uid'] === $user->getUID() && $privateKey) {


### PR DESCRIPTION
…h email

When user tries to set the password without logging
in for once and no session available, the user-keys
encryption was failing to create the private key
for the new password. This change helps to fix the
issue.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
With the new user creation with email address, the user-keys encryption were failing. That is user was not able to set the password, who is not even logged in and there is no session available. This change fixes the issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/encryption/issues/54

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With the new user creation with email address, the user-keys encryption were failing. That is user was not able to set the password, who is not even logged in and there is no session available. This change fixes the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create `admin` user and enable encryption with masterkeys
- Create `user1` with lets say `foo@gmail.com`.
- An email should arrive to `foo@gmail.com`, click the link provided in the email to set the password.
- There should not be any issue faced while setting the password for `user1`
- Now do the same procedure with masterkey encryption enabled. 
- It worked fine.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
