### PR TITLE
Acceptance test steps for public link share

### DIFF
--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -11,9 +11,8 @@ Feature: external-storage
     And user "user0" has created a folder "/local_storage/foo"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo/textfile0.txt"
     And user "user0" has shared folder "/local_storage/foo" with user "user1"
-    When user "user1" creates a share using the sharing API with settings
+    When user "user1" creates a public link share using the sharing API with settings
       | path      | foo |
-      | shareType | 3   |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the share fields of the last share should include

--- a/tests/acceptance/features/apiMain/transfer-ownership.feature
+++ b/tests/acceptance/features/apiMain/transfer-ownership.feature
@@ -186,9 +186,8 @@ Feature: transfer-ownership
 		And user "user0" has created a folder "/test"
 		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
 		And user "user0" has shared folder "/test" with user "user2" with permissions 31
-		And user "user1" has created a share with settings
+		And user "user1" has created a public link share with settings
 			| path      | /test/somefile.txt |
-			| shareType | 3                  |
 		When the administrator transfers ownership of path "test" from "user0" to "user1" using the occ command
 		And the command should have been successful
 		Then the downloaded content when downloading file "/test/somefile.txt" for user "user2" with range "bytes=0-6" should be "This is"
@@ -253,13 +252,11 @@ Feature: transfer-ownership
 		And user "user0" has created a folder "/test"
 		And user "user0" has created a folder "/test/foo"
 		And user "user0" has uploaded file "data/textfile.txt" to "/test/somefile.txt"
-		And user "user0" creates a share using the sharing API with settings
+		And user "user0" creates a public link share using the sharing API with settings
 			| path      | /test/somefile.txt |
-			| shareType | 3                  |
 		And user "user0" has shared file "/test" with user "user1" with permissions 31
-		And user "user1" creates a share using the sharing API with settings
+		And user "user1" creates a public link share using the sharing API with settings
 			| path      | /test |
-			| shareType | 3                  |
 		When the administrator transfers ownership from "user0" to "user1" using the occ command
 		Then the command should have been successful
 		And as "user0" the folder "/test" should not exist

--- a/tests/acceptance/features/apiShareManagement/createShare.feature
+++ b/tests/acceptance/features/apiShareManagement/createShare.feature
@@ -66,11 +66,10 @@ Feature: sharing
 			|1              |100            |
 			|2              |200            |
 
-	Scenario Outline: Creating a new public share of a file
+	Scenario Outline: Creating a new public link share of a file
 		Given using OCS API version "<ocs_api_version>"
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path      | welcome.txt |
-			| shareType | 3           |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the last public shared file should be able to be downloaded without a password
@@ -80,11 +79,10 @@ Feature: sharing
 			|2              |200            |
 
 	@smokeTest
-	Scenario Outline: Creating a new public share of a file with password
+	Scenario Outline: Creating a new public link share of a file with password
 		Given using OCS API version "<ocs_api_version>"
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path      | welcome.txt |
-			| shareType | 3           |
 			| password  | publicpw    |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
@@ -94,11 +92,10 @@ Feature: sharing
 			|1              |100            |
 			|2              |200            |
 
-	Scenario Outline: Trying to create a new public share of a file with edit permissions results in a read-only share
+	Scenario Outline: Trying to create a new public link share of a file with edit permissions results in a read-only share
 		Given using OCS API version "<ocs_api_version>"
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path        | welcome.txt |
-			| shareType   | 3           |
 			| permissions | 31          |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
@@ -115,11 +112,10 @@ Feature: sharing
 			|1              |100            |
 			|2              |200            |
 
-	Scenario Outline: Creating a new public share of a folder
+	Scenario Outline: Creating a new public link share of a folder
 		Given using OCS API version "<ocs_api_version>"
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path      | PARENT   |
-			| shareType | 3        |
 			| password  | publicpw |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
@@ -158,9 +154,8 @@ Feature: sharing
 	Scenario Outline: Creating a link share with no specified permissions defaults to read permissions
 		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has created a folder "/afolder"
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path      | /afolder |
-			| shareType | 3        |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
@@ -176,9 +171,8 @@ Feature: sharing
 		Given using OCS API version "<ocs_api_version>"
 		And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
 		And user "user0" has created a folder "/afolder"
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path      | /afolder |
-			| shareType | 3        |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And the share fields of the last share should include
@@ -193,9 +187,8 @@ Feature: sharing
 	Scenario Outline: Creating a link share with edit permissions keeps it
 		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has created a folder "/afolder"
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path        | /afolder |
-			| shareType   | 3        |
 			| permissions | 15       |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
@@ -260,11 +253,10 @@ Feature: sharing
 			|1              |100            |
 			|2              |200            |
 
