### PR TITLE
Automate squizlabs/php_codesniffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ help:
 	@echo -e "make clean\t\t\tclean everything"
 	@echo -e "make install-composer-deps\tinstall composer dependencies"
 	@echo -e "make update-composer\t\tupdate composer.lock"
-	@echo -e "make install-nodejs-deps\t\tinstall Node JS and Javascript dependencies"
+	@echo -e "make install-nodejs-deps\tinstall Node JS and Javascript dependencies"
 	@echo
 	@echo -e "Note that running 'make' without arguments already installs all required dependencies"
 	@echo
@@ -196,6 +196,7 @@ test-php-lint: $(composer_dev_deps)
 .PHONY: test-php-style
 test-php-style: $(composer_dev_deps)
 	$(composer_deps)/bin/php-cs-fixer fix -v --diff --diff-format udiff --dry-run --allow-risky yes
+	$(composer_deps)/bin/phpcs --runtime-set ignore_warnings_on_exit --standard=phpcs.xml tests/acceptance
 	php build/OCPSinceChecker.php
 
 .PHONY: test-php-style-fix

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "jarnaiz/behat-junit-formatter": "^1.3",
         "mikey179/vfsStream": "^1.6",
         "owncloud/coding-standard": "^1.0",
+        "squizlabs/php_codesniffer": "3.*",
         "phpunit/phpunit": "^5.7",
         "rdx/behat-variables": "^1.2",
         "roave/security-advisories": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "877502d6d6413a3205010925d8eaf358",
+    "content-hash": "d5dab3f1e734c13923a671823ccdd03e",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -5255,6 +5255,17 @@
         {
             "name": "roave/security-advisories",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Roave/SecurityAdvisories.git",
+                "reference": "0abc14e0df387fe74b4b32e0b8647d1639256d38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/0abc14e0df387fe74b4b32e0b8647d1639256d38",
+                "reference": "0abc14e0df387fe74b4b32e0b8647d1639256d38",
+                "shasum": ""
+            },
             "conflict": {
                 "3f/pygmentize": "<1.2",
                 "adodb/adodb-php": "<5.20.12",
@@ -5425,7 +5436,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2018-09-17T20:20:31+00:00"
+            "time": "2018-08-14T15:39:17+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -6006,6 +6017,57 @@
                 "page"
             ],
             "time": "2017-05-22T14:16:06+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-09-23T23:08:17+00:00"
         },
         {
             "name": "symfony/browser-kit",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -19,6 +19,10 @@
 		<exclude name="Generic.WhiteSpace.DisallowTabIndent.NonIndentTabsUsed" />
 	</rule>
 
+	<rule ref="Generic.Files.LineLength">
+		<exclude name="Generic.Files.LineLength.TooLong" />
+	</rule>
+
 	<rule ref="PEAR">
 		<exclude name="Generic.Commenting.DocComment.ShortNotCapital" />
 		<exclude name="Generic.Commenting.DocComment.SpacingAfter" />

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -1657,7 +1657,7 @@ trait BasicStructure {
 				'local',
 				'null::null',
 				'-c',
-				'datadir=' . $this->getServerRoot(). '/' . LOCAL_STORAGE_DIR_ON_REMOTE_SERVER
+				'datadir=' . $this->getServerRoot() . '/' . LOCAL_STORAGE_DIR_ON_REMOTE_SERVER
 			]
 		);
 		// stdOut should have a string like "Storage created with id 65"

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -97,13 +97,13 @@ class DetailsDialog extends OwncloudPage {
 	 */
 	public function changeDetailsTab($tabName) {
 		$tabId = $this->getDetailsTabId($tabName);
-		$tabSwitchXpath = "//li[@data-tabid='".$tabId."']";
+		$tabSwitchXpath = "//li[@data-tabid='" . $tabId . "']";
 		$tabSwitch = $this->find("xpath", $tabSwitchXpath);
 		if ($tabSwitch === null) {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" could not find tab switch with id $tabName"
-				);
+			);
 		}
 		$this->waitTillElementIsNotNull($tabSwitchXpath);
 		$tabSwitch->focus();

--- a/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
@@ -110,7 +110,7 @@ class FileActionsMenu extends OwncloudPage {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" could not find action button with label $this->deleteActionLabel"
-				);
+			);
 		}
 		$detailsBtn->focus();
 		$detailsBtn->click();


### PR DESCRIPTION
## Description
- implement ``phpcs`` to enforce the existing acceptance test code style rules
- do it as an extra step of the existing ``test-php-style`` make target
- fix style of code

## Related Issue
- Fixes #32782 

## Motivation and Context
See issue.

## How Has This Been Tested?
Local run:
```
make test-php-style
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
