### PR TITLE
Manage local storage via testing app

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -372,6 +372,38 @@ class SetupHelper {
 
 	/**
 	 *
+	 * @param string $dirPathFromServerRoot e.g. 'apps2/myapp/appinfo'
+	 * @param string|null $baseUrl
+	 * @param string|null $adminUsername
+	 * @param string|null $adminPassword
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public static function rmDirOnServer(
+		$dirPathFromServerRoot,
+		$baseUrl = null,
+		$adminUsername = null,
+		$adminPassword = null
+	) {
+		$baseUrl = self::checkBaseUrl($baseUrl, "rmDirOnServer");
+		$adminUsername = self::checkAdminUsername($adminUsername, "rmDirOnServer");
+		$adminPassword = self::checkAdminPassword($adminPassword, "rmDirOnServer");
+		$result = OcsApiHelper::sendRequest(
+			$baseUrl, $adminUsername, $adminPassword, "DELETE",
+			"/apps/testing/api/v1/dir",
+			['dir' => $dirPathFromServerRoot]
+		);
+
+		if ($result->getStatusCode() !== 200) {
+			throw new \Exception(
+				"could not delete directory $dirPathFromServerRoot " . $result->getReasonPhrase()
+			);
+		}
+	}
+
+	/**
+	 *
 	 * @param string $filePathFromServerRoot e.g. 'app2/myapp/appinfo/info.xml'
 	 * @param string $content
 	 * @param string|null $baseUrl
@@ -403,6 +435,40 @@ class SetupHelper {
 		if ($result->getStatusCode() !== 200) {
 			throw new \Exception(
 				"could not create file $filePathFromServerRoot " . $result->getReasonPhrase()
+			);
+		}
+	}
+
+	/**
+	 *
+	 * @param string $filePathFromServerRoot e.g. 'app2/myapp/appinfo/info.xml'
+	 * @param string|null $baseUrl
+	 * @param string|null $adminUsername
+	 * @param string|null $adminPassword
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public static function deleteFileOnServer(
+		$filePathFromServerRoot,
+		$baseUrl = null,
+		$adminUsername = null,
+		$adminPassword = null
+	) {
+		$baseUrl = self::checkBaseUrl($baseUrl, "deleteFileOnServer");
+		$adminUsername = self::checkAdminUsername($adminUsername, "deleteFileOnServer");
+		$adminPassword = self::checkAdminPassword($adminPassword, "deleteFileOnServer");
+		$result = OcsApiHelper::sendRequest(
+			$baseUrl, $adminUsername, $adminPassword, "DELETE",
+			"/apps/testing/api/v1/file",
+			[
+				'file' => $filePathFromServerRoot
+			]
+		);
+
+		if ($result->getStatusCode() !== 200) {
+			throw new \Exception(
+				"could not delete file $filePathFromServerRoot " . $result->getReasonPhrase()
 			);
 		}
 	}

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -42,7 +42,7 @@ Feature: external-storage
     Given user "user0" has been created
     And user "user0" has created a folder "/local_storage/foo3"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/foo3/textfile0.txt"
-    And file "foo3/textfile0.txt" has been deleted in local storage
+    And file "foo3/textfile0.txt" has been deleted from local storage on the server
     When user "user0" downloads the file "local_storage/foo3/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "404"
     And as "user0" the file "local_storage/foo3/textfile0.txt" should not exist

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -164,6 +164,11 @@ trait BasicStructure {
 	private $requestToken;
 
 	/**
+	 * @var string
+	 */
+	private $storageId = null;
+
+	/**
 	 * The local source IP address from which to initiate API actions.
 	 * Defaults to system-selected address matching IP address family and scope.
 	 *
@@ -1243,7 +1248,11 @@ trait BasicStructure {
 	 * @return void
 	 */
 	public function createLocalFileOfSpecificSize($name, $size) {
-		$file = \fopen($this->workStorageDirLocation() . $name, 'w');
+		$folder = $this->workStorageDirLocation();
+		if (!\is_dir($folder)) {
+			\mkDir($folder);
+		}
+		$file = \fopen($folder . $name, 'w');
 		\fseek($file, $size - 1, SEEK_CUR);
 		\fwrite($file, 'a'); // write a dummy char at SIZE position
 		\fclose($file);
@@ -1299,15 +1308,19 @@ trait BasicStructure {
 	}
 
 	/**
-	 * @Given file :filename has been deleted in local storage
+	 * @Given file :filename has been deleted from local storage on the server
 	 *
 	 * @param string $filename
 	 *
 	 * @return void
 	 */
 	public function fileHasBeenDeletedInLocalStorage($filename) {
-		// ToDo: use testing app to cleanup files in local storage
-		\unlink($this->localStorageDirLocation() . $filename);
+		SetupHelper::deleteFileOnServer(
+			LOCAL_STORAGE_DIR_ON_REMOTE_SERVER . "/$filename",
+			$this->getBaseUrl(),
+			$this->getAdminUsername(),
+			$this->getAdminPassword()
+		);
 	}
 
 	/**
@@ -1563,7 +1576,7 @@ trait BasicStructure {
 	 * @return string
 	 */
 	public function temporaryStorageSubfolderName() {
-		return "work";
+		return "work_tmp";
 	}
 
 	/**
@@ -1578,13 +1591,6 @@ trait BasicStructure {
 	 */
 	public function workStorageDirLocation() {
 		return $this->acceptanceTestsDirLocation() . $this->temporaryStorageSubfolderName() . "/";
-	}
-
-	/**
-	 * @return string
-	 */
-	public function localStorageDirLocation() {
-		return $this->workStorageDirLocation() . "local_storage/";
 	}
 
 	/**
@@ -1609,18 +1615,37 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	public function removeFilesFromLocalStorageBefore() {
-		// ToDo: use testing app to cleanup files in local storage
-		$dir = $this->localStorageDirLocation();
-		$di = new RecursiveDirectoryIterator(
-			$dir, FilesystemIterator::SKIP_DOTS
+	public function setupLocalStorageBefore() {
+		SetupHelper::init(
+			$this->getAdminUsername(),
+			$this->getAdminPassword(),
+			$this->getBaseUrl(),
+			$this->getOcPath()
 		);
-		$ri = new RecursiveIteratorIterator(
-			$di, RecursiveIteratorIterator::CHILD_FIRST
+		SetupHelper::mkDirOnServer(
+			LOCAL_STORAGE_DIR_ON_REMOTE_SERVER
 		);
-		foreach ($ri as $file) {
-			$file->isDir() ?  \rmdir($file) : \unlink($file);
-		}
+		$result = SetupHelper::runOcc(
+			[
+				'files_external:create',
+				'local_storage',
+				'local',
+				'null::null',
+				'-c',
+				'datadir=' . $this->getServerRoot(). '/' . LOCAL_STORAGE_DIR_ON_REMOTE_SERVER
+			]
+		);
+		// stdOut should have a string like "Storage created with id 65"
+		$storageIdWords = \explode(" ", \trim($result['stdOut']));
+		$this->storageId = $storageIdWords[4];
+		SetupHelper::runOcc(
+			[
+				'files_external:option',
+				$this->storageId,
+				'enable_sharing',
+				'true'
+			]
+		);
 	}
 
 	/**
@@ -1628,18 +1653,22 @@ trait BasicStructure {
 	 *
 	 * @return void
 	 */
-	public function removeFilesFromLocalStorageAfter() {
-		// ToDo: use testing app to cleanup files in local storage
-		$dir = $this->localStorageDirLocation();
-		$di = new RecursiveDirectoryIterator(
-			$dir, FilesystemIterator::SKIP_DOTS
-		);
-		$ri = new RecursiveIteratorIterator(
-			$di, RecursiveIteratorIterator::CHILD_FIRST
-		);
-		foreach ($ri as $file) {
-			$file->isDir() ?  \rmdir($file) : \unlink($file);
+	public function removeLocalStorageAfter() {
+		if ($this->storageId !== null) {
+			SetupHelper::runOcc(
+				[
+					'files_external:delete',
+					'-y',
+					$this->storageId
+				]
+			);
 		}
+		SetupHelper::rmDirOnServer(
+			LOCAL_STORAGE_DIR_ON_REMOTE_SERVER
+		);
+		SetupHelper::rmDirOnServer(
+			TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -55,7 +55,7 @@ const ACCEPTANCE_TEST_DIR_ON_REMOTE_SERVER = "tests/acceptance";
 // The following directory should NOT already exist on the remote server-under-test.
 // Acceptance tests are free to do anything needed in this directory, and to
 // delete it during or at the end of testing.
-const TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER = ACCEPTANCE_TEST_DIR_ON_REMOTE_SERVER . "/work";
+const TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER = ACCEPTANCE_TEST_DIR_ON_REMOTE_SERVER . "/server_tmp";
 
 // The following directory is created, used, and deleted by tests that need to
 // use some "local external storage" on the server.


### PR DESCRIPTION
## Description
Add methods that call the testing app to do file and folder deletes.

Use them to teardown ``local_storage`` after test scenarios.

Use them for ``fileHasBeenDeletedInLocalStorage($filename)`` 

Call the folder on the server-under-test ``server_tmp`` rather than the current ``work`` to differentiate it clearly, particularly in the "usual" case where the file system of the test runner and the system-under-test happen to be the same. Similarly, rename the folder for storing temporary files created by the test-runner from ``work`` to ``work_tmp``. This helps demonstrate a clear separation between the 2 folder usages, and that there are no "hanging" references to the old ``work`` folder.

## Motivation and Context
Test runner code currently creates ``local_storage`` via the testing app, but tries to clean it up at the end by deleting the files/folders in the local file system, rather than in the file system of the system-under-test.

There is also a test step method ``fileHasBeenDeletedInLocalStorage($filename)`` - that currently deletes the file in the local file system, which is not effective if the system-under-test is remote.

The testing app now has the ability to delete files and folders on the system-under-test. So we can use that.

## How Has This Been Tested?
CI


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
