### PR TITLE
Allow public link share password to be overridden by PUBLIC_LINK_SHARE_PASSWORD

### DIFF
--- a/tests/acceptance/features/apiShareManagement/createShare.feature
+++ b/tests/acceptance/features/apiShareManagement/createShare.feature
@@ -83,10 +83,10 @@ Feature: sharing
 		Given using OCS API version "<ocs_api_version>"
 		When user "user0" creates a public link share using the sharing API with settings
 			| path      | welcome.txt |
-			| password  | publicpw    |
+			| password  | %public%    |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
-		And the last public shared file should be able to be downloaded with password "publicpw"
+		And the last public shared file should be able to be downloaded with password "%public%"
 		Examples:
 			|ocs_api_version|ocs_status_code|
 			|1              |100            |
@@ -116,10 +116,10 @@ Feature: sharing
 		Given using OCS API version "<ocs_api_version>"
 		When user "user0" creates a public link share using the sharing API with settings
 			| path      | PARENT   |
-			| password  | publicpw |
+			| password  | %public% |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
-		Then the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder with password "publicpw" and the content should be "wnCloud"
+		Then the public should be able to download the range "bytes=1-7" of file "/parent.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
 		Examples:
 			|ocs_api_version|ocs_status_code|
 			|1              |100            |

--- a/tests/acceptance/features/apiShareManagement/multilinksharing.feature
+++ b/tests/acceptance/features/apiShareManagement/multilinksharing.feature
@@ -11,21 +11,21 @@ Feature: multilinksharing
 		Given using OCS API version "<ocs_api_version>"
 		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| password     | publicpw    |
+			| password     | %public%    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |
 			| permissions  | 15          |
 			| name         | sharedlink1 |
 		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| password     | publicpw    |
+			| password     | %public%    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |
 			| permissions  | 15          |
 			| name         | sharedlink2 |
 		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| password     | publicpw    |
+			| password     | %public%    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |
 			| permissions  | 15          |
@@ -47,19 +47,19 @@ Feature: multilinksharing
 		Given using OCS API version "<ocs_api_version>"
 		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| password    | publicpw      |
+			| password    | %public%      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink1   |
 		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| password    | publicpw      |
+			| password    | %public%      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink2   |
 		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| password    | publicpw      |
+			| password    | %public%      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink3   |
@@ -80,14 +80,14 @@ Feature: multilinksharing
 		Given using OCS API version "<ocs_api_version>"
 		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| password     | publicpw    |
+			| password     | %public%    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |
 			| permissions  | 15          |
 			| name         | sharedlink1 |
 		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| password     | publicpw    |
+			| password     | %public%    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |
 			| permissions  | 15          |
@@ -108,13 +108,13 @@ Feature: multilinksharing
 		Given using OCS API version "1"
 		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| password    | publicpw      |
+			| password    | %public%      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink1   |
 		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| password    | publicpw      |
+			| password    | %public%      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink2   |
@@ -129,19 +129,19 @@ Feature: multilinksharing
 		Given using OCS API version "<ocs_api_version>"
 		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| password    | publicpw      |
+			| password    | %public%      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink1   |
 		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| password    | publicpw      |
+			| password    | %public%      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink2   |
 		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| password    | publicpw      |
+			| password    | %public%      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink3   |
@@ -160,13 +160,13 @@ Feature: multilinksharing
 		Given using OCS API version "1"
 		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| password    | publicpw      |
+			| password    | %public%      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink1   |
 		And the user has created a public link share with settings
 			| path        | textfile0.txt |
-			| password    | publicpw      |
+			| password    | %public%      |
 			| expireDate  | +3 days       |
 			| permissions | 1             |
 			| name        | sharedlink2   |
@@ -179,14 +179,14 @@ Feature: multilinksharing
 		Given using OCS API version "1"
 		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| password     | publicpw    |
+			| password     | %public%    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |
 			| permissions  | 15          |
 			| name         | sharedlink1 |
 		And the user has created a public link share with settings
 			| path         | FOLDER      |
-			| password     | publicpw    |
+			| password     | %public%    |
 			| expireDate   | +3 days     |
 			| publicUpload | true        |
 			| permissions  | 15          |

