### PR TITLE
Allow variable length etag in acceptance tests

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -78,7 +78,7 @@ Feature: Search
       | {http://owncloud.org/ns}fileid             | \d*                                                                                               |
       | {http://owncloud.org/ns}permissions        | ^(RDNVW\|RMDNVW)$                                                                                 |
       | {DAV:}getlastmodified                      | ^[MTWFS][uedhfriatno]{2},\s(\d){2}\s[JFMAJSOND][anebrpyulgctov]{2}\s\d{4}\s\d{2}:\d{2}:\d{2} GMT$ |
-      | {DAV:}getetag                              | ^\"[a-f0-9]{32}\"$                                                                                |
+      | {DAV:}getetag                              | ^\"[a-f0-9]{1,32}\"$                                                                                |
       | {DAV:}getcontenttype                       | text\/plain                                                                                       |
       | {http://owncloud.org/ns}size               | 15                                                                                                |
       | {http://owncloud.org/ns}owner-id           | user0                                                                                             |


### PR DESCRIPTION
## Description
Just check for a string of 1 to 32 hex characters when verifying that an etag property value looks reasonable.

## Motivation and Context
CI fails on ``files_primary_s3`` because the length of the etag returned there is less than 32 characters.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
