### PR TITLE
Acceptance test steps for status messages and reason phrases

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -818,6 +818,100 @@ trait BasicStructure {
 	}
 
 	/**
+	 * Check the text in an HTTP reason phrase
+	 *
+	 * @Then /^the HTTP reason phrase should be "([^"]*)"$/
+	 *
+	 * @param string $reasonPhrase
+	 *
+	 * @return void
+	 */
+	public function theHTTPReasonPhraseShouldBe($reasonPhrase) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$reasonPhrase,
+			$this->getResponse()->getReasonPhrase(),
+			'Unexpected HTTP reason phrase in response'
+		);
+	}
+
+	/**
+	 * Check the text in an HTTP reason phrase
+	 * Use this step form if the expected text contains double quotes,
+	 * single quotes and other content that theHTTPReasonPhraseShouldBe()
+	 * cannot handle.
+	 *
+	 * After the step, write the expected text in PyString form like:
+	 *
+	 * """
+	 * File "abc.txt" can't be shared due to reason "xyz"
+	 * """
+	 *
+	 * @Then /^the HTTP reason phrase should be:$/
+	 *
+	 * @param PyStringNode $reasonPhrase
+	 *
+	 * @return void
+	 */
+	public function theHTTPReasonPhraseShouldBePyString(
+		PyStringNode $reasonPhrase
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$reasonPhrase->getRaw(),
+			$this->getResponse()->getReasonPhrase(),
+			'Unexpected HTTP reason phrase in response'
+		);
+	}
+
+	/**
+	 * Check the text in an OCS status message
+	 *
+	 * @Then /^the OCS status message should be "([^"]*)"$/
+	 *
+	 * @param string $statusMessage
+	 *
+	 * @return void
+	 */
+	public function theOCSStatusMessageShouldBe($statusMessage) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$statusMessage,
+			$this->getOCSResponseStatusMessage(
+				$this->getResponse()
+			),
+			'Unexpected OCS status message in response'
+		);
+	}
+
+	/**
+	 * Check the text in an OCS status message.
+	 * Use this step form if the expected text contains double quotes,
+	 * single quotes and other content that theOCSStatusMessageShouldBe()
+	 * cannot handle.
+	 *
+	 * After the step, write the expected text in PyString form like:
+	 *
+	 * """
+	 * File "abc.txt" can't be shared due to reason "xyz"
+	 * """
+	 *
+	 * @Then /^the OCS status message should be:$/
+	 *
+	 * @param PyStringNode $statusMessage
+	 *
+	 * @return void
+	 */
+	public function theOCSStatusMessageShouldBePyString(
+		PyStringNode $statusMessage
+	) {
+		PHPUnit_Framework_Assert::assertEquals(
+			$statusMessage->getRaw(),
+			$this->getOCSResponseStatusMessage(
+				$this->getResponse()
+			),
+			'Unexpected OCS status message in response'
+		);
+	}
+
+	/**
 	 * @Then /^the XML "([^"]*)" "([^"]*)" value should be "([^"]*)"$/
 	 *
 	 * @param string $key1


### PR DESCRIPTION
## Description
Add acceptance test steps that can check the text of the message that comes with an HTTP or OCS response status code.

For HTTP it is called "reason phrase".
For OCS, we call it "status message".

## Motivation and Context
We don't have any acceptance test steps that let you check the text message that comes with an HTTP or OCS response status code.

## How Has This Been Tested?
Running some new app acceptance test scenarios locally that will use these steps.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