--- a/tests/acceptance/features/apiShareManagement/updateShare.feature
+++ b/tests/acceptance/features/apiShareManagement/updateShare.feature
@@ -61,12 +61,12 @@ Feature: sharing
 		And as user "user0"
 		When the user creates a public link share using the sharing API with settings
 			| path      | welcome.txt |
-			| password  | publicpw    |
+			| password  | %public%    |
 		And the user updates the last share using the sharing API with
 			| expireDate | +3 days |
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"
-		And the last public shared file should be able to be downloaded with password "publicpw"
+		And the last public shared file should be able to be downloaded with password "%public%"
 		Examples:
 			|ocs_api_version|ocs_status_code|
 			|1              |100            |
@@ -111,7 +111,7 @@ Feature: sharing
 		When the user creates a public link share using the sharing API with settings
 			| path      | FOLDER |
 		And the user updates the last share using the sharing API with
-			| password | publicpw |
+			| password | %public% |
 		And the user gets the info of the last share using the sharing API
 		Then the OCS status code should be "<ocs_status_code>"
 		And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
+++ b/tests/acceptance/features/apiShareOperations/downloadFromShare.feature
@@ -54,8 +54,8 @@ Feature: sharing
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with public with default permissions
 		When user "user0" creates a public link share using the sharing API with settings
 			| path         | PARENT   |
-			| password     | publicpw |
-		Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "publicpw" and the content should be "wnCloud"
+			| password     | %public% |
+		Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read/Write permission 
 		Given user "user1" has been created
@@ -80,9 +80,9 @@ Feature: sharing
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read/Write permission 
 		When user "user0" creates a public link share using the sharing API with settings
 			| path         | PARENT   |
-			| password     | publicpw |
+			| password     | %public% |
 			| permissions  | 15       |
-		Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "publicpw" and the content should be "wnCloud"
+		Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"
 
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with a user with Read only permission 
 		Given user "user1" has been created
@@ -107,6 +107,6 @@ Feature: sharing
 	Scenario: Download a file that is in a folder contained in a folder that has been shared with public with Read only permission 
 		When user "user0" creates a public link share using the sharing API with settings
 			| path         | PARENT   |
-			| password     | publicpw |
+			| password     | %public% |
 			| permissions  | 1        |
-		Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "publicpw" and the content should be "wnCloud"
+		Then the public should be able to download the range "bytes=1-7" of file "/CHILD/child.txt" from inside the last public shared folder with password "%public%" and the content should be "wnCloud"

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -65,9 +65,9 @@ Feature: sharing
 		Given as user "user0"
 		And the user has created a public link share with settings
 			| path        | FOLDER   |
-			| password    | publicpw |
+			| password    | %public% |
 			| permissions | 4        |
-		When the public uploads file "test.txt" with password "publicpw" and content "test" using the old WebDAV API
+		When the public uploads file "test.txt" with password "%public%" and content "test" using the old WebDAV API
 		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
 	Scenario: Uploading file to a user upload-only share folder works
@@ -96,9 +96,9 @@ Feature: sharing
 		Given as user "user0"
 		And the user has created a public link share with settings
 			| path        | FOLDER   |
-			| password    | publicpw |
+			| password    | %public% |
 			| permissions | 15       |
-		When the public uploads file "test.txt" with password "publicpw" and content "test" using the old WebDAV API
+		When the public uploads file "test.txt" with password "%public%" and content "test" using the old WebDAV API
 		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
 	@smokeTest
@@ -138,9 +138,9 @@ Feature: sharing
 		Given as user "user0"
 		And the user has created a public link share with settings
 			| path        | FOLDER   |
-			| password    | publicpw |
+			| password    | %public% |
 			| permissions | 15       |
-		When the public uploads file "test.txt" with password "publicpw" and content "test" using the old WebDAV API
+		When the public uploads file "test.txt" with password "%public%" and content "test" using the old WebDAV API
 		Then the content of file "/FOLDER/test.txt" for user "user0" should be "test"
 
 	Scenario: Uploading to a user shared folder with read/write permission when the sharer has unsufficient quota does not work

