### PR TITLE
Dont use preferences table quota any longer

### DIFF
--- a/lib/private/User/SyncService.php
+++ b/lib/private/User/SyncService.php
@@ -223,12 +223,6 @@ class SyncService {
 				$a->setQuota($quota);
 			}
 		}
-		if ($quota === null) {
-			list($hasKey, $quota) = $this->readUserConfig($uid, 'files', 'quota');
-			if ($hasKey) {
-				$a->setQuota($quota);
-			}
-		}
 		if (\array_key_exists('quota', $a->getUpdatedFields())) {
 			$this->logger->debug(
 				"Setting quota for <$uid> to <$quota>", ['app' => self::class]


### PR DESCRIPTION
When quota is synced for an account (on login, and on user:sync), it is read from the user backend.

If the backend doesn't provide a quota, or, if it provides null - core (since 10.0.9 https://github.com/owncloud/core/commit/b62cad68f02a0edcc4c720170959b18cb6e44b51) will bring in the quota from `oc_preferences` which is where it was stored before `oc_accounts`. 

The problem comes now because the `user_management` app sets the quota directly on the accounts table - meaning we have two sources of truth for the quota value. If users have manually assigned quotas from their admin, these will have been stored in the accounts table. These will be overwritten with the `oc_preferences` values on user sync (login, or `user:sync`). 

This PR removes the logic from the `SyncService` to take the quota from the `oc_preferences` table - aligning the ownCLoud built in user management to fully utilise the `oc_accounts` table as the source of truth.

However, we now must consider the migration path. There can still be scenarios where the value in `oc_preferences` is the correct source of the quota value. Vice-versa, if the quota is changed in the UI, this value will have been set in the `oc_accounts` table and this should be the value used in future.

Migration proposal:

 - If quota is only in oc_preferences, use this, assign to `oc_accounts`, delete row from `oc_preference` - current behaviour
 - If quota is in `oc_preferences` and `oc_acccounts` and value is the same,  delete row from `oc_preference` - cleanup old row
 - If quota is in `oc_preferences` and `oc_accounts` and the value is different, use `oc_accounts` value,delete row from `oc_preference` - as it will have been assigned manually sign 10 upgrade

This should result in cleaned quotas from `oc_preferences`, and the correctly values present in `oc_accounts` - and future modifications will be persisted correctly. 

Scenarios to consider:
 - upgrade from 9.1 to 10 with ldap
 - direct install to 10.0.10 with this patch
 - setting quota from UI whilst using ldap
