### PR TITLE
[stable10] Register areCredentialsValid as a sensitive logging method

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -103,11 +103,14 @@ class Log implements ILogger {
 		//LoginController
 		'tryLogin',
 
-		//bind
+		//User_LDAP\Connection
 		'bind',
 
-		//invokeLDAPMethod
-		'invokeLDAPMethod'
+		//User_LDAP\LDAP
+		'invokeLDAPMethod',
+
+		//User_LDAP\Access
+		'areCredentialsValid'
 
 	];
 


### PR DESCRIPTION
Backport of https://github.com/owncloud/core/pull/32673 to stable10