### PR TITLE
check file existence after upload with wrong checksums

### DIFF
--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -141,12 +141,16 @@ Feature: checksums
     And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
     And user "user0" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:f005ba11" using the WebDAV API
     Then the HTTP status code should be "400"
+    And user "user0" should not see the following elements
+      | /myChunkedFile.txt |
 
   Scenario Outline: Upload a file where checksum does not match
     Given using <dav_version> DAV path
     And file "/chksumtst.txt" has been deleted for user "user0"
     When user "user0" uploads file with checksum "SHA1:f005ba11" and content "Some Text" to "/chksumtst.txt" using the WebDAV API
     Then the HTTP status code should be "400"
+    And user "user0" should not see the following elements
+      | /chksumtst.txt |
     Examples:
 			| dav_version   |
 			| old           |
@@ -194,3 +198,5 @@ Feature: checksums
     Given using new DAV path
     When user "user0" uploads chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e" using the WebDAV API
     Then the HTTP status code should be "503"
+    And user "user0" should not see the following elements
+      | /myChecksumFile.txt |


### PR DESCRIPTION
## Description
when an upload should not work (in this case because of wrong checksums), we should not only check the status code but also if the file exists or not

## Related Issue
- https://github.com/owncloud/files_primary_s3/issues/128

## Motivation and Context
do not trust the code

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