-	Scenario Outline: Do not allow sharing of the root
+	Scenario Outline: Do not allow public sharing of the root
 		Given using OCS API version "<ocs_api_version>"
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path      | / |
-			| shareType | 3 |
 		Then the OCS status code should be "<ocs_status_code>"
 		Examples:
 			|ocs_api_version|ocs_status_code|
@@ -274,13 +266,11 @@ Feature: sharing
 	Scenario: Only allow 1 link share per file/folder
 		Given using OCS API version "1"
 		And as user "user0"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path      | welcome.txt |
-			| shareType | 3           |
 		And the last share id has been remembered
-		When the user creates a share using the sharing API with settings
+		When the user creates a public link share using the sharing API with settings
 			| path      | welcome.txt |
-			| shareType | 3           |
 		Then the share ids should match
 
 	@smokeTest

--- a/tests/acceptance/features/apiShareManagement/disableSharing.feature
+++ b/tests/acceptance/features/apiShareManagement/disableSharing.feature
@@ -58,10 +58,10 @@ So that ownCloud users cannot share file or folder
 			|1              |200             |
 			|2              |404             |
 
-	Scenario Outline: user tries to create public share of a file when the sharing api has been disabled
+	Scenario Outline: user tries to create public link share of a file when the sharing api has been disabled
 		Given using OCS API version "<ocs_api_version>"
 		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to create a public share of file "welcome.txt" using the sharing API
+		Then user "user0" should not be able to create a public link share of file "welcome.txt" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:
@@ -70,10 +70,10 @@ So that ownCloud users cannot share file or folder
 			|2              |404             |
 
 	@smokeTest
-	Scenario Outline: user tries to create public share of a folder when the sharing api has been disabled
+	Scenario Outline: user tries to create public link share of a folder when the sharing api has been disabled
 		Given using OCS API version "<ocs_api_version>"
 		When parameter "shareapi_enabled" of app "core" has been set to "no"
-		Then user "user0" should not be able to create a public share of folder "/FOLDER" using the sharing API
+		Then user "user0" should not be able to create a public link share of folder "/FOLDER" using the sharing API
 		And the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
 		Examples:

--- a/tests/acceptance/features/apiShareManagement/multilinksharing.feature
+++ b/tests/acceptance/features/apiShareManagement/multilinksharing.feature
@@ -9,25 +9,22 @@ Feature: multilinksharing
 	@smokeTest
 	Scenario Outline: Creating three public shares of a folder
 		Given using OCS API version "<ocs_api_version>"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| shareType    | 3           |
 			| password     | publicpw    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |
 			| permissions  | 15          |
 			| name         | sharedlink1 |
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| shareType    | 3           |
 			| password     | publicpw    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |
 			| permissions  | 15          |
 			| name         | sharedlink2 |
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| shareType    | 3           |
 			| password     | publicpw    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |
@@ -48,23 +45,20 @@ Feature: multilinksharing
 
 	Scenario Outline: Creating three public shares of a file
 		Given using OCS API version "<ocs_api_version>"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| shareType   | 3             |
 			| password    | publicpw      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink1   |
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| shareType   | 3             |
 			| password    | publicpw      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink2   |
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| shareType   | 3             |
 			| password    | publicpw      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
@@ -84,17 +78,15 @@ Feature: multilinksharing
 
 	Scenario Outline: Check that updating password doesn't remove name of links
 		Given using OCS API version "<ocs_api_version>"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| shareType    | 3           |
 			| password     | publicpw    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |
 			| permissions  | 15          |
 			| name         | sharedlink1 |
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| shareType    | 3           |
 			| password     | publicpw    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |
@@ -114,16 +106,14 @@ Feature: multilinksharing
 
 	Scenario: Deleting a file deletes also its public links
 		Given using OCS API version "1"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| shareType   | 3             |
 			| password    | publicpw      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink1   |
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| shareType   | 3             |
 			| password    | publicpw      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
@@ -135,30 +125,27 @@ Feature: multilinksharing
 		And as user "user0" the public shares of file "/textfile0.txt" should be
 			| | | |
 
-	Scenario Outline: Deleting one public share of a file doesn't affect the rest
+	Scenario Outline: Deleting one public link share of a file doesn't affect the rest
 		Given using OCS API version "<ocs_api_version>"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| shareType   | 3             |
 			| password    | publicpw      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink1   |
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| shareType   | 3             |
 			| password    | publicpw      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink2   |
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| shareType   | 3             |
 			| password    | publicpw      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink3   |
