### PR TITLE
do not use stream to check file downloads

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -320,9 +320,7 @@ trait Sharing {
 		$url, $user = null, $password = null, $mimeType = null
 	) {
 		$headers = ['X-Requested-With' => 'XMLHttpRequest'];
-		$this->response = HttpRequestHelper::get(
-			$url, $user, $password, $headers, null, null, null, true
-		);
+		$this->response = HttpRequestHelper::get($url, $user, $password, $headers);
 		PHPUnit_Framework_Assert::assertEquals(
 			200,
 			$this->response->getStatusCode()
@@ -470,7 +468,7 @@ trait Sharing {
 			$headers['OC-Autorename'] = 1;
 		}
 		$this->response = HttpRequestHelper::put(
-			$url, $token, $password, $headers, $body, null, null, true
+			$url, $token, $password, $headers, $body
 		);
 	}
 


### PR DESCRIPTION
## Description
after https://github.com/owncloud/core/pull/32594 we do user `stream` and `timeout` option together for guzzle, sometimes they don't work together and we receive `GuzzleHttp\Ring\Exception\RingException`
This specially happens with LDAP and encryption testing
I don't think we need the stream upload here in the first place
Even the change of #32594 is not yet in master we want to have the change here also

## How Has This Been Tested?
run failing tests in stable10 with the changes

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
