### PR TITLE
UI-tests - get element of highlighted content in search

### DIFF
--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -59,6 +59,7 @@ class FileRow extends OwncloudPage {
 	protected $acceptShareBtnXpath = "//span[@class='fileactions']//a[contains(@class,'accept')]";
 	protected $declinePendingShareBtnXpath = "//a[@data-action='Reject']";
 	protected $sharingDialogXpath = ".//div[@class='dialogContainer']";
+	protected $highlightsXpath = "//div[@class='highlights']";
 
 	/**
 	 *
@@ -475,5 +476,24 @@ class FileRow extends OwncloudPage {
 		}
 		$element->click();
 		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
+	 * returns the element that contains the highlighted content of the file
+	 * when using elastic search
+	 *
+	 * @throws ElementNotFoundException
+	 * @return NodeElement
+	 */
+	public function getHighlightsElement() {
+		$element = $this->rowElement->find("xpath", $this->highlightsXpath);
+		if ($element === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->highlightsXpath " .
+				" highlights element not found"
+			);
+		}
+		return $element;
 	}
 }


### PR DESCRIPTION
## Description
search-elastic shows part of the file content, we need to be able to get that from the fileRow

## Related Issue
https://github.com/owncloud/search_elastic/issues/26

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
