### PR TITLE
[stable10] Backport of Fix the token exception classes to avoid infin…

### DIFF
--- a/lib/public/InvalidUserTokenException.php
+++ b/lib/public/InvalidUserTokenException.php
@@ -28,6 +28,7 @@ namespace OCP;
  * @since 10.0.10
  */
 class InvalidUserTokenException extends UserTokenException {
+
 	/**
 	 * InvalidUserTokenException constructor.
 	 *
@@ -35,7 +36,7 @@ class InvalidUserTokenException extends UserTokenException {
 	 * @param int $code
 	 * @since 10.0.10
 	 */
-	public function __construct($message = "", $code = 0) {
-		parent::__construct($message, $code, $this);
+	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+		parent::__construct($message, $code, $previous);
 	}
 }

--- a/lib/public/UserTokenExpiredException.php
+++ b/lib/public/UserTokenExpiredException.php
@@ -28,6 +28,9 @@ namespace OCP;
  * @since 10.0.10
  */
 class UserTokenExpiredException extends UserTokenException {
+	/** @var UserTokenExpiredException */
+	private $previousException;
+
 	/**
 	 * UserTokenExpiredException constructor.
 	 *
@@ -35,7 +38,7 @@ class UserTokenExpiredException extends UserTokenException {
 	 * @param int $code
 	 * @since 10.0.10
 	 */
-	public function __construct($message = "", $code = 0) {
-		parent::__construct($message, $code, $this);
+	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+		parent::__construct($message, $code, $previous);
 	}
 }

--- a/lib/public/UserTokenMismatchException.php
+++ b/lib/public/UserTokenMismatchException.php
@@ -35,7 +35,7 @@ class UserTokenMismatchException extends UserTokenException {
 	 * @param int $code
 	 * @since 10.0.10
 	 */
-	public function __construct($message = "", $code = 0) {
-		parent::__construct($message, $code, $this);
+	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+		parent::__construct($message, $code, $previous);
 	}
 }

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -522,7 +522,7 @@ class UsersController extends Controller {
 		try {
 			$this->checkPasswordSetToken($token, $userId);
 		} catch (UserTokenException $e) {
-			if ($e->getPrevious() instanceof UserTokenExpiredException) {
+			if ($e instanceof UserTokenExpiredException) {
 				return new TemplateResponse(
 					'settings', 'resendtokenbymail',
 					[


### PR DESCRIPTION
…ite loop with getPrevious

Fix the users token exception class to avoid infinite
loop when getPrevious method is called.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This change removes the usage of `$this` to the previous exception arg passed. It was causing infinite loop while logging exceptions, when used with other apps.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/32684

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change removes the usage of `$this` to the previous exception arg passed. It was causing infinite loop while logging exceptions, when used with other apps.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create user `admin` and login as admin
- Now try to create user `user1` with email as `bar@bar.com`
- Now delete `user1`
- Create `user1` again with email as `foo@bar.com`
- Now try to access the link obtained at `bar@bar.com`. Invalid token is observed.
- Try to access the link obtained at `foo@bar.com`. The set password page is shown to user. Correct behaviour.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
