### PR TITLE
Acceptance tests for resetting user passwords with the provisioning API

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -1,0 +1,58 @@
+@api
+Feature: reset user password
+  As an admin
+  I want to be able to reset a user's password
+  So that I can secure individual access to resources on the ownCloud server
+
+  Background:
+    Given using OCS API version "1"
+
+  @smokeTest
+  Scenario: reset user password
+    Given user "brand-new-user" has been created
+    When the administrator resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+
+  Scenario: admin tries to reset the password of a user that does not exist
+    When the administrator resets the password of user "not-a-user" to "anotherPwd123" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+
+  @smokeTest
+  Scenario: subadmin should be able to reset the password of a user in their group
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+
+  Scenario: subadmin should not be able to reset the password of a user not in their group
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" tries to reset the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+
+  Scenario: a user should not be able to reset the password of another user
+    Given user "wannabeadmin" has been created
+    And user "brand-new-user" has been created
+    When user "wannabeadmin" tries to reset the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+
+  Scenario: a user should be able to reset their own password
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -1,0 +1,58 @@
+@api
+Feature: reset user password
+  As an admin
+  I want to be able to reset a user's password
+  So that I can secure individual access to resources on the ownCloud server
+
+  Background:
+    Given using OCS API version "2"
+
+  @smokeTest
+  Scenario: reset user password
+    Given user "brand-new-user" has been created
+    When the administrator resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+
+  Scenario: admin tries to reset the password of a user that does not exist
+    When the administrator resets the password of user "not-a-user" to "anotherPwd123" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+
+  @smokeTest
+  Scenario: subadmin should be able to reset the password of a user in their group
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+
+  Scenario: subadmin should not be able to reset the password of a user not in their group
+    Given user "subadmin" has been created
+    And user "brand-new-user" has been created
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" tries to reset the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+
+  Scenario: a user should not be able to reset the password of another user
+    Given user "wannabeadmin" has been created
+    And user "brand-new-user" has been created
+    When user "wannabeadmin" tries to reset the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+
+  Scenario: a user should be able to reset their own password
+    Given user "brand-new-user" has been created
+    When user "brand-new-user" resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -410,6 +410,60 @@ trait Provisioning {
 	}
 
 	/**
+	 * @When the administrator resets the password of user :username to :password using the provisioning API
+	 * @Given the administrator has reset the password of user :username to :password
+	 *
+	 * @param string $username of the user whose password is reset
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function adminResetsPasswordOfUserUsingTheProvisioningApi($username, $password) {
+		$this->userResetsPasswordOfUserUsingTheProvisioningApi(
+			$this->getAdminUsername(),
+			$username,
+			$password
+		);
+	}
+
+	/**
+	 * @When user :user resets the password of user :username to :password using the provisioning API
+	 * @Given user :user has reset the password of user :username to :password
+	 *
+	 * @param string $user that does the password reset
+	 * @param string $username of the user whose password is reset
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function userResetsPasswordOfUserUsingTheProvisioningApi($user, $username, $password) {
+		$this->userTriesToResetPasswordOfUserUsingTheProvisioningApi(
+			$user, $username, $password
+		);
+		$this->rememberUserPassword($username, $password);
+	}
+
+	/**
+	 * @When user :user tries to reset the password of user :username to :password using the provisioning API
+	 * @Given user :user has tried to reset the password of user :username to :password
+	 *
+	 * @param string $user that does the password reset
+	 * @param string $username of the user whose password is reset
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function userTriesToResetPasswordOfUserUsingTheProvisioningApi($user, $username, $password) {
+		$bodyTable = new TableNode([['key', 'password'], ['value', $password]]);
+		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$user,
+			"PUT",
+			"/cloud/users/$username",
+			$bodyTable
+		);
+	}
+
+	/**
 	 * @When /^the administrator sends a user deletion request for user "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $user
@@ -599,6 +653,29 @@ trait Provisioning {
 			$this->createdUsers[$user] = $userData;
 		} elseif ($this->currentServer === 'REMOTE') {
 			$this->createdRemoteUsers[$user] = $userData;
+		}
+	}
+
+	/**
+	 * remember the password of a user that already exists so that you can use
+	 * ordinary test steps after changing their password.
+	 *
+	 * @param string $user
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function rememberUserPassword(
+		$user, $password
+	) {
+		if ($this->currentServer === 'LOCAL') {
+			if (\array_key_exists($user, $this->createdUsers)) {
+				$this->createdUsers[$user]['password'] = $password;
+			}
+		} elseif ($this->currentServer === 'REMOTE') {
+			if (\array_key_exists($user, $this->createdRemoteUsers)) {
+				$this->createdRemoteUsers[$user]['password'] = $password;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
Add acceptance test steps that reset a user password using the provisioning API.
Add test scenarios to check what admin, sub-admin and ordinary users can and cannot do to reset passwords with the provisioning API.

## Motivation and Context
I want to do various user password resets from password_policy tests,
but such tests do not exist in core yet.

## How Has This Been Tested?
Local run of the new acceptance test feature files.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
