### PR TITLE
Acceptance test steps that specify the password to be used

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -9,11 +9,14 @@ Feature: reset user password
 
   @smokeTest
   Scenario: reset user password
-    Given user "brand-new-user" has been created
+    Given these users have been created:
+      | username       | password | displayname | email                    |
+      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "anotherPwd123" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "1234" should not be able to download file "textfile0.txt"
 
   Scenario: admin tries to reset the password of a user that does not exist
     When the administrator resets the password of user "not-a-user" to "anotherPwd123" using the provisioning API
@@ -22,37 +25,49 @@ Feature: reset user password
 
   @smokeTest
   Scenario: subadmin should be able to reset the password of a user in their group
-    Given user "subadmin" has been created
-    And user "brand-new-user" has been created
+    Given these users have been created:
+      | username       | password | displayname | email                    |
+      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
+      | subadmin       | Sa4567   | Sub Admin   | sub.admin@oc.com.np      |
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "subadmin" resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "anotherPwd123" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "1234" should not be able to download file "textfile0.txt"
 
   Scenario: subadmin should not be able to reset the password of a user not in their group
-    Given user "subadmin" has been created
-    And user "brand-new-user" has been created
+    Given these users have been created:
+      | username       | password | displayname | email                    |
+      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
+      | subadmin       | Sa4567   | Sub Admin   | sub.admin@oc.com.np      |
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "subadmin" tries to reset the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "anotherPwd123" should not be able to download file "textfile0.txt"
 
   Scenario: a user should not be able to reset the password of another user
-    Given user "wannabeadmin" has been created
-    And user "brand-new-user" has been created
+    Given these users have been created:
+      | username       | password | displayname    | email                    |
+      | brand-new-user | 1234     | New user       | brand.new.user@oc.com.np |
+      | wannabeadmin   | Wa4567   | Wanna Be Admin | wanna.be.admin@oc.com.np |
     When user "wannabeadmin" tries to reset the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "anotherPwd123" should not be able to download file "textfile0.txt"
 
   Scenario: a user should be able to reset their own password
-    Given user "brand-new-user" has been created
+    Given these users have been created:
+      | username       | password | displayname | email                    |
+      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
     When user "brand-new-user" resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "anotherPwd123" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "1234" should not be able to download file "textfile0.txt"

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -9,11 +9,14 @@ Feature: reset user password
 
   @smokeTest
   Scenario: reset user password
-    Given user "brand-new-user" has been created
+    Given these users have been created:
+      | username       | password | displayname | email                    |
+      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "anotherPwd123" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "1234" should not be able to download file "textfile0.txt"
 
   Scenario: admin tries to reset the password of a user that does not exist
     When the administrator resets the password of user "not-a-user" to "anotherPwd123" using the provisioning API
@@ -22,37 +25,49 @@ Feature: reset user password
 
   @smokeTest
   Scenario: subadmin should be able to reset the password of a user in their group
-    Given user "subadmin" has been created
-    And user "brand-new-user" has been created
+    Given these users have been created:
+      | username       | password | displayname | email                    |
+      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
+      | subadmin       | Sa4567   | Sub Admin   | sub.admin@oc.com.np      |
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "subadmin" resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "anotherPwd123" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "1234" should not be able to download file "textfile0.txt"
 
   Scenario: subadmin should not be able to reset the password of a user not in their group
-    Given user "subadmin" has been created
-    And user "brand-new-user" has been created
+    Given these users have been created:
+      | username       | password | displayname | email                    |
+      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
+      | subadmin       | Sa4567   | Sub Admin   | sub.admin@oc.com.np      |
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "subadmin" tries to reset the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "anotherPwd123" should not be able to download file "textfile0.txt"
 
   Scenario: a user should not be able to reset the password of another user
-    Given user "wannabeadmin" has been created
-    And user "brand-new-user" has been created
+    Given these users have been created:
+      | username       | password | displayname    | email                    |
+      | brand-new-user | 1234     | New user       | brand.new.user@oc.com.np |
+      | wannabeadmin   | Wa4567   | Wanna Be Admin | wanna.be.admin@oc.com.np |
     When user "wannabeadmin" tries to reset the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "1234" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "anotherPwd123" should not be able to download file "textfile0.txt"
 
   Scenario: a user should be able to reset their own password
