### PR TITLE
Create local_storage files on the server

### DIFF
--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -73,7 +73,7 @@ Feature: checksums
   Scenario Outline: Downloading a file from local storage has correct checksum
     Given using <dav_version> DAV path
     # Create the file directly in local storage, bypassing ownCloud
-    And file "prueba_cksum.txt" with text "Test file for checksums" has been created in local storage
+    And file "prueba_cksum.txt" with text "Test file for checksums" has been created in local storage on the server
     # Do a first download, which will trigger ownCloud to calculate a checksum for the file
     When user "user0" downloads the file "/local_storage/prueba_cksum.txt" using the WebDAV API
     # Now do a download that is expected to have a checksum with it

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1098,12 +1098,15 @@ trait BasicStructure {
 	}
 
 	/**
+	 * Creates a file locally in the file system of the test runner
+	 * The file will be available to upload to the server
+	 *
 	 * @param string $name
 	 * @param string $size
 	 *
 	 * @return void
 	 */
-	public function createFileSpecificSize($name, $size) {
+	public function createLocalFileOfSpecificSize($name, $size) {
 		$file = \fopen($this->workStorageDirLocation() . $name, 'w');
 		\fseek($file, $size - 1, SEEK_CUR);
 		\fwrite($file, 'a'); // write a dummy char at SIZE position
@@ -1116,26 +1119,18 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	public function createFileWithText($name, $text) {
-		$file = \fopen($this->workStorageDirLocation() . $name, 'w');
-		\fwrite($file, $text);
-		\fclose($file);
+	public function createFileOnServerWithText($name, $text) {
+		SetupHelper::createFileOnServer(
+			$this->getBaseUrl(),
+			$this->getAdminUsername(),
+			$this->getAdminPassword(),
+			$name,
+			$text
+		);
 	}
 
 	/**
-	 * @Given file :filename of size :size has been created in local storage
-	 *
-	 * @param string $filename
-	 * @param string $size
-	 *
-	 * @return void
-	 */
-	public function fileHasBeenCreatedInLocalStorageWithSize($filename, $size) {
-		$this->createFileSpecificSize("local_storage/$filename", $size);
-	}
-
-	/**
-	 * @Given file :filename with text :text has been created in local storage
+	 * @Given file :filename with text :text has been created in local storage on the server
 	 *
 	 * @param string $filename
 	 * @param string $text
@@ -1143,7 +1138,9 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function fileHasBeenCreatedInLocalStorageWithText($filename, $text) {
-		$this->createFileWithText("local_storage/$filename", $text);
+		$this->createFileOnServerWithText(
+			LOCAL_STORAGE_DIR_ON_REMOTE_SERVER . "/$filename", $text
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1682,7 +1682,7 @@ trait WebDav {
 	 */
 	public function userAddsAFileTo($user, $destination, $bytes) {
 		$filename = "filespecificSize.txt";
-		$this->createFileSpecificSize($filename, $bytes);
+		$this->createLocalFileOfSpecificSize($filename, $bytes);
 		PHPUnit_Framework_Assert::assertFileExists($this->workStorageDirLocation() . $filename);
 		$this->userUploadsAFileTo(
 			$user,

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -542,7 +542,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			// We do not expect to be able to delete the file,
 			// so do not waste time doing too many retries.
 			$pageObject->deleteFile(
-				$name, $session, $expectToDeleteFile, MINIMUMRETRYCOUNT
+				$name, $session, $expectToDeleteFile, MINIMUM_RETRY_COUNT
 			);
 		}
 	}
@@ -598,7 +598,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		foreach ($filesTable as $file) {
 			$username = $this->featureContext->getCurrentUser();
 			$currentTime = \microtime(true);
-			$end = $currentTime + (LONGUIWAITTIMEOUTMILLISEC / 1000);
+			$end = $currentTime + (LONG_UI_WAIT_TIMEOUT_MILLISEC / 1000);
 			//retry deleting in case the file is locked (code 403)
 			while ($currentTime <= $end) {
 				$response = DeleteHelper::delete(
@@ -623,7 +623,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 					);
 				}
 				
-				\usleep(STANDARDSLEEPTIMEMICROSEC);
+				\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 				$currentTime = \microtime(true);
 			}
 			
@@ -740,7 +740,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$previousNotificationsCount = 0;
 
 		for ($retryCounter = 0;
-			 $retryCounter < STANDARDRETRYCOUNT;
+			 $retryCounter < STANDARD_RETRY_COUNT;
 			 $retryCounter++) {
 			$this->theUserUploadsOverwritingTheFileUsingTheWebUI($name);
 
@@ -761,7 +761,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 				echo $message;
 				\error_log($message);
 				$previousNotificationsCount = $currentNotificationsCount;
-				\usleep(STANDARDSLEEPTIMEMICROSEC);
+				\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			} else {
 				break;
 			}
@@ -1384,7 +1384,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		for ($i = 1; $i <= $this->filesPage->getSizeOfFileFolderList(); $i++) {
 			$actionMenu = $this->filesPage->openFileActionsMenuByNo($i);
 			
-			$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC;
+			$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC;
 			$currentTime = \microtime(true);
 			$end = $currentTime + ($timeout_msec / 1000);
 			while ($currentTime <= $end) {
@@ -1401,7 +1401,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 				if ($windowHeight >= $deleteBtnCoordinates ["top"]) {
 					break;
 				}
-				\usleep(STANDARDSLEEPTIMEMICROSEC);
+				\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 				$currentTime = \microtime(true);
 			}
 			

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -349,9 +349,9 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 				$count = (int) $count;
 			}
 			$currentTime = \microtime(true);
-			$end = $currentTime + (STANDARDUIWAITTIMEOUTMILLISEC / 1000);
+			$end = $currentTime + (STANDARD_UI_WAIT_TIMEOUT_MILLISEC / 1000);
 			while ($currentTime <= $end && ($count !== \count($dialogs))) {
-				\usleep(STANDARDSLEEPTIMEMICROSEC);
+				\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 				$currentTime = \microtime(true);
 				$dialogs = $this->owncloudPage->getOcDialogs();
 			}

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -132,7 +132,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @throws \Exception
 	 */
 	public function theUserSharesTheFileFolderWithTheUserUsingTheWebUI(
-		$folder, $remote, $user, $maxRetries = STANDARDRETRYCOUNT, $quiet = false
+		$folder, $remote, $user, $maxRetries = STANDARD_RETRY_COUNT, $quiet = false
 	) {
 		$this->filesPage->waitTillPageIsloaded($this->getSession());
 		try {

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -43,3 +43,16 @@ const MINIMUMUIWAITTIMEOUTMICROSEC = MINIMUMUIWAITTIMEOUTMILLISEC * 1000;
 const STANDARDRETRYCOUNT = 5;
 // Minimum number of times to retry where retries are useful
 const MINIMUMRETRYCOUNT = 2;
+
+// The remote server-under-test might or might not happen to have this directory.
+// If it does not exist, then the tests may end up creating it.
+const ACCEPTANCE_TEST_DIR_ON_REMOTE_SERVER = "tests/acceptance";
+
+// The following directory should NOT already exist on the remote server-under-test.
+// Acceptance tests are free to do anything needed in this directory, and to
+// delete it during or at the end of testing.
+const TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER = ACCEPTANCE_TEST_DIR_ON_REMOTE_SERVER . "/work";
+
+// The following directory is created, used, and deleted by tests that need to
+// use some "local external storage" on the server.
+const LOCAL_STORAGE_DIR_ON_REMOTE_SERVER = TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER . "/local_storage";

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -28,21 +28,21 @@ $classLoader->addPsr4("TestHelpers\\", __DIR__ . "/../../../TestHelpers", true);
 $classLoader->register();
 
 // Sleep for 10 milliseconds
-const STANDARDSLEEPTIMEMILLISEC = 10;
-const STANDARDSLEEPTIMEMICROSEC = STANDARDSLEEPTIMEMILLISEC * 1000;
+const STANDARD_SLEEP_TIME_MILLISEC = 10;
+const STANDARD_SLEEP_TIME_MICROSEC = STANDARD_SLEEP_TIME_MILLISEC * 1000;
 
 // Long timeout for use in code that needs to wait for known slow UI
-const LONGUIWAITTIMEOUTMILLISEC = 60000;
+const LONG_UI_WAIT_TIMEOUT_MILLISEC = 60000;
 // Default timeout for use in code that needs to wait for the UI
-const STANDARDUIWAITTIMEOUTMILLISEC = 10000;
+const STANDARD_UI_WAIT_TIMEOUT_MILLISEC = 10000;
 // Minimum timeout for use in code that needs to wait for the UI
-const MINIMUMUIWAITTIMEOUTMILLISEC = 500;
-const MINIMUMUIWAITTIMEOUTMICROSEC = MINIMUMUIWAITTIMEOUTMILLISEC * 1000;
+const MINIMUM_UI_WAIT_TIMEOUT_MILLISEC = 500;
+const MINIMUM_UI_WAIT_TIMEOUT_MICROSEC = MINIMUM_UI_WAIT_TIMEOUT_MILLISEC * 1000;
 
 // Default number of times to retry where retries are useful
-const STANDARDRETRYCOUNT = 5;
+const STANDARD_RETRY_COUNT = 5;
 // Minimum number of times to retry where retries are useful
-const MINIMUMRETRYCOUNT = 2;
+const MINIMUM_RETRY_COUNT = 2;
 
 // The remote server-under-test might or might not happen to have this directory.
 // If it does not exist, then the tests may end up creating it.
@@ -56,3 +56,8 @@ const TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER = ACCEPTANCE_TEST_DIR_ON_REMOTE_SER
 // The following directory is created, used, and deleted by tests that need to
 // use some "local external storage" on the server.
 const LOCAL_STORAGE_DIR_ON_REMOTE_SERVER = TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER . "/local_storage";
+
+// Deprecated forms of constants
+// ToDo: remove these after app acceptance tests have been adjusted
+const STANDARDSLEEPTIMEMICROSEC = STANDARD_SLEEP_TIME_MILLISEC * 1000;
+const STANDARDUIWAITTIMEOUTMILLISEC = 10000;

--- a/tests/acceptance/features/lib/AdminAppsSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminAppsSettingsPage.php
@@ -87,13 +87,13 @@ class AdminAppsSettingsPage extends OwncloudPage {
 	 */
 	public function waitForAjaxCallsToStartAndFinish(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$start = \microtime(true);
 		$this->waitForAjaxCallsToStart($session);
 		$end = \microtime(true);
 		$timeout_msec = $timeout_msec - (($end - $start) * 1000);
-		$timeout_msec = \max($timeout_msec, MINIMUMUIWAITTIMEOUTMILLISEC);
+		$timeout_msec = \max($timeout_msec, MINIMUM_UI_WAIT_TIMEOUT_MILLISEC);
 		$this->waitForOutstandingAjaxCalls($session, $timeout_msec);
 	}
 }

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -276,13 +276,13 @@ class AdminSharingSettingsPage extends OwncloudPage {
 	 */
 	public function waitForAjaxCallsToStartAndFinish(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$start = \microtime(true);
 		$this->waitForAjaxCallsToStart($session);
 		$end = \microtime(true);
 		$timeout_msec = $timeout_msec - (($end - $start) * 1000);
-		$timeout_msec = \max($timeout_msec, MINIMUMUIWAITTIMEOUTMILLISEC);
+		$timeout_msec = \max($timeout_msec, MINIMUM_UI_WAIT_TIMEOUT_MILLISEC);
 		$this->waitForOutstandingAjaxCalls($session, $timeout_msec);
 	}
 }

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -100,7 +100,7 @@ class FilesPage extends FilesPageBasic {
 	 */
 	public function createFolder(
 		Session $session, $name = null,
-		$timeoutMsec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeoutMsec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		if ($name === null) {
 			$name = \substr(\str_shuffle($this->strForNormalFileName), 0, 8);
@@ -165,7 +165,7 @@ class FilesPage extends FilesPageBasic {
 			if ($newFolderButton === null || !$newFolderButton->isVisible()) {
 				break;
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 		while ($currentTime <= $end) {
@@ -175,7 +175,7 @@ class FilesPage extends FilesPageBasic {
 			} catch (ElementNotFoundException $e) {
 				//loop around
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 
@@ -283,7 +283,7 @@ class FilesPage extends FilesPageBasic {
 		$fromFileName,
 		$toFileName,
 		Session $session,
-		$maxRetries = STANDARDRETRYCOUNT
+		$maxRetries = STANDARD_RETRY_COUNT
 	) {
 		if (\is_array($toFileName)) {
 			$toFileName = \implode($toFileName);
@@ -324,7 +324,7 @@ class FilesPage extends FilesPageBasic {
 	 * @return void
 	 */
 	public function moveFileTo(
-		$name, $destination, Session $session, $maxRetries = STANDARDRETRYCOUNT
+		$name, $destination, Session $session, $maxRetries = STANDARD_RETRY_COUNT
 	) {
 		$toMoveFileRow = $this->findFileRowByName($name, $session);
 		$destinationFileRow = $this->findFileRowByName($destination, $session);
@@ -447,12 +447,12 @@ class FilesPage extends FilesPageBasic {
 			);
 		}
 		$currentTime = \microtime(true);
-		$end = $currentTime + (STANDARDUIWAITTIMEOUTMILLISEC / 1000);
+		$end = $currentTime + (STANDARD_UI_WAIT_TIMEOUT_MILLISEC / 1000);
 		while ($uploadProgressbar->isVisible()) {
 			if ($currentTime > $end) {
 				break;
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 	}

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -330,7 +330,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 		$name,
 		Session $session,
 		$expectToDeleteFile = true,
-		$maxRetries = STANDARDRETRYCOUNT
+		$maxRetries = STANDARD_RETRY_COUNT
 	) {
 		$this->initAjaxCounters($session);
 		$this->resetSumStartedAjaxRequests($session);
@@ -360,7 +360,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 						. "\n-------------------------\n"
 					);
 				}
-				\usleep(STANDARDSLEEPTIMEMICROSEC);
+				\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			}
 		}
 		if ($expectToDeleteFile && ($counter > 0)) {
@@ -542,7 +542,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = LONGUIWAITTIMEOUTMILLISEC
+		$timeout_msec = LONG_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$this->initAjaxCounters($session);
 		$currentTime = \microtime(true);
@@ -597,7 +597,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 				}
 			}
 
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 
@@ -622,7 +622,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	 */
 	public function waitTillFileRowsAreReady(
 		Session $session,
-		$timeout_msec = LONGUIWAITTIMEOUTMILLISEC
+		$timeout_msec = LONG_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -639,7 +639,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 				}
 			}
 
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 
@@ -672,7 +672,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 				"could not find the appSettings section"
 			);
 		}
-		$timeout_msec = LONGUIWAITTIMEOUTMILLISEC;
+		$timeout_msec = LONG_UI_WAIT_TIMEOUT_MILLISEC;
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($appSettingsDiv->getAttribute('style') !== $this->styleOfCheckboxWhenVisible) {
@@ -682,7 +682,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 					" timed out waiting for show hidden files checkbox to appear"
 				);
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 		

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -187,7 +187,7 @@ class DetailsDialog extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -199,7 +199,7 @@ class DetailsDialog extends OwncloudPage {
 			} catch (ElementNotFoundException $e) {
 				// Just loop and try again if the element was not found yet.
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 

--- a/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
@@ -66,7 +66,7 @@ class FileActionsMenu extends OwncloudPage {
 	 * @return void
 	 */
 	public function rename(
-		$xpathToWaitFor = null, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$xpathToWaitFor = null, $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$renameBtn = $this->findButton($this->renameActionLabel);
 		if ($renameBtn === null) {
@@ -137,7 +137,7 @@ class FileActionsMenu extends OwncloudPage {
 			);
 		} else {
 			$this->waitFor(
-				STANDARDUIWAITTIMEOUTMILLISEC / 1000, [$button, 'isVisible']
+				STANDARD_UI_WAIT_TIMEOUT_MILLISEC / 1000, [$button, 'isVisible']
 			);
 			return $button;
 		}

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -185,7 +185,7 @@ class FileRow extends OwncloudPage {
 			);
 		} else {
 			$this->waitFor(
-				STANDARDUIWAITTIMEOUTMILLISEC / 1000, [$sharingDailog, 'isVisible']
+				STANDARD_UI_WAIT_TIMEOUT_MILLISEC / 1000, [$sharingDailog, 'isVisible']
 			);
 			return $this->getPage("FilesPageElement\\SharingDialog");
 		}

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -96,7 +96,7 @@ class SharingDialog extends OwncloudPage {
 	 * @return NodeElement AutocompleteElement
 	 */
 	public function fillShareWithField(
-		$input, Session $session, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$input, Session $session, $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$shareWithField = $this->findShareWithField();
 		$this->fillFieldAndKeepFocus($shareWithField, $input, $session);

--- a/tests/acceptance/features/lib/GeneralErrorPage.php
+++ b/tests/acceptance/features/lib/GeneralErrorPage.php
@@ -57,7 +57,7 @@ class GeneralErrorPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -65,7 +65,7 @@ class GeneralErrorPage extends OwncloudPage {
 			if ($this->findAll("xpath", $this->errorMessageXpath)) {
 				break;
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 

--- a/tests/acceptance/features/lib/LoginPage.php
+++ b/tests/acceptance/features/lib/LoginPage.php
@@ -77,7 +77,7 @@ class LoginPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -87,7 +87,7 @@ class LoginPage extends OwncloudPage {
 			) {
 				break;
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 

--- a/tests/acceptance/features/lib/Notification.php
+++ b/tests/acceptance/features/lib/Notification.php
@@ -64,7 +64,7 @@ class Notification extends OwncloudPage {
 	 * @return void
 	 */
 	public function followLink(
-		Session $session, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		Session $session, $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$link = $this->notificationElement->find(
 			"xpath", $this->notificationLinkXpath

--- a/tests/acceptance/features/lib/NotificationsEnabledOwncloudPage.php
+++ b/tests/acceptance/features/lib/NotificationsEnabledOwncloudPage.php
@@ -56,7 +56,7 @@ class NotificationsEnabledOwncloudPage extends OwncloudPage {
 	public function waitForNotifications() {
 		$button = $this->findNotificationsButton();
 		$this->waitFor(
-			STANDARDUIWAITTIMEOUTMILLISEC / 1000, [$button, 'isVisible']
+			STANDARD_UI_WAIT_TIMEOUT_MILLISEC / 1000, [$button, 'isVisible']
 		);
 	}
 

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -57,7 +57,7 @@ class OwncloudPage extends Page {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -71,7 +71,7 @@ class OwncloudPage extends Page {
 					break;
 				}
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 
@@ -93,7 +93,7 @@ class OwncloudPage extends Page {
 	 */
 	public function waitTillElementIsNull(
 		$xpath,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -106,7 +106,7 @@ class OwncloudPage extends Page {
 			if ($element === null) {
 				break;
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 	}
@@ -119,7 +119,7 @@ class OwncloudPage extends Page {
 	 * @return NodeElement|null
 	 */
 	public function waitTillElementIsNotNull(
-		$xpath, $timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$xpath, $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -130,12 +130,12 @@ class OwncloudPage extends Page {
 				 */
 				$element = $this->find("xpath", $xpath);
 				if ($element === null || !$element->isValid()) {
-					\usleep(STANDARDSLEEPTIMEMICROSEC);
+					\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 				} else {
 					return $element;
 				}
 			} catch (WebDriverException $e) {
-				\usleep(STANDARDSLEEPTIMEMICROSEC);
+				\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			}
 			$currentTime = \microtime(true);
 		}
@@ -421,7 +421,7 @@ class OwncloudPage extends Page {
 	 */
 	public function waitForOutstandingAjaxCalls(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$this->initAjaxCounters($session);
 		$timeout_msec = (int) $timeout_msec;
@@ -437,7 +437,7 @@ class OwncloudPage extends Page {
 				//to catch non-jQuery XHR requests
 				//but if window.activeAjaxCount was not set, ignore it
 				$waitingResult = $session->wait(
-					STANDARDSLEEPTIMEMILLISEC,
+					STANDARD_SLEEP_TIME_MILLISEC,
 					"(
 						typeof jQuery != 'undefined' 
 						&& (0 === jQuery.active) 
@@ -454,7 +454,7 @@ class OwncloudPage extends Page {
 				//show Exception message, but do not throw it
 				echo $e->getMessage() . "\n";
 			} finally {
-				\usleep(STANDARDSLEEPTIMEMICROSEC);
+				\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 				$currentTime = \microtime(true);
 			}
 		}
@@ -500,7 +500,7 @@ class OwncloudPage extends Page {
 			if ((int) $activeAjax > 0) {
 				break;
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 	}
@@ -516,13 +516,13 @@ class OwncloudPage extends Page {
 	 */
 	public function waitForAjaxCallsToStartAndFinish(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$start = \microtime(true);
 		$this->waitForAjaxCallsToStart($session);
 		$end = \microtime(true);
 		$timeout_msec = $timeout_msec - (($end - $start) * 1000);
-		$timeout_msec = \max($timeout_msec, MINIMUMUIWAITTIMEOUTMILLISEC);
+		$timeout_msec = \max($timeout_msec, MINIMUM_UI_WAIT_TIMEOUT_MILLISEC);
 		$this->waitForOutstandingAjaxCalls($session, $timeout_msec);
 	}
 
@@ -663,14 +663,14 @@ class OwncloudPage extends Page {
 	 */
 	public function waitForScrollingToFinish(
 		Session $session, $scrolledElement,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		// Wait so that, if scrolling is going to happen, it will have started.
 		// Otherwise, we might start checking early, before scrolling begins.
 		// The downside here is that if scrolling is not needed at all then we
 		// wasted time waiting.
 		// TODO: find a way to avoid this sleep
-		\usleep(MINIMUMUIWAITTIMEOUTMICROSEC);
+		\usleep(MINIMUM_UI_WAIT_TIMEOUT_MICROSEC);
 		$session->executeScript(
 			'
 			jQuery.scrolling = 0;
@@ -688,7 +688,7 @@ class OwncloudPage extends Page {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end && $result !== 0) {
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$result = (int)$session->evaluateScript("jQuery.scrolling");
 			$currentTime = \microtime(true);
 		}

--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -65,7 +65,7 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -73,7 +73,7 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 			if ($this->findById($this->personalProfilePanelId) !== null) {
 				break;
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 

--- a/tests/acceptance/features/lib/PersonalSecuritySettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSecuritySettingsPage.php
@@ -87,7 +87,7 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 			$this->createNewAppPasswordLoadingIndicatorClass
 		) !== false
 		) {
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 		}
 	}
 

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -140,7 +140,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 		$fromFileName,
 		$toFileName,
 		Session $session,
-		$maxRetries = STANDARDRETRYCOUNT
+		$maxRetries = STANDARD_RETRY_COUNT
 	) {
 		throw new \Exception("not implemented");
 	}
@@ -156,7 +156,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 * @return void
 	 */
 	public function moveFileTo(
-		$name, $destination, Session $session, $maxRetries = STANDARDRETRYCOUNT
+		$name, $destination, Session $session, $maxRetries = STANDARD_RETRY_COUNT
 	) {
 		throw new \Exception("not implemented");
 	}

--- a/tests/acceptance/features/lib/SharedWithYouPage.php
+++ b/tests/acceptance/features/lib/SharedWithYouPage.php
@@ -89,7 +89,7 @@ class SharedWithYouPage extends FilesPageBasic {
 		$name,
 		Session $session,
 		$expectToDeleteFile = true,
-		$maxRetries = STANDARDRETRYCOUNT
+		$maxRetries = STANDARD_RETRY_COUNT
 	) {
 		$this->initAjaxCounters($session);
 		$this->resetSumStartedAjaxRequests($session);
@@ -119,7 +119,7 @@ class SharedWithYouPage extends FilesPageBasic {
 						. "\n-------------------------\n"
 					);
 				}
-				\usleep(STANDARDSLEEPTIMEMICROSEC);
+				\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			}
 		}
 		if ($expectToDeleteFile && ($counter > 0)) {


### PR DESCRIPTION
## Description
Modify acceptance test steps that create files in "local_storage" to use the testing app to create the files.

## Related Issue

## Motivation and Context
There is acceptance test code that still creates files in the local filesystem and expects them to "appear" in the server file system. We do not want to assume this works any more.

## How Has This Been Tested?
Local runs of affected acceptance tests e.g.:
```
./tests/acceptance/run.sh tests/acceptance/features/apiMain/checksums.feature:73
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
