### PR TITLE
Abstract username and password

### DIFF
--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -2,7 +2,7 @@
 Feature: capabilities
 	Background:
 		Given using OCS API version "1"
-		And as user "admin"
+		And as user "%admin%"
 
 	@smokeTest
 	Scenario: Check that the sharing API can be enabled

--- a/tests/acceptance/features/apiMain/caldav.feature
+++ b/tests/acceptance/features/apiMain/caldav.feature
@@ -6,14 +6,14 @@ Feature: caldav
 
 	@caldav
 	Scenario: Accessing a not existing calendar of another user
-		When user "admin" requests calendar "user0/MyCalendar" using the new WebDAV API
+		When user "%admin%" requests calendar "user0/MyCalendar" using the new WebDAV API
 		Then the CalDAV HTTP status code should be "404"
 		And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
 		And the CalDAV error message should be "Node with name 'MyCalendar' could not be found"
 
 	@caldav
 	Scenario: Accessing a not shared calendar of another user
-		Given user "admin" has successfully created a calendar named "MyCalendar"
+		Given user "%admin%" has successfully created a calendar named "MyCalendar"
 		When user "user0" requests calendar "admin/MyCalendar" using the new WebDAV API
 		Then the CalDAV HTTP status code should be "404"
 		And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"

--- a/tests/acceptance/features/apiMain/carddav.feature
+++ b/tests/acceptance/features/apiMain/carddav.feature
@@ -6,14 +6,14 @@ Feature: carddav
 
   @carddav
   Scenario: Accessing a not existing addressbook of another user
-    When user "admin" requests address book "user0/MyAddressbook" using the new WebDAV API
+    When user "%admin%" requests address book "user0/MyAddressbook" using the new WebDAV API
     Then the CardDAV HTTP status code should be "404"
     And the CardDAV exception should be "Sabre\DAV\Exception\NotFound"
     And the CardDAV error message should be "Addressbook with name 'MyAddressbook' could not be found"
 
   @carddav
   Scenario: Accessing a not shared addressbook of another user
-    Given user "admin" has successfully created an address book named "MyAddressbook"
+    Given user "%admin%" has successfully created an address book named "MyAddressbook"
     When user "user0" requests address book "admin/MyAddressbook" using the new WebDAV API
     Then the CardDAV HTTP status code should be "404"
     And the CardDAV exception should be "Sabre\DAV\Exception\NotFound"

--- a/tests/acceptance/features/apiMain/tokenAuth.feature
+++ b/tests/acceptance/features/apiMain/tokenAuth.feature
@@ -4,13 +4,13 @@ Feature: tokenAuth
 	Background:
 		Given using OCS API version "1"
 		And these users have been created:
-			| username    | password | displayname  | email                 |
-			| user1       | 1234     | User One     | u1@oc.com.np          |
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And token auth has been enforced
 
 	Scenario: creating a user with basic auth should be blocked when token auth is enforced
 		Given user "brand-new-user" has been deleted
-		When the administrator sends a user creation request for user "brand-new-user" password "456firstpwd" using the provisioning API
+		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
 		Then the OCS status code should be "997"
 		And the HTTP status code should be "401"
 

--- a/tests/acceptance/features/apiMetadataApps/tags.feature
+++ b/tests/acceptance/features/apiMetadataApps/tags.feature
@@ -6,7 +6,7 @@ Feature: tags
     Given user "user0" has been created
     When user "user0" creates a "normal" tag with name "<tag_name>" using the WebDAV API
     Then the HTTP status code should be "201"
-    And the following tags should exist for "admin"
+    And the following tags should exist for "%admin%"
       |<tag_name>|normal|
     And the following tags should exist for "user0"
       |<tag_name>|normal|
@@ -20,18 +20,18 @@ Feature: tags
     Given user "user0" has been created
     When user "user0" creates a "not user-assignable" tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "400"
-    And tag "JustARegularTagName" should not exist for "admin"
+    And tag "JustARegularTagName" should not exist for "%admin%"
 
   Scenario: Creating a not user-visible tag as regular user should fail
     Given user "user0" has been created
     When user "user0" creates a "not user-visible" tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "400"
-    And tag "JustARegularTagName" should not exist for "admin"
+    And tag "JustARegularTagName" should not exist for "%admin%"
 
   @smokeTest
   Scenario: Creating a not user-assignable tag with groups as admin should work
     Given user "user0" has been created
-    When user "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
+    When user "%admin%" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
     Then the HTTP status code should be "201"
     And the "not user-assignable" tag with name "TagWithGroups" should have the groups "group1|group2"
 
@@ -44,9 +44,9 @@ Feature: tags
   @smokeTest
   Scenario Outline: Renaming a normal tag as regular user should work
     Given user "user0" has been created
-    And user "admin" has created a "normal" tag with name "<tag_name>"
+    And user "%admin%" has created a "normal" tag with name "<tag_name>"
     When user "user0" edits the tag with name "<tag_name>" and sets its name to "AnotherTagName" using the WebDAV API
-    Then the following tags should exist for "admin"
+    Then the following tags should exist for "%admin%"
       | AnotherTagName | normal |
     Examples:
       | tag_name            |
@@ -56,37 +56,37 @@ Feature: tags
 
   Scenario: Renaming a not user-assignable tag as regular user should fail
     Given user "user0" has been created
-    And user "admin" has created a "not user-assignable" tag with name "JustARegularTagName"
+    And user "%admin%" has created a "not user-assignable" tag with name "JustARegularTagName"
     When user "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the WebDAV API
-    Then the following tags should exist for "admin"
+    Then the following tags should exist for "%admin%"
       | JustARegularTagName | not user-assignable |
 
   Scenario: Renaming a not user-visible tag as regular user should fail
     Given user "user0" has been created
-    And user "admin" has created a "not user-visible" tag with name "JustARegularTagName"
+    And user "%admin%" has created a "not user-visible" tag with name "JustARegularTagName"
     When user "user0" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the WebDAV API
-    Then the following tags should exist for "admin"
+    Then the following tags should exist for "%admin%"
       | JustARegularTagName | not user-visible |
 
   Scenario: Editing tag groups as admin should work
     Given user "user0" has been created
-    And user "admin" has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
-    When user "admin" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the WebDAV API
+    And user "%admin%" has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
+    When user "%admin%" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the WebDAV API
     Then the "not user-assignable" tag with name "TagWithGroups" should have the groups "group1|group3"
 
   Scenario: Editing tag groups as regular user should fail
     Given user "user0" has been created
-    And user "admin" has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
+    And user "%admin%" has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
     When user "user0" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the WebDAV API
     Then the "not user-assignable" tag with name "TagWithGroups" should have the groups "group1|group2"
 
   @smokeTest
   Scenario: Deleting a normal tag as regular user should work
     Given user "user0" has been created
-    And user "admin" has created a "normal" tag with name "JustARegularTagName"
+    And user "%admin%" has created a "normal" tag with name "JustARegularTagName"
     When user "user0" deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "204"
-    And tag "JustARegularTagName" should not exist for "admin"
+    And tag "JustARegularTagName" should not exist for "%admin%"
 
   Scenario: Deleting a normal tag that has already been assigned to a file should work
     Given user "user0" has been created
@@ -95,42 +95,42 @@ Feature: tags
     And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
     When user "user0" deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "204"
-    And tag "JustARegularTagName" should not exist for "admin"
+    And tag "JustARegularTagName" should not exist for "%admin%"
     And file "/myFileToTag.txt" should have no tags for user "user0"
 
   Scenario: Deleting a not user-assignable tag as regular user should fail
     Given user "user0" has been created
-    And user "admin" has created a "not user-assignable" tag with name "JustARegularTagName"
+    And user "%admin%" has created a "not user-assignable" tag with name "JustARegularTagName"
     When user "user0" deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "403"
-    And the following tags should exist for "admin"
+    And the following tags should exist for "%admin%"
       | JustARegularTagName | not user-assignable |
 
   Scenario: Deleting a not user-visible tag as regular user should fail
     Given user "user0" has been created
-    And user "admin" has created a "not user-visible" tag with name "JustARegularTagName"
+    And user "%admin%" has created a "not user-visible" tag with name "JustARegularTagName"
     When user "user0" deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "404"
-    And the following tags should exist for "admin"
+    And the following tags should exist for "%admin%"
       | JustARegularTagName | not user-visible |
 
   Scenario: Deleting a not user-assignable tag as admin should work
-    Given user "admin" has created a "not user-assignable" tag with name "JustARegularTagName"
-    When user "admin" deletes the tag with name "JustARegularTagName" using the WebDAV API
+    Given user "%admin%" has created a "not user-assignable" tag with name "JustARegularTagName"
+    When user "%admin%" deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "204"
-    And tag "JustARegularTagName" should not exist for "admin"
+    And tag "JustARegularTagName" should not exist for "%admin%"
 
   Scenario: Deleting a not user-visible tag as admin should work
-    Given user "admin" has created a "not user-visible" tag with name "JustARegularTagName"
-    When user "admin" deletes the tag with name "JustARegularTagName" using the WebDAV API
+    Given user "%admin%" has created a "not user-visible" tag with name "JustARegularTagName"
+    When user "%admin%" deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "204"
-    And tag "JustARegularTagName" should not exist for "admin"
+    And tag "JustARegularTagName" should not exist for "%admin%"
 
   @smokeTest
   Scenario: Assigning a normal tag to a file shared by someone else as regular user should work
     Given user "user0" has been created
     And user "user1" has been created
-    And user "admin" has created a "normal" tag with name "JustARegularTagName"
+    And user "%admin%" has created a "normal" tag with name "JustARegularTagName"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
@@ -141,8 +141,8 @@ Feature: tags
   Scenario: Assigning a normal tag to a file belonging to someone else as regular user should fail
     Given user "user0" has been created
     And user "user1" has been created
-    And user "admin" has created a "normal" tag with name "MyFirstTag"
-    And user "admin" has created a "normal" tag with name "MySecondTag"
+    And user "%admin%" has created a "normal" tag with name "MyFirstTag"
+    And user "%admin%" has created a "normal" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
     And user "user1" adds the tag "MySecondTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
@@ -153,8 +153,8 @@ Feature: tags
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as regular user should fail
     Given user "user0" has been created
     And user "user1" has been created
-    And user "admin" has created a "normal" tag with name "MyFirstTag"
-    And user "admin" has created a "not user-assignable" tag with name "MySecondTag"
+    And user "%admin%" has created a "normal" tag with name "MyFirstTag"
+    And user "%admin%" has created a "not user-assignable" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
@@ -168,7 +168,7 @@ Feature: tags
     And user "user1" has been created
     And group "group1" has been created
     And user "user1" has been added to group "group1"
-    And user "admin" has created a "not user-assignable" tag with name "JustARegularTagName" and groups "group1"
+    And user "%admin%" has created a "not user-assignable" tag with name "JustARegularTagName" and groups "group1"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     When user "user1" adds the tag "JustARegularTagName" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
@@ -179,8 +179,8 @@ Feature: tags
   Scenario: Assigning a not user-visible tag to a file shared by someone else as regular user should fail
     Given user "user0" has been created
     And user "user1" has been created
-    And user "admin" has created a "normal" tag with name "MyFirstTag"
-    And user "admin" has created a "not user-visible" tag with name "MySecondTag"
+    And user "%admin%" has created a "normal" tag with name "MyFirstTag"
+    And user "%admin%" has created a "not user-visible" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0" using the WebDAV API
@@ -228,8 +228,8 @@ Feature: tags
   Scenario: Unassigning a normal tag from a file shared by someone else as regular user should work
     Given user "user0" has been created
     And user "user1" has been created
-    And user "admin" has created a "normal" tag with name "MyFirstTag"
-    And user "admin" has created a "normal" tag with name "MySecondTag"
+    And user "%admin%" has created a "normal" tag with name "MyFirstTag"
+    And user "%admin%" has created a "normal" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has shared file "/myFileToTag.txt" with user "user1"
     And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt" owned by "user0"
@@ -242,8 +242,8 @@ Feature: tags
   Scenario: Unassigning a normal tag from a file unshared by someone else as regular user should fail
     Given user "user0" has been created
     And user "user1" has been created
-    And user "admin" has created a "normal" tag with name "MyFirstTag"
-    And user "admin" has created a "normal" tag with name "MySecondTag"
+    And user "%admin%" has created a "normal" tag with name "MyFirstTag"
+    And user "%admin%" has created a "normal" tag with name "MySecondTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     And user "user0" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
@@ -361,7 +361,7 @@ Feature: tags
     And user "another_admin" has added the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0"
     And user "user0" has added the tag "MySecondTag" to "/myFileToTag.txt" shared by "user0"
     And user "user0" has removed all shares from the file named "/myFileToTag.txt"
