### PR TITLE
Test public link share using email with email to self checked

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -220,9 +220,10 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @param string $name
 	 * @param TableNode $settings table with the settings and no header
 	 *                            possible settings: name, permission,
-	 *                            password, expiration, email
+	 *                            password, expiration, email, emailToSelf
 	 *                            the permissions values has to be written exactly
 	 *                            the way its written in the UI
+	 *                            Setting emailToSelf will send a copy of email to the link creator
 	 *
 	 * @return void
 	 * @throws \Exception
@@ -865,13 +866,17 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			if (!isset($settingsArray['email'])) {
 				$settingsArray['email'] = null;
 			}
+			if (!isset($settingsArray['emailToSelf'])) {
+				$settingsArray['emailToSelf'] = null;
+			}
 			$linkName = $this->publicShareTab->createLink(
 				$this->getSession(),
 				$settingsArray ['name'],
 				$settingsArray ['permission'],
 				$settingsArray ['password'],
 				$settingsArray ['expiration'],
-				$settingsArray ['email']
+				$settingsArray ['email'],
+				$settingsArray ['emailToSelf']
 			);
 			if ($settingsArray['name'] !== null) {
 				PHPUnit_Framework_Assert::assertSame(

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
@@ -41,6 +41,7 @@ class EditPublicLinkPopup extends OwncloudPage {
 	private $expirationDateLabelXpath = ".//label[contains(text(), 'Expiration')]";
 	private $expirationDateInputXpath = ".//input[contains(@class,'expirationDate')]";
 	private $emailInputXpath = "//form[@id='emailPrivateLink']//input[@class='select2-input']";
+	private $emailToSelfCheckboxXpath = "//form[@id='emailPrivateLink']" . "//input[@class='emailPrivateLinkForm--emailToSelf']";
 	private $shareButtonXpath = ".//button[contains(text(), 'Share')]";
 	private $permissionLabelXpath = [
 		'read' => ".//label[contains(@for, 'sharingDialogAllowPublicRead')]",
@@ -194,6 +195,23 @@ class EditPublicLinkPopup extends OwncloudPage {
 			);
 		}
 		$emailInput->setValue($email . "\n");
+	}
+
+	/**
+	 *
+	 * @return void
+	 */
+	public function setEmailToSelf() {
+		$checkbox = $this->popupElement->find("xpath", $this->emailToSelfCheckboxXpath);
+		if ($checkbox === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->emailToSelfCheckboxXpath" .
+				" could not find the checkbox for sending the self copy of email of the public link. " .
+				" Maybe the email isn't filled."
+				);
+		}
+		$checkbox->click();
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -75,6 +75,7 @@ class PublicLinkTab extends OwncloudPage {
 	 * @param string $password
 	 * @param string $expirationDate
 	 * @param string $email
+	 * @param bool $emailToSelf
 	 *
 	 * @return string the name of the created public link
 	 */
@@ -84,7 +85,8 @@ class PublicLinkTab extends OwncloudPage {
 		$permissions = null,
 		$password = null,
 		$expirationDate = null,
-		$email = null
+		$email = null,
+		$emailToSelf = null
 	) {
 		$createLinkBtn = $this->publicLinkTabElement->find(
 			"xpath", $this->createLinkBtnXpath
@@ -121,6 +123,9 @@ class PublicLinkTab extends OwncloudPage {
 		}
 		if ($email !== null) {
 			$editPublicLinkPopupPageObject->setLinkEmail($email);
+		}
+		if ($emailToSelf === "true" && $email !== null) {
+			$editPublicLinkPopupPageObject->setEmailToSelf();
 		}
 		$linkName = $editPublicLinkPopupPageObject->getLinkName();
 		$editPublicLinkPopupPageObject->save();

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -149,3 +149,20 @@ So that public sharing is limited according to organization policy
 			User One shared simple-folder with you
 			"""
 		And the email address "foo@bar.co" should have received an email containing last shared public link
+
+	Scenario: user shares a public link via email and sends a copy to self
+		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+		And the user has reloaded the current page of the webUI
+		When the user creates a new public link for the folder "simple-folder" using the webUI with
+		| email | foo@bar.co |
+		| emailToSelf | true |
+		Then the email address "foo@bar.co" should have received an email with the body containing
+			"""
+			User One shared simple-folder with you
+			"""
+		And the email address "u1@oc.com.np" should have received an email with the body containing
+			"""
+			User One shared simple-folder with you
+			"""
+		And the email address "foo@bar.co" should have received an email containing last shared public link
+		And the email address "u1@oc.com.np" should have received an email containing last shared public link


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This adds a test that the user and the creator of the link both gets the email if the `Send a copy to self` is checked.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to #30892 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
