### PR TITLE
Deletion of user should also delete applicable users for the storage

### DIFF
--- a/tests/lib/Files/External/Service/UserStoragesServiceTest.php
+++ b/tests/lib/Files/External/Service/UserStoragesServiceTest.php
@@ -24,6 +24,7 @@
 namespace Test\Files\External\Service;
 
 use OC\Files\Config\UserMountCache;
+use OC\Files\External\Service\DBConfigService;
 use OC\Files\External\Service\GlobalStoragesService;
 use OC\Files\External\Service\UserStoragesService;
 use OC\Files\External\StorageConfig;
@@ -258,6 +259,11 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 		$backendService = \OC::$server->getStoragesBackendService();
 		$userSession = \OC::$server->getUserSession();
 		$this->service = new UserStoragesService($backendService, $this->dbConfig, $userSession, $userMountCache);
+
+		$dbConfigService = new DBConfigService(\OC::$server->getDatabaseConnection(), \OC::$server->getCrypto());
+		$id = $dbConfigService->addMount('/directtest', 'foo', 'bar', 100, DBConfigService::MOUNT_TYPE_PERSONAl);
+		$dbConfigService->addApplicable($id, DBConfigService::APPLICABLE_TYPE_USER, 'user1');
+
 		$this->assertTrue($this->service->deleteAllMountsForUser($user1));
 		$storarge1Result1 = $userMountCache->getMountsForStorageId(10);
 		$storarge1Result2 = $userMountCache->getMountsForStorageId(12);
@@ -265,5 +271,6 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 		$this->assertEquals(1, \count($storarge1Result2));
 		$this->assertEquals(12, $storarge1Result2[0]->getStorageId());
 		$this->assertEquals('/bar/', $storarge1Result2[0]->getMountPoint());
+		$this->assertNull($dbConfigService->getMountById($id));
 	}
 }


### PR DESCRIPTION
When a user is deleted the storage added by the user
should be removed from the db. This change helps to
remove the user from the applicable with the help
of DBConfigService.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
When a user is deleted, the storages created by user should be cleaned from the db. That is the applicable array should not have any more residues about the user.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/32637

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When a user is deleted, the storages created by user should be cleaned from the db. That is the applicable array should not have any more residues about the user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Following the procedure from steps to produce in https://github.com/owncloud/core/issues/32637#issue-358009322:
- In the newly installed machine before deleting `user4` the tables were like this:
```
sqlite> select * from oc_mounts;
id          storage_id  root_id     user_id     mount_point
----------  ----------  ----------  ----------  -----------
1           1           1           admin       /admin/    
2           4           23          user4       /user4/    
3           3           28          user4       /user4/file
sqlite> select * from oc_external_applicable;
applicable_id  mount_id    type        value     
-------------  ----------  ----------  ----------
1              1           1                     
3              2           3           user1     
4              2           3           user2     
5              2           3           user4     
6              2           3           user3     
7              3           3           user4     
sqlite> select * from oc_external_mounts;
mount_id    mount_point  storage_backend  auth_backend        priority    type      
----------  -----------  ---------------  ------------------  ----------  ----------
1           /sftp        sftp             password::password  100         1         
2           /sftpuser4   sftp             password::password  100         1         
3           /sftpdirect  sftp             password::password  100         2         
sqlite> select * from oc_external_config;
config_id   mount_id    key         value     
----------  ----------  ----------  ----------
1           1           host        localhost 
2           1           root        /tmp/a    
3           1           user        sujith    
4           1           password    9f16a17347
5           2           host        localhost 
6           2           root        /tmp/a    
7           2           user        sujith    
8           2           password    aaafba9dc9
9           3           host        localhost 
10          3           root        /tmp/a    
11          3           user        sujith    
12          3           password    6c9d98c910
sqlite>
```
- After `user4` is deleted table is as shown below:
```
sqlite> select * from oc_mounts;
id          storage_id  root_id     user_id     mount_point
----------  ----------  ----------  ----------  -----------
1           1           1           admin       /admin/    
4           3           28          admin       /admin/file
sqlite> select * from oc_external_applicable;
applicable_id  mount_id    type        value     
-------------  ----------  ----------  ----------
1              1           1                     
3              2           3           user1     
4              2           3           user2     
6              2           3           user3     
sqlite> select * from oc_external_mounts;
mount_id    mount_point  storage_backend  auth_backend        priority    type      
----------  -----------  ---------------  ------------------  ----------  ----------
1           /sftp        sftp             password::password  100         1         
2           /sftpuser4   sftp             password::password  100         1         
sqlite> select * from oc_external_config;
config_id   mount_id    key         value     
----------  ----------  ----------  ----------
1           1           host        localhost 
2           1           root        /tmp/a    
3           1           user        sujith    
4           1           password    9f16a17347
5           2           host        localhost 
6           2           root        /tmp/a    
7           2           user        sujith    
8           2           password    aaafba9dc9
sqlite>
```
- Create `user4` again and the table is as shown:
```
sqlite> select * from oc_mounts;
id          storage_id  root_id     user_id     mount_point
----------  ----------  ----------  ----------  -----------
1           1           1           admin       /admin/    
4           3           28          admin       /admin/file
5           3           28          user4       /user4/file
6           5           33          user4       /user4/    
sqlite> select * from oc_external_applicable;
applicable_id  mount_id    type        value     
-------------  ----------  ----------  ----------
1              1           1                     
3              2           3           user1     
4              2           3           user2     
6              2           3           user3     
8              2           3           user4     
9              4           3           user4     
sqlite> select * from oc_external_mounts;
mount_id    mount_point  storage_backend  auth_backend        priority    type      
----------  -----------  ---------------  ------------------  ----------  ----------
1           /sftp        sftp             password::password  100         1         
2           /sftpuser4   sftp             password::password  100         1         
4           /sftpdirect  sftp             password::password  100         2         
sqlite> select * from oc_external_config;
config_id   mount_id    key         value     
----------  ----------  ----------  ----------
1           1           host        localhost 
2           1           root        /tmp/a    
3           1           user        sujith    
4           1           password    9f16a17347
5           2           host        localhost 
6           2           root        /tmp/a    
7           2           user        sujith    
8           2           password    aaafba9dc9
13          4           host        localhost 
14          4           root        /tmp/a    
15          4           user        sujith    
16          4           password    7e35de472a
sqlite>
```
- Again delete `user4` and the table is as shown below:
```
sqlite> select * from oc_mounts;
id          storage_id  root_id     user_id     mount_point
----------  ----------  ----------  ----------  -----------
1           1           1           admin       /admin/    
4           3           28          admin       /admin/file
sqlite> select * from oc_external_applicable;
applicable_id  mount_id    type        value     
-------------  ----------  ----------  ----------
1              1           1                     
3              2           3           user1     
4              2           3           user2     
6              2           3           user3     
sqlite> select * from oc_external_mounts;
mount_id    mount_point  storage_backend  auth_backend        priority    type      
----------  -----------  ---------------  ------------------  ----------  ----------
1           /sftp        sftp             password::password  100         1         
2           /sftpuser4   sftp             password::password  100         1         
sqlite> select * from oc_external_config;
config_id   mount_id    key         value     
----------  ----------  ----------  ----------
1           1           host        localhost 
2           1           root        /tmp/a    
3           1           user        sujith    
4           1           password    9f16a17347
5           2           host        localhost 
6           2           root        /tmp/a    
7           2           user        sujith    
8           2           password    aaafba9dc9
sqlite>
```
- Also verified after the deletion the admin settings never showed user4 for the storage  `sftpuser4`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