-		When user "user0" deletes public share named "sharedlink2" in file "/textfile0.txt" using the sharing API
+		When user "user0" deletes public link share named "sharedlink2" in file "/textfile0.txt" using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And as user "user0" the public shares of file "/textfile0.txt" should be
@@ -171,16 +158,14 @@ Feature: multilinksharing
 
 	Scenario: Overwriting a file doesn't remove its public shares
 		Given using OCS API version "1"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| shareType   | 3             |
 			| password    | publicpw      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink1   |
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| shareType   | 3             |
 			| password    | publicpw      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
@@ -192,17 +177,15 @@ Feature: multilinksharing
 
 	Scenario: Renaming a folder doesn't remove its public shares
 		Given using OCS API version "1"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| shareType    | 3           |
 			| password     | publicpw    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |
 			| permissions  | 15          |
 			| name         | sharedlink1 |
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| shareType    | 3           |
 			| password     | publicpw    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |

--- a/tests/acceptance/features/apiShareManagement/reShare.feature
+++ b/tests/acceptance/features/apiShareManagement/reShare.feature
@@ -84,9 +84,8 @@ Feature: sharing
 		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 1
-		When user "user1" creates a share using the sharing API with settings
+		When user "user1" creates a public link share using the sharing API with settings
 			| path         | /test |
-			| shareType    | 3     |
 			| publicUpload | false |
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"
@@ -99,9 +98,8 @@ Feature: sharing
 		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 15
-		When user "user1" creates a share using the sharing API with settings
+		When user "user1" creates a public link share using the sharing API with settings
 			| path         | /test |
-			| shareType    | 3     |
 			| publicUpload | false |
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "<http_status_code>"

--- a/tests/acceptance/features/apiShareManagement/updateShare.feature
+++ b/tests/acceptance/features/apiShareManagement/updateShare.feature
@@ -23,12 +23,11 @@ Feature: sharing
 			|1              |100            |
 			|2              |200            |
 
-	Scenario Outline: Creating a new public share, updating its expiration date and getting its info
+	Scenario Outline: Creating a new public link share, updating its expiration date and getting its info
 		Given using OCS API version "<ocs_api_version>"
 		And as user "user0"
-		When the user creates a share using the sharing API with settings
+		When the user creates a public link share using the sharing API with settings
 			| path      | FOLDER |
-			| shareType | 3      |
 		And the user updates the last share using the sharing API with
 			| expireDate | +3 days |
 		And the user gets the info of the last share using the sharing API
@@ -57,12 +56,11 @@ Feature: sharing
 			|1              |100            |
 			|2              |200            |
 
-	Scenario Outline: Creating a new public share with password and adding an expiration date
+	Scenario Outline: Creating a new public link share with password and adding an expiration date
 		Given using OCS API version "<ocs_api_version>"
 		And as user "user0"
-		When the user creates a share using the sharing API with settings
+		When the user creates a public link share using the sharing API with settings
 			| path      | welcome.txt |
-			| shareType | 3           |
 			| password  | publicpw    |
 		And the user updates the last share using the sharing API with
 			| expireDate | +3 days |
@@ -74,12 +72,11 @@ Feature: sharing
 			|1              |100            |
 			|2              |200            |
 
-	Scenario Outline: Creating a new public share, updating its expiration date and getting its info
+	Scenario Outline: Creating a new public link share, updating its expiration date and getting its info
 		Given using OCS API version "<ocs_api_version>"
 		And as user "user0"
-		When the user creates a share using the sharing API with settings
+		When the user creates a public link share using the sharing API with settings
 			| path      | FOLDER |
-			| shareType | 3      |
 		And the user updates the last share using the sharing API with
 			| expireDate | +3 days |
 		And the user gets the info of the last share using the sharing API
@@ -108,12 +105,11 @@ Feature: sharing
 			|1              |100            |
 			|2              |200            |
 
-	Scenario Outline: Creating a new public share, updating its password and getting its info
+	Scenario Outline: Creating a new public link share, updating its password and getting its info
 		Given using OCS API version "<ocs_api_version>"
 		And as user "user0"
-		When the user creates a share using the sharing API with settings
+		When the user creates a public link share using the sharing API with settings
 			| path      | FOLDER |
-			| shareType | 3      |
 		And the user updates the last share using the sharing API with
 			| password | publicpw |
 		And the user gets the info of the last share using the sharing API
@@ -141,12 +137,11 @@ Feature: sharing
 			|1              |100            |
 			|2              |200            |
 
-	Scenario Outline: Creating a new public share, updating its permissions and getting its info
+	Scenario Outline: Creating a new public link share, updating its permissions and getting its info
 		Given using OCS API version "<ocs_api_version>"
 		And as user "user0"
