### PR TITLE
Make targets for acceptance tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -345,7 +345,7 @@ pipeline:
     commands:
       - touch /drone/saved-settings.sh
       - . /drone/saved-settings.sh
-      - ./tests/drone/test-acceptance.sh --remote
+      - make test-acceptance-api TESTING_REMOTE_SYSTEM=true
     when:
       matrix:
         TEST_SUITE: api
@@ -363,7 +363,7 @@ pipeline:
     commands:
       - touch /drone/saved-settings.sh
       - . /drone/saved-settings.sh
-      - ./tests/drone/test-acceptance.sh --remote
+      - make test-acceptance-webui TESTING_REMOTE_SYSTEM=true
     when:
       matrix:
         TEST_SUITE: selenium

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,8 @@ help:
 	@echo -e "make test-php-style\t\trun PHP code style checks"
 	@echo -e "make test-js\t\t\trun Javascript tests"
 	@echo -e "make test-js-debug\t\trun Javascript tests in debug mode (continuous)"
-	@echo -e "make test-acceptance\t\trun acceptance tests"
+	@echo -e "make test-acceptance-api\trun API acceptance tests"
+	@echo -e "make test-acceptance-webui\trun webUI acceptance tests"
 	@echo -e "make clean-test\t\t\tclean test results"
 	@echo
 	@echo It is also possible to run individual PHP test files with the following command:
@@ -180,13 +181,13 @@ test-js: $(nodejs_deps)
 test-js-debug: $(nodejs_deps)
 	NODE_PATH='$(NODE_PREFIX)/node_modules' $(KARMA) start tests/karma.config.js
 
-.PHONY: test-acceptance
-test-acceptance: $(composer_dev_deps)
-	$(MAKE) -C tests/acceptance \
-		BEHAT_SUITE=$(BEHAT_SUITE) \
-		OC_TEST_ALT_HOME=$(OC_TEST_ALT_HOME) \
-		OC_TEST_ENCRYPTION_ENABLED=$(OC_TEST_ENCRYPTION_ENABLED) \
-		OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED=$(OC_TEST_ENCRYPTION_MASTER_KEY_ENABLED)
+.PHONY: test-acceptance-api
+test-acceptance-api: $(composer_dev_deps)
+	./tests/acceptance/run.sh --type api
+
+.PHONY: test-acceptance-webui
+test-acceptance-webui: $(composer_dev_deps)
+	./tests/acceptance/run.sh --type webUI
 
 .PHONY: test-php-lint
 test-php-lint: $(composer_dev_deps)
@@ -206,7 +207,7 @@ test-php-phan: $(PHAN_BIN)
 	php $(PHAN_BIN) --config-file .phan/config.php --require-config-exists -p
 
 .PHONY: test
-test: test-php-lint test-php-style test-php test-js test-acceptance
+test: test-php-lint test-php-style test-php test-js test-acceptance-api test-acceptance-webui
 
 .PHONY: clean-test-acceptance
 clean-test-acceptance:


### PR DESCRIPTION
## Description
Add make targets ``test-acceptance-api`` and ``test-acceptance-webui``
Use them in drone

## Related Issue
https://github.com/owncloud/QA/issues/582

## Motivation and Context
Have a standard way to run acceptance tests using ``make`` commands similar to other ``make test-php-style`` etc. See QA issue referenced above.

## How Has This Been Tested?
Local runs of:
```
make test-acceptance-api BEHAT_SUITE=apiCapabilities
make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiCapabilities/capabilities.feature
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
