### PR TITLE
Always prepend a slash to SetupHelper ocPath

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -178,6 +178,18 @@ class SetupHelper {
 	}
 
 	/**
+	 * Fixup OC path so that it always starts with a "/" and does not end with
+	 * a "/".
+	 *
+	 * @param string $ocPath
+	 *
+	 * @return string
+	 */
+	private static function normaliseOcPath($ocPath) {
+		return '/' . \trim($ocPath, '/');
+	}
+
+	/**
 	 *
 	 * @param string $adminUsername
 	 * @param string $adminPassword
@@ -200,7 +212,7 @@ class SetupHelper {
 		self::$adminUsername = $adminUsername;
 		self::$adminPassword = $adminPassword;
 		self::$baseUrl = \rtrim($baseUrl, '/');
-		self::$ocPath = '/' . \trim($ocPath, '/');
+		self::$ocPath = self::normaliseOcPath($ocPath);
 	}
 
 	/**
@@ -427,6 +439,8 @@ class SetupHelper {
 		}
 		if ($ocPath === null) {
 			$ocPath = self::$ocPath;
+		} else {
+			$ocPath = self::normaliseOcPath($ocPath);
 		}
 
 		$body = [];
@@ -470,7 +484,7 @@ class SetupHelper {
 		self::resetOpcache($baseUrl, $adminUsername, $adminPassword);
 		return $return;
 	}
-	
+
 	/**
 	 * @param string $baseUrl
 	 * @param string $user
@@ -490,7 +504,7 @@ class SetupHelper {
 			);
 		} catch (ServerException $e) {
 			echo "could not reset opcache, if tests fail try to set " .
-				 "'opcache.revalidate_freq=0' in the php.ini file\n";
+				"'opcache.revalidate_freq=0' in the php.ini file\n";
 		}
 	}
 }


### PR DESCRIPTION
## Description
In ``SetupHelper``, always normalize ``ocPath`` to have a leading ``/`` no matter where it is passed in.

## Motivation and Context
If I call ``SetupHelper::init`` with an ``ocPath`` that does not start with a ``/`` then ``SetupHelper`` is nice to me and puts a slash in front. Everything works.

But if I call ``SetupHelper::runOcc`` and pass it ``ocPath`` in the call, then the ``/`` is not added to the front. This causes ``runOcc`` to fail.

I noticed will developing some new acceptance test code that uses ``runOcc``

## How Has This Been Tested?
Local API acceptance test runs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