-		When the user creates a share using the sharing API with settings
+		When the user creates a public link share using the sharing API with settings
 			| path      | FOLDER |
-			| shareType | 3      |
 		And the user updates the last share using the sharing API with
 			| permissions | 7 |
 		And the user gets the info of the last share using the sharing API
@@ -174,12 +169,11 @@ Feature: sharing
 			|1              |100            |
 			|2              |200            |
 
-	Scenario Outline: Creating a new public share, updating publicUpload option and getting its info
+	Scenario Outline: Creating a new public link share, updating publicUpload option and getting its info
 		Given using OCS API version "<ocs_api_version>"
 		And as user "user0"
-		When the user creates a share using the sharing API with settings
+		When the user creates a public link share using the sharing API with settings
 			| path      | FOLDER |
-			| shareType | 3      |
 		And the user updates the last share using the sharing API with
 			| publicUpload | true |
 		And the user gets the info of the last share using the sharing API
@@ -246,9 +240,8 @@ Feature: sharing
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 17
 		And as user "user1"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path         | /test |
-			| shareType    | 3     |
 			| publicUpload | false |
 		When the user updates the last share using the sharing API with
 			| publicUpload | true |
@@ -338,9 +331,8 @@ Feature: sharing
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 31
 		And as user "user1"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path         | /test |
-			| shareType    | 3     |
 			| publicUpload | false |
 		When the user updates the last share using the sharing API with
 			| publicUpload | true |
@@ -357,9 +349,8 @@ Feature: sharing
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 17
 		And as user "user1"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | /test |
-			| shareType   | 3     |
 			| permissions | 1     |
 		When the user updates the last share using the sharing API with
 			| permissions | 15 |
@@ -376,9 +367,8 @@ Feature: sharing
 		And user "user0" has created a folder "/test"
 		And user "user0" has shared folder "/test" with user "user1" with permissions 31
 		And as user "user1"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | /test |
-			| shareType   | 3     |
 			| permissions | 1     |
 		When the user updates the last share using the sharing API with
 			| permissions | 15 |

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -8,9 +8,8 @@ Feature: sharing
 	@smokeTest
 	Scenario: Downloading from upload-only share is forbidden
 		Given user "user0" has moved file "/textfile0.txt" to "/FOLDER/test.txt"
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path        | FOLDER |
-			| shareType   | 3      |
 			| permissions | 4      |
 		Then the public shared file "test.txt" should not be able to be downloaded
 		And the HTTP status code should be "404"
@@ -53,9 +52,8 @@ Feature: sharing
 
 	@smokeTest
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with public with default permissions
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path         | PARENT   |
-			| shareType    | 3        |
 			| password     | publicpw |
 		Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "publicpw" and the content should be "wnCloud"
 
@@ -80,9 +78,8 @@ Feature: sharing
 		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read/Write permission 
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path         | PARENT   |
-			| shareType    | 3        |
 			| password     | publicpw |
 			| permissions  | 15       |
 		Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "publicpw" and the content should be "wnCloud"
@@ -108,9 +105,8 @@ Feature: sharing
 		Then the user "user1" should be able to download the file "/PARENT (2)/CHILD/child.txt" using the sharing API
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read only permission 
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path         | PARENT   |
-			| shareType    | 3        |
 			| password     | publicpw |
 			| permissions  | 1        |
 		Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "publicpw" and the content should be "wnCloud"

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -8,9 +8,8 @@ Feature: sharing
 	@smokeTest
 	Scenario: Uploading same file to a public upload-only share multiple times
 		Given as user "user0"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | FOLDER |
-			| shareType   | 3      |
 			| permissions | 4      |
 		When the public uploads file "test.txt" with content "test" using the old WebDAV API
 		And the public uploads file "test.txt" with content "test2" with autorename mode using the old WebDAV API
@@ -18,18 +17,16 @@ Feature: sharing
 		And the content of file "/FOLDER/test (2).txt" for user "user0" should be "test2"
 
 	Scenario: Uploading file to a public upload-only share that was deleted does not work
-		Given user "user0" has created a share with settings
+		Given user "user0" has created a public link share with settings
 			| path        | FOLDER |
-			| shareType   | 3      |
 			| permissions | 4      |
 		When user "user0" deletes file "/FOLDER" using the WebDAV API
 		Then publicly uploading a file should not work
 		And the HTTP status code should be "404"
 
 	Scenario: Uploading file to a public read-only share folder does not work
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path        | FOLDER |
-			| shareType   | 3      |
 			| permissions | 1      |
 		Then publicly uploading a file should not work
 		And the HTTP status code should be "403"
