### PR TITLE
[stable10] Fix thumbnail test failing locally due to `enable_previews` set to false

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -629,6 +629,37 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * enable the previews on all tests tagged with '@enablePreviews'
+	 *
+	 * Sometimes when testing locally, or if the `enable_previews` is turned off,
+	 * the tests such as the one testing thumbnails may fail. This enables the preview
+	 * on such tests.
+	 *
+	 * @BeforeScenario @webUI&&@enablePreviews
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function enablePreviewBeforeScenario() {
+		if ($this->oldPreviewSetting === null) {
+			$oldPreviewSetting = SetupHelper::runOcc(
+				['config:system:get', 'enable_previews']
+				)['stdOut'];
+			$this->oldPreviewSetting = \trim($oldPreviewSetting);
+		}
+		SetupHelper::runOcc(
+			[
+				'config:system:set',
+				'enable_previews',
+				'--type',
+				'boolean',
+				'--value',
+				'true'
+			]
+			);
+	}
+
+	/**
 	 * @return string
 	 */
 	public function getSessionId() {

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -1,4 +1,4 @@
-@webUI @insulated
+@webUI @insulated @enablePreviews
 Feature: browse directly to details tab
 As a user
 I want to be able to browse directly to display the details about a file


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Backport for #32861 