-    Given user "brand-new-user" has been created
+    Given these users have been created:
+      | username       | password | displayname | email                    |
+      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
     When user "brand-new-user" resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And the content of file "textfile0.txt" for user "brand-new-user" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "anotherPwd123" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "1234" should not be able to download file "textfile0.txt"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -248,6 +248,7 @@ trait WebDav {
 	 * @param string $type
 	 * @param string|null $requestBody
 	 * @param string|null $davPathVersion
+	 * @param string|null $password
 	 *
 	 * @return ResponseInterface
 	 */
@@ -259,7 +260,8 @@ trait WebDav {
 		$body = null,
 		$type = "files",
 		$requestBody = null,
-		$davPathVersion = null
+		$davPathVersion = null,
+		$password = null
 	) {
 		if ($this->customDavPath !== null) {
 			$path = $this->customDavPath . $path;
@@ -269,9 +271,12 @@ trait WebDav {
 			$davPathVersion = $this->getDavPathVersion();
 		}
 
+		if ($password === null) {
+			$password  = $this->getPasswordForUser($user);
+		}
 		return WebDavHelper::makeDavRequest(
 			$this->getBaseUrl(),
-			$user, $this->getPasswordForUser($user), $method,
+			$user, $password, $method,
 			$path, $headers, $body, $requestBody, $davPathVersion,
 			$type
 		);
@@ -480,6 +485,27 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" using password "([^"]*)" should not be able to download file "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $password
+	 * @param string $fileName
+	 *
+	 * @return void
+	 */
+	public function userUsingPasswordShouldNotBeAbleToDownloadFile(
+		$user, $password, $fileName
+	) {
+		$this->downloadFileAsUserUsingPassword($user, $fileName, $password);
+		PHPUnit_Framework_Assert::assertGreaterThanOrEqual(
+			400, $this->getResponse()->getStatusCode(), 'download must fail'
+		);
+		PHPUnit_Framework_Assert::assertLessThanOrEqual(
+			499, $this->getResponse()->getStatusCode(), '4xx error expected'
+		);
+	}
+
+	/**
 	 * @Then /^the downloaded content should be "([^"]*)"$/
 	 *
 	 * @param string $content
@@ -525,7 +551,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function contentOfFileShouldBePyString(
-		$fileName, $user, PyStringNode $content
+		$fileName, PyStringNode $content
 	) {
 		$this->contentOfFileShouldBe($fileName, $content->getRaw());
 	}
@@ -553,7 +579,24 @@ trait WebDav {
 	 * @return void
 	 */
 	public function contentOfFileForUserShouldBe($fileName, $user, $content) {
-		$this->userDownloadsTheFileUsingTheAPI($user, $fileName);
+		$this->downloadFileAsUserUsingPassword($user, $fileName);
+		$this->downloadedContentShouldBe($content);
+	}
+
+	/**
+	 * @Then /^the content of file "([^"]*)" for user "([^"]*)" using password "([^"]*)" should be "([^"]*)"$/
+	 *
+	 * @param string $fileName
+	 * @param string $user
+	 * @param string $password
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function contentOfFileForUserUsingPasswordShouldBe(
+		$fileName, $user, $password, $content
+	) {
+		$this->downloadFileAsUserUsingPassword($user, $fileName, $password);
 		$this->downloadedContentShouldBe($content);
 	}
 
@@ -573,6 +616,24 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then /^the content of file "([^"]*)" for user "([^"]*)" using password "([^"]*)" should be:$/
+	 *
+	 * @param string $fileName
+	 * @param string $user
+	 * @param string $password
+	 * @param PyStringNode $content
+	 *
+	 * @return void
+	 */
+	public function contentOfFileForUserUsingPasswordShouldBePyString(
+		$fileName, $user, $password, PyStringNode $content
+	) {
+		$this->contentOfFileForUserUsingPasswordShouldBe(
+			$fileName, $user, $password, $content->getRaw()
+		);
+	}
+
+	/**
 	 * @Then /^the content of file "([^"]*)" for user "([^"]*)" should be "([^"]*)" plus end-of-line$/
 	 *
 	 * @param string $fileName
@@ -582,7 +643,27 @@ trait WebDav {
 	 * @return void
 	 */
 	public function contentOfFileForUserShouldBePlusEndOfLine($fileName, $user, $content) {
-		$this->contentOfFileForUserShouldBe($fileName, $user, "$content\n");
+		$this->contentOfFileForUserShouldBe(
+			$fileName, $user, "$content\n"
+		);
+	}
+
+	/**
+	 * @Then /^the content of file "([^"]*)" for user "([^"]*)" using password "([^"]*)" should be "([^"]*)" plus end-of-line$/
+	 *
+	 * @param string $fileName
+	 * @param string $user
+	 * @param string $password
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function contentOfFileForUserUsingPasswordShouldBePlusEndOfLine(
+		$fileName, $user, $password, $content
+	) {
+		$this->contentOfFileForUserUsingPasswordShouldBe(
+			$fileName, $user, $password, "$content\n"
+		);
 	}
 
 	/**
@@ -626,7 +707,7 @@ trait WebDav {
 	 * @return void
 	 */
 	public function theUserDownloadsTheFileUsingTheAPI($fileName) {
-		$this->userDownloadsTheFileUsingTheAPI($this->currentUser, $fileName);
+		$this->downloadFileAsUserUsingPassword($this->currentUser, $fileName);
 	}
 
 	/**
@@ -637,9 +718,47 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function userDownloadsTheFileUsingTheAPI($user, $fileName) {
+	public function userDownloadsTheFileUsingTheAPI(
+		$user, $fileName
+	) {
+		$this->downloadFileAsUserUsingPassword($user, $fileName);
+	}
+
+	/**
+	 * @When user :user using password :password downloads the file :fileName using the WebDAV API
+	 *
+	 * @param string $user
+	 * @param string $fileName
+	 * @param string|null $password
+	 *
+	 * @return void
+	 */
+	public function userUsingPasswordDownloadsTheFileUsingTheAPI(
+		$user, $password, $fileName
+	) {
+		$this->downloadFileAsUserUsingPassword($user, $fileName, $password);
+	}
+
+	/**
+	 * @param string $user
+	 * @param string $fileName
+	 * @param string|null $password
+	 *
+	 * @return void
+	 */
+	public function downloadFileAsUserUsingPassword(
+		$user, $fileName, $password = null
+	) {
 		$this->response = $this->makeDavRequest(
-			$user, 'GET', $fileName, []
+			$user,
+			'GET',
+			$fileName,
+			[],
+			null,
+			"files",
+			null,
+			null,
+			$password
 		);
 	}
 


### PR DESCRIPTION
## Description
- Add acceptance test step that specify the password to be used when downloading a file and checking the content, or checking that the download fails.
- Use those steps to check the result of resetting user passwords

## Motivation and Context
Sometimes, e.g. after changing the password of a user, we want to check specifically that the new password works and that the old password does not work. So make acceptance test steps that can specify the password to be used. That makes it clear about exactly what access is being tested.

## How Has This Been Tested?
Local acceptance test runs of reset password scenarios.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
