### PR TITLE
Add missing require_once bootstrap.php to acceptance test contexts

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIAdminAppsSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminAppsSettingsContext.php
@@ -26,6 +26,8 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\AdminAppsSettingsPage;
 
+require_once 'bootstrap.php';
+
 /**
  * WebUI AdminAppsSettings context.
  */

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -26,6 +26,8 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Page\AdminSharingSettingsPage;
 
+require_once 'bootstrap.php';
+
 /**
  * WebUI AdminSharingSettings context.
  */


### PR DESCRIPTION
## Description
Add the missing ``require_once`` to be consistent.

## Motivation and Context
```
require_once 'bootstrap.php';
```
is missing from some acceptance test Behat context PHP files.

It does not seem to be a problem when running the suites like we do with ``run.sh`` (which puts a lot of ``behat`` switches on the command). But when running a raw ``behat`` command, there can be errors like:
```
Can not find a matching value for an argument `$adminSharingSettingsPage` of the method `WebUIAdminSharingSettingsContext::__construct()`.
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
