### PR TITLE
Refactor acceptance test methods for accessing testing app

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -273,18 +273,90 @@ class SetupHelper {
 	}
 
 	/**
+	 * @param string|null $adminUsername
+	 * @param string $callerName
 	 *
-	 * @param string $baseUrl
-	 * @param string $adminUsername
-	 * @param string $adminPassword
+	 * @return string
+	 * @throws Exception
+	 */
+	private static function checkAdminUsername(
+		$adminUsername, $callerName) {
+		if (self::$adminUsername === null
+			&& $adminUsername === null
+		) {
+			throw new Exception(
+				"$callerName called without adminUsername - pass the username or call SetupHelper::init"
+			);
+		}
+		if ($adminUsername === null) {
+			$adminUsername = self::$adminUsername;
+		}
+		return $adminUsername;
+	}
+
+	/**
+	 * @param string|null $adminPassword
+	 * @param string $callerName
+	 *
+	 * @return string
+	 * @throws Exception
+	 */
+	private static function checkAdminPassword(
+		$adminPassword, $callerName) {
+		if (self::$adminPassword === null
+			&& $adminPassword === null
+		) {
+			throw new Exception(
+				"$callerName called without adminPassword - pass the password or call SetupHelper::init"
+			);
+		}
+		if ($adminPassword === null) {
+			$adminPassword = self::$adminPassword;
+		}
+		return $adminPassword;
+	}
+
+	/**
+	 * @param string|null $baseUrl
+	 * @param string $callerName
+	 *
+	 * @return string
+	 * @throws Exception
+	 */
+	private static function checkBaseUrl(
+		$baseUrl, $callerName) {
+		if (self::$baseUrl === null
+			&& $baseUrl === null
+		) {
+			throw new Exception(
+				"$callerName called without baseUrl - pass the baseUrl or call SetupHelper::init"
+			);
+		}
+		if ($baseUrl === null) {
+			$baseUrl = self::$baseUrl;
+		}
+		return $baseUrl;
+	}
+
+	/**
+	 *
 	 * @param string $dirPathFromServerRoot e.g. 'apps2/myapp/appinfo'
+	 * @param string|null $baseUrl
+	 * @param string|null $adminUsername
+	 * @param string|null $adminPassword
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
 	public static function mkDirOnServer(
-		$baseUrl, $adminUsername, $adminPassword, $dirPathFromServerRoot
+		$dirPathFromServerRoot,
+		$baseUrl = null,
+		$adminUsername = null,
+		$adminPassword = null
 	) {
+		$baseUrl = self::checkBaseUrl($baseUrl, "mkDirOnServer");
+		$adminUsername = self::checkAdminUsername($adminUsername, "mkDirOnServer");
+		$adminPassword = self::checkAdminPassword($adminPassword, "mkDirOnServer");
 		$result = OcsApiHelper::sendRequest(
 			$baseUrl, $adminUsername, $adminPassword, "POST",
 			"/apps/testing/api/v1/dir",
@@ -300,18 +372,25 @@ class SetupHelper {
 
 	/**
 	 *
-	 * @param string $baseUrl
-	 * @param string $adminUsername
-	 * @param string $adminPassword
 	 * @param string $filePathFromServerRoot e.g. 'app2/myapp/appinfo/info.xml'
 	 * @param string $content
+	 * @param string|null $baseUrl
+	 * @param string|null $adminUsername
+	 * @param string|null $adminPassword
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
 	public static function createFileOnServer(
-		$baseUrl, $adminUsername, $adminPassword, $filePathFromServerRoot, $content
+		$filePathFromServerRoot,
+		$content,
+		$baseUrl = null,
+		$adminUsername = null,
+		$adminPassword = null
 	) {
+		$baseUrl = self::checkBaseUrl($baseUrl, "createFileOnServer");
+		$adminUsername = self::checkAdminUsername($adminUsername, "createFileOnServer");
+		$adminPassword = self::checkAdminPassword($adminPassword, "createFileOnServer");
 		$result = OcsApiHelper::sendRequest(
 			$baseUrl, $adminUsername, $adminPassword, "POST",
 			"/apps/testing/api/v1/file",
@@ -400,42 +479,15 @@ class SetupHelper {
 		$ocPath = null,
 		$envVariables = null
 	) {
-		if (self::$adminUsername === null
-			&& $adminUsername === null
-		) {
-			throw new Exception(
-				"runOcc called without adminUsername - pass the username or call SetupHelper::init"
-			);
-		}
-		if (self::$adminPassword === null
-			&& $adminPassword === null
-		) {
-			throw new Exception(
-				"runOcc called without adminPassword - pass the password or call SetupHelper::init"
-			);
-		}
-		if (self::$baseUrl === null
-			&& $baseUrl === null
-		) {
-			throw new Exception(
-				"runOcc called without baseUrl - pass the baseUrl or call SetupHelper::init"
-			);
-		}
+		$baseUrl = self::checkBaseUrl($baseUrl, "runOcc");
+		$adminUsername = self::checkAdminUsername($adminUsername, "runOcc");
+		$adminPassword = self::checkAdminPassword($adminPassword, "runOcc");
 		if (self::$ocPath === null
 			&& $ocPath === null
 		) {
 			throw new Exception(
 				"runOcc called without ocPath - pass the ocPath or call SetupHelper::init"
 			);
-		}
-		if ($adminUsername === null) {
-			$adminUsername = self::$adminUsername;
-		}
-		if ($adminPassword === null) {
-			$adminPassword = self::$adminPassword;
-		}
-		if ($baseUrl === null) {
-			$baseUrl = self::$baseUrl;
 		}
 		if ($ocPath === null) {
 			$ocPath = self::$ocPath;

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -38,67 +38,9 @@ class AppManagementContext implements Context {
 	private $oldAppsPaths;
 
 	/**
-	 * @var string location of the root folder of ownCloud on the server
-	 */
-	private $serverRoot = null;
-
-	/**
 	 * @var string stdout of last command
 	 */
 	private $cmdOutput;
