### PR TITLE
Allow REGULAR_USER_PASSWORD env var

### DIFF
--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -196,6 +196,12 @@ trait BasicStructure {
 		if ($adminPasswordFromEnvironment !== false) {
 			$this->adminPassword = $adminPasswordFromEnvironment;
 		}
+
+		// get the regular user password from the environment (if defined)
+		$regularUserPasswordFromEnvironment = $this->getRegularUserPasswordFromEnvironment();
+		if ($regularUserPasswordFromEnvironment !== false) {
+			$this->regularUserPassword = $regularUserPasswordFromEnvironment;
+		}
 	}
 
 	/**
@@ -214,6 +220,15 @@ trait BasicStructure {
 	 */
 	private static function getAdminPasswordFromEnvironment() {
 		return \getenv('ADMIN_PASSWORD');
+	}
+
+	/**
+	 * Get the externally-defined regular user password, if any
+	 *
+	 * @return string|false
+	 */
+	private static function getRegularUserPasswordFromEnvironment() {
+		return \getenv('REGULAR_USER_PASSWORD');
 	}
 
 	/**


### PR DESCRIPTION
## Description
When acceptance test scenarios start, check if env var ``REGULAR_USER_PASSWORD`` is set, and use that value.

## Motivation and Context
``ADMIN_USERNAME`` and ``ADMIN_PASSWORD`` can be set as env variables before running the acceptance tests. There is also the default "regular user password", it would be nice to allow this to be overridden by an env variable also.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