-    When user "admin" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
+    When user "%admin%" removes the tag "MyFirstTag" from "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then the HTTP status code should be "404"
 
   Scenario: Overwriting existing normal tags should fail
@@ -371,19 +371,19 @@ Feature: tags
     Then the HTTP status code should be "409"
 
   Scenario: Overwriting existing not user-assignable tags should fail
-    Given user "admin" has created a "not user-assignable" tag with name "MyFirstTag"
-    When user "admin" creates a "not user-assignable" tag with name "MyFirstTag" using the WebDAV API
+    Given user "%admin%" has created a "not user-assignable" tag with name "MyFirstTag"
+    When user "%admin%" creates a "not user-assignable" tag with name "MyFirstTag" using the WebDAV API
     Then the HTTP status code should be "409"
 
   Scenario: Overwriting existing not user-visible tags should fail
-    Given user "admin" has created a "not user-visible" tag with name "MyFirstTag"
-    When user "admin" creates a "not user-visible" tag with name "MyFirstTag" using the WebDAV API
+    Given user "%admin%" has created a "not user-visible" tag with name "MyFirstTag"
+    When user "%admin%" creates a "not user-visible" tag with name "MyFirstTag" using the WebDAV API
     Then the HTTP status code should be "409"
 
   Scenario: Getting tags only works with access to the file
     Given user "user0" has been created
     And user "user1" has been created
-    And user "admin" has created a "normal" tag with name "MyFirstTag"
+    And user "%admin%" has created a "normal" tag with name "MyFirstTag"
     And user "user0" has uploaded file "data/textfile.txt" to "/myFileToTag.txt"
     When user "user0" adds the tag "MyFirstTag" to "/myFileToTag.txt" shared by "user0" using the WebDAV API
     Then file "/myFileToTag.txt" should have the following tags for user "user0"
@@ -394,12 +394,12 @@ Feature: tags
     Given user "user0" has been created
     And group "group1" has been created
     And user "user0" has been added to group "group1"
-    When user "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
+    When user "%admin%" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
     Then the HTTP status code should be "201"
     And the user "user0" should be able to assign the "not user-assignable" tag with name "TagWithGroups"
 
   Scenario: User cannot assign tags when not in the tag's groups
     Given user "user0" has been created
-    When user "admin" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
+    When user "%admin%" creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
     Then the HTTP status code should be "201"
     And the user "user0" should not be able to assign the "not user-assignable" tag with name "TagWithGroups"

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -11,7 +11,7 @@ So that I can give a user access to the resources of the group
 	Scenario Outline: adding a user to a group
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -24,7 +24,7 @@ So that I can give a user access to the resources of the group
 	Scenario Outline: adding a user to a group
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -51,7 +51,7 @@ So that I can give a user access to the resources of the group
 	Scenario Outline: adding a user to a group that has a forward-slash in the group name
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -73,7 +73,7 @@ So that I can give a user access to the resources of the group
 	Scenario: admin tries to add user to a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | not-group |
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
@@ -81,7 +81,7 @@ So that I can give a user access to the resources of the group
 
 	Scenario: admin tries to add user to a group without sending the group
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid |  |
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
@@ -90,7 +90,7 @@ So that I can give a user access to the resources of the group
 	Scenario: admin tries to add a user which does not exist to a group
 		Given user "not-user" has been deleted
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/groups" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "103"
 		And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -10,14 +10,14 @@ So that I can give people controlled individual access to resources on the ownCl
 	@smokeTest
 	Scenario: admin creates a user
 		Given user "brand-new-user" has been deleted
-		When the administrator sends a user creation request for user "brand-new-user" password "456firstpwd" using the provisioning API
+		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "brand-new-user" should exist
 
 	Scenario: admin tries to create an existing user
 		Given user "brand-new-user" has been created
-		When the administrator sends a user creation request for user "brand-new-user" password "456newpwd" using the provisioning API
+		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
 		And the API should not return any data
@@ -25,14 +25,14 @@ So that I can give people controlled individual access to resources on the ownCl
 	Scenario: admin tries to create an existing disabled user
 		Given user "brand-new-user" has been created
 		And user "brand-new-user" has been disabled
-		When the administrator sends a user creation request for user "brand-new-user" password "456newpwd" using the provisioning API
+		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
 		And the API should not return any data
 
 	Scenario: Admin creates a new user and adds him directly to a group
 		Given group "newgroup" has been created
-		When the administrator sends a user creation request for user "newuser" password "456firstpwd" group "newgroup" using the provisioning API
+		When the administrator sends a user creation request for user "newuser" password "%alt1%" group "newgroup" using the provisioning API
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "newuser" should belong to group "newgroup"

--- a/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
@@ -10,8 +10,8 @@ So that I can make a client app or script for provisioning users/groups that can
 	Scenario: admin deletes the user
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
-		And a new client token for "admin" has been generated
-		And a new browser session for "admin" has been started
+		And a new client token for "%admin%" has been generated
+		And a new browser session for "%admin%" has been started
 		And the user has generated a new app password named "my-client"
 		When the user requests "/ocs/v1.php/cloud/users/brand-new-user" with "DELETE" using the generated app password 
 		Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -11,7 +11,7 @@ So that I can give administrative privilege of a group to a user
 	Scenario: admin creates a subadmin
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -20,7 +20,7 @@ So that I can give administrative privilege of a group to a user
 	Scenario: admin tries to create a subadmin using a user which does not exist
 		Given user "not-user" has been deleted
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/subadmins" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
@@ -29,7 +29,7 @@ So that I can give administrative privilege of a group to a user
 	Scenario: admin tries to create a subadmin using a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | not-group |
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"
@@ -40,7 +40,7 @@ So that I can give administrative privilege of a group to a user
 		And user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "admin" has sent HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		And user "%admin%" has sent HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -10,7 +10,7 @@ So that I can remove access to files and resources for a user, without actually 
 	@smokeTest
 	Scenario: admin disables an user
 		Given user "user1" has been created
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "user1" should be disabled
@@ -57,7 +57,7 @@ So that I can remove access to files and resources for a user, without actually 
 	Scenario: Admin can disable another admin user
 		Given user "another-admin" has been created
 		And user "another-admin" has been added to group "admin"
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "another-admin" should be disabled
@@ -66,9 +66,9 @@ So that I can remove access to files and resources for a user, without actually 
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been added to group "new-group"
-		And user "admin" has been added to group "new-group"
+		And user "%admin%" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "subadmin" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -10,7 +10,7 @@ So that I can change user information
 	@smokeTest
 	Scenario: Edit a user
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | quota                    |
 			| value | 12MB                     |
 			| key   | email                    |
@@ -21,17 +21,17 @@ So that I can change user information
 
 	Scenario: Override existing user email
 		Given user "brand-new-user" has been created
-		And user "admin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+		And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | email                    |
 			| value | brand-new-user@gmail.com |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And user "admin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+		And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | email                      |
 			| value | brand-new-user@example.com |
 		And the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the user attributes returned by the API should include

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -11,7 +11,7 @@ So that I can give a user access to their files and resources again if they are 
 	Scenario: admin enables an user
 		Given user "user1" has been created
 		And user "user1" has been disabled
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/enable"
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/enable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "user1" should be enabled
@@ -20,7 +20,7 @@ So that I can give a user access to their files and resources again if they are 
 		Given user "another-admin" has been created
 		And user "another-admin" has been added to group "admin"
 		And user "another-admin" has been disabled
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "another-admin" should be enabled
@@ -29,9 +29,9 @@ So that I can give a user access to their files and resources again if they are 
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been added to group "new-group"
-		And user "admin" has been added to group "new-group"
+		And user "%admin%" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And user "subadmin" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
@@ -9,7 +9,7 @@ So that I can get the information of a specific application
 
 	@smokeTest
 	Scenario: admin gets app info
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/apps/files"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps/files"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the XML "data" "id" value should be "files"

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -9,7 +9,7 @@ So that I can manage apps
 
 	@smokeTest
 	Scenario: admin gets enabled apps
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the apps returned by the API should include

--- a/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
@@ -14,7 +14,7 @@ So that I can know which users are in a group
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "123" has been added to group "new-group"
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the users returned by the API should be
@@ -23,7 +23,7 @@ So that I can know which users are in a group
 
 	Scenario: admin tries to get users in the empty group
 		Given group "new-group" has been created
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the list of users returned by the API should be empty

--- a/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
@@ -12,7 +12,7 @@ So that I can see all the groups in my ownCloud
 		Given group "0" has been created
 		And group "new-group" has been created
 		And group "España" has been created
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
 		Then the groups returned by the API should be
 			| España    |
 			| admin     |

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdminGroups.feature
@@ -12,7 +12,7 @@ So that I can know in which groups the user has administrative rights
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/subadmins"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/subadmins"
 		Then the subadmin groups returned by the API should be
 			| new-group |
 		And the OCS status code should be "100"
@@ -21,7 +21,7 @@ So that I can know in which groups the user has administrative rights
 	Scenario: admin tries to get subadmin groups of a user which do not exist
 		Given user "not-user" has been deleted
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/not-user/subadmins"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/not-user/subadmins"
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
 		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -12,7 +12,7 @@ So that I can manage subadmins of a group
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
 		Then the subadmin users returned by the API should be
 			| brand-new-user |
 		And the OCS status code should be "100"
@@ -21,7 +21,7 @@ So that I can manage subadmins of a group
 	Scenario: admin tries to get subadmin users of a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/not-group/subadmins"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/not-group/subadmins"
 		Then the OCS status code should be "101"
 		And the HTTP status code should be "200"
 		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -9,13 +9,13 @@ So that I can get information about user
 	@smokeTest
 	Scenario: admin gets existing user
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the display name returned by the API should be "brand-new-user"
 
 	Scenario: admin tries to get a not existing user
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
 		Then the OCS status code should be "998"
 		And the HTTP status code should be "200"
 		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
@@ -21,7 +21,7 @@ So that I can manage group membership
 		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
 		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
 		And user "brand-new-user" has been added to group "नेपाली"
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
 		Then the groups returned by the API should be
 			| new-group            |
 			| 0                    |
@@ -52,7 +52,7 @@ So that I can manage group membership
 		And user "brand-new-user" has been added to group "Mgmt/Sydney"
 		And user "brand-new-user" has been added to group "var/../etc"
 		And user "brand-new-user" has been added to group "priv/subadmins/1"
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
 		Then the groups returned by the API should be
 			| new-group            |
 			| 0                    |
@@ -93,7 +93,7 @@ So that I can manage group membership
 	Scenario: admin gets groups of an user who is not in any groups
 		Given user "brand-new-user" has been created
 		And group "unused-group" has been created
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the list of groups returned by the API should be empty

--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -10,7 +10,7 @@ So that I can see who has access to ownCloud
 	@smokeTest
 	Scenario: admin gets all users
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
 		And the users returned by the API should be

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -12,7 +12,7 @@ So that I can manage user access to group resources
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
 		And user "brand-new-user" has been added to group "<group_id>"
-		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200" 
@@ -27,7 +27,7 @@ So that I can manage user access to group resources
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
 		And user "brand-new-user" has been added to group "<group_id>"
-		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200" 
@@ -56,7 +56,7 @@ So that I can manage user access to group resources
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
 		And user "brand-new-user" has been added to group "<group_id>"
-		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
@@ -71,7 +71,7 @@ So that I can manage user access to group resources
 	Scenario: admin tries to remove a user from a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | not-group |
 		Then the OCS status code should be "102"
 		And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
@@ -12,7 +12,7 @@ So that I cam manage administrative access rights for groups
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -10,64 +10,64 @@ Feature: reset user password
   @smokeTest
   Scenario: reset user password
     Given these users have been created:
-      | username       | password | displayname | email                    |
-      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
-    When the administrator resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+      | username       | password  | displayname | email                    |
+      | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
+    When the administrator resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the content of file "textfile0.txt" for user "brand-new-user" using password "anotherPwd123" should be "ownCloud test text file 0" plus end-of-line
-    But user "brand-new-user" using password "1234" should not be able to download file "textfile0.txt"
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
   Scenario: admin tries to reset the password of a user that does not exist
-    When the administrator resets the password of user "not-a-user" to "anotherPwd123" using the provisioning API
+    When the administrator resets the password of user "not-a-user" to "%alt1%" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
 
   @smokeTest
   Scenario: subadmin should be able to reset the password of a user in their group
     Given these users have been created:
-      | username       | password | displayname | email                    |
-      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
-      | subadmin       | Sa4567   | Sub Admin   | sub.admin@oc.com.np      |
+      | username       | password   | displayname | email                    |
+      | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
+      | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    When user "subadmin" resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the content of file "textfile0.txt" for user "brand-new-user" using password "anotherPwd123" should be "ownCloud test text file 0" plus end-of-line
-    But user "brand-new-user" using password "1234" should not be able to download file "textfile0.txt"
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
   Scenario: subadmin should not be able to reset the password of a user not in their group
     Given these users have been created:
