### PR TITLE
Set content-length to 0 for lazyops 202 response

### DIFF
--- a/apps/dav/lib/DAV/LazyOpsPlugin.php
+++ b/apps/dav/lib/DAV/LazyOpsPlugin.php
@@ -100,6 +100,7 @@ class LazyOpsPlugin extends ServerPlugin {
 
 		$response->setStatus(202);
 		$response->setHeader('Connection', 'close');
+		$response->setHeader('Content-Length', '0');
 		$response->setHeader('OC-JobStatus-Location', $location);
 
 		$this->shutdownManager->register(function () use ($request, $response) {

--- a/apps/dav/tests/unit/DAV/LazyOpsPluginTest.php
+++ b/apps/dav/tests/unit/DAV/LazyOpsPluginTest.php
@@ -84,8 +84,9 @@ class LazyOpsPluginTest extends TestCase {
 		$request->method('getHeader')->with('OC-LazyOps')->willReturn(true);
 		$response= $this->createMock(ResponseInterface::class);
 		$response->expects($this->once())->method('setStatus')->with(202);
-		$response->expects($this->exactly(2))->method('setHeader')->withConsecutive(
+		$response->expects($this->exactly(3))->method('setHeader')->withConsecutive(
 			['Connection', 'close'],
+			['Content-Length', '0'],
 			['OC-JobStatus-Location', self::stringStartsWith('/remote.php/dav/job-status/alice/')]
 		);
 

--- a/tests/acceptance/features/apiWebdavOperations/uploadFileAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavOperations/uploadFileAsyncUsingNewChunking.feature
@@ -18,6 +18,8 @@ Feature: upload file using new chunking
       | 3 | CCCCC |
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^finished$/      |
@@ -34,6 +36,8 @@ Feature: upload file using new chunking
       | 1 | AAAAA |
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^finished$/      |
@@ -50,6 +54,8 @@ Feature: upload file using new chunking
       | 1 | AAAAA |
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^finished$/      |
@@ -67,6 +73,8 @@ Feature: upload file using new chunking
       | 3 | CCCCC |
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^finished$/      |
@@ -93,6 +101,8 @@ Feature: upload file using new chunking
     When user "user0" moves new chunk file with id "chunking-42" asynchronously to "/myChunkedFile.txt" with size 5 using the WebDAV API
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status       | /^error$/ |
@@ -104,9 +114,12 @@ Feature: upload file using new chunking
     And user "user0" has uploaded new chunk file "1" with "AAAAA" to id "chunking-42"
     And user "user0" has uploaded new chunk file "2" with "BBBBB" to id "chunking-42"
     And user "user0" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
+    And the MOVE dav requests are slowed down by 3 seconds
     When user "user0" moves new chunk file with id "chunking-42" asynchronously to "/myChunkedFile.txt" with size 15 using the WebDAV API
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^finished$/      |
@@ -122,9 +135,12 @@ Feature: upload file using new chunking
     And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
     And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
     And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And the MOVE dav requests are slowed down by 3 seconds
     And user "user0" moves new chunk file with id "chunking-42" asynchronously to "/<file-name>" using the WebDAV API
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^finished$/      |

--- a/tests/acceptance/features/apiWebdavProperties/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavProperties/moveFileAsync.feature
@@ -13,6 +13,8 @@ Feature: move (rename) file
     When user "user0" moves file "/welcome.txt" asynchronously to "/FOLDER/<destination-file-name>" using the WebDAV API
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^finished$/      |
@@ -33,6 +35,8 @@ Feature: move (rename) file
     When user "user0" moves file "/welcome.txt" asynchronously to "/FOLDER/welcome.txt" using the WebDAV API
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | ETag   | /^[0-9a-f]{32}$/  |
@@ -42,8 +46,11 @@ Feature: move (rename) file
 
   Scenario: Moving and overwriting a file
     When user "user0" moves file "/welcome.txt" asynchronously to "/textfile0.txt" using the WebDAV API
+    And the MOVE dav requests are slowed down by 3 seconds
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^finished$/      |
@@ -56,6 +63,8 @@ Feature: move (rename) file
     When user "user0" moves file "/textfile0.txt" asynchronously to "/TextFile0.txt" using the WebDAV API
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^finished$/      |
@@ -68,6 +77,8 @@ Feature: move (rename) file
     When user "user0" moves file "/textfile1.txt" asynchronously to "/TextFile0.txt" using the WebDAV API
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^finished$/      |
@@ -81,6 +92,8 @@ Feature: move (rename) file
     When user "user0" moves file "/textfile1.txt" asynchronously to "/PARENT/Parent.txt" using the WebDAV API
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^finished$/      |
@@ -258,12 +271,14 @@ Feature: move (rename) file
   Scenario: Moving and overwriting a file
     #need to slowdown the request for longer than the timeout
     #when doing LazyOps the server does not close the connection
-    #so we timout the request and chech the job-status
+    #so we timeout the request and check the job-status
     Given the HTTP-Request-timeout is set to 5 seconds
     And the MOVE dav requests are slowed down by 10 seconds
     When user "user0" moves file "/welcome.txt" asynchronously to "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "202"
     And the following headers should match these regular expressions
+      | Connection | /^close$/ |
+      | Content-Length | /^0$/ |
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/user0\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "user0" should match these regular expressions
       | status | /^started$/      |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
The LazyOps 202 response should have a `Content-Length: 0` header to make any proxy in between close the connection ... maybe even apache itself.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes confused proxies

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- manual testing

## Screenshots (if appropriate):
![error](https://user-images.githubusercontent.com/956847/45553199-89d3c480-b833-11e8-9915-bbd432894db8.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Forward port needed