--- a/tests/acceptance/features/bootstrap/BasicStructure.php
+++ b/tests/acceptance/features/bootstrap/BasicStructure.php
@@ -90,6 +90,13 @@ trait BasicStructure {
 	private $alternateAdminPassword = '';
 
 	/**
+	 * The password to use in tests that create public link shares
+	 *
+	 * @var string
+	 */
+	private $publicLinkSharePassword = '';
+
+	/**
 	 * @var string
 	 */
 	private $ocPath = '';
@@ -207,6 +214,7 @@ trait BasicStructure {
 		$this->alt3UserPassword = "aVeryLongPassword42TheMeaningOfLife";
 		$this->subAdminPassword = "IamAJuniorAdmin42";
 		$this->alternateAdminPassword = "IHave99LotsOfPriv";
+		$this->publicLinkSharePassword = "publicPwd1";
 
 		// in case of CI deployment we take the server url from the environment
 		$testServerUrl = \getenv('TEST_SERVER_URL');
@@ -271,6 +279,12 @@ trait BasicStructure {
 		$alternateAdminPasswordFromEnvironment = $this->getAlternateAdminPasswordFromEnvironment();
 		if ($alternateAdminPasswordFromEnvironment !== false) {
 			$this->alternateAdminPassword = $alternateAdminPasswordFromEnvironment;
+		}
+
+		// get the public link share password from the environment (if defined)
+		$publicLinkSharePasswordFromEnvironment = $this->getPublicLinkSharePasswordFromEnvironment();
+		if ($publicLinkSharePasswordFromEnvironment !== false) {
+			$this->publicLinkSharePassword = $publicLinkSharePasswordFromEnvironment;
 		}
 	}
 
@@ -344,6 +358,15 @@ trait BasicStructure {
 	 */
 	private static function getAlternateAdminPasswordFromEnvironment() {
 		return \getenv('ALTERNATE_ADMIN_PASSWORD');
+	}
+
+	/**
+	 * Get the externally-defined public link share password, if any
+	 *
+	 * @return string|false
+	 */
+	private static function getPublicLinkSharePasswordFromEnvironment() {
+		return \getenv('PUBLIC_LINK_SHARE_PASSWORD');
 	}
 
 	/**
@@ -1377,6 +1400,8 @@ trait BasicStructure {
 			return (string) $this->getAdminPassword();
 		} elseif ($functionalPassword === "%altadmin%") {
 			return (string) $this->alternateAdminPassword;
+		} elseif ($functionalPassword === "%public%") {
+			return (string) $this->publicLinkSharePassword;
 		} else {
 			return $functionalPassword;
 		}

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -93,6 +93,9 @@ trait Sharing {
 				$dateModification = $fd['expireDate'];
 				$fd['expireDate'] = \date('Y-m-d', \strtotime($dateModification));
 			}
+			if (\array_key_exists('password', $fd)) {
+				$fd['password'] = $this->getActualPassword($fd['password']);
+			}
 		}
 		$this->response = HttpRequestHelper::post(
 			$fullUrl, $user, $this->getPasswordForUser($user), null, $fd
@@ -419,6 +422,7 @@ trait Sharing {
 	private function checkDownload(
 		$url, $user = null, $password = null, $mimeType = null
 	) {
+		$password = $this->getActualPassword($password);
 		$headers = ['X-Requested-With' => 'XMLHttpRequest'];
 		$this->response = HttpRequestHelper::get($url, $user, $password, $headers);
 		PHPUnit_Framework_Assert::assertEquals(
@@ -559,6 +563,7 @@ trait Sharing {
 		$body = 'test',
 		$autorename = false
 	) {
+		$password = $this->getActualPassword($password);
 		$url = $this->getBaseUrl() . "/public.php/webdav/";
 		$url .= \rawurlencode(\ltrim($filename, '/'));
 		$token = $this->getLastShareToken();

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -455,6 +455,7 @@ trait WebDav {
 	public function publicDownloadsTheFileInsideThePublicSharedFolderWithPassword(
 		$path, $password, $range
 	) {
+		$password = $this->getActualPassword($password);
 		$fullUrl = $this->getBaseUrl() . "/public.php/webdav$path";
 		$headers = [
 			'X-Requested-With' => 'XMLHttpRequest',


### PR DESCRIPTION
## Description
The public link share password can be inserted into steps that use it by putting ``%public%``.

The default value is ``publicPwd1``.

The default can be overridden by setting the env variable ``PUBLIC_LINK_SHARE_PASSWORD``

## Related Issue
- Fixes #32871 

## Motivation and Context
Allow acceptance tests to use a flexible password when creating public link shares.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
- [ ] Backport (if applicable set "backport-request" label and remove when the backport was done)
