### PR TITLE
Improve acceptance tests status fail messages

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -783,6 +783,10 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function theOCSStatusCodeShouldBe($statusCode, $message = "") {
+		if ($message === "") {
+			$message = "OCS status code is not the expected value";
+		}
+
 		if (\is_array($statusCode)) {
 			PHPUnit_Framework_Assert::assertContains(
 				$this->getOCSResponseStatusCode($this->response), $statusCode,
@@ -805,6 +809,10 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function theHTTPStatusCodeShouldBe($statusCode, $message = "") {
+		if ($message === "") {
+			$message = "HTTP status code is not the expected value";
+		}
+
 		if (\is_array($statusCode)) {
 			PHPUnit_Framework_Assert::assertContains(
 				$this->response->getStatusCode(), $statusCode,

--- a/tests/acceptance/features/bootstrap/CommandLine.php
+++ b/tests/acceptance/features/bootstrap/CommandLine.php
@@ -279,7 +279,9 @@ trait CommandLine {
 		$lines = $this->findLines($this->lastStdOut, $text);
 		if (empty($lines)) {
 			throw new \Exception(
-				"The command did not output the expected text on stdout '$text'"
+				"The command output did not contain the expected text on stdout '$text'\n" .
+				"The command output on stdout was:\n" .
+				$this->lastStdOut
 			);
 		}
 	}
@@ -299,7 +301,9 @@ trait CommandLine {
 		$lines = $this->findLines($this->lastStdErr, $text);
 		if (empty($lines)) {
 			throw new \Exception(
-				"The command did not output the expected text on stderr '$text'"
+				"The command output did not contain the expected text on stderr '$text'\n" .
+				"The command output on stderr was:\n" .
+				$this->lastStdOut
 			);
 		}
 	}


### PR DESCRIPTION
## Description
Provide more information when a status code or status message is not the expected one.

## Motivation and Context
When making new tests, or when a test unexpectedly fails, it is nice to see what the actual command output was (as well as what the expected output is). Often it is just a little difference in the text, and it is much easier if the test failure output shows this.

When running scenario outlines, Behat does not make it clear which step has failed. So make the steps that check HTTP and OCS status have an explicit fail message that lets you know which of these steps the code is evaluating.

## How Has This Been Tested?
Local CI runs with test scenarios under development.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
