### PR TITLE
Fixup relative paths to work/localstorage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   - sh -c "if [ '$TEST_DAV' = '1' ]; then echo \"Testing DAV\"; fi"
 
   - sh -c "if [ '$TEST_DAV' = '1' ]; then bash apps/dav/tests/ci/$TC/script.sh; fi"
-  - sh -c "if [ '$TC' = 'selenium' ]; then cd tests/acceptance; ./run.sh --tags ~@mailhog; fi"
+  - sh -c "if [ '$TC' = 'selenium' ]; then ./tests/acceptance/run.sh --tags ~@mailhog; fi"
 
 matrix:
   include:

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1104,7 +1104,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function createFileSpecificSize($name, $size) {
-		$file = \fopen("work/$name", 'w');
+		$file = \fopen($this->workStorageDirLocation() . $name, 'w');
 		\fseek($file, $size - 1, SEEK_CUR);
 		\fwrite($file, 'a'); // write a dummy char at SIZE position
 		\fclose($file);
@@ -1117,7 +1117,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function createFileWithText($name, $text) {
-		$file = \fopen("work/$name", 'w');
+		$file = \fopen($this->workStorageDirLocation() . $name, 'w');
 		\fwrite($file, $text);
 		\fclose($file);
 	}
@@ -1154,7 +1154,8 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function fileHasBeenDeletedInLocalStorage($filename) {
-		\unlink("work/local_storage/$filename");
+		// ToDo: use testing app to cleanup files in local storage
+		\unlink($this->localStorageDirLocation() . $filename);
 	}
 
 	/**
@@ -1368,12 +1369,41 @@ trait BasicStructure {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function temporaryStorageSubfolderName() {
+		return "work";
+	}
+
+	/**
+	 * @return string
+	 */
+	public function acceptanceTestsDirLocation() {
+		return \dirname(__FILE__) . "/../../";
+	}
+
+	/**
+	 * @return string
+	 */
+	public function workStorageDirLocation() {
+		return $this->acceptanceTestsDirLocation() . $this->temporaryStorageSubfolderName() . "/";
+	}
+
+	/**
+	 * @return string
+	 */
+	public function localStorageDirLocation() {
+		return $this->workStorageDirLocation() . "local_storage/";
+	}
+
+	/**
 	 * @BeforeScenario @local_storage
 	 *
 	 * @return void
 	 */
 	public function removeFilesFromLocalStorageBefore() {
-		$dir = "./work/local_storage/";
+		// ToDo: use testing app to cleanup files in local storage
+		$dir = $this->localStorageDirLocation();
 		$di = new RecursiveDirectoryIterator(
 			$dir, FilesystemIterator::SKIP_DOTS
 		);
@@ -1391,7 +1421,8 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function removeFilesFromLocalStorageAfter() {
-		$dir = "./work/local_storage/";
+		// ToDo: use testing app to cleanup files in local storage
+		$dir = $this->localStorageDirLocation();
 		$di = new RecursiveDirectoryIterator(
 			$dir, FilesystemIterator::SKIP_DOTS
 		);

--- a/tests/acceptance/features/bootstrap/Checksums.php
+++ b/tests/acceptance/features/bootstrap/Checksums.php
@@ -42,7 +42,12 @@ trait Checksums {
 	public function userUploadsFileToWithChecksumUsingTheAPI(
 		$user, $source, $destination, $checksum
 	) {
-		$file = \GuzzleHttp\Stream\Stream::factory(\fopen($source, 'r'));
+		$file = \GuzzleHttp\Stream\Stream::factory(
+			\fopen(
+				$this->acceptanceTestsDirLocation() . $source,
+				'r'
+			)
+		);
 		$this->response = $this->makeDavRequest(
 			$user,
 			'PUT',

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1421,7 +1421,12 @@ trait WebDav {
 	 * @return void
 	 */
 	public function userUploadsAFileTo($user, $source, $destination) {
-		$file = \GuzzleHttp\Stream\Stream::factory(\fopen($source, 'r'));
+		$file = \GuzzleHttp\Stream\Stream::factory(
+			\fopen(
+				$this->acceptanceTestsDirLocation() . $source,
+				'r'
+			)
+		);
 		$this->response = $this->makeDavRequest(
 			$user, "PUT", $destination, [], $file
 		);
@@ -1457,8 +1462,12 @@ trait WebDav {
 	public function userUploadsAFileToWithChunks(
 		$user, $source, $destination, $chunkingVersion = null
 	) {
-		$size = \filesize($source);
-		$contents = \file_get_contents($source);
+		$size = \filesize(
+			$this->acceptanceTestsDirLocation() . $source
+		);
+		$contents = \file_get_contents(
+			$this->acceptanceTestsDirLocation() . $source
+		);
 
 		// use two chunks for the sake of testing
 		$chunks = [];
@@ -1674,9 +1683,13 @@ trait WebDav {
 	public function userAddsAFileTo($user, $destination, $bytes) {
 		$filename = "filespecificSize.txt";
 		$this->createFileSpecificSize($filename, $bytes);
-		PHPUnit_Framework_Assert::assertFileExists("work/$filename");
-		$this->userUploadsAFileTo($user, "work/$filename", $destination);
-		$this->removeFile("work/", $filename);
+		PHPUnit_Framework_Assert::assertFileExists($this->workStorageDirLocation() . $filename);
+		$this->userUploadsAFileTo(
+			$user,
+			$this->temporaryStorageSubfolderName() . "/$filename",
+			$destination
+		);
+		$this->removeFile($this->workStorageDirLocation(), $filename);
 		$expectedElements = new TableNode([["$destination"]]);
 		$this->checkElementList($user, $expectedElements);
 	}

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -408,7 +408,7 @@ function teardown() {
 		# Clear storage folder
 		# This depends on the test runner and server being the same file system
 		# ToDo: use the testing app to cleanup.
-		rm -Rf work/local_storage/*
+		rm -Rf ${SCRIPT_PATH}/work/local_storage/*
 	fi
 	
 	if [ "${OC_TEST_ALT_HOME}" = "1" ]
@@ -577,7 +577,7 @@ fi
 
 if [ -z "${BEHAT_YML}" ]
 then
-	BEHAT_YML="config/behat.yml"
+	BEHAT_YML="${SCRIPT_PATH}/config/behat.yml"
 fi
 
 if [ -z "${MAILHOG_HOST}" ]

--- a/tests/drone/test-acceptance.sh
+++ b/tests/drone/test-acceptance.sh
@@ -9,6 +9,4 @@ fi
 declare -x OC_TEST_ALT_HOME
 [[ -z "${OC_TEST_ALT_HOME}" ]] && OC_TEST_ALT_HOME=1
 
-pushd tests/acceptance
-    ./run.sh "$@"
-popd
+./tests/acceptance/run.sh "$@"


### PR DESCRIPTION
## Description
Remove the assumption that the current working directory is ``tests/acceptance``
That means using others ways to find out where the ``tests/acceptance/data`` and ``tests/acceptance/work`` folders can be found for various file upload/download test steps.

## Related Issue
https://github.com/owncloud/QA/issues/582

## Motivation and Context
Currently the acceptance tests ``run.sh`` script must be run by first ``cd tests/acceptance`` then ``./run.sh`` 
It would be more convenient if we can run it from wherever, e.g. ``./tests/acceptance/run.sh``

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
