### PR TITLE
Test removing email addresses from public link share

### DIFF
--- a/tests/TestHelpers/EmailHelper.php
+++ b/tests/TestHelpers/EmailHelper.php
@@ -77,7 +77,7 @@ class EmailHelper {
 	public static function getBodyOfEmail($mailhogUrl, $address, $numEmails = 1, $waitTimeSec = EMAIL_WAIT_TIMEOUT_SEC) {
 		$currentTime = \time(true);
 		$end = $currentTime + $waitTimeSec;
-		
+
 		while ($currentTime <= $end) {
 			$skip = 1;
 			foreach (self::getEmails($mailhogUrl)->items as $item) {

--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -57,6 +57,24 @@ class EmailContext implements Context {
 	}
 
 	/**
+	 * @Then the email address :address should not have received an email
+	 *
+	 * @param string $address
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function assertThatEmailDoesntExistWithTheAddress($address) {
+		try {
+			EmailHelper::getBodyOfLastEmail($this->mailhogUrl, $address, 3);
+		} catch (\Exception $err) {
+			PHPUnit_Framework_Assert::assertTrue(true);
+			return;
+		}
+		throw \Exception("Email exists with email address: {$address}.");
+	}
+
+	/**
 	 * @BeforeScenario @mailhog
 	 *
 	 * @return void

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -35,6 +35,7 @@ use TestHelpers\HttpRequestHelper;
 use TestHelpers\EmailHelper;
 use TestHelpers\SetupHelper;
 use OC\Files\External\Auth\Password\Password;
+use Page\FilesPageElement\SharingDialogElement\EditPublicLinkPopup;
 
 require_once 'bootstrap.php';
 
@@ -90,6 +91,11 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	private $oldFedSharingFallbackSetting = null;
 
 	private $publicShareTab;
+	/**
+	 *
+	 * @var EditPublicLinkPopup
+	 */
+	private $publicSharingPopup;
 	private $linkName;
 
 	/**
@@ -198,6 +204,68 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->sharingDialog = $this->filesPage->openSharingDialog(
 			$name, $this->getSession()
 		);
+	}
+
+	/**
+	 * @Given the user has opened the public link share tab
+	 * @When the user opens the public link share tab
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException
+	 */
+	public function theUserHasOpenedThePublicLinkShareTab() {
+		$this->publicShareTab = $this->sharingDialog->openPublicShareTab();
+	}
+
+	/**
+	 * @When the user opens the create public link share popup
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException
+	 */
+	public function theUserOpensTheCreatePublicLinkSharePopup() {
+		$this->publicSharingPopup = $this->publicShareTab->openSharingPopup();
+	}
+
+	/**
+	 * @When the user adds the following email addresses using the webUI:
+	 *
+	 * @param TableNode $emails
+	 *
+	 * @return void
+	 */
+	public function theUserAddsTheFollowingEmailAddressesUsingTheWebUI(TableNode $emails) {
+		foreach ($emails as $row) {
+			$this->publicSharingPopup->setLinkEmail($row['email']);
+		}
+	}
+
+	/**
+	 * @When the user removes the following email addresses using the webUI:
+	 *
+	 * @param TableNode $emails
+	 *
+	 * @return void
+	 */
+	public function theUserRemovesTheFollowingEmailAddressesUsingTheWebui(TableNode $emails) {
+		foreach ($emails as $row) {
+			$this->publicSharingPopup->unsetLinkEmail($row['email']);
+		}
+	}
+
+	/**
+	 * @When the user creates the public link using the webUI
+	 *
+	 * @return void
+	 */
+	public function createsThePublicLinkUsingTheWebUI() {
+		$linkName = $this->publicSharingPopup->getLinkName();
+
+		$this->publicSharingPopup->save();
+		$this->publicSharingPopup->waitForAjaxCallsToStartAndFinish($this->getSession());
+
+		$linkUrl = $this->publicShareTab->getLinkUrl($linkName);
+		$this->addToListOfCreatedPublicLinks($linkName, $linkUrl);
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
@@ -42,13 +42,15 @@ class EditPublicLinkPopup extends OwncloudPage {
 	private $expirationDateInputXpath = ".//input[contains(@class,'expirationDate')]";
 	private $emailInputXpath = "//form[@id='emailPrivateLink']//input[@class='select2-input']";
 	private $emailToSelfCheckboxXpath = "//form[@id='emailPrivateLink']" . "//input[@class='emailPrivateLinkForm--emailToSelf']";
+	private $emailInputCloseXpath = "//a[@class='select2-search-choice-close']";
 	private $shareButtonXpath = ".//button[contains(text(), 'Share')]";
 	private $permissionLabelXpath = [
 		'read' => ".//label[contains(@for, 'sharingDialogAllowPublicRead')]",
 		'read-write' => ".//label[contains(@for, 'sharingDialogAllowPublicReadWrite')]",
 		'upload' => ".//label[contains(@for, 'sharingDialogAllowPublicUpload')]"
 	];
-	
+	private $popupCloseButton = "//a[@class='oc-dialog-close']";
+
 	/**
 	 * sets the NodeElement for the current popup
 	 * a little bit like __construct() but as we access this "sub-page-object"
@@ -198,6 +200,25 @@ class EditPublicLinkPopup extends OwncloudPage {
 	}
 
 	/**
+	 * Remove email from Email Input box
+	 *
+	 * @param string $email
+	 *
+	 * @return void
+	 */
+	public function unsetLinkEmail($email) {
+		$emailRemoveBtns = $this->popupElement->findAll("xpath", $this->emailInputCloseXpath);
+		foreach ($emailRemoveBtns as $emailRemoveBtn) {
+			$precedingSiblingNodeWithEmail = $emailRemoveBtn->getParent()->find('xpath', '/div');
+			$text = $precedingSiblingNodeWithEmail->getText();
+			if ($text === $email) {
+				$emailRemoveBtn->click();
+				return;
+			}
+		}
+	}
+
+	/**
 	 *
 	 * @return void
 	 */
@@ -228,5 +249,17 @@ class EditPublicLinkPopup extends OwncloudPage {
 			);
 		}
 		$saveButton->click();
+	}
+
+	public function close() {
+		$closeButton = $this->popupElement->find("xpath", $this->popupCloseButton);
+		if ($closeButton === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->popupCloseButton" .
+				" could not find save button of the public link popup"
+				);
+		}
+		$closeButton->click();
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -44,6 +44,12 @@ class PublicLinkTab extends OwncloudPage {
 	private $linkEntryByNameXpath = ".//*[@class='link-entry--title' and .=%s]/..";
 	private $linkUrlInputXpath = ".//input";
 	private $publicLinkWarningMessageXpath = ".//*[@class='error-message-global'][last()]";
+
+	/**
+	 *
+	 * @var EditPublicLinkPopup
+	 */
+	private $editPublicLinkPopupPageObject;
 	
 	/**
 	 * as it's not possible to run __construct() we need to run this function
@@ -88,27 +94,7 @@ class PublicLinkTab extends OwncloudPage {
 		$email = null,
 		$emailToSelf = null
 	) {
-		$createLinkBtn = $this->publicLinkTabElement->find(
-			"xpath", $this->createLinkBtnXpath
-		);
-		if ($createLinkBtn === null) {
-			throw new ElementNotFoundException(
-				__METHOD__ .
-				" xpath $this->createLinkBtnXpath" .
-				" could not find create public link button"
-			);
-		}
-		$createLinkBtn->click();
-
-		$popupElement = $this->waitTillElementIsNotNull($this->popupXpath);
-		/**
-		 *
-		 * @var EditPublicLinkPopup $editPublicLinkPopupPageObject
-		 */
-		$editPublicLinkPopupPageObject = $this->getPage(
-			"FilesPageElement\\SharingDialogElement\\EditPublicLinkPopup"
-		);
-		$editPublicLinkPopupPageObject->setElement($popupElement);
+		$editPublicLinkPopupPageObject = $this->openSharingPopup();
 		if ($name !== null) {
 			$editPublicLinkPopupPageObject->setLinkName($name);
 		}
@@ -134,6 +120,34 @@ class PublicLinkTab extends OwncloudPage {
 		$editPublicLinkPopupPageObject->save();
 		$this->waitForAjaxCallsToStartAndFinish($session);
 		return $linkName;
+	}
+
+	/**
+	 * @return NodeElement
+	 *
+	 * @throws ElementNotFoundException
+	 */
+	public function openSharingPopup() {
+		$createLinkBtn = $this->publicLinkTabElement->find(
+			"xpath", $this->createLinkBtnXpath
+			);
+		if ($createLinkBtn === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->createLinkBtnXpath" .
+				" could not find create public link button"
+				);
+		}
+		$createLinkBtn->click();
+
+		$popupElement = $this->waitTillElementIsNotNull($this->popupXpath);
+
+		$this->editPublicLinkPopupPageObject = $this->getPage(
+			"FilesPageElement\\SharingDialogElement\\EditPublicLinkPopup"
+		);
+		$this->editPublicLinkPopupPageObject->setElement($popupElement);
+
+		return $this->editPublicLinkPopupPageObject;
 	}
 
 	/**
@@ -183,7 +197,8 @@ class PublicLinkTab extends OwncloudPage {
 	 * @return void
 	 */
 	public function closeSharingPopup() {
-		throw new Exception("not implemented");
+		$this->editPublicLinkPopupPageObject->close();
+		$this->waitTillElementIsNull($this->popupXpath);
 	}
 
 	/**

--- a/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingExternal/shareByPublicLink.feature
@@ -182,3 +182,33 @@ So that public sharing is limited according to organization policy
 			"""
 		And the email address "foo@bar.co" should have received an email containing last shared public link
 		And the email address "foo@barr.co" should have received an email containing last shared public link
+
+	Scenario: user shares a public link via email adding few addresses before and then removing some addresses afterwards
+		Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
+		And the user has reloaded the current page of the webUI
+		When the user opens the share dialog for the folder "simple-folder"
+		And the user opens the public link share tab
+		And the user opens the create public link share popup
+		And the user adds the following email addresses using the webUI:
+		|email            |
+		| foo1234@bar.co  |
+		| foo5678@bar.co  |
+		| foo1234@barr.co |
+		| foo5678@barr.co |
+		And the user removes the following email addresses using the webUI:
+		| email            |
+		| foo1234@bar.co   |
+		| foo5678@barr.co  |
+		And the user creates the public link using the webUI
+		Then the email address "foo5678@bar.co" should have received an email with the body containing
+			"""
+			User One shared simple-folder with you
+			"""
+		And the email address "foo1234@barr.co" should have received an email with the body containing
+			"""
+			User One shared simple-folder with you
+			"""
+		And the email address "foo5678@bar.co" should have received an email containing last shared public link
+		And the email address "foo1234@barr.co" should have received an email containing last shared public link
+		But the email address "foo1234@bar.co" should not have received an email
+		And the email address "foo5678@barr.co" should not have received an email


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This adds a test for removing email addresses from the email input box of the public link share dialog. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #30892 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [x] Backport (if applicable set "backport-request" label and remove when the backport was done)