@@ -58,18 +55,16 @@ Feature: sharing
 
 	Scenario: Uploading to a public upload-only share
 		Given as user "user0"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | FOLDER |
-			| shareType   | 3      |
 			| permissions | 4      |
 		When the public uploads file "test.txt" with content "test" using the old WebDAV API
 		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
 	Scenario: Uploading to a public upload-only share with password
 		Given as user "user0"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | FOLDER   |
-			| shareType   | 3        |
 			| password    | publicpw |
 			| permissions | 4        |
 		When the public uploads file "test.txt" with password "publicpw" and content "test" using the old WebDAV API
@@ -99,9 +94,8 @@ Feature: sharing
 
 	Scenario: Uploading to a public read/write share with password
 		Given as user "user0"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | FOLDER   |
-			| shareType   | 3        |
 			| password    | publicpw |
 			| permissions | 15       |
 		When the public uploads file "test.txt" with password "publicpw" and content "test" using the old WebDAV API
@@ -142,9 +136,8 @@ Feature: sharing
 	@smokeTest
 	Scenario: Uploading to a public read/write share with password
 		Given as user "user0"
-		And the user has created a share with settings
+		And the user has created a public link share with settings
 			| path        | FOLDER   |
-			| shareType   | 3        |
 			| password    | publicpw |
 			| permissions | 15       |
 		When the public uploads file "test.txt" with password "publicpw" and content "test" using the old WebDAV API
@@ -175,9 +168,8 @@ Feature: sharing
 		Then the HTTP status code should be "507"
 
 	Scenario: Uploading file to a public shared folder with read/write permission when the sharer has unsufficient quota does not work
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path        | FOLDER |
-			| shareType   | 3      |
 			| permissions | 15     |
 		When the quota of user "user0" has been set to "0"
 		Then publicly uploading a file should not work
@@ -208,18 +200,16 @@ Feature: sharing
 		Then the HTTP status code should be "507"
 
 	Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has unsufficient quota does not work
-		When user "user0" creates a share using the sharing API with settings
+		When user "user0" creates a public link share using the sharing API with settings
 			| path        | FOLDER |
-			| shareType   | 3      |
 			| permissions | 4      |
 		When the quota of user "user0" has been set to "0"
 		Then publicly uploading a file should not work
 		And the HTTP status code should be "507"
 
 	Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder
-		Given user "user0" has created a share with settings
+		Given user "user0" has created a public link share with settings
 			| path        | FOLDER |
-			| shareType   | 3      |
 			| permissions | 4      |
 		When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "no"
 		Then publicly uploading a file should not work
@@ -227,18 +217,16 @@ Feature: sharing
 
 	Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder
 		Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-		And user "user0" has created a share with settings
+		And user "user0" has created a public link share with settings
 			| path        | FOLDER |
-			| shareType   | 3      |
 			| permissions | 31     |
 		When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "yes"
 		Then publicly uploading a file should not work
 		And the HTTP status code should be "403"
 
 	Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder
-		Given user "user0" has created a share with settings
+		Given user "user0" has created a public link share with settings
 			| path        | FOLDER |
-			| shareType   | 3      |
 			| permissions | 4      |
 		And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
 		And parameter "shareapi_allow_public_upload" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -29,9 +29,8 @@ Feature: download file
 
   Scenario Outline: download a public shared file with range
     Given using <dav_version> DAV path
-    When user "user0" creates a share using the sharing API with settings
+    When user "user0" creates a public link share using the sharing API with settings
       | path      | welcome.txt |
-      | shareType | 3           |
     And the public downloads the last public shared file with range "bytes=51-77" using the old WebDAV API
     Then the downloaded content should be "example file for developers"
     Examples:
@@ -41,9 +40,8 @@ Feature: download file
 
   Scenario Outline: download a public shared file inside a folder with range
     Given using <dav_version> DAV path
-    When user "user0" creates a share using the sharing API with settings
+    When user "user0" creates a public link share using the sharing API with settings
       | path      | PARENT |
-      | shareType | 3      |
     And the public downloads file "/parent.txt" from inside the last public shared folder with range "bytes=1-7" using the old WebDAV API
     Then the downloaded content should be "wnCloud"
     Examples:

--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -108,9 +108,8 @@ Feature: get file properties
   Scenario Outline: A file that is shared by link has a share-types property
     Given using <dav_version> DAV path
     And user "user0" has created a folder "/test"
-    And user "user0" has created a share with settings
+    And user "user0" has created a public link share with settings
       | path        | test |
