### PR TITLE
Add test steps to create a public share with an expiry date

### DIFF
--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -77,7 +77,7 @@ class SharingHelper {
 		$sharePassword = null,
 		$permissions = null,
 		$linkName = null,
-		$expireDate = null, // unused, to be implemented
+		$expireDate = null,
 		$ocsApiVersion = 1,
 		$sharingApiVersion = 1
 	) {
@@ -169,6 +169,9 @@ class SharingHelper {
 		}
 		if ($linkName !== null) {
 			$fd['name'] = $linkName;
+		}
+		if ($expireDate !== null) {
+			$fd['expireDate'] = \date('Y-m-d', \strtotime($expireDate));
 		}
 
 		return HttpRequestHelper::post($fullUrl, $user, $password, null, $fd);

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -130,6 +130,8 @@ trait Sharing {
 	 * @param boolean $publicUpload
 	 * @param string|null $sharePassword
 	 * @param string|int|string[]|int[]|null $permissions
+	 * @param string $linkName
+	 * @param string $expireDate
 	 *
 	 * @return void
 	 */
@@ -138,7 +140,9 @@ trait Sharing {
 		$path,
 		$publicUpload = false,
 		$sharePassword = null,
-		$permissions = null
+		$permissions = null,
+		$linkName = null,
+		$expireDate = null
 	) {
 		$this->response = SharingHelper::createShare(
 			$this->getBaseUrl(),
@@ -150,8 +154,8 @@ trait Sharing {
 			$publicUpload,
 			$sharePassword,
 			$permissions,
-			null, // linkName
-			null, // expireDate
+			$linkName,
+			$expireDate,
 			$this->ocsApiVersion,
 			$this->sharingApiVersion
 		);
@@ -210,6 +214,42 @@ trait Sharing {
 	public function aPublicShareOfIsCreatedWithPermission($path, $permissions) {
 		$this->createAPublicShare(
 			$this->currentUser, $path, true, null, $permissions
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)" using the sharing API with expiry "([^"]*)"$/
+	 * @Given /^user "([^"]*)" has created a public share of (?:file|folder) "([^"]*)" with expiry "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $path
+	 * @param string $expiryDate in a valid date format, e.g. "+30 days"
+	 *
+	 * @return void
+	 */
+	public function userCreatesAPublicShareOfWithExpiry(
+		$user, $path, $expiryDate
+	) {
+		$this->createAPublicShare(
+			$user, $path, true, null, null, null, $expiryDate
+		);
+	}
+
+	/**
+	 * @When /^the user creates a public share of (?:file|folder) "([^"]*)" using the sharing API with expiry "([^"]*)$"/
+	 * @Given /^the user has created a public share of (?:file|folder) "([^"]*)" with expiry "([^"]*)$/
+	 *
+	 * @param string $user
+	 * @param string $path
+	 * @param string $expiryDate in a valid date format, e.g. "+30 days"
+	 *
+	 * @return void
+	 */
+	public function aPublicShareOfIsCreatedWithExpiry(
+		$user, $path, $expiryDate
+	) {
+		$this->createAPublicShare(
+			$this->currentUser, $path, true, null, null, null, $expiryDate
 		);
 	}
 
@@ -544,6 +584,7 @@ trait Sharing {
 	 * @param string $password
 	 * @param int $permissions
 	 * @param string $linkName
+	 * @param string $expireDate
 	 *
 	 * @return void
 	 */
@@ -555,7 +596,8 @@ trait Sharing {
 		$publicUpload = null,
 		$password = null,
 		$permissions = null,
-		$linkName = null
+		$linkName = null,
+		$expireDate = null
 	) {
 		$this->response = SharingHelper::createShare(
 			$this->getBaseUrl(),
@@ -568,7 +610,7 @@ trait Sharing {
 			$password,
 			$permissions,
 			$linkName,
-			null, //expireDate
+			$expireDate,
 			$this->ocsApiVersion,
 			$this->sharingApiVersion
 		);


### PR DESCRIPTION
## Description
Add acceptance test steps that allow "creates a share with expiry".
Implement the ``expireDate`` parameter in ``SharingHelper`` - for some reason nobody ever got around to doing this.

## Motivation and Context
We need to be able to test creating a public share with an expiry date.

At the moment it has to be done in 2 steps, create the share then set the expiry date. So we cannot test fully the API endpoint that creates the share in the first place.

## How Has This Been Tested?
Local runs of app acceptance tests that need to use this new step.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
