### PR TITLE
Tag features with app-required

### DIFF
--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -1,4 +1,4 @@
-@api
+@api @federation-app-required
 Feature: federated
 	Background:
 		Given using OCS API version "1"

--- a/tests/acceptance/features/apiMain/dav-versions.feature
+++ b/tests/acceptance/features/apiMain/dav-versions.feature
@@ -1,4 +1,5 @@
-@api
+@api @files_versions-app-required
+
 Feature: dav-versions
   Background:
     Given using OCS API version "2"

--- a/tests/acceptance/features/apiMetadataApps/comments.feature
+++ b/tests/acceptance/features/apiMetadataApps/comments.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api @TestAlsoOnExternalUserBackend @comments-app-required
 Feature: Comments
   Background:
     Given using new DAV path

--- a/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addGroup.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: add groups
 As an admin
 I want to be able to add groups

--- a/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addToGroup.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: add users to group
 As a admin
 I want to be able to add users to a group

--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: add user
 As an admin
 I want to be able to add users

--- a/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: access user provisioning API using app password
 As an ownCloud user
 I want to be able to use the provisioning API with an app password

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: create a subadmin
 As an admin
 I want to be able to make a user the subadmin of a group

--- a/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteGroup.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: delete groups
 As an admin
 I want to be able to delete groups

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: delete users
 As an admin
 I want to be able to delete users

--- a/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required @comments-app-required
 Feature: disable an app
 As an admin
 I want to be able to disable an enabled app

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: disable user
 As an admin
 I want to be able to disable a user

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: edit users
 As an admin
 I want to be able to edit a user

--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: enable an app
 As an admin
 I want to be able to enable a disabled app

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: enable user
 As an admin
 I want to be able to enable a user

--- a/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get app info
 As an admin
 I want to be able to get app info

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get apps
 As an admin
 I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroup.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get group
 As an admin
 I want to be able to get group details

--- a/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getGroups.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get groups
 As an admin
 I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdminGroups.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get subadmin groups
 As an admin
 I want to be able to get the groups in which the user is subadmin

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get subadmins
 As an admin
 I want to be able to get the list of subadmins of a group

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get user
 As an admin 
 I want to be able to get user

--- a/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUserGroups.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get user groups
 As an admin
 I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get users
 As an admin
 I want to be able to list the users that exist

--- a/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeFromGroup.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: remove a user from a group
 As an admin
 I want to be able to remove a user from a group

--- a/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: remove subadmin
 As an admin
 I want to be able to remove subadmin rights to a user from a group

--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: reset user password
   As an admin
   I want to be able to reset a user's password

--- a/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addGroup.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: add groups
 As an admin
 I want to be able to add groups

--- a/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addToGroup.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: add users to group
 As a admin
 I want to be able to add users to a group

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: add user
 As an admin
 I want to be able to add users

--- a/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: access user provisioning API using app password
 As an ownCloud user
 I want to be able to use the provisioning API with an app password

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: create a subadmin
 As an admin
 I want to be able to make a user the subadmin of a group

--- a/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteGroup.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: delete groups
 As an admin
 I want to be able to delete groups

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: delete users
 As an admin
 I want to be able to delete users

--- a/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required @comments-app-required
 Feature: disable an app
 As an admin
 I want to be able to disable an enabled app

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: disable user
 As an admin
 I want to be able to disable a user

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: edit users
 As an admin
 I want to be able to edit a user

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: enable an app
 As an admin
 I want to be able to enable a disabled app

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: enable user
 As an admin
 I want to be able to enable a user

--- a/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get app info
 As an admin
 I want to be able to get app info

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get apps
 As an admin
 I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroup.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get group
 As an admin
 I want to be able to get group details

--- a/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getGroups.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get groups
 As an admin
 I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdminGroups.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get subadmin groups
 As an admin
 I want to be able to get the groups in which the user is subadmin

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get subadmins
 As an admin
 I want to be able to get the list of subadmins of a group

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get user
 As an admin 
 I want to be able to get user