-      | username       | password | displayname | email                    |
-      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
-      | subadmin       | Sa4567   | Sub Admin   | sub.admin@oc.com.np      |
+      | username       | password   | displayname | email                    |
+      | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
+      | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" tries to reset the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    When user "subadmin" tries to reset the password of user "brand-new-user" to "%alt1%" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    And the content of file "textfile0.txt" for user "brand-new-user" using password "1234" should be "ownCloud test text file 0" plus end-of-line
-    But user "brand-new-user" using password "anotherPwd123" should not be able to download file "textfile0.txt"
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%regular%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
 
   Scenario: a user should not be able to reset the password of another user
     Given these users have been created:
-      | username       | password | displayname    | email                    |
-      | brand-new-user | 1234     | New user       | brand.new.user@oc.com.np |
-      | wannabeadmin   | Wa4567   | Wanna Be Admin | wanna.be.admin@oc.com.np |
-    When user "wannabeadmin" tries to reset the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+      | username       | password   | displayname    | email                    |
+      | brand-new-user | %regular%  | New user       | brand.new.user@oc.com.np |
+      | wannabeadmin   | %altadmin% | Wanna Be Admin | wanna.be.admin@oc.com.np |
+    When user "wannabeadmin" tries to reset the password of user "brand-new-user" to "%alt1%" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    And the content of file "textfile0.txt" for user "brand-new-user" using password "1234" should be "ownCloud test text file 0" plus end-of-line
-    But user "brand-new-user" using password "anotherPwd123" should not be able to download file "textfile0.txt"
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%regular%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
 
   Scenario: a user should be able to reset their own password
     Given these users have been created:
-      | username       | password | displayname | email                    |
-      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
-    When user "brand-new-user" resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+      | username       | password  | displayname | email                    |
+      | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
+    When user "brand-new-user" resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    And the content of file "textfile0.txt" for user "brand-new-user" using password "anotherPwd123" should be "ownCloud test text file 0" plus end-of-line
-    But user "brand-new-user" using password "1234" should not be able to download file "textfile0.txt"
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -11,7 +11,7 @@ So that I can give a user access to the resources of the group
 	Scenario Outline: adding a user to a group
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
@@ -24,7 +24,7 @@ So that I can give a user access to the resources of the group
 	Scenario Outline: adding a user to a group
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
@@ -51,7 +51,7 @@ So that I can give a user access to the resources of the group
 	Scenario Outline: adding a user to a group that has a forward-slash in the group name
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
@@ -74,7 +74,7 @@ So that I can give a user access to the resources of the group
 	Scenario: admin tries to add user to a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | not-group |
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
@@ -82,7 +82,7 @@ So that I can give a user access to the resources of the group
 
 	Scenario: admin tries to add user to a group without sending the group
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid |  |
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
@@ -91,7 +91,7 @@ So that I can give a user access to the resources of the group
 	Scenario: admin tries to add a user which does not exist to a group
 		Given user "not-user" has been deleted
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/groups" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/groups" with body
 			| groupid | new-group |
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -10,14 +10,14 @@ So that I can give people controlled individual access to resources on the ownCl
 	@smokeTest
 	Scenario: Create a user
 		Given user "brand-new-user" has been deleted
-		When the administrator sends a user creation request for user "brand-new-user" password "456firstpwd" using the provisioning API
+		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "brand-new-user" should exist
 
 	Scenario: admin tries to create an existing user
 		Given user "brand-new-user" has been created
-		When the administrator sends a user creation request for user "brand-new-user" password "456newpwd" using the provisioning API
+		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
 		And the API should not return any data
@@ -25,14 +25,14 @@ So that I can give people controlled individual access to resources on the ownCl
 	Scenario: admin tries to create an existing disabled user
 		Given user "brand-new-user" has been created
 		And user "brand-new-user" has been disabled
-		When the administrator sends a user creation request for user "brand-new-user" password "456newpwd" using the provisioning API
+		When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
 		And the API should not return any data
 
 	Scenario: Admin creates a new user and adds him directly to a group
 		Given group "newgroup" has been created
-		When the administrator sends a user creation request for user "newuser" password "456firstpwd" group "newgroup" using the provisioning API
+		When the administrator sends a user creation request for user "newuser" password "%alt1%" group "newgroup" using the provisioning API
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "newuser" should belong to group "newgroup"

--- a/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
@@ -10,8 +10,8 @@ So that I can make a client app or script for provisioning users/groups that can
 	Scenario: admin deletes the user
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
-		And a new client token for "admin" has been generated
-		And a new browser session for "admin" has been started
+		And a new client token for "%admin%" has been generated
+		And a new browser session for "%admin%" has been started
 		And the user has generated a new app password named "my-client"
 		When the user requests "/ocs/v2.php/cloud/users/brand-new-user" with "DELETE" using the generated app password 
 		Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -11,7 +11,7 @@ So that I can give administrative privilege of a group to a user
 	Scenario: admin creates a subadmin
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
@@ -20,7 +20,7 @@ So that I can give administrative privilege of a group to a user
 	Scenario: admin tries to create a subadmin using a user which does not exist
 		Given user "not-user" has been deleted
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/subadmins" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/not-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
@@ -29,7 +29,7 @@ So that I can give administrative privilege of a group to a user
 	Scenario: admin tries to create a subadmin using a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "%admin%" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | not-group |
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
@@ -40,7 +40,7 @@ So that I can give administrative privilege of a group to a user
 		And user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been made a subadmin of group "new-group"
-		And user "admin" has sent HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		And user "%admin%" has sent HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | new-group |
 		When user "subadmin" sends HTTP method "POST" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -10,7 +10,7 @@ So that I can remove access to files and resources for a user, without actually 
 	@smokeTest
 	Scenario: admin disables an user
 		Given user "user1" has been created
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/disable"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "user1" should be disabled
@@ -59,7 +59,7 @@ So that I can remove access to files and resources for a user, without actually 
 	Scenario: Admin can disable another admin user
 		Given user "another-admin" has been created
 		And user "another-admin" has been added to group "admin"
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/disable"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "another-admin" should be disabled
@@ -68,9 +68,9 @@ So that I can remove access to files and resources for a user, without actually 
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been added to group "new-group"
-		And user "admin" has been added to group "new-group"
+		And user "%admin%" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "subadmin" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -10,7 +10,7 @@ So that I can change user information
 	@smokeTest
 	Scenario: Edit a user
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | quota                    |
 			| value | 12MB                     |
 			| key   | email                    |
@@ -21,17 +21,17 @@ So that I can change user information
 
 	Scenario: Override existing user email
 		Given user "brand-new-user" has been created
-		And user "admin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+		And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | email                    |
 			| value | brand-new-user@gmail.com |
 		And the OCS status code should be "200"
 		And the HTTP status code should be "200"
-		And user "admin" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
+		And user "%admin%" has sent HTTP method "PUT" to OCS API endpoint "/cloud/users/brand-new-user" with body
 			| key   | email                      |
 			| value | brand-new-user@example.com |
 		And the OCS status code should be "200"
 		And the HTTP status code should be "200"
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the user attributes returned by the API should include

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -11,7 +11,7 @@ So that I can give a user access to their files and resources again if they are 
 	Scenario: admin enables an user
 		Given user "user1" has been created
 		And user "user1" has been disabled
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/enable"
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/user1/enable"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "user1" should be enabled
@@ -20,7 +20,7 @@ So that I can give a user access to their files and resources again if they are 
 		Given user "another-admin" has been created
 		And user "another-admin" has been added to group "admin"
 		And user "another-admin" has been disabled
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/another-admin/enable"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "another-admin" should be enabled
@@ -29,9 +29,9 @@ So that I can give a user access to their files and resources again if they are 
 		Given user "subadmin" has been created
 		And group "new-group" has been created
 		And user "subadmin" has been added to group "new-group"
-		And user "admin" has been added to group "new-group"
+		And user "%admin%" has been added to group "new-group"
 		And user "subadmin" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
+		When user "%admin%" sends HTTP method "PUT" to OCS API endpoint "/cloud/users/subadmin/disable"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And user "subadmin" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
@@ -9,7 +9,7 @@ So that I can get the information of a specific application
 
 	@smokeTest
 	Scenario: admin gets app info
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/apps/files"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps/files"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the XML "data" "id" value should be "files"

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -9,7 +9,7 @@ So that I can manage apps
 
 	@smokeTest
 	Scenario: admin gets enabled apps
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/apps?filter=enabled"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the apps returned by the API should include

--- a/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
@@ -14,7 +14,7 @@ So that I can know which users are in a group
 		And group "new-group" has been created
 		And user "brand-new-user" has been added to group "new-group"
 		And user "123" has been added to group "new-group"
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the users returned by the API should be
@@ -23,7 +23,7 @@ So that I can know which users are in a group
 
 	Scenario: admin tries to get users in the empty group
 		Given group "new-group" has been created
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the list of users returned by the API should be empty

--- a/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
@@ -12,7 +12,7 @@ So that I can see all the groups in my ownCloud
 		Given group "0" has been created
 		And group "new-group" has been created
 		And group "España" has been created
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups"
 		Then the groups returned by the API should be
 			| España    |
 			| admin     |

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdminGroups.feature
@@ -12,7 +12,7 @@ So that I can know in which groups the user has administrative rights
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/subadmins"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/subadmins"
 		Then the subadmin groups returned by the API should be
 			| new-group |
 		And the OCS status code should be "200"
@@ -21,7 +21,7 @@ So that I can know in which groups the user has administrative rights
 	Scenario: admin tries to get subadmin groups of a user which do not exist
 		Given user "not-user" has been deleted
 		And group "new-group" has been created
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/not-user/subadmins"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/not-user/subadmins"
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
 		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -12,7 +12,7 @@ So that I can manage subadmins of a group
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/new-group/subadmins"
 		Then the subadmin users returned by the API should be
 			| brand-new-user |
 		And the OCS status code should be "200"
@@ -21,7 +21,7 @@ So that I can manage subadmins of a group
 	Scenario: admin tries to get subadmin users of a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/not-group/subadmins"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/groups/not-group/subadmins"
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"
 		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -9,13 +9,13 @@ So that I can get information about user
 	@smokeTest
 	Scenario: admin gets an existing user
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the display name returned by the API should be "brand-new-user"
 
 	Scenario: admin tries to get a not existing user
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/test"
 		Then the OCS status code should be "404"
 		And the HTTP status code should be "404"
 		And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
@@ -21,7 +21,7 @@ So that I can manage group membership
 		And user "brand-new-user" has been added to group "Admin & Finance (NP)"
 		And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
 		And user "brand-new-user" has been added to group "नेपाली"
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
 		Then the groups returned by the API should be
 			| new-group            |
 			| 0                    |
@@ -52,7 +52,7 @@ So that I can manage group membership
 		And user "brand-new-user" has been added to group "Mgmt/Sydney"
 		And user "brand-new-user" has been added to group "var/../etc"
 		And user "brand-new-user" has been added to group "priv/subadmins/1"
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users/brand-new-user/groups"
 		Then the groups returned by the API should be
 			| new-group            |
 			| 0                    |

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -10,7 +10,7 @@ So that I can see who has access to ownCloud
 	@smokeTest
 	Scenario: admin gets all users
 		Given user "brand-new-user" has been created
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/cloud/users"
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
 		And the users returned by the API should be

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -12,7 +12,7 @@ So that I can manage user access to group resources
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
 		And user "brand-new-user" has been added to group "<group_id>"
-		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200" 
@@ -27,7 +27,7 @@ So that I can manage user access to group resources
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
 		And user "brand-new-user" has been added to group "<group_id>"
-		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
@@ -56,7 +56,7 @@ So that I can manage user access to group resources
 		Given user "brand-new-user" has been created
 		And group "<group_id>" has been created
 		And user "brand-new-user" has been added to group "<group_id>"
-		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | <group_id> |
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"
@@ -71,7 +71,7 @@ So that I can manage user access to group resources
 	Scenario: admin tries to remove a user from a group which does not exist
 		Given user "brand-new-user" has been created
 		And group "not-group" has been deleted
-		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
+		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/groups" with body
 			| groupid | not-group |
 		Then the OCS status code should be "400"
 		And the HTTP status code should be "400"

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -12,7 +12,7 @@ So that I cam manage administrative access rights for groups
 		Given user "brand-new-user" has been created
 		And group "new-group" has been created
 		And user "brand-new-user" has been made a subadmin of group "new-group"
