### PR TITLE
Support more licenses: gpl and ocl

### DIFF
--- a/build/license.php
+++ b/build/license.php
@@ -22,9 +22,10 @@ class Licenses {
 	protected $paths = [];
 	protected $mailMap = [];
 	public $authors = [];
+	private $licenseText = [];
 
 	public function __construct() {
-		$this->licenseText = <<<EOD
+		$this->licenseText['agpl'] = <<<EOD
 /**
 @AUTHORS@
  *
@@ -45,18 +46,61 @@ class Licenses {
  *
  */
 EOD;
-		$this->licenseText = \str_replace('@YEAR@', \date("Y"), $this->licenseText);
+		$this->licenseText['gpl'] = <<<EOS
+/**
+@AUTHORS@
+ *
+ * @copyright Copyright (c) @YEAR@, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+EOS;
+		$this->licenseText['ocl'] = <<<EOS
+/**
+ *
+ * @copyright Copyright (c) @YEAR@, ownCloud GmbH
+ * @license OCL
+ *
+ * This code is covered by the ownCloud Commercial License.
+ *
+ * You should have received a copy of the ownCloud Commercial License
+ * along with this program. If not, see <https://owncloud.com/licenses/owncloud-commercial/>.
+ *
+ */
+EOS;
+
+		$this->licenseText = \array_map(function ($text) {
+			return \str_replace('@YEAR@', \date('Y'), $text);
+		}, $this->licenseText);
 	}
 
 	/**
 	 * @param string|string[] $folder
 	 * @param string|bool $gitRoot
 	 */
-	function exec($folder, $gitRoot = false) {
+	function exec($folder, $license, $gitRoot = false) {
+		if (isset($this->licenseText[$license])) {
+			echo "Unknown license $license. Supported: agpl, gpl or ocl";
+		}
+		$license = $this->licenseText[$license];
 
 		if (\is_array($folder)) {
 			foreach($folder as $f) {
-				$this->exec($f, $gitRoot);
+				$this->exec($f, $license, $gitRoot);
 			}
 			return;
 		}
@@ -66,7 +110,7 @@ EOD;
 		}
 
 		if (\is_file($folder)) {
-			$this->handleFile($folder, $gitRoot);
+			$this->handleFile($folder, $license, $gitRoot);
 			return;
 		}
 
@@ -89,7 +133,7 @@ EOD;
 
 		foreach ($iterator as $file) {
 			/** @var SplFileInfo $file */
-			$this->handleFile($file, $gitRoot);
+			$this->handleFile($file, $license, $gitRoot);
 		}
 	}
 
@@ -117,7 +161,7 @@ With help from many libraries and frameworks including:
 	 * @param string $path
 	 * @param string|bool $gitRoot
 	 */
-	function handleFile($path, $gitRoot) {
+	function handleFile($path, $license, $gitRoot) {
 		$source = \file_get_contents($path);
 		if ($this->isMITLicensed($source)) {
 			echo "MIT licensed file: $path" . PHP_EOL;
@@ -125,7 +169,7 @@ With help from many libraries and frameworks including:
 		}
 		$source = $this->eatOldLicense($source);
 		$authors = $this->getAuthors($path, $gitRoot);
-		$license = \str_replace('@AUTHORS@', $authors, $this->licenseText);
+		$license = \str_replace('@AUTHORS@', $authors, $license);
 
 		$source = "<?php" . PHP_EOL . $license . PHP_EOL . $source;
 		\file_put_contents($path,$source);
@@ -201,9 +245,9 @@ With help from many libraries and frameworks including:
 		}
 
 		$out = \shell_exec(
-			\sprintf("git blame --line-porcelain -L %d, %s | sed -n 's/^author //p;s/^author-mail //p' | sed 'N;s/\\n/ /' | sort -f | uniq"),
+			\sprintf("git blame --line-porcelain -L %d, %s | sed -n 's/^author //p;s/^author-mail //p' | sed 'N;s/\\n/ /' | sort -f | uniq",
 			(int)$licenseHeaderEndsAtLine,
-			\escapeshellarg($file)
+			\escapeshellarg($file))
 		);
 
 		if ($gitRoot) {
@@ -255,7 +299,11 @@ With help from many libraries and frameworks including:
 
 $licenses = new Licenses;
 if (isset($argv[1])) {
-	$licenses->exec($argv[1], isset($argv[2]) ? $argv[1] : false);
+	if (!isset($argv[2])) {
+		echo 'Second argument has to be the license';
+		return;
+	}
+	$licenses->exec($argv[1], $argv[2], isset($argv[3]) ? $argv[1] : false);
 } else {
 
 	$licenses->exec([
@@ -284,6 +332,6 @@ if (isset($argv[1])) {
 		__DIR__ . '/../remote.php',
 		__DIR__ . '/../status.php',
 		__DIR__ . '/../version.php',
-	]);
+	], 'agpl');
 	$licenses->writeAuthorsFile();
 }


### PR DESCRIPTION
## Description
the build script license.php now supports the licenses gpl and ocl in addition to agpl

## How Has This Been Tested?
https://github.com/owncloud/data_exporter/pull/45

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