-      | shareType   | 3    |
       | permissions | 31   |
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
       | {http://owncloud.org/ns}share-types |
@@ -137,9 +136,8 @@ Feature: get file properties
       | shareType   | 1    |
       | permissions | 31   |
       | shareWith   | grp2 |
-    And user "user0" has created a share with settings
+    And user "user0" has created a public link share with settings
       | path        | test |
-      | shareType   | 3    |
       | permissions | 31   |
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
       | {http://owncloud.org/ns}share-types |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -112,6 +112,34 @@ trait Sharing {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" creates a public link share using the sharing API with settings$/
+	 * @Given /^user "([^"]*)" has created a public link share with settings$/
+	 *
+	 * @param string $user
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 */
+	public function userCreatesAPublicLinkShareWithSettings($user, $body) {
+		$rows = $body->getRows();
+		// A public link share is shareType 3
+		$rows[] = ['shareType', '3'];
+		$newBody = new TableNode($rows);
+		$this->userCreatesAShareWithSettings($user, $newBody);
+	}
+
+	/**
+	 * @When /^the user creates a public link share using the sharing API with settings$/
+	 *
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 */
+	public function theUserCreatesAPublicLinkShareWithSettings($body) {
+		$this->userCreatesAPublicLinkShareWithSettings($this->currentUser, $body);
+	}
+
+	/**
 	 * @Given /^the user has created a share with settings$/
 	 *
 	 * @param TableNode|null $body
@@ -120,6 +148,19 @@ trait Sharing {
 	 */
 	public function theUserHasCreatedAShareWithSettings($body) {
 		$this->userCreatesAShareWithSettings($this->currentUser, $body);
+		$this->theOCSStatusCodeShouldBe([100, 200]);
+		$this->theHTTPStatusCodeShouldBe(200);
+	}
+
+	/**
+	 * @Given /^the user has created a public link share with settings$/
+	 *
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 */
+	public function theUserHasCreatedAPublicLinkShareWithSettings($body) {
+		$this->theUserCreatesAPublicLinkShareWithSettings($body);
 		$this->theOCSStatusCodeShouldBe([100, 200]);
 		$this->theHTTPStatusCodeShouldBe(200);
 	}
@@ -163,32 +204,32 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)" using the sharing API$/
-	 * @Given /^user "([^"]*)" has created a public share of (?:file|folder) "([^"]*)"$/
+	 * @When /^user "([^"]*)" creates a public link share of (?:file|folder) "([^"]*)" using the sharing API$/
+	 * @Given /^user "([^"]*)" has created a public link share of (?:file|folder) "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $path
 	 *
 	 * @return void
 	 */