-		When user "admin" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
+		When user "%admin%" sends HTTP method "DELETE" to OCS API endpoint "/cloud/users/brand-new-user/subadmins" with body
 			| groupid | new-group |
 		Then the OCS status code should be "200"
 		And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -10,64 +10,64 @@ Feature: reset user password
   @smokeTest
   Scenario: reset user password
     Given these users have been created:
-      | username       | password | displayname | email                    |
-      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
-    When the administrator resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+      | username       | password  | displayname | email                    |
+      | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
+    When the administrator resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And the content of file "textfile0.txt" for user "brand-new-user" using password "anotherPwd123" should be "ownCloud test text file 0" plus end-of-line
-    But user "brand-new-user" using password "1234" should not be able to download file "textfile0.txt"
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
   Scenario: admin tries to reset the password of a user that does not exist
-    When the administrator resets the password of user "not-a-user" to "anotherPwd123" using the provisioning API
+    When the administrator resets the password of user "not-a-user" to "%alt1%" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
 
   @smokeTest
   Scenario: subadmin should be able to reset the password of a user in their group
     Given these users have been created:
-      | username       | password | displayname | email                    |
-      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
-      | subadmin       | Sa4567   | Sub Admin   | sub.admin@oc.com.np      |
+      | username       | password   | displayname | email                    |
+      | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
+      | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
     And group "new-group" has been created
     And user "brand-new-user" has been added to group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    When user "subadmin" resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And the content of file "textfile0.txt" for user "brand-new-user" using password "anotherPwd123" should be "ownCloud test text file 0" plus end-of-line
-    But user "brand-new-user" using password "1234" should not be able to download file "textfile0.txt"
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
   Scenario: subadmin should not be able to reset the password of a user not in their group
     Given these users have been created:
-      | username       | password | displayname | email                    |
-      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
-      | subadmin       | Sa4567   | Sub Admin   | sub.admin@oc.com.np      |
+      | username       | password   | displayname | email                    |
+      | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
+      | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
     And group "new-group" has been created
     And user "subadmin" has been made a subadmin of group "new-group"
-    When user "subadmin" tries to reset the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+    When user "subadmin" tries to reset the password of user "brand-new-user" to "%alt1%" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    And the content of file "textfile0.txt" for user "brand-new-user" using password "1234" should be "ownCloud test text file 0" plus end-of-line
-    But user "brand-new-user" using password "anotherPwd123" should not be able to download file "textfile0.txt"
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%regular%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
 
   Scenario: a user should not be able to reset the password of another user
     Given these users have been created:
-      | username       | password | displayname    | email                    |
-      | brand-new-user | 1234     | New user       | brand.new.user@oc.com.np |
-      | wannabeadmin   | Wa4567   | Wanna Be Admin | wanna.be.admin@oc.com.np |
-    When user "wannabeadmin" tries to reset the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+      | username       | password   | displayname    | email                    |
+      | brand-new-user | %regular%  | New user       | brand.new.user@oc.com.np |
+      | wannabeadmin   | %altadmin% | Wanna Be Admin | wanna.be.admin@oc.com.np |
+    When user "wannabeadmin" tries to reset the password of user "brand-new-user" to "%alt1%" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    And the content of file "textfile0.txt" for user "brand-new-user" using password "1234" should be "ownCloud test text file 0" plus end-of-line
-    But user "brand-new-user" using password "anotherPwd123" should not be able to download file "textfile0.txt"
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%regular%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
 
   Scenario: a user should be able to reset their own password
     Given these users have been created:
-      | username       | password | displayname | email                    |
-      | brand-new-user | 1234     | New user    | brand.new.user@oc.com.np |
-    When user "brand-new-user" resets the password of user "brand-new-user" to "anotherPwd123" using the provisioning API
+      | username       | password  | displayname | email                    |
+      | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
+    When user "brand-new-user" resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And the content of file "textfile0.txt" for user "brand-new-user" using password "anotherPwd123" should be "ownCloud test text file 0" plus end-of-line
-    But user "brand-new-user" using password "1234" should not be able to download file "textfile0.txt"
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -24,7 +24,7 @@ Feature: sharing
 	Scenario Outline: getting all shares of a user using another user
 		Given using OCS API version "<ocs_api_version>"
 		And user "user0" has shared file "textfile0.txt" with user "user1"
-		When user "admin" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
+		When user "%admin%" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
 		And file "textfile0.txt" should not be included in the response

--- a/tests/acceptance/features/apiTrashbin/trashbin-new-endpoint.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbin-new-endpoint.feature
@@ -3,7 +3,7 @@ Feature: trashbin-new-endpoint
 	Background:
 		Given using OCS API version "1"
 		And using new DAV path
-		And as user "admin"
+		And as user "%admin%"
 
 	@smokeTest
 	Scenario: deleting a file moves it to trashbin

--- a/tests/acceptance/features/apiTrashbin/trashbin-old-endpoint.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbin-old-endpoint.feature
@@ -3,7 +3,7 @@ Feature: trashbin-new-endpoint
 	Background:
 		Given using OCS API version "1"
 		And using old DAV path
-		And as user "admin"
+		And as user "%admin%"
 
 	@smokeTest
 	Scenario: deleting a file moves it to trashbin