--- a/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserGroups.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get user groups
 As an admin
 I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: get users
 As an admin
 I want to be able to list the users that exist

--- a/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeFromGroup.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: remove a user from a group
 As an admin
 I want to be able to remove a user from a group

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: remove subadmin
 As an admin
 I want to be able to remove subadmin rights to a user from a group

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -1,4 +1,4 @@
-@api
+@api @provisioning_api-app-required
 Feature: reset user password
   As an admin
   I want to be able to reset a user's password

--- a/tests/acceptance/features/apiShareManagement/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagement/deleteShare.feature
@@ -73,7 +73,7 @@ Feature: sharing
 			|1              |100            |
 			|2              |200            |
 
-	@smokeTest
+	@smokeTest @files_trashbin-app-required
 	Scenario: deleting a file out of a share as recipient creates a backup for the owner
 		Given using OCS API version "1"
 		And user "user0" has created a folder "/shared"
@@ -86,6 +86,7 @@ Feature: sharing
 		And as "user0" the file "/shared_file.txt" should exist in trash
 		And as "user1" the file "/shared_file.txt" should exist in trash
 
+	@files_trashbin-app-required
 	Scenario: deleting a folder out of a share as recipient creates a backup for the owner
 		Given using OCS API version "1"
 		And user "user0" has created a folder "/shared"

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -14,7 +14,7 @@ Feature: sharing
 		Then as "user1" the file "/shared/shared_file.txt" should exist
 		And as "user0" the file "/shared/shared_file.txt" should exist
 
-	@smokeTest
+	@smokeTest @files_trashbin-app-required
 	Scenario: moving a file out of a share as recipient creates a backup for the owner
 		Given user "user0" has created a folder "/shared"
 		And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -25,6 +25,7 @@ Feature: sharing
 		And as "user0" the file "/shared/shared_file.txt" should not exist
 		And as "user0" the file "/shared_file.txt" should exist in trash
 
+	@files_trashbin-app-required
 	Scenario: moving a folder out of a share as recipient creates a backup for the owner
 		Given user "user0" has created a folder "/shared"
 		And user "user0" has created a folder "/shared/sub"

--- a/tests/acceptance/features/apiTrashbin/trashbin-new-endpoint.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbin-new-endpoint.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api @TestAlsoOnExternalUserBackend @files_trashbin-app-required
 Feature: trashbin-new-endpoint
 	Background:
 		Given using OCS API version "1"

--- a/tests/acceptance/features/apiTrashbin/trashbin-old-endpoint.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbin-old-endpoint.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api @TestAlsoOnExternalUserBackend @files_trashbin-app-required
 Feature: trashbin-new-endpoint
 	Background:
 		Given using OCS API version "1"

--- a/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @comments-app-required
 Feature: admin apps settings
 	As an admin
 	I want to be able to manage apps settings on the ownCloud server

--- a/tests/acceptance/features/webUITrashbin/restore.feature
+++ b/tests/acceptance/features/webUITrashbin/restore.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @files_trashbin-app-required
 Feature: Restore deleted files/folders
 As a user
 I would like to restore files/folders

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @files_trashbin-app-required
 Feature: files and folders can be deleted from the trashbin
   As a user
   I want to delete files and folders from the trashbin

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @files_trashbin-app-required
 Feature: files and folders exist in the trashbin after being deleted
   As a user
   I want deleted files and folders to be available in the trashbin


### PR DESCRIPTION
## Description
We already have the tag name "standard" ``notifications-app-required``

Keep using this format. Tag test features/scenarios that test or only work with the following:
```
comments-app-required
federation-app-required
provisioning_api-app-required
files_trashbin-app-required
files_versions-app-required
```
Then it will be easy for external scripts to specify the combination of tags that they do or do not want to run.

## Motivation and Context
1) When doing automated tests of some systems, those systems can be, for example, an image that comes pre-configured with some "standard" apps not there, or disabled. e.g. the trashbin or versions app might be disabled. For such an image, we want to be able to not tests that use/test those "missing" apps.

2) It can be handy to be able to run just the tests related to a particular app, even though the app is bundled in core.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