-	public function userCreatesAPublicShareOf($user, $path) {
+	public function userCreatesAPublicLinkShareOf($user, $path) {
 		$this->createAPublicShare($user, $path);
 	}
 
 	/**
-	 * @When /^the user creates a public share of (?:file|folder) "([^"]*)" using the sharing API$/
-	 * @Given /^the user has created a public share of (?:file|folder) "([^"]*)"$/
+	 * @When /^the user creates a public link share of (?:file|folder) "([^"]*)" using the sharing API$/
+	 * @Given /^the user has created a public link share of (?:file|folder) "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @return void
 	 */
-	public function aPublicShareOfIsCreated($path) {
+	public function aPublicLinkShareOfIsCreated($path) {
 		$this->createAPublicShare($this->currentUser, $path);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)" using the sharing API with (read|update|create|delete|change|share|all) permission(?:s|)$/
-	 * @Given /^user "([^"]*)" has created a public share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 * @When /^user "([^"]*)" creates a public link share of (?:file|folder) "([^"]*)" using the sharing API with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 * @Given /^user "([^"]*)" has created a public link share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|share|all) permission(?:s|)$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -196,30 +237,30 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
-	public function userCreatesAPublicShareOfWithPermission(
+	public function userCreatesAPublicLinkShareOfWithPermission(
 		$user, $path, $permissions
 	) {
 		$this->createAPublicShare($user, $path, true, null, $permissions);
 	}
 
 	/**
-	 * @When /^the user creates a public share of (?:file|folder) "([^"]*)" using the sharing API with (read|update|create|delete|change|share|all) permission(?:s|)$/
-	 * @Given /^the user has created a public share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 * @When /^the user creates a public link share of (?:file|folder) "([^"]*)" using the sharing API with (read|update|create|delete|change|share|all) permission(?:s|)$/
+	 * @Given /^the user has created a public link share of (?:file|folder) "([^"]*)" with (read|update|create|delete|change|share|all) permission(?:s|)$/
 	 *
 	 * @param string $path
 	 * @param string|int|string[]|int[]|null $permissions
 	 *
 	 * @return void
 	 */
-	public function aPublicShareOfIsCreatedWithPermission($path, $permissions) {
+	public function aPublicLinkShareOfIsCreatedWithPermission($path, $permissions) {
 		$this->createAPublicShare(
 			$this->currentUser, $path, true, null, $permissions
 		);
 	}
 
 	/**
-	 * @When /^user "([^"]*)" creates a public share of (?:file|folder) "([^"]*)" using the sharing API with expiry "([^"]*)"$/
-	 * @Given /^user "([^"]*)" has created a public share of (?:file|folder) "([^"]*)" with expiry "([^"]*)"$/
+	 * @When /^user "([^"]*)" creates a public link share of (?:file|folder) "([^"]*)" using the sharing API with expiry "([^"]*)"$/
+	 * @Given /^user "([^"]*)" has created a public link share of (?:file|folder) "([^"]*)" with expiry "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -227,7 +268,7 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
-	public function userCreatesAPublicShareOfWithExpiry(
+	public function userCreatesAPublicLinkShareOfWithExpiry(
 		$user, $path, $expiryDate
 	) {
 		$this->createAPublicShare(
@@ -236,8 +277,8 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^the user creates a public share of (?:file|folder) "([^"]*)" using the sharing API with expiry "([^"]*)$"/
-	 * @Given /^the user has created a public share of (?:file|folder) "([^"]*)" with expiry "([^"]*)$/
+	 * @When /^the user creates a public link share of (?:file|folder) "([^"]*)" using the sharing API with expiry "([^"]*)$"/
+	 * @Given /^the user has created a public link share of (?:file|folder) "([^"]*)" with expiry "([^"]*)$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -245,7 +286,7 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
-	public function aPublicShareOfIsCreatedWithExpiry(
+	public function aPublicLinkShareOfIsCreatedWithExpiry(
 		$user, $path, $expiryDate
 	) {
 		$this->createAPublicShare(
@@ -452,14 +493,14 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should not be able to create a public share of (?:file|folder) "([^"]*)" using the sharing API$/
+	 * @Then /^user "([^"]*)" should not be able to create a public link share of (?:file|folder) "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $sharer
 	 * @param string $filepath
 	 *
 	 * @return void
 	 */
-	public function shouldNotBeAbleToCreatePublicShare($sharer, $filepath) {
+	public function shouldNotBeAbleToCreatePublicLinkShare($sharer, $filepath) {
 		$this->createAPublicShare($sharer, $filepath);
 		PHPUnit_Framework_Assert::assertEquals(
 			404,
@@ -1199,8 +1240,8 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" deletes public share named "([^"]*)" in (?:file|folder) "([^"]*)" using the sharing API$/
-	 * @Given /^user "([^"]*)" has deleted public share named "([^"]*)" in (?:file|folder) "([^"]*)"$/
+	 * @When /^user "([^"]*)" deletes public link share named "([^"]*)" in (?:file|folder) "([^"]*)" using the sharing API$/
+	 * @Given /^user "([^"]*)" has deleted public link share named "([^"]*)" in (?:file|folder) "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $name
@@ -1208,7 +1249,7 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
-	public function userDeletesPublicShareNamedUsingTheSharingApi(
+	public function userDeletesPublicLinkShareNamedUsingTheSharingApi(
 		$user, $name, $path
 	) {
 		$share_id = $this->getPublicShareIDByName($user, $path, $name);

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -103,12 +103,12 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When /^the administrator (enables|disables) mail notification on public share using the webUI$/
+	 * @When /^the administrator (enables|disables) mail notification on public link share using the webUI$/
 	 * @param string $action
 	 *
 	 * @return void
 	 */
-	public function adminTogglesMailNotificationOnPublicShare($action) {
+	public function adminTogglesMailNotificationOnPublicLinkShare($action) {
 		$this->adminSharingSettingsPage->toggleMailNotification($action);
 		$this->adminSharingSettingsPage->waitForAjaxCallsToStartAndFinish(
 			$this->getSession()
@@ -116,13 +116,13 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When /^the administrator (enables|disables) social media share on public share using the webUI$/
+	 * @When /^the administrator (enables|disables) social media share on public link share using the webUI$/
 	 * @param string $action
 	 *
 	 * @return void
 	 */
-	public function adminTogglesSocialShareOnPublicShare($action) {
-		$this->adminSharingSettingsPage->toggleSocialShareOnPublicShare($action);
+	public function adminTogglesSocialShareOnPublicLinkShare($action) {
+		$this->adminSharingSettingsPage->toggleSocialShareOnPublicLinkShare($action);
 		$this->adminSharingSettingsPage->waitForAjaxCallsToStartAndFinish(
 			$this->getSession()
 		);

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -146,7 +146,7 @@ class AdminSharingSettingsPage extends OwncloudPage {
 	}
 
 	/**
-	 * toggle mail notification on public share
+	 * toggle mail notification on public link share
 	 *
 	 * @param string $action "enables|disables"
 	 *
@@ -161,13 +161,13 @@ class AdminSharingSettingsPage extends OwncloudPage {
 	}
 
 	/**
-	 * toggle social share on public share
+	 * toggle social share on public link share
 	 *
 	 * @param string $action "enables|disables"
 	 *
 	 * @return void
 	 */
-	public function toggleSocialShareOnPublicShare($action) {
+	public function toggleSocialShareOnPublicLinkShare($action) {
 		$this->toggleCheckbox(
 			$action,
 			$this->shareFileViaSocialMediaOnPublicShareCheckboxXpath,

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -52,7 +52,7 @@ class SharingDialog extends OwncloudPage {
 	private $permissionsFieldByUserName = ".//*[@id='shareWithList']//*[@class='has-tooltip username' and .='%s']/..";
 	private $permissionLabelXpath = ".//label[@for='%s']";
 	private $showCrudsXpath = ".//*[@class='showCruds']";
-	private $publicShareTabLinkXpath = ".//li[contains(@class,'subtab-publicshare')]";
+	private $publicLinksShareTabXpath = ".//li[contains(@class,'subtab-publicshare')]";
 
 	private $sharedWithGroupAndSharerName = null;
 
@@ -437,15 +437,15 @@ class SharingDialog extends OwncloudPage {
 	 * @return PublicLinkTab
 	 */
 	public function openPublicShareTab() {
-		$publicShareTabLink = $this->find("xpath", $this->publicShareTabLinkXpath);
-		if ($publicShareTabLink === null) {
+		$publicLinksShareTab = $this->find("xpath", $this->publicLinksShareTabXpath);
+		if ($publicLinksShareTab === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
-				" xpath $this->publicShareTabLinkXpath " .
-				"could not find link to open public share tab"
+				" xpath $this->publicLinksShareTabXpath " .
+				"could not find public links share tab"
 			);
 		}
-		$publicShareTabLink->click();
+		$publicLinksShareTab->click();
 		$publicLinkTab = $this->getPage(
 			"FilesPageElement\\SharingDialogElement\\PublicLinkTab"
 		);

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -67,7 +67,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	}
 
 	/**
-	 * adding public share to particular server
+	 * adding public link share to particular server
 	 *
 	 * @param string $server
 	 *

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -29,17 +29,17 @@ Feature: admin sharing settings
 			| capability    | path_to_element | value |
 			| files_sharing | public@@@upload | EMPTY |
 
-	Scenario: enable mail notification on public share
+	Scenario: enable mail notification on public link share
 		Given the administrator has browsed to the admin sharing settings page
-		When the administrator enables mail notification on public share using the webUI
+		When the administrator enables mail notification on public link share using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element    | value |
 			| files_sharing | public@@@send_mail | 1     |
 
-	Scenario: disable social media share on public share
+	Scenario: disable social media share on public link share
 		Given the administrator has browsed to the admin sharing settings page
-		When the administrator disables social media share on public share using the webUI
+		When the administrator disables social media share on public link share using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element       | value |
@@ -121,19 +121,19 @@ Feature: admin sharing settings
 			| capability    | path_to_element | value |
 			| files_sharing | public@@@upload | 1     |
 
-	Scenario: disable mail notification on public share
+	Scenario: disable mail notification on public link share
 		Given parameter "shareapi_allow_public_send_mail" of app "core" has been set to "no"
 		And the administrator has browsed to the admin sharing settings page
-		When the administrator disables mail notification on public share using the webUI
+		When the administrator disables mail notification on public link share using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element    | value |
 			| files_sharing | public@@@send_mail | EMPTY |
 
-	Scenario: enable social media share on public share
+	Scenario: enable social media share on public link share
 		Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
 		And the administrator has browsed to the admin sharing settings page
-		When the administrator enables social media share on public share using the webUI
+		When the administrator enables social media share on public link share using the webUI
 		And the user retrieves the capabilities using the capabilities API
 		Then the capabilities should contain
 			| capability    | path_to_element       | value |


### PR DESCRIPTION
## Description
Hide the magic link share numbers from the gherkin test code
Add steps to specifically create pubic link shares
Call them "public link share" rather than just "public share" or whatever else they were called.

Note: to-do some day, hide the magic for share type 0 (share with a user) and 1 (share with a group).

## Motivation and Context
Acceptance test steps for shares have a lot of tests that mention ``shareType`` with "magic numbers" 0, 1, 3. 
Type 3 is a public link share. Hide this magic, and hopefully make the test steps more readable.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