--- a/tests/acceptance/features/bootstrap/Auth.php
+++ b/tests/acceptance/features/bootstrap/Auth.php
@@ -166,7 +166,7 @@ trait Auth {
 	public function aNewClientTokenHasBeenGenerated($user) {
 		$body = \json_encode(
 			[
-				'user' => $user,
+				'user' => $this->getActualUsername($user),
 				'password' => $this->getPasswordForUser($user),
 			]
 		);
@@ -268,7 +268,7 @@ trait Auth {
 
 		// Login and extract new token
 		$body = [
-			'user' => $user,
+			'user' => $this->getActualUsername($user),
 			'password' => $this->getPasswordForUser($user),
 			'requesttoken' => $this->requestToken
 		];

--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -82,6 +82,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 * @return void
 	 */
 	public function userRequestsCalendarUsingTheAPI($user, $calendar) {
+		$user = $this->featureContext->getActualUsername($user);
 		$davUrl = $this->featureContext->getBaseUrl()
 			. "/remote.php/dav/calendars/$calendar";
 
@@ -151,6 +152,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	 * @throws \Exception
 	 */
 	public function userHasCreatedACalendarNamed($user, $name) {
+		$user = $this->featureContext->getActualUsername($user);
 		$davUrl = $this->featureContext->getBaseUrl()
 			. "/remote.php/dav/calendars/$user/$name";
 

--- a/tests/acceptance/features/bootstrap/CardDavContext.php
+++ b/tests/acceptance/features/bootstrap/CardDavContext.php
@@ -82,6 +82,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	 * @throws \Exception
 	 */
 	public function userRequestsAddressBookUsingTheAPI($user, $addressBook) {
+		$user = $this->featureContext->getActualUsername($user);
 		$davUrl = $this->featureContext->getBaseUrl()
 			. "/remote.php/dav/addressbooks/users/$addressBook";
 
@@ -100,6 +101,7 @@ class CardDavContext implements \Behat\Behat\Context\Context {
 	 * @throws \Exception
 	 */
 	public function userHasCreatedAnAddressBookNamed($user, $addressBook) {
+		$user = $this->featureContext->getActualUsername($user);
 		$davUrl = $this->featureContext->getBaseUrl()
 			. "/remote.php/dav/addressbooks/users/$user/$addressBook";
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -268,7 +268,7 @@ trait Provisioning {
 			}
 
 			if (isset($row['password'])) {
-				$password = $row['password'];
+				$password = $this->getActualPassword($row['password']);
 			} else {
 				$password = $this->getPasswordForUser($row ['username']);
 			}
@@ -375,6 +375,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function adminSendsUserCreationRequestUsingTheProvisioningApi($user, $password) {
+		$password = $this->getActualPassword($password);
 		$bodyTable = new TableNode([['userid', $user], ['password', $password]]);
 		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$this->getAdminUsername(),
@@ -437,6 +438,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userResetsPasswordOfUserUsingTheProvisioningApi($user, $username, $password) {
+		$password = $this->getActualPassword($password);
 		$this->userTriesToResetPasswordOfUserUsingTheProvisioningApi(
 			$user, $username, $password
 		);
@@ -454,6 +456,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function userTriesToResetPasswordOfUserUsingTheProvisioningApi($user, $username, $password) {
+		$password = $this->getActualPassword($password);
 		$bodyTable = new TableNode([['key', 'password'], ['value', $password]]);
 		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
@@ -912,6 +915,7 @@ trait Provisioning {
 	 * @throws \Exception
 	 */
 	public function userHasBeenAddedToGroup($user, $group, $method = null) {
+		$user = $this->getActualUsername($user);
 		if ($method === null && \getenv("TEST_EXTERNAL_USER_BACKENDS") === "true") {
 			//guess yourself
 			$method = "ldap";

--- a/tests/acceptance/features/bootstrap/Tags.php
+++ b/tests/acceptance/features/bootstrap/Tags.php
@@ -50,7 +50,7 @@ trait Tags {
 	) {
 		$this->response = TagsHelper::createTag(
 			$this->getBaseUrl(),
-			$user,
+			$this->getActualUsername($user),
 			$this->getPasswordForUser($user),
 			$name, $userVisible, $userAssignable, $groups,
 			$this->getDavPathVersion('systemtags')
@@ -135,7 +135,7 @@ trait Tags {
 	public function requestTagsForUser($user, $withGroups = false) {
 		$this->response = TagsHelper:: requestTagsForUser(
 			$this->getBaseUrl(),
-			$user,
+			$this->getActualUsername($user),
 			$this->getPasswordForUser($user),
 			$withGroups
 		);
@@ -173,6 +173,7 @@ trait Tags {
 	 * @throws \Exception
 	 */
 	public function theFollowingTagsShouldExistFor($user, TableNode $table) {
+		$user = $this->getActualUsername($user);
 		foreach ($table->getRowsHash() as $rowDisplayName => $rowType) {
 			$tagData = $this->requestTagByDisplayName($user, $rowDisplayName);
 			if ($tagData === null) {
@@ -340,6 +341,7 @@ trait Tags {
 	 * @throws \Exception
 	 */
 	public function editTagGroups($user, $oldName, $groups) {
+		$user = $this->getActualUsername($user);
 		$properties = [
 						'{http://owncloud.org/ns}groups' => $groups
 					  ];
@@ -359,7 +361,7 @@ trait Tags {
 		$tagID = $this->findTagIdByName($name);
 		$this->response = TagsHelper::deleteTag(
 			$this->getBaseUrl(),
-			$user,
+			$this->getActualUsername($user),
 			$this->getPasswordForUser($user),
 			$tagID,
 			$this->getDavPathVersion('systemtags')
@@ -551,6 +553,8 @@ trait Tags {
 	 * @return void
 	 */
 	private function untag($untaggingUser, $tagName, $fileName, $fileOwner) {
+		$untaggingUser = $this->getActualUsername($untaggingUser);
+		$fileOwner = $this->getActualUsername($fileOwner);
 		$fileID = $this->getFileIdForPath($fileOwner, $fileName);
 		$tagID = $this->findTagIdByName($tagName);
 		$path = "/systemtags-relations/files/$fileID/$tagID";

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -749,6 +749,7 @@ trait WebDav {
 	public function downloadFileAsUserUsingPassword(
 		$user, $fileName, $password = null
 	) {
+		$password = $this->getActualPassword($password);
 		$this->response = $this->makeDavRequest(
 			$user,
 			'GET',

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -204,6 +204,8 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 * @throws \Exception
 	 */
 	public function loginAs($username, $password, $target = 'FilesPage') {
+		$username = $this->featureContext->getActualUsername($username);
+		$password = $this->featureContext->getActualPassword($password);
 		$session = $this->getSession();
 		$this->loginPage->waitTillPageIsLoaded($session);
 		$nextPage = $this->loginPage->loginAs(

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -167,6 +167,8 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	public function theUserLogsInWithUsernameAndInvalidPasswordUsingTheWebUI(
 		$username, $password
 	) {
+		$username = $this->featureContext->getActualUsername($username);
+		$password = $this->featureContext->getActualPassword($password);
 		$this->loginPage->loginAs($username, $password, 'LoginPage');
 		$this->loginPage->waitTillPageIsLoaded($this->getSession());
 	}
@@ -284,6 +286,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theUserResetsThePasswordToUsingTheWebui($newPassword) {
+		$newPassword = $this->featureContext->getActualPassword($newPassword);
 		$this->loginPage->resetThePassword($newPassword, $this->getSession());
 	}
 	

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -117,25 +117,28 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	public function theUserChangesThePasswordToUsingTheWebUI($newPassword) {
 		$username = $this->featureContext->getCurrentUser();
 		$oldPassword = \trim($this->featureContext->getUserPassword($username));
+		$newPassword = $this->featureContext->getActualPassword($newPassword);
 		$this->personalGeneralSettingsPage->changePassword(
 			$oldPassword, $newPassword, $this->getSession()
 		);
 	}
 	
 	/**
-	 * @When the user changes the password to :newPassword entering the wrong current password using the webUI
-	 * @Given the user has changed the password to :newPassword entering the wrong current password using the webUI
+	 * @When the user changes the password to :newPassword entering the wrong current password :wrongPassword using the webUI
+	 * @Given the user has changed the password to :newPassword entering the wrong current password :wrongPassword using the webUI
 	 *
 	 * @param string $newPassword
+	 * @param string $wrongPassword
 	 *
 	 * @return void
 	 */
 	public function theUserChangesThePasswordWrongCurrentPasswordUsingTheWebUI(
-		$newPassword
+		$newPassword, $wrongPassword
 	) {
-		$oldPassword = "thisisawrongpassword";
+		$newPassword = $this->featureContext->getActualPassword($newPassword);
+		$wrongPassword = $this->featureContext->getActualPassword($wrongPassword);
 		$this->personalGeneralSettingsPage->changePassword(
-			$oldPassword, $newPassword, $this->getSession()
+			$wrongPassword, $newPassword, $this->getSession()
 		);
 	}
 

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -7,10 +7,10 @@ So that I can find my favorite file/folder easily
 
 	Background:
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 
 	@smokeTest

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -7,10 +7,10 @@ So that I can remove my favorite file/folder from favorite page
 
 	Background:
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 
 	@smokeTest

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -6,10 +6,10 @@ So that I can see the details immediately without needing to click in the UI
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 
 	@smokeTest
 	Scenario Outline: Browse directly to the sharing details of a file

--- a/tests/acceptance/features/webUIFiles/createFolders.feature
+++ b/tests/acceptance/features/webUIFiles/createFolders.feature
@@ -6,10 +6,10 @@ So that I can organise my data structure
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 
 	@smokeTest

--- a/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
+++ b/tests/acceptance/features/webUIFiles/createFoldersEdgeCases.feature
@@ -6,10 +6,10 @@ So that I can organise my data structure
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 
 	Scenario Outline: Create a folder using special characters
 		When the user creates a folder with the name <folder_name> using the webUI

--- a/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUIFiles/deleteFilesFolders.feature
@@ -6,10 +6,10 @@ So that I can keep my filing system clean and tidy
 
 	Background:
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 
 	@smokeTest

--- a/tests/acceptance/features/webUIFiles/hiddenFile.feature
+++ b/tests/acceptance/features/webUIFiles/hiddenFile.feature
@@ -7,10 +7,10 @@ So that I can choose to see the files that I want.
 
 	Background:
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 
 	@smokeTest

--- a/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
+++ b/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
@@ -6,10 +6,10 @@ So that I can manage and work with my files
 
 	Background:
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 
 	@skipOnINTERNETEXPLORER

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -7,10 +7,10 @@ So that I can find needed files quickly
 
   Background:
     Given these users have been created:
-    |username|password|displayname|email       |
-    |user1   |1234    |User One   |u1@oc.com.np|
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "1234" using the webUI
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
 
   @smokeTest
   Scenario: Simple search

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -11,34 +11,34 @@ Feature: login users
 	@TestAlsoOnExternalUserBackend
 	Scenario: simple user login
 		Given these users have been created but not initialized:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		When the user logs in with username "user1" and password "1234" using the webUI
+		When the user logs in with username "user1" and password "%regular%" using the webUI
 		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
 	@smokeTest
 	Scenario: admin login
 		Given the user has browsed to the login page
-		When the user logs in with username "admin" and password "admin" using the webUI
+		When the user logs in with username "%admin%" and password "%admin%" using the webUI
 		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
 	@smokeTest
 	Scenario: admin login with invalid password
 		Given the user has browsed to the login page
-		When the user logs in with username "admin" and invalid password "invalidpassword" using the webUI
+		When the user logs in with username "%admin%" and invalid password "%regular%" using the webUI
 		Then the user should be redirected to a webUI page with the title "ownCloud"
 
 	Scenario: access the personal general settings page when not logged in
 		When the user attempts to browse to the personal general settings page
 		Then the user should be redirected to a webUI page with the title "ownCloud"
-		When the user logs in with username "admin" and password "admin" using the webUI after a redirect from the "personal general settings" page
+		When the user logs in with username "%admin%" and password "%admin%" using the webUI after a redirect from the "personal general settings" page
 		Then the user should be redirected to a webUI page with the title "Settings - ownCloud"
 
 	Scenario: access the personal general settings page when not logged in using incorrect then correct password
 		When the user attempts to browse to the personal general settings page
 		Then the user should be redirected to a webUI page with the title "ownCloud"
-		When the user logs in with username "admin" and invalid password "qwerty" using the webUI
+		When the user logs in with username "%admin%" and invalid password "%regular%" using the webUI
 		Then the user should be redirected to a webUI page with the title "ownCloud"
-		When the user logs in with username "admin" and password "admin" using the webUI after a redirect from the "personal general settings" page
+		When the user logs in with username "%admin%" and password "%admin%" using the webUI after a redirect from the "personal general settings" page
 		Then the user should be redirected to a webUI page with the title "Settings - ownCloud"

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -7,10 +7,10 @@ So that I can login to my account again after forgetting the password
 
 	Background:
 		Given these users have been created but not initialized:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user logs in with username "user1" and invalid password "invalidpassword" using the webUI
+		And the user logs in with username "user1" and invalid password "%alt3%" using the webUI
 
 	@smokeTest
 	Scenario: send password reset email
@@ -30,10 +30,10 @@ So that I can login to my account again after forgetting the password
 		When the user requests the password reset link using the webUI
 		And the user follows the password reset link from email address "u1@oc.com.np"
 		Then the user should be redirected to a webUI page with the title "ownCloud"
-		When the user resets the password to "newpassword" using the webUI
+		When the user resets the password to "%alt1%" using the webUI
 		Then the email address "u1@oc.com.np" should have received an email with the body containing
 			"""
 			Password changed successfully
 			"""
-		When the user logs in with username "user1" and password "newpassword" using the webUI
+		When the user logs in with username "user1" and password "%alt1%" using the webUI
 		Then the user should be redirected to a webUI page with the title "Files - ownCloud"

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -6,10 +6,10 @@ So that I can organise my data structure
 
 	Background:
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 
 	Scenario: An attempt to move a file into a sub-folder using rename is not allowed

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -6,10 +6,10 @@ So that I can organise my data structure
 
 	Background:
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 
 	Scenario: An attempt to move a folder into a sub-folder using rename is not allowed

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
@@ -6,10 +6,10 @@ So that I can be reached by the owncloud server
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the personal general settings page
 
 	@skip @issue-32385

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
@@ -6,10 +6,10 @@ So that other users can recognize me by it
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the personal general settings page
 
 	@smokeTest

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -6,22 +6,22 @@ So that I can login with my new password
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the personal general settings page
 
 	@smokeTest
 	Scenario: Change password 
-		When the user changes the password to "passcode" using the webUI
-		And the user re-logs in with username "user1" and password "passcode" using the webUI
+		When the user changes the password to "%alt1%" using the webUI
+		And the user re-logs in with username "user1" and password "%alt1%" using the webUI
 		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
 
 	Scenario: Password change with wrong current password
-		When the user changes the password to "passcode" entering the wrong current password using the webUI
+		When the user changes the password to "%alt1%" entering the wrong current password "%alt2%" using the webUI
 		Then a password error message should be displayed on the webUI with the text "Wrong current password"
 
 	Scenario: New password is same as current password
-		When the user changes the password to "1234" using the webUI
+		When the user changes the password to "%regular%" using the webUI
 		Then a password error message should be displayed on the webUI with the text "The new password cannot be the same as the previous one"

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -7,10 +7,10 @@ So that I can personalise the User Interface
 	@smokeTest
 	Scenario: change language
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the personal general settings page
 		When the user changes the language to "Русский" using the webUI
 		Then the user should be redirected to a webUI page with the title "Настройки - ownCloud"

--- a/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
@@ -6,10 +6,10 @@ So that I can enable, allow and deny access to and from other storage systems or
 
 	Background:
 			Given these users have been created but not initialized:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+				| username | password  | displayname | email        |
+				| user1    | %regular% | User One    | u1@oc.com.np |
 			And the user has browsed to the login page
-			And the user has logged in with username "user1" and password "1234" using the webUI
+			And the user has logged in with username "user1" and password "%regular%" using the webUI
 			And the user has browsed to the personal security settings page
 
 	@smokeTest

--- a/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFiles.feature
@@ -6,10 +6,10 @@ So that I can organise my data structure
 
 	Background:
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 
 	@smokeTest

--- a/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
@@ -6,10 +6,10 @@ So that I can recognize my file easily
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 
 	Scenario Outline: Rename the existing file inside a problematic folder
 		When the user opens the folder <folder> using the webUI

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -6,10 +6,10 @@ So that I can organise my data structure
 
 	Background:
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 
 	Scenario Outline: Rename a folder using special characters

--- a/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
@@ -6,13 +6,13 @@ So that users cannot share files
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		
 	@TestAlsoOnExternalUserBackend
 	@smokeTest
 	Scenario: Users tries to share via WebUI when Sharing is disabled
 		Given the setting "Allow apps to use the Share API" in the section "Sharing" has been disabled
 		And the user has browsed to the login page
-		When the user logs in with username "user1" and password "1234" using the webUI
+		When the user logs in with username "user1" and password "%regular%" using the webUI
 		Then it should not be possible to share the folder "simple-folder" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -7,17 +7,17 @@ I want to be able to forbid a user that received a share from me to share it fur
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
-		|user2   |1234    |User Two   |u2@oc.com.np|
-		|user3   |1234    |User Three |u2@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
+			| user2    | %alt1%    | User Two    | u2@oc.com.np |
+			| user3    | %alt2%    | User Three  | u2@oc.com.np |
 		And these groups have been created:
-		|groupname|
-		|grp1     |
+			| groupname |
+			| grp1      |
 		And user "user1" has been added to group "grp1"
 		And user "user2" has been added to group "grp1"
 		And the user has browsed to the login page
-		And the user has logged in with username "user2" and password "1234" using the webUI
+		And the user has logged in with username "user2" and password "%alt1%" using the webUI
 
 	@skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend
 	@smokeTest
@@ -27,7 +27,7 @@ I want to be able to forbid a user that received a share from me to share it fur
 		When the user shares the folder "simple-folder" with the user "User One" using the webUI
 		And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
 		| share | no |
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		Then it should not be possible to share the folder "simple-folder (2)" using the webUI
 
 	@TestAlsoOnExternalUserBackend
@@ -36,5 +36,5 @@ I want to be able to forbid a user that received a share from me to share it fur
 		Given the setting "Allow resharing" in the section "Sharing" has been disabled
 		And the user has browsed to the files page
 		When the user shares the folder "simple-folder" with the user "User One" using the webUI
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		Then it should not be possible to share the folder "simple-folder (2)" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -6,19 +6,19 @@ So that users can only share files with specific users and groups
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
-		|user2   |1234    |User Two   |u2@oc.com.np|
-		|user3   |1234    |User Three |u2@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
+			| user2    | %alt1%    | User Two    | u2@oc.com.np |
+			| user3    | %alt2%    | User Three  | u2@oc.com.np |
 		And these groups have been created:
-		|groupname|
-		|grp1     |
-		|grp2     |
+			| groupname |
+			| grp1      |
+			| grp2      |
 		And user "user1" has been added to group "grp1"
 		And user "user2" has been added to group "grp1"
 		And user "user3" has been added to group "grp2"
 		And the user has browsed to the login page
-		And the user has logged in with username "user2" and password "1234" using the webUI
+		And the user has logged in with username "user2" and password "%alt1%" using the webUI
 	
 	@TestAlsoOnExternalUserBackend
 	@smokeTest
@@ -27,7 +27,7 @@ So that users can only share files with specific users and groups
 		When the user browses to the files page
 		Then it should not be possible to share the folder "simple-folder" with "User Three" using the webUI
 		When the user shares the folder "simple-folder" with the user "User One" using the webUI
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		Then the folder "simple-folder (2)" should be listed on the webUI
 
 	@TestAlsoOnExternalUserBackend
@@ -37,7 +37,7 @@ So that users can only share files with specific users and groups
 		When the user browses to the files page
 		Then it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
 		When the user shares the folder "simple-folder" with the group "grp1" using the webUI
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		Then the folder "simple-folder (2)" should be listed on the webUI
 
 	@TestAlsoOnExternalUserBackend
@@ -45,7 +45,7 @@ So that users can only share files with specific users and groups
 		Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been disabled
 		And the user browses to the files page
 		When the user shares the folder "simple-folder" with the group "grp2" using the webUI
-		And the user re-logs in with username "user3" and password "1234" using the webUI
+		And the user re-logs in with username "user3" and password "%alt2%" using the webUI
 		Then the folder "simple-folder (2)" should be listed on the webUI
 
 	@TestAlsoOnExternalUserBackend
@@ -56,5 +56,5 @@ So that users can only share files with specific users and groups
 		Then it should not be possible to share the folder "simple-folder" with "grp1" using the webUI
 		And it should not be possible to share the folder "simple-folder" with "grp2" using the webUI
 		When the user shares the folder "simple-folder" with the user "User One" using the webUI
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		Then the folder "simple-folder (2)" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingExternal/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal/federationSharing.feature
@@ -7,19 +7,19 @@ So that other users have access to these files
 	Background:
 		Given using server "REMOTE"
 		And these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And using server "LOCAL"
 		And these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 
 	Scenario: test the single steps of sharing a folder to a remote server
 		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
 		And the user shares the folder "simple-empty-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
 		And the user accepts the offered remote shares using the webUI
 		And using server "REMOTE"
 		Then as "user1" the folder "/simple-folder (2)" should exist
@@ -29,9 +29,9 @@ So that other users have access to these files
 	Scenario: test the single steps of receiving a federation share
 		Given using server "REMOTE"
 		And these users have been created:
-			|username|password|displayname|email       |
-			|user2   |1234    |User Two   |u2@oc.com.np|
-			|user3   |1234    |User Two   |u2@oc.com.np|
+			| username | password | displayname | email        |
+			| user2    | %alt1%   | User Two    | u2@oc.com.np |
+			| user3    | %alt2%   | User Two    | u2@oc.com.np |
 		And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
 		And user "user2" from server "REMOTE" has shared "simple-empty-folder" with user "user1" from server "LOCAL"
 		And user "user3" from server "REMOTE" has shared "lorem.txt" with user "user1" from server "LOCAL"
@@ -63,18 +63,18 @@ So that other users have access to these files
 		When the user shares the folder "simple-folder" with the remote user "user1@%remote_server_without_scheme%" using the webUI
 		And the user sets the sharing permissions of "user1@%remote_server_without_scheme% (federated)" for "simple-folder" using the webUI to
 		| delete | no |
-		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
 		And the user accepts the offered remote shares using the webUI
 		And the user opens the folder "simple-folder (2)" using the webUI
 		Then it should not be possible to delete the file "lorem.txt" using the webUI
 
 	@skipOnMICROSOFTEDGE
 	Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
-		When the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+		When the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
 		And the user shares the folder "simple-folder" with the remote user "user1@%local_server_without_scheme%" using the webUI
 		And the user sets the sharing permissions of "user1@%local_server_without_scheme% (federated)" for "simple-folder" using the webUI to
 		| delete | no |
-		And the user re-logs in with username "user1" and password "1234" to "%local_server%" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
 		And the user accepts the offered remote shares using the webUI
 		And the user opens the folder "simple-folder (2)" using the webUI
 		Then it should not be possible to delete the file "lorem.txt" using the webUI
@@ -83,7 +83,7 @@ So that other users have access to these files
 		Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		When user "user1" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/lorem.txt" using the WebDAV API
-		And the user re-logs in with username "user1" and password "1234" to "%local_server%" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
 		And the user opens the folder "simple-folder" using the webUI
 		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" on the local server should be the same as the local "lorem.txt"
@@ -94,7 +94,7 @@ So that other users have access to these files
 		When the user accepts the offered remote shares using the webUI
 		And the user opens the folder "simple-folder (2)" using the webUI
 		And the user uploads overwriting the file "lorem.txt" using the webUI and retries if the file is locked
-		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
 		And the user opens the folder "simple-folder" using the webUI
 		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
@@ -103,7 +103,7 @@ So that other users have access to these files
 		Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		When user "user1" on "REMOTE" uploads file "filesForUpload/new-lorem.txt" to "simple-folder (2)/new-lorem.txt" using the WebDAV API
-		And the user re-logs in with username "user1" and password "1234" to "%local_server%" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
 		And the user opens the folder "simple-folder" using the webUI
 		Then the file "new-lorem.txt" should be listed on the webUI
 		And the content of "new-lorem.txt" on the local server should be the same as the local "new-lorem.txt"
@@ -114,7 +114,7 @@ So that other users have access to these files
 		When the user accepts the offered remote shares using the webUI
 		And the user opens the folder "simple-folder (2)" using the webUI
 		And the user uploads the file "new-lorem.txt" using the webUI
-		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
 		And the user opens the folder "simple-folder" using the webUI
 		Then the file "new-lorem.txt" should be listed on the webUI
 		And the content of "new-lorem.txt" on the remote server should be the same as the local "new-lorem.txt"
@@ -123,7 +123,7 @@ So that other users have access to these files
 		Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		When user "user1" on "REMOTE" moves file "/simple-folder%20(2)/lorem-big.txt" to "/simple-folder%20(2)/renamed%20file.txt" using the WebDAV API
-		When the user re-logs in with username "user1" and password "1234" to "%local_server%" using the webUI
+		When the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
 		And the user opens the folder "simple-folder" using the webUI
 		Then the file "renamed file.txt" should be listed on the webUI
 		But the file "lorem-big.txt" should not be listed on the webUI
@@ -135,7 +135,7 @@ So that other users have access to these files
 		When the user accepts the offered remote shares using the webUI
 		When the user opens the folder "simple-folder (2)" using the webUI
 		And the user renames the file "lorem-big.txt" to "renamed file.txt" using the webUI
-		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
 		And the user opens the folder "simple-folder" using the webUI
 		Then the file "renamed file.txt" should be listed on the webUI
 		And the content of "renamed file.txt" on the remote server should be the same as the original "simple-folder/lorem-big.txt"
@@ -145,7 +145,7 @@ So that other users have access to these files
 		Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
 		And user "user1" from server "REMOTE" has accepted the last pending share
 		When user "user1" on "REMOTE" deletes file "simple-folder (2)/data.zip" using the WebDAV API
-		And the user re-logs in with username "user1" and password "1234" to "%local_server%" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" to "%local_server%" using the webUI
 		And the user opens the folder "simple-folder" using the webUI
 		Then the file "data.zip" should not be listed on the webUI
 
@@ -155,15 +155,15 @@ So that other users have access to these files
 		When the user accepts the offered remote shares using the webUI
 		And the user opens the folder "simple-folder (2)" using the webUI
 		And the user deletes the file "data.zip" using the webUI
-		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
 		And the user opens the folder "simple-folder" using the webUI
 		Then the file "data.zip" should not be listed on the webUI
 
 	Scenario: receive same name federation share from two users
 		Given using server "REMOTE"
 		And these users have been created:
-			|username|password|displayname|email       |
-			|user2   |1234    |User Two   |u2@oc.com.np|
+			| username | password | displayname | email        |
+			| user2    | %alt1%   | User Two    | u2@oc.com.np |
 		And user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
 		And user "user2" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
 		And the user has reloaded the current page of the webUI
@@ -196,7 +196,7 @@ So that other users have access to these files
 		When user "user1" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API
 		And the user has reloaded the current page of the webUI
 		And the user shares the file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with the remote user "user1@%remote_server_without_scheme%" using the webUI
-		And the user re-logs in with username "user1" and password "1234" to "%remote_server%" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" to "%remote_server%" using the webUI
 		And the user accepts the offered remote shares using the webUI
 		And using server "REMOTE"
 		Then as "user1" the file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -10,10 +10,10 @@ So that public sharing is limited according to organization policy
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 
 	@smokeTest
 	Scenario: simple sharing by public link
@@ -46,12 +46,12 @@ So that public sharing is limited according to organization policy
 	Scenario: mount public link
 		Given using server "REMOTE"
 		And these users have been created:
-		|username|password|displayname|email       |
-		|user2   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user2    | %regular% | User One    | u1@oc.com.np |
 		When the user creates a new public link for the folder "simple-folder" using the webUI
 		And the user logs out of the webUI
 		And the public accesses the last created public link using the webUI
-		And the public adds the public link to "%remote_server%" as user "user2" with the password "1234" using the webUI
+		And the public adds the public link to "%remote_server%" as user "user2" with the password "%regular%" using the webUI
 		And the user accepts the offered remote shares using the webUI
 		Then the folder "simple-folder (2)" should be listed on the webUI
 		When the user opens the folder "simple-folder (2)" using the webUI
@@ -63,13 +63,13 @@ So that public sharing is limited according to organization policy
 	Scenario: mount public link and overwrite file
 		Given using server "REMOTE"
 		And these users have been created:
-		|username|password|displayname|email       |
-		|user2   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user2    | %regular% | User One    | u1@oc.com.np |
 		When the user creates a new public link for the folder "simple-folder" using the webUI with
 		| permission | read-write |
 		And the user logs out of the webUI
 		And the public accesses the last created public link using the webUI
-		And the public adds the public link to "%remote_server%" as user "user2" with the password "1234" using the webUI
+		And the public adds the public link to "%remote_server%" as user "user2" with the password "%regular%" using the webUI
 		And the user accepts the offered remote shares using the webUI
 		Then the folder "simple-folder (2)" should be listed on the webUI
 		When the user opens the folder "simple-folder (2)" using the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroups.feature
@@ -6,29 +6,29 @@ So that those groups can access the files and folders
 
 	Background:
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
-			|user2   |1234    |User Two   |u2@oc.com.np|
-			|user3   |1234    |User Three |u2@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
+			| user2    | %alt1%    | User Two    | u2@oc.com.np |
+			| user3    | %alt2%    | User Three  | u2@oc.com.np |
 		And these groups have been created:
 			|groupname|
 			|grp1     |
 		And user "user1" has been added to group "grp1"
 		And user "user2" has been added to group "grp1"
 		And the user has browsed to the login page
-		And the user has logged in with username "user3" and password "1234" using the webUI
+		And the user has logged in with username "user3" and password "%alt2%" using the webUI
 
 	@TestAlsoOnExternalUserBackend
 	@smokeTest
 	Scenario: share a folder with an internal group
 		When the user shares the folder "simple-folder" with the group "grp1" using the webUI
 		And the user shares the file "testimage.jpg" with the group "grp1" using the webUI
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		Then the folder "simple-folder (2)" should be listed on the webUI
 		And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
 		And the file "testimage (2).jpg" should be listed on the webUI
 		And the file "testimage (2).jpg" should be marked as shared with "grp1" by "User Three" on the webUI
-		When the user re-logs in with username "user2" and password "1234" using the webUI
+		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
 		Then the folder "simple-folder (2)" should be listed on the webUI
 		And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User Three" on the webUI
 		And the file "testimage (2).jpg" should be listed on the webUI
@@ -38,7 +38,7 @@ So that those groups can access the files and folders
 	Scenario: share a file with an internal group a member overwrites and unshares the file
 		When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
 		And the user shares the file "new-lorem.txt" with the group "grp1" using the webUI
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
 		When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
@@ -48,17 +48,17 @@ So that those groups can access the files and folders
 		When the user unshares the file "new-lorem.txt" using the webUI
 		Then the file "new-lorem.txt" should not be listed on the webUI
 		# check that another group member can still see the file
-		When the user re-logs in with username "user2" and password "1234" using the webUI
+		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
 		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# check that the original file owner can still see the file
-		When the user re-logs in with username "user2" and password "1234" using the webUI
+		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
 		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: share a folder with an internal group and a member uploads, overwrites and deletes files
 		When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
 		And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		And the user opens the folder "new-simple-folder" using the webUI
 		Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
@@ -72,13 +72,13 @@ So that those groups can access the files and folders
 		When the user deletes the file "data.zip" using the webUI
 		Then the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible to another group member
-		When the user re-logs in with username "user2" and password "1234" using the webUI
+		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
 		And the user opens the folder "new-simple-folder" using the webUI
 		Then the content of "lorem.txt" should be the same as the local "lorem.txt"
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		And the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
-		When the user re-logs in with username "user3" and password "1234" using the webUI
+		When the user re-logs in with username "user3" and password "%alt2%" using the webUI
 		And the user opens the folder "new-simple-folder" using the webUI
 		Then the content of "lorem.txt" should be the same as the local "lorem.txt"
 		And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
@@ -90,17 +90,17 @@ So that those groups can access the files and folders
 		When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
 		And the user shares the folder "new-simple-folder" with the group "grp1" using the webUI
 		# unshare the received shared folder and check it is gone
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		And the user unshares the folder "new-simple-folder" using the webUI
 		Then the folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible to another group member
-		When the user re-logs in with username "user2" and password "1234" using the webUI
+		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
 		Then the folder "new-simple-folder" should be listed on the webUI
 		When the user opens the folder "new-simple-folder" using the webUI
 		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 		# check that the folder is still visible for the share owner
-		When the user re-logs in with username "user3" and password "1234" using the webUI
+		When the user re-logs in with username "user3" and password "%alt2%" using the webUI
 		Then the folder "new-simple-folder" should be listed on the webUI
 		When the user opens the folder "new-simple-folder" using the webUI
 		Then the file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups/shareWithGroupsEdgeCases.feature
@@ -6,31 +6,31 @@ So that those groups can access the files and folders
 
 	Scenario Outline: sharing  files and folder with an internal problematic group name
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
-			|user2   |1234    |User Two   |u2@oc.com.np|
-			|user3   |1234    |User Three |u2@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
+			| user2    | %alt1%    | User Two    | u2@oc.com.np |
+			| user3    | %alt2%    | User Three  | u2@oc.com.np |
 		And these groups have been created:
 			|groupname|
 			|<group>  |
 		And user "user1" has been added to group "<group>"
 		And user "user2" has been added to group "<group>"
 		And the user has browsed to the login page
-		And the user has logged in with username "user3" and password "1234" using the webUI
+		And the user has logged in with username "user3" and password "%alt2%" using the webUI
 		When the user shares the folder "simple-folder" with the group "<group>" using the webUI
 		And the user shares the file "testimage.jpg" with the group "<group>" using the webUI
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		Then the folder "simple-folder (2)" should be listed on the webUI
 		And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
 		And the file "testimage (2).jpg" should be listed on the webUI
 		And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
-		When the user re-logs in with username "user2" and password "1234" using the webUI
+		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
 		Then the folder "simple-folder (2)" should be listed on the webUI
 		And the folder "simple-folder (2)" should be marked as shared with "<group>" by "User Three" on the webUI
 		And the file "testimage (2).jpg" should be listed on the webUI
 		And the file "testimage (2).jpg" should be marked as shared with "<group>" by "User Three" on the webUI
 		Examples:
-		|group    |
-		|?\?@#%@,;|
-		 |नेपाली            |
+			| group     |
+			| ?\?@#%@,; |
+			| नेपाली    |
 

--- a/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/acceptShares.feature
@@ -6,10 +6,10 @@ Feature: accept/decline shares coming from internal users
 
 	Background:
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
-			|user2   |1234    |User Two   |u2@oc.com.np|
-			|user3   |1234    |User Three |u2@oc.com.np|
+          | username | password  | displayname | email        |
+          | user1    | %regular% | User One    | u1@oc.com.np |
+          | user2    | %alt1%    | User Two    | u2@oc.com.np |
+          | user3    | %alt2%    | User Three  | u2@oc.com.np |
 		And these groups have been created:
 			|groupname|
 			|grp1     |
@@ -22,7 +22,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
 		And user "user2" has shared folder "/simple-folder" with group "grp1"
 		And user "user2" has shared file "/testimage.jpg" with user "user1"
-		When the user logs in with username "user1" and password "1234" using the webUI
+		When the user logs in with username "user1" and password "%regular%" using the webUI
 		Then the folder "simple-folder (2)" should not be listed on the webUI
 		And the file "testimage (2).jpg" should not be listed on the webUI
 		But the folder "simple-folder" should be listed in the shared-with-you page on the webUI
@@ -34,7 +34,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
 		And user "user2" has shared folder "/simple-folder" with user "user3"
 		And user "user1" has shared folder "/simple-folder" with user "user3"
-		When the user logs in with username "user3" and password "1234" using the webUI
+		When the user logs in with username "user3" and password "%alt2%" using the webUI
 		Then the folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
 		And the folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
 
@@ -44,7 +44,7 @@ Feature: accept/decline shares coming from internal users
 		And user "user2" has shared folder "/simple-folder" with user "user3"
 		And user "user1" has created a folder "/simple-folder/from_user1"
 		And user "user1" has shared folder "/simple-folder" with user "user3"
-		And the user has logged in with username "user3" and password "1234" using the webUI
+		And the user has logged in with username "user3" and password "%alt2%" using the webUI
 		When the user accepts the share "simple-folder" offered by user "User One" using the webUI
 		And the user accepts the share "simple-folder" offered by user "User Two" using the webUI
 		Then the folder "simple-folder (2)" shared by "User One" should be in state "" in the shared-with-you page on the webUI
@@ -57,7 +57,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
 		And user "user2" has shared folder "/simple-folder" with user "user3"
 		And user "user1" has shared folder "/simple-folder" with user "user3"
-		When the user logs in with username "user3" and password "1234" using the webUI
+		When the user logs in with username "user3" and password "%alt2%" using the webUI
 		Then the folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
 		And the folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
 
@@ -66,7 +66,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
 		And user "user2" has shared folder "/simple-folder" with user "user1"
 		And user "user2" has shared file "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
 		Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
 		And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
@@ -80,7 +80,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
 		And user "user2" has shared folder "/simple-folder" with user "user1"
 		And user "user2" has shared file "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		When the user declines the share "simple-folder" offered by user "User Two" using the webUI
 		Then the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
 		And the file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
@@ -92,7 +92,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
 		And user "user2" has shared folder "/simple-folder" with user "user1"
 		And user "user2" has shared file "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
 		And the user reloads the current page of the webUI
 		And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
@@ -105,7 +105,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
 		And user "user2" has shared folder "/simple-folder" with user "user1"
 		And user "user2" has shared file "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
 		And the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
 		Then the folder "simple-folder (2)" should be in state "Declined" in the shared-with-you page on the webUI
@@ -117,7 +117,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
 		And user "user2" has shared folder "/simple-folder" with user "user1"
 		And user "user2" has shared file "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user declines the share "simple-folder" offered by user "User Two" using the webUI
 		When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
 		Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
@@ -129,7 +129,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
 		And user "user2" has shared folder "/simple-folder" with user "user1"
 		And user "user2" has shared folder "/simple-folder" with group "grp1"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
 		And the user reloads the current page of the webUI
 		Then the folder "simple-folder (2)" should be in state "" in the shared-with-you page on the webUI
@@ -139,7 +139,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
 		And user "user2" has shared folder "/simple-folder" with user "user1"
 		And user "user2" has shared folder "/simple-folder" with group "grp1"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		When the user declines the share "simple-folder" offered by user "User Two" using the webUI
 		And the user reloads the current page of the webUI
 		Then the folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
@@ -148,7 +148,7 @@ Feature: accept/decline shares coming from internal users
 	Scenario: reshare a share that you received to a group that you are member of
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
 		And user "user2" has shared folder "/simple-folder" with user "user1"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		When the user accepts the share "simple-folder" offered by user "User Two" using the webUI
 		And the user has browsed to the files page
 		And the user shares the folder "simple-folder (2)" with the group "grp1" using the webUI
@@ -164,7 +164,7 @@ Feature: accept/decline shares coming from internal users
 		And user "user2" has shared folder "/testimage.jpg" with group "grp1"
 		And user "user1" has accepted the share "/simple-folder" offered by user "user2"
 		And user "user1" has accepted the share "/testimage.jpg" offered by user "user2"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		When the user unshares the folder "simple-folder (2)" using the webUI
 		And the user unshares the file "testimage (2).jpg" using the webUI
 		Then the folder "simple-folder (2)" should not be listed in the files page on the webUI
@@ -177,7 +177,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
 		And user "user2" has shared folder "/simple-folder" with group "grp1"
 		And user "user2" has shared folder "/testimage.jpg" with user "user1"
-		When the user logs in with username "user1" and password "1234" using the webUI
+		When the user logs in with username "user1" and password "%regular%" using the webUI
 		Then the folder "simple-folder (2)" should be listed on the webUI
 		And the file "testimage (2).jpg" should be listed on the webUI
 		And the folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
@@ -189,7 +189,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
 		And user "user2" has shared folder "/simple-folder" with group "grp1"
 		And user "user2" has shared folder "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		When the user declines the share "simple-folder (2)" offered by user "User Two" using the webUI
 		And the user declines the share "testimage (2).jpg" offered by user "User Two" using the webUI
 		And the user has browsed to the files page
@@ -202,7 +202,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
 		And user "user2" has shared folder "/simple-folder" with group "grp1"
 		And user "user2" has shared folder "/testimage.jpg" with user "user1"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		When the user unshares the folder "simple-folder (2)" using the webUI
 		And the user unshares the file "testimage (2).jpg" using the webUI
 		Then the folder "simple-folder (2)" should not be listed on the webUI
@@ -214,7 +214,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
 		And user "user2" has shared folder "/simple-folder" with user "user1"
 		And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		When the user unshares the folder "simple-folder-renamed" using the webUI
 		Then the folder "simple-folder-renamed" should not be listed on the webUI
 		And the folder "simple-folder-renamed" should be in state "Declined" in the shared-with-you page on the webUI
@@ -223,7 +223,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
 		And user "user2" has shared folder "/simple-folder" with user "user1"
 		And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder/shared"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		When the user opens the folder "simple-folder" using the webUI
 		And the user unshares the folder "shared" using the webUI
 		Then the folder "shared" should not be listed on the webUI
@@ -233,7 +233,7 @@ Feature: accept/decline shares coming from internal users
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
 		And user "user2" has shared folder "/simple-folder" with user "user1"
 		And user "user1" has moved folder "/simple-folder (2)" to "/simple-folder-renamed"
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		When the user unshares the folder "simple-folder-renamed" using the webUI
 		And the user accepts the share "simple-folder-renamed" offered by user "User Two" using the webUI
 		Then the folder "simple-folder-renamed" should be in state "" in the shared-with-you page on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareAutocompletion.feature
@@ -6,15 +6,15 @@ So that I can efficiently share my files with other users or groups
 
 	Background:
 		Given these users have been created but not initialized:
-			| username    | password | displayname     | email                 |
-			| user1       | 1234     | User One        | u1@oc.com.np          |
-			| two         | 1234     | User Two        | u2@oc.com.np          |
-			| user3       | 1234     | Three           | u3@oc.com.np          |
-			| u444        | 1234     | Four            | u3@oc.com.np          |
-			| usergrp     | 1234     | User Ggg        | u@oc.com.np           |
-			| five        | 1234     | User Group      | five@oc.com.np        |
-			| regularuser | 1234     | User Regular    | regularuser@oc.com.np |
-			| usersmith   | 1234     | John Finn Smith | js@oc.com.np          |
+			| username    | password  | displayname     | email                 |
+			| user1       | %regular% | User One        | u1@oc.com.np          |
+			| two         | %regular% | User Two        | u2@oc.com.np          |
+			| user3       | %regular% | Three           | u3@oc.com.np          |
+			| u444        | %regular% | Four            | u3@oc.com.np          |
+			| usergrp     | %regular% | User Ggg        | u@oc.com.np           |
+			| five        | %regular% | User Group      | five@oc.com.np        |
+			| regularuser | %regular% | User Regular    | regularuser@oc.com.np |
+			| usersmith   | %regular% | John Finn Smith | js@oc.com.np          |
 		And these groups have been created:
 			| groupname     |
 			| finance1      |
@@ -27,7 +27,7 @@ So that I can efficiently share my files with other users or groups
 	@skipOnLDAP @user_ldap-issue-175
 	@smokeTest
 	Scenario: autocompletion of regular existing users
-		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 		And the user has opened the share dialog for the folder "simple-folder"
 		When the user types "us" in the share-with-field
@@ -37,7 +37,7 @@ So that I can efficiently share my files with other users or groups
 	@skipOnLDAP
 	@smokeTest
 	Scenario: autocompletion of regular existing groups
-		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 		And the user has opened the share dialog for the folder "simple-folder"
 		When the user types "fi" in the share-with-field
@@ -45,7 +45,7 @@ So that I can efficiently share my files with other users or groups
 		And the users own name should not be listed in the autocomplete list on the webUI
 		
 	Scenario: autocompletion for a pattern that does not match any user or group
-		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 		And the user has opened the share dialog for the folder "simple-folder"
 		When the user types "doesnotexist" in the share-with-field
@@ -55,11 +55,11 @@ So that I can efficiently share my files with other users or groups
 	@skipOnLDAP
 	Scenario: autocomplete short user/display names when completely typed
 		Given the administrator has set the minimum characters for sharing autocomplete to "4"
-		And the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has logged in with username "regularuser" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 		And these users have been created but not initialized:
 			| username | password | displayname | email        |
-			| use      | 1234     | Use         | uz@oc.com.np |
+			| use      | %alt1%   | Use         | uz@oc.com.np |
 		And the user has opened the share dialog for the folder "simple-folder"
 		When the user types "Use" in the share-with-field
 		Then only "Use" should be listed in the autocomplete list on the webUI
@@ -70,7 +70,7 @@ So that I can efficiently share my files with other users or groups
 		And these groups have been created:
 			| groupname |
 			| fi        |
-		And the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has logged in with username "regularuser" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 		And the user has opened the share dialog for the folder "simple-folder"
 		When the user types "fi" in the share-with-field
@@ -78,7 +78,7 @@ So that I can efficiently share my files with other users or groups
 
 	@skipOnLDAP
 	Scenario: autocompletion when minimum characters is the default (2) and not enough characters are typed
-		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 		And the user has opened the share dialog for the folder "simple-folder"
 		When the user types "u" in the share-with-field
@@ -88,7 +88,7 @@ So that I can efficiently share my files with other users or groups
 	@skipOnLDAP
 	Scenario: autocompletion when minimum characters is increased and not enough characters are typed
 		Given the administrator has set the minimum characters for sharing autocomplete to "4"
-		And the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has logged in with username "regularuser" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 		And the user has opened the share dialog for the folder "simple-folder"
 		When the user types "use" in the share-with-field
@@ -98,7 +98,7 @@ So that I can efficiently share my files with other users or groups
 	@skipOnLDAP
 	Scenario: autocompletion when increasing the minimum characters for sharing autocomplete
 		Given the administrator has set the minimum characters for sharing autocomplete to "3"
-		And the user has logged in with username "regularuser" and password "1234" using the webUI
+		And the user has logged in with username "regularuser" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 		And the user has opened the share dialog for the folder "simple-folder"
 		When the user types "use" in the share-with-field
@@ -107,7 +107,7 @@ So that I can efficiently share my files with other users or groups
 
 	@skipOnLDAP @user_ldap-issue-175
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
-		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 		And the user has shared the folder "simple-folder" with the user "User One" using the webUI
 		And the user has opened the share dialog for the folder "simple-folder"
@@ -117,7 +117,7 @@ So that I can efficiently share my files with other users or groups
 
 	@skipOnLDAP @user_ldap-issue-175
 	Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (file)
-		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 		And the user has shared the file "data.zip" with the user "User Ggg" using the webUI
 		And the user has opened the share dialog for the file "data.zip"
@@ -127,7 +127,7 @@ So that I can efficiently share my files with other users or groups
 
 	@skipOnLDAP
 	Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
-		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 		And the user shares the folder "simple-folder" with the group "finance1" using the webUI
 		And the user has opened the share dialog for the folder "simple-folder"
@@ -137,7 +137,7 @@ So that I can efficiently share my files with other users or groups
 
 	@skipOnLDAP
 	Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (file)
-		Given the user has logged in with username "regularuser" and password "1234" using the webUI
+		Given the user has logged in with username "regularuser" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 		And the user shares the file "data.zip" with the group "finance1" using the webUI
 		And the user has opened the share dialog for the file "data.zip"

--- a/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers/shareWithUsers.feature
@@ -6,18 +6,18 @@ So that those users can access the files and folders
 
 	Background:
 		Given these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
-			|user2   |1234    |User Two   |u2@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
+			| user2    | %alt1%    | User Two    | u2@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user2" and password "1234" using the webUI
+		And the user has logged in with username "user2" and password "%alt1%" using the webUI
 
 	@TestAlsoOnExternalUserBackend
 	@smokeTest
 	Scenario: share a file & folder with another internal user
 		When the user shares the folder "simple-folder" with the user "User One" using the webUI
 		And the user shares the file "testimage.jpg" with the user "User One" using the webUI
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		Then the folder "simple-folder (2)" should be listed on the webUI
 		And the folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
 		And the file "testimage (2).jpg" should be listed on the webUI
@@ -30,7 +30,7 @@ So that those users can access the files and folders
 	Scenario: share a file with another internal user who overwrites and unshares the file
 		When the user renames the file "lorem.txt" to "new-lorem.txt" using the webUI
 		And the user shares the file "new-lorem.txt" with the user "User One" using the webUI
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
 		When the user uploads overwriting the file "new-lorem.txt" using the webUI and retries if the file is locked
@@ -40,14 +40,14 @@ So that those users can access the files and folders
 		When the user unshares the file "new-lorem.txt" using the webUI
 		Then the file "new-lorem.txt" should not be listed on the webUI
 		# check that the original file owner can still see the file
-		When the user re-logs in with username "user2" and password "1234" using the webUI
+		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
 		Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
 	@TestAlsoOnExternalUserBackend
 	Scenario: share a folder with another internal user who uploads, overwrites and deletes files
 		When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
 		And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		And the user opens the folder "new-simple-folder" using the webUI
 		Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
@@ -61,7 +61,7 @@ So that those users can access the files and folders
 		When the user deletes the file "data.zip" using the webUI
 		Then the file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
-		When the user re-logs in with username "user2" and password "1234" using the webUI
+		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
 		And the user opens the folder "new-simple-folder" using the webUI
 		Then the file "lorem.txt" should be listed on the webUI
 		And the content of "lorem.txt" should be the same as the local "lorem.txt"
@@ -74,11 +74,11 @@ So that those users can access the files and folders
 		When the user renames the folder "simple-folder" to "new-simple-folder" using the webUI
 		And the user shares the folder "new-simple-folder" with the user "User One" using the webUI
 		# unshare the received shared folder and check it is gone
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		And the user unshares the folder "new-simple-folder" using the webUI
 		Then the folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible for the share owner
-		When the user re-logs in with username "user2" and password "1234" using the webUI
+		When the user re-logs in with username "user2" and password "%alt1%" using the webUI
 		Then the folder "new-simple-folder" should be listed on the webUI
 		When the user opens the folder "new-simple-folder" using the webUI
 		Then the file "lorem.txt" should be listed on the webUI
@@ -89,6 +89,6 @@ So that those users can access the files and folders
 		When the user shares the folder "simple-folder" with the user "User One" using the webUI
 		And the user sets the sharing permissions of "User One" for "simple-folder" using the webUI to
 		| delete | no |
-		And the user re-logs in with username "user1" and password "1234" using the webUI
+		And the user re-logs in with username "user1" and password "%regular%" using the webUI
 		And the user opens the folder "simple-folder (2)" using the webUI
 		Then it should not be possible to delete the file "lorem.txt" using the webUI

--- a/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
@@ -7,11 +7,11 @@ So that I will be redirected to the most appropriate screen
 	Background:
 		Given the app "notifications" has been enabled
 		And these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
-			|user2   |1234    |User Two   |u2@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
+			| user2    | %alt1%    | User Two    | u2@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user2" and password "1234" using the webUI
+		And the user has logged in with username "user2" and password "%alt1%" using the webUI
 
 	@smokeTest
 	Scenario: notification link redirection in case a share is pending

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -7,17 +7,17 @@ So that those groups can access the files and folders
 	Background:
 		Given the app "notifications" has been enabled
 		And these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
-			|user2   |1234    |User Two   |u2@oc.com.np|
-			|user3   |1234    |User Three |u2@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
+			| user2    | %alt1%    | User Two    | u2@oc.com.np |
+			| user3    | %alt2%    | User Three  | u2@oc.com.np |
 		And these groups have been created:
 			|groupname|
 			|grp1     |
 		And user "user1" has been added to group "grp1"
 		And user "user2" has been added to group "grp1"
 		And the user has browsed to the login page
-		And the user has logged in with username "user2" and password "1234" using the webUI
+		And the user has logged in with username "user2" and password "%alt1%" using the webUI
 
 	Scenario: notifications about new share is displayed
 		Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
@@ -27,7 +27,7 @@ So that those groups can access the files and folders
 			| title                                            |
 			| "User Three" shared "simple-folder" with you  |
 			| "User Three" shared "data.zip" with you       |
-		When the user re-logs in with username "user1" and password "1234" using the webUI
+		When the user re-logs in with username "user1" and password "%regular%" using the webUI
 		Then the user should see 2 notifications on the webUI with these details
 			| title                                            |
 			| "User Three" shared "simple-folder" with you  |

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -7,11 +7,11 @@ So that those users can access the files and folders
 	Background:
 		Given the app "notifications" has been enabled
 		And these users have been created:
-			|username|password|displayname|email       |
-			|user1   |1234    |User One   |u1@oc.com.np|
-			|user2   |1234    |User Two   |u2@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
+			| user2    | %alt1%    | User Two    | u2@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user2" and password "1234" using the webUI
+		And the user has logged in with username "user2" and password "%alt1%" using the webUI
 
 	@smokeTest
 	Scenario: notifications about new share is displayed when autoacepting is disabled

--- a/tests/acceptance/features/webUITrashbin/restore.feature
+++ b/tests/acceptance/features/webUITrashbin/restore.feature
@@ -6,10 +6,10 @@ So that I can recover accidentally deleted files/folders in ownCloud
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 
 	@smokeTest

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -6,10 +6,10 @@ Feature: files and folders can be deleted from the trashbin
 
   Background:
     Given these users have been created:
-      |username|password|displayname|email       |
-      |user1   |1234    |User One   |u1@oc.com.np|
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "1234" using the webUI
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
     And the following files have been deleted
       | name          |
       | data.zip      |

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -6,10 +6,10 @@ Feature: files and folders exist in the trashbin after being deleted
 
   Background:
     Given these users have been created:
-      |username|password|displayname|email       |
-      |user1   |1234    |User One   |u1@oc.com.np|
+      | username | password  | displayname | email        |
+      | user1    | %regular% | User One    | u1@oc.com.np |
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "1234" using the webUI
+    And the user has logged in with username "user1" and password "%regular%" using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -7,10 +7,10 @@ So that I can store files in ownCloud
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 
 	@smokeTest
 	Scenario: simple upload of a file that does not exist before

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -9,10 +9,10 @@ that is not academically correct but saves a lot of time
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 
 	Scenario: simple upload of a file that does not exist before
 		When the user uploads the file "new-'single'quotes.txt" using the webUI

--- a/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
+++ b/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
@@ -7,14 +7,14 @@ So that I can store it in owncloud
 
 	Background:
 		Given these users have been created:
-		|username|password|displayname|email       |
-		|user1   |1234    |User One   |u1@oc.com.np|
+			| username | password  | displayname | email        |
+			| user1    | %regular% | User One    | u1@oc.com.np |
 
 	@smokeTest
 	Scenario: simple upload of a file with the size greater than the size of quota
 		Given the quota of user "user1" has been set to "10 MB"
 		And the user has browsed to the login page
-		And the user has logged in with username "user1" and password "1234" using the webUI
+		And the user has logged in with username "user1" and password "%regular%" using the webUI
 		And the user has browsed to the files page
 		And a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
 		When the user uploads the file "big-video.mp4" using the webUI


### PR DESCRIPTION
## Description
1) Lots of places in the core acceptance tests mention the "admin" username literally, e.g. ``as user "admin"``. Implement a "functional" user ``%admin%`` and whenever that is used as a username, the code underneath replaces it with the actual current admin username.

The admin username defaults to ``admin`` and is overridden by setting env variable ``ADMIN_USERNAME``

2) The core acceptance tests use different passwords in various places.  Sometimes it is not critical, but just so that the different usernames in a scenario have different passwords to reduce the chance of a test passing with mixed-up authentication. Other times it is essential, e.g. when doing password change tests the original and new password have to be different.
So this PR provides "functional" passwords:

 Step form | Env Variable | Default | Description
----------|----------|----------|--------------------
 ``%admin%`` | ``ADMIN_PASSWORD``  | admin | password for the main administrator account that must already exist 
 ``%subadmin%`` | ``SUB_ADMIN_PASSWORD`` | IamAJuniorAdmin42 | password to use when creating a sub-admin account 
 ``%altadmin%`` | ``ALTERNATE_ADMIN_PASSWORD`` | IHave99LotsOfPriv | password to use when creating a second full administrator account 
 ``%regular%`` | ``REGULAR_USER_PASSWORD`` | 123456 | the default password for use with a new user 
 ``%alt1%`` | ``ALT1_USER_PASSWORD`` | IamAJuniorAdmin42 | an alternate password for use with regular users 
 ``%alt2%`` | ``ALT2_USER_PASSWORD`` | AaBb2Cc3Dd4 | an alternate password for use with regular users 
 ``%alt3%`` | ``ALT3_USER_PASSWORD`` | aVeryLongPassword42TheMeaningOfLife | an alternate password for use with regular users 

This should be backward-compatible with existing tests in apps. Specifying a "hard-coded" password or admin username still works. App acceptance tests can be updated to use these new username-password-abstraction features as needed.

## Motivation and Context
Be able to:
- run the acceptance test suite against a system-under-test that has a different admin username and/or password (not just admin/admin)
- run the acceptance test suite against a system-under-test that has various password policies in place. So we need to be able to specify the various passwords that the test scenarios should use for the different functional accounts that are created for testing (e.g. regular user, sub-admin and an extra admin account). That will allow the test runner to specify password that are complex-enough to be valid on the SUT.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