-
-	/**
-	 * Get the path of the ownCloud server root directory
-	 *
-	 * @return string
-	 * @throws Exception
-	 */
-	private function getServerRoot() {
-		if ($this->serverRoot === null) {
-			$this->serverRoot = SetupHelper::getServerRoot(
-				$this->featureContext->getBaseUrl(),
-				$this->featureContext->getAdminUsername(),
-				$this->featureContext->getAdminPassword()
-			);
-		}
-		return $this->serverRoot;
-	}
-
-	/**
-	 * Make a directory under the server root on the ownCloud server
-	 *
-	 * @param string $dirPathFromServerRoot e.g. 'apps2/myapp/appinfo'
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	private function mkDirOnServer($dirPathFromServerRoot) {
-		SetupHelper::mkDirOnServer(
-			$this->featureContext->getBaseUrl(),
-			$this->featureContext->getAdminUsername(),
-			$this->featureContext->getAdminPassword(),
-			$dirPathFromServerRoot
-		);
-	}
-
-	/**
-	 * Create a file under the server root on the ownCloud server
-	 *
-	 * @param string $filePathFromServerRoot e.g. 'app2/myapp/appinfo/info.xml'
-	 * @param string $content
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	private function createFileOnServer($filePathFromServerRoot, $content) {
-		SetupHelper::createFileOnServer(
-			$this->featureContext->getBaseUrl(),
-			$this->featureContext->getAdminUsername(),
-			$this->featureContext->getAdminPassword(),
-			$filePathFromServerRoot,
-			$content
-		);
-	}
 
 	/**
 	 * @BeforeScenario
@@ -166,11 +108,11 @@ class AppManagementContext implements Context {
 	 * @throws Exception
 	 */
 	public function setAppDirectories($dir1, $dir2) {
-		$fullpath1 = $this->getServerRoot() . "/$dir1";
-		$fullpath2 = $this->getServerRoot() . "/$dir2";
+		$fullpath1 = $this->featureContext->getServerRoot() . "/$dir1";
+		$fullpath2 = $this->featureContext->getServerRoot() . "/$dir2";
 
-		$this->mkDirOnServer($dir1);
-		$this->mkDirOnServer($dir2);
+		$this->featureContext->mkDirOnServer($dir1);
+		$this->featureContext->mkDirOnServer($dir2);
 		$this->setAppsPaths(
 			[
 				['path' => $fullpath1, 'url' => $dir1, 'writable' => true],
@@ -218,8 +160,8 @@ class AppManagementContext implements Context {
 			$ocVersion
 		);
 		$targetDir = "$dir/$appId/appinfo";
-		$this->mkDirOnServer($targetDir);
-		$this->createFileOnServer("$targetDir/info.xml", $appInfo);
+		$this->featureContext->mkDirOnServer($targetDir);
+		$this->featureContext->createFileOnServerWithContent("$targetDir/info.xml", $appInfo);
 	}
 
 	/**
@@ -246,7 +188,7 @@ class AppManagementContext implements Context {
 	 */
 	public function appPathIs($appId, $dir) {
 		PHPUnit_Framework_Assert::assertEquals(
-			$this->getServerRoot() . "/$dir/$appId",
+			$this->featureContext->getServerRoot() . "/$dir/$appId",
 			\trim($this->cmdOutput)
 		);
 	}

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -66,6 +66,11 @@ trait BasicStructure {
 	private $ocPath = '';
 
 	/**
+	 * @var string location of the root folder of ownCloud on the local server under test
+	 */
+	private $localServerRoot = null;
+
+	/**
 	 * @var string
 	 */
 	private $currentUser = '';
@@ -1114,18 +1119,37 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @param string $name
-	 * @param string $text
+	 * Make a directory under the server root on the ownCloud server
+	 *
+	 * @param string $dirPathFromServerRoot e.g. 'apps2/myapp/appinfo'
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function mkDirOnServer($dirPathFromServerRoot) {
+		SetupHelper::mkDirOnServer(
+			$dirPathFromServerRoot,
+			$this->getBaseUrl(),
+			$this->getAdminUsername(),
+			$this->getAdminPassword()
+		);
+	}
+
+	/**
+	 * @param string $filePathFromServerRoot
+	 * @param string $content
 	 *
 	 * @return void
 	 */
-	public function createFileOnServerWithText($name, $text) {
+	public function createFileOnServerWithContent(
+		$filePathFromServerRoot, $content
+	) {
 		SetupHelper::createFileOnServer(
+			$filePathFromServerRoot,
+			$content,
 			$this->getBaseUrl(),
 			$this->getAdminUsername(),
-			$this->getAdminPassword(),
-			$name,
-			$text
+			$this->getAdminPassword()
 		);
 	}
 
@@ -1138,7 +1162,7 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function fileHasBeenCreatedInLocalStorageWithText($filename, $text) {
-		$this->createFileOnServerWithText(
+		$this->createFileOnServerWithContent(
 			LOCAL_STORAGE_DIR_ON_REMOTE_SERVER . "/$filename", $text
 		);
 	}
@@ -1391,6 +1415,23 @@ trait BasicStructure {
 	 */
 	public function localStorageDirLocation() {
 		return $this->workStorageDirLocation() . "local_storage/";
+	}
+
+	/**
+	 * Get the path of the ownCloud server root directory
+	 *
+	 * @return string
+	 * @throws Exception
+	 */
+	public function getServerRoot() {
+		if ($this->localServerRoot === null) {
+			$this->localServerRoot = SetupHelper::getServerRoot(
+				$this->getBaseUrl(),
+				$this->getAdminUsername(),
+				$this->getAdminPassword()
+			);
+		}
+		return $this->localServerRoot;
 	}
 
 	/**


### PR DESCRIPTION
## Description
Refactor acceptance test code as described below.

## Motivation and Context
Some methods in ``SetupHelper`` force you to pass admin username, password, baseUrl every time. Shuffle the parameters and make admin username, password, baseUrl optional - like the way runOcc does it.

``AppManagementContext`` has methods ``getServerRoot`` ``mkDirOnServer`` and ``createFileOnServer`` that are more widely useful. Move them into ``BasicStructure`` and call them from there.

This stuff was noticed in developing PR #32800 that moves creation of ``local_storage`` to use the testing app. But this stuff is good to have in place first anyway, so that any other changes can immediately make use of it.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